### PR TITLE
Initial contribution of LLJB to the Eclipse OMR Project

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -70,7 +70,7 @@ if(OMR_LLJB)
 	if(NOT OMR_JITBUILDER)
 		message(FATAL_ERROR "OMR_LLJB is enabled but OMR_JITBUILDER is not enabled")
 	endif()
-	set (OMR_LLJB_TEST ON CACHE BOOL "Enable lljb tests")
+	set(OMR_LLJB_TEST ON CACHE BOOL "Enable lljb tests")
 endif()
 
 ## Enable OMR_JITBUILDER_TEST if OMR_JITBUILDER is enabled.

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -70,6 +70,7 @@ if(OMR_LLJB)
 	if(NOT OMR_JITBUILDER)
 		message(FATAL_ERROR "OMR_LLJB is enabled but OMR_JITBUILDER is not enabled")
 	endif()
+	set (OMR_LLJB_TEST ON CACHE BOOL "Enable lljb tests")
 endif()
 
 ## Enable OMR_JITBUILDER_TEST if OMR_JITBUILDER is enabled.

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -44,6 +44,7 @@ set(OMR_THREAD ON CACHE BOOL "Enable thread library")
 set(OMR_COMPILER OFF CACHE BOOL "Enable the Compiler")
 set(OMR_JITBUILDER OFF CACHE BOOL "Enable building JitBuilder")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "Enable building the test compiler")
+set(OMR_LLJB OFF CACHE BOOL "Enable building LLJB")
 
 set(OMR_GC ON CACHE BOOL "Enable the GC")
 set(OMR_GC_TEST ${OMR_GC} CACHE BOOL "Enable the GC tests.")
@@ -51,13 +52,23 @@ set(OMR_GC_TEST ${OMR_GC} CACHE BOOL "Enable the GC tests.")
 set(OMR_USE_NATIVE_ENCODING ON CACHE BOOL
 	"Indicates that runtime components should use the systems native encoding (currently only defined for z/OS)"
 )
-## OMR_COMPILER is required for OMR_JITBUILDER and OMR_TEST_COMPILER
+## OMR_COMPILER is required for OMR_JITBUILDER, OMR_TEST_COMPILER and OMR_LLJB
 if(NOT OMR_COMPILER)
 	if(OMR_JITBUILDER)
 		message(FATAL_ERROR "OMR_JITBUILDER is enabled but OMR_COMPILER is not enabled")
+	else()
+		if(OMR_LLJB)
+			message(FATAL_ERROR "OMR_LLJB is enabled but OMR_COMPILER and OMR_JITBUILDER are not enabled")
+		endif()
 	endif()
 	if(OMR_TEST_COMPILER)
 		message(FATAL_ERROR "OMR_TEST_COMPILER is enabled but OMR_COMPILER is not enabled")
+	endif()
+endif()
+
+if(OMR_LLJB)
+	if(NOT OMR_JITBUILDER)
+		message(FATAL_ERROR "OMR_LLJB is enabled but OMR_JITBUILDER is not enabled")
 	endif()
 endif()
 

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -52,6 +52,10 @@ if(OMR_TEST_COMPILER)
 	add_subdirectory(compilertest)
 endif()
 
+if(OMR_LLJB_TEST)
+	add_subdirectory(lljbtest)
+endif()
+
 if(OMR_JITBUILDER_TEST)
 	add_subdirectory(tril)
 	add_subdirectory(compilertriltest)

--- a/fvtest/lljbtest/CMakeLists.txt
+++ b/fvtest/lljbtest/CMakeLists.txt
@@ -19,59 +19,50 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-find_package(LLVM 8 REQUIRED CONFIG)
-
-# we need clang to generate IR from C++
-find_program(CLANG_EXECUTABLE  NAMES clang)
-
-if (NOT CLANG_EXECUTABLE)
-    message(SEND_ERROR "Could not find clang")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	find_package(LLVM 8 REQUIRED CONFIG
+		PATHS "/usr/local/opt/llvm\@8/bin/:${PATH}"
+	)
+else()
+	find_package(LLVM 8 REQUIRED CONFIG)
 endif()
 
-# Generate llvm bitcode files from C++ using clang
-function(generate_module_from_cpp src)
-    add_custom_command(
-        OUTPUT
-            ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
-        COMMAND
-            ${CLANG_EXECUTABLE} -S -emit-llvm -std=c++0x -O0 -o ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll ${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
-        MAIN_DEPENDENCY
-            ${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
-    )
-    add_custom_target(generate_module_from_cpp_${src} ALL
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
-    )
+# we need clang to generate IR from C++
+find_program(CLANG_EXECUTABLE  NAMES clang++)
 
-endfunction(generate_module_from_cpp)
+if (NOT CLANG_EXECUTABLE)
+	message(FATAL_ERROR "Could not find clang++")
+endif()
 
-
+# Generate llvm bitcode files from C++ using clang++
+function(generate_module_from_cxx src)
+	add_custom_command(
+		OUTPUT
+			${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
+		COMMAND
+			${CLANG_EXECUTABLE} -S -emit-llvm -std=c++0x -O0 -o ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll ${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
+		MAIN_DEPENDENCY
+			${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
+	)
+	add_custom_target(generate_module_from_cxx_${src} ALL
+		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
+	)
+endfunction(generate_module_from_cxx)
 
 add_executable(lljb_run
 	lljb_run.cpp
 )
 
-target_include_directories(lljb_run
-    PRIVATE
-        ${CMAKE_SOURCE_DIR}/jitbuilder/
-        ${CMAKE_SOURCE_DIR}/compiler/
-        ${CMAKE_SOURCE_DIR}/omr/
-)
-
 target_link_libraries(lljb_run
-    lljb
-    LLVMIRReader
-    LLVMCore
-    LLVMSupport
-	omrGtest
-	${CMAKE_DL_LIBS}
+	lljb
 )
 
 function(add_lljb_test test)
-    generate_module_from_cpp(${test})
-    add_test(
-        NAME lljb_${test}_test
-        COMMAND lljb_run ${test}.ll
-    )
+	generate_module_from_cxx(${test})
+	add_test(
+		NAME lljb_${test}_test
+		COMMAND lljb_run ${test}.ll
+	)
 endfunction(add_lljb_test)
 
 add_lljb_test(add)
@@ -92,6 +83,6 @@ add_lljb_test(unions)
 
 # the following tests work only on Linux and macOS
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    add_lljb_test(mandelbrot)
-    add_lljb_test(time)
+	add_lljb_test(mandelbrot)
+	add_lljb_test(time)
 endif()

--- a/fvtest/lljbtest/CMakeLists.txt
+++ b/fvtest/lljbtest/CMakeLists.txt
@@ -1,0 +1,97 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+find_package(LLVM 8 REQUIRED CONFIG)
+
+# we need clang to generate IR from C++
+find_program(CLANG_EXECUTABLE  NAMES clang)
+
+if (NOT CLANG_EXECUTABLE)
+    message(SEND_ERROR "Could not find clang")
+endif()
+
+# Generate llvm bitcode files from C++ using clang
+function(generate_module_from_cpp src)
+    add_custom_command(
+        OUTPUT
+            ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
+        COMMAND
+            ${CLANG_EXECUTABLE} -S -emit-llvm -std=c++0x -O0 -o ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll ${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
+        MAIN_DEPENDENCY
+            ${CMAKE_CURRENT_SOURCE_DIR}/${src}.cpp
+    )
+    add_custom_target(generate_module_from_cpp_${src} ALL
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${src}.ll
+    )
+
+endfunction(generate_module_from_cpp)
+
+
+
+add_executable(lljb_run
+	lljb_run.cpp
+)
+
+target_include_directories(lljb_run
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/jitbuilder/
+        ${CMAKE_SOURCE_DIR}/compiler/
+        ${CMAKE_SOURCE_DIR}/omr/
+)
+
+target_link_libraries(lljb_run
+    lljb
+    LLVMIRReader
+    LLVMCore
+    LLVMSupport
+	omrGtest
+	${CMAKE_DL_LIBS}
+)
+
+function(add_lljb_test test)
+    generate_module_from_cpp(${test})
+    add_test(
+        NAME lljb_${test}_test
+        COMMAND lljb_run ${test}.ll
+    )
+endfunction(add_lljb_test)
+
+add_lljb_test(add)
+add_lljb_test(arrays)
+add_lljb_test(conditional)
+add_lljb_test(div)
+add_lljb_test(doubles)
+add_lljb_test(floats)
+add_lljb_test(function_call)
+add_lljb_test(loops)
+add_lljb_test(md5)
+add_lljb_test(mul)
+add_lljb_test(print_string)
+add_lljb_test(structs)
+add_lljb_test(sub)
+add_lljb_test(ternary)
+add_lljb_test(unions)
+
+# the following tests work only on Linux and macOS
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    add_lljb_test(mandelbrot)
+    add_lljb_test(time)
+endif()

--- a/fvtest/lljbtest/add.cpp
+++ b/fvtest/lljbtest/add.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int add()
+   {
+   int x = 1;
+   int y = 2;
+   int z = x + y;
+   return z;
+   }

--- a/fvtest/lljbtest/arrays.cpp
+++ b/fvtest/lljbtest/arrays.cpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+void foo(int * x)
+   {
+   x[3] = 2;
+   }
+
+int main()
+   {
+   int table1[2];
+   int table2[2][2];
+   table1[0] = 1;
+   foo((int *)table2);
+   int z = table1[0] + table2[1][1];
+   return z;
+   }

--- a/fvtest/lljbtest/conditional.cpp
+++ b/fvtest/lljbtest/conditional.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int conditional()
+   {
+   int x = 1;
+   int y = 2;
+   int z;
+   if (x < 2)
+      {
+      z = x + y;
+      }
+   else
+      {
+      z = y - x;
+      }
+   return z;
+   }

--- a/fvtest/lljbtest/div.cpp
+++ b/fvtest/lljbtest/div.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int divide()
+   {
+   int x = 12;
+   int y = 4;
+   int z = x/y;
+   return z;
+   }

--- a/fvtest/lljbtest/doubles.cpp
+++ b/fvtest/lljbtest/doubles.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+double foo(){
+   double x = 3.1;
+   double y = 0.1;
+   if (x > 0)
+      {
+      x = x + 1.1;
+      y = y + 1.1;
+      }
+   return (x - y);
+   }
+
+int main()
+   {
+   return (int) foo();
+   }

--- a/fvtest/lljbtest/floats.cpp
+++ b/fvtest/lljbtest/floats.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <cstdio>
+
+float foo()
+   {
+   float x = 3.1f;
+   float y = 0.1f;
+   if (x > 0.0f)
+      {
+      x = x + 1.2f;
+      y = y + 1.1f;
+      }
+   return (x - y);
+   }
+
+int main()
+   {
+   return (int) foo();
+   }

--- a/fvtest/lljbtest/function_call.cpp
+++ b/fvtest/lljbtest/function_call.cpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int foo()
+   {
+   return 3;
+   }
+
+int main()
+   {
+   return foo();
+   }

--- a/fvtest/lljbtest/lljb_run.cpp
+++ b/fvtest/lljbtest/lljb_run.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "lljb/Module.hpp"
+#include "lljb/Compiler.hpp"
+#include "lljb/IRVisitor.hpp"
+#include "JitBuilder.hpp"
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include <iostream>
+#include <cassert>
+
+int main(int argc, char * argv[])
+   {
+
+   bool jitInitialized = initializeJit();
+   assert(jitInitialized && "Jit Failed to initialize");
+
+   const char * filename = argv[1];
+
+   llvm::LLVMContext context;
+   llvm::SMDiagnostic SMDiags;
+   lljb::Module module(filename, SMDiags, context);
+
+   lljb::Compiler compiler(&module);
+   compiler.compile();
+
+   lljb::JittedFunction jc = compiler.getJittedCodeEntry();
+   auto result = jc();
+   std::cout << "return value: " << result << std::endl;
+
+   shutdownJit();
+
+   return 0;
+   }

--- a/fvtest/lljbtest/lljb_run.cpp
+++ b/fvtest/lljbtest/lljb_run.cpp
@@ -30,16 +30,22 @@
 #include "llvm/Support/SourceMgr.h"
 
 #include <iostream>
-#include <cassert>
 
 int main(int argc, char * argv[])
    {
+   if (argc != 2)
+      {
+      std::cerr << "Usage: " << argv[0] << " <module.ll>" << std::endl;
+      exit(EXIT_FAILURE);
+      }
 
-   bool jitInitialized = initializeJit();
-   assert(jitInitialized && "Jit Failed to initialize");
+   if (!initializeJit())
+      {
+      std::cerr << "Failed to initialize JIT" << std::endl;
+      exit(EXIT_FAILURE);
+      }
 
    const char * filename = argv[1];
-
    llvm::LLVMContext context;
    llvm::SMDiagnostic SMDiags;
    lljb::Module module(filename, SMDiags, context);

--- a/fvtest/lljbtest/loops.cpp
+++ b/fvtest/lljbtest/loops.cpp
@@ -26,14 +26,16 @@ int main()
    int y = 0;
    int i = 0;
 
-   while (i < 10 && (x >= y || y >= 0)){ // this generates phi nodes
+   while (i < 10 && (x >= y || y >= 0)) // this generates phi nodes
+      {
       x += 1;
       i++;
-   }
+      }
 
-   for (i = 0; i < 7; i++){
+   for (i = 0; i < 7; i++)
+      {
       y += 1;
-   }
+      }
 
    return x - y;
    }

--- a/fvtest/lljbtest/loops.cpp
+++ b/fvtest/lljbtest/loops.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int main()
+   {
+   int x = 0;
+   int y = 0;
+   int i = 0;
+
+   while (i < 10 && (x >= y || y >= 0)){ // this generates phi nodes
+      x += 1;
+      i++;
+   }
+
+   for (i = 0; i < 7; i++){
+      y += 1;
+   }
+
+   return x - y;
+   }

--- a/fvtest/lljbtest/mandelbrot.cpp
+++ b/fvtest/lljbtest/mandelbrot.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <time.h>
+
+typedef double FP_t;
+
+__attribute__((noinline))
+void mandelbrot(int x_pixels, int y_pixels, int* out_table, int max_iterations)
+   {
+   FP_t x_scale_factor = 3.5 / (FP_t) x_pixels;
+   FP_t y_scale_factor = 2.0 / (FP_t) y_pixels;
+
+   for (int py = 0; py < y_pixels; ++py)
+      {
+      for (int px = 0; px < x_pixels; ++px)
+         {
+         FP_t x0 = px * x_scale_factor - 2.5;
+         FP_t y0 = py * y_scale_factor - 1.0;
+
+         FP_t x = 0.0;
+         FP_t y = 0.0;
+         int iteration = 0;
+         while (x*x + y*y <= 2*2)
+            {
+            if (iteration == max_iterations) break;
+            FP_t x_temp = x*x - y*y + x0;
+            y = 2*x*y + y0;
+            x = x_temp;
+            iteration += 1;
+            }
+
+         out_table[py*x_pixels + px] = iteration;
+         }
+      }
+   }
+
+void print_image(int x_pixels, int y_pixels, int* table)
+   {
+   for (int py = 0; py < y_pixels; ++py)
+      {
+      for (int px = 0; px < x_pixels; ++px)
+         {
+         if (table[py*x_pixels + px] > 150)
+            {
+            printf("*");
+            }
+         else
+            {
+            printf(" ");
+            }
+         }
+      printf("\n");
+      }
+   }
+
+void tdiff(struct timespec * start, struct timespec * end, struct timespec * diff)
+   {
+   if ((end->tv_nsec-start->tv_nsec)<0)
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec-1;
+      diff->tv_nsec = 1000000000+end->tv_nsec-start->tv_nsec;
+      }
+      else
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec;
+      diff->tv_nsec = end->tv_nsec-start->tv_nsec;
+      }
+   }
+
+int main(void)
+   {
+   int small_table [3][4];
+   mandelbrot(4, 3, (int*)small_table, 10);
+   print_image(4, 3, (int*)small_table);
+
+   int table[34][80];
+   clockid_t clockid = CLOCK_MONOTONIC;
+
+   struct timespec start_time, end_time;
+   clock_gettime(clockid, &start_time);
+   mandelbrot(80, 34, (int*)table, 300000);
+   clock_gettime(clockid, &end_time);
+
+   struct timespec time_diff;
+   tdiff(&start_time, &end_time, &time_diff);
+   FP_t time_taken = (double)time_diff.tv_sec + time_diff.tv_nsec*1.0e-9;
+   printf("Calculated Mandelbrot set in %lf (s)\n", time_taken);
+
+   print_image(80, 34, (int*)table);
+
+   return 0;
+   }

--- a/fvtest/lljbtest/md5.cpp
+++ b/fvtest/lljbtest/md5.cpp
@@ -1,0 +1,445 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * Derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm
+ * https://www.ietf.org/rfc/rfc1321.txt
+ */
+
+#include <cstring>
+#include <cstdio>
+#include <cstdint>
+#include <time.h>
+
+#define S11 7
+#define S12 12
+#define S13 17
+#define S14 22
+#define S21 5
+#define S22 9
+#define S23 14
+#define S24 20
+#define S31 4
+#define S32 11
+#define S33 16
+#define S34 23
+#define S41 6
+#define S42 10
+#define S43 15
+#define S44 21
+
+void MD5MemCpy (unsigned char * output, unsigned char * input, uint32_t len)
+   {
+   for (int i = 0; i < len; i++)
+      output[i] = input[i];
+   }
+
+void MD5MemSet (unsigned char * output, int value, uint32_t len)
+   {
+   for (int i = 0; i < len; i++)
+      ((char *)output)[i] = (char)value;
+   }
+
+uint32_t FFTransform(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t x, uint32_t s, uint32_t ac)
+   {
+   uint32_t result = a + ((b & c) | (~b & d)) + x + ac;
+   result = (result << s) | (result >> (32 - s));
+   result += result + b;
+   return result;
+   }
+
+uint32_t GGTransform(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t x, uint32_t s, uint32_t ac){
+  uint32_t result = a + ((b & d) | (c & (~d))) + x + ac;
+  result = (result << s) | (result >> (32 - s));
+  result += result + b;
+  return result;
+}
+
+uint32_t HHTransform(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t x, uint32_t s, uint32_t ac)
+   {
+   uint32_t result = a + (b ^ c ^ d) + x + ac;
+   result = (result << s) | (result >> (32 - s));
+   result += result + b;
+   return result;
+   }
+
+uint32_t IITransform(uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t x, uint32_t s, uint32_t ac)
+   {
+   uint32_t result = a + (c ^ (b | (~d))) + x + ac;
+   result = (result << s) | (result >> (32 - s));
+   result += result + b;
+   return result;
+   }
+
+void MD5Init(uint32_t  * state, uint32_t  * count)
+   {
+   state[0] = 0x67452301;
+   state[1] = 0xefcdab89;
+   state[2] = 0x98badcfe;
+   state[3] = 0x10325476;
+   count[0] = 0;
+   count[1] = 0;
+   }
+
+
+/* Encodes input (unsigned ) into output (unsigned char). Assumes len is
+  a multiple of 4.
+ */
+void Encode (unsigned char *output, uint32_t  *input, uint32_t len)
+   {
+   for (int i = 0, j = 0; j < len; i++, j += 4)
+      {
+      output[j] = (unsigned char)(input[i] & 0xff);
+      output[j+1] = (unsigned char)((input[i] >> 8) & 0xff);
+      output[j+2] = (unsigned char)((input[i] >> 16) & 0xff);
+      output[j+3] = (unsigned char)((input[i] >> 24) & 0xff);
+      }
+   }
+
+/* Decodes input (unsigned char) into output (unsigned ). Assumes len is
+  a multiple of 4.
+ */
+void Decode (uint32_t  *output, unsigned char *input, uint32_t len)
+   {
+   uint32_t i, j, a = 8, b = 16, c = 24;
+
+   for (i = 0, j = 0; j < len; i++, j += 4)
+      {
+      output[i] = input[j] | input[j+1] << 8 | input[j+2] << 16 | input[j+3] << 24;
+      }
+   }
+
+/* MD5 basic transformation. Transforms state based on block.
+ */
+void MD5Transform (uint32_t * state, unsigned char block[64])
+   {
+   uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+
+   Decode (x, block, 64);
+
+   /* Round 1 */
+   a = FFTransform(a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
+   d = FFTransform (d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
+   c = FFTransform (c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
+   b = FFTransform (b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
+   a = FFTransform (a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
+   d = FFTransform (d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
+   c = FFTransform (c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
+   b = FFTransform (b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
+   a = FFTransform (a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
+   d = FFTransform (d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
+   c = FFTransform (c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+   b = FFTransform (b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+   a = FFTransform (a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+   d = FFTransform (d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+   c = FFTransform (c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+   b = FFTransform (b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+
+   /* Round 2 */
+   a = GGTransform (a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
+   d = GGTransform (d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
+   c = GGTransform (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+   b = GGTransform (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
+   a = GGTransform (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
+   d = GGTransform (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
+   c = GGTransform (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+   b = GGTransform (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
+   a = GGTransform (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
+   d = GGTransform (d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+   c = GGTransform (c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
+   b = GGTransform (b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
+   a = GGTransform (a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+   d = GGTransform (d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
+   c = GGTransform (c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
+   b = GGTransform (b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+
+   /* Round 3 */
+   a = HHTransform (a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
+   d = HHTransform (d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
+   c = HHTransform (c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+   b = HHTransform (b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+   a = HHTransform (a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
+   d = HHTransform (d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
+   c = HHTransform (c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
+   b = HHTransform (b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+   a = HHTransform (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+   d = HHTransform (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
+   c = HHTransform (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
+   b = HHTransform (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
+   a = HHTransform (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
+   d = HHTransform (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+   c = HHTransform (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+   b = HHTransform (b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
+
+   /* Round 4 */
+   a = IITransform (a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
+   d = IITransform (d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
+   c = IITransform (c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+   b = IITransform (b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
+   a = IITransform (a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+   d = IITransform (d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
+   c = IITransform (c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+   b = IITransform (b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
+   a = IITransform (a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
+   d = IITransform (d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+   c = IITransform (c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
+   b = IITransform (b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+   a = IITransform (a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
+   d = IITransform (d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+   c = IITransform (c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
+   b = IITransform (b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
+
+   state[0] += a;
+   state[1] += b;
+   state[2] += c;
+   state[3] += d;
+
+   /* Zeroize sensitive information.
+
+   */
+   MD5MemSet ((unsigned char *)x, 0, sizeof (x));
+   }
+
+/* MD5 block update operation. Continues an MD5 message-digest
+  operation, processing another message block, and updating the
+  context.
+ */
+void MD5Update (unsigned  * state, unsigned  * count, unsigned char * buffer, unsigned char * input, unsigned int inputLen)
+   {
+   unsigned int i, index, partLen;
+
+   /* Compute number of bytes mod 64 */
+   index = (unsigned int)((count[0] >> 3) & 0x3F);
+
+   /* Update number of bits */
+   if ((count[0] += ((unsigned )inputLen << 3)) < ((unsigned )inputLen << 3)) count[1]++;
+
+   count[1] += ((unsigned )inputLen >> 29);
+
+   partLen = 64 - index;
+
+   /* Transform as many times as possible. */
+   if (inputLen >= partLen)
+      {
+      MD5MemCpy((unsigned char *)&buffer[index], (unsigned char *)input, partLen);
+      MD5Transform (state, buffer);
+
+      for (i = partLen; i + 63 < inputLen; i += 64)
+         MD5Transform (state, &input[i]);
+
+      index = 0;
+      }
+   else i = 0;
+
+   /* Buffer remaining input */
+   MD5MemCpy ((unsigned char *)&buffer[index], (unsigned char *)&input[i], inputLen-i);
+   }
+
+/* MD5 finalization. Ends an MD5 message-digest operation, writing the
+  the message digest and zeroizing the context.
+ */
+void MD5Final (unsigned char * digest,unsigned  * state, unsigned  * count, unsigned char * buffer)
+   {
+   unsigned char PADDING[64];
+   PADDING[0] = 0x80;
+   for (uint32_t i = 1; i < 64; i++)
+      {
+      PADDING[i] = 0;
+      }
+   unsigned char bits[8];
+   uint32_t index, padLen;
+
+   /* Save number of bits */
+   Encode((unsigned char *) bits, count, 8);
+
+   /* Pad out to 56 mod 64.*/
+   index = (count[0] >> 3) & 0x3f;
+   if (index < 56) padLen = 56 - index;
+   else padLen = 120 - index;
+   MD5Update (state, count, buffer, PADDING, padLen);
+   /* Append length (before padding) */
+   MD5Update (state, count, buffer, bits, 8);
+
+   /* Store state in digest */
+   Encode (digest, state, 16);
+
+   }
+
+void timeDiff(struct timespec * start, struct timespec * end, struct timespec * diff)
+   {
+   if ((end->tv_nsec-start->tv_nsec)<0)
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec-1;
+      diff->tv_nsec = 1000000000+end->tv_nsec-start->tv_nsec;
+      }
+      else
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec;
+      diff->tv_nsec = end->tv_nsec-start->tv_nsec;
+      }
+   }
+
+void printDigest(unsigned char * digest, uint32_t len)
+   {
+   unsigned char c;
+   uint32_t i;
+   for (i = 0; i < len; i++)
+      {
+      c = digest[i];
+      printf("%x\n",c);
+      }
+   }
+
+
+int main()
+   {
+   char * message = (char *) "rcABJf7Dnv6wMWDHzUYXX0IH2lG0CtN8srdHoAKxd2ymbaw5eyc8PEAtOrnc1rax2nZbIhZn\
+   fs7o3UAsHNkm6VsLH9u3E5vXmtMcVQsMWyctZWu5zwqABtrGwpQgjQ37O9bv6X1nKlExblyFuCVNQA1UpOGW8Lfe2PV\
+   zZy87VDJSC2pWixIg4dmY0MNrX7WUSLdAXFqus90fjHGvFM7Omc7DHY9ZCFZWf6K3HwEmRr7gvHOFEsx7DGsSALPPCC\
+   HPE9D1VASKkhzRihtQ5zx7eTGs48JnAlVcfVElhnAvwMXwvIcc5IR7FPSeRtZfzxK5MY6eptUIB9aUm0ejxajb10Op0b\
+   Z9qqhF54NbYvpkfEmGAUeaPSVTNnLDXkKk5NYk7XhNzSome71Y7ac4iMPJZgt8ecubtVjS2oi3c9QLMLVGQomdeGyE7WG\
+   tTQTUh98DEVdivFHi7Trn8s2l7pFI5CMPva5nxz8pq1Fs3s1RkplR1j1F5BbwSpQesmCtOlBezfnIGyGXDv8atJB2Rp7UT\
+   b7PuoToxnVohc53bRoNb6NkeQyitQ6UXPsCrtKlKGke5Nh5vP8LVtatlqe2fqYR93Hav2FuRNOM85LEzng5vNAshMZ9g\
+   TWNoksv0akcjOffE3EvOThd3m3Pe0k23FZWYkM1SldhZmXcsFVZWJpdVozMRRaQmSSMXURIuUeBAiiUOf9x8uLgsu8UH\
+   35sm3VK4DfIhlHjXUfLTiZgjWyCxV9nkpdmR7Ysaif18WH8HMCbFiad4mWAdp4RDvEpAiFOSqVlCtgs8qmo7XYNyuCo8\
+   jBguJ0RNbamILpNWxTAOvRGOTCqUjcbCPgaAv15mbZzeGrnDcMNTAm7MYck8DITGTkfkrYgJdr2g4JCwk2Zs2BfrP6jp\
+   AhBjyFlPOZeK1ix6IEqzRHpIbavWobTvGDdp85z5rwUuSDLUNDqxEV6aDNZGp7PeIwHVgv6jPRVoR6snIsm2Is7NCStE\
+   xTg4nEBtjp5Dg3ZvdSVuhKEqtfxIX54y3Y34WZaGxcbhX6wIVC55wYMgbXGlbNAnWndOJdh36OPlDERXfPY7CWy7MiOe\
+   HU9eTI4nUtkt5DArdzH1Yw1GI9CEDnIyHhJTZQOVXEgPqKfStc137gJYGIlJFOvOlxzVoXK3Cnp4F6xYLnHnpYQxvaAj\
+   njDQp8ECDaXSE9R9s0j6UMWDOI8uVkRkO8xs2BEk6aKBeIFGxBu1BE7E7nQYvP3j7nf60J3PjfaCM3MuuXK3cteeIMj2v\
+   MnEDZjX6hN2E2MKATHfPvJqw8YCCnnc0fBS1WEs8j270aleRXhNA4EwNQOxEb3qjl7XRV5OQCihy1ePb9fLawxhLgdnr0\
+   1ps1TYVf4BWGoB3XcqQEWYW2h7aW1XEDxHosk1ccw7fXmSwzhDPwdJzvMNNrEttncopt3rje4YI6SFkDNOR1sjFXpiry8\
+   RV5r1hZTdHZPTALMhhqWQaUi34HMpIAyyCit7lLToBUlJ27CWVH1hkf3AjNFrituc6VJdbfo9JnJsqY9amkqa61VKiMqy\
+   R1cGgApuWI6QFa8KrYdb0TeXaiYVmixxaQn852a4HxGzn4Lv9xXi5dEICGJSxhJ0wJ4o398fCiertQheML7ucq5QWJwwW\
+   5BkVh8g7ilmDiS0LRpoeEKp6FZEGAgUQnRKnOAIBHPPBosuM9hhsztrBfINXK7yCpRY6inLB0wPIEbL1V4JfNNFMmWhYQ\
+   w5dyOTAO5Ck2vBO1bjbDW3GOj3WaVP0LCv0EhPkaoyBFQYqj7PkbMXIo2p3efqp7zYxrpwLxpVsooNAqH1Hqsz3SkUKXt\
+   U8QPpUCgySdWy4sIhQTk7yro1tPyOtSkGzr3oVtgYHXASMSQSb97cpSvMDs6bnNo3p0Bss3EM6xgQ0TuWBEGG7TXBbYSu\
+   CNQWfYkl3uZX41smUO0NYExaPlBCrHSrinOE25lXANsZ2pJ7fqwhdkCG6n92IK5uuOdK2Rz172MZYqRNSiRdGTrCUjjBU\
+   yZHs6t7mfl3wi1WegrsndJHCqAtP18DBo8Aa3Sfdvp0v9rKeQBKpDxYhdUNqbaPsnJxS23YxjmDvGQknW2xjIfUs40WUQ\
+   fieJvBJ4vvUTfcgwgtzjTuYjwfnSsH6GcD6PI1XRifUTq6EZFBHlVObHf80TindFGyOJWHuVk1ComJgYPRGo1MeASywSg\
+   C1kIdJdGK4WGtpfWX5VgtYthEZzUs78oW3OCJtio3dXxzoHP2O17Cp5CiGMKlQ0APjAbFg23ManflHSIqrpVrC3l6WdW4\
+   iuyn5pg5WGS7UIWkbCU6LIN2nQtexhKOK9eUGGU3Vb9dJjGxDyHVuxlfz6xJ2AyXHpvqRmFFIjkV6xFPiH6tZIJyzxVTO\
+   3L1C7dXK4zYq8ixRnW6sIR9HpUxG1S5NXWuAc6VElttQryDDovuqU0mUADmL0oyaHUkVxc6JEUvtvdzk9mJLpb5dDlJQi\
+   tD1A1vO41B6mAGWDUTlYJhAWBaEcDB9PY6CJhrsbxnKfCfFtktcxsUv8LXWclakk9H5THVia59CzM5eMB652bKNj24XAR\
+   xFwaj6s6FPcNUyl9Ve4CYNcq8KzP1siWD4RSs7F6dy0PeRGp2LinxJ5CgndakAGRwfb0AETj2sZbg0UnN1yj6u8KJq5HI\
+   P1iCRx2PyEHEMpWbfrmEKYvim9m8XcY8nsG1X5nnkrw4yQJhFPXEodBwqQqnEd2l31oVEkEx2TsYrgsYgHqGALHcmzQkv\
+   rdfYoReGUshmwDJaRthKzNPVpoKbBiuws9JOHGXUISvgOxaO4YKXKnoUeiveZY0KzcNrlsAvM7yg2OwZA1NluaqUUDine\
+   h8F2vqv3jGXtr0DFsmILeM7j50VwEnueTWqWtUOhNdEikbrSBdZqS2lLZnQbeOVji1ApSeT5mBTOV0BChMFTHAgvnNGoD\
+   HXMd8pKSqAOn8MVmsyPy2yptKVR04YqGtZhDvSO2bAQeL4jGaoe801qeG8xORdB5eSMM9zzXMAmdCdLfMMa741e26zagZ\
+   U9RbnLoKT5S8Ln7FlYHyQoTHs0gERxILNZbnYcXTiuPyvufG5EbOnzCxhfhvy19P7TophY8ZPAxDPHzq0wyROnVu9nKFg\
+   LwWO2PgGuBq0uB0dK6Qb1AwIT4H6LSfhGFlg4Bw8rUUQICyMqcBU1Fltcsv2vxxAVZPpuHC55f8WLwqOKzvJeJDRnbxuj\
+   cr1qnz9dvX7H6Yi4njBaYE7yeTi8GJORQG5jIuwTlJEHFC3oxErvkwMedlhFPDHvFf1mImSEso4J2D16CUVFn6tC2eqfR\
+   45g9iLU4pkg4Eyr1tmgeSb5JDtYnxaGweharwmTiT8mp161brmqUuocdC1v745Na1Z0qmEmvLdJmdTPTpgLqeeUV0VfDp\
+   9cf4OAR9cgpTkeGhJKT7lIFjL31z9BiuLJ0SNSZpZJpTlkPnrWnYuNFTcRkoN3Tq5keeQNk6BUCgqP8vWeprENBpkLBq0\
+   IshHtqto4pm5Q3dBecGz6L6iMzX44Zk9X3qXUhaojDJ5urQ5Gn2mzfdXEDSdF2tIXxN54tNnK5r8y7M5H1hdARSSpuWkU\
+   1s72NX8ryQhxSpxRPXXjvrAI9EkBs6enyt255berOFxqcoUU4xWS42ezcLcbWl3OcQvGLXjCSBav3ual1FBFUBnhBRx9f\
+   Y1oH60VKtwGTOfPQykqEujwXB4E2H1Xo4fMTbHCzCR6ZwxO79YRbYN50fys3AJK3eaxtkuT5dTbGyIFG51KXG9V2Ju91o\
+   IeSKdvg7hCxurps8CgVBMPEeaLEgttECxjK45k1dNkw4APzEWAl962friBCMPt8ZFwQNWnUmwR3HHiKmk3Oi1YCmYP3wD\
+   3AZbnusC3M8Nb0Mpa44FSdH0lyjgnWxQWAKwqw1nr6Zg84Xgzqkoa0DLmwiwBbYsRsAbKB37juKoc0f9tKO2Ds1IbBM12\
+   i7t1CF8IUrRq6s1B4MfnBFWFtqwDKQHL6UINGqFg1JxQ61qFVYBa1WUzDaNTQiTPlet1Id92Az8QuMKPwySW3h5HaF91r\
+   Rm3EiJdVT78ssR7cdFFpfOz0FRlXfBUk6b7UW4JovoKClGEcVeNyfrJidTBNLCb76iJwDzD8XvAceDzQBzIbeNkBrMCSP\
+   qJVp8oKTqG2gB0xbpwbA6TP4hkbuteeGHr504jNdZfpljUuljSafrE33SW8dzPy6lwhJaPZq8DBpKTT873YWcSobPhP3b\
+   VsEQzr2ugxcaTPhHm7zAoNy4eJbjkgIA7LiqtBpMO4mPQBSpGh2NLMq4Kgw2myeikVYbckqvExC0peNEOxcMiRXi4fKY7\
+   wkI9dDa5aOzSEBFvrBU8R4PfHoWDCvqo7PccTNBtoIte48wKTKfsjJupgDDVBfeVrpyKGkp9VjfLV7SwXOxjJnjFXFMIA\
+   OCjWz8WZDw9tEpACgfyDoxFhKS55dsw24uKxC44KSgHLd0lvXlNzRjLHh0r8jtvlHQUz43AP25Pqjss5xCDL1KOB2fliI\
+   we8cvP78pNLyeThIVdHJcz7Tm8MhZkz60JhosHoiV9psbtG0iw1AKEs4tIuYAK3W3pFAxg8m7d5trvXzLpIpddhs11hhf\
+   nsRvPEjEfFjJBUVC0fMhUitdpl0G0UPOrP1MozPsUDEtO3szjwhatuYq7pFNrGlsCvsjBOfGyOMgi4mKNbeIIGMkp7KYk\
+   UpZUiE0LpsaLM9Y7LPyGMtQ8OfXddHLA9WiwojNWVKfSXY2hiMHEupc3ZJMmp0b9vNroN4718ugcV1GzviD5Rpx0eh6bd\
+   eR6OJXIpChkbbMpZiHT918pR8Sh5Af4eEnxMcY3Y2oMoFdsUXx37mCEF1ATA4e3o0HrJxOfYBXJUZemKJXouHjuyAMKCS\
+   V1geLkS2mGEvmT9fJvQC0vGzfNArBBaIIMDThqLtrW8Vxam6MxoQAycDfPHWDUNP7uEEYF5xlkS5gLDl86a1KwMLuI2zo\
+   B8IW1v0NlO6tWbfA5BtIIYZaXTjJYdx201P6lqZuRDBDW3xcJ7faRLP0sgBEhqwYGEojPaucNvde5ydkGRYUsOdc6wPnJ\
+   a6nqkm4Ti0y3FS72cr79DOmVjkTE2hSV9iaVNBrpiw7PSxS733n1xZFSubMEJgnE4qDVYWhhfu1CLJapQVpFOFfOmUF6M\
+   mt2rMfFil9iCyJYPAShBMQrzECHQs0RoXH9tyEnqmRdGoKqDGB8LSgXplFiOuk8LiE3lXU3zQ0VyEax3NmgFg3jj8qTEJ\
+   xs6Hc97B27eiY8UrFN63Uv6NQ9kfj58CJA1KH6WJ8Cr7xr4KExlhQxjuop4SNEN3T7SZSY3BwQ3ePVp494av6LgMQ3z97\
+   hz1A1uPpyBtGI1i3KAiPU6hPPHcPLRCesE2wawpq8ocv8Lqo8CDV3M9vD27XLKQu89gw1CAezcpIWL7a7ILSsdSRlStoT\
+   DWaAOvslhJ1GaEJqyRCkQ0JAh7UnAeGUM8t9LkWMG0DyZIvM6H9VOpHleIw86Z1mkJi7Kcx9DfiJaVvJ2Q1KtdOd78Kh6\
+   Np6bV7zJICXfoKe5XlKmq12irCVHQYtseKSxUDkUhrR2IJ6moXuEZT8lzYPm0S9FPRnudSuvafHvlLU3ZBQWTPD7Fcmh2\
+   aMVIIun6mp7n5bgJJtO7x8U0oK9PAMPUEMjwklLWHCMLLGfKGNOSstWahUJiPEOGIIB0LlFS6GP4BXapWJTLSwvYZA9Oq\
+   KWwOTCyXUNGmuVqVTRBFLt4gGCQ5Uhosywy2U5uw9sLQzyuL4IpAwXL3sAY32jixzHrDekTQLWzmirmhW7Vg8hGT05xFC\
+   ls2MZyQRcBSvXn5QbabWpUrueTncyt7dOX9DxGaV7z0fDshiOtPYtzqXAMy0e1QYJ5ol3F7oxyJm0iaoyArYdlOKpvNUF\
+   Kct5YBQ4NkjAxYMN7Zn8iylUfC9mOfeLcEgiXCRdxpjFTpb04Isx7KQKkyyrC8pnXTI2wsVaZ3yb1VagXuYS2E0CDyiJ5\
+   vdeNwA9SV1ATX7SUBURTDKFu6JC6iehXHjl9AezVOSWrDW2Bg4wrsc9McfDyqybin8EpjcbtIpz7f6qicpK4yt7eGRnrO\
+   8RTgUO7nrkJi1BwfT7ZylgkigEwwXdQMSJ2lCTYdQ4qieB5Zm7xV4y0b7fEZlZminP4dDK1Y4YxofBdQNI8OnVBoG3mp3\
+   5EF6N5s9O4SZq0EW2SwpcfhCKaPUO9VqfkJzfnSzvLGgFsQOJ8vHhWIRjIAKriJFK9t84Z6Xd27YEG5zPCACgCwMB4uas\
+   V4BefAywRmN9tTfK2DEg9B9dMrag9k2DuYK2nDwiObQolGBMpvVJzNLOacdnhGZgBy8Tia22fEyuPF6KtO2wcLKSpoQca\
+   452FiLQG1DXzOn7XzZUUPLHlkQiTtToDIIpjD3aWZDWVcPRRkJAj4zZJOv0neK8N0jOeQOkrt9uDTpANeM70PL8VSv7wz\
+   6ksPyrGSpUQUz5M2OrNOluBMZwf9vV2h6H9dpm679GplifHaEYCTu7LiJaDIQwCXTV6WpzqFVnpuJ60g8ezdwuEeVPbot\
+   J9nU6fmBJr1LCvCMWLuF8XlvmUvcWamNiNLbtg1rftZ474HsbR6XFSXO1Bdi397JQJWCokm0xLU01U77HX6WRN7KeeSBc\
+   bdzY1lEza7pAFm1pOMvsxubFCU4e32rmmBvhU4tvTWKS7hlOAjziD2LO5HaAYn7pUIzGW3Fq9eHyvXKBjtid3X7XV2jpG\
+   HAnZmUm5x5KXucteRAGHnssXYPCcrvacqMDIfv7qeEGgbMMu2As19jH65aMt6bGeXA3KkVN1Pb3FH0zaJH6unUszm57NH\
+   i5T22ivsUGkaxevCmnraRZZTeGd7dn6x5KDz329cuZzFFDVJVCjw41TK2t9VnT5CuxXxx5B3Q4T5zjZL2uEYz7AjTjR5S\
+   cd8mwoAZPYAyHhiFnhDbaC8wCMLekYc3MbsSE7zfLFpfZigIIM47hnxHGRPh2HTtdczEQ2cIpAoRuUMcsDzdXaYWsK7sp\
+   7l7YUMnnRkSMnMJUzD5c1kp2eZ9vEPowwZuduH7CDZqiHu5yhJqm7mx3QndyKtMO4rHW8xtj3uuEf2blFpUP5xLdeUiru\
+   f5UMy69i4zFWlR21ISZ1vn1tlbMJZn4gCGvr81zHYkG36Dki7zWHJE7ClI2AuBc1MmgUHnhJsXzlD2tB5Ie6W2E0TplXm\
+   nT0KKbnhDVKUqC9YSHbzJr0pt8wqgvRxSBHFQOuxExVh2C0DL3z4xu9UHUmbSWAizyIkpNQMNGB1HDRjFS6wqR6CumJl3\
+   4vGElq7U7DWF1oTkatq1aQRwNa1mjaGnBuyXToIDkO0Xbb8R7lAz0qozmRb5NiLsIAabaTOsxyN02UL6Bea0evl5Kkczb\
+   VcXUgXBx1TScXbmxBxWP7d3NTgyEqvKdYJEtpr43Egp9AHMPnRLu037r4rHO44HHSN7bLeK7K43uWj92gRNgi0NXD4gId\
+   Gul3qyu9EYal0Ve46KLeIvxm0zrxXYJTeN3zQ7go4S9OB3PL9kOhm7gUS8XNbXvrctgluhaprZwTFAXgJ6CTS93QiEEtz\
+   OQeMwBhTAnzqOhZsGhilqlhCIKgJoZGMS4cCVAtp7nR672oZDV4zIsRJ0afbofFd8vL0zXST1iDB5u7QuF90zZLZqvmyZ\
+   OZCRW1gbiah8CJWJU4CUBtiJ2iYVoq9LY77g4OBY1WXCaCheC6afCJ1gdBbq71A7tsx3lB2j6ESVZewqRaYzqGAnvDtNB\
+   8b5sJLAMPrAT9Zi8cZufGDokWWep34vVAEXSrHiLzNcAIp2NzJ5yDFqj8YfT7hd027r48rcmSXgw0bSch6URmPfbnI6BG\
+   vUOO3PbHT0S1IC41bN3olGCwo3ejwxrQPukLhSDKzMnUtqsCKrRdqCRnVbd3TDE6VVIudrcrKghc13mPPhD2WbtwQVQVS\
+   OEuQBdrxY2tLEkNmmGG9YplGRG1JDiDKva0AMLPwIMuwwQs3mxQNNk2n9VsfH5C4PtPJKayn5UXvoHIsc7m8tLivVMWyr\
+   QJqJEHy8itcnahSztPvwwddPUhG0EWLKyiqOI2j8Mncq7HQKdY9mCT6E9F17T0mHMzk9IiglOyNHmbXrkDyxnxbMQsLYy\
+   d3zPQF7kiTqB3f8QHdIPIX9xOVXBy7OBTe8nirdXM4u2xBL5DWKEC7UerZCi45ZeDAK13LBLkDIQaQIpgUFgVOGk75xue\
+   rjk5cC03o6juUqTpftyqiYTmp7IWm7PFVNVJp5iTwJ2fbkWDL5uoTQiCqRG2PaHj6xWI3qcyDBcPLnWl5mgxmOBHKjSo4\
+   T7PKbwCLDoHzf77mCUWHG0hDdBvUAB2rcLi4HGJ7VsHH1WTIUnx41z1A3OhfYQhNOmlmGIg63VsOqoaf2nzrx0jZIcFXq\
+   1yzgaYCv5e0tE8EQXdhQsMChRkG3RUoeSwiEYAMXivwDmNluY1OIpFgXICLP7UW2Z5mafC4L3teeV9PTev8xVqC8qNdcD\
+   e4aFLJ1yLLbbsw1GKd6rLiZfkgmGnLfQALwrVLxburOIQZgNfFrJPkwp8dBu0dI1HQDKlHRyjjVvyMdLyQ3pRK25sin45\
+   Z4Zhtsu5hV7wkOd5fzutfycjdsPcFEElgeE2LKBjRhDqHcReqijNpRS4HMos0exXulCOnwTz8VWc3MtsAGgJRy9lzXNUE\
+   nQRkcf53gYdKPxlAjJGFAxs0ye9ZP4RGxOQ5h1w5l9T5aJBv0TUlPQLqPMtUodDPw76fsx3uaD3rEKtyuDtRKIcEp3Xge\
+   EGGdxCrPPBIIdFT5BjVuawtCXwDonvi2AitBr7zURQ6a4Lvscwdb70KDYkLwGCpKETXef4KZrtoQlQswBHrNDWfhiPhOj\
+   hH1WToeEqMoCGP6pQbF2rgia22wRgPokWmL6MALfYKp9xpfsEULNPEltsVgGyVEDMDBEuX3uCtprhJngOgBjD7BgL2yRL\
+   hfLpdEW8yXWJX1mmCc3AO9V80XApCpLc2u3sVv68feUDz2HtgJpJJaxiZoyDeEP9nOAV6npoLiOqE4LEgI8HtD6s4tCkd\
+   J8rHlBX5m80QZL5dMLhuRv2RJkQ9ywUgAdl0qXUm7hhuNiPH2ksSPTjESAN506sHdJlwwxc1XwvwkU8yh3ftrIx70d2Sg\
+   fTuJ4BmlbcuLM6xY7xNoHUyoMdy2dR9X9vGJzrMHiidiQpUS0ExytTFy7O5ltIXv9FuljNri4XU7xeKaUu8ZMRkJt5QoR\
+   mJPSZzx0tENLxXfMHmMmlGUHLdUrHEXJdWjRoAqKFQDDUGf8ukb7uF7GBlinDU4qaS1V2cY2x3QiA7ZLfBRtfMV8H8D8i\
+   U5LMg4R5tg3XfEq6yJlIAl6VgApI9165ZYkmZrr3RBnbZCdIrB5TXx67S1VqprfSuXkbGQHiijYRcCGUgkeLtlxkiqYL7\
+   KfpEnpr4I4temJnDS6MGxMB5iBnEEjTBjqUIeqodI9peNyvkT9ExD6GdLDykjis0mZqTEfXCNEqXzzbJHICLlOju5KF5o\
+   KgXtIvsjtz164zZMmfndjVIvl9EeRZtsKehEDziQhELSGeTc5ifAS2buAz15EY9emedLBRNeMNJMw2RiRn203d5NvkbeX\
+   0OTgtUwo7cRLlHtIiVsovsRXcKZxNhAqaBYGNr0YxePEKGyhQjpQ8MRaZilGEJ7JoeytSIcPAXsug0FutaoQAM3zY00Q0\
+   HmUuBBkfwmijqNRIPqMNK7ej0vxKSp10uqte4YuLCKOkU9DhyDMqRbBwTYosxkz7C1I8Ci9LUahSiHO7SRVoH1dOR4agV\
+   rZfTLrzut4vUed5A56plR14EKWrnhPaXZv2tbSreWWjTHYfxDX0ep7BqeSqPYTaqQ6gpeqeRggJ7KT18RGKTgQ0KPyey2\
+   pu5hZnlmL8z1gAQ3wQ6GGHspnKAqEnO85YvxDTqJgWhRUe9ZZSt8AduEzIyavm5b3Xpbwu4sTnZpPvb";
+
+   uint32_t  state[4];
+   unsigned  count[2];
+   unsigned char buffer[20000];
+   strcpy((char *) buffer, message);
+   unsigned char digest[16];
+   uint32_t len = strlen(message);
+
+   clockid_t clockid = CLOCK_MONOTONIC;
+   struct timespec start_time, end_time, time_diff;
+   clock_gettime(clockid, &start_time);
+
+   MD5Init((uint32_t  *) state, (uint32_t  *) count);
+   MD5Update((uint32_t  *) state, (uint32_t  *) count, (unsigned char *) buffer, (unsigned char *) message, len);
+   MD5Final((unsigned char *)digest, (uint32_t  *) state, (uint32_t  *) count, (unsigned char *) buffer);
+   clock_gettime(clockid, &end_time);
+   timeDiff(&start_time, &end_time, &time_diff);
+   double time_taken = (double)time_diff.tv_sec + time_diff.tv_nsec*1.0e-9;
+   printf("Calculated MD5 hash in %lf (s)\n", time_taken);
+
+   printDigest((unsigned char *) digest, 16);
+   return 0;
+   }

--- a/fvtest/lljbtest/mul.cpp
+++ b/fvtest/lljbtest/mul.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int multiply()
+   {
+   int x = 1;
+   int y = 3;
+   int z = x * y;
+   return z;
+   }

--- a/fvtest/lljbtest/print_string.cpp
+++ b/fvtest/lljbtest/print_string.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdio.h>
+
+int main()
+   {
+   printf("hello, world!\n");
+   return 3;
+   }

--- a/fvtest/lljbtest/structs.cpp
+++ b/fvtest/lljbtest/structs.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+struct Foo
+   {
+   int x;
+   int y[2];
+   };
+
+int fooMemberAdder(struct Foo * foo)
+   {
+   return foo->x + foo->y[1];
+   }
+
+int main()
+   {
+   int x = 1;
+   Foo foo = {x,{1,2}};
+   return fooMemberAdder(&foo);
+   }

--- a/fvtest/lljbtest/sub.cpp
+++ b/fvtest/lljbtest/sub.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int subtract()
+   {
+   int x = 5;
+   int y = 2;
+   int z = x - y;
+   return z;
+   }

--- a/fvtest/lljbtest/ternary.cpp
+++ b/fvtest/lljbtest/ternary.cpp
@@ -26,9 +26,5 @@ int main()
    int y = x ? 2 : 3;
    int z = x + y;
 
-   float a = 0.0f;
-   float b = a ? 1.0f : 0.0f;
-   float c = a + b;
-
-   return z + c;
+   return z;
    }

--- a/fvtest/lljbtest/ternary.cpp
+++ b/fvtest/lljbtest/ternary.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+int main()
+   {
+   int x = 1;
+   int y = x ? 2 : 3;
+   int z = x + y;
+
+   float a = 0.0f;
+   float b = a ? 1.0f : 0.0f;
+   float c = a + b;
+
+   return z + c;
+   }

--- a/fvtest/lljbtest/time.cpp
+++ b/fvtest/lljbtest/time.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <ctime>
+#include <cstdio>
+#include <unistd.h>
+
+void current_time(struct timespec *time)
+   {
+   clock_gettime(CLOCK_MONOTONIC, time);
+   }
+
+void time_diff(struct timespec * start, struct timespec * end, struct timespec * diff)
+   {
+   if ((end->tv_nsec - start->tv_nsec) < 0)
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec-1;
+      diff->tv_nsec = 1000000000+end->tv_nsec-start->tv_nsec;
+      }
+   else
+      {
+      diff->tv_sec = end->tv_sec-start->tv_sec;
+      diff->tv_nsec = end->tv_nsec-start->tv_nsec;
+      }
+   }
+
+int main()
+   {
+   struct timespec startTime;
+   struct timespec endTime;
+   struct timespec diff;
+   current_time(&startTime);
+   usleep(2000*1000);
+   current_time(&endTime);
+
+   time_diff(&startTime, &endTime, &diff);
+   double time = (double) diff.tv_sec + diff.tv_nsec*1.0e-9;
+
+   printf("current time %lf (s)\n", time);
+   return (int) time;
+   }

--- a/fvtest/lljbtest/unions.cpp
+++ b/fvtest/lljbtest/unions.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <cstdint>
+
+union Foo
+   {
+   int32_t m1;
+   int64_t m3;
+   };
+
+int main()
+   {
+   Foo foo;
+   Foo bar;
+   foo.m1 = 1;
+   bar.m3 = 2;
+   return foo.m1 + bar.m3;
+   }

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -141,6 +141,10 @@ if(OMR_JITBUILDER_TEST)
 	)
 endif()
 
+if(OMR_LLJB)
+	add_subdirectory(lljb)
+endif()
+
 # install(TARGETS jitbuilder
 #         ARCHIVE       DESTINATION ${CMAKE_BINARY_DIR}/jitbuilder_release
 #         PUBLIC_HEADER DESTINATION ${CMAKE_BINARY_DIR}/jitbuilder_release/include

--- a/jitbuilder/lljb/CMakeLists.txt
+++ b/jitbuilder/lljb/CMakeLists.txt
@@ -1,0 +1,55 @@
+###############################################################################
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#############################################################################
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(ENV{PATH} "/usr/local/opt/llvm\@8/bin/:${PATH}")
+endif()
+
+find_package(LLVM 8 REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+#include_directories(${LLVM_INCLUDE_DIRS})
+
+add_library(lljb SHARED
+    src/Compiler.cpp
+    src/MethodBuilder.cpp
+    src/Module.cpp
+    src/IRVisitor.cpp
+)
+
+get_property(JITBUILDER_INCLUDE TARGET jitbuilder PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+target_include_directories(lljb
+    PUBLIC
+        include/
+        ${JITBUILDER_INCLUDE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../compiler
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+        ${LLVM_INCLUDE_DIRS}
+)
+
+target_link_libraries(lljb
+    PUBLIC
+        jitbuilder
+        LLVMIRReader
+        LLVMCore
+        LLVMSupport
+)

--- a/jitbuilder/lljb/CMakeLists.txt
+++ b/jitbuilder/lljb/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2020, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,36 +20,35 @@
 #############################################################################
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(ENV{PATH} "/usr/local/opt/llvm\@8/bin/:${PATH}")
+	find_package(LLVM 8 REQUIRED CONFIG
+		PATHS "/usr/local/opt/llvm\@8/bin/:${PATH}"
+	)
+else()
+	find_package(LLVM 8 REQUIRED CONFIG)
 endif()
 
-find_package(LLVM 8 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-#include_directories(${LLVM_INCLUDE_DIRS})
 
 add_library(lljb SHARED
-    src/Compiler.cpp
-    src/MethodBuilder.cpp
-    src/Module.cpp
-    src/IRVisitor.cpp
-)
-
-get_property(JITBUILDER_INCLUDE TARGET jitbuilder PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-
-target_include_directories(lljb
-    PUBLIC
-        include/
-        ${JITBUILDER_INCLUDE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../compiler
-        ${CMAKE_CURRENT_SOURCE_DIR}/../..
-        ${LLVM_INCLUDE_DIRS}
+	src/Compiler.cpp
+	src/MethodBuilder.cpp
+	src/Module.cpp
+	src/IRVisitor.cpp
 )
 
 target_link_libraries(lljb
-    PUBLIC
-        jitbuilder
-        LLVMIRReader
-        LLVMCore
-        LLVMSupport
+	PUBLIC
+		jitbuilder
+		LLVMIRReader
+		LLVMCore
+		LLVMSupport
+)
+
+target_include_directories(lljb
+	PUBLIC
+		include/
+		${omr_SOURCE_DIR}/compiler
+		${omr_SOURCE_DIR}
+		${LLVM_INCLUDE_DIRS}
 )

--- a/jitbuilder/lljb/README.md
+++ b/jitbuilder/lljb/README.md
@@ -60,6 +60,6 @@ OMR_JITBUILDER
 OMR_COMPILER
 ```
 
-## Enable Tests
+## Tests
 
-todo...
+LLJB tests are located in `fvtest/lljbtest`.

--- a/jitbuilder/lljb/README.md
+++ b/jitbuilder/lljb/README.md
@@ -1,0 +1,65 @@
+<!--
+Copyright (c) 2020, 2020 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# LLJB
+
+LLVM + JitBuilder = LLJB
+
+# About
+
+The LLJB project enables interoperability between LLVM and JitBuilder. LLJB
+takes LLVM Intermediate Representation (IR) files and uses JitBuilder API to
+construct equivalent OMR Compiler IL. The OMR Compiler then performs
+optimizations and generates native code for every function in the module.
+
+# Additional Requirements
+
+You need the following to build lljb:
+
+* clang 8.0
+* llvm 8.0
+
+### On macOS - using Homebrew
+
+```
+brew install llvm@8
+```
+
+### On Ubuntu
+```
+apt install clang-8 llvm-8 llvm-8-dev
+```
+
+## Enabling building LLJB
+
+You must use the CMake build system to build LLJB. The following are
+the options that must be enabled when configuring CMake build:
+
+```
+OMR_LLJB
+OMR_JITBUILDER
+OMR_COMPILER
+```
+
+## Enable Tests
+
+todo...

--- a/jitbuilder/lljb/include/lljb/Compiler.hpp
+++ b/jitbuilder/lljb/include/lljb/Compiler.hpp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LLJB_COMPILER_HPP
+#define LLJB_COMPILER_HPP
+
+#include "lljb/Module.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+#include "llvm/ADT/DenseMap.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace lljb
+{
+
+typedef int32_t (*JittedFunction)();
+
+class Compiler
+   {
+
+public:
+
+   Compiler(Module * module);
+
+   ~Compiler();
+
+   /**
+    * @brief Compile each function in the module
+    *
+    */
+   void compile();
+
+   /**
+    * @brief Get the pointer to the entry function in the module.
+    * If there are more than one function in the module, then the address
+    * corresponds to "main"
+    *
+    * @return JittedFunction
+    */
+   JittedFunction getJittedCodeEntry();
+
+   /**
+    * @brief create a mapping between the llvm::Function in a module to
+    * the adress in the codecache with the compiled method
+    *
+    * @param llvmFunc the llvm::Function *
+    * @param entry the void *
+    */
+   void mapCompiledFunction(llvm::Function * llvmFunc, void * entry);
+
+   /**
+    * @brief Get the address of the compiled function corresponding to the
+    * llvm::Function of the compiled module
+    *
+    * @param func the llvm::Function *
+    * @return void * the address of the compiled function
+    */
+   void * getFunctionAddress(llvm::Function * func);
+
+   /**
+    * @brief Get the name of an aggregate's field from its index.
+    *
+    * @param index
+    * @return char*
+    */
+   char * getObjectMemberNameFromIndex(unsigned index);
+
+   private:
+
+   /**
+    * @brief Define Structs in the llvm Module
+    *
+    */
+   void defineTypes();
+
+   /**
+    * @brief construct OMR IL for an llvm::Function and const
+    *
+    * @param func
+    * @return void*
+    */
+   void * compileMethod(llvm::Function &func);
+
+   /**
+    * @brief Generate a null-terminated parameter name using the index of an
+    * aggregate type's member. This is needed because we refer to object fields
+    * using their names. Example of generated name if member index is 1: "m1\0"
+    *
+    * @param memberIndex
+    * @return char*
+    */
+   char * stringifyObjectMemberIndex(unsigned memberIndex);
+
+   TR::TypeDictionary _typeDictionary;
+   llvm::DenseMap<llvm::Function *, void *> _compiledFunctionMap;
+   llvm::DenseMap<unsigned, char *> _objectMemberMap;
+   Module * _module;
+   };
+
+} /** namespace lljb */
+
+#endif /* LLJB_COMPILER_HPP */

--- a/jitbuilder/lljb/include/lljb/IRVisitor.hpp
+++ b/jitbuilder/lljb/include/lljb/IRVisitor.hpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LLJB_IRVISITOR_HPP
+#define LLJB_IRVISITOR_HPP
+
+#include "lljb/MethodBuilder.hpp"
+
+#include "llvm/IR/InstVisitor.h"
+
+namespace lljb
+{
+
+struct IRVisitor : public llvm::InstVisitor<IRVisitor>
+   {
+   IRVisitor(
+      MethodBuilder* methodBuilder,
+      TR::BytecodeBuilder* builder,
+      TR::TypeDictionary * td) :
+   _methodBuilder(methodBuilder),
+   _builder(builder),
+   _td(td)
+   {}
+
+   /************************************************************************
+    *
+    *  LLVM IR Instruction visitors
+    *
+    ************************************************************************/
+
+   /************************************************************************
+    * Implemented visitors
+    ************************************************************************/
+   void visitReturnInst(llvm::ReturnInst &I);
+   void visitAllocaInst(llvm::AllocaInst &I);
+   void visitLoadInst(llvm::LoadInst     &I);
+   void visitStoreInst(llvm::StoreInst   &I);
+   void visitBinaryOperator(llvm::BinaryOperator &I);
+
+   /**
+    * visitCmpInst handles the following instructions:
+    * llvm::ICmpInst
+    * llvm::FCmpInst
+    */
+   void visitCmpInst(llvm::CmpInst &I); // handles both llvm::ICmpInst and llvm::FCmpInst
+
+   void visitBranchInst(llvm::BranchInst &I);
+   void visitCallInst(llvm::CallInst &I);
+
+   /**
+    * visitCastInst handles the following instructions:
+    * llvm::AddrSpaceCastInst
+    * llvm::BitCastInst
+    * llvm::FPExtInst
+    * llvm::FPToSIInst
+    * llvm::FPToUIInst
+    * llvm::FPTruncInst
+    * llvm::IntToPtrInst
+    * llvm::PtrToIntInst
+    * llvm::SExtInst
+    * llvm::SIToFPInst
+    * llvm::TruncInst
+    * llvm::UIToFPInst
+    */
+   void visitCastInst(llvm::CastInst &I);
+   /**
+    * ZExtInst needs to be handled separately from other cast instructions
+    * because we need to use UnsignedConvertTo service instead of ConvertTo
+    *
+    */
+   void visitZExtInst(llvm::ZExtInst &I);
+
+   void visitGetElementPtrInst(llvm::GetElementPtrInst &I);
+   void visitPHINode(llvm::PHINode &I);
+   void visitSelectInst(llvm::SelectInst &I);
+
+
+   /************************************************************************
+    * Unimplemented visitors
+    ************************************************************************/
+
+   /* Handles cases of visiting an unimplemented instruction */
+   void visitInstruction(llvm::Instruction &I);
+
+   //void visitUnaryOperator(llvm::UnaryOperator &I);
+   //void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &I);
+   //void visitAtomicRMWInst(llvm::AtomicRMWInst &I);
+   //void visitFenceInst(llvm::FenceInst   &I);
+   //void visitVAArgInst(llvm::VAArgInst   &I);
+   //void visitExtractElementInst(llvm::ExtractElementInst &I);
+   //void visitInsertElementInst(llvm::InsertElementInst &I);
+   //void visitShuffleVectorInst(llvm::ShuffleVectorInst &I);
+   //void visitExtractValueInst(llvm::ExtractValueInst &I);
+   //void visitInsertValueInst(llvm::InsertValueInst &I);
+   //void visitLandingPadInst(llvm::LandingPadInst &I);
+   //void visitFuncletPadInst(llvm::FuncletPadInst &I);
+   //void visitCleanupPadInst(llvm::CleanupPadInst &I);
+   //void visitCatchPadInst(llvm::CatchPadInst &I);
+   //void visitDbgDeclareInst(llvm::DbgDeclareInst &I);
+   //void visitDbgValueInst(llvm::DbgValueInst &I);
+   //void visitDbgVariableIntrinsic(llvm::DbgVariableIntrinsic &I);
+   //void visitDbgLabelInst(llvm::DbgLabelInst &I);
+   //void visitDbgInfoIntrinsic(llvm::DbgInfoIntrinsic &I);
+   //void visitMemSetInst(llvm::MemSetInst &I);
+   //void visitMemCpyInst(llvm::MemCpyInst &I);
+   //void visitMemMoveInst(llvm::MemMoveInst &I);
+   //void visitMemTransferInst(llvm::MemTransferInst &I);
+   //void visitMemIntrinsic(llvm::MemIntrinsic &I);
+   //void visitVAStartInst(llvm::VAStartInst &I);
+   //void visitVAEndInst(llvm::VAEndInst &I);
+   //void visitVACopyInst(llvm::VACopyInst &I);
+   //void visitIntrinsicInst(llvm::IntrinsicInst &I);
+   //void visitInvokeInst(llvm::InvokeInst &I);
+   //void visitSwitchInst(llvm::SwitchInst &I);
+   //void visitIndirectBrInst(llvm::IndirectBrInst &I);
+   //void visitResumeInst(llvm::ResumeInst &I);
+   //void visitUnreachableInst(llvm::UnreachableInst &I);
+   //void visitCleanupReturnInst(llvm::CleanupReturnInst &I);
+   //void visitCatchReturnInst(llvm::CatchReturnInst &I);
+   //void visitCatchSwitchInst(llvm::CatchSwitchInst &I);
+   //void visitTerminator(llvm::Instruction &I);
+   //void visitUnaryInstruction(llvm::UnaryInstruction &I);
+   //void visitCallBase(llvm::CallBase &I);
+   //void visitCallSite(llvm::CallSite CS);
+
+
+
+private:
+   /**
+    * Helpers
+    */
+
+   TR::IlValue * createConstIntIlValue(llvm::Value * value);
+   TR::IlValue * createConstFPIlValue(llvm::Value * value);
+   TR::IlValue * createConstExprIlValue(llvm::Value * value);
+   TR::IlValue * createConstantDataArrayVal(llvm::Value * value);
+   TR::IlValue * loadParameter(llvm::Value * value);
+   TR::IlValue * loadGlobal(llvm::Value * value);
+   TR::IlValue * getIlValue(llvm::Value * value);
+
+   /**
+    * Private fields
+    */
+   MethodBuilder * _methodBuilder;
+   TR::BytecodeBuilder * _builder;
+   TR::TypeDictionary * _td;
+
+   }; // struct IRVisitor
+
+} // namespace lljb
+
+#endif

--- a/jitbuilder/lljb/include/lljb/MethodBuilder.hpp
+++ b/jitbuilder/lljb/include/lljb/MethodBuilder.hpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LLJB_METHODBUILDER_HPP
+#define LLJB_METHODBUILDER_HPP
+
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+
+#include "llvm/IR/Function.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace lljb
+{
+
+class Compiler;
+
+class State : public TR::VirtualMachineState
+   {
+   public:
+
+   virtual void Commit(TR::IlBuilder *b) override final {}
+
+   virtual void Reload(TR::IlBuilder *b) override final {}
+
+   virtual VirtualMachineState *MakeCopy() override final
+      {
+      return new State(*this);
+      }
+
+   virtual void MergeInto(TR::VirtualMachineState *other,
+                        TR::IlBuilder *b) override final
+      {
+      }
+   }; // class State
+
+class MethodBuilder : public TR::MethodBuilder
+   {
+
+public:
+
+   MethodBuilder(TR::TypeDictionary *td, llvm::Function &func, Compiler * compiler);
+
+   ~MethodBuilder();
+
+   static TR::IlType * getIlType(TR::TypeDictionary * td,llvm::Type * type);
+
+   virtual bool buildIL() override;
+   TR::IlValue * getIlValue(llvm::Value * value);
+   char * getParamNameFromIndex(unsigned index);
+   void mapIRtoIlValue(llvm::Value * irValue, TR::IlValue * ilValue);
+   TR::BytecodeBuilder * getByteCodeBuilder(llvm::Value * value);
+   void defineFunction(llvm::Function * func, std::size_t numParams, TR::IlType **paramTypes);
+   void allocateLocal(llvm::Value * value, TR::IlType * allocatedType);
+   char * getLocalNameFromValue(llvm::Value * value);
+   char * getMemberNameFromIndex(unsigned index);
+
+   /**
+    * @brief Check whether this llvm::Value corresponds to a local variable that
+    * we are going to store into or load from by checking the llvm::Value to local
+    * variable name mapping
+    *
+    * @param value the source or dest llvm::Value
+    * @return true if indirect load/store in cases of aggregates
+    * @return false if value corresponds to a local variable
+    */
+   bool isIndirectLoadOrStore(llvm::Value * value);
+
+private:
+
+   void assignBuildersToBasicBlocks();
+   void defineParameters();
+
+   /**
+    * @brief Generate a null-terminated parameter name using the index of the
+    * parameter. For example, if paramIndex is 1, then the generated parameter
+    * name would be "p1\0"
+    *
+    * @param paramIndex
+    * @return const char*
+    */
+   char * stringifyParamIndex(unsigned paramIndex);
+
+   llvm::Function& _function;
+   llvm::DenseMap<llvm::Value *, TR::BytecodeBuilder * > _BBToBuilderMap;
+   llvm::DenseMap<llvm::Value *, TR::IlValue *> _valueMap;
+   llvm::DenseMap<unsigned, char *> _parameterMap;
+   llvm::DenseMap<llvm::Function *, void *> _definedFunctions;
+   Compiler * _compiler;
+   llvm::DenseMap<llvm::Value *, char *> _localsMap;
+   int32_t _numLocals;
+
+   }; /* class MethodBuilder */
+
+} /* namespace lljb */
+
+
+
+#endif /* LLJB_METHODBUILDER_HPP */

--- a/jitbuilder/lljb/include/lljb/Module.hpp
+++ b/jitbuilder/lljb/include/lljb/Module.hpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LLJB_MODULE_HPP
+#define LLJB_MODULE_HPP
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+
+#include <memory>
+
+
+namespace llvm
+{
+   class LLVMContext;
+   class SMDiagnostic;
+}
+
+namespace lljb
+{
+
+class Module
+   {
+
+public:
+   Module(const char * filename, llvm::SMDiagnostic &SMDiags, llvm::LLVMContext &context);
+
+   std::unique_ptr<llvm::Module>& getLLVMModule()
+      {
+      return _llvmModule;
+      }
+
+   int32_t numFunctions()
+      {
+      return _llvmModule->getFunctionList().size();
+      }
+
+   llvm::simple_ilist<llvm::Function>::iterator funcIterBegin()
+      {
+      return _llvmModule->getFunctionList().begin();
+      }
+
+   llvm::simple_ilist<llvm::Function>::iterator funcIterEnd()
+      {
+      return _llvmModule->getFunctionList().end();
+      }
+
+   llvm::Function * getMainFunction();
+
+
+private:
+
+   std::unique_ptr<llvm::Module> _llvmModule;
+   bool _constructed;
+   const char * _filename;
+
+   }; // class Module
+
+} // namespace lljb
+
+
+#endif /* LLJB_MODULE_HPP */

--- a/jitbuilder/lljb/src/Compiler.cpp
+++ b/jitbuilder/lljb/src/Compiler.cpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "lljb/Compiler.hpp"
+#include "lljb/MethodBuilder.hpp"
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdio>
+#include <ctime>
+#include <cstring>
+
+#if defined(OSX) || defined(LINUX)
+#include <unistd.h>
+#endif
+
+#include <string>
+#include <vector>
+
+namespace lljb
+{
+
+Compiler::Compiler(Module * module)
+    :
+   _typeDictionary(),
+   _module(module)
+   {
+   defineTypes();
+   }
+
+void
+Compiler::compile()
+   {
+   for (auto func = _module->funcIterBegin(); func != _module->funcIterEnd() ; func++)
+      {
+      if (!(*func).isDeclaration())
+         mapCompiledFunction(&*func,(compileMethod(*func)));
+      }
+   }
+
+JittedFunction
+Compiler::getJittedCodeEntry()
+   {
+   llvm::Function * entryFunction = _module->getMainFunction();
+   assert(entryFunction && "entry function not found");
+   return (JittedFunction) getFunctionAddress(entryFunction);
+   }
+
+void *
+Compiler::compileMethod(llvm::Function &func)
+   {
+   MethodBuilder methodBuilder(&_typeDictionary, func, this);
+   void * result = 0;
+   methodBuilder.Compile(&result);
+   return result;
+   }
+
+void
+Compiler::mapCompiledFunction(llvm::Function * llvmFunc, void * entry)
+   {
+   _compiledFunctionMap[llvmFunc] = entry;
+   }
+
+void *
+Compiler::getFunctionAddress(llvm::Function * func)
+   {
+   void * entry = _compiledFunctionMap[func];
+   if (!entry)
+      {
+      if (func->getName().equals("printf")) entry = (void *) &printf;
+      else if (func->getName().equals("putc")) entry = (void *) &putc;
+      else if (func->getName().equals("clock_gettime")) entry = (void *) &clock_gettime;
+#if defined(OSX) || defined(LINUX)
+      else if (func->getName().contains("usleep")) entry = (void *) &usleep;
+#endif
+      else if (func->getName().equals("strcpy")) entry = (void *) &strcpy;
+      else if (func->getName().equals("strlen")) entry = (void *) &strlen;
+      else
+         {
+         llvm::outs() << "function being looked up:" << func->getName() << "\n";
+         assert( 0 && "function not found");
+         }
+      }
+   return entry;
+   }
+
+char *
+Compiler::stringifyObjectMemberIndex(unsigned memberIndex)
+   {
+   // All structs will share the same name for their members. First check if a member for an
+   // index has already been generated before creating a new one.
+   char * memberString = _objectMemberMap[memberIndex];
+   if (memberString) return memberString;
+
+   std::string indexString = std::to_string(memberIndex);
+   memberString = new char[indexString.length()+2];
+   sprintf(memberString, "m%d",memberIndex);
+   _objectMemberMap[memberIndex] = memberString;
+   return memberString;
+   }
+
+void
+Compiler::defineTypes()
+   {
+   std::vector<llvm::StructType*> structTypes = _module->getLLVMModule()->getIdentifiedStructTypes();
+   for (auto structType : structTypes)
+      {
+      llvm::StringRef structName = structType->getName();
+      _typeDictionary.DefineStruct(structName.data());
+      unsigned elIndex = 0;
+      for (auto elIter = structType->element_begin(); elIter != structType->element_end(); ++elIter)
+         {
+         llvm::Type * fieldType = structType->getElementType(elIndex);
+         if (fieldType->isAggregateType())
+            {
+            _typeDictionary.DefineField(
+               structName.data(),
+               stringifyObjectMemberIndex(elIndex),
+               _typeDictionary.PointerTo(MethodBuilder::getIlType(
+                  &_typeDictionary,
+                  fieldType)));
+            }
+         else
+            {
+               _typeDictionary.DefineField(
+                  structName.data(),
+                  stringifyObjectMemberIndex(elIndex),
+                  MethodBuilder::getIlType(
+                     &_typeDictionary,
+                     fieldType));
+            }
+         elIndex++;
+         }
+      _typeDictionary.CloseStruct(structName.data());
+      }
+   }
+
+char *
+Compiler::getObjectMemberNameFromIndex(unsigned index)
+   {
+   return _objectMemberMap[index];
+   }
+
+Compiler::~Compiler()
+   {
+   _objectMemberMap.clear();
+   }
+
+
+} // namespace lljb

--- a/jitbuilder/lljb/src/IRVisitor.cpp
+++ b/jitbuilder/lljb/src/IRVisitor.cpp
@@ -1,0 +1,559 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "lljb/IRVisitor.hpp"
+
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <vector>
+
+namespace lljb
+{
+
+void
+IRVisitor::visitInstruction(llvm::Instruction &I)
+   {
+   llvm::outs() << "Unimplemented instruction being visited: " << I << "\n";
+   assert(0 && "Unimplemented instruction!");
+   }
+
+void
+IRVisitor::visitReturnInst(llvm::ReturnInst &I)
+   {
+   if (!I.getNumOperands())
+      {
+      _builder->Return();
+      }
+   else
+      {
+      llvm::Value * value = I.getOperand(0);
+      TR::IlValue * ilValue = getIlValue(value);
+      _builder->Return(ilValue);
+      }
+   }
+
+void
+IRVisitor::visitAllocaInst(llvm::AllocaInst &I)
+   {
+   TR::IlValue * ilValue = nullptr;
+   if (I.getAllocatedType()->isStructTy())
+      {
+      llvm::StructType * llvmStruct = llvm::dyn_cast<llvm::StructType>(I.getAllocatedType());
+      ilValue = _builder->CreateLocalStruct(_methodBuilder->getIlType(_td,llvmStruct));
+      unsigned elIndex = 0;
+      for (auto elIter = llvmStruct->element_begin();
+            elIter != llvmStruct->element_end(); ++elIter)
+         {
+         llvm::Type * fieldType = llvmStruct->getElementType(elIndex);
+         if (fieldType->isArrayTy())
+            {
+            TR::IlValue * arrayField = _builder->CreateLocalArray(
+               fieldType->getArrayNumElements(),
+               _methodBuilder->getIlType(_td,fieldType));
+            _builder->StoreAt(
+               _builder->StructFieldInstanceAddress(
+                  llvmStruct->getStructName().data(),
+                  _methodBuilder->getMemberNameFromIndex(elIndex),
+                  ilValue),
+               arrayField);
+            }
+         elIndex++;
+         }
+      }
+   else if (I.getAllocatedType()->isArrayTy())
+      {
+      llvm::Type * type = I.getAllocatedType();
+      unsigned numElements = type->getArrayNumElements();
+      type = type->getArrayElementType();
+      while (1)
+         {
+         if (type->isArrayTy())
+            {
+            numElements *= type->getArrayNumElements();
+            type = type->getArrayElementType();
+            }
+         else
+            {
+            break;
+            }
+         }
+      ilValue = _builder->CreateLocalArray(
+                           numElements,
+                           _methodBuilder->getIlType(_td,type));
+      }
+   else
+      {
+      _methodBuilder->allocateLocal(
+      &I,
+      _methodBuilder->getIlType(_td, I.getAllocatedType()));
+      }
+   _methodBuilder->mapIRtoIlValue(&I, ilValue);
+   }
+
+void
+IRVisitor::visitLoadInst(llvm::LoadInst &I)
+   {
+   llvm::Value * source = I.getPointerOperand();
+   TR::IlValue * loadedVal = nullptr;
+   if (_methodBuilder->isIndirectLoadOrStore(source))
+      {
+      TR::IlValue * ilSrc = getIlValue(source);
+      loadedVal = _builder->LoadAt(
+                              _td->PointerTo(_methodBuilder->getIlType(_td,I.getType())),
+                              _builder->
+                              IndexAt(
+                                 _td->PointerTo(_methodBuilder->getIlType(_td,I.getType())),
+                                 ilSrc,
+                                 _builder->ConstInt32(0)));
+      }
+   else
+      {
+      loadedVal = _builder->Load(_methodBuilder->getLocalNameFromValue(source));
+      }
+   _methodBuilder->mapIRtoIlValue(&I, loadedVal);
+   }
+
+void
+IRVisitor::visitStoreInst(llvm::StoreInst &I)
+   {
+   llvm::Value * dest = I.getPointerOperand();
+   llvm::Value * value = I.getOperand(0);
+   TR::IlValue * ilValue = getIlValue(value);
+   if (_methodBuilder->isIndirectLoadOrStore(dest))
+      {
+      _builder->StoreAt(
+               _builder->IndexAt(
+                  _td->PointerTo(_methodBuilder->getIlType(_td,value->getType())),
+                  _methodBuilder->getIlValue(dest),
+                  _builder->ConstInt32(0)),
+               ilValue);
+      }
+   else
+      {
+      _builder->Store(_methodBuilder->getLocalNameFromValue(dest), ilValue);
+      }
+   }
+
+void
+IRVisitor::visitBinaryOperator(llvm::BinaryOperator &I)
+   {
+   TR::IlValue * lhs = getIlValue(I.getOperand(0));
+   TR::IlValue * rhs = getIlValue(I.getOperand(1));
+   TR::IlValue * result = nullptr;
+   switch (I.getOpcode())
+      {
+      case llvm::Instruction::BinaryOps::Add:
+      case llvm::Instruction::BinaryOps::FAdd:
+         result = _builder->Add(lhs,rhs);
+         break;
+      case llvm::Instruction::BinaryOps::Sub:
+      case llvm::Instruction::BinaryOps::FSub:
+         result = _builder->Sub(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::Mul:
+      case llvm::Instruction::BinaryOps::FMul:
+         result = _builder->Mul(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::SDiv:
+      case llvm::Instruction::BinaryOps::FDiv:
+      case llvm::Instruction::BinaryOps::UDiv:
+         result = _builder->Div(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::Shl:
+         if (!I.getOperand(1)->getType()->isIntegerTy(32))
+               rhs = _builder->ConvertTo(_td->Int32, rhs);
+         result = _builder->ShiftL(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::AShr:
+         if (!I.getOperand(1)->getType()->isIntegerTy(32))
+               rhs = _builder->ConvertTo(_td->Int32, rhs);
+         result = _builder->ShiftR(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::LShr:
+         if (!I.getOperand(1)->getType()->isIntegerTy(32))
+               rhs = _builder->ConvertTo(_td->Int32, rhs);
+         result = _builder->UnsignedShiftR(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::And:
+         result = _builder->And(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::Or:
+         result = _builder->Or(lhs, rhs);
+         break;
+      case llvm::Instruction::BinaryOps::Xor:
+         result = _builder->Xor(lhs, rhs);
+         break;
+      default:
+         llvm::outs() << "Instruction being visited: " << I << "\n";
+         assert(0 && "Unknown binary operand");
+         break;
+      }
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+void
+IRVisitor::visitCmpInst(llvm::CmpInst &I)
+   {
+   TR::IlValue * lhs = getIlValue(I.getOperand(0));
+   TR::IlValue * rhs = getIlValue(I.getOperand(1));
+
+   TR::IlValue * result = nullptr;
+
+   switch (I.getPredicate())
+      {
+      case llvm::CmpInst::Predicate::ICMP_EQ:
+      case llvm::CmpInst::Predicate::FCMP_OEQ:
+      case llvm::CmpInst::Predicate::FCMP_UEQ:
+         result = _builder->EqualTo(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_NE:
+      case llvm::CmpInst::Predicate::FCMP_ONE:
+      case llvm::CmpInst::Predicate::FCMP_UNE:
+         result = _builder->NotEqualTo(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_UGT:
+         result = _builder->UnsignedGreaterThan(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_UGE:
+         result = _builder->UnsignedGreaterOrEqualTo(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_ULT:
+         result = _builder->UnsignedLessThan(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_ULE:
+         result = _builder->UnsignedLessOrEqualTo(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_SGT:
+      case llvm::CmpInst::Predicate::FCMP_OGT:
+      case llvm::CmpInst::Predicate::FCMP_UGT:
+         result = _builder->GreaterThan(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_SGE:
+      case llvm::CmpInst::Predicate::FCMP_OGE:
+      case llvm::CmpInst::Predicate::FCMP_UGE:
+         result = _builder->GreaterOrEqualTo(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_SLT:
+      case llvm::CmpInst::Predicate::FCMP_OLT:
+      case llvm::CmpInst::Predicate::FCMP_ULT:
+         result = _builder->LessThan(lhs, rhs);
+         break;
+      case llvm::CmpInst::Predicate::ICMP_SLE:
+      case llvm::CmpInst::Predicate::FCMP_OLE:
+      case llvm::CmpInst::Predicate::FCMP_ULE:
+         result = _builder->LessOrEqualTo(lhs, rhs);
+         break;
+      default:
+         assert(0 && "Unknown CmpInst predicate");
+         break;
+      }
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+void
+IRVisitor::visitBranchInst(llvm::BranchInst &I)
+   {
+   if (I.isUnconditional())
+      {
+      llvm::Value * dest = I.getSuccessor(0);
+      TR::BytecodeBuilder * destBuilder = _methodBuilder->getByteCodeBuilder(dest);
+      assert(destBuilder && "failed to find builder for target basic block");
+      _builder->Goto(destBuilder);
+      }
+   else
+      {
+      TR::IlValue * condition = getIlValue(I.getCondition());
+      TR::IlBuilder * ifTrue = _methodBuilder->getByteCodeBuilder(I.getSuccessor(0));
+      TR::IlBuilder * ifFalse = _methodBuilder->getByteCodeBuilder(I.getSuccessor(1));
+      assert(ifTrue && ifFalse && condition && "Failed to find destination blocks for ifThenElse");
+      _builder->IfThenElse(&ifTrue, &ifFalse, condition);
+      }
+   }
+
+void
+IRVisitor::visitCallInst(llvm::CallInst &I)
+   {
+   TR::IlValue * result = nullptr;
+   llvm::Function * callee = I.getCalledFunction();
+   const char * calleeName = callee->getName().data();
+   std::size_t numParams = I.arg_size();
+   std::vector<TR::IlValue *> params;
+   std::vector<TR::IlType *> paramTypes;
+   for (int i = 0; i < numParams; i++)
+      {
+      TR::IlValue * parameter = getIlValue(I.getArgOperand(i));
+      params.push_back(parameter);
+      paramTypes.push_back(_methodBuilder->getIlType(_td,I.getArgOperand(i)->getType()));
+      }
+   _methodBuilder->defineFunction(callee,numParams, paramTypes.data());
+   result = _builder->Call(calleeName, numParams, params.data());
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+void
+IRVisitor::visitCastInst(llvm::CastInst &I)
+   {
+   TR::IlValue * srcVal = getIlValue(I.getOperand(0));
+   TR::IlType * toIlType = _methodBuilder->getIlType(_td,I.getDestTy());
+   TR::IlValue * result = _builder->ConvertTo(toIlType, srcVal);
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+void
+IRVisitor::visitZExtInst(llvm::ZExtInst &I)
+   {
+   TR::IlValue * srcVal = getIlValue(I.getOperand(0));
+   TR::IlType * toIlType = _methodBuilder->getIlType(_td,I.getDestTy());
+   TR::IlValue * result = _builder->UnsignedConvertTo(toIlType, srcVal);
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+void
+IRVisitor::visitGetElementPtrInst(llvm::GetElementPtrInst &I)
+   {
+   TR::IlValue * ilValue = nullptr;
+   if (I.getSourceElementType()->isStructTy())
+      {
+      llvm::ConstantInt * indextConstantInt = llvm::dyn_cast<llvm::ConstantInt>(I.getOperand(2));
+      unsigned elementIndex = indextConstantInt->getZExtValue();
+      ilValue = _builder->StructFieldInstanceAddress(I.getSourceElementType()->getStructName().data(),
+                                                               _methodBuilder->getMemberNameFromIndex(elementIndex),
+                                                               getIlValue(I.getOperand(0)));
+      }
+   else if (I.getSourceElementType()->isArrayTy())
+      {
+      if (I.getSourceElementType()->getArrayElementType()->isArrayTy())
+         {
+         llvm::ConstantInt * indextConstantInt = llvm::dyn_cast<llvm::ConstantInt>(I.getOperand(2));
+         int64_t elementIndex = indextConstantInt->getSExtValue();
+         elementIndex *= I.getSourceElementType()->getArrayNumElements();
+         ilValue =
+               _builder->IndexAt(
+                  _td->PointerTo(
+                     _methodBuilder->getIlType(_td,I.getSourceElementType()->getArrayElementType())),
+                  getIlValue(I.getOperand(0)),
+                  _builder->ConstInt32(elementIndex));
+         }
+      else
+         {
+         TR::IlValue * elementIndex = getIlValue(I.getOperand(2));
+         ilValue =
+               _builder->IndexAt(
+                  _td->PointerTo(
+                     _methodBuilder->getIlType(_td,I.getSourceElementType()->getArrayElementType())),
+                  getIlValue(I.getOperand(0)),
+                  elementIndex);
+         }
+      }
+   else
+      {
+      assert((I.getNumOperands() == 2) && "unhandled getElementPtr case");
+      ilValue = _builder->IndexAt(
+         _td->PointerTo(
+               _methodBuilder->getIlType(_td, I.getSourceElementType())),
+         getIlValue(I.getOperand(0)),
+         getIlValue(I.getOperand(1)));
+      }
+   _methodBuilder->mapIRtoIlValue(&I, ilValue);
+   }
+
+void
+IRVisitor::visitPHINode(llvm::PHINode &I)
+   {
+   unsigned incomingEdgeCount = I.getNumIncomingValues();
+   llvm::DenseMap<llvm::BasicBlock *, TR::IlValue *> valueMap;
+   TR::IlValue * ilValue = nullptr;
+   llvm::ConstantInt * firstCondition = llvm::dyn_cast<llvm::ConstantInt>(I.getIncomingValue(0));
+   unsigned isOr = firstCondition->getZExtValue();
+
+   for (unsigned i = 0; i < incomingEdgeCount; i++)
+      {
+      llvm::BasicBlock * basicBlock = I.getIncomingBlock(i);
+      llvm::Value * value = I.getIncomingValue(i);
+      if (value->getValueID() == llvm::Value::ValueTy::ConstantIntVal)
+         {
+         llvm::BranchInst * branchInst = llvm::dyn_cast<llvm::BranchInst>(basicBlock->getTerminator());
+         value = branchInst->getCondition();
+         }
+      valueMap[basicBlock] = getIlValue(value);
+      }
+   if (isOr) ilValue = _builder->Or(valueMap[I.getIncomingBlock(0)],valueMap[I.getIncomingBlock(1)]);
+   else      ilValue = _builder->And(valueMap[I.getIncomingBlock(0)],valueMap[I.getIncomingBlock(1)]);
+
+   if (incomingEdgeCount > 2)
+      {
+      unsigned currentCaseIndex = 2;
+      while (currentCaseIndex < incomingEdgeCount)
+         {
+         if (isOr) ilValue = _builder->Or(ilValue, valueMap[I.getIncomingBlock(currentCaseIndex)]);
+         else      ilValue = _builder->And(ilValue, valueMap[I.getIncomingBlock(currentCaseIndex)]);
+         currentCaseIndex++;
+         }
+      }
+   _methodBuilder->mapIRtoIlValue(&I, ilValue);
+   }
+
+void
+IRVisitor::visitSelectInst(llvm::SelectInst &I)
+   {
+   TR::IlValue * condition = getIlValue(I.getCondition());
+   TR::IlValue * ifTrue = getIlValue(I.getTrueValue());
+   TR::IlValue * ifFalse = getIlValue(I.getFalseValue());
+   TR::IlValue * result = _builder->Select(condition, ifTrue, ifFalse);
+   _methodBuilder->mapIRtoIlValue(&I, result);
+   }
+
+TR::IlValue *
+IRVisitor::createConstIntIlValue(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::ConstantInt * constInt = llvm::dyn_cast<llvm::ConstantInt>(value);
+   int64_t signExtendedValue = constInt->getSExtValue();
+   if (constInt->getBitWidth() <= 8) ilValue = _builder->ConstInt8(signExtendedValue);
+   else if (constInt->getBitWidth() <= 16) ilValue = _builder->ConstInt16(signExtendedValue);
+   else if (constInt->getBitWidth() <= 32) ilValue = _builder->ConstInt32(signExtendedValue);
+   else if (constInt->getBitWidth() <= 64) ilValue = _builder->ConstInt64(signExtendedValue);
+
+   return ilValue;
+   }
+
+TR::IlValue *
+IRVisitor::createConstFPIlValue(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::ConstantFP * constFP = llvm::dyn_cast<llvm::ConstantFP>(value);
+   llvm::APFloat apf = constFP->getValueAPF();
+   if (apf.getSizeInBits(apf.getSemantics()) <= 32)
+      {
+      float rawValue = apf.convertToFloat();
+      ilValue = _builder->ConstFloat(rawValue);
+      }
+   else
+      {
+      double rawValue = apf.convertToDouble();
+      ilValue = _builder->ConstDouble(rawValue);
+      }
+
+   return ilValue;
+}
+
+TR::IlValue *
+IRVisitor::loadParameter(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::Argument * arg = llvm::dyn_cast<llvm::Argument>(value);
+   ilValue = _builder->Load(_methodBuilder->getParamNameFromIndex(arg->getArgNo()));
+   return ilValue;
+   }
+
+TR::IlValue *
+IRVisitor::loadGlobal(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::GlobalVariable * globalVar = llvm::dyn_cast<llvm::GlobalVariable>(value);
+   ilValue = getIlValue(globalVar->getInitializer());
+   return ilValue;
+   }
+
+TR::IlValue * IRVisitor::createConstExprIlValue(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::ConstantExpr * constExpr = llvm::dyn_cast<llvm::ConstantExpr>(value);
+   ilValue = getIlValue(constExpr->getOperand(0));
+   return ilValue;
+   }
+
+TR::IlValue *
+IRVisitor::createConstantDataArrayVal(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = nullptr;
+   llvm::ConstantDataArray * constDataArray = llvm::dyn_cast<llvm::ConstantDataArray>(value);
+   ilValue = _builder->ConstString(constDataArray->getAsCString().data());
+   return ilValue;
+   }
+
+TR::IlValue *
+IRVisitor::getIlValue(llvm::Value * value)
+   {
+   TR::IlValue * ilValue = _methodBuilder->getIlValue(value);
+   if (ilValue) return ilValue;
+   switch (value->getValueID())
+      {
+      /* Constants */
+      case llvm::Value::ValueTy::ConstantExprVal:
+         ilValue = createConstExprIlValue(value);
+         break;
+      case llvm::Value::ValueTy::GlobalVariableVal:
+         ilValue = loadGlobal(value);
+         break;
+      case llvm::Value::ValueTy::FunctionVal:
+      case llvm::Value::ValueTy::GlobalAliasVal:
+      case llvm::Value::ValueTy::GlobalIFuncVal:
+      case llvm::Value::ValueTy::BlockAddressVal:
+         assert(0 && "Unsupported constant value type");
+         break;
+
+      /* Constant data value types */
+      case llvm::Value::ValueTy::ConstantIntVal:
+         ilValue = createConstIntIlValue(value);
+         break;
+      case llvm::Value::ValueTy::ConstantFPVal:
+         ilValue = createConstFPIlValue(value);
+         break;
+      case llvm::Value::ValueTy::ConstantDataArrayVal:
+         ilValue = createConstantDataArrayVal(value);
+         break;
+      case llvm::Value::ValueTy::ConstantAggregateZeroVal:
+      case llvm::Value::ValueTy::ConstantDataVectorVal:
+      case llvm::Value::ValueTy::ConstantPointerNullVal:
+      case llvm::Value::ValueTy::ConstantTokenNoneVal:
+         assert(0 && "Unsupported constant data value type");
+         break;
+
+      /* Constant aggregate value types */
+      case llvm::Value::ValueTy::ConstantStructVal:
+         //break; //todo uncomment when done implementing
+      case llvm::Value::ValueTy::ConstantArrayVal:
+      case llvm::Value::ValueTy::ConstantVectorVal:
+         assert(0 && "Unsupported constant aggregate value type");
+         break;
+
+      /* Other value types */
+      case llvm::Value::ValueTy::ArgumentVal:
+         ilValue = loadParameter(value);
+         break;
+      case llvm::Value::ValueTy::BasicBlockVal:
+         assert(0 && "Basicblock should not be looked up this way");
+         break;
+
+      default:
+         break;
+      }
+   assert (ilValue && "failed to retrieve ilValue from llvm Value!");
+   return ilValue;
+   }
+
+} // namespace lljb

--- a/jitbuilder/lljb/src/MethodBuilder.cpp
+++ b/jitbuilder/lljb/src/MethodBuilder.cpp
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ilgen/TypeDictionary.hpp"
+
+#include "lljb/MethodBuilder.hpp"
+#include "lljb/IRVisitor.hpp"
+#include "lljb/Compiler.hpp"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+#include <cstdio>
+#include <vector>
+
+namespace lljb
+{
+
+
+MethodBuilder::MethodBuilder(
+      TR::TypeDictionary *td,
+      llvm::Function &func,
+      Compiler * compiler) :
+   TR::MethodBuilder(td),
+   _function(func),
+   _compiler(compiler),
+   _numLocals(0)
+   {
+   DefineFile(func.getParent()->getSourceFileName().data());
+   DefineLine("n/a"); // line number is only available if the bitcode file was
+                     // generated with debug info, hence not dealing with that
+   DefineName(func.getName().data());
+   DefineReturnType(getIlType(td,func.getReturnType()));
+   setUseBytecodeBuilders();
+   defineParameters();
+   }
+
+bool
+MethodBuilder::buildIL()
+   {
+   AllLocalsHaveBeenDefined(); // treat all locals we define as temps
+   State * state = new State();
+   setVMState(state);
+   assignBuildersToBasicBlocks();
+
+   TR::BytecodeBuilder * firstBuilder = _BBToBuilderMap[&(_function.getEntryBlock())];
+   assert (firstBuilder && "first builder not found!");
+   AppendBytecodeBuilder(firstBuilder);
+
+   for (llvm::BasicBlock &BB : _function)
+      {
+      TR::BytecodeBuilder * builder = _BBToBuilderMap[&BB];
+      builder->setVMState(state);
+      IRVisitor visitor(this, builder,typeDictionary());
+      visitor.visit(BB);
+      }
+
+   return true;
+   }
+
+TR::IlType *
+MethodBuilder::getIlType(TR::TypeDictionary * td, llvm::Type * type)
+   {
+   TR::IlType * ilType = nullptr;
+   switch (type->getTypeID())
+      {
+      case llvm::Type::TypeID::IntegerTyID: // arbitrary bitwidth integers
+         if (type->isIntegerTy(8)) ilType = td->Int8;
+         else if (type->isIntegerTy(16)) ilType = td->Int16;
+         else if (type->isIntegerTy(32)) ilType = td->Int32;
+         else if (type->isIntegerTy(64)) ilType = td->Int64;
+         else assert(0 && "Unsupported integer type");
+         break;
+      case llvm::Type::TypeID::FloatTyID: // 32-bit floating point type
+         ilType = td->Float;
+         break;
+      case llvm::Type::TypeID::DoubleTyID: // 64-bit floating point type
+         ilType = td->Double;
+         break;
+      case llvm::Type::TypeID::PointerTyID: // Pointers
+         ilType = td->PointerTo(getIlType(td,type->getPointerElementType()));
+         break;
+      case llvm::Type::TypeID::VoidTyID: // type with no size
+         ilType = td->NoType;
+         break;
+      case llvm::Type::TypeID::StructTyID: // Structures
+         ilType = td->LookupStruct(type->getStructName().data());
+         break;
+      case llvm::Type::TypeID::ArrayTyID: // Arrays
+         ilType = getIlType(td,type->getArrayElementType());
+         break;
+      case llvm::Type::TypeID::LabelTyID: // Label type
+      case llvm::Type::TypeID::HalfTyID: // 16-bit floating point type
+      case llvm::Type::TypeID::X86_FP80TyID: // 80-bit floating point type (X87)
+      case llvm::Type::TypeID::FP128TyID: // 128-bit floating point type (112-bit mantissa)
+      case llvm::Type::TypeID::PPC_FP128TyID: // 128-bit floating point type (2 64-bits) -- PPC
+      case llvm::Type::TypeID::X86_MMXTyID: // 64-bit MMX vectors -- X86
+      case llvm::Type::TypeID::TokenTyID: // Tokens
+      case llvm::Type::TypeID::FunctionTyID: // Functions
+      case llvm::Type::TypeID::VectorTyID: // SIMD "packed" format, or other vector types
+      case llvm::Type::TypeID::MetadataTyID: // Metadata type
+      default:
+         llvm::outs() << "invalid type: " << *type << "\n";
+         assert(0 && "Unsupported llvm type!");
+         break;
+      }
+   return ilType;
+   }
+
+void
+MethodBuilder::assignBuildersToBasicBlocks()
+   {
+   int32_t index = 0;
+
+   for (llvm::BasicBlock &BB : _function)
+      {
+      TR::BytecodeBuilder * currentBuilder = OrphanBytecodeBuilder(index);
+      _BBToBuilderMap[&BB] = currentBuilder;
+      index ++;
+      }
+   }
+
+void
+MethodBuilder::defineParameters()
+   {
+   for (auto arg = _function.arg_begin(); arg != _function.arg_end(); ++arg)
+      {
+      DefineParameter(stringifyParamIndex(arg->getArgNo()), getIlType(typeDictionary(),arg->getType()));
+      }
+   }
+
+char *
+MethodBuilder::stringifyParamIndex(unsigned paramIndex)
+   {
+   std::string indexString = std::to_string(paramIndex);
+   char * paramString = new char[indexString.length()+2];
+   sprintf(paramString, "p%d",paramIndex);
+   _parameterMap[paramIndex] = paramString;
+   return paramString;
+   }
+
+char *
+MethodBuilder::getParamNameFromIndex(unsigned index)
+   {
+   return _parameterMap[index];
+   }
+
+char *
+MethodBuilder::getMemberNameFromIndex(unsigned index)
+   {
+   return _compiler->getObjectMemberNameFromIndex(index);
+   }
+
+TR::IlValue *
+MethodBuilder::getIlValue(llvm::Value * value)
+   {
+   return _valueMap[value];
+   }
+
+void
+MethodBuilder::mapIRtoIlValue(llvm::Value * irValue, TR::IlValue * ilValue)
+   {
+   _valueMap[irValue] = ilValue;
+   }
+
+TR::BytecodeBuilder *
+MethodBuilder::getByteCodeBuilder(llvm::Value * value)
+   {
+   return _BBToBuilderMap[value];
+   }
+
+void
+MethodBuilder::defineFunction(llvm::Function * func, std::size_t numParams, TR::IlType **paramTypes)
+   {
+   if (_definedFunctions[func]) return;
+   const char * name = func->getName().data();
+   const char * fileName = func->getParent()->getSourceFileName().data();
+   const char * lineNumer = "n/a";
+   void * entry = _compiler->getFunctionAddress(func);
+   TR::IlType * returnType = getIlType(typeDictionary(),func->getReturnType());
+   if (!numParams)
+      {
+      DefineFunction(name,
+                     fileName,
+                     lineNumer,
+                     entry,
+                     returnType,
+                     0);
+      }
+   else
+      {
+      DefineFunction(name,
+                        fileName,
+                        lineNumer,
+                        entry,
+                        returnType,
+                        numParams,
+                        paramTypes);
+
+      }
+   _definedFunctions[func] = entry;
+   }
+
+void
+MethodBuilder::allocateLocal(llvm::Value * value, TR::IlType * allocatedType)
+   {
+   assert((!_localsMap[value]) && "local already allocated");
+
+   std::string currentIndex = std::to_string(_numLocals);
+   char * name = new char[currentIndex.length()+2];
+   sprintf(name, "r%d",_numLocals);
+   _localsMap[value] = name;
+   _numLocals++;
+
+   DefineLocal(name, allocatedType);
+   }
+
+bool
+MethodBuilder::isIndirectLoadOrStore(llvm::Value * value)
+   {
+   if (_localsMap[value]) return false;
+   return true;
+   }
+
+char *
+MethodBuilder::getLocalNameFromValue(llvm::Value * value)
+   {
+   return _localsMap[value];
+   }
+
+MethodBuilder::~MethodBuilder()
+   {
+   _parameterMap.clear();
+   _localsMap.clear();
+   }
+
+} // namespace lljb

--- a/jitbuilder/lljb/src/Module.cpp
+++ b/jitbuilder/lljb/src/Module.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "lljb/Module.hpp"
+
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/SourceMgr.h"
+
+
+namespace lljb
+{
+
+Module::Module(
+      const char * filename,
+      llvm::SMDiagnostic &SMDiags,
+      llvm::LLVMContext &context) :
+   _llvmModule(nullptr),
+   _constructed(false),
+   _filename(filename)
+   {
+   _llvmModule = (llvm::parseIRFile(_filename, SMDiags, context));
+   if (!_llvmModule)
+      {
+      SMDiags.print(_filename, llvm::errs());
+      }
+   else
+      {
+      _constructed = true;
+      }
+   llvm::outs() << "Module loaded:" << _llvmModule->getModuleIdentifier() << "\n";
+   }
+
+llvm::Function *
+Module::getMainFunction()
+   {
+   if (numFunctions() == 1)
+      return &(*(funcIterBegin()));
+   return _llvmModule->getFunction("main");
+   }
+
+} // namespace lljb


### PR DESCRIPTION
The LLJB project enables interoperability between LLVM and JitBuilder.
LLJB takes LLVM Intermediate Representation (IR) files and uses
JitBuilder API to construct equivalent OMR Compiler IL. The OMR Compiler
then performs optimizations and genates native code for every function
in the module.

LLJB is being contributed as a subproject of JitBuilder.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>