### PR TITLE
AArch64: Add code for compressed refs to memory reference

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -391,6 +391,15 @@ void OMR::ARM64::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
 
 void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::CodeGenerator *cg)
    {
+   if (cg->comp()->useCompressedPointers())
+      {
+      if (subTree->getOpCodeValue() == TR::l2a && subTree->getReferenceCount() == 1 && subTree->getRegister() == NULL)
+         {
+         cg->decReferenceCount(subTree);
+         subTree = subTree->getFirstChild();
+         }
+      }
+
    if (subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL)
       {
       if (_baseRegister != NULL)


### PR DESCRIPTION
This commit adds code to support compressed references to
`OMR::ARM64::MemoryReference::populateMemoryRefernce`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>