### PR TITLE
Remove duplicate if branches from addConstantToLong

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3616,11 +3616,7 @@ TR::Register *addConstantToLong(TR::Node * node, TR::Register *srcHighReg, TR::R
    TR::Register *highReg = cg->allocateRegister();
    TR::RegisterPair *trgReg = cg->allocateRegisterPair(lowReg, highReg);
 
-   if (lowValue >= 0 && lowValue <= UPPER_IMMED)
-      {
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addic, node, lowReg, srclowReg, lowValue);
-      }
-   else if (lowValue >= LOWER_IMMED && lowValue < 0)
+   if (lowValue >= LOWER_IMMED && lowValue <= UPPER_IMMED)
       {
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addic, node, lowReg, srclowReg, lowValue);
       }


### PR DESCRIPTION
Previously, the addConstantToLong function used on 32-bit performed two
separate checks to see if an addic instruction could be used to perform
the lower part of the addition with duplicate code. The duplicate
branches of this if statement have now been merged together with one
check for the range of lowValue.

This has been done because the previous code was optimized incorrectly
by XLC 13.1 on ppc32 Linux under certain conditions and the range check
would not work correctly, resulting in an invalid addic instruction
being generated.

Signed-off-by: Ben Thomas <ben@benthomas.ca>