### PR TITLE
Heap Resize: Concurrent KO/Uninitialized Mark Map Bug fix

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -30,6 +30,7 @@
 
 #include "BaseVirtual.hpp"
 #include "EnvironmentBase.hpp"
+#include "ModronAssertions.h"
 
 class MM_AllocateDescription;
 class MM_AllocationContext;
@@ -194,7 +195,18 @@ public:
 	 * moved from one subspace to another.
 	 * @param env[in] The thread which performed the change in heap geometry 
 	 */
-	virtual void heapReconfigured(MM_EnvironmentBase* env) = 0;
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
+	{
+		heapReconfigured(env); /* Required temporarily to not break dependency with heapReconfigure API changes */
+	};
+	
+	/* Required temporarily to not break dependency with heapReconfigure API changes */
+	virtual void heapReconfigured(MM_EnvironmentBase *env) 
+	{
+		/* ALl collectors except Scavenger & Realtime should have their own implementation */
+		MM_GCPolicy gc_policy = env->getExtensions()->configurationOptions._gcPolicy;
+		Assert_MM_true(gc_policy == OMR_GC_POLICY_METRONOME || gc_policy == OMR_GC_POLICY_GENCON);
+	};
 
 	/**
 	 * Post collection broadcast event, indicating that the collection has been completed.

--- a/gc/base/Heap.cpp
+++ b/gc/base/Heap.cpp
@@ -433,12 +433,12 @@ MM_Heap::heapRemoveRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, u
  * The heap has had its memory shuffled between memory subspaces and/or memory pools.
  */
 void
-MM_Heap::heapReconfigured(MM_EnvironmentBase* env)
+MM_Heap::heapReconfigured(MM_EnvironmentBase* env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
 	MM_GlobalCollector* globalCollector = env->getExtensions()->getGlobalCollector();
 
 	if (NULL != globalCollector) {
-		globalCollector->heapReconfigured(env);
+		globalCollector->heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 	}
 }
 

--- a/gc/base/Heap.hpp
+++ b/gc/base/Heap.hpp
@@ -148,7 +148,7 @@ public:
 	 * moved from one subspace to another.
 	 * @param env[in] The thread which performed the change in heap geometry 
 	 */
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress);
 
 	virtual bool objectIsInGap(void *object);
 

--- a/gc/base/MemorySpace.cpp
+++ b/gc/base/MemorySpace.cpp
@@ -515,9 +515,9 @@ MM_MemorySpace::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
  * 
  */
 void
-MM_MemorySpace::heapReconfigured(MM_EnvironmentBase *env)
+MM_MemorySpace::heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
-	_heap->heapReconfigured(env);
+	_heap->heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 }
 
 /**

--- a/gc/base/MemorySpace.hpp
+++ b/gc/base/MemorySpace.hpp
@@ -181,7 +181,7 @@ public:
 	 * moved from one subspace to another.
 	 * @param env[in] The thread which performed the change in heap geometry 
 	 */
-	void heapReconfigured(MM_EnvironmentBase *env);
+	void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress);
 
 	static MM_MemorySpace *getMemorySpace(void *memorySpace) { return (MM_MemorySpace *)memorySpace; }
 

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1380,16 +1380,16 @@ MM_MemorySubSpace::heapRemoveRange(MM_EnvironmentBase* env, MM_MemorySubSpace* s
  * 
  */
 void
-MM_MemorySubSpace::heapReconfigured(MM_EnvironmentBase* env)
+MM_MemorySubSpace::heapReconfigured(MM_EnvironmentBase* env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
 	if (!_usesGlobalCollector && (NULL != _collector)) {
-		_collector->heapReconfigured(env);
+		_collector->heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 	}
 
 	if (_parent) {
-		_parent->heapReconfigured(env);
+		_parent->heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 	} else if (_memorySpace) {
-		_memorySpace->heapReconfigured(env);
+		_memorySpace->heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 	}
 }
 

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -404,7 +404,7 @@ public:
 	 * moved from one subspace to another.
 	 * @param env[in] The thread which performed the change in heap geometry 
 	 */
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason = HEAP_RECONFIG_NONE, MM_MemorySubSpace *subspace = NULL, void *lowAddress = NULL, void *highAddress = NULL);
 
 	virtual void *findFreeEntryEndingAtAddr(MM_EnvironmentBase *env, void *addr);
 	virtual void *findFreeEntryTopStartingAtAddr(MM_EnvironmentBase *env, void *addr);

--- a/gc/base/segregated/MemorySubSpaceSegregated.cpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.cpp
@@ -310,9 +310,9 @@ MM_MemorySubSpaceSegregated::heapRemoveRange(MM_EnvironmentBase *env, MM_MemoryS
 }
 
 void
-MM_MemorySubSpaceSegregated::heapReconfigured(MM_EnvironmentBase *env)
+MM_MemorySubSpaceSegregated::heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
-	MM_MemorySubSpaceUniSpace::heapReconfigured(env);
+	MM_MemorySubSpaceUniSpace::heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 	if (_regionExpansionBase != _regionExpansionTop) {
 		expandRegionPool();
 	}

--- a/gc/base/segregated/MemorySubSpaceSegregated.hpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.hpp
@@ -114,7 +114,7 @@ public:
 
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
 	virtual bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace = NULL, void *lowAddress = NULL, void *highAddress = NULL);
 
 	virtual MM_MemoryPool *getMemoryPool();
 	

--- a/gc/base/segregated/SegregatedGC.cpp
+++ b/gc/base/segregated/SegregatedGC.cpp
@@ -126,11 +126,6 @@ MM_SegregatedGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *sub
 	return _markingScheme->heapRemoveRange(env, subspace, size, lowAddress, highAddress, lowValidAddress, highValidAddress);
 }
 
-void MM_SegregatedGC::heapReconfigured(MM_EnvironmentBase* env)
-{
-	/* OMRTODO implement proper heap resizing in segregated heaps */
-}
-
 bool
 MM_SegregatedGC::collectorStartup(MM_GCExtensionsBase* extensions)
 {

--- a/gc/base/segregated/SegregatedGC.hpp
+++ b/gc/base/segregated/SegregatedGC.hpp
@@ -96,7 +96,6 @@ public:
 
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
 	virtual bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	virtual void heapReconfigured(MM_EnvironmentBase* env);
 
 	virtual bool isMarked(void *objectPtr) { return _markingScheme->isMarked(static_cast<omrobjectptr_t>(objectPtr)); }
 

--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -409,18 +409,6 @@ MM_ConcurrentCardTable::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpa
 }
 
 /**
- * Re-size all structures which are dependent on the current size of the heap.
- * No new memory has been added to a heap reconfiguration.  This call typically is the result
- * of having segment range changes (memory redistributed between segments) or the meaning of
- * memory changed.
- *
- */
-void
-MM_ConcurrentCardTable::heapReconfigured(MM_EnvironmentBase *env)
-{
-}
-
-/**
  *					Object creation and destruction
  * 					===============================
  *

--- a/gc/base/standard/ConcurrentCardTable.hpp
+++ b/gc/base/standard/ConcurrentCardTable.hpp
@@ -320,12 +320,6 @@ public:
 	 * @return true if contraction is successful
 	 */
 	bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	/**
-	 * Called when the heap geometry has been reconfigured but no memory was added or removed from the heap (happens during tilt).
-	 * @param[in] env The thread which caused the heap geometry change (typically the master GC thread)
-	 * @note This implementation does nothing.
-	 */
-	void heapReconfigured(MM_EnvironmentBase *env);
 	
 	/**
 	 * @return A pointer to the mutable card table stats structure

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -3267,23 +3267,6 @@ MM_ConcurrentGC::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspa
 	/* Expand any superclass structures including mark bits*/
 	bool result = MM_ParallelGlobalGC::heapAddRange(env, subspace, size, lowAddress, highAddress);
 
-	if (result) {
-		/* If we are within a concurrent cycle we need to initialize the mark bits
-		 * for new region of heap now
-		 */
-		if (CONCURRENT_OFF < _stats.getExecutionMode()) {
-			/* If subspace is concurrently collectible then clear bits otherwise
-			 * set the bits on to stop tracing INTO this area during concurrent
-			 * mark cycle.
-			 */
-			if (subspace->isConcurrentCollectable()) {
-				_markingScheme->setMarkBitsInRange(env, lowAddress, highAddress, true);
-			} else {
-				_markingScheme->setMarkBitsInRange(env, lowAddress, highAddress, false);
-			}
-		}
-	}
-
 	_heapAlloc = _extensions->heap->getHeapTop();
 
 	Trc_MM_ConcurrentGC_heapAddRange_Exit(env->getLanguageVMThread());
@@ -3329,34 +3312,63 @@ MM_ConcurrentGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *sub
  * @see MM_ParallelGlobalGC::heapReconfigured()
  */
 void
-MM_ConcurrentGC::heapReconfigured(MM_EnvironmentBase *env)
+MM_ConcurrentGC::heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
-	/* If called outside a global collection for a heap expand/contract..
+	Assert_MM_true(reason != HEAP_RECONFIG_NONE);
+
+	/* _rebuildInitWorkForAdd/_rebuildInitWorkForRemove are not sufficient for determining on how to proceed with headReconfigured
+	 * We end up here in the following scenarios:
+	 *  1) During heap expand - after heapAddRange
+	 *  2) During heap contact - after heapRemoveRange
+	 *  3) After Scavenger Tilt (no resize)
+	 *
+	 *  It is necessary that _rebuildInitWorkForAdd is set when we're here during an expand (after heapAddRange), or
+	 *  _rebuildInitWorkForRemove in the case of contract. However, it is not a sufficient check to ensure the reason we're
+	 *  here. For instance, when Concurent is on, _rebuildInitWorkForAdd will be set but not cleared.
+	 *  As a result, we can have multiple calls of expands interleaved with contracts, resulting in both flags being set.
+	 *  Similarly, we can end up here after scavenger tilt with any of the flags set.
 	 */
-	if (!_stwCollectionInProgress && (_rebuildInitWorkForAdd || _rebuildInitWorkForRemove)) {
-		/* ... and a concurrent cycle has not yet started then we
-		 *  tune to heap here to reflect new heap size
-		 *  Note: CMVC 153167 : Under gencon, there is a timing hole where
-		 *  if we are in the middle of initializing the heap ranges while a
-		 *  scavenge occurs, and if the scavenge causes the heap to contract,
-		 *  we will try to memset ranges that are now contracted (decommitted memory)
-		 *  when we resume the init work.
+
+	if ((lowAddress != NULL) && (highAddress != NULL)) {
+		Assert_MM_true(_rebuildInitWorkForAdd && (reason == HEAP_RECONFIG_EXPAND));
+		/* If we are within a concurrent cycle we need to initialize the mark bits
+		 * for new region of heap now
 		 */
-		if (_stats.getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
-			tuneToHeap(env);
-		} else {
-			/* Heap expand/contract is during a concurrent cycle..we need to adjust the trace target so
-			 * that the trace rate is adjusted correctly on  subsequent allocates.
+		if (CONCURRENT_OFF < _stats.getExecutionMode()) {
+			/* If subspace is concurrently collectible then clear bits otherwise
+			 * set the bits on to stop tracing INTO this area during concurrent
+			 * mark cycle.
 			 */
-			adjustTraceTarget();
+			_markingScheme->setMarkBitsInRange(env, lowAddress, highAddress, subspace->isConcurrentCollectable());
 		}
 	}
 
-	/* Expand any superclass structures */
-	MM_ParallelGlobalGC::heapReconfigured(env);
+	/* If called outside a global collection for a heap expand/contract.. */
+	if((reason == HEAP_RECONFIG_CONTRACT) || (reason == HEAP_RECONFIG_EXPAND)) {
+		Assert_MM_true(_rebuildInitWorkForAdd || _rebuildInitWorkForRemove);
+		if (!_stwCollectionInProgress) {
+			/* ... and a concurrent cycle has not yet started then we
+			 *  tune to heap here to reflect new heap size
+			 *  Note: CMVC 153167 : Under gencon, there is a timing hole where
+			 *  if we are in the middle of initializing the heap ranges while a
+			 *  scavenge occurs, and if the scavenge causes the heap to contract,
+			 *  we will try to memset ranges that are now contracted (decommitted memory)
+			 *  when we resume the init work.
+			 */
+			if (_stats.getExecutionMode() < CONCURRENT_INIT_COMPLETE) {
+				tuneToHeap(env);
+			} else {
+				/* Heap expand/contract is during a concurrent cycle..we need to adjust the trace target so
+				 * that the trace rate is adjusted correctly on  subsequent allocates.
+				 */
+				adjustTraceTarget();
+			}
+		}
+	}
 
-	/* ...and then expand the card table */
-	((MM_ConcurrentCardTable *)_cardTable)->heapReconfigured(env);
+
+	/* Expand any superclass structures */
+	MM_ParallelGlobalGC::heapReconfigured(env, reason, subspace, lowAddress, highAddress);
 }
 
 /**

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -426,7 +426,7 @@ public:
 	
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
 	virtual bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress);
 
 	void finalCleanCards(MM_EnvironmentBase *env);
 

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1345,10 +1345,9 @@ MM_ParallelGlobalGC::heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace 
  * @see MM_GlobalCollector::heapReconfigured()
  */
 void
-MM_ParallelGlobalGC::heapReconfigured(MM_EnvironmentBase *env)
+MM_ParallelGlobalGC::heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
 {
 	_sweepScheme->heapReconfigured(env);
-	
 }
 
 bool

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -289,7 +289,7 @@ public:
 
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
 	virtual bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress);
 
 	virtual	uint32_t getGCTimePercentage(MM_EnvironmentBase *env);
 

--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -114,7 +114,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::tearDown(MM_EnvironmentBase *env)
 	/* Remove the heap range represented */
 	if (NULL != _subSpace) {
 		_subSpace->heapRemoveRange(env, _subSpace, ((uintptr_t)_highAddress) - ((uintptr_t)_lowAddress), _lowAddress, _highAddress, lowValidAddress, highValidAddress);
-		_subSpace->heapReconfigured(env);
+		_subSpace->heapReconfigured(env, HEAP_RECONFIG_CONTRACT);
 	}
 	MM_PhysicalSubArenaVirtualMemory::tearDown(env);
 }
@@ -188,12 +188,30 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::inflate(MM_EnvironmentBase *env)
 			Assert_MM_inflateInvalidRange();
 		}
 
+		void *lowAddress = _highSemiSpaceRegion->getLowAddress();
+		void *highAddress = _highSemiSpaceRegion->getHighAddress();
+
 		/* Inform the semi spaces that they have been expanded */
-		bool result = subSpaceAllocate->expanded(env, this, _highSemiSpaceRegion->getSize(), _highSemiSpaceRegion->getLowAddress(), _highSemiSpaceRegion->getHighAddress(), false);
-		subSpaceAllocate->heapReconfigured(env);
-		result = result && subSpaceSurvivor->expanded(env, this, _lowSemiSpaceRegion->getSize(), _lowSemiSpaceRegion->getLowAddress(), _lowSemiSpaceRegion->getHighAddress(), false);
-		subSpaceSurvivor->heapReconfigured(env);
-		return result;
+		bool resultExpandAllocate = subSpaceAllocate->expanded(env, this, _highSemiSpaceRegion->getSize(), lowAddress, highAddress, false);
+
+		if (resultExpandAllocate) {
+			subSpaceAllocate->heapReconfigured(env, HEAP_RECONFIG_EXPAND, subSpaceAllocate, lowAddress, highAddress);
+		} else {
+			subSpaceAllocate->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+		}
+
+		lowAddress = _lowSemiSpaceRegion->getLowAddress();
+		highAddress = _lowSemiSpaceRegion->getHighAddress();
+
+		bool resultExpandSurvivor = subSpaceSurvivor->expanded(env, this, _lowSemiSpaceRegion->getSize(), lowAddress, highAddress, false);
+
+		if(resultExpandSurvivor) {
+			subSpaceSurvivor->heapReconfigured(env, HEAP_RECONFIG_EXPAND, subSpaceSurvivor, lowAddress, highAddress);
+		} else {
+			subSpaceSurvivor->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+		}
+
+		return resultExpandAllocate && resultExpandSurvivor;
 	}
 	return false;
 }
@@ -686,7 +704,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 			removeMemoryTop,
 			previousValidAddressNotRemoved,
 			(void *)allocateSegmentBase);
-		_subSpace->heapReconfigured(env);
+		_subSpace->heapReconfigured(env, HEAP_RECONFIG_CONTRACT);
 
 		/* Decommit the heap (the return value really doesn't matter here - its already too late) */
 		_heap->decommitMemory(
@@ -869,7 +887,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 			removeMemoryTop,
 			previousValidAddressNotRemoved,
 			(void *)survivorSegmentBase);
-		_subSpace->heapReconfigured(env);
+		_subSpace->heapReconfigured(env, HEAP_RECONFIG_CONTRACT);
 
 		/* Decommit the heap (the return value really doesn't matter here - its already too late) */
 		_heap->decommitMemory(
@@ -1046,7 +1064,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::tilt(MM_EnvironmentBase *env, uintptr
 	((MM_MemorySubSpaceSemiSpace *)_subSpace)->setSurvivorSpaceSizeRatio(survivorSpaceSize / ((_highSemiSpaceRegion->getSize() + _lowSemiSpaceRegion->getSize()) / 100));
 
 	/* Broadcast that the heap has been reconfigured */
-	_subSpace->heapReconfigured(env);
+	_subSpace->heapReconfigured(env, HEAP_RECONFIG_SCAVENGER_TILT);
 }
 
 /**
@@ -1253,8 +1271,12 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::expandNoCheck(MM_EnvironmentBase *env
 		/* Broadcast the expansion of the heap, but do not add the memory to any free lists.
 		 * Must be done after segment information has been updated.
 		 */
-		_subSpace->heapAddRange(env, _subSpace, splitExpandSize, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
-		_subSpace->heapReconfigured(env);
+		bool expandResult = _subSpace->heapAddRange(env, _subSpace, splitExpandSize, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
+		if (expandResult) {
+			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, _subSpace, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
+		} else {
+			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+		}
 		
 		/* Include the memory into the free lists */
 		if(debug) {
@@ -1315,8 +1337,12 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::expandNoCheck(MM_EnvironmentBase *env
 		/* Broadcast the expansion of the heap, but do not add the memory to any free lists.
 		 * Must be done after segment information has been updated.
 		 */
-		_subSpace->heapAddRange(env, _subSpace, splitExpandSize, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
-		_subSpace->heapReconfigured(env);
+		bool expandResult = _subSpace->heapAddRange(env, _subSpace, splitExpandSize, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
+		if (expandResult) {
+			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, _subSpace, newLowAddress, (void *) (((uintptr_t)newLowAddress) + splitExpandSize));
+		} else {
+			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+		}
 
 		/* Include the memory into the free lists. */
 		if(debug) {

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4426,19 +4426,6 @@ MM_Scavenger::percolateGarbageCollect(MM_EnvironmentBase *env,  MM_MemorySubSpac
 	return result;
 }
 
-
-/**
- * Re-size all structures which are dependent on the current size of the heap.
- * No new memory has been added to a heap reconfiguration.  This call typically is the result
- * of having segment range changes (memory redistributed between segments) or the meaning of
- * memory changed.
- *
- */
-void
-MM_Scavenger::heapReconfigured(MM_EnvironmentBase *env)
-{
-}
-
 void
 MM_Scavenger::globalCollectionStart(MM_EnvironmentBase *env)
 {

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -815,8 +815,6 @@ public:
 	virtual bool canCollectorExpand(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, uintptr_t expandSize);
 	virtual uintptr_t getCollectorExpandSize(MM_EnvironmentBase *env);
 
-	virtual void heapReconfigured(MM_EnvironmentBase *env);
-
 	MM_Scavenger(MM_EnvironmentBase *env, MM_HeapRegionManager *regionManager) :
 		MM_Collector()
 		, _delegate(env)

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -283,7 +283,7 @@ OMR_GC_InitializeCollector(OMR_VMThread* omrVMThread)
 			}
 
 			/* Make sure sweep scheme is up-to-date with the heap configuration */
-			globalCollector->heapReconfigured(env);
+			globalCollector->heapReconfigured(env, HEAP_RECONFIG_EXPAND, NULL, NULL, NULL);
 		}
 	}
 

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -276,6 +276,13 @@ typedef enum {
 } CompactReason;
 
 typedef enum {
+	HEAP_RECONFIG_NONE = 0,
+	HEAP_RECONFIG_EXPAND = 1,
+	HEAP_RECONFIG_CONTRACT = 2,
+	HEAP_RECONFIG_SCAVENGER_TILT = 3
+} HeapReconfigReason;
+
+typedef enum {
 	COMPACT_PREVENTED_NONE = 0,
 	COMPACT_PREVENTED_CRITICAL_REGIONS
 } CompactPreventedReason;


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/8020

- MarkMap init consolidated

MarkMap init logic has been merged to resolve the timing hole outlined in https://github.com/eclipse/openj9/issues/8020#issuecomment-573843125. MarkMap init is dependent on Concurrent State of the global collector, with the init logic split between `heapAddRange` and `heapReconfigured`, any changes in states between the two may leave expanded mark map uninited. Hence, the decision to init (`setMarkBitsInRange`) the mark map has been moved from `heapAddRange` to `heapReconfigured` which is where we determine if an update to the init table is required (`tuneToHeap`/`determineInitWork`). As a result, init is no longer affected by the change in Concurrent state and we eliminate the timing window. This guarantees that the MarkMap will be inited, either on the spot or afterwards by updating the init table.

- Introduced `HeapReconfigReason` and reworked `heapReconfigred` API

heapReconfigred now distinguishes different reasons for reconfiguration (Expand, contract, etc), this functionality is required for the Mark Map init changes, specifically for Gencon and it is used when Scavenger resizes tenure _(PhysicalSubArenaVirtualMemorySemiSpace)_ or global collecter preforms a resize _(PhysicalSubArenaVirtualMemoryFlat)_. At the time, this new information is only consumed by Concurrent Global Collecter (ConcurrentGC.cpp), for policies making use of other collectors, the HeapReconfigReason param defaults to `NONE`.  

The Reconfig reasons are dealt in the following ways by Concurrent Global Collector:

- We should never end up in `heapReconfigured` with `RECONFIG_NONE` reason
- `RECONFIG_CONTRACT` signifies that `heapRemoveRange` had taken place, in which case, we just need to update init table (`tuneToHeap`) when Concurrent is Off, otherwise just `adjustTraceTargets`
- If `heapAddRange` takes place then `heapReconfigured` is called with `RECONFIG_EXPAND` and have have two different cases:  
      1)  heapAddRange was successful (returns true), heap reconfig should be provided with `lowAddress` & `highAddress` which will be used to init mark map
      2) heapAddRange returns false, signifies a failed `heapAddRange`, address params are expected to be NULL, in which case mark map won't be inited but we'll still either `tuneToHeap` or `adjustTraceTarget`.

Signed-off-by: Salman Rana <salman.rana@ibm.com>