### PR TITLE
Runtime compressed refs work

### DIFF
--- a/gc/base/IndexableObjectScanner.hpp
+++ b/gc/base/IndexableObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,7 @@ protected:
 	 * @param[in] scanPtr pointer to the array cell where scanning will start
 	 * @param[in] endPtr pointer to the array cell where scanning will stop
 	 * @param[in] scanMap first portion of bitmap for slots to scan
-	 * @param[in] elementSize array element size must be aligned to sizeof(fomrobject_t)
+	 * @param[in] elementSize array element size must be aligned to the size of an object to object reference
 	 * @param[in] flags scanning context flags
 	 */
 	GC_IndexableObjectScanner(

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -901,9 +901,6 @@ public:
 		: _delegate((fomrobject_t)OMR_OBJECT_METADATA_FLAGS_MASK)
 	{
 		_typeId = __FUNCTION__;
-#if defined(OBJECT_MODEL_MODRON_ASSERTIONS)
-		Assert_MM_true((8 * (sizeof(fomrobject_t) - 1)) >= _delegate.getObjectHeaderSlotFlagsShift());
-#endif /* defined(OBJECT_MODEL_MODRON_ASSERTIONS) */
 	}
 };
 #if defined(OMR_EXAMPLE)

--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,6 +62,9 @@ protected:
 	fomrobject_t *_scanPtr;					/**< Pointer to base of object slots mapped by current _scanMap */
 	GC_SlotObject _slotObject;				/**< Create own SlotObject class to provide output */
 	uintptr_t _flags;						/**< Scavenger context flags (scanRoots, scanHeap, ...) */
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	bool const _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	
 public:
 	/**
@@ -101,6 +104,9 @@ protected:
 		, _scanPtr(scanPtr)
 		, _slotObject(env->getOmrVM(), NULL)
 		, _flags(flags | headObjectScanner)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(env->compressObjectReferences())
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	{
 		_typeId = __FUNCTION__;
 	}
@@ -123,42 +129,29 @@ protected:
 	 *
 	 * @param[in] env Current environment
 	 * @see getNextSlotMap()
-	 * @see putNextSlotMapBit()
 	 */
 	MMINLINE void
 	initialize(MM_EnvironmentBase *env)
 	{
 	}
 
+public:
 	/**
-	 * Helper function can be used to rebuild bit map of reference fields in
-	 * implementation of getNextSlotMap(). Simply call this method once for
-	 * each object slot holding a reference pointer. Best to present reference
-	 * fields in increasing address order until method returns false or no
-	 * more fields.
-	 *
-	 * If the method returns false, the field presented in the call will not
-	 * be included in the slot map and must be presented first in the next
-	 * call to getNextSlotMap().
+	 * Return back true if object references are compressed
+	 * @return true, if object references are compressed
 	 */
-	MMINLINE bool
-	putNextSlotMapBit(fomrobject_t *nextSlotAddress)
-	{
-		if (0 != _scanMap) {
-			intptr_t bitOffset = nextSlotAddress - _scanPtr;
-			if (_bitsPerScanMap < bitOffset) {
-				_scanMap |= (uintptr_t)1 << bitOffset;
-			} else {
-				return false;
-			}
-		} else {
-			_scanPtr = nextSlotAddress;
-			_scanMap = 1;
-		}
+	MMINLINE bool compressObjectReferences() {
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+		return _compressObjectReferences;
+#else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
+		return false;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	}
 
-public:
 	/**
 	 * Leaf objects contain no reference slots (eg plain value object or empty array).
 	 *
@@ -186,16 +179,17 @@ public:
 	MMINLINE GC_SlotObject *
 	getNextSlot()
 	{
+		bool const compressed = compressObjectReferences();
 		while (NULL != _scanPtr) {
 			/* while there is at least one bit-mapped slot, advance scan ptr to a non-NULL slot or end of map */
-			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == *_scanPtr))) {
-				_scanPtr += 1;
+			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == (compressed ? (uintptr_t)*(uint32_t*)_scanPtr : *(uintptr_t*)_scanPtr)))) {
+				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 			}
 			if (0 != _scanMap) {
 				/* set up to return slot object for non-NULL slot at scan ptr and advance scan ptr */
 				_slotObject.writeAddressToSlot(_scanPtr);
-				_scanPtr += 1;
+				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 				return &_slotObject;
 			}
@@ -257,10 +251,11 @@ public:
 	MMINLINE GC_SlotObject *
 	getNextSlot(bool* isLeafSlot)
 	{
+		bool const compressed = compressObjectReferences();
 		while (NULL != _scanPtr) {
 			/* while there is at least one bit-mapped slot, advance scan ptr to a non-NULL slot or end of map */
-			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == *_scanPtr))) {
-				_scanPtr += 1;
+			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == (compressed ? (uintptr_t)*(uint32_t*)_scanPtr : *(uintptr_t*)_scanPtr)))) {
+				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 				_leafMap >>= 1;
 			}
@@ -268,7 +263,7 @@ public:
 				/* set up to return slot object for non-NULL slot at scan ptr and advance scan ptr */
 				_slotObject.writeAddressToSlot(_scanPtr);
 				*isLeafSlot = (0 != (1 & _leafMap));
-				_scanPtr += 1;
+				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 				_leafMap >>= 1;
 				return &_slotObject;

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2770,6 +2770,7 @@ MM_ConcurrentGC::localMark(MM_EnvironmentBase *env, uintptr_t sizeToTrace)
 {
 	omrobjectptr_t objectPtr;
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
+	uint32_t const referenceSize = env->compressObjectReferences() ? sizeof(uint32_t) : sizeof(uintptr_t);
 
 	env->_workStack.reset(env, _markingScheme->getWorkPackets());
 	Assert_MM_true(env->_cycleState == NULL);
@@ -2785,7 +2786,7 @@ MM_ConcurrentGC::localMark(MM_EnvironmentBase *env, uintptr_t sizeToTrace)
 		} else 	if (((MM_ConcurrentCardTable *)_cardTable)->isObjectInActiveTLH(env,objectPtr)) {
 			env->_workStack.pushDefer(env,objectPtr);
 			/* We are deferring the tracing but get some "tracing credit" */
-			sizeTraced += sizeof(fomrobject_t);
+			sizeTraced += referenceSize;
 		} else if (((MM_ConcurrentCardTable *)_cardTable)->isObjectInUncleanedDirtyCard(env,objectPtr)) {
 			/* Dont need to trace this object now as we will re-visit it
 			 * later when we clean the card during concurrent card cleaning


### PR DESCRIPTION
Remove explicit and implicit (pointer math) uses of
sizeof(fomrobject_t).

The example and fvtest code are not updated in this change.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>