### PR TITLE
Remove the unused depend Power pseudoinstruction

### DIFF
--- a/compiler/p/codegen/OMRInstOpCode.hpp
+++ b/compiler/p/codegen/OMRInstOpCode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -179,7 +179,6 @@ class InstOpCode: public OMR::InstOpCode
 
         bool isAdmin() {return _mnemonic==ret      ||
                                _mnemonic==fence    ||
-                               _mnemonic==depend   ||
                                _mnemonic==proc     ||
                                _mnemonic==assocreg ||
                                _mnemonic==dd;}

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -551,7 +551,6 @@
    dd,               // define word
    assocreg,         // Associate real registers with Virtual registers.
    vgdnop,           // Virtual Guard NOP instruction
-   depend,           // Instruction to hang dependency on
    probenop,         // Probe NOP (for RI)
    iflong,           // compare and branch long
    setblong,         // compare long and set boolean

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -5877,16 +5877,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::depend,
-   /* .name        = */ "depend",
-   /* .description =    "Instruction to hang dependency on", */
-   /* .opcode      = */ 0x00000000,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_None,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::probenop,
    /* .name        = */ "nop",
    /* .description =    "Probe NOP (for RI)", */

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ OMR::Power::Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
    uint8_t *cursor           = instructionStart;
-   if (self()->getOpCodeValue() == TR::InstOpCode::depend || self()->getOpCodeValue() == TR::InstOpCode::assocreg)
+   if (self()->getOpCodeValue() == TR::InstOpCode::assocreg)
       {
       }
    else
@@ -84,7 +84,7 @@ OMR::Power::Instruction::generateBinaryEncoding()
 int32_t
 OMR::Power::Instruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   if (self()->getOpCodeValue() == TR::InstOpCode::depend || self()->getOpCodeValue() == TR::InstOpCode::assocreg)
+   if (self()->getOpCodeValue() == TR::InstOpCode::assocreg)
       {
       self()->setEstimatedBinaryLength(0);
       return currentEstimate;


### PR DESCRIPTION
The Power codegen previously had an unused pseudoinstruction called
depend that was meant to simply hang dependencies off of. However, this
instruction is unused and the assocreg instruction provides the same
functionality. To simplify things, the redundant depend instruction has
been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>