### PR TITLE
Fix missing volatile in CS large object copy

### DIFF
--- a/gc/structs/ForwardedHeader.cpp
+++ b/gc/structs/ForwardedHeader.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #endif /* defined(FORWARDEDHEADER_DEBUG) */
 #include <string.h>
 #include "AtomicOperations.hpp"
+#include "ModronAssertions.h"
 
 #if defined(FORWARDEDHEADER_DEBUG)
 void
@@ -256,6 +257,7 @@ MM_ForwardedHeader::copyOrWaitOutline(omrobjectptr_t destinationObjectPtr)
 
 			if (0 == remainingSizeToCopy) {
 				if (participatingInCopy) {
+					Assert_MM_true(outstandingCopies > 0);
 					MM_AtomicOperations::storeSync();
 					uintptr_t newValue = ((outstandingCopies - 1) << OUTSTANDING_COPIES_SHIFT) | _beingCopiedTag;
 					if (oldValue != lockCompareExchangeObjectHeader(destinationObjectPtr, oldValue, newValue)) {

--- a/gc/structs/ForwardedHeader.hpp
+++ b/gc/structs/ForwardedHeader.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,15 +79,6 @@ class MM_ForwardedHeader
 public:
 protected:
 private:
-struct MutableHeaderFields {
-		/* first slot must be always aligned as for an object slot */
-		fomrobject_t slot;
-
-#if defined (OMR_GC_COMPRESSED_POINTERS)
-		/* this field must be here to reserve space if slots are 4 bytes long (extend to 8 bytes starting from &MutableHeaderFields.clazz) */
-		uint32_t overlap;
-#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
-};
 	omrobjectptr_t _objectPtr;					/**< the object on which to act */
 	uintptr_t _preserved; 						/**< a backup copy of the header fields which may be modified by this class */
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
@@ -216,9 +207,9 @@ private:
 	{
 		uintptr_t value = 0;
 		if (compressObjectReferences()) {
-			value = *(uint32_t*)destinationObjectPtr;
+			value = *(volatile uint32_t*)destinationObjectPtr;
 		} else {
-			value = *(uintptr_t*)destinationObjectPtr;
+			value = *(volatile uintptr_t*)destinationObjectPtr;
 		}
 		return value;
 	}


### PR DESCRIPTION
When retrying to win a chunk to copy, to be sure we properly re-read the
the fields of the control word, the address of control word must be of
type pointer to volatile word.

Without it we may (for example) end up missing just incremented
outstandingCopies count and eventually hit negative value on way down
when decrementing.

The missing volatile is regression from relatively recent re-org for
CR/nonCR runtime feature: #4627
Original code indeed used to read the control word through
volatile MutableHeaderFields::slot *

Fixes: eclipse/openj9#8478

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>