### PR TITLE
Migrate x86 processor info from codegen to CPU

### DIFF
--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -44,11 +44,12 @@ namespace OMR
 namespace ARM64
 {
 
-class CPU : public OMR::CPU
+class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
 protected:
 
    CPU() : OMR::CPU() {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
 public:
 

--- a/compiler/arm/env/OMRCPU.hpp
+++ b/compiler/arm/env/OMRCPU.hpp
@@ -44,11 +44,12 @@ namespace OMR
 namespace ARM
 {
 
-class CPU : public OMR::CPU
+class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
 protected:
 
    CPU() : OMR::CPU() {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
 public:
 

--- a/compiler/env/CPU.hpp
+++ b/compiler/env/CPU.hpp
@@ -26,11 +26,12 @@
 
 namespace TR
 {
-class CPU : public OMR::CPUConnector
+class OMR_EXTENSIBLE CPU : public OMR::CPUConnector
    {
    public:
 
    CPU() : OMR::CPUConnector() {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPUConnector(processorDescription) {}
 
    };
 }

--- a/compiler/env/OMRCPU.cpp
+++ b/compiler/env/OMRCPU.cpp
@@ -29,6 +29,15 @@
 #include "env/defines.h"
 #include "omrcfg.h"
 
+
+TR::CPU TR::detect(OMRPortLibrary * const omrPortLib)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc processorDescription;
+   omrsysinfo_get_processor_description(&processorDescription);
+   return TR::CPU(processorDescription);
+   }
+
 TR::CPU *
 OMR::CPU::self()
    {
@@ -87,4 +96,12 @@ OMR::CPU::initializeByHostQuery()
    _majorArch = TR::arch_unknown;
 #endif
 
+   }
+
+bool
+OMR::CPU::supportsFeature(uint32_t feature)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   BOOLEAN supported = omrsysinfo_processor_has_feature(&_processorDescription, feature);
+   return (TRUE == supported);
    }

--- a/compiler/env/OMRCompilerEnv.cpp
+++ b/compiler/env/OMRCompilerEnv.cpp
@@ -32,7 +32,8 @@ OMR::CompilerEnv::CompilerEnv(
       rawAllocator(raw),
       _initialized(false),
       _persistentAllocator(persistentAllocatorKit),
-      regionAllocator(_persistentAllocator)
+      regionAllocator(_persistentAllocator),
+      omrPortLib(NULL)
    {
    }
 

--- a/compiler/env/OMRCompilerEnv.hpp
+++ b/compiler/env/OMRCompilerEnv.hpp
@@ -107,6 +107,8 @@ public:
 
    TR::PersistentAllocator &persistentAllocator() { return _persistentAllocator; }
 
+   OMRPortLibrary * const omrPortLib;
+
 protected:
    // Initialize 'target' environment for this compiler
    //

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -27,10 +27,8 @@
 bool
 OMR::Power::CPU::getPPCis64bit()
    {
-   TR_Processor p = id();
-   TR_ASSERT(p >= TR_FirstPPCProcessor && p <= TR_LastPPCProcessor, "Not a valid PPC Processor Type");
-
-   return (p >= TR_FirstPPC64BitProcessor)? true : false;
+   TR_ASSERT(self()->id() >= TR_FirstPPCProcessor && self()->id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type");
+   return (self()->id() >= TR_FirstPPC64BitProcessor)? true : false;
    }
 
 bool
@@ -45,4 +43,25 @@ OMR::Power::CPU::isTargetWithinIFormBranchRange(intptrj_t targetAddress, intptrj
    intptrj_t range = targetAddress - sourceAddress;
    return range <= self()->maxIFormBranchForwardOffset() &&
           range >= self()->maxIFormBranchBackwardOffset();
+   }
+
+bool 
+OMR::Power::CPU::getSupportsHardwareSQRT()
+   {
+   TR_ASSERT(self()->id() >= TR_FirstPPCProcessor && self()->id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type");
+   return self()->id() >= TR_FirstPPCHwSqrtProcessor;
+   }
+
+bool
+OMR::Power::CPU::getSupportsHardwareRound()
+   {
+   TR_ASSERT(self()->id() >= TR_FirstPPCProcessor && self()->id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type");
+   return self()->id() >= TR_FirstPPCHwRoundProcessor;
+   }
+   
+bool
+OMR::Power::CPU::getSupportsHardwareCopySign()
+   {
+   TR_ASSERT(self()->id() >= TR_FirstPPCProcessor && self()->id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type");
+   return self()->id() >= TR_FirstPPCHwCopySignProcessor;
    }

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -38,25 +38,24 @@ namespace OMR { typedef OMR::Power::CPU CPUConnector; }
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
-#define VALID_PROCESSOR TR_ASSERT(id() >= TR_FirstPPCProcessor && id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type")
-
 namespace OMR
 {
 
 namespace Power
 {
 
-class CPU : public OMR::CPU
+class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
 protected:
 
    CPU() : OMR::CPU() {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
 public:
 
-   bool getSupportsHardwareSQRT() { VALID_PROCESSOR; return id() >= TR_FirstPPCHwSqrtProcessor; }
-   bool getSupportsHardwareRound() { VALID_PROCESSOR; return id() >= TR_FirstPPCHwRoundProcessor; }
-   bool getSupportsHardwareCopySign() { VALID_PROCESSOR; return id() >= TR_FirstPPCHwCopySignProcessor;}
+   bool getSupportsHardwareSQRT();
+   bool getSupportsHardwareRound();
+   bool getSupportsHardwareCopySign();
 
    bool getPPCis64bit();
    bool getPPCSupportsVMX() { return false; }

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -27,7 +27,6 @@
 #include "infra/Flags.hpp"
 #include "x/runtime/X86Runtime.hpp"
 
-
 TR_X86CPUIDBuffer *
 OMR::X86::CPU::queryX86TargetCPUID()
    {
@@ -126,3 +125,52 @@ OMR::X86::CPU::supportsTransactionalMemoryInstructions()
    flags32_t processorFeatureFlags8(self()->getX86ProcessorFeatureFlags8());
    return processorFeatureFlags8.testAny(TR_RTM);
    }
+
+bool
+OMR::X86::CPU::isGenuineIntel()
+   {
+   return self()->isAtLeast(OMR_PROCESSOR_X86_INTEL_FIRST) && self()->isAtMost(OMR_PROCESSOR_X86_INTEL_LAST);
+   }
+
+bool
+OMR::X86::CPU::isAuthenticAMD()
+   {
+   return self()->isAtLeast(OMR_PROCESSOR_X86_AMD_FIRST) && self()->isAtMost(OMR_PROCESSOR_X86_AMD_LAST);
+   }
+
+bool
+OMR::X86::CPU::requiresLFence()
+   {
+   return false;  /* Dummy for now, we may need LFENCE in future processors*/
+   }
+
+bool
+OMR::X86::CPU::supportsFCOMIInstructions()
+   {
+   return self()->supportsFeature(OMR_FEATURE_X86_FPU) || self()->supportsFeature(OMR_FEATURE_X86_CMOV);
+   }
+
+bool
+OMR::X86::CPU::supportsMFence()
+   {
+   return self()->supportsFeature(OMR_FEATURE_X86_SSE2);
+   }
+
+bool
+OMR::X86::CPU::supportsLFence()
+   {
+   return self()->supportsFeature(OMR_FEATURE_X86_SSE2);
+   }
+
+bool
+OMR::X86::CPU::supportsSFence()
+   {
+   return self()->supportsFeature(OMR_FEATURE_X86_SSE2) || self()->supportsFeature(OMR_FEATURE_X86_MMX);
+   }
+
+bool
+OMR::X86::CPU::prefersMultiByteNOP()
+   {
+   return self()->isGenuineIntel() && !self()->is(OMR_PROCESSOR_X86_INTELPENTIUM);
+   }
+

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -36,6 +36,7 @@ namespace OMR { typedef OMR::X86::CPU CPUConnector; }
 #include <stdint.h>
 #include "compiler/env/OMRCPU.hpp"
 #include "env/jittypes.h"
+#include "omrport.h"
 
 struct TR_X86CPUIDBuffer;
 namespace TR { class Compilation; }
@@ -47,11 +48,12 @@ namespace OMR
 namespace X86
 {
 
-class CPU : public OMR::CPU
+class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
 protected:
 
    CPU() : OMR::CPU() {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
 public:
 
@@ -88,9 +90,16 @@ public:
       {
       return targetAddress == sourceAddress + (int32_t)(targetAddress - sourceAddress);
       }
-
+   bool isGenuineIntel();
+   bool isAuthenticAMD();
+   
+   bool requiresLFence();
+   bool supportsFCOMIInstructions();
+   bool supportsMFence();
+   bool supportsLFence();
+   bool supportsSFence();
+   bool prefersMultiByteNOP();
    };
-
 }
 
 }

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -135,7 +135,7 @@ OMR::Z::CPU::getSupportsHardwareSQRT()
 bool
 OMR::Z::CPU::hasPopulationCountInstruction()
    {
-   return getSupportsMiscellaneousInstructionExtensions3Facility();
+   return self()->getSupportsMiscellaneousInstructionExtensions3Facility();
    }
 
 bool

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -45,7 +45,7 @@ namespace OMR
 namespace Z
 {
 
-class CPU : public OMR::CPU
+class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
    public:
 
@@ -261,8 +261,7 @@ class CPU : public OMR::CPU
    protected:
 
    CPU();
-
-   protected:
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
    enum
       {


### PR DESCRIPTION
The purpose of this change is to make x86 consistent with other platforms (Power, Z) which use the CPU class instead of codegen to query and cache processor related information.

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>