### PR TITLE
WIP: Decouple TR_PrexArgInfo from TR_InlinerTracer

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3862,8 +3862,6 @@ TR_IndirectCallSite::addTargetIfThereIsSingleImplementer (TR_InlinerBase* inline
 
 bool TR_IndirectCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner)
    {
-   //inliner->tracer()->dumpPrexArgInfo(_ecsPrexArgInfo);
-
    if (addTargetIfMethodIsNotOverriden(inliner) ||
        addTargetIfMethodIsNotOverridenInReceiversHierarchy(inliner) ||
        addTargetIfThereIsSingleImplementer(inliner) ||

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -6420,7 +6420,8 @@ OMR_InlinerUtil::clearArgInfoForNonInvariantArguments(TR_CallTarget *target, TR_
       {
       if (tracePrex)
          traceMsg(comp(), "ARGS PROPAGATION: argInfo %p after clear arg info for non-invariant arguments", argInfo);
-      argInfo->dumpTrace();
+      if (tracer->heuristicLevel())
+         argInfo->dumpTrace();
       }
    }
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -6280,30 +6280,6 @@ TR_InlinerDelimiter::~TR_InlinerDelimiter()
    debugTrace(_tracer,"</%s>",_tag);
    }
 
-void TR_InlinerTracer::dumpPrexArgInfo(TR_PrexArgInfo* argInfo)
-   {
-   if (!argInfo || !heuristicLevel())
-      return;
-
-   traceMsg( comp(),  "<argInfo address = %p numArgs = %d>\n", argInfo, argInfo->getNumArgs());
-   for (int i = 0 ; i < argInfo->getNumArgs(); i++)
-
-      {
-      TR_PrexArgument* arg = argInfo->get(i);
-      if (arg && arg->getClass())
-         {
-         char* className = TR::Compiler->cls.classSignature(comp(), arg->getClass(), trMemory());
-         traceMsg( comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d argIsKnownObject=%d koi=%d class=%p className= %s/>\n",
-         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->hasKnownObjectIndex(), arg->getKnownObjectIndex(), arg->getClass(), className);
-         }
-      else
-         {
-         traceMsg( comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d/>\n", i, arg, arg ? arg->classIsFixed() : 0, arg ? arg->classIsPreexistent() : 0);
-         }
-      }
-      traceMsg( comp(),  "</argInfo>\n");
-   }
-
 bool
 OMR_InlinerPolicy::willBeInlinedInCodeGen(TR::RecognizedMethod method)
    {
@@ -6446,7 +6422,7 @@ OMR_InlinerUtil::clearArgInfoForNonInvariantArguments(TR_CallTarget *target, TR_
       {
       if (tracePrex)
          traceMsg(comp(), "ARGS PROPAGATION: argInfo %p after clear arg info for non-invariant arguments", argInfo);
-      tracer->dumpPrexArgInfo(argInfo);
+      argInfo->dumpTrace();
       }
    }
 

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -129,7 +129,6 @@ class TR_InlinerTracer : public TR_LogTracer
       void dumpCallTarget (TR_CallTarget *, const char *fmt, ...);
       void dumpInline (TR_LinkHead<TR_CallTarget> *targets, const char *fmt, ...);
       void dumpPartialInline (TR_InlineBlocks *partialInline);
-      void dumpPrexArgInfo(TR_PrexArgInfo* argInfo);
 
       void dumpDeadCalls(TR_LinkHead<TR_CallSite> *sites);
 

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -68,7 +68,6 @@ TR_PrexArgument::TR_PrexArgument(
 void TR_PrexArgInfo::dumpTrace() {
    traceMsg(TR::comp(),  "<argInfo address = %p numArgs = %d>\n", this, getNumArgs());
    for (int i = 0 ; i < getNumArgs(); i++)
-
       {
       TR_PrexArgument* arg = get(i);
       if (arg && arg->getClass())

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -64,3 +64,23 @@ TR_PrexArgument::TR_PrexArgument(
       }
 #endif
    }
+
+void TR_PrexArgInfo::dumpTrace() {
+   traceMsg(TR::comp(),  "<argInfo address = %p numArgs = %d>\n", this, getNumArgs());
+   for (int i = 0 ; i < getNumArgs(); i++)
+
+      {
+      TR_PrexArgument* arg = get(i);
+      if (arg && arg->getClass())
+         {
+         char* className = TR::Compiler->cls.classSignature(TR::comp(), arg->getClass(), TR::comp()->trMemory());
+         traceMsg(TR::comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d argIsKnownObject=%d koi=%d class=%p className= %s/>\n",
+         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->hasKnownObjectIndex(), arg->getKnownObjectIndex(), arg->getClass(), className);
+         }
+      else
+         {
+         traceMsg(TR::comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d/>\n", i, arg, arg ? arg->classIsFixed() : 0, arg ? arg->classIsPreexistent() : 0);
+         }
+      }
+   traceMsg(TR::comp(),  "</argInfo>\n");
+}

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -140,6 +140,8 @@ class TR_PrexArgInfo
 
    int32_t getNumArgs() { return _numArgs; }
 
+   void dumpTrace();
+
    private:
 
    int32_t _numArgs;

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -26,9 +26,9 @@
 #include <string.h>
 #include "env/KnownObjectTable.hpp"
 #include "env/TRMemory.hpp"
+#include "ras/LogTracer.hpp"
 
 class TR_CallSite;
-class TR_InlinerTracer;
 class TR_OpaqueClassBlock;
 class TR_VirtualGuard;
 namespace TR { class Compilation; }
@@ -109,15 +109,15 @@ class TR_PrexArgInfo
    static TR_PrexArgInfo* enhance(TR_PrexArgInfo *dest, TR_PrexArgInfo *source, TR::Compilation *comp);
 
    static void propagateReceiverInfoIfAvailable (TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-                                              TR_PrexArgInfo * argInfo, TR_InlinerTracer *tracer);
+                                              TR_PrexArgInfo * argInfo, TR_LogTracer *tracer);
 
    static void propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-      TR_PrexArgInfo * argInfo, TR_InlinerTracer *tracer);
+      TR_PrexArgInfo * argInfo, TR_LogTracer *tracer);
 
-   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_InlinerTracer *tracer);
+   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_LogTracer *tracer);
 
-   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
-   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
+   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_LogTracer* tracer);
+   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_LogTracer* tracer);
    /**
     * \brief
     *    Get arg info for arguments of callNode that are parameters of the caller
@@ -148,7 +148,7 @@ class TR_PrexArgInfo
    TR_PrexArgument **_args;
    //
 #ifdef J9_PROJECT_SPECIFIC
-   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_InlinerTracer* tracer);
+   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_LogTracer* tracer);
    static bool hasArgInfoForChild (TR::Node *child, TR_PrexArgInfo * argInfo);
    static TR_PrexArgument* getArgForChild(TR::Node *child, TR_PrexArgInfo* argInfo);
 #endif


### PR DESCRIPTION
Move code from TR_InlinerTracer into TR_PrexArgInfo class so that TR_PrexArgInfo is no longer tightly couple to the TR_InlinerTracer class.

This should make the TR_PrexArgInfo class more reusable.

- Move code from `TR_InlinerTracer::dumpPrexArgInfo` into the new method `TR_PrexArgInfo::dumpTrace`
- Change `TR_PrexArgInfo` method signatures to accept a `TR_LogTracer` argument instead of a `TR_InlinerTracer` argument since `TR_LogTracer` is a less specialized class.

Note: this needs to be merged at the same time as https://github.com/eclipse/openj9/pull/8419

Fixes: https://github.com/eclipse/openj9/issues/7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>