### PR TITLE
Compile with xlc_r on AIX

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -23,7 +23,7 @@ pipeline {
             steps {
                 timestamps {
                     checkout scm
-                    
+
                     setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
@@ -36,7 +36,7 @@ pipeline {
 
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
+                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
 
                         echo 'Compile...'
                         sh '''export CCACHE_EXTRAFILES="$PWD/omrcfg.h" && make -j8'''

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
@@ -22,7 +22,7 @@ pipeline {
 
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
+                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
 
                         echo 'Compile...'
                         sh '''export CCACHE_EXTRAFILES="$PWD/omrcfg.h" && make -j4'''


### PR DESCRIPTION
xlc_r is the reentrant version of xlc. Invoking the compiler changes
many default configuration, to produce thread-safe code. As well,
pthreads will be linked by default to each executable.

Signed-off-by: Robert Young <rwy0717@gmail.com>