### PR TITLE
Use setProperty instead of setProperties in Z system linkages

### DIFF
--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,7 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
       TR::SystemLinkage(cg, TR_SystemLinux)
    {
    setProperties(FirstParmAtFixedOffset);
-   setProperties(SmallIntParmsAlignedRight);
+   setProperty(SmallIntParmsAlignedRight);
 
    if (cg->comp()->target().is64Bit())
       {

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -89,8 +89,7 @@ TR::S390zOSSystemLinkage::S390zOSSystemLinkage(TR::CodeGenerator* cg)
       _ppa2Snippet(NULL)
    {
    setProperties(FirstParmAtFixedOffset);
-   setProperties(SmallIntParmsAlignedRight);
-
+   setProperty(SmallIntParmsAlignedRight);
    setProperty(SplitLongParm);
    setProperty(SkipGPRsForFloatParms);
 


### PR DESCRIPTION
The `setProperties` API overrides all previously set properties, while
the `setProperty` API appends a property to the existing list. We want
the latter, not the former semantics.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>