### PR TITLE
Fix null pointer deref when encoding a MemoryReference

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1377,7 +1377,8 @@ uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
          else if (displacement != 0)
             {
             *wcursor = 0x38000000 | (displacement & 0x0000ffff);
-            index->setRegisterFieldRT(wcursor);
+            base->setRegisterFieldRT(wcursor);
+            base->setRegisterFieldRA(wcursor);
             cursor += PPC_INSTRUCTION_LENGTH;
             wcursor++;                                  // addi Rb,Rb,disp
             }


### PR DESCRIPTION
Previously, there was an issue when encoding a TR::MemoryReference on
Power that used delayed indexed form but without an index register set.
The comment in the code implied that the correct thing to do here was to
use addi to add the displacement to the base register. However, instead
we were trying to fill one of the fields of the instruction with the
index register, which was NULL. This code has now been corrected to
encode the correct instruction.

Signed-off-by: Ben Thomas <ben@benthomas.ca>