### PR TITLE
Remove xlC V1R11 workaround in optimizer

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1229,12 +1229,6 @@ TR::VPClassType *TR::VPClassType::create(OMR::ValuePropagation *vp, const char *
    return TR::VPUnresolvedClass::create(vp, sig, len, method);
    }
 
-//Workaround for zOS V1R11 bug
-#if defined(J9ZOS390)
-#pragma noinline(TR::VPResolvedClass::VPResolvedClass(TR_OpaqueClassBlock *,TR::Compilation *))
-#pragma noinline(TR::VPResolvedClass::VPResolvedClass(TR_OpaqueClassBlock *, TR::Compilation *, int32_t))
-#endif
-
 TR::VPResolvedClass *TR::VPResolvedClass::create(OMR::ValuePropagation *vp, TR_OpaqueClassBlock *klass)
    {
    // If the class is final, we really want to make this a fixed class


### PR DESCRIPTION
This workaround was for a very old version of xlC compiler (10 years
old) which we no longer build with. Code archeology reveals the
original bug was a compile time crash with the following backtrace:

```
Method_being_compiled=sun/io/Converters.cache(ILjava/lang/Object;)Ljava/lang/Class;

TR_J9VM::getBaseComponentClass(TR_OpaqueClassBlock*,int&)
TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock*,int&,TR_Memory*)
TR_VPResolvedClass::create(TR_ValuePropagation*,TR_OpaqueClassBlock*)
constrainCheckcast(TR_ValuePropagation*,TR_Node*)
TR_ValuePropagation::processTrees(TR_TreeTop*,TR_TreeTop*)
TR_GlobalValuePropagation::processBlock(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionNode(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionSubgraph(TR_StructureSubGraphNode*,bool,bool,bool)
TR_GlobalValuePropagation::processRegionNode(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionSubgraph(TR_StructureSubGraphNode*,bool,bool,bool)
TR_GlobalValuePropagation::processStructure(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionSubgraph(TR_StructureSubGraphNode*,bool,bool,bool)
TR_GlobalValuePropagation::perform()
```

```
Method_being_compiled=java/util/WeakHashMap.isEqual(Ljava/lang/Object;Ljava/lang/Object;)Z

TR_J9VM::getBaseComponentClass(TR_OpaqueClassBlock*,int&)
TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock*,int&,TR_Memory*)
TR_VPFixedClass::create(TR_ValuePropagation*,TR_OpaqueClassBlock*)
constrainIfcmpeqne(TR_ValuePropagation*,TR_Node*,bool)
constrainIfcmpne(TR_ValuePropagation*,TR_Node*)
TR_ValuePropagation::processTrees(TR_TreeTop*,TR_TreeTop*)
TR_GlobalValuePropagation::processBlock(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionNode(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionNode(TR_StructureSubGraphNode*,bool,bool)
TR_GlobalValuePropagation::processRegionSubgraph(TR_StructureSubGraphNode*,bool,bool,bool)
TR_GlobalValuePropagation::perform()
TR_OptimizerImpl::performOptimization(TR_OptimizerImpl::Optimization*,int,int,int)
TR_OptimizerImpl::performOptimization(TR_OptimizerImpl::Optimization*,int,int,int)
TR_OptimizerImpl::optimize()
```

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>