### PR TITLE
Common getOffsetToFirstParm in the linkage class across codegens

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -192,7 +192,7 @@ TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
-   _properties._offsetToFirstParm             = 0; // To be determined
+   self()->setOffsetToFirstParm(0); // To be determined
    _properties._offsetToFirstLocal            = 0; // To be determined
    }
 

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -192,7 +192,7 @@ TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
-   self()->setOffsetToFirstParm(0); // To be determined
+   setOffsetToFirstParm(0); // To be determined
    _properties._offsetToFirstLocal            = 0; // To be determined
    }
 

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -101,7 +101,6 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _j9methodArgumentRegister; // for icallVMprJavaSendStatic
    uint8_t _numberOfDependencyGPRegisters;
-   int8_t _offsetToFirstParm;
    int8_t _offsetToFirstLocal;
 
    uint32_t getNumIntArgRegs() const {return _numIntegerArgumentRegisters;}
@@ -263,8 +262,6 @@ struct ARM64LinkageProperties
       {
       return _j9methodArgumentRegister;
       }
-
-   int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1118,16 +1118,17 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
 
    TR::Machine *machine = _cg->machine();
-   const TR::ARMLinkageProperties &linkage = _cg->getLinkage(methodSymbol->getLinkageConvention())->getProperties();
+   TR::Linkage* linkage = _cg->getLinkage(methodSymbol->getLinkageConvention());
+   const TR::ARMLinkageProperties &linkageProperties = linkage->getProperties();
 
    uint32_t numIntArgs   = 0;
    uint32_t numFloatArgs = 0;
 
    int32_t offset;
-   if (linkage.getRightToLeft())
-      offset = linkage.getOffsetToFirstParm();
+   if (linkageProperties.getRightToLeft())
+      offset = linkage->getOffsetToFirstParm();
    else
-      offset = snippet->getSizeOfArguments() + linkage.getOffsetToFirstParm();
+      offset = snippet->getSizeOfArguments() + linkage->getOffsetToFirstParm();
 
    for (int i = callNode->getFirstArgumentIndex(); i < callNode->getNumChildren(); i++)
       {
@@ -1137,68 +1138,68 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
          case TR::Int16:
          case TR::Int32:
          case TR::Address:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 4;
-            if (numIntArgs < linkage.getNumIntArgRegs())
+            if (numIntArgs < linkageProperties.getNumIntArgRegs())
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "str\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
+               print(pOutFile, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(numIntArgs)));
                bufferPos += 4;
                }
             numIntArgs++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 4;
             break;
          case TR::Int64:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 8;
-            if (numIntArgs < linkage.getNumIntArgRegs())
+            if (numIntArgs < linkageProperties.getNumIntArgRegs())
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "str\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
+               print(pOutFile, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(numIntArgs)));
                bufferPos += 4;
-               if (numIntArgs < linkage.getNumIntArgRegs() - 1)
+               if (numIntArgs < linkageProperties.getNumIntArgRegs() - 1)
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 4);
                   trfprintf(pOutFile, "str\t[gr7, %+d], ", offset + 4);
-                  print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs + 1)));
+                  print(pOutFile, machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(numIntArgs + 1)));
                   bufferPos += 4;
                   }
                }
             numIntArgs += 2;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 8;
             break;
 // TODO FLOAT
 #if 0
          case TR::Float:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 4;
-            if (numFloatArgs < linkage.getNumFloatArgRegs())
+            if (numFloatArgs < linkageProperties.getNumFloatArgRegs())
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "stfs\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
+               print(pOutFile, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(numFloatArgs)));
                bufferPos += 4;
                }
             numFloatArgs++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 4;
             break;
          case TR::Double:
-            if (!linkage.getRightToLeft())
+            if (!linkageProperties.getRightToLeft())
                offset -= 8;
-            if (numFloatArgs < linkage.getNumFloatArgRegs())
+            if (numFloatArgs < linkageProperties.getNumFloatArgRegs())
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "stfd\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
+               print(pOutFile, machine->getRealRegister(linkageProperties.getFloatArgumentRegister(numFloatArgs)));
                bufferPos += 4;
                }
             numFloatArgs++;
-            if (linkage.getRightToLeft())
+            if (linkageProperties.getRightToLeft())
                offset += 8;
             break;
 #endif

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1118,7 +1118,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
 
    TR::Machine *machine = _cg->machine();
-   TR::Linkage* linkage = _cg->getLinkage(methodSymbol->getLinkageConvention());
+   TR::Linkage *linkage = _cg->getLinkage(methodSymbol->getLinkageConvention());
    const TR::ARMLinkageProperties &linkageProperties = linkage->getProperties();
 
    uint32_t numIntArgs   = 0;

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -159,7 +159,6 @@ TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
        TR::RealRegister::NoReg, // vtable index register
        TR::RealRegister::NoReg,  // j9method argument register
        15,                      // numberOfDependencyGPRegisters
-       0,                       // offsetToFirstStackParm (relative to old sp)
        -4,                      // offsetToFirstLocal (not counting out-args)
        4,                       // numIntegerArgumentRegisters
        0,                       // firstIntegerArgumentRegister (index into ArgumentRegisters)
@@ -175,6 +174,12 @@ TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
        0                        // firstFloatReturnRegister
 #endif
     };
+
+TR::ARMSystemLinkage::ARMSystemLinkage(TR::CodeGenerator *cg)
+   : TR::Linkage(cg)
+   {
+   self()->setOffsetToFirstParm(0);
+   }
 
 void TR::ARMSystemLinkage::initARMRealRegisterLinkage()
    {

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -178,7 +178,7 @@ TR::ARMLinkageProperties TR::ARMSystemLinkage::properties =
 TR::ARMSystemLinkage::ARMSystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
    {
-   self()->setOffsetToFirstParm(0);
+   setOffsetToFirstParm(0);
    }
 
 void TR::ARMSystemLinkage::initARMRealRegisterLinkage()

--- a/compiler/arm/codegen/ARMSystemLinkage.hpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.hpp
@@ -43,7 +43,7 @@ class ARMSystemLinkage : public TR::Linkage
 
    public:
 
-   ARMSystemLinkage(TR::CodeGenerator *codeGen) : TR::Linkage(codeGen) {}
+   ARMSystemLinkage(TR::CodeGenerator *codeGen);
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -644,7 +644,7 @@ printf("%s: numIntegerArgs %d numMemArgs %d\n", sig,  numIntegerArgs, numMemArgs
    numIntegerArgs = 0;
    numFloatArgs = 0;
 
-   int32_t argSize = -(properties.getOffsetToFirstParm());
+   int32_t argSize = -(self()->getOffsetToFirstParm());
    int32_t memArg  = 0;
    for (i = from; (isHelper && i > to) || (!isHelper && i < to); i += step)
       {

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,7 +91,6 @@ struct ARMLinkageProperties
    TR::RealRegister::RegNum _j9methodArgumentRegister;    // for icallVMprJavaSendStatic
 
    uint8_t                                 _numberOfDependencyGPRegisters;
-   int8_t                                  _offsetToFirstParm;
    int8_t                                  _offsetToFirstLocal;
 
    uint8_t                                 _numIntegerArgumentRegisters;
@@ -262,8 +261,6 @@ struct ARMLinkageProperties
       {
       return _j9methodArgumentRegister;
       }
-
-   int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -59,15 +59,3 @@ OMR::Linkage::argumentRegisterKind(TR::Node *argumentNode)
    else
       return TR_GPR;
    }
-
-int32_t
-OMR::Linkage::getOffsetToFirstParm() const
-   { 
-   return _offsetToFirstParm;
-   }
-
-int32_t
-OMR::Linkage::setOffsetToFirstParm(int32_t offset)
-   {
-   return _offsetToFirstParm = offset;
-   }

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -59,3 +59,15 @@ OMR::Linkage::argumentRegisterKind(TR::Node *argumentNode)
    else
       return TR_GPR;
    }
+
+int32_t
+OMR::Linkage::getOffsetToFirstParm() const
+   { 
+   return _offsetToFirstParm;
+   }
+
+int32_t
+OMR::Linkage::setOffsetToFirstParm(int32_t offset)
+   {
+   return _offsetToFirstParm = offset;
+   }

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -159,13 +159,13 @@ class OMR_EXTENSIBLE Linkage
     *    order) passed by the caller on the stack. It is up to the linkage to make use of this function to initialize
     *    parameter offsets depending on the order in which the caller passes the arguments to the callee.
     */
-   virtual int32_t getOffsetToFirstParm() const;
+   inline int32_t getOffsetToFirstParm() const;
 
    /** @brief
     *    Sets the offset (in number of bytes) from the stack frame pointer to the location on the stack where the first
     *    (closest to the frame pointer) parameter is located. 
     */
-   virtual int32_t setOffsetToFirstParm(int32_t offset);
+   inline int32_t setOffsetToFirstParm(int32_t offset);
 
    /**
     * @brief Provides the entry point in a method to use when that method is invoked

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -137,25 +137,26 @@ class OMR_EXTENSIBLE Linkage
     *    (closest to the frame pointer) parameter is located. 
     *
     *  @details
-    *    For example given the following stack frame layout, and assuming a call to a function with 4 parameters:
+    *    For example given the following stack frame layout, for a stack which grows towards 0x0000 (we subtract the
+    *    stack pointer for each additional frame), and assuming a call to a function with 4 parameters:
     *
     *    @code
-    *        0x0588     +--------+
-    *                   |  ARG1  |
-    *        0x0580     +--------+
-    *                   |  ARG2  |
-    *        0x0578     +--------+
-    *                   |  ARG3  |
-    *        0x0570     +--------+   <- offset to first parm relative to the frame pointer (0x0570 - 0x0530 = 0x0040)
+    *        0x04E8     +--------+   <- stack pointer
+    *                   |  ....  |
+    *        0x0518     +--------+   <- frame pointer
+    *                   |  ....  |
+    *        0x0550     +--------+   <- offset to first parm relative to the frame pointer (0x0550 - 0x0518 = 0x0038)
     *                   |  ARG4  |
-    *        0x0568     +--------+ 
-    *                   |  ....  |
-    *        0x0530     +--------+   <- frame pointer
-    *                   |  ....  |
-    *        0x0500     +--------+   <- stack pointer
+    *        0x0558     +--------+
+    *                   |  ARG3  |
+    *        0x0560     +--------+
+    *                   |  ARG2  |
+    *        0x0568     +--------+
+    *                   |  ARG1  |
+    *        0x0570     +--------+
     *    @endcode
     *
-    *    The offset returned by this function (0x0040 in the above example) may not be the first argument (in argument
+    *    The offset returned by this function (0x0038 in the above example) may not be the first argument (in argument
     *    order) passed by the caller on the stack. It is up to the linkage to make use of this function to initialize
     *    parameter offsets depending on the order in which the caller passes the arguments to the callee.
     */

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -132,6 +132,41 @@ class OMR_EXTENSIBLE Linkage
     */
    virtual void performPostBinaryEncoding() { }
 
+   /** @brief
+    *    Gets the offset (in number of bytes) from the stack frame pointer to the location on the stack where the first
+    *    (closest to the frame pointer) parameter is located. 
+    *
+    *  @details
+    *    For example given the following stack frame layout, and assuming a call to a function with 4 parameters:
+    *
+    *    @code
+    *        0x0588     +--------+
+    *                   |  ARG1  |
+    *        0x0580     +--------+
+    *                   |  ARG2  |
+    *        0x0578     +--------+
+    *                   |  ARG3  |
+    *        0x0570     +--------+   <- offset to first parm relative to the frame pointer (0x0570 - 0x0530 = 0x0040)
+    *                   |  ARG4  |
+    *        0x0568     +--------+ 
+    *                   |  ....  |
+    *        0x0530     +--------+   <- frame pointer
+    *                   |  ....  |
+    *        0x0500     +--------+   <- stack pointer
+    *    @endcode
+    *
+    *    The offset returned by this function (0x0040 in the above example) may not be the first argument (in argument
+    *    order) passed by the caller on the stack. It is up to the linkage to make use of this function to initialize
+    *    parameter offsets depending on the order in which the caller passes the arguments to the callee.
+    */
+   virtual int32_t getOffsetToFirstParm() const;
+
+   /** @brief
+    *    Sets the offset (in number of bytes) from the stack frame pointer to the location on the stack where the first
+    *    (closest to the frame pointer) parameter is located. 
+    */
+   virtual int32_t setOffsetToFirstParm(int32_t offset);
+
    /**
     * @brief Provides the entry point in a method to use when that method is invoked
     *        from a method compiled with the same linkage.
@@ -167,6 +202,8 @@ class OMR_EXTENSIBLE Linkage
 protected:
 
    TR::CodeGenerator *_cg;
+
+   int32_t _offsetToFirstParm;
    };
 }
 

--- a/compiler/codegen/OMRLinkage_inlines.hpp
+++ b/compiler/codegen/OMRLinkage_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,4 +79,15 @@ OMR::Linkage::trStackMemory()
    return self()->trMemory();
    }
 
+int32_t
+OMR::Linkage::getOffsetToFirstParm() const
+   { 
+   return _offsetToFirstParm;
+   }
+
+int32_t
+OMR::Linkage::setOffsetToFirstParm(int32_t offset)
+   {
+   return _offsetToFirstParm = offset;
+   }
 #endif

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -83,7 +83,7 @@ TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argS
    const TR::PPCLinkageProperties& properties = self()->getProperties();
 
    TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
-                                                                              argSize+properties.getOffsetToFirstParm(), length, self()->cg());
+                                                                              argSize+self()->getOffsetToFirstParm(), length, self()->cg());
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode;

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -119,7 +119,6 @@ struct PPCLinkageProperties
    TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _j9methodArgumentRegister;    // for icallVMprJavaSendStatic
    uint8_t _numberOfDependencyGPRegisters;
-   int8_t _offsetToFirstParm;
    int8_t _offsetToFirstLocal;
 
    uint32_t getNumIntArgRegs() const {return _numIntegerArgumentRegisters;}
@@ -348,8 +347,6 @@ struct PPCLinkageProperties
       {
       return _j9methodArgumentRegister;
       }
-
-   int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -339,7 +339,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
 
       // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
       _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
-      _properties._offsetToFirstParm             = isBE?48:32;
+      self()->setOffsetToFirstParm(isBE ? 48 : 32);
       _properties._offsetToFirstLocal            = isBE?48:32;
       }
    else
@@ -348,14 +348,14 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
          {
          // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
          _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
-         _properties._offsetToFirstParm             = 24;
+         self()->setOffsetToFirstParm(24);
          _properties._offsetToFirstLocal            = 24;
          }
       else
          {
          // Volatile GPR (0,3-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
          _properties._numberOfDependencyGPRegisters = 11 + 14 + 5 + 20 + 18;
-         _properties._offsetToFirstParm             = 8;
+         self()->setOffsetToFirstParm(8);
          _properties._offsetToFirstLocal            = 8;
          }
       }
@@ -466,7 +466,7 @@ TR::PPCSystemLinkage::mapParameters(
    ListIterator<TR::ParameterSymbol> parameterIterator(&parmList);
    TR::ParameterSymbol              *parmCursor = parameterIterator.getFirst();
    const TR::PPCLinkageProperties&    linkage           = getProperties();
-   int32_t                          offsetToFirstParm = linkage.getOffsetToFirstParm();
+   int32_t                          offsetToFirstParm = self()->getOffsetToFirstParm();
    int32_t offset_from_top = 0;
    int32_t slot_size = sizeof(uintptr_t);
 
@@ -567,7 +567,7 @@ TR::PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 
    method->setLocalMappingCursor(stackIndex);
 
-   int32_t offsetToFirstParm = linkage.getOffsetToFirstParm();
+   int32_t offsetToFirstParm = self()->getOffsetToFirstParm();
    mapParameters(method, method->getParameterList());
 
 #ifdef __LITTLE_ENDIAN__
@@ -709,7 +709,7 @@ TR::PPCSystemLinkage::createPrologue(
    // stack frame if there are any saved non-volatiles
    //
 
-   if ( size > properties.getOffsetToFirstParm()  - argSize)
+   if (size > self()->getOffsetToFirstParm() - argSize)
       {
       if (size > (-LOWER_IMMED))
          {
@@ -804,7 +804,7 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
    // Some opcodes write into temps above stack, therefore need to allocate
    // stack frame if there are any saved non-volatiles
    //
-   if (size > properties.getOffsetToFirstParm() - saveSize)
+   if (size > self()->getOffsetToFirstParm() - saveSize)
       {
       if (size > UPPER_IMMED)
          {

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -339,7 +339,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
 
       // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
       _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
-      self()->setOffsetToFirstParm(isBE ? 48 : 32);
+      setOffsetToFirstParm(isBE ? 48 : 32);
       _properties._offsetToFirstLocal            = isBE?48:32;
       }
    else
@@ -348,14 +348,14 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
          {
          // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
          _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
-         self()->setOffsetToFirstParm(24);
+         setOffsetToFirstParm(24);
          _properties._offsetToFirstLocal            = 24;
          }
       else
          {
          // Volatile GPR (0,3-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
          _properties._numberOfDependencyGPRegisters = 11 + 14 + 5 + 20 + 18;
-         self()->setOffsetToFirstParm(8);
+         setOffsetToFirstParm(8);
          _properties._offsetToFirstLocal            = 8;
          }
       }

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,7 +117,6 @@ struct RVLinkageProperties
    TR::RealRegister::RegNum _stackPointerRegister;
    TR::RealRegister::RegNum _framePointerRegister;
    uint8_t _numberOfDependencyGPRegisters;
-   int8_t _offsetToFirstParm;
    int8_t _offsetToFirstLocal;
 
    uint32_t getNumIntArgRegs() const {return _numIntegerArgumentRegisters;}
@@ -254,8 +253,6 @@ struct RVLinkageProperties
       {
       return _framePointerRegister;
       }
-
-   int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -183,7 +183,7 @@ TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    _properties._framePointerRegister        = TR::RealRegister::s0;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
-   self()->setOffsetToFirstParm(0); // To be determined
+   setOffsetToFirstParm(0); // To be determined
    _properties._offsetToFirstLocal            = 0; // To be determined
    }
 

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,7 +183,7 @@ TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    _properties._framePointerRegister        = TR::RealRegister::s0;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
-   _properties._offsetToFirstParm             = 0; // To be determined
+   self()->setOffsetToFirstParm(0); // To be determined
    _properties._offsetToFirstLocal            = 0; // To be determined
    }
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -167,7 +167,7 @@ TR::AMD64Win64FastCallLinkage::AMD64Win64FastCallLinkage(TR::CodeGenerator *cg)
 
    _properties._framePointerRegister = TR::RealRegister::ebp;
    _properties._methodMetaDataRegister = TR::RealRegister::NoReg;
-   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
+   setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
 
    memset(_properties._registerFlags, 0, sizeof(_properties._registerFlags));
@@ -361,7 +361,7 @@ TR::AMD64ABILinkage::AMD64ABILinkage(TR::CodeGenerator *cg)
 
    _properties._framePointerRegister = TR::RealRegister::ebp;
    _properties._methodMetaDataRegister = TR::RealRegister::NoReg;
-   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
+   setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
 
    memset(_properties._registerFlags, 0, sizeof(_properties._registerFlags));

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -167,7 +167,7 @@ TR::AMD64Win64FastCallLinkage::AMD64Win64FastCallLinkage(TR::CodeGenerator *cg)
 
    _properties._framePointerRegister = TR::RealRegister::ebp;
    _properties._methodMetaDataRegister = TR::RealRegister::NoReg;
-   _properties._offsetToFirstParm = RETURN_ADDRESS_SIZE;
+   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
 
    memset(_properties._registerFlags, 0, sizeof(_properties._registerFlags));
@@ -361,7 +361,7 @@ TR::AMD64ABILinkage::AMD64ABILinkage(TR::CodeGenerator *cg)
 
    _properties._framePointerRegister = TR::RealRegister::ebp;
    _properties._methodMetaDataRegister = TR::RealRegister::NoReg;
-   _properties._offsetToFirstParm = RETURN_ADDRESS_SIZE;
+   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
 
    memset(_properties._registerFlags, 0, sizeof(_properties._registerFlags));

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,7 +85,7 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
    const TR::X86LinkageProperties&    linkage           = self()->getProperties();
-   int32_t                           offsetToFirstParm = linkage.getOffsetToFirstParm();
+   int32_t                           offsetToFirstParm = self()->getOffsetToFirstParm();
    uint32_t                          stackIndex        = linkage.getOffsetToFirstLocal();
    TR::GCStackAtlas                  *atlas             = self()->cg()->getStackAtlas();
    int32_t                           i;
@@ -344,7 +344,7 @@ void OMR::X86::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());
    TR::AutomaticSymbol               *localCursor       = automaticIterator.getFirst();
    const TR::X86LinkageProperties&    linkage           = self()->getProperties();
-   int32_t                           offsetToFirstParm = linkage.getOffsetToFirstParm();
+   int32_t                           offsetToFirstParm = self()->getOffsetToFirstParm();
    uint32_t                          stackIndex        = linkage.getOffsetToFirstLocal();
    TR::GCStackAtlas                  *atlas             = self()->cg()->getStackAtlas();
 
@@ -459,7 +459,7 @@ void OMR::X86::Linkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
    TR::ParameterSymbol              *parmCursor   = parameterIterator.getFirst();
-   int32_t                          offsetToFirstParm = self()->getProperties().getOffsetToFirstParm();
+   int32_t                          offsetToFirstParm = self()->getOffsetToFirstParm();
    if (self()->getProperties().passArgsRightToLeft())
       {
       int32_t currentOffset = offsetToFirstParm;

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,7 +128,6 @@ struct X86LinkageProperties
    uint32_t                 _preservedRegisterMapForGC;
    TR::RealRegister::RegNum _framePointerRegister;
    TR::RealRegister::RegNum _methodMetaDataRegister;
-   int8_t                   _offsetToFirstParm;
    int8_t                   _offsetToFirstLocal;           // Points immediately after the local with highest address
 
    uint8_t                 _numScratchRegisters;
@@ -207,8 +206,6 @@ struct X86LinkageProperties
    TR::RealRegister::RegNum getDoubleReturnRegister()   const {return _returnRegisters[1];}
    TR::RealRegister::RegNum getFramePointerRegister()   const {return _framePointerRegister;}
    TR::RealRegister::RegNum getMethodMetaDataRegister() const {return _methodMetaDataRegister;}
-
-   int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -786,7 +786,7 @@ TR::X86SystemLinkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
    int32_t sizeOfOutGoingArgs = 0;
    uint16_t numIntArgs = 0, numFloatArgs = 0;
    ListIterator<TR::ParameterSymbol> parameterIterator(&method->getParameterList());
-   uint32_t bump = getProperties().getOffsetToFirstParm();
+   uint32_t bump = self()->getOffsetToFirstParm();
 
    for (TR::ParameterSymbol *parmCursor = parameterIterator.getFirst(); parmCursor; parmCursor = parameterIterator.getNext())
       {

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -127,7 +127,7 @@ TR::IA32SystemLinkage::IA32SystemLinkage(
    _properties._numberOfVolatileXMMRegisters = p - _properties._numberOfVolatileGPRegisters;
    _properties._numVolatileRegisters = p;
 
-   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
+   setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
    _properties._OutgoingArgAlignment = IA32_DEFAULT_STACK_ALIGNMENT;
 

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -127,7 +127,7 @@ TR::IA32SystemLinkage::IA32SystemLinkage(
    _properties._numberOfVolatileXMMRegisters = p - _properties._numberOfVolatileGPRegisters;
    _properties._numVolatileRegisters = p;
 
-   _properties._offsetToFirstParm = RETURN_ADDRESS_SIZE;
+   self()->setOffsetToFirstParm(RETURN_ADDRESS_SIZE);
    _properties._offsetToFirstLocal = _properties.getAlwaysDedicateFramePointerRegister() ? -GPR_REG_WIDTH : 0;
    _properties._OutgoingArgAlignment = IA32_DEFAULT_STACK_ALIGNMENT;
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -223,7 +223,6 @@ private:
 
    int32_t _offsetToRegSaveArea;
    int32_t _offsetToLongDispSlot;
-   int32_t _offsetToFirstParm;
    uint8_t _numberOfDependencyGPRegisters;
    int32_t _offsetToFirstLocal;
    bool    _stackSizeCheckNeeded;
@@ -550,9 +549,6 @@ enum TR_DispatchType
    virtual TR::RealRegister::RegNum getENVPointerRegister() { return TR::RealRegister::NoReg; }
    virtual TR::RealRegister::RegNum getCAAPointerRegister() { return TR::RealRegister::NoReg; }
    virtual TR::RealRegister::RegNum getParentDSAPointerRegister() { return TR::RealRegister::NoReg; }
-
-   virtual int32_t setOffsetToFirstParm   (int32_t offset)  { return _offsetToFirstParm = offset; }
-   virtual int32_t getOffsetToFirstParm()    { return _offsetToFirstParm; }
 
    virtual uint32_t setOffsetToFirstLocal(uint32_t offset)  { return _offsetToFirstLocal = offset; }
    virtual uint32_t getOffsetToFirstLocal()        { return _offsetToFirstLocal; }

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -211,14 +211,14 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
    setGPRSaveAreaEndOffset(160);
 
    // x'1c0' see ICST_PAR in tpf/icstk.h
-   self()->setOffsetToFirstParm(448);
+   setOffsetToFirstParm(448);
 #else
    if (cg->comp()->target().is64Bit())
       {
       setOffsetToRegSaveArea(16);
       setGPRSaveAreaBeginOffset(48);
       setGPRSaveAreaEndOffset(128);
-      self()->setOffsetToFirstParm(160);
+      setOffsetToFirstParm(160);
       setOffsetToLongDispSlot(8);
       }
    else
@@ -226,13 +226,13 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
       setOffsetToRegSaveArea(8);
       setGPRSaveAreaBeginOffset(24);
       setGPRSaveAreaEndOffset(64);
-      self()->setOffsetToFirstParm(96);
+      setOffsetToFirstParm(96);
       setOffsetToLongDispSlot(4);
       }
 #endif /* defined(OMRZTPF) */
 
    setOffsetToFirstLocal(0);
-   setOutgoingParmAreaBeginOffset(self()->getOffsetToFirstParm());
+   setOutgoingParmAreaBeginOffset(getOffsetToFirstParm());
    setOutgoingParmAreaEndOffset(0);
    setStackFrameSize(0);
    setNumberOfDependencyGPRegisters(32);

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -211,14 +211,14 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
    setGPRSaveAreaEndOffset(160);
 
    // x'1c0' see ICST_PAR in tpf/icstk.h
-   setOffsetToFirstParm(448);
+   self()->setOffsetToFirstParm(448);
 #else
    if (cg->comp()->target().is64Bit())
       {
       setOffsetToRegSaveArea(16);
       setGPRSaveAreaBeginOffset(48);
       setGPRSaveAreaEndOffset(128);
-      setOffsetToFirstParm(160);
+      self()->setOffsetToFirstParm(160);
       setOffsetToLongDispSlot(8);
       }
    else
@@ -226,13 +226,13 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
       setOffsetToRegSaveArea(8);
       setGPRSaveAreaBeginOffset(24);
       setGPRSaveAreaEndOffset(64);
-      setOffsetToFirstParm(96);
+      self()->setOffsetToFirstParm(96);
       setOffsetToLongDispSlot(4);
       }
 #endif /* defined(OMRZTPF) */
 
    setOffsetToFirstLocal(0);
-   setOutgoingParmAreaBeginOffset(getOffsetToFirstParm());
+   setOutgoingParmAreaBeginOffset(self()->getOffsetToFirstParm());
    setOutgoingParmAreaEndOffset(0);
    setStackFrameSize(0);
    setNumberOfDependencyGPRegisters(32);
@@ -267,7 +267,7 @@ void TR::S390zLinuxSystemLinkage::createPrologue(TR::Instruction* cursor)
    //
    // TODO: We should be using OMR::align here once mapStack is fixed so we don't pass negative offsets
    size_t localSize = ((-1 * static_cast<int32_t>(bodySymbol->getLocalMappingCursor())) + (8 - 1)) & ~(8 - 1);
-   setStackFrameSize(((getOffsetToFirstParm() + argSize + localSize) + (8 - 1)) & ~(8 - 1));
+   setStackFrameSize(((self()->getOffsetToFirstParm() + argSize + localSize) + (8 - 1)) & ~(8 - 1));
 
    int32_t stackFrameSize = getStackFrameSize();
 
@@ -275,7 +275,7 @@ void TR::S390zLinuxSystemLinkage::createPrologue(TR::Instruction* cursor)
 
    if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(comp(), "Initial stackFrameSize = %d\n Offset to first parameter = %d\n Argument size = %d\n Local size = %d\n", stackFrameSize, getOffsetToFirstParm(), argSize, localSize);
+      traceMsg(comp(), "Initial stackFrameSize = %d\n Offset to first parameter = %d\n Argument size = %d\n Local size = %d\n", stackFrameSize, self()->getOffsetToFirstParm(), argSize, localSize);
       }
 
    // Now that we know the stack frame size, map the stack backwards

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -175,17 +175,17 @@ TR::S390zOSSystemLinkage::S390zOSSystemLinkage(TR::CodeGenerator* cg)
 
    if (cg->comp()->target().is64Bit())
       {
-      setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 128);
+      self()->setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 128);
       }
    else
       {
-      setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 64);
+      self()->setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 64);
       }
 
    setOffsetToRegSaveArea(2048);
    setOffsetToLongDispSlot(0);
    setOffsetToFirstLocal(0);
-   setOutgoingParmAreaBeginOffset(getOffsetToFirstParm() - XPLINK_STACK_FRAME_BIAS);
+   setOutgoingParmAreaBeginOffset(self()->getOffsetToFirstParm() - XPLINK_STACK_FRAME_BIAS);
    setOutgoingParmAreaEndOffset(0);
    setStackFrameSize(0);
    setNumberOfDependencyGPRegisters(32);
@@ -228,7 +228,7 @@ void TR::S390zOSSystemLinkage::createPrologue(TR::Instruction* cursor)
    //
    // TODO: We should be using OMR::align here once mapStack is fixed so we don't pass negative offsets
    size_t localSize = ((-1 * static_cast<int32_t>(bodySymbol->getLocalMappingCursor())) + (8 - 1)) & ~(8 - 1);
-   setStackFrameSize((((getOffsetToFirstParm() + argSize + localSize) + (32 - 1)) & ~(32 - 1)) - XPLINK_STACK_FRAME_BIAS);
+   setStackFrameSize((((self()->getOffsetToFirstParm() + argSize + localSize) + (32 - 1)) & ~(32 - 1)) - XPLINK_STACK_FRAME_BIAS);
 
    int32_t stackFrameSize = getStackFrameSize();
 
@@ -236,7 +236,7 @@ void TR::S390zOSSystemLinkage::createPrologue(TR::Instruction* cursor)
 
    if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(comp(), "Initial stackFrameSize = %d\n Offset to first parameter = %d\n Argument size = %d\n Local size = %d\n", stackFrameSize, getOffsetToFirstParm(), argSize, localSize);
+      traceMsg(comp(), "Initial stackFrameSize = %d\n Offset to first parameter = %d\n Argument size = %d\n Local size = %d\n", stackFrameSize, self()->getOffsetToFirstParm(), argSize, localSize);
       }
 
    // Now that we know the stack frame size, map the stack backwards
@@ -1075,7 +1075,7 @@ TR::S390zOSSystemLinkage::spillGPRsInPrologue(TR::Node* node, TR::Instruction* c
    TR::RealRegister * gpr0Real = getRealRegister(TR::RealRegister::GPR0);
    TR::RealRegister * gpr3Real = getRealRegister(TR::RealRegister::GPR3);
    TR::RealRegister * caaReal  = getRealRegister(getCAAPointerRegister());  // 31 bit oly
-   gpr3ParmOffset = getOffsetToFirstParm() + 2 * gprSize;
+   gpr3ParmOffset = self()->getOffsetToFirstParm() + 2 * gprSize;
 
    _firstSaved = REGNUM(firstSaved + TR::RealRegister::FirstGPR);
    _lastSaved  = REGNUM(lastSaved  + TR::RealRegister::FirstGPR);

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -175,17 +175,17 @@ TR::S390zOSSystemLinkage::S390zOSSystemLinkage(TR::CodeGenerator* cg)
 
    if (cg->comp()->target().is64Bit())
       {
-      self()->setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 128);
+      setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 128);
       }
    else
       {
-      self()->setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 64);
+      setOffsetToFirstParm(XPLINK_STACK_FRAME_BIAS + 64);
       }
 
    setOffsetToRegSaveArea(2048);
    setOffsetToLongDispSlot(0);
    setOffsetToFirstLocal(0);
-   setOutgoingParmAreaBeginOffset(self()->getOffsetToFirstParm() - XPLINK_STACK_FRAME_BIAS);
+   setOutgoingParmAreaBeginOffset(getOffsetToFirstParm() - XPLINK_STACK_FRAME_BIAS);
    setOutgoingParmAreaEndOffset(0);
    setStackFrameSize(0);
    setNumberOfDependencyGPRegisters(32);


### PR DESCRIPTION
The `getOffsetToFirstParm` API currently belongs to linkage properties
class in each codegen, with the Z codegen being the exception having it
inside of the Z specific `OMRLinkage`. This API is however used
throughout all codegens and can belong to the common code `OMRLinkage`
class. We migrate the API there for use in downstream projects.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>