### PR TITLE
WIP: Clean up duplicated queries in x codegen

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -81,47 +81,6 @@ class TR_OpaqueMethodBlock;
 
 static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg);
 
-// The following functions are simple enough to inline, and are called often
-// enough that we want to take advantage of inlining.  However, it is used
-// across multiple translation units, preventing us from just using 'inline'
-// TODO: Put in own header file shared by the various TreeEvaluator.cpp
-// (but not TreeEvaluator.hpp, too many files include this).
-
-// Right now, this function is duplicated in TreeEval, ControlFlowEval, Binary &UnaryEval.
-inline bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return cg->comp()->target().is64Bit() && node->getSize() > 4;
-   }
-
-// Right now, this is duplicated in ControlFlowEval, BinaryEval and TreeEval.
-inline intptrj_t integerConstNodeValue(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   if (getNodeIs64Bit(node, cg))
-      {
-      return node->getLongInt();
-      }
-   else
-      {
-      TR_ASSERT(node->getSize() <= 4, "For efficiency on IA32, only call integerConstNodeValue for 32-bit constants");
-      return node->getInt();
-      }
-   }
-// Right now, this is duplicated in ControlFlowEval, BinaryEval and TreeEval.
-inline bool constNodeValueIs32BitSigned(TR::Node *node, intptrj_t *value, TR::CodeGenerator *cg)
-   {
-   *value = integerConstNodeValue(node, cg);
-   if (cg->comp()->target().is64Bit())
-      {
-      return IS_32BIT_SIGNED(*value);
-      }
-   else
-      {
-      TR_ASSERT(IS_32BIT_SIGNED(*value), "assertion failure");
-      return true;
-      }
-   }
-
-
 static inline TR::Instruction *generateWiderCompare(TR::Node *node, TR::Register *targetReg,
                                                    intptrj_t value,
                                                    TR::CodeGenerator *cg)

--- a/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
+++ b/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
@@ -29,6 +29,7 @@
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RegisterConstants.hpp"
+#include "codegen/TreeEvaluator.hpp"
 #include "compile/Compilation.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
@@ -40,18 +41,12 @@
 
 namespace TR { class Register; }
 
-// This is duplicated from TR::TreeEvaluator
-inline bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return cg->comp()->target().is64Bit() && node->getSize() > 4;
-   }
-
 // tempRegArray is an array of temporary registers
 // decomposeIntegerMultiplier needs to update this array if it allocates new temporary registers inside
 TR::Register *TR_X86IntegerMultiplyDecomposer::decomposeIntegerMultiplier(int32_t &tempRegArraySize, TR::Register **tempRegArray)
    {
    TR::Compilation* comp = _cg->comp();
-   bool nodeIs64Bit = getNodeIs64Bit(_node, _cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(_node, _cg);
    int64_t absMultiplier = _multiplier;
    if (_multiplier < 0)
       {
@@ -314,7 +309,7 @@ TR::Register *TR_X86IntegerMultiplyDecomposer::generateDecompositionInstructions
                         int32_t index, int32_t &tempRegArraySize, TR::Register **tempRegArray)
    {
    const integerMultiplyComposition& composition = _integerMultiplySolutions[index];
-   bool nodeIs64Bit = getNodeIs64Bit(_node, _cg);
+   bool nodeIs64Bit = TR::TreeEvaluator::getNodeIs64Bit(_node, _cg);
    // initialize and allocate registers to be used by the composition
    // source register is defined to be ordinal register 0
    TR::Register *registerMap[MAX_NUM_REGISTERS];

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2415,26 +2415,6 @@ TR::RealRegister::RegNum OMR::X86::CodeGenerator::pickNOPRegister(TR::Instructio
 //
 #define NUM_BIG_BAD_TEMP_REGS (2)
 
-// TODO: Don't duplicate this function all over the place.  Find a good header for it.
-inline bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return cg->comp()->target().is64Bit() && node->getSize() > 4;
-   }
-
-// TODO: Don't duplicate this function all over the place.  Find a good header for it.
-inline intptrj_t integerConstNodeValue(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   if (getNodeIs64Bit(node, cg))
-      {
-      return node->getLongInt();
-      }
-   else
-      {
-      TR_ASSERT(node->getSize() <= 4, "For efficiency on IA32, only call integerConstNodeValue for 32-bit constants");
-      return node->getInt();
-      }
-   }
-
 bool OMR::X86::CodeGenerator::nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state)
    {
    TR_SimulatedNodeState &nodeState = self()->simulatedNodeState(node, state);
@@ -2585,7 +2565,7 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
       bool usesMul = true;
       if (secondChild->getOpCode().isLoadConst() &&
          (self()->comp()->target().is64Bit() || !nodeType.isInt64()) &&
-         populationCount(integerConstNodeValue(secondChild, self())) <= 2)
+         populationCount(TR::TreeEvaluator::integerConstNodeValue(secondChild, self())) <= 2)
          {
          // Will probably use shifts/adds/etc instead of multiply
          //


### PR DESCRIPTION
The duplicated queries getNodeIs64Bit, integerConstNodeValue
and constNodeValueIs32BitSigned in multiple files are removed.
The properly defined version of those in TreeEvaluator are kept 
and are called from.

Signed-off-by: Yiling Han <Yiling.Han@ibm.com>