### PR TITLE
Track the total usage of the code cache

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1002,6 +1002,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"poisonDeadSlots",    "O\tpaints all dead slots with deadf00d", SET_OPTION_BIT(TR_PoisonDeadSlots), "F"},
    {"prepareForOSREvenIfThatDoesNothing",   "O\temit the call to prepareForOSR even if there is no slot sharing", SET_OPTION_BIT(TR_EnablePrepareForOSREvenIfThatDoesNothing), "F"},
    {"printAbsoluteTimestampInVerboseLog", "O\tPrint Absolute Timestamp in vlog", SET_OPTION_BIT(TR_PrintAbsoluteTimestampInVerboseLog), "F", NOT_IN_SUBSET},
+   {"printCodeCacheUsage",        "M\tPrint code cache usage at shutdown", SET_OPTION_BIT(TR_PrintCodeCacheUsage), "F", NOT_IN_SUBSET},
    {"printErrorInfoOnCompFailure",        "O\tPrint compilation error info to stderr", SET_OPTION_BIT(TR_PrintErrorInfoOnCompFailure), "F", NOT_IN_SUBSET},
    {"privatizeOverlaps",  "O\tif BCD storageRefs are going to overlap then do the move through a temp", SET_OPTION_BIT(TR_PrivatizeOverlaps), "F"},
    {"profile",            "O\tcompile a profiling method body", SET_OPTION_BIT(TR_Profile), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -293,7 +293,7 @@ enum TR_CompilationOptions
    TR_UseSamplingJProfilingForAllFirstTimeComps   = 0x02000000 + 6,
    TR_NoStoreAOT                          = 0x04000000 + 6,
    TR_NoLoadAOT                           = 0x08000000 + 6,
-   // Available                           = 0x10000000 + 6,
+   TR_PrintCodeCacheUsage                 = 0x10000000 + 6,
    TR_UseSamplingJProfilingForDLT                 = 0x20000000 + 6,
    TR_UseSamplingJProfilingForInterpSampledMethods= 0x40000000 + 6,
    TR_EmitRelocatableELFFile              = 0x80000000 + 6,

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,6 +126,12 @@ public:
       {
       public:
       RepositoryMonitorCriticalSection(TR::CodeCacheManager *mgr);
+      };
+
+   class UsageMonitorCriticalSection : public CriticalSection
+      {
+      public:
+      UsageMonitorCriticalSection(TR::CodeCacheManager *mgr);
       };
 
    TR::CodeCacheConfig & codeCacheConfig() { return _config; }
@@ -274,6 +280,11 @@ public:
     */
    void freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment) {}
 
+   void increaseCurrTotalUsedInBytes(size_t size);
+   void decreaseCurrTotalUsedInBytes(size_t size);
+   size_t getCurrTotalUsedInBytes() const { return _currTotalUsedInBytes; }
+   size_t getMaxUsedInBytes() const { return _maxUsedInBytes; }
+
 protected:
 
    TR::RawAllocator               _rawAllocator;
@@ -291,6 +302,9 @@ protected:
    bool                           _lowCodeCacheSpaceThresholdReached; /*!< true if close to exhausting available code cache */
    bool                           _codeCacheFull;
 
+   TR::Monitor                   *_usageMonitor;
+   size_t                         _currTotalUsedInBytes;
+   size_t                         _maxUsedInBytes;
 #if (HOST_OS == OMR_LINUX)
    public:
    /**


### PR DESCRIPTION
To support `-XX:+PrintCodeCache`(eclipse/openj9#8184), the high water
mark of the code cache usage needs to be tracked.
The usage is tracked when increasing/decreasing the code cache repository
take place and also the reuse of the free blocks in the code cache.

The code cache usage reported in the javacore dump file will
reflect this change because `increase/decreaseFreeSpaceInCodeCacheRepository`
will also be called when the free blocks are reused/freed.

Added `TR_PrintCodeCacheUsage` to `TR_CompilationOptions`. It's set
when `-XX:+PrintCodeCache` is passed to the JVM or when it's set
as an environment variable.

Also added information on the config size, the total free size,
and the used size for each code cache in `printOccupancyStats()`
which is used by OpenJ9 to show the code cache usage
when `TR_PrintCompMem` is set.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>