### PR TITLE
Allow extra context to be printed on assertion failures

### DIFF
--- a/compiler/infra/Assert.hpp
+++ b/compiler/infra/Assert.hpp
@@ -47,6 +47,21 @@
  *                              failure. Used to indicate that a function has not been
  *                              implemented and may not be called.
  *
+ * A number of helper macros are also provided for printing more detailed contextual
+ * information on fatal assertion failures to assist with debugging.
+ *
+ * \def TR_ASSERT_FATAL_WITH_DETAIL
+ * a fatal assertion which will print the provided contextual information upon failure
+ * in addition to the provided message.
+ *
+ * \def TR_ASSERT_FATAL_WITH_NODE
+ * a fatal assertion which will print NodeAssertionContext for the provided node upon
+ * failure in addition to the provided message.
+ *
+ * \def TR_ASSERT_FATAL_WITH_INSTRUCTION
+ * a fatal assertion which will print InstructionAssertionContext for the provided
+ * instruction upon failure in addition to the provided message.
+ *
  * We also provide Expect and Ensure, based on the developing C++ Core guidelines [1].
  *
  * \def Expect                  Precondition macro, only defined for DEBUG and
@@ -80,24 +95,40 @@ namespace TR
 
    void OMR_NORETURN trap();
 
-   // Don't use these directly.
-   //
-   // Use the TR_ASSERT* macros instead as they control the string
-   // contents in production builds.
-   void OMR_NORETURN fatal_assertion(const char *file, int line, const char *condition, const char *format, ...);
-
+   /**
+    * Represents context to be printed alongside an assertion failure message.
+    *
+    * After printing the message and stack trace associated with an assertion failure, the relevant context will be
+    * printed to stderr by calling its printContext function. Contextual information generally includes relevant details
+    * about the state of the compiler at the time of the failure, such as the tree containing a node which resulted in
+    * an assertion failure.
+    */
    class AssertionContext
       {
       public:
+
+      /**
+       * Prints contextual information about the assertion for debugging purposes.
+       *
+       * It is valid for this function to itself result in an assertion failure (potentially with its own context)
+       * during the process of printing. To prevent boundless recursion, the context of such an assertion failure will
+       * not be printed.
+       */
       virtual void printContext() const = 0;
       };
 
+   /**
+    * An assertion context which does not print any information.
+    */
    class NullAssertionContext : public AssertionContext
       {
       public:
       virtual void printContext() const {}
       };
 
+   /**
+    * An assertion context which prints the treetop containing a particular node.
+    */
    class NodeAssertionContext : public AssertionContext
       {
       TR::Node *_node;
@@ -108,6 +139,9 @@ namespace TR
       virtual void printContext() const;
       };
 
+   /**
+    * An assertion context which prints instructions surrounding a particular instructions.
+    */
    class InstructionAssertionContext : public AssertionContext
       {
       TR::Instruction *_instruction;
@@ -118,6 +152,11 @@ namespace TR
       virtual void printContext() const;
       };
 
+   // Don't use these directly.
+   //
+   // Use the TR_ASSERT* macros instead as they control the string
+   // contents in production builds.
+   void OMR_NORETURN fatal_assertion(const char *file, int line, const char *condition, const char *format, ...);
    void OMR_NORETURN fatal_assertion_with_detail(const AssertionContext& ctx, const char *file, int line, const char *condition, const char *format, ...);
 
    // Non fatal assertions may in some circumstances return, so do not mark them as

--- a/compiler/p/codegen/OMRInstOpCode.hpp
+++ b/compiler/p/codegen/OMRInstOpCode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,6 +183,8 @@ class InstOpCode: public OMR::InstOpCode
                                _mnemonic==proc     ||
                                _mnemonic==assocreg ||
                                _mnemonic==dd;}
+
+        const char* getMnemonicName() { return metadata[_mnemonic].name; }
 
         static const uint32_t getOpCodeBinaryEncoding(Mnemonic opCode)
            {return metadata[opCode].opcode;}


### PR DESCRIPTION
This PR adds two new macros for asserts that print out more detailed contextual information to assist in debugging: `TR_ASSERT_FATAL_WITH_NODE` and `TR_ASSERT_FATAL_WITH_INSTRUCTION`. When an assert using one of these two macros is triggered, it will print out the relevant context: the treetop that contains the node in question or a small window of instructions surrounding the instruction in question. In addition, by setting the environment variable `TR_AssertFullContext`, the entire method will be printed instead of just the failing node/instruction.

The method by which context is printed is easily extensible by subclassing `TR::AssertionContext` and using the more powerful `TR_ASSERT_FATAL_WITH_DETAIL` macro.

As an example, I added a test assert in the Power binary encoder and then triggered it in OpenJ9, which resulted in the following output:

```
Assertion failed at /root/hostdir/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/vm/compiler/../omr/compiler/p/codegen/PPCBinaryEncoding.cpp:1081: false
VMState: 0x0005ff09
	Instruction 0x736ceebe5ec0 [rldicr] (generated from node 0x736ceeb54490 [acall]): TEST ASSERT
compiling sun/reflect/Reflection.getCallerClass()Ljava/lang/Class; at level: cold
#0: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x833404) [0x736d059a3404]
#1: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x8424ac) [0x736d059b24ac]
#2: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x5278e0) [0x736d056978e0]
#3: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x5283d0) [0x736d056983d0]
#4: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x8cfd40) [0x736d05a3fd40]
#5: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x8cf968) [0x736d05a3f968]
#6: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x890ef0) [0x736d05a00ef0]
#7: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x49e684) [0x736d0560e684]
#8: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x49bea8) [0x736d0560bea8]
#9: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x499090) [0x736d05609090]
#10: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x4ba518) [0x736d0562a518]
#11: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x1480e4) [0x736d052b80e4]
#12: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x14920c) [0x736d052b920c]
#13: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9prt29.so(+0x39d38) [0x736d06269d38]
#14: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x14b2b0) [0x736d052bb2b0]
#15: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x14b86c) [0x736d052bb86c]
#16: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x146d84) [0x736d052b6d84]
#17: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x1470f8) [0x736d052b70f8]
#18: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x1471f4) [0x736d052b71f4]
#19: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9prt29.so(+0x39d38) [0x736d06269d38]
#20: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9jit29.so(+0x1476a0) [0x736d052b76a0]
#21: /home/thomasbc/openj9-build/openj9-openjdk-jdk8/build/linux-ppc64le-normal-server-release/images/j2sdk-image/jre/lib/ppc64le/compressedrefs/libj9thr29.so(+0x10374) [0x736d06460374]
#22: /lib/powerpc64le-linux-gnu/libpthread.so.0(+0x885c) [0x736d0705885c]
#23: function clone+0x98 [0x736d07229028]


Instruction context:

...
    0x736cefc600f4 00000074 [    0x736ceebe5b00] f98f0038          0 	std 	[gr15, 56], gr12
    0x736cefc600f8 00000078 [    0x736ceebe5ba0] 3d602000          0 	lis 	gr11, 0000000000002000
    0x736cefc600fc 0000007c [    0x736ceebe5ce0] f96efff9          0 	stdu 	[gr14, -8], gr11
    0x736cefc60100 00000080 [    0x736ceebe5d80] 3d600000          0 	lis 	gr11, 0000000000000000
    0x736cefc60104 00000084 [    0x736ceebe5e20] 616b0000          0 	ori 	gr11, gr11, 0
 [    0x736ceebe5ec0]	0 	rldicr 	gr11, gr11, 0000000000000020, FFFFFFFF00000000
 [    0x736ceebe5f70]	0 	oris 	gr11, gr11, 6
 [    0x736ceebe6010]	0 	ori 	gr11, gr11, 55800
 [    0x736ceebe6150]	0 	stdu 	[gr14, -8], gr11
 [    0x736ceebe6290]	0 	std 	[gr15, 32], gr14
 [    0x736ceebe6330]	0 	li 	gr11, 0000000000000006
...
(Set env var TR_AssertFullContext for full context)

Node context:

...
n4n       treetop                                                                             [    0x736ceeb54440] bci=[-1,0,-] rc=0 vc=45 vn=- li=2 udi=- nc=1
n5n         acall  sun/reflect/Reflection.getCallerClass()Ljava/lang/Class;[#374  native static Method] [flags 0x500 0x0 ] (sharedMemory )  [    0x736ceeb54490] bci=[-1,0,-] rc=0 vc=45 vn=- li=2 udi=21664 nc=1 flg=0x40000
n8n           aladd                                                                           [    0x736ceeb54580] bci=[-1,0,-] rc=0 vc=45 vn=- li=2 udi=15408 nc=2
n6n             aconst 0x6dd00 (sun/reflect/Reflection.class) (classPointerConstant X!=0 sharedMemory )  [    0x736ceeb544e0] bci=[-1,0,-] rc=0 vc=45 vn=- li=2 udi=14912 nc=0 flg=0x10004
n7n             lconst 48 (highWordZero X!=0 X>=0 )                                           [    0x736ceeb54530] bci=[-1,0,-] rc=0 vc=45 vn=- li=2 udi=- nc=0 flg=0x4104
...
(Set env var TR_AssertFullContext for full context)
```

Asserts using these new macros can greatly assist in debugging assert failures that disappear when tracing is enabled and can allow some very simple issues to be diagnosed without needing to resort to analyzing corefiles or logs.

This PR does not yet add any uses of this new functionality, it only adds the supporting infrastructure. The PR for phase 3 of #4720 will be making use of this for its sanity checks.