### PR TITLE
Added support for loadaddr in copy propagation

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2244,7 +2244,7 @@ bool TR_CopyPropagation::isCorrectToReplace(TR::Node *useNode, TR::Node *storeNo
 
 TR::Node * TR_CopyPropagation::isLoadVarWithConst(TR::Node *node)
    {
-   if (node->getOpCode().isLoadVarDirect() &&
+     if ((node->getOpCode().isLoadVarDirect() || (node->getOpCodeValue() == TR::loadaddr)) &&
        node->getSymbolReference()->getSymbol()->isAutoOrParm())
       {
       return node;


### PR DESCRIPTION
This PR is a fixed version of #4699 which caused crashes in Openj9 acceptance build. The original change will incorrectly replace `loadaddr B` with the rhs of store B, i.e. given `B = aload A`, `loadaddr B` becomes `aload A`.

The original PR is reverted in #4708, this PR adds back the change with correct behavior.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>
