### PR TITLE
Revert "Make double map true as default option "

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1358,7 +1358,7 @@ public:
 		, largePageFailOnError(false)
 		, largePageFailedToSatisfy(false)
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-		, isArrayletDoubleMapRequested(true)
+		, isArrayletDoubleMapRequested(false)
 #endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
 		, requestedPageSize(0)
 		, requestedPageFlags(OMRPORT_VMEM_PAGE_FLAG_NOT_USED)


### PR DESCRIPTION
Reverts eclipse/omr#4735

This PR is causing intermittent failures in openj9, that will take some time to fix. Reverting this PR will make the double-mapping feature disabled by default.