### PR TITLE
Merge pull request #4737 from gacholio/unsigned

### DIFF
--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -182,7 +182,7 @@ public:
 		bool const compressed = compressObjectReferences();
 		while (NULL != _scanPtr) {
 			/* while there is at least one bit-mapped slot, advance scan ptr to a non-NULL slot or end of map */
-			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == (compressed ? (uintptr_t)*(uint32_t*)_scanPtr : *(uintptr_t*)_scanPtr)))) {
+			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == GC_SlotObject::readSlot(_scanPtr, compressed)))) {
 				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 			}
@@ -254,7 +254,7 @@ public:
 		bool const compressed = compressObjectReferences();
 		while (NULL != _scanPtr) {
 			/* while there is at least one bit-mapped slot, advance scan ptr to a non-NULL slot or end of map */
-			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == (compressed ? (uintptr_t)*(uint32_t*)_scanPtr : *(uintptr_t*)_scanPtr)))) {
+			while ((0 != _scanMap) && ((0 == (1 & _scanMap)) || (0 == GC_SlotObject::readSlot(_scanPtr, compressed)))) {
 				_scanPtr = GC_SlotObject::addToSlotAddress(_scanPtr, 1, compressed);
 				_scanMap >>= 1;
 				_leafMap >>= 1;

--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -62,12 +62,20 @@ private:
 
 public:
 	/**
-	 * log2(size of an object to object reference)
+	 * Read the value of a slot.
 	 *
+	 * @param[in] slotPtr the slot address
 	 * @param[in] compressed true if object to object references are compressed, false if not
-	 * @return the shift value
+	 * @return the raw contents of the slot (NOT rebased/shifted for compressed references)
 	 */
-	MMINLINE static uintptr_t logReferenceSize(bool compressed) { return compressed ? 2 : OMR_LOG_POINTER_SIZE; }
+	MMINLINE static fomrobject_t readSlot(fomrobject_t *slotPtr, bool compressed)
+	{
+		if (compressed) {
+			return (fomrobject_t)*(uint32_t*)slotPtr;
+		} else {
+			return (fomrobject_t)*(uintptr_t*)slotPtr;
+		}
+	}
 
 	/**
 	 * Calculate the difference between two object slot addresses, in slots
@@ -77,27 +85,48 @@ public:
 	 * @param[in] compressed true if object to object references are compressed, false if not
 	 * @return p1 - p2 in slots
 	 */
-	MMINLINE static uintptr_t subtractSlotAddresses(fomrobject_t *p1, fomrobject_t *p2, bool compressed) { return ((uintptr_t)p1 - (uintptr_t)p2) >> logReferenceSize(compressed); }
+	MMINLINE static intptr_t subtractSlotAddresses(fomrobject_t *p1, fomrobject_t *p2, bool compressed)
+	{
+		if (compressed) {
+			return (uint32_t*)p1 - (uint32_t*)p2;
+		} else {
+			return (uintptr_t*)p1 - (uintptr_t*)p2;
+		}
+	}
 
 	/**
 	 * Calculate the addition of an integer to an object slot address
 	 *
-	 * @param[in] base the base slot pointer
+	 * @param[in] base the base slot address
 	 * @param[in] index the index to add
 	 * @param[in] compressed true if object to object references are compressed, false if not
 	 * @return the adjusted address
 	 */
-	MMINLINE static fomrobject_t *addToSlotAddress(fomrobject_t * base, uintptr_t index, bool compressed) { return (fomrobject_t*)((uintptr_t)base + (index << logReferenceSize(compressed))); }
+	MMINLINE static fomrobject_t *addToSlotAddress(fomrobject_t *base, intptr_t index, bool compressed)
+	{
+		if (compressed) {
+			return (fomrobject_t*)((uint32_t*)base + index);
+		} else {
+			return (fomrobject_t*)((uintptr_t*)base + index);
+		}
+	}
 
 	/**
 	 * Calculate the subtraction of an integer from an object slot address
 	 *
-	 * @param[in] base the base slot pointer
+	 * @param[in] base the base slot address
 	 * @param[in] index the index to subtract
 	 * @param[in] compressed true if object to object references are compressed, false if not
 	 * @return the adjusted address
 	 */
-	MMINLINE static fomrobject_t *subtractFromSlotAddress(fomrobject_t * base, uintptr_t index, bool compressed) { return (fomrobject_t*)((uintptr_t)base - (index << logReferenceSize(compressed))); }
+	MMINLINE static fomrobject_t *subtractFromSlotAddress(fomrobject_t *base, intptr_t index, bool compressed)
+	{
+		if (compressed) {
+			return (fomrobject_t*)((uint32_t*)base - index);
+		} else {
+			return (fomrobject_t*)((uintptr_t*)base - index);
+		}
+	}
 
 	/**
 	 * Return back true if object references are compressed


### PR DESCRIPTION
GC_SlotObject::subtractSlotPointers must return intptr_t rather than
uintptr_t to be compatible with the pointer subtraction it replaces.

Also fix the pointer math helpers to use direct pointer math instead of
computing the offsets manually.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>