### PR TITLE
Merge pull request #4705 from bragaigor/verbose_option

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -257,7 +257,9 @@ public:
 	bool largePageWarnOnError;
 	bool largePageFailOnError;
 	bool largePageFailedToSatisfy;
+#if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 	bool isArrayletDoubleMapRequested;
+#endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
 	uintptr_t requestedPageSize;
 	uintptr_t requestedPageFlags;
 	uintptr_t gcmetadataPageSize;
@@ -1355,7 +1357,9 @@ public:
 		, largePageWarnOnError(false)
 		, largePageFailOnError(false)
 		, largePageFailedToSatisfy(false)
+#if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 		, isArrayletDoubleMapRequested(false)
+#endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
 		, requestedPageSize(0)
 		, requestedPageFlags(OMRPORT_VMEM_PAGE_FLAG_NOT_USED)
 		, gcmetadataPageSize(0)

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -96,7 +96,13 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 	}
 
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	if(extensions->isVLHGC() && extensions->indexableObjectModel.isDoubleMappingEnabled()) {
+	/*
+	 * The decision to create a heap with a shared file descriptor is based on if double map was requested
+	 * or not, because we do not know at this point the actual heap page size (double map does not support
+	 * huge pages). Nonetheless, this is a safe operation because in case page size equals system's huge page
+	 * the mode flag OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN will be ignored.
+	 */
+	if(extensions->isVLHGC() && extensions->isArrayletDoubleMapRequested) {
 		mode |= OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN;
 	}
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,11 +230,24 @@ MM_VerboseHandlerOutput::handleInitializedRegion(J9HookInterface** hook, uintptr
 	MM_InitializedEvent* event = (MM_InitializedEvent*)eventData;
 	MM_VerboseWriterChain* writer = _manager->getWriterChain();
 	MM_EnvironmentBase* env = MM_EnvironmentBase::getEnvironment(event->currentThread);
+#if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
+	bool isArrayletDoubleMapRequested = _extensions->isArrayletDoubleMapRequested;
+	const char *arrayletDoubleMappingStatus = _extensions->indexableObjectModel.isDoubleMappingEnabled() ? "enabled" : "disabled";
+	const char *arrayletDoubleMappingRequested = isArrayletDoubleMapRequested ? "true" : "false";
+#endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
 
 	writer->formatAndOutput(env, 1, "<region>");
 	writer->formatAndOutput(env, 2, "<attribute name=\"regionSize\" value=\"%zu\" />", event->regionSize);
 	writer->formatAndOutput(env, 2, "<attribute name=\"regionCount\" value=\"%zu\" />", event->regionCount);
 	writer->formatAndOutput(env, 2, "<attribute name=\"arrayletLeafSize\" value=\"%zu\" />", event->arrayletLeafSize);
+#if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
+	if (_extensions->isVLHGC()) {
+		writer->formatAndOutput(env, 2, "<attribute name=\"arrayletDoubleMappingRequested\" value=\"%s\"/>", arrayletDoubleMappingRequested);
+		if (isArrayletDoubleMapRequested) {
+			writer->formatAndOutput(env, 2, "<attribute name=\"arrayletDoubleMapping\" value=\"%s\"/>", arrayletDoubleMappingStatus);
+		}
+	}
+#endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
 	writer->formatAndOutput(env, 1, "</region>");
 }
 

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2010, 2019 IBM Corp. and others
+Copyright (c) 2010, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -656,7 +656,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	
 	<complexType name="region">
 		<sequence maxOccurs="1" minOccurs="1">
-			<element ref="vgc:attribute" maxOccurs="3" minOccurs="0" />
+			<element ref="vgc:attribute" maxOccurs="5" minOccurs="0" />
 		</sequence>
 	</complexType>	
 


### PR DESCRIPTION
Introduce double mapping verbose GC option for
balanced GC policy where it outputs "true" if arraylet
double mapping is enabled and "false" otherwise

Update schema.xsd with balanced verbose gc options

This update is required by eclipse/openj9#8254
Related to issue: #4703

Signed-off-by: Igor Braga <higorb1@gmail.com>