### PR TITLE
CMake: Refactor _LONG_LONG definition

### DIFF
--- a/cmake/modules/platform/arch/s390.cmake
+++ b/cmake/modules/platform/arch/s390.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 # the distinction
 set(TR_HOST_ARCH    z)
 set(TR_HOST_BITS    64)
-list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_S390 TR_TARGET_S390)
+list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_S390 TR_TARGET_S390 _LONG_LONG)
 
 if(OMR_ENV_DATA64)
 	list(APPEND TR_COMPILE_DEFINITIONS TR_HOST_64BIT TR_TARGET_64BIT BITVECTOR_64BIT)

--- a/cmake/modules/platform/os/linux.cmake
+++ b/cmake/modules/platform/os/linux.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,6 @@ elseif(OMR_HOST_ARCH STREQUAL "s390")
 
 	list(APPEND OMR_PLATFORM_DEFINITIONS
 		-DS390
-		-D_LONG_LONG
 	)
 endif()
 


### PR DESCRIPTION
In the autoconf world _LONG_LONG is only defined by the compiler component.
Update cmake config to reflect that.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>