### PR TITLE
Added Unix Implementations for Element Extracting Functions in OMRSOCK API

### DIFF
--- a/fvtest/porttest/omrsockTest.cpp
+++ b/fvtest/porttest/omrsockTest.cpp
@@ -94,12 +94,18 @@ TEST(PortSockTest, library_function_pointers_not_null)
 }
 
 /**
- * Test the omrsock per thread buffer.
+ * Test the omrsock per thread buffer using @ref omrsock_getaddrinfo_create_hints
+ * and all functions that extract details from the per thread buffer.
  * 
  * In this test, per thread buffer related functions set up a buffer to store
- * information such as the hints structures created in @ref omrsock_getaddrinfo_create_hints.
+ * information such as the hints structures created in 
+ * @ref omrsock_getaddrinfo_create_hints. Since the per thread buffer can't be easily 
+ * directly tested, it will be tested with @ref omrsock_getaddrinfo_create_hints.
+ *
+ * @note Errors such as invalid arguments, and/or returning the wrong family or 
+ * socket type from hints compared to the ones passed into hints, will be reported.
  */
-TEST(PortSockTest, per_thread_buffer_functionality)
+TEST(PortSockTest, create_hints_and_element_extraction)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 
@@ -115,9 +121,8 @@ TEST(PortSockTest, per_thread_buffer_functionality)
 }
 
 /**
- * Test @ref omrsock_getaddrinfo_create_hints, @ref omrsock_getaddrinfo, 
- * @ref omrsock_freeaddrinfo and all functions that extract details from
- * @ref omrsock_getaddrinfo results.
+ * Test @ref omrsock_getaddrinfo, @ref omrsock_freeaddrinfo and all functions 
+ * that extract details from @ref omrsock_getaddrinfo results.
  * 
  * In this test, the relevant variables are passed into  
  * @ref omrsock_getaddrinfo_create_hints. The generated hints are passed into 
@@ -130,7 +135,7 @@ TEST(PortSockTest, per_thread_buffer_functionality)
  * socket type from @ref omrsock_getaddrinfo compared to the ones passed into hints, 
  * will be reported.
  */
-TEST(PortSockTest, getaddrinfo_creation_and_extraction)
+TEST(PortSockTest, getaddrinfo_and_freeaddrinfo)
 {
 	/* Unimplemented. */
 }

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -2013,7 +2013,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsock.c::omrsock_getaddrinfo "omrsock_getaddrinfo"*/
 	int32_t (*sock_getaddrinfo)(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result) ;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_length "omrsock_getaddrinfo_length"*/
-	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length) ;
+	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length) ;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_family "omrsock_getaddrinfo_family"*/
 	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index )	;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_socktype "omrsock_getaddrinfo_socktype"*/

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -102,7 +102,8 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
  * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
  * @param[out] length The number of results.
  *
- * @return 0, if no errors occurred, otherwise return an error.
+ * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
+ * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
 omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
@@ -119,7 +120,8 @@ omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
  * @param[out] family The family at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
  *
- * @return 0, if no errors occurred, otherwise return an error.
+ * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
+ * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
 omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index)
@@ -136,7 +138,8 @@ omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
  * @param[out] socktype The socket type at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
  *
- * @return 0, if no errors occurred, otherwise return an error.
+ * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
+ * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
 omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index)
@@ -153,7 +156,8 @@ omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinf
  * @param[out] protocol The protocol family at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
  *
- * @return 0, if no errors occurred, otherwise return an error.
+ * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
+ * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
 omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int32_t index)

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -105,7 +105,7 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
  * @return 0, if no errors occurred, otherwise return an error.
  */
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length)
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -616,7 +616,7 @@ omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_add
 extern J9_CFUNC int32_t
 omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length);
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length);
 extern J9_CFUNC int32_t
 omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -80,7 +80,7 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 }
 
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length)
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -69,6 +69,7 @@ omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_add
 	ptbHints->ai_protocol = protocol;
 
 	(ptBuffer->addrInfoHints).addrInfo = ptbHints;
+	(ptBuffer->addrInfoHints).length = 1;
 	*hints = &ptBuffer->addrInfoHints;
 	return 0;
 }

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -83,25 +83,75 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 int32_t
 omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
 {
-	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+	if (NULL == handle) {
+		return OMRPORT_ERROR_INVALID_ARGUMENTS;
+	}
+
+	*length = handle->length;
+	return 0;
 }
 
 int32_t
 omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index)
-{
-	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+{	
+	if ((NULL == handle) || (NULL == handle->addrInfo) || (index < 0) || (index >= handle->length)) {
+		return OMRPORT_ERROR_INVALID_ARGUMENTS;
+	}
+
+	omr_os_addrinfo *info = handle->addrInfo;
+	int32_t i = 0;
+
+	for (i = 0; i < index; i++) {
+		info = info->ai_next;
+		if (NULL == info) {
+			return OMRPORT_ERROR_INVALID_ARGUMENTS;
+		}
+	}
+
+	*family = info->ai_family;
+	return 0;
 }
 
 int32_t
 omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index)
 {
-	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+	if ((NULL == handle) || (NULL == handle->addrInfo) || (index < 0) || (index >= handle->length)) {
+		return OMRPORT_ERROR_INVALID_ARGUMENTS;
+	}
+
+	omr_os_addrinfo *info = handle->addrInfo;
+	int32_t i = 0;
+	
+	for (i = 0; i < index; i++) {
+		info = info->ai_next;
+		if (NULL == info) {
+			return OMRPORT_ERROR_INVALID_ARGUMENTS;
+		}
+	}
+
+	*socktype = info->ai_socktype;
+	return 0;
 }
 
 int32_t
 omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int32_t index)
 {
-	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+	if ((NULL == handle) || (NULL == handle->addrInfo) || (index < 0) || (index >= handle->length)) {
+		return OMRPORT_ERROR_INVALID_ARGUMENTS;
+	}
+
+	omr_os_addrinfo *info = handle->addrInfo;
+	int32_t i = 0;
+
+	for (i = 0; i < index; i++) {
+		info = info->ai_next;
+		if (NULL == info) {
+			return OMRPORT_ERROR_INVALID_ARGUMENTS;
+		}
+	}
+
+	*protocol = info->ai_protocol;
+	return 0;
 }
 
 int32_t

--- a/port/win32/omrsock.c
+++ b/port/win32/omrsock.c
@@ -51,7 +51,7 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 }
 
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length)
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }


### PR DESCRIPTION
- Fixed minor changes to argument name in omrsock_getaddrinfo_length.
- Added Unix Implementations for extracting elements of OMRAddrInfoNode struct.
- Added tests to further test omrsock_getaddrinfo_create_hints and per thread buffer functions,
  using newly implemented element extraction functions.

Issue: #4745

Depends on PR: #4555 