### PR TITLE
CMake: Remove guards for windows around ddr code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,7 +142,7 @@ configure_file(include_core/omrversionstrings.cmake.h.in omrversionstrings.h)
 ### Set up DDR configuration
 ###
 include(OmrDDRSupport)
-if(OMR_DDR AND NOT OMR_OS_WINDOWS)
+if(OMR_DDR)
 	make_ddr_set(omrddr)
 	ddr_add_headers(omrddr
 		${omr_BINARY_DIR}/omrcfg.h

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,16 +38,19 @@ set(DDR_INFO_DIR "${CMAKE_BINARY_DIR}/ddr_info")
 set(OMR_SEPARATE_DEBUG_INFO OFF CACHE BOOL "Maintain debug info in a separate file")
 
 function(make_ddr_set set_name)
-	# if DDR is not enabled, just skip
-	# Also skip if we are on windows since it is unsupported at the moment
-	if((OMR_HOST_OS STREQUAL "win") OR (NOT OMR_DDR))
-		return()
-	endif()
 	set(DDR_TARGET_NAME "${set_name}")
 	set(DDR_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/${DDR_TARGET_NAME}")
 	set(DDR_MACRO_INPUTS_FILE "${DDR_BIN_DIR}/macros.list")
 	set(DDR_TOOLS_EXPORT "${omr_BINARY_DIR}/ddr/tools/DDRTools.cmake")
 	set(DDR_CONFIG_STAMP "${DDR_BIN_DIR}/config.stamp")
+
+	# if DDR is not enabled, just skip
+	# Also skip if we are on a multi config generator since it is unsupported at the moment
+	if(OMR_MULTI_CONFIG OR (NOT OMR_DDR))
+		# create a dummy target to avoid potential errors if ddr disabled
+		add_custom_target("${DDR_TARGET_NAME}")
+		return()
+	endif()
 
 	add_custom_command(
 		OUTPUT  "${DDR_CONFIG_STAMP}"
@@ -73,7 +76,7 @@ function(make_ddr_set set_name)
 endfunction(make_ddr_set)
 
 function(ddr_set_add_targets ddr_set)
-	if((OMR_HOST_OS STREQUAL "win") OR (NOT OMR_DDR))
+	if(OMR_MULTI_CONFIG OR (NOT OMR_DDR))
 		return()
 	endif()
 
@@ -93,7 +96,7 @@ function(ddr_set_add_targets ddr_set)
 endfunction(ddr_set_add_targets)
 
 function(target_enable_ddr tgt)
-	if((OMR_HOST_OS STREQUAL "win") OR (NOT OMR_DDR))
+	if(OMR_MULTI_CONFIG OR (NOT OMR_DDR))
 		return()
 	endif()
 

--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,4 +205,17 @@ macro(omr_detect_system_information)
 	message(STATUS "OMR: The target data size is ${OMR_ENV_TARGET_DATASIZE}")
 
 	omr_find_semaphore_implementation()
+
+	# Check if we are a multi config generator
+	# CMake 3.10 adds GENERATOR_IS_MULTI_CONFIG property
+	# otherwise Visual Studio and XCode are the only multi config generators
+	if(CMAKE_VERSION VERSION_LESS 3.10)
+		get_property(OMR_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+	else()
+		if(CMAKE_GENERATOR MATCHES "^Visual Studio|^Xcode")
+			set(OMR_MULTI_CONFIG TRUE)
+		else()
+			set(OMR_MULTI_CONFIG FALSE)
+		endif()
+	endif()
 endmacro(omr_detect_system_information)


### PR DESCRIPTION
DDR works on windows, however it does not work on multi-config generators.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>