### PR TITLE
heapReconfigure API Rework Follow-Up

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -195,19 +195,8 @@ public:
 	 * moved from one subspace to another.
 	 * @param env[in] The thread which performed the change in heap geometry 
 	 */
-	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress)
-	{
-		heapReconfigured(env); /* Required temporarily to not break dependency with heapReconfigure API changes */
-	};
+	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress) {}
 	
-	/* Required temporarily to not break dependency with heapReconfigure API changes */
-	virtual void heapReconfigured(MM_EnvironmentBase *env) 
-	{
-		/* ALl collectors except Scavenger & Realtime should have their own implementation */
-		MM_GCPolicy gc_policy = env->getExtensions()->configurationOptions._gcPolicy;
-		Assert_MM_true(gc_policy == OMR_GC_POLICY_METRONOME || gc_policy == OMR_GC_POLICY_GENCON);
-	};
-
 	/**
 	 * Post collection broadcast event, indicating that the collection has been completed.
 	 * @param subSpace the memory subspace where the collection occurred

--- a/gc/base/PhysicalSubArenaVirtualMemoryFlat.cpp
+++ b/gc/base/PhysicalSubArenaVirtualMemoryFlat.cpp
@@ -120,9 +120,9 @@ MM_PhysicalSubArenaVirtualMemoryFlat::inflate(MM_EnvironmentBase *env)
 			MM_MemorySubSpace *genericSubSpace = ((MM_MemorySubSpaceFlat *)_subSpace)->getChildSubSpace();
 			result = genericSubSpace->expanded(env, this, _region->getSize(), lowAddress, highAddress, false);
 			if (result) {
-				_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, genericSubSpace, lowAddress, highAddress);
+				genericSubSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, genericSubSpace, lowAddress, highAddress);
 			} else {
-				_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+				genericSubSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
 			}
 		}
 	}
@@ -221,9 +221,9 @@ MM_PhysicalSubArenaVirtualMemoryFlat::expandNoCheck(MM_EnvironmentBase *env, uin
 
 		if(result) {
 			genericSubSpace->addExistingMemory(env, this, expandSize, lowExpandAddress, highExpandAddress, true);
-			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, genericSubSpace, lowExpandAddress, highExpandAddress);
+			genericSubSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND, genericSubSpace, lowExpandAddress, highExpandAddress);
 		} else {
-			_subSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
+			genericSubSpace->heapReconfigured(env, HEAP_RECONFIG_EXPAND);
 		}
 	}
 


### PR DESCRIPTION
Follow-up changes to https://github.com/eclipse/omr/pull/4716 to remove code which was required temporarily to not break OpenJ9 heapReconfigured API dependency 

Signed-off-by: Salman Rana <salman.rana@ibm.com>