### PR TITLE
Add Identityless node flag

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5751,6 +5751,35 @@ OMR::Node::printIsHeapificationAlloc()
    }
 
 
+bool
+OMR::Node::isIdentityless()
+   {
+   TR_ASSERT(self()->getOpCode().isNew(), "Opcode must be isNew");
+   return _flags.testAny(Identityless);
+   }
+
+void
+OMR::Node::setIdentityless(bool v)
+   {
+   TR::Compilation * c = TR::comp();
+   TR_ASSERT(self()->getOpCode().isNew(), "Opcode must be isNew");
+   if (performNodeTransformation2(c,"O^O NODE FLAGS: Setting Identityless flag on node %p to %d\n", self(), v))
+      _flags.set(Identityless, v);
+   }
+
+bool
+OMR::Node::chkIdentityless()
+   {
+   return self()->getOpCode().isNew() && _flags.testAny(Identityless);
+   }
+
+const char *
+OMR::Node::printIsIdentityless()
+   {
+   return self()->chkIdentityless() ? "Identityless " : "";
+   }
+
+
 
 bool
 OMR::Node::isLiveMonitorInitStore()

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1121,10 +1121,16 @@ public:
    bool chkHeapificationStore();
    const char * printIsHeapificationStore();
 
+   // Flags only used for isNew() opcodes
    bool isHeapificationAlloc();
    void setHeapificationAlloc(bool v);
    bool chkHeapificationAlloc();
    const char * printIsHeapificationAlloc();
+
+   bool isIdentityless();
+   void setIdentityless(bool v);
+   bool chkIdentityless();
+   const char * printIsIdentityless();
 
    bool isLiveMonitorInitStore();
    void setLiveMonitorInitStore(bool v);
@@ -2086,6 +2092,7 @@ protected:
       // Flags only used for isNew() opcodes
       //
       HeapificationAlloc                    = 0x00001000,
+      Identityless                          = 0x00002000,
 
       // Flag used by TR::newarray and TR::anewarray
       //

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1095,6 +1095,7 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
 #endif
    output.append(format, node->printIsHeapificationStore());
    output.append(format, node->printIsHeapificationAlloc());
+   output.append(format, node->printIsIdentityless());
    output.append(format, node->printIsLiveMonitorInitStore());
    output.append(format, node->printIsMethodEnterExitGuard());
    output.append(format, node->printReturnIsDummy());


### PR DESCRIPTION
This flag expresses that the identity of the resulting object of a node
is unobservable. Eventually, this flag will enable transformations that
take advantage of the lack of identity.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>