### PR TITLE
Remove unused compressed ref flags

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,7 +147,6 @@ set(OMR_GC_VLHGC OFF CACHE BOOL "TODO: Document")
 set(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD OFF CACHE BOOL "Enable VLHGC concurrent copy forward")
 
 set(OMR_INTERP_HAS_SEMAPHORES ON CACHE BOOL "TODO: Document")
-set(OMR_INTERP_SMALL_MONITOR_SLOT OFF CACHE BOOL "TODO: Document")
 
 set(OMR_THR_ADAPTIVE_SPIN ON CACHE BOOL "TODO: Document")
 set(OMR_THR_JLM ON CACHE BOOL "TODO: Document")

--- a/configure
+++ b/configure
@@ -683,8 +683,6 @@ OMR_THR_CUSTOM_SPIN_OPTIONS
 OMR_THR_THREE_TIER_LOCKING
 OMR_THR_FORK_SUPPORT
 OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-OMR_INTERP_SMALL_MONITOR_SLOT
-OMR_INTERP_COMPRESSED_OBJECT_HEADER
 OMR_GC_COMPRESSED_POINTERS
 OMR_ENV_DATA64
 OMR_ARCH_RISCV
@@ -794,7 +792,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -877,8 +874,6 @@ enable_OMR_ARCH_S390
 enable_OMR_ARCH_RISCV
 enable_OMR_ENV_DATA64
 enable_OMR_GC_COMPRESSED_POINTERS
-enable_OMR_INTERP_COMPRESSED_OBJECT_HEADER
-enable_OMR_INTERP_SMALL_MONITOR_SLOT
 enable_OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 enable_OMR_THR_FORK_SUPPORT
 enable_OMR_THR_THREE_TIER_LOCKING
@@ -974,7 +969,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1227,15 +1221,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1373,7 +1358,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1526,7 +1511,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1666,10 +1650,6 @@ Optional Features:
   --enable-OMR_ARCH_RISCV
   --enable-OMR_ENV_DATA64
   --enable-OMR_GC_COMPRESSED_POINTERS
-
-  --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER
-
-  --enable-OMR_INTERP_SMALL_MONITOR_SLOT
 
   --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 
@@ -5800,44 +5780,6 @@ else
 fi
 else
   OMR_GC_COMPRESSED_POINTERS=0
-
-
-fi
-
-
-# Check whether --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER was given.
-if test "${enable_OMR_INTERP_COMPRESSED_OBJECT_HEADER+set}" = set; then :
-  enableval=$enable_OMR_INTERP_COMPRESSED_OBJECT_HEADER; if test "x${enableval}" = xyes; then :
-  OMR_INTERP_COMPRESSED_OBJECT_HEADER=1
-
-   $as_echo "#define OMR_INTERP_COMPRESSED_OBJECT_HEADER 1" >>confdefs.h
-
-else
-  OMR_INTERP_COMPRESSED_OBJECT_HEADER=0
-
-
-fi
-else
-  OMR_INTERP_COMPRESSED_OBJECT_HEADER=0
-
-
-fi
-
-
-# Check whether --enable-OMR_INTERP_SMALL_MONITOR_SLOT was given.
-if test "${enable_OMR_INTERP_SMALL_MONITOR_SLOT+set}" = set; then :
-  enableval=$enable_OMR_INTERP_SMALL_MONITOR_SLOT; if test "x${enableval}" = xyes; then :
-  OMR_INTERP_SMALL_MONITOR_SLOT=1
-
-   $as_echo "#define OMR_INTERP_SMALL_MONITOR_SLOT 1" >>confdefs.h
-
-else
-  OMR_INTERP_SMALL_MONITOR_SLOT=0
-
-
-fi
-else
-  OMR_INTERP_SMALL_MONITOR_SLOT=0
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2019 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -434,8 +434,6 @@ OMRCFG_DEFINE_FLAG([OMR_ENV_DATA64],[],
 )
 
 OMRCFG_DEFINE_FLAG_OFF([OMR_GC_COMPRESSED_POINTERS])
-OMRCFG_DEFINE_FLAG_OFF([OMR_INTERP_COMPRESSED_OBJECT_HEADER])
-OMRCFG_DEFINE_FLAG_OFF([OMR_INTERP_SMALL_MONITOR_SLOT])
 
 OMRCFG_DEFINE_FLAG_OFF([OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS])
 

--- a/example/glue/configure_includes/configure_aix_ppc.mk
+++ b/example/glue/configure_includes/configure_aix_ppc.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,8 +39,6 @@ ifeq (aix_ppc-64_cmprssptrs, $(SPEC))
     --enable-OMR_ARCH_POWER \
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 endif

--- a/example/glue/configure_includes/configure_linux_390.mk
+++ b/example/glue/configure_includes/configure_linux_390.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,8 +39,6 @@ ifeq (linux_390-64_cmprssptrs_codecov, $(SPEC))
     --enable-OMR_ARCH_S390 \
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 endif
@@ -51,8 +49,6 @@ ifeq (linux_390-64_cmprssptrs, $(SPEC))
     --enable-OMR_ARCH_S390 \
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 endif

--- a/example/glue/configure_includes/configure_linux_ppc.mk
+++ b/example/glue/configure_includes/configure_linux_ppc.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,8 +68,6 @@ ifeq (linux_ppc-64_cmprssptrs_gcc, $(SPEC))
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_ENV_GCC \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 endif
@@ -83,8 +81,6 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc_cuda, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_JITBUILDER \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_OPT_CUDA \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_TEST_COMPILER \
@@ -100,8 +96,6 @@ ifeq (linux_ppc-64_cmprssptrs_le_gcc, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_JITBUILDER \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_TEST_COMPILER \
     --enable-OMR_THR_FORK_SUPPORT
@@ -114,8 +108,6 @@ ifeq (linux_ppc-64_cmprssptrs_le, $(SPEC))
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 
@@ -128,8 +120,6 @@ ifeq (linux_ppc-64_cmprssptrs, $(SPEC))
     --enable-OMR_ARCH_POWER \
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
 

--- a/example/glue/configure_includes/configure_linux_riscv.mk
+++ b/example/glue/configure_includes/configure_linux_riscv.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,9 +71,7 @@ endif
 
 ifneq (,$(findstring _cmprssptrs, $(SPEC)))
   CONFIGURE_ARGS += \
-    --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT
+    --enable-OMR_GC_COMPRESSED_POINTERS
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o

--- a/example/glue/configure_includes/configure_linux_x86.mk
+++ b/example/glue/configure_includes/configure_linux_x86.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,8 +52,6 @@ ifeq (linux_x86-64_cmprssptrs_cuda, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_GC_TLH_PREFETCH_FTA \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_OPT_CUDA \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_THR_FORK_SUPPORT
@@ -67,8 +65,6 @@ ifeq (linux_x86-64_cmprssptrs, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_GC_TLH_PREFETCH_FTA \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
     --enable-OMR_PORT_NUMA_SUPPORT \
     --enable-OMR_THR_FORK_SUPPORT

--- a/example/glue/configure_includes/configure_win_x86.mk
+++ b/example/glue/configure_includes/configure_win_x86.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,8 +47,6 @@ ifeq (win_x86-64_cmprssptrs_cuda, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_GC_TLH_PREFETCH_FTA \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_OPT_CUDA \
     --enable-OMR_PORT_ALLOCATE_TOP_DOWN \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
@@ -62,8 +60,6 @@ ifeq (win_x86-64_cmprssptrs, $(SPEC))
     --enable-OMR_ENV_LITTLE_ENDIAN \
     --enable-OMR_GC_COMPRESSED_POINTERS \
     --enable-OMR_GC_TLH_PREFETCH_FTA \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_ALLOCATE_TOP_DOWN \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 endif

--- a/example/glue/configure_includes/configure_zos_390.mk
+++ b/example/glue/configure_includes/configure_zos_390.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,8 +41,6 @@ ifeq (zos_390-64_cmprssptrs, $(SPEC))
     --enable-OMR_ARCH_S390 \
     --enable-OMR_ENV_DATA64 \
     --enable-OMR_GC_COMPRESSED_POINTERS \
-    --enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-    --enable-OMR_INTERP_SMALL_MONITOR_SLOT \
     --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
 endif
 

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -151,11 +151,6 @@
 #cmakedefine OMR_GC_TLH_PREFETCH_FTA
 #cmakedefine OMR_GC_VLHGC
 
-/**
- * Flag to indicate that on 64-bit platforms, the monitor slot in object headers is a U32 rather than a UDATA.
- * ifRemoved: The monitor slot is a UDATA.
- */
-#cmakedefine OMR_INTERP_SMALL_MONITOR_SLOT
 
 /**
  * Add support for CUDA

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,17 +142,6 @@
 #undef OMR_GC_REALTIME
 #undef OMR_GC_TLH_PREFETCH_FTA
 #undef OMR_GC_VLHGC
-
-/**
- * Flag to indicate that on 64-bit platforms, the monitor slot and class slot in object headers are U32 rather than UDATA.
- */
-#undef OMR_INTERP_COMPRESSED_OBJECT_HEADER
-
-/**
- * Flag to indicate that on 64-bit platforms, the monitor slot in object headers is a U32 rather than a UDATA.
- * ifRemoved: The monitor slot is a UDATA.
- */
-#undef OMR_INTERP_SMALL_MONITOR_SLOT
 
 /**
  * Add support for CUDA

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2019 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,9 +74,7 @@ OMR_GC_THREAD_LOCAL_HEAP := @OMR_GC_THREAD_LOCAL_HEAP@
 OMR_GC_TLH_PREFETCH_FTA := @OMR_GC_TLH_PREFETCH_FTA@
 OMR_GC_VLHGC := @OMR_GC_VLHGC@
 OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD := @OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD@
-OMR_INTERP_COMPRESSED_OBJECT_HEADER := @OMR_INTERP_COMPRESSED_OBJECT_HEADER@
 OMR_INTERP_HAS_SEMAPHORES := @OMR_INTERP_HAS_SEMAPHORES@
-OMR_INTERP_SMALL_MONITOR_SLOT := @OMR_INTERP_SMALL_MONITOR_SLOT@
 OMR_COMPILER := @OMR_COMPILER@
 OMR_JITBUILDER := @OMR_JITBUILDER@
 OMR_NOTIFY_POLICY_CONTROL := @OMR_NOTIFY_POLICY_CONTROL@


### PR DESCRIPTION
OMR_INTERP_COMPRESSED_OBJECT_HEADER and OMR_INTERP_SMALL_MONITOR_SLOT
are no longer used for anything

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>