### PR TITLE
Update port library's processor detection APIs and enums

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1170,42 +1170,91 @@ typedef struct OMROSKernelInfo {
 typedef enum OMRProcessorArchitecture {
 
 	OMR_PROCESSOR_UNDEFINED,
+	OMR_PROCESSOR_FIRST,
 
-	OMR_PROCESSOR_S390_UNKNOWN,
+	// 390 Processors
+	OMR_PROCESSOR_S390_FIRST = OMR_PROCESSOR_FIRST,
+	OMR_PROCESSOR_S390_UNKNOWN = OMR_PROCESSOR_S390_FIRST,
 	OMR_PROCESSOR_S390_GP6,
+	OMR_PROCESSOR_S390_Z10 = OMR_PROCESSOR_S390_GP6,
 	OMR_PROCESSOR_S390_GP7,
 	OMR_PROCESSOR_S390_GP8,
 	OMR_PROCESSOR_S390_GP9,
+	OMR_PROCESSOR_S390_Z196 = OMR_PROCESSOR_S390_GP9,
 	OMR_PROCESSOR_S390_GP10,
+	OMR_PROCESSOR_S390_ZEC12 = OMR_PROCESSOR_S390_GP10,
 	OMR_PROCESSOR_S390_GP11,
+	OMR_PROCESSOR_S390_Z13 = OMR_PROCESSOR_S390_GP11,
 	OMR_PROCESSOR_S390_GP12,
+	OMR_PROCESSOR_S390_Z14 = OMR_PROCESSOR_S390_GP12,
 	OMR_PROCESSOR_S390_GP13,
+	OMR_PROCESSOR_S390_Z15 = OMR_PROCESSOR_S390_GP13,
 	OMR_PROCESSOR_S390_GP14,
+	OMR_PROCESSOR_S390_ZNEXT = OMR_PROCESSOR_S390_GP14,
+	OMR_PROCESSOR_S390_LAST = OMR_PROCESSOR_S390_GP14,
 
-	OMR_PROCESSOR_PPC_UNKNOWN,
-	OMR_PROCESSOR_PPC_7XX,
-	OMR_PROCESSOR_PPC_GP,
-	OMR_PROCESSOR_PPC_GR,
-	OMR_PROCESSOR_PPC_NSTAR,
-	OMR_PROCESSOR_PPC_PULSAR,
+	// ARM Processors
+	OMR_PROCESSOR_ARM_FIRST,
+	OMR_PROCESSOR_ARM_UNKNOWN = OMR_PROCESSOR_ARM_FIRST,
+	OMR_PROCESSOR_ARM_V6,
+	OMR_PROCESSOR_ARM_V7,
+	OMR_PROCESSOR_ARM_LAST = OMR_PROCESSOR_ARM_V7,
+
+	// ARM64 / AARCH64 Processors
+	OMR_PROCESSOR_ARM64_FISRT,
+	OMR_PROCESSOR_ARM64_UNKNOWN = OMR_PROCESSOR_ARM64_FISRT,
+	OMR_PROCESSOR_ARM64_V8_A,
+	OMR_PROCESSOR_ARM64_LAST = OMR_PROCESSOR_ARM64_V8_A,
+
+	// PPC Processors
+	OMR_PROCESSOR_PPC_FIRST,
+	OMR_PROCESSOR_PPC_UNKNOWN = OMR_PROCESSOR_PPC_FIRST,
+	OMR_PROCESSOR_PPC_RIOS1,
 	OMR_PROCESSOR_PPC_PWR403,
 	OMR_PROCESSOR_PPC_PWR405,
 	OMR_PROCESSOR_PPC_PWR440,
 	OMR_PROCESSOR_PPC_PWR601,
 	OMR_PROCESSOR_PPC_PWR602,
 	OMR_PROCESSOR_PPC_PWR603,
+	OMR_PROCESSOR_PPC_82XX,
+	OMR_PROCESSOR_PPC_7XX,
 	OMR_PROCESSOR_PPC_PWR604,
-	OMR_PROCESSOR_PPC_PWR620,
+	// The following processors support SQRT in hardware
+	OMR_PROCESSOR_PPC_HW_SQRT_FIRST,
+	OMR_PROCESSOR_PPC_RIOS2 = OMR_PROCESSOR_PPC_HW_SQRT_FIRST,
+	OMR_PROCESSOR_PPC_PWR2S,
+	// The following processors are 64-bit implementations
+	OMR_PROCESSOR_PPC_64BIT_FIRST,
+	OMR_PROCESSOR_PPC_PWR620 = OMR_PROCESSOR_PPC_64BIT_FIRST,
 	OMR_PROCESSOR_PPC_PWR630,
-	OMR_PROCESSOR_PPC_RIOS1,
-	OMR_PROCESSOR_PPC_RIOS2,
-	OMR_PROCESSOR_PPC_P6,
-	OMR_PROCESSOR_PPC_P7,
+	OMR_PROCESSOR_PPC_NSTAR,
+	OMR_PROCESSOR_PPC_PULSAR,
+	// The following processors support the PowerPC AS architecture
+	// PPC AS includes the new branch hint 'a' and 't' bits
+	OMR_PROCESSOR_PPC_AS_FIRST,
+	OMR_PROCESSOR_PPC_GP = OMR_PROCESSOR_PPC_AS_FIRST,
+	OMR_PROCESSOR_PPC_GR,
+	// The following processors support VMX
+	OMR_PROCESSOR_PPC_VMX_FIRST,
+	OMR_PROCESSOR_PPC_GPUL = OMR_PROCESSOR_PPC_VMX_FIRST,
+	OMR_PROCESSOR_PPC_HW_ROUND_FIRST,
+	OMR_PROCESSOR_PPC_HW_COPY_SIGN_FIRST = OMR_PROCESSOR_PPC_HW_ROUND_FIRST,
+	OMR_PROCESSOR_PPC_P6 = OMR_PROCESSOR_PPC_HW_COPY_SIGN_FIRST,
+	OMR_PROCESOSR_PPC_ATLAS,
+	OMR_PROCESSOR_PPC_BALANCED,
+	OMR_PROCESSOR_PPC_CELLPX,
+	// The following processors support VSX
+	OMR_PROCESSOR_PPC_VSX_FIRST,
+	OMR_PROCESSOR_PPC_P7 = OMR_PROCESSOR_PPC_VSX_FIRST,
 	OMR_PROCESSOR_PPC_P8,
 	OMR_PROCESSOR_PPC_P9,
+	OMR_PROCESSOR_PPC_LAST = OMR_PROCESSOR_PPC_P9,
 
-	OMR_PROCESSOR_X86_UNKNOWN,
-	OMR_PROCESSOR_X86_INTELPENTIUM,
+	// X86 Processors
+	OMR_PROCESSOR_X86_FIRST,
+	OMR_PROCESSOR_X86_UNKNOWN = OMR_PROCESSOR_X86_FIRST,
+	OMR_PROCESSOR_X86_INTEL_FIRST,
+	OMR_PROCESSOR_X86_INTELPENTIUM = OMR_PROCESSOR_X86_INTEL_FIRST,
 	OMR_PROCESSOR_X86_INTELP6,
 	OMR_PROCESSOR_X86_INTELPENTIUM4,
 	OMR_PROCESSOR_X86_INTELCORE2,
@@ -1213,11 +1262,19 @@ typedef enum OMRProcessorArchitecture {
 	OMR_PROCESSOR_X86_INTELNEHALEM,
 	OMR_PROCESSOR_X86_INTELWESTMERE,
 	OMR_PROCESSOR_X86_INTELSANDYBRIDGE,
+	OMR_PROCESSOR_X86_INTELIVYBRIDGE,
 	OMR_PROCESSOR_X86_INTELHASWELL,
-	OMR_PROCESSOR_X86_AMDK5,
+	OMR_PROCESSOR_X86_INTELBROADWELL,
+	OMR_PROCESSOR_X86_INTELSKYLAKE,
+	OMR_PROCESSOR_X86_INTEL_LAST = OMR_PROCESSOR_X86_INTELSKYLAKE,
+	OMR_PROCESSOR_X86_AMD_FIRST,
+	OMR_PROCESSOR_X86_AMDK5 = OMR_PROCESSOR_X86_AMD_FIRST,
 	OMR_PROCESSOR_X86_AMDK6,
 	OMR_PROCESSOR_X86_AMDATHLONDURON,
 	OMR_PROCESSOR_X86_AMDOPTERON,
+	OMR_PROCESSOR_X86_AMDFAMILY15H,
+	OMR_PROCESSOR_X86_AMD_LAST = OMR_PROCESSOR_X86_AMDFAMILY15H,
+	OMR_PROCESSOR_X86_LAST = OMR_PROCESSOR_X86_AMDFAMILY15H,
 
 	OMR_PROCESOR_RISCV32_UNKNOWN,
 	OMR_PROCESOR_RISCV64_UNKNOWN,
@@ -1226,8 +1283,8 @@ typedef enum OMRProcessorArchitecture {
 
 } OMRProcessorArchitecture;
 
-/* Holds processor type and features used with j9sysinfo_get_processor_description
- * and j9sysinfo_processor_has_feature
+/* Holds processor type and features used with omrsysinfo_get_processor_description
+ * and omrsysinfo_processor_has_feature
  */
 #define OMRPORT_SYSINFO_FEATURES_SIZE 5
 typedef struct OMRProcessorDesc {
@@ -1417,7 +1474,7 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_MCE     7 /* Machine Check Exception. */
 #define OMR_FEATURE_X86_CX8     8 /* Compare-and-exchange 8 bytes (64 bits) instruction */
 #define OMR_FEATURE_X86_APIC    9 /* APIC On-Chip. */
-#define OMR_FEATURE_X86_10     10 /* Reserved */
+#define OMR_FEATURE_X86_0_10   10 /* Reserved */
 #define OMR_FEATURE_X86_SEP    11 /* SYSENTER and SYSEXIT Instructions. */
 #define OMR_FEATURE_X86_MTRR   12 /* Memory Type Range Registers. */
 #define OMR_FEATURE_X86_PGE    13 /* Page Global Bit. */
@@ -1427,7 +1484,7 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_PSE_36 17 /* 36-Bit Page Size Extension. */
 #define OMR_FEATURE_X86_PSN    18 /* Processor Serial Number. */
 #define OMR_FEATURE_X86_CLFSH  19 /* CLFLUSH Instruction. */
-#define OMR_FEATURE_X86_20     20 /* Reserved */
+#define OMR_FEATURE_X86_0_20   20 /* Reserved */
 #define OMR_FEATURE_X86_DS     21 /* Debug Store. */
 #define OMR_FEATURE_X86_ACPI   22 /* Thermal Monitor and Software Controlled Clock Facilities. */
 #define OMR_FEATURE_X86_MMX    23 /* Intel MMX Technology. */
@@ -1437,7 +1494,7 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_SS     27 /* Self Snoop. */
 #define OMR_FEATURE_X86_HTT    28 /* Hyper Threading. */
 #define OMR_FEATURE_X86_TM     29 /* Thermal Monitor. */
-#define OMR_FEATURE_X86_30     30 /* Reserved */
+#define OMR_FEATURE_X86_0_30   30 /* Reserved */
 #define OMR_FEATURE_X86_PBE    31 /* Pending Break Enable. */
 
 /* INTEL INSTRUCTION SET REFERENCE, A-M
@@ -1454,12 +1511,12 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_TM2          32 + 8 /* Thermal Monitor 2. */
 #define OMR_FEATURE_X86_SSSE3        32 + 9 /* Supplemental Streaming SIMD Extensions 3 */
 #define OMR_FEATURE_X86_CNXT_ID      32 + 10 /* L1 Context ID. */
-#define OMR_FEATURE_X86_11           32 + 11 /* Reserved */
+#define OMR_FEATURE_X86_SDBG         32 + 11 /* Processor supports IA32_DEBUG_INTERFACE MSR for silicon debug. */
 #define OMR_FEATURE_X86_FMA          32 + 12 /* FMA extensions using YMM state. */
 #define OMR_FEATURE_X86_CMPXCHG16B   32 + 13 /* CMPXCHG16B Available. */
 #define OMR_FEATURE_X86_XTPR         32 + 14 /* xTPR Update Control. */
 #define OMR_FEATURE_X86_PDCM         32 + 15 /* Perfmon and Debug Capability. */
-#define OMR_FEATURE_X86_16           32 + 16 /* Reserved. */
+#define OMR_FEATURE_X86_1_16         32 + 16 /* Reserved. */
 #define OMR_FEATURE_X86_PCID         32 + 17 /* Process-context identifiers. */
 #define OMR_FEATURE_X86_DCA          32 + 18 /* Processor supports the ability to prefetch data from a memory mapped device. */
 #define OMR_FEATURE_X86_SSE4_1       32 + 19 /* Processor supports SSE4.1. */
@@ -1474,6 +1531,45 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_AVX          32 + 28 /* Processor supports the AVX instruction extensions. */
 #define OMR_FEATURE_X86_F16C         32 + 29 /* 16-bit floating-point conversion instructions. */
 #define OMR_FEATURE_X86_RDRAND       32 + 30 /* Processor supports RDRAND instruction. */
+#define OMR_FEATURE_X86_1_31         32 + 31 /* Not used */
+
+
+/* INTEL INSTRUCTION SET REFERENCE, A-M
+ * Vol. 2A 3-194 Table 3-8. Feature Information Returned in the EBX Register
+ */
+#define OMR_FEATURE_X86_FSGSBASE              64 + 0 /* RDFSBASE/RDGSBASE/WRFSBASE/WRGSBASE */
+#define OMR_FEATURE_X86_IA32_TSC_ADJUST       64 + 1 /* MSR is supported if 1 */
+#define OMR_FEATURE_X86_SGX                   64 + 2 /* Software Guard Extensions */
+#define OMR_FEATURE_X86_BMI1                  64 + 3 /* BMI1 */
+#define OMR_FEATURE_X86_HLE                   64 + 4 /* HLE */
+#define OMR_FEATURE_X86_AVX2                  64 + 5 /* AVX2 */
+#define OMR_FEATURE_X86_FDP_EXCPTN_ONLY       64 + 6 /* x87 FPU Data Pointer updated only on x87 exceptions if 1 */
+#define OMR_FEATURE_X86_SMEP                  64 + 7 /* Supervisor-Mode Execution Prevention */ 
+#define OMR_FEATURE_X86_BMI2                  64 + 8 /* BMI2 */
+#define OMR_FEATURE_X86_ERMSB                 64 + 9 /* Enhanced REP MOVSB/STOSB */
+#define OMR_FEATURE_X86_INVPCID               64 + 10 /* Processor supports INVPCID instruction for system software that manages process-context
+identifiers */
+#define OMR_FEATURE_X86_RTM                   64 + 11 /* RTM */
+#define OMR_FEATURE_X86_RDT_M                 64 + 12 /* Processor supports Intel Resource Director Technology Monitoring */ 
+#define OMR_FEATURE_X86_DEPRECATES_FPUCSDS    64 + 13 /* Deprecates FPU CS and FPU DS values */ 
+#define OMR_FEATURE_X86_MPX                   64 + 14 /* Processor supports Intel Memory Protection Extensions */
+#define OMR_FEATURE_X86_RDT_A                 64 + 15 /* Processor supports Intel Resource Director Technology Allocation capability */
+#define OMR_FEATURE_X86_2_16                  64 + 16 /* Reserved */          
+#define OMR_FEATURE_X86_2_17                  64 + 17 /* Reserved */
+#define OMR_FEATURE_X86_RDSEED                64 + 18 /* RDSEED */
+#define OMR_FEATURE_X86_ADX                   64 + 19 /* ADX */
+#define OMR_FEATURE_X86_SMAP                  64 + 20 /* Processor supports Supervisor-Mode Access Prevention */
+#define OMR_FEATURE_X86_2_21                  64 + 21 /* Reserved */
+#define OMR_FEATURE_X86_2_22                  64 + 22 /* Reserved */
+#define OMR_FEATURE_X86_CLFLUSHOPT            64 + 23 /* CLFLUSHOPT */
+#define OMR_FEATURE_X86_CLWB                  64 + 24 /* CLWB */
+#define OMR_FEATURE_INTEL_PROCESSOR_TRACE     64 + 25 /* Intel Processor Trace */
+#define OMR_FEATURE_X86_2_26                  64 + 26 /* Reserved */
+#define OMR_FEATURE_X86_2_27                  64 + 27 /* Reserved */
+#define OMR_FEATURE_X86_2_28                  64 + 28 /* Reserved */
+#define OMR_FEATURE_X86_SHA                   64 + 29 /* Processor supports Intel Secure Hash Algorithm extensions */
+#define OMR_FEATURE_X86_2_30                  64 + 30 /* Reserved */
+#define OMR_FEATURE_X86_2_31                  64 + 31 /* Reserved */
 
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -30,7 +30,9 @@
 
 #include "omrport.h"
 
+#if (defined(J9X86) || defined(J9HAMMER))
 extern intptr_t
 omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
+#endif
 
 #endif /* SYSINFOHELPERS_H_ */

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -631,7 +631,7 @@ omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcesso
 
 #if defined(J9OS_I5)
 #if defined(J9OS_I5_V5R4)
-	if ((OMR_FEATURE_PPC_HAS_VSX == feature) || (OMRPORT_PPC_FEATURE_HAS_ALTIVEC == feature) || (OMRPORT_PPC_FEATURE_HTM == feature)) {
+	if ((OMR_FEATURE_PPC_HAS_VSX == feature) || (OMR_FEATURE_PPC_HAS_ALTIVEC == feature) || (OMR_FEATURE_PPC_HTM == feature)) {
 		Trc_PRT_sysinfo_processor_has_feature_Exit((UDATA)rc);
 		return rc;
 	}


### PR DESCRIPTION
This change involves updating the omrsysinfo_get_x86_description() API and
a few enums.

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>