### PR TITLE
Change how far conditional branch expansion works on Power

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -106,14 +106,6 @@
 #include <sys/debug.h>
 #endif
 
-static int32_t identifyFarConditionalBranches(int32_t estimate, TR::CodeGenerator *cg);
-
-
-
-
-
-
-
 OMR::Power::CodeGenerator::CodeGenerator() :
    OMR::CodeGenerator(),
      _stackPtrRegister(NULL),
@@ -1713,6 +1705,22 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
    self()->getLinkage()->createPrologue(data->cursorInstruction);
    }
 
+static void expandFarConditionalBranches(TR::CodeGenerator *cg)
+   {
+   for (TR::Instruction *instr = cg->getFirstInstruction(); instr; instr = instr->getNext())
+      {
+      TR::PPCConditionalBranchInstruction *branch = instr->getPPCConditionalBranchInstruction();
+
+      if (branch && branch->getLabelSymbol())
+         {
+         int32_t distance = branch->getLabelSymbol()->getEstimatedCodeLocation() - branch->getEstimatedBinaryLocation();
+
+         if (distance < (int32_t)TR::getMinSigned<TR::Int16>() || distance > (int32_t)TR::getMaxSigned<TR::Int16>())
+            branch->expandIntoFarBranch();
+         }
+      }
+   }
+
 void OMR::Power::CodeGenerator::doBinaryEncoding()
    {
    TR_PPCBinaryEncodingData data;
@@ -1744,9 +1752,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
 
    data.estimate = self()->setEstimatedLocationsForSnippetLabels(data.estimate);
    if (data.estimate > 32768)
-      {
-      data.estimate = identifyFarConditionalBranches(data.estimate, self());
-      }
+      expandFarConditionalBranches(self());
 
    self()->setEstimatedCodeLength(data.estimate);
 
@@ -1878,74 +1884,6 @@ TR::Register *OMR::Power::CodeGenerator::gprClobberEvaluate(TR::Node *node)
       {
       return resultReg;
       }
-   }
-
-
-static int32_t identifyFarConditionalBranches(int32_t estimate, TR::CodeGenerator *cg)
-   {
-   TR_Array<TR::PPCConditionalBranchInstruction *> candidateBranches(cg->trMemory(), 256);
-   TR::Instruction *cursorInstruction = cg->getFirstInstruction();
-
-   while (cursorInstruction)
-      {
-      TR::PPCConditionalBranchInstruction *branch = cursorInstruction->getPPCConditionalBranchInstruction();
-      if (branch != NULL)
-         {
-         if (abs(branch->getEstimatedBinaryLocation() - branch->getLabelSymbol()->getEstimatedCodeLocation()) > 16384)
-            {
-            candidateBranches.add(branch);
-            }
-         }
-      cursorInstruction = cursorInstruction->getNext();
-      }
-
-   // The following heuristic algorithm penalizes backward branches in
-   // estimation, since it should be rare that a backward branch needs
-   // a far relocation.
-
-   for (int32_t i=candidateBranches.lastIndex(); i>=0; i--)
-      {
-      int32_t myLocation=candidateBranches[i]->getEstimatedBinaryLocation();
-      int32_t targetLocation=candidateBranches[i]->getLabelSymbol()->getEstimatedCodeLocation();
-      int32_t  j;
-
-      if (targetLocation >= myLocation)
-         {
-         for (j=i+1; j<candidateBranches.size() &&
-                     targetLocation>candidateBranches[j]->getEstimatedBinaryLocation();
-              j++)
-            ;
-
-         // We might be branching to a Interface snippet which might contain a 4
-         // byte alignment in 64bit. This means we need to add 4 to the target
-         // in order to be conservatively correct for the offset calculation
-         // We could improve this by only adding 4 when the target is a Interface Call Snippet
-         if (cg->comp()->target().is64Bit())
-            targetLocation+=4;
-         if ((targetLocation-myLocation + (j-i-1)*4) >= 32768)
-            {
-            candidateBranches[i]->setFarRelocation(true);
-            }
-         else
-            {
-            candidateBranches.remove(i);
-            }
-         }
-      else    // backward branch
-         {
-         for (j=i-1; j>=0 && targetLocation<=candidateBranches[j]->getEstimatedBinaryLocation(); j--)
-            ;
-         if ((myLocation-targetLocation + (i-j-1)*4) > 32768)
-            {
-            candidateBranches[i]->setFarRelocation(true);
-            }
-         else
-            {
-            candidateBranches.remove(i);
-            }
-         }
-      }
-      return(estimate+4*candidateBranches.size());
    }
 
 bool OMR::Power::CodeGenerator::canTransformUnsafeSetMemory()

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -553,7 +553,7 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    virtual Kind getKind() { return IsConditionalBranch; }
 
-
+   void expandIntoFarBranch();
 
    TR::Register    *getConditionRegister()              {return _conditionRegister;}
    TR::Register    *setConditionRegister(TR::Register *cr) {return (_conditionRegister = cr);}
@@ -564,7 +564,6 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
    int32_t setEstimatedBinaryLocation(int32_t l) {return (_estimatedBinaryLocation = l);}
 
    bool            getFarRelocation() {return _farRelocation;}
-   bool            setFarRelocation(bool b) {return (_farRelocation = b);}
 
    bool       reverseLikeliness() {return (_likeliness = !_likeliness);}
    bool       getLikeliness()    {return _likeliness;}


### PR DESCRIPTION
On Power, the maximum distance of a conditional branch is less than the
maximum distance of an unconditional branch. As a result of this, it is
possible for the target of a conditional branch instruction to be
out of range. In this case, it is necessary to transform that
conditional branch into a flipped conditional branch around an
unconditional branch.

The previous implementation of this had several notable issues. The
expansion of conditional branches was previously delayed until
generateBinaryEncoding was called on the conditional branch in question,
resulting in that function being much more complex than it needs to be.
Additionally, the previous implementation was trying to be clever and
avoid including the extra 4 bytes of estimated length for conditional
branches in some cases, meaning that the estimated locations of
instructions/labels would actually be incorrect and any code using them
needed to manually account for potential expansion of conditional
branches.

This has now been replaced with a new implementation, which performs the
actual expansion prior to calling generateBinaryEncoding by expanding
into multiple TR::Instruction objects. Additionally, the cleverness
relating to estimated lengths of conditional branch instructions has
been removed to simplify how far conditional branches are identified.

Signed-off-by: Ben Thomas <ben@benthomas.ca>