### PR TITLE
AArch64: Fix logic allocating fp register when child node register is not clobberable

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -260,7 +260,7 @@ commonFpUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, bool isDoubl
    TR::Register *srcReg = cg->evaluate(firstChild);
    TR::Register *trgReg;
 
-   if (node->getReferenceCount() > 1)
+   if (firstChild->getReferenceCount() > 1)
       {
       trgReg = isDouble ? cg->allocateRegister(TR_FPR) : cg->allocateSinglePrecisionRegister();
       }


### PR DESCRIPTION
Fix `commonFPUnaryEvaluator` to correctly allocate a register
when the child node is not clobberable.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>