### PR TITLE
Remove the unused Power ba and bla instructions

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -647,13 +647,11 @@ static bool isEBBTerminatingBranch(TR::Instruction *instr)
    switch (ppcInstr->getOpCodeValue())
       {
       case TR::InstOpCode::b:                // Unconditional branch
-      case TR::InstOpCode::ba:               // Branch to absolute address
       case TR::InstOpCode::bctr:             // Branch to count register
       case TR::InstOpCode::bctrl:            // Branch to count register and link
       case TR::InstOpCode::bfctr:            // Branch false to count register
       case TR::InstOpCode::btctr:            // Branch true to count register
       case TR::InstOpCode::bl:               // Branch and link
-      case TR::InstOpCode::bla:              // Branch and link to absolute address
       case TR::InstOpCode::blr:              // Branch to link register
       case TR::InstOpCode::blrl:             // Branch to link register and link
       case TR::InstOpCode::beql:             // Branch and link if equal

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,6 @@
    andi_r,           // AND immediate
    andis_r,          // AND immediate shifted
    b,                // Unconditional branch
-   ba,               // Branch to absolute address
    bctr,             // Branch to count register
    bctrl,            // Branch to count register and link
    bdnz,             // Branch if CTR!=0 after decrementing it
@@ -83,7 +82,6 @@
    blel,             // Branch and link if less than or equal
    blt,              // Branch if less than
    bltl,             // Branch and link if less than
-   bla,              // Branch and link to absolute address
    blr,              // Branch to link register
    blrl,             // Branch to link register and link
    bne,              // Branch if not equal

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -482,16 +482,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::ba,
-   /* .name        = */ "ba",
-   /* .description =    "Branch to absolute address", */
-   /* .opcode      = */ 0x48000002,
-   /* .format      = */ I_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_PPCrios1,
-   /* .properties  = */ PPCOpProp_BranchOp,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::bctr,
    /* .name        = */ "bctr",
    /* .description =    "Branch to count register", */
@@ -655,16 +645,6 @@
    /* .opcode      = */ 0x41800001,
    /* .format      = */ UNKNOWN_FORMAT,
    /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_BranchOp,
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::bla,
-   /* .name        = */ "bla",
-   /* .description =    "Branch and link to absolute address", */
-   /* .opcode      = */ 0x48000003,
-   /* .format      = */ I_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_PPCrios1,
    /* .properties  = */ PPCOpProp_BranchOp,
    },
 


### PR DESCRIPTION
Previously, the Power codegen had the ability to generate ba and bla
instructions. These instructions were able to branch to any absolute
sign-extended 24-bit address. However, the binary encoding logic never
supported these instructions and they would be exceedingly difficult to
use, as ensuring an address falls within the range a ba/bla instruction
could branch to would be difficult. As a result of this, these
instructions have been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>