### PR TITLE
AArch64: Fix for populateMemoryReference() with no base register

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -507,7 +507,17 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
          {
          intptrj_t amount = (subTree->getOpCodeValue() == TR::iconst) ?
                              subTree->getInt() : subTree->getLongInt();
-         self()->addToOffset(subTree, amount, cg);
+         if (_baseRegister != NULL)
+            {
+            self()->addToOffset(subTree, amount, cg);
+            }
+         else
+            {
+            _baseRegister = cg->allocateRegister();
+            _baseNode = subTree;
+            self()->setBaseModifiable();
+            loadConstant64(cg, subTree, amount, _baseRegister);
+            }
          }
       else
          {


### PR DESCRIPTION
This commit fixes a case in populateMemoryReference() where no base
register has been allocated with aconst/iconst/lconst.

Closes: eclipse/openj9#8475

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>