### PR TITLE
Added support for loadaddr in copy propagation

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -59,7 +59,6 @@
 #include "optimizer/TransformUtil.hpp"
 #include "ras/Debug.hpp"
 
-
 #define OPT_DETAILS "O^O COPY PROPAGATION: "
 
 
@@ -803,7 +802,6 @@ int32_t TR_CopyPropagation::perform()
 
          if (!useNode) continue;
          if (useNode->getReferenceCount() == 0) continue;
-         if (useNode->getOpCodeValue() == TR::loadaddr) continue;
 
          TR::Node *loadNode, *baseNode;
          int32_t regNumber;
@@ -2244,7 +2242,7 @@ bool TR_CopyPropagation::isCorrectToReplace(TR::Node *useNode, TR::Node *storeNo
 
 TR::Node * TR_CopyPropagation::isLoadVarWithConst(TR::Node *node)
    {
-   if (node->getOpCode().isLoadVarDirect() &&
+     if ((node->getOpCode().isLoadVarDirect() || (node->getOpCodeValue() == TR::loadaddr)) &&
        node->getSymbolReference()->getSymbol()->isAutoOrParm())
       {
       return node;


### PR DESCRIPTION
Replace a load of an auto sym ref A by a loadaddr
of an auto sym ref B if there was a store of A :
store A = loadaddr B
feeding the load of sym ref A.

Signed-off-by: Vijay Sundaresan <vijaysun@ca.ibm.com>