### PR TITLE
Add VectorFacilityEnhancement1 feature on Z::CPU

### DIFF
--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -350,6 +350,27 @@ OMR::Z::CPU::setSupportsVectorFacilityEnhancement2(bool value)
    else
       {
       _flags.reset(S390SupportsVectorFacilityEnhancement2);
+      }
+
+   return value;
+   }
+
+bool
+OMR::Z::CPU::getSupportsVectorFacilityEnhancement1()
+   {
+   return _flags.testAny(S390SupportsVectorFacilityEnhancement1);
+   }
+
+bool
+OMR::Z::CPU::setSupportsVectorFacilityEnhancement1(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsVectorFacilityEnhancement1);
+      }
+   else
+      {
+      _flags.reset(S390SupportsVectorFacilityEnhancement1);
       }
 
    return value;

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -204,6 +204,19 @@ class CPU : public OMR::CPU
     *     Determines whether the Vector Enhancement 2 facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsVectorFacilityEnhancement2(bool value);
+
+   /** \brief
+    *     Determines whether the Vector Enhancement 1 facility is available on the current processor.
+    */
+   bool getSupportsVectorFacilityEnhancement1();
+   
+   /** \brief
+    *     Determines whether the Vector Enhancement 1 facility is available on the current processor.
+    *
+    *  \param value
+    *     Determines whether the Vector Enhancement 1 facility is available (if \c true) or not (if \c false).
+    */
+   bool setSupportsVectorFacilityEnhancement1(bool value);
    
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
@@ -270,6 +283,7 @@ class CPU : public OMR::CPU
       S390SupportsMIE3                         = 0x00400000,
       S390SupportsVectorFacilityEnhancement2   = 0x00800000,
       S390SupportsVectorPDEnhancementFacility  = 0x01000000,
+      S390SupportsVectorFacilityEnhancement1   = 0x02000000,
       };
 
    Architecture _supportedArch;


### PR DESCRIPTION
Add associated flag, set and get function for `VectorFacilityEnhancement1` feature for z platform. This feature is required for recognizing `Math.fma` method on Z platform.

Issue: eclipse/openj9#7474
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>