### PR TITLE
Moving supportVMInternalNatives from OMR to Openj9

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1117,8 +1117,6 @@ bool OMR::CodeGenerator::profiledPointersRequireRelocation() { return self()->co
 
 bool OMR::CodeGenerator::needGuardSitesEvenWhenGuardRemoved() { return self()->comp()->compileRelocatableCode(); }
 
-bool OMR::CodeGenerator::supportVMInternalNatives() { return !self()->comp()->compileRelocatableCode(); }
-
 bool OMR::CodeGenerator::supportsInternalPointers()
    {
    if (_disableInternalPointers)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1422,7 +1422,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool constantAddressesCanChangeSize(TR::Node *node);
    bool profiledPointersRequireRelocation();
    bool needGuardSitesEvenWhenGuardRemoved();
-   bool supportVMInternalNatives();
 
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
    bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; }


### PR DESCRIPTION
Moving supportVMInternalNatives from OMR to Openj9
  
  Moved CodeGenerator::supportVMInternalNatives() from
    OMRCodeGenerator to J9CodeGenerator with no other changes

    Resolves: #1865

Signed-off-by: Siri Sahithi Ponangi <sahithi.ponangi@unb.ca>