### PR TITLE
Revert PR4699 "Added support for loadaddr in copy propagation."

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -59,6 +59,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "ras/Debug.hpp"
 
+
 #define OPT_DETAILS "O^O COPY PROPAGATION: "
 
 
@@ -802,6 +803,7 @@ int32_t TR_CopyPropagation::perform()
 
          if (!useNode) continue;
          if (useNode->getReferenceCount() == 0) continue;
+         if (useNode->getOpCodeValue() == TR::loadaddr) continue;
 
          TR::Node *loadNode, *baseNode;
          int32_t regNumber;
@@ -2242,7 +2244,7 @@ bool TR_CopyPropagation::isCorrectToReplace(TR::Node *useNode, TR::Node *storeNo
 
 TR::Node * TR_CopyPropagation::isLoadVarWithConst(TR::Node *node)
    {
-     if ((node->getOpCode().isLoadVarDirect() || (node->getOpCodeValue() == TR::loadaddr)) &&
+   if (node->getOpCode().isLoadVarDirect() &&
        node->getSymbolReference()->getSymbol()->isAutoOrParm())
       {
       return node;


### PR DESCRIPTION
Recent changes in PR4699 to add support to copy propagation for
loadaddr nodes are responsible for acceptance build failures at
OpenJ9 with a variety of crashes. This change backs out the
changes in PR4699 until the cause of the problem is identified.

This reverts commit d27fc6166b643f07d8fc83d4c5cf5c7976bbb4ba.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>