### PR TITLE
Change ilgen exception to correct exception type

### DIFF
--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1216,7 +1216,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
                {
                if (self()->catchBlocksHaveRealPredecessors())
                   {
-                  comp->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
+                  comp->failCompilation<TR::NoRecompilationRecoverableILGenException>("Catch blocks have real predecessors");
                   }
                }
 


### PR DESCRIPTION
Control flow analaysis can not handle CFG with `catch blocks have
real predecessors` so we should avoid inline or compile such method.
Use `NoRecompilationRecoverableILGenException` for this purpose.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>