### PR TITLE
Add NoRecompilationRecoverableILGenException

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,12 +69,24 @@ struct ILGenFailure : public virtual CompilationException
  * Recoverable IL Generation Failure exception type.
  *
  * Thrown on an IL Generation Failure condition which the compiler can
- * recover either by continuing the compilation, or by allowing a
- * recompilation to occur.
+ * recover either by
+ * 1. continuing the compilation of the caller method if the failing method is an inlined callee
+ * 2. allowing a recompilation to occur for the failing method if it's the outermost method
  */
 struct RecoverableILGenException : public virtual CompilationException
    {
    virtual const char* what() const throw() { return "Recoverable IL Gen Exception"; }
+   };
+
+/**
+ * Special recoverable IL Generation Failure exception type.
+ *
+ * Different from general RecoverableILGenException in that
+ * recompilation is not allowed when the failing method is the outermost method.
+ */
+struct NoRecompilationRecoverableILGenException: public RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "Recoverable IL Gen Exception with no recompilation if failing method is outermost"; }
    };
 
 /**


### PR DESCRIPTION
Very often when failing ilgen is because of limitation of the compiler
we would want the caller's compilation to continue but don't want to
recompile the failing method itself because it would fail again due to
the limitation. Added NoRecompilationRecoverableILGenException for such case.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>