### PR TITLE
Revert "Added support for loadaddr in copy propagation"

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2244,7 +2244,7 @@ bool TR_CopyPropagation::isCorrectToReplace(TR::Node *useNode, TR::Node *storeNo
 
 TR::Node * TR_CopyPropagation::isLoadVarWithConst(TR::Node *node)
    {
-     if ((node->getOpCode().isLoadVarDirect() || (node->getOpCodeValue() == TR::loadaddr)) &&
+   if (node->getOpCode().isLoadVarDirect() &&
        node->getSymbolReference()->getSymbol()->isAutoOrParm())
       {
       return node;


### PR DESCRIPTION
This reverts commit e1519a01cd43304b4e15e8cdcf10f17af2a0445a.

Intermittent failures are found in Openj9 build, those failures need more time to investigate, thus reverting the change.

#4740 is created to document this problem.

Signed-off-by: liqunl <liqunl@ca.ibm.com>