### PR TITLE
Add a new dynamic constant API to dereference the pointer

### DIFF
--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -367,6 +367,7 @@ void *       TR_ResolvedMethod::getConstantDynamicTypeFromCP(int32_t cpIndex)   
 bool         TR_ResolvedMethod::isConstantDynamic(int32_t cpIndex)            { TR_UNIMPLEMENTED(); return false; }
 bool         TR_ResolvedMethod::isUnresolvedConstantDynamic(int32_t cpIndex)  { TR_UNIMPLEMENTED(); return false; }
 void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex)              { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex, uintptrj_t *obj)              { TR_UNIMPLEMENTED(); return 0; }
 void *       TR_ResolvedMethod::methodTypeConstant(int32_t)                { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::isUnresolvedMethodType(int32_t)            { TR_UNIMPLEMENTED(); return false; }
 void *       TR_ResolvedMethod::methodHandleConstant(int32_t)              { TR_UNIMPLEMENTED(); return 0; }

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,6 +138,7 @@ public:
    virtual bool isConstantDynamic(int32_t cpIndex);
    virtual bool isUnresolvedConstantDynamic(int32_t cpIndex);
    virtual void *dynamicConstant(int32_t cpIndex);
+   virtual void *dynamicConstant(int32_t cpIndex, uintptrj_t *obj);
    virtual void *methodTypeConstant(int32_t cpIndex);
    virtual bool isUnresolvedMethodType(int32_t cpIndex);
    virtual void *methodHandleConstant(int32_t cpIndex);


### PR DESCRIPTION
With `JITServer`, the dynamic constant object uintptrj_t
needs to be dereferenced at the client instead of the server.
It’s taken care of by `TR_ResolvedJ9JITServerMethod::dynamicConstant()`.
To prevent the caller from dereferencing the pointer directly at the server, adding a new `dynamicConstant` API to deference it.
The server will send one message to retrieve both the pointer
and the object values in `TR_ResolvedJ9JITServerMethod::dynamicConstant()`.
Since the caller could be run at the client or the server,
the new API should always be used when dereferencing the pointer.
The old API `dynamicConstant(int32_t cpIndex)` will be deprecated next.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>