### PR TITLE
Added support for loadaddr in copy propagation

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1089,16 +1089,6 @@ public:
    bool isNonNull();
    void setIsNonNull(bool v);
 
-   bool pointsToNull();
-   void setPointsToNull(bool v);
-   bool chkPointsToNull();
-   const char * printPointsToNull();
-
-   bool pointsToNonNull();
-   void setPointsToNonNull(bool v);
-   bool chkPointsToNonNull();
-   const char * printPointsToNonNull();
-
    // Only used during local analysis
    bool containsCall();
    void setContainsCall(bool v);
@@ -1601,6 +1591,16 @@ public:
    void setIsAdjunct(bool v);
 
    // Flags used by TR::loadaddr
+   bool pointsToNull();
+   void setPointsToNull(bool v);
+   bool chkPointsToNull();
+   const char * printPointsToNull();
+
+   bool pointsToNonNull();
+   void setPointsToNonNull(bool v);
+   bool chkPointsToNonNull();
+   const char * printPointsToNonNull();
+
    bool cannotTrackLocalUses();
    void setCannotTrackLocalUses(bool v);
    bool chkCannotTrackLocalUses();


### PR DESCRIPTION
Replace a load of an auto sym ref A by a loadaddr of an auto sym ref B
if there was a store of A : store A = loadaddr B feeding the load of
sym ref A.

Node flags specific to loadaddr are preserved.

Fixes #4740 

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>