### PR TITLE
Remove dynamicConstant(int32_t cpIndex)

### DIFF
--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -366,7 +366,6 @@ bool         TR_ResolvedMethod::isUnresolvedString(int32_t, bool optimizeForAOT)
 void *       TR_ResolvedMethod::getConstantDynamicTypeFromCP(int32_t cpIndex)   { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::isConstantDynamic(int32_t cpIndex)            { TR_UNIMPLEMENTED(); return false; }
 bool         TR_ResolvedMethod::isUnresolvedConstantDynamic(int32_t cpIndex)  { TR_UNIMPLEMENTED(); return false; }
-void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex)              { TR_UNIMPLEMENTED(); return 0; }
 void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex, uintptrj_t *obj)              { TR_UNIMPLEMENTED(); return 0; }
 void *       TR_ResolvedMethod::methodTypeConstant(int32_t)                { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::isUnresolvedMethodType(int32_t)            { TR_UNIMPLEMENTED(); return false; }

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -137,7 +137,6 @@ public:
    virtual bool isUnresolvedString(int32_t cpIndex, bool optimizeForAOT = false);
    virtual bool isConstantDynamic(int32_t cpIndex);
    virtual bool isUnresolvedConstantDynamic(int32_t cpIndex);
-   virtual void *dynamicConstant(int32_t cpIndex);
    virtual void *dynamicConstant(int32_t cpIndex, uintptrj_t *obj);
    virtual void *methodTypeConstant(int32_t cpIndex);
    virtual bool isUnresolvedMethodType(int32_t cpIndex);


### PR DESCRIPTION
PR #4726 adds a new `dynamicConstant()` API
`dynamicConstant(int32_t cpIndex, uintptrj_t *obj)`.
The new API dereferences the dynamic constant object pointer
into the passed in parameter `obj`. The reason is that
in the JITServer mode, the server will need to send a message
to the client to retrieve both the pointer and the object value
in TR_ResolvedJ9JITServerMethod::dynamicConstant().
Since the caller of dynamicConstant () could be run at the
client or the server, the new API should always be used
when the dynamic constant object pointer needs to be dereferenced.

It'd be a better practice to deprecate
dynamicConstant(int32_t cpIndex) to reduce the chances
of the caller from dereferencing the pointer directly at the server.

Closes #4731

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>