### PR TITLE
AArch64: Add code for compressed refs - l2aEvaluator, aloadEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -401,8 +401,23 @@ OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
    node->setRegister(tempReg);
 
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ldrimmx, node, tempReg, tempMR);
+   TR::InstOpCode::Mnemonic op;
+   int32_t sizeOfMR;
+
+   if (TR::Compiler->om.generateCompressedObjectHeaders() &&
+       (node->getSymbol()->isClassObject() ||
+        (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())))
+      {
+      op = TR::InstOpCode::ldrimmw;
+      sizeOfMR = 4;
+      }
+   else
+      {
+      op = TR::InstOpCode::ldrimmx;
+      sizeOfMR = 8;
+      }
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, sizeOfMR, cg);
+   generateTrg1MemInstruction(cg, op, node, tempReg, tempMR);
 
    if (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())
       {

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -188,7 +188,7 @@
     TR::TreeEvaluator::l2dEvaluator, // TR::l2d		// convert long integer to double
     TR::TreeEvaluator::l2iEvaluator, // TR::l2b		// convert long integer to byte
     TR::TreeEvaluator::l2iEvaluator, // TR::l2s		// convert long integer to short integer
-    TR::TreeEvaluator::passThroughEvaluator, // TR::l2a		// convert long integer to address
+    TR::TreeEvaluator::l2aEvaluator, // TR::l2a		// convert long integer to address
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lu2fEvaluator ,	// TR::lu2f		// convert unsigned long integer to float
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lu2dEvaluator ,	// TR::lu2d		// convert unsigned long integer to double
     TR::TreeEvaluator::passThroughEvaluator, // TR::lu2a		// convert unsigned long integer to address


### PR DESCRIPTION
This commit adds code for compressed refs for AArch64:
l2aEvaluator(), aloadEvaluator()

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>