### PR TITLE
AArch64: Add generateNop to code generator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -533,4 +533,13 @@ OMR::ARM64::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress,
    return
       !self()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(targetAddress, sourceAddress) ||
       self()->comp()->getOption(TR_StressTrampolines);
+   }
+
+TR::Instruction *
+OMR::ARM64::CodeGenerator::generateNop(TR::Node *node, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (self()->trHeapMemory()) TR::Instruction(TR::InstOpCode::nop, node, preced, self());
+   else
+      return new (self()->trHeapMemory()) TR::Instruction(TR::InstOpCode::nop, node, self());
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -392,6 +392,13 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     * @param[in] data : binary encoding data
     */
    void generateBinaryEncodingPrePrologue(TR_ARM64BinaryEncodingData &data);
+
+   /**
+    * @brief Generates nop
+    * @param[in] node: node
+    * @param[in] preced : preceding instruction
+    */
+   TR::Instruction *generateNop(TR::Node *node, TR::Instruction *preced = 0);
 
    private:
 


### PR DESCRIPTION
This commit adds `generateNop` function to `OMR::ARM64::CodeGenerator`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>