### PR TITLE
AArch64: Add code for compressed refs - istoreEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -511,7 +511,14 @@ OMR::ARM64::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg
 TR::Register *
 OMR::ARM64::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::strimmw, 4, cg);
+   TR::Compilation *comp = cg->comp();
+
+   commonStoreEvaluator(node, TR::InstOpCode::strimmw, 4, cg);
+
+   if (comp->useCompressedPointers() && node->getOpCode().isIndirect())
+      node->setStoreAlreadyEvaluated(true);
+
+   return NULL;
    }
 
 TR::Register *


### PR DESCRIPTION
This commit adds code to support compressed references
to `istoreEvaluator` in aarch64.
It calls `setStoreAlreadyEvaluated` when using compressed refs
and the store is indirect.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>