### PR TITLE
Use VFT test in hierarchy guard converted from profiled guard with VFT test

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,9 +134,17 @@ TR_VirtualGuard::createVftGuard
 (TR_VirtualGuardKind kind, TR::Compilation * comp, int16_t calleeIndex,
  TR::Node* callNode, TR::TreeTop * destination, TR_OpaqueClassBlock *thisClass)
    {
+   return createVftGuardWithReceiver(kind, comp, calleeIndex, callNode, destination, thisClass, callNode->getFirstArgument());
+   }
+
+TR::Node*
+TR_VirtualGuard::createVftGuardWithReceiver
+(TR_VirtualGuardKind kind, TR::Compilation * comp, int16_t calleeIndex,
+ TR::Node* callNode, TR::TreeTop * destination, TR_OpaqueClassBlock *thisClass, TR::Node* receiverNode)
+   {
    TR::SymbolReferenceTable *symRefTab = comp->getSymRefTab();
 
-   TR::Node* vft = TR::Node::createWithSymRef(TR::aloadi, 1, 1, callNode->getSecondChild(), symRefTab->findOrCreateVftSymbolRef());
+   TR::Node* vft = TR::Node::createWithSymRef(TR::aloadi, 1, 1, receiverNode, symRefTab->findOrCreateVftSymbolRef());
    TR::Node* aconstNode = TR::Node::aconst(callNode, (uintptrj_t)thisClass);
    aconstNode->setIsClassPointerConstant(true);
    aconstNode->setInlinedSiteIndex(calleeIndex);
@@ -159,7 +167,7 @@ TR_VirtualGuard::createMethodGuard
 (TR_VirtualGuardKind kind, TR::Compilation * comp, int16_t calleeIndex,
  TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol, TR_OpaqueClassBlock *thisClass)
    {
-   return createMethodGuardWithReceiver (kind, comp, calleeIndex, callNode, destination, calleeSymbol, thisClass, callNode->getSecondChild());
+   return createMethodGuardWithReceiver (kind, comp, calleeIndex, callNode, destination, calleeSymbol, thisClass, callNode->getFirstArgument());
    }
 
 /*

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,6 +105,15 @@ class TR_VirtualGuard
          TR::Node *,
          TR::TreeTop *,
          TR_OpaqueClassBlock *);
+
+   static TR::Node *createVftGuardWithReceiver(
+         TR_VirtualGuardKind,
+         TR::Compilation *,
+         int16_t calleeIndex,
+         TR::Node *,
+         TR::TreeTop *,
+         TR_OpaqueClassBlock *,
+         TR::Node* receiverNode);
 
    static TR::Node *createMethodGuard(
          TR_VirtualGuardKind,

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2190,20 +2190,27 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
           (node->getSymbolReference() == vp->comp()->getSymRefTab()->findVftSymbolRef()))
          {
          TR_OpaqueClassBlock *clazz = NULL;
+         TR::VPClassType *type = NULL;
          if (base->isClassObject() == TR_yes)
             {
             // base can only be an instance of java/lang/Class, since
             // we can't load <vft> relative to a J9Class.
             clazz = vp->comp()->getClassClassPointer();
+            if (clazz != NULL)
+               type = TR::VPFixedClass::create(vp, clazz);
             }
          else if (base->isFixedClass())
             {
             clazz = base->getClass();
+            if (clazz != NULL)
+               type = TR::VPFixedClass::create(vp, clazz);
             }
-
-         TR::VPClassType *type = NULL;
-         if (clazz != NULL)
-            type = TR::VPFixedClass::create(vp, clazz);
+         else if (base->getClass() &&
+                  base->getClassType() &&
+                  base->getClassType()->asResolvedClass())
+            {
+            type = TR::VPResolvedClass::create(vp, base->getClass());
+            }
 
          TR::VPClassPresence *nonnull = TR::VPNonNullObject::create(vp);
          TR::VPObjectLocation *loc =


### PR DESCRIPTION
This PR fix a problem where VP converts a profiled guard with VFT test to a hierarchy guard with method test. A method test is not sufficient as the optimizer may assume the receiver has a fixed type based on the guard and transform the code based on this assumption. One example is devirtualization.

This PR also create `ResolvedClass` constraint on a VFT load if the object class is resolved.