### PR TITLE
Merge the concrete classes of the refactored shared cache. 

### DIFF
--- a/sharedcache/CacheCRCChecker.cpp
+++ b/sharedcache/CacheCRCChecker.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "CacheCRCChecker.hpp"
+
+#include "omrutil.h"
+
+U_32
+CacheCRCChecker::computeRegionCRC()
+{
+    /*
+     * 1535=1.5k - 1.  Chosen so that we aren't stepping on exact power of two boundaries through
+     * the cache and yet we use a decent number of samples through the cache.
+     * For a 16Meg cache this will cause us to take 10000 samples.
+     * For a 100Meg cache this will cause us to take 68000 samples.
+     */
+
+    U_32 stepSize = 1535;
+    U_32 regionSize = _crcFocus.region()->regionSize();
+
+    if ((regionSize / stepSize) > _maxCRCSamples) {
+        stepSize = regionSize / _maxCRCSamples;
+    }
+
+    U_32 seed = omrcrc32(0, NULL, 0);
+
+    return _crcFocus.region()->computeCRC(seed, stepSize);
+}
+
+void
+CacheCRCChecker::updateRegionCRC()
+{
+    U_32 value = 0;
+
+    value = computeRegionCRC();
+
+    if (value != 0) {
+        *_crcFocus.focus() = value;
+    }
+}
+
+bool
+CacheCRCChecker::isRegionCRCValid()
+{
+    U_32 value = computeRegionCRC();
+    return *_crcFocus.focus() == value;
+}

--- a/sharedcache/CacheCRCChecker.hpp
+++ b/sharedcache/CacheCRCChecker.hpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(CACHE_CRC_CHECKER_HPP_INCLUDED)
+#define CACHE_CRC_CHECKER_HPP_INCLUDED
+
+#include "OSCacheRegionFocus.hpp"
+#include "OSCacheConfigOptions.hpp"
+
+class CacheCRCChecker
+{
+protected:
+    OSCacheRegionFocus<UDATA> _crcFocus;
+    U_32 _maxCRCSamples;
+
+public:
+    CacheCRCChecker(OSCacheRegion* region, UDATA* crcField, U_32 maxCRCSamples)
+        : _crcFocus(region, crcField)
+        , _maxCRCSamples(maxCRCSamples)
+    {}
+
+    virtual U_32 computeRegionCRC();
+    virtual void updateRegionCRC();
+    virtual bool isRegionCRCValid();
+};
+#endif

--- a/sharedcache/OSCacheContiguousRegion.cpp
+++ b/sharedcache/OSCacheContiguousRegion.cpp
@@ -1,0 +1,90 @@
+#include "OSCacheContiguousRegion.hpp"
+#include "OSCacheMemoryProtector.hpp"
+
+#include "omrutil.h"
+
+OSCacheContiguousRegion::OSCacheContiguousRegion(OSCacheLayout* layout,
+                                                 int regionID,
+                                                 bool pageBoundaryAligned)
+    : OSCacheRegion(layout, regionID)
+    , _regionStart(NULL)
+    , _regionSize(0)
+    , _pageBoundaryAligned(pageBoundaryAligned)
+{}
+
+bool
+OSCacheContiguousRegion::adjustRegionStartAndSize(void* blockAddress, uintptr_t size)
+{
+    _regionStart = blockAddress;
+    _regionSize = size;
+    return true;
+}
+
+bool
+OSCacheContiguousRegion::alignToPageBoundary(UDATA osPageSize)
+{
+    if(_pageBoundaryAligned) {
+        if(osPageSize > 0) {
+            _regionStart = (void*) ROUND_UP_TO(osPageSize, (UDATA) _regionStart);
+
+            UDATA naiveEnd   = (UDATA) _regionStart + _regionSize;
+            UDATA roundedEnd = ROUND_DOWN_TO(osPageSize, naiveEnd);
+
+            _regionSize = roundedEnd - (UDATA) _regionStart;
+            _layout->notifyRegionSizeAdjustment(*this);
+        }
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool
+OSCacheContiguousRegion::isAddressInRegion(void* itemAddress)
+{
+    return isBlockInRegion(itemAddress, 0);
+}
+
+bool
+OSCacheContiguousRegion::isBlockInRegion(void* itemAddress, UDATA itemSize)
+{
+    return (void*) ((UDATA) regionStartAddress() + regionSize()) >= (void*) ((UDATA) itemAddress + itemSize)
+        && regionStartAddress() <= itemAddress;
+}
+
+void*
+OSCacheContiguousRegion::regionEnd()
+{
+    return (void*) ((UDATA)_regionStart + _regionSize);
+}
+
+void*
+OSCacheContiguousRegion::regionStartAddress() const
+{
+    return _regionStart;
+}
+
+UDATA
+OSCacheContiguousRegion::regionSize() const
+{
+    return _regionSize;
+}
+
+UDATA
+OSCacheContiguousRegion::renderToMemoryProtectionFlags()
+{
+    return _protectionOptions->renderToFlags();
+}
+
+IDATA
+OSCacheContiguousRegion::setPermissions(OSCacheMemoryProtector* protector)
+{
+    return protector->setPermissions(*this);
+}
+
+U_32
+OSCacheContiguousRegion::computeCRC(U_32 seed, U_32 stepSize)
+{
+    return omrcrcSparse32(seed, (U_8*) _regionStart, (U_32) _regionSize, stepSize);
+}

--- a/sharedcache/OSCacheContiguousRegion.hpp
+++ b/sharedcache/OSCacheContiguousRegion.hpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#if !defined(OSCACHE_CONTIGUOUS_REGION_HPP_INCLUDED)
+#define OSCACHE_CONTIGUOUS_REGION_HPP_INCLUDED
+
+#include "CacheMemoryProtectionOptions.hpp"
+#include "OSCacheLayout.hpp"
+#include "OSCacheRegion.hpp"
+
+#include "env/TRMemory.hpp"
+#include "omrport.h"
+
+class OSCacheContiguousRegion : public OSCacheRegion
+{
+protected:
+    void* _regionStart;
+    UDATA _regionSize;
+    bool _pageBoundaryAligned;
+
+    CacheMemoryProtectionOptions* _protectionOptions;
+
+public:
+    TR_ALLOC(TR_Memory::SharedCacheRegion)
+
+    OSCacheContiguousRegion(OSCacheLayout* layout, int regionID, bool pageBoundaryAligned);
+
+    virtual void* regionStartAddress() const override;
+    virtual void* regionEnd();
+    virtual UDATA regionSize() const override;
+
+    virtual bool adjustRegionStartAndSize(void* blockAddress, uintptr_t size) override;
+    virtual bool alignToPageBoundary(UDATA osPageSize) override;
+
+    virtual UDATA renderToMemoryProtectionFlags() override;
+
+    virtual bool isAddressInRegion(void* itemAddress) override;
+    virtual bool isBlockInRegion(void* itemAddress, UDATA itemSize) override;
+
+    virtual IDATA setPermissions(OSCacheMemoryProtector* protector) override;
+
+    virtual U_32 computeCRC(U_32 seed, U_32 stepSize) override;
+
+    virtual void serialize(OSCacheRegionSerializer* serializer) override
+    {
+        serializer->serialize(this);
+    }
+
+    virtual void initialize(OSCacheRegionInitializer* initializer) override
+    {
+        initializer->initialize(this);
+    }
+};
+#endif

--- a/sharedcache/OSCacheImpl.cpp
+++ b/sharedcache/OSCacheImpl.cpp
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "omrport.h"
+
+#include "OSCacheUtils.hpp"
+#include "OSCacheImpl.hpp"
+
+OSCacheImpl::OSCacheImpl(OMRPortLibrary* library,
+			 OSCacheConfigOptions* configOptions,
+			 IDATA numLocks,
+			 char* cacheName,
+			 char* cacheLocation)
+    : OSCache(configOptions)
+    , _portLibrary(library)
+    , _numLocks(numLocks)
+    , _cacheName(cacheName)
+    , _cacheLocation(cacheLocation)
+{}
+
+IDATA
+OSCacheImpl::initCacheDirName(const char* ctrlDirName)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+
+    char fullPathName[OMRSH_MAXPATH];
+
+    IDATA openMode = _configOptions->openMode();
+    IDATA cacheDirPermissions = _configOptions->cacheDirPermissions();
+
+    if (!(_cacheLocation = (char*)omrmem_allocate_memory(OMRSH_MAXPATH, OMRMEM_CATEGORY_CLASSES))) {
+        return -1;
+    }
+
+    IDATA rc = OSCacheUtils::getCacheDirName(OMRPORTLIB,
+                                             ctrlDirName,
+                                             _cacheLocation,
+                                             OMRSH_MAXPATH,
+                                             _configOptions);
+
+    if (rc == -1) {
+        return -1;
+    }
+
+    rc = OSCacheUtils::createCacheDir(OMRPORTLIB,
+                                      _cacheLocation,
+                                      cacheDirPermissions,
+                                      ctrlDirName == NULL);
+    if (rc == -1) {
+        /* remove trailing '/' */
+        _cacheLocation[strlen(_cacheLocation)-1] = '\0';
+        return -1;
+    }
+
+    /* In the original commonStartup, there are here segments of code
+       that should be provided by overloading subclasses, or handled by
+       checks to the configuration object. Also, stuff with generation
+       and version labels, and buildIDs. How the cachePathName is
+       populated using that information. */
+    return 0;
+}
+
+/* This is an unhelpful name that describes an obscure feature: the
+   ability to disclaim regions of memory from page
+   protection. Specifically, if an area of memory is no longer needed
+   by a program, the program can use the disclaim64 routine to declare
+   it as such to AIX OS. Hence the flag. The omrmmap_dont_need
+   routine wraps it inside port/unix/omrmmap.c. If OMR is running on
+   Linux or OS X (which is vastly more likely), the call
+   madvise((void*)roundedStart, roundedLength, MADV_DONTNEED) is used
+   instead (it does the same thing, basically, but because it's an
+   "advisement", it shrinks from making hard guarantees). madvise is
+   documented here:
+
+   http://man7.org/linux/man-pages/man2/madvise.2.html
+*/
+
+void
+OSCacheImpl::dontNeedMetadata(const void* startAddress, size_t length)
+{
+    /* AIX does not allow memory to be disclaimed for memory mapped files */
+#if !defined(AIXPPC)
+    /* why does it need the specific VM?!? It only appears to use it to get at the
+       portLibrary. But the _portLibrary just points to a table of C functions. I can't
+       imagine how those addresses might be dependent on the thread or VM objects.
+       This seems totally unnecessary to me, since we have _portLibrary at the ready
+       in this class. So, I've removed the VM parameter. */
+    //OMRPORT_ACCESS_FROM_VMC(currentThread->_vm);
+    OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+    omrmmap_dont_need(startAddress, length);
+#endif
+}
+
+void
+OSCacheImpl::commonInit()
+{
+    _errorCode = 0;
+    _runningReadOnly = false;
+}
+
+void
+OSCacheImpl::commonCleanup()
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+
+    Trc_SHR_OSC_commonCleanup_Entry();
+
+    if (_cacheName) {
+        omrmem_free_memory(_cacheName);
+    }
+
+    if (_cachePathName) {
+        omrmem_free_memory(_cachePathName);
+    }
+
+    if (_cacheLocation) {
+        omrmem_free_memory(_cacheLocation);
+    }
+
+    /* If the cache is destroyed and then restarted, we still need portLibrary, versionData and generation */
+    commonInit();
+
+    Trc_SHR_OSC_commonCleanup_Exit();
+}
+
+/**
+ * Sets the protection as specified by flags for the memory pages
+ * containing all or part of the interval address->(address+len)
+ *
+ * @param[in] portLibrary An instance of portLibrary
+ * @param[in] address 	Pointer to the shared memory region.
+ * @param[in] length	The size of memory in bytes spanning the region in which we want to set protection
+ * @param[in] flags 	The specified protection to apply to the pages in the specified interval
+ *
+ * @return 0 if the operations has been successful, -1 if an error has occured
+ */
+IDATA
+OSCacheImpl::setRegionPermissions(OSCacheRegion* region)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+
+    OSCacheMemoryProtector* protector = constructMemoryProtector();
+    return region->setPermissions(protector);
+}

--- a/sharedcache/OSCacheImpl.hpp
+++ b/sharedcache/OSCacheImpl.hpp
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OSCACHE_IMPL_HPP_INCLUDED)
+#define OSCACHE_IMPL_HPP_INCLUDED
+
+#include <cstring>
+
+#include "OSCache.hpp"
+#include "OSCacheConfigOptions.hpp"
+#include "OSCacheMemoryProtector.hpp"
+
+#include "omr.h"
+#include "omrport.h"
+#include "ut_omrshr.h"
+
+typedef enum SH_CacheFileAccess {
+    OMRSH_CACHE_FILE_ACCESS_ALLOWED 				= 0,
+    OMRSH_CACHE_FILE_ACCESS_CANNOT_BE_DETERMINED,
+    OMRSH_CACHE_FILE_ACCESS_GROUP_ACCESS_REQUIRED,
+    OMRSH_CACHE_FILE_ACCESS_OTHERS_NOT_ALLOWED,
+} SH_CacheFileAccess;
+
+#define OMRSH_OSCACHE_CREATE 			0x1
+#define OMRSH_OSCACHE_OPEXIST_DESTROY	0x2
+#define OMRSH_OSCACHE_OPEXIST_STATS		0x4
+#define OMRSH_OSCACHE_OPEXIST_DO_NOT_CREATE	0x8
+#define OMRSH_OSCACHE_UNKNOWN -1
+
+/*
+ * The different results from attempting to open/create a cache are
+ * defined below. Failure cases MUST all be less than zero.
+ */
+#define OMRSH_OSCACHE_OPENED 2
+#define OMRSH_OSCACHE_CREATED 1
+#define OMRSH_OSCACHE_FAILURE -1
+#define OMRSH_OSCACHE_CORRUPT -2
+#define OMRSH_OSCACHE_NO_CACHE -6
+
+#define OMRSH_OSCACHE_HEADER_OK 0
+#define OMRSH_OSCACHE_HEADER_CORRUPT -2
+#define OMRSH_OSCACHE_HEADER_MISSING -3
+#define OMRSH_OSCACHE_SEMAPHORE_MISMATCH -5
+
+#define OMRSH_OSCACHE_READONLY_RETRY_COUNT 10
+#define OMRSH_OSCACHE_READONLY_RETRY_SLEEP_MILLIS 10
+
+#define OSC_TRACE(configOptions, var) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_INFO, var)
+#define OSC_TRACE1(configOptions, var, p1) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_INFO, var, p1)
+#define OSC_TRACE2(configOptions, var, p1, p2) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_INFO, var, p1, p2)
+#define OSC_ERR_TRACE(configOptions, var) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_ERROR, var)
+#define OSC_ERR_TRACE1(configOptions, var, p1) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_ERROR, var, p1)
+#define OSC_ERR_TRACE2(configOptions, var, p1, p2) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_ERROR, var, p1, p2)
+#define OSC_ERR_TRACE4(configOptions, var, p1, p2, p3, p4) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_ERROR, var, p1, p2, p3, p4)
+#define OSC_WARNING_TRACE(configOptions, var) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_WARNING, var)
+#define OSC_WARNING_TRACE1(configOptions, var, p1) if (configOptions->verboseEnabled()) omrnls_printf(J9NLS_WARNING, var, p1)
+
+#define OMRSH_MAXPATH EsMaxPath
+
+class OSCacheIterator;
+
+/*
+ * This class houses utility functions that depend on the state of
+ * cache internals. Those that don't depend on cache internals are static
+ * functions, and are stored in the OSCache*Utils namespaces.
+ */
+class OSCacheImpl : public OSCache
+{
+protected:   
+    omrthread_t self;
+    OMRPortLibrary* _portLibrary;
+
+    UDATA _runningReadOnly;
+    IDATA _errorCode;
+
+    IDATA _numLocks;
+
+    char *_cacheLocation;
+    char *_cacheName;
+    char *_cachePathName;
+    
+public:
+    OSCacheImpl(OMRPortLibrary* library, OSCacheConfigOptions* configOptions, IDATA numLocks,
+                char* cacheName, char* cacheLocation);
+
+    virtual ~OSCacheImpl()
+    {
+        omrthread_t self = (omrthread_t) NULL;
+        omrthread_attach_ex(&self, J9THREAD_ATTR_DEFAULT);
+
+        _portLibrary->port_shutdown_library(_portLibrary);
+        omrthread_detach(self);
+    }
+
+    /**
+     * Advise the OS to release resources used by a section of the shared classes cache
+     */
+    virtual void dontNeedMetadata(const void* startAddress, size_t length);
+
+    virtual OSCacheIterator* constructCacheIterator(char* resultBuf) = 0;
+
+    bool runningReadOnly() const
+    {
+        return _runningReadOnly;
+    }
+
+    virtual bool startup(const char* cacheName, const char* ctrlDirName) = 0;
+
+    virtual bool started()  = 0;
+    virtual void finalise() = 0;
+
+    virtual const char* cacheLocation()
+    {
+        return _cacheLocation;
+    }
+
+    OMRPortLibrary* portLibrary()
+    {
+        return _portLibrary;
+    }
+
+    OSCacheConfigOptions* configOptions()
+    {
+        return _configOptions;
+    }
+
+    virtual OSCacheMemoryProtector* constructMemoryProtector() = 0;
+
+    virtual IDATA setRegionPermissions(OSCacheRegion* region);
+
+protected:
+    virtual IDATA initCacheDirName(const char* ctrlDirName);
+    virtual IDATA initCacheName(const char* cacheName) = 0;
+
+    virtual void errorHandler(U_32 moduleName, U_32 id, LastErrorInfo *lastErrorInfo) = 0;
+
+    void initialize();
+
+    void commonInit();
+    void commonCleanup();
+
+    virtual IDATA verifyCacheHeader() = 0;
+};
+#endif

--- a/sharedcache/OSCacheRegionBumpFocus.hpp
+++ b/sharedcache/OSCacheRegionBumpFocus.hpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OS_CACHE_REGION_BUMP_FOCUS_HPP_INCLUDED)
+#define OS_CACHE_REGION_BUMP_FOCUS_HPP_INCLUDED
+
+#include "OSCacheContiguousRegion.hpp"
+#include "OSCacheRegionFocus.hpp"
+
+#include "omrport.h"
+
+template <typename T>
+class OSCacheRegionBumpFocus : public OSCacheRegionFocus<T>
+{
+public:
+    OSCacheRegionBumpFocus(OSCacheContiguousRegion* region, T* focus)
+        : OSCacheRegionFocus<T>(region, focus)
+    {}
+
+    inline operator T*()
+    {
+        return this->_focus;
+    }
+
+    inline operator const T*() const
+    {
+        return this->_focus;
+    }
+
+    OSCacheRegionBumpFocus& operator +=(UDATA bump)
+    {
+        if (!blockInRange(bump)) {
+            return *this;
+        }
+
+        this->_focus = (T*) ((U_8*) (this->_focus) + bump);
+        
+        return *this;
+    }
+
+    T* operator ++(int)
+    {
+        if (!blockInRange(sizeof(T))) {
+            return NULL;
+        }
+
+        T* focus = this->_focus;
+        this->_focus++;
+        
+        return focus;
+    }
+
+    inline bool operator <(const OSCacheRegionBumpFocus<T>& rhs) const
+    {
+        return this->_region == rhs._region && this->_focus < rhs._focus;
+    }
+
+    inline bool operator ==(const OSCacheRegionBumpFocus<T>& rhs) const
+    {
+        return this->_region == rhs._region && this->_focus == rhs._focus;
+    }
+
+    virtual OSCacheRegionBumpFocus<T>& operator =(T* newFocus)
+    {
+        this->_focus = newFocus;
+        return *this;
+    }
+
+protected:
+    inline bool blockInRange(UDATA size) const
+    {
+        return this->_region->isBlockInRegion((void*) this->_focus, size);
+    }
+};
+#endif

--- a/sharedcache/OSCacheRegionFocus.hpp
+++ b/sharedcache/OSCacheRegionFocus.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OS_CACHE_REGION_FOCUS_HPP_INCLUDED)
+#define OS_CACHE_REGION_FOCUS_HPP_INCLUDED
+
+#include "OSCacheRegion.hpp"
+
+#include "shrnls.h"
+#include "ut_omrshr.h"
+
+template <typename T>
+class OSCacheRegionFocus
+{
+protected:
+    OSCacheRegion* _region;
+    T* _focus;
+
+public:
+    OSCacheRegionFocus(OSCacheRegion* region, T* focus)
+        : _region(region)
+        , _focus(focus)
+    {
+        Trc_SHR_Assert_True(region != NULL && region->isAddressInRegion((void*) focus));
+    }
+
+    OSCacheRegion* region()
+    {
+        return _region;
+    }
+
+    T* focus() const
+    {
+        return _focus;
+    }  
+};
+#endif

--- a/sharedcache/OSCacheStats.hpp
+++ b/sharedcache/OSCacheStats.hpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+x * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+*******************************************************************************/
+
+#if !defined(OS_CACHE_STATS_HPP_INCLUDED)
+#define OS_CACHE_STATS_HPP_INCLUDED
+
+#include "omrport.h"
+
+class OSCacheStats
+{
+public:
+    virtual IDATA prepareCache(const char* cacheName, const char* cacheDirName) = 0;
+    virtual void shutdownCache() = 0;
+    virtual void getCacheStats() = 0;
+};
+#endif

--- a/sharedcache/OSCacheUtils.cpp
+++ b/sharedcache/OSCacheUtils.cpp
@@ -1,0 +1,239 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#include "omrcfg.h"
+#include "omrargscan.h"
+#include "omrport.h"
+#include "pool_api.h"
+#include "shrnls.h"
+#include "omrsharedhelper.h"
+#include "sharedconsts.h"
+
+#include "OSCacheImpl.hpp"
+#include "OSCacheConfigOptions.hpp"
+#include "OSCacheUtils.hpp"
+
+IDATA
+OSCacheUtils::getCacheDirName(OMRPortLibrary* portLibrary,
+                              const char* ctrlDirName,
+                              char* buffer,
+                              UDATA bufferSize,
+                              OSCacheConfigOptions* configOptions)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+    IDATA rc;
+
+    /* Cache directory used is the omrshmem dir, regardless of whether we're using omrshmem or omrmmap */
+
+    if ((NULL == ctrlDirName) && !configOptions->groupAccessEnabled())
+        {
+            /* omrshmem_getDir() always tries the CSIDL_LOCAL_APPDATA directory (C:\Documents and Settings\username\Local Settings\Application Data)
+             * first on Windows if ctrlDirName is NULL, regardless of whether OMRSHMEM_GETDIR_USE_USERHOME is set or not. So OMRSHMEM_GETDIR_USE_USERHOME is effective on UNIX only.
+             */
+
+            configOptions->useUserHomeDirectoryForCacheDir();
+        }
+
+    rc = omrshmem_getDir(ctrlDirName, configOptions->renderToFlags(), buffer, bufferSize);
+
+    if (rc == -1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Create the directory to use for the cache file or control file(s)
+ *
+ * @param [in] portLibrary  A portLibrary
+ * @param[in] cacheDirName The name of the cache directory
+ * @param[in] cacheDirPermissions The permissions of the created cache directory
+ * @param[in] cleanMemorySegments, set TRUE to call cleanSharedMemorySegments. It will clean sysv memory segments.
+ *                              It should be set to TRUE if the ctrlDirName is NULL. This stops shared memory
+ *                              from being leaked when wiped from /tmp, the default sysv location if ctrlDirName
+ *                              is NULL.
+ *
+ * Returns -1 for error, >=0 for success
+ */
+IDATA
+OSCacheUtils::createCacheDir(OMRPortLibrary* portLibrary, char* cacheDirName, UDATA cacheDirPermissions, bool cleanMemorySegments)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+    IDATA rc;
+
+    Trc_SHR_OSC_createCacheDir_Entry(cacheDirName, cleanMemorySegments);
+
+    omrthread_t self;
+    omrthread_attach_ex(&self, J9THREAD_ATTR_DEFAULT);
+
+    rc = omrshmem_createDir(cacheDirName, cacheDirPermissions, cleanMemorySegments);
+
+    omrthread_detach(self);
+
+    Trc_SHR_OSC_createCacheDir_Exit();
+    return rc;
+}
+
+/* Returns the full path of a cache based on the current cacheDir value */
+IDATA
+OSCacheUtils::getCachePathName(OMRPortLibrary* portLibrary,
+                               const char* cacheDirName,
+                               char* buffer,
+                               UDATA bufferSize,
+                               const char* cacheName)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+
+    Trc_SHR_OSC_getCachePathName_Entry(cacheName);
+
+    omrstr_printf(buffer, bufferSize, "%s%s", cacheDirName, cacheName);
+
+    Trc_SHR_OSC_getCachePathName_Exit();
+
+    return 0;
+}
+
+UDATA
+OSCacheUtils::statCache(OMRPortLibrary* portLibrary,
+                        const char* cacheDirName,
+                        const char* cacheName,
+                        bool displayNotFoundMsg)
+{
+    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+    char fullPath[OMRSH_MAXPATH];
+
+    Trc_SHR_OSC_statCache_Entry(cacheName);
+
+    omrstr_printf(fullPath, OMRSH_MAXPATH, "%s%s", cacheDirName, cacheName);
+
+    if (omrfile_attr(fullPath) == EsIsFile) {
+        Trc_SHR_OSC_statCache_cacheFound();
+        return 1;
+    }
+
+    if (displayNotFoundMsg) {
+        omrnls_printf(J9NLS_ERROR, OMRNLS_SHRC_OSCACHE_NOT_EXIST);
+    }
+
+    Trc_SHR_OSC_statCache_cacheNotFound();
+    return 0;
+}
+
+/**
+ * This method performs additional checks to catch scenarios that are not handled by permission and/or mode settings provided by operating system,
+ * to avoid any unintended access to shared cache file
+ *
+ * @param [in] portLibrary  The port library
+ * @param [in] findHandle  The handle of the shared cache file
+ * @param[in] openMode The file access mode
+ * @param[in] lastErrorInfo     Pointer to store last portable error code and/or message
+ *
+ * @return enum SH_CacheFileAccess indicating if the process can access the shared cache file set or not
+ */
+SH_CacheFileAccess
+OSCacheUtils::checkCacheFileAccess(OMRPortLibrary *portLibrary,
+                                   UDATA fileHandle,
+                                   OSCacheConfigOptions* configOptions,
+                                   LastErrorInfo *lastErrorInfo)
+{
+    SH_CacheFileAccess cacheFileAccess = OMRSH_CACHE_FILE_ACCESS_ALLOWED;
+
+    if (NULL != lastErrorInfo) {
+        lastErrorInfo->_lastErrorCode = 0;
+    }
+
+#if !defined(WIN32)
+    OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+    J9FileStat statBuf;
+    IDATA rc = omrfile_fstat(fileHandle, &statBuf);
+
+    if (-1 != rc) {
+        UDATA uid = omrsysinfo_get_euid();
+
+        if (statBuf.ownerUid != uid) {
+            UDATA gid = omrsysinfo_get_egid();
+            bool sameGroup = false;
+
+            if (statBuf.ownerGid == gid) {
+                sameGroup = true;
+                Trc_SHR_OSC_File_checkCacheFileAccess_GroupIDMatch(gid, statBuf.ownerGid);
+            } else {
+                /* check supplementary groups */
+                U_32 *list = NULL;
+                IDATA size = 0;
+                IDATA i = 0;
+
+                size = omrsysinfo_get_groups(&list, OMRMEM_CATEGORY_CLASSES_SHC_CACHE);
+                if (size > 0) {
+                    for (i = 0; i < size; i++) {
+                        if (statBuf.ownerGid == list[i]) {
+                            sameGroup = true;
+                            Trc_SHR_OSC_File_checkCacheFileAccess_SupplementaryGroupMatch(list[i], statBuf.ownerGid);
+                            break;
+                        }
+                    }
+                } else {
+                    cacheFileAccess = OMRSH_CACHE_FILE_ACCESS_CANNOT_BE_DETERMINED;
+                    if (NULL != lastErrorInfo) {
+                        lastErrorInfo->populate(OMRPORTLIB);
+                    }
+
+                    Trc_SHR_OSC_File_checkCacheFileAccess_GetGroupsFailed();
+                    goto _end;
+                }
+                if (NULL != list) {
+                    omrmem_free_memory(list);
+                }
+            }
+            if (sameGroup) {
+                /* This process belongs to same group as owner of the shared cache file. */
+                if (configOptions->groupAccessEnabled()) {
+                    /* If 'groupAccess' option is not set, it implies this process wants to access a shared cache file that it created.
+                     * But this process is not the owner of the cache file.
+                     * This implies we should not allow this process to use the cache.
+                     */
+                    cacheFileAccess = OMRSH_CACHE_FILE_ACCESS_GROUP_ACCESS_REQUIRED;
+                    Trc_SHR_OSC_File_checkCacheFileAccess_GroupAccessRequired();
+                }
+            } else {
+                /* This process does not belong to same group as owner of the shared cache file.
+                 * Do not allow access to the cache.
+                 */
+                cacheFileAccess = OMRSH_CACHE_FILE_ACCESS_OTHERS_NOT_ALLOWED;
+                Trc_SHR_OSC_File_checkCacheFileAccess_OthersNotAllowed();
+            }
+        }
+    } else {
+        cacheFileAccess = OMRSH_CACHE_FILE_ACCESS_CANNOT_BE_DETERMINED;
+
+        if (NULL != lastErrorInfo) {
+            lastErrorInfo->populate(OMRPORTLIB);
+        }
+
+        Trc_SHR_OSC_File_checkCacheFileAccess_FileStatFailed();
+    }
+
+ _end:
+#endif /* !defined(oWIN32) */
+
+    return cacheFileAccess;
+}

--- a/sharedcache/OSCacheUtils.hpp
+++ b/sharedcache/OSCacheUtils.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OS_CACHE_UTILS_HPP_INCLUDED)
+#define OS_CACHE_UTILS_HPP_INCLUDED
+
+#include "OSCacheConfigOptions.hpp"
+#include "OSCacheImpl.hpp"
+
+#include "omr.h"
+#include "ut_omrshr.h"
+
+class OSCacheUtils
+{
+public:
+  static IDATA getCacheDirName(OMRPortLibrary* portLibrary,
+                               const char* ctrlDirName,
+                               char* buffer,
+                               UDATA bufferSize,
+                               OSCacheConfigOptions* configOptions);
+
+  static IDATA createCacheDir(OMRPortLibrary* portLibrary,
+                              char* cacheDirName,
+                              UDATA cacheDirPermissions,
+                              bool cleanMemorySegments);
+    
+  static IDATA getCachePathName(OMRPortLibrary* portLibrary,
+                                const char* cacheDirName,
+                                char* buffer,
+                                UDATA bufferSize,
+                                const char* cacheName);
+    
+  static UDATA statCache(OMRPortLibrary* portLibrary,
+                         const char* cacheDirName,
+                         const char* cacheName,
+                         bool displayNotFoundMsg);
+    
+  static SH_CacheFileAccess checkCacheFileAccess(OMRPortLibrary *portLibrary,
+                                                 UDATA fileHandle,
+                                                 OSCacheConfigOptions* configOptions,
+                                                 LastErrorInfo *lastErrorInfo);
+};
+#endif

--- a/sharedcache/SynchronizedCacheCounter.cpp
+++ b/sharedcache/SynchronizedCacheCounter.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "SynchronizedCacheCounter.hpp"
+
+bool
+SynchronizedCacheCounter::incrementCount(OSCacheImpl& osCache)
+{
+    UDATA oldNum, value;
+
+    if (!osCache.started() || osCache.runningReadOnly()) {
+        Trc_SHR_Assert_ShouldNeverHappen();
+        return false;
+    }
+
+    oldNum = *_regionFocus.focus();
+    value = 0;
+
+    osCache.setRegionPermissions(_regionFocus.region());
+
+    do {
+        value = oldNum + 1;
+        oldNum = VM_AtomicSupport::lockCompareExchange(_regionFocus.focus(), oldNum, value);
+    } while ((UDATA)value != (oldNum + 1));
+
+    osCache.setRegionPermissions(_regionFocus.region());
+
+    Trc_SHR_CC_incReaderCount_Exit(value);
+
+    return true;
+}
+
+bool
+SynchronizedCacheCounter::decrementCount(OSCacheImpl& osCache)
+{
+    UDATA oldNum, value;
+
+    if (!osCache.started() || osCache.runningReadOnly()) {
+        Trc_SHR_Assert_ShouldNeverHappen();
+        return false;
+    }
+
+    oldNum = *_regionFocus.focus();
+    value = 0;
+
+    do {
+        if (0 == oldNum) {
+            break;
+        }
+
+        value = oldNum - 1;
+        oldNum = VM_AtomicSupport::lockCompareExchange(_regionFocus.focus(), oldNum, value);
+    } while ((UDATA) value != (oldNum - 1));
+
+    Trc_SHR_CC_decReaderCount_Exit(value);
+
+    return true;
+}
+
+volatile UDATA
+SynchronizedCacheCounter::count() const {
+    return *_regionFocus.focus();
+}

--- a/sharedcache/SynchronizedCacheCounter.hpp
+++ b/sharedcache/SynchronizedCacheCounter.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+#if !defined(SYNCHRONIZED_CACHE_COUNTER_HPP_INCLUDED)
+#define SYNCHRONIZED_CACHE_COUNTER_HPP_INCLUDED
+
+#include "OSCacheImpl.hpp"
+#include "OSCacheRegionFocus.hpp"
+
+#include "AtomicSupport.hpp"
+#include "omr.h"
+#include "omrport.h"
+#include "shrnls.h"
+#include "ut_omrshr.h"
+
+class SynchronizedCacheCounter
+{
+protected:
+    OSCacheRegionFocus<volatile UDATA> _regionFocus;
+
+public:
+    SynchronizedCacheCounter(OSCacheRegion* region, UDATA* counter)
+        : _regionFocus(region, counter)
+    {}
+
+    virtual bool incrementCount(OSCacheImpl& osCache);
+    virtual bool decrementCount(OSCacheImpl& osCache);
+
+    virtual volatile UDATA count() const;
+};
+#endif


### PR DESCRIPTION
These classes are further down the OSCache class hierarchy than the
abstract OSCache classes, but higher up than the semantic-specific
classes.

Issue: #4610

Signed-off-by: Mark Thom <mark.thom@unb.ca>