### PR TITLE
Fix and enable sub-int32 tests on Z

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -2388,6 +2388,42 @@ OMR::Z::TreeEvaluator::caddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    return generic32BitAddEvaluator(node, cg);
    }
 
+TR::Register *
+OMR::Z::TreeEvaluator::bsubEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   // We don't have an instruction which adds a source register with a target memory reference, so force the
+   // evaluation of both chlidren here and pass the BAD mnemonic for the register-to-memory operand to the generic
+   // analyzer to ensure it is never generated
+   cg->evaluate(lhsChild);
+   cg->evaluate(rhsChild);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::SR, TR::InstOpCode::BAD, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
+   }
+
+TR::Register *
+OMR::Z::TreeEvaluator::ssubEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::SR, TR::InstOpCode::SH, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
+   }
+
 /**
  * isubEvaluator - subtract 2 integers or subtract a short from an integer
  * (child1 - child2)
@@ -2413,27 +2449,6 @@ TR::Register *
 OMR::Z::TreeEvaluator::lsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    return lsubHelper64(node, cg);
-   }
-
-
-/**
- * bsubEvaluator - subtract 2 bytes
- * (child1 - child2)
- */
-TR::Register *
-OMR::Z::TreeEvaluator::bsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return generic32BitSubEvaluator(node, cg);
-   }
-
-/**
- * ssubEvaluator - subtract 2 short integers
- * (child1 - child2)
- */
-TR::Register *
-OMR::Z::TreeEvaluator::ssubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return generic32BitSubEvaluator(node, cg);
    }
 
 /**

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -2343,23 +2343,40 @@ lmulHelper64(TR::Node * node, TR::CodeGenerator * cg)
    return targetRegister;
    }
 
-
-/**
- * baddEvaluator - add 2 bytes
- */
 TR::Register *
-OMR::Z::TreeEvaluator::baddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
+OMR::Z::TreeEvaluator::baddEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   return generic32BitAddEvaluator(node, cg);
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   // We don't have an instruction which adds a source register with a target memory reference, so force the
+   // evaluation of both chlidren here and pass the BAD mnemonic for the register-to-memory operand to the generic
+   // analyzer to ensure it is never generated
+   cg->evaluate(lhsChild);
+   cg->evaluate(rhsChild);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::AR, TR::InstOpCode::BAD, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
    }
 
-/**
- * saddEvaluator - add 2 short integers
- */
 TR::Register *
-OMR::Z::TreeEvaluator::saddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
+OMR::Z::TreeEvaluator::saddEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   return generic32BitAddEvaluator(node, cg);
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::AR, TR::InstOpCode::AH, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
    }
 
 /**

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -2558,6 +2558,42 @@ OMR::Z::TreeEvaluator::mulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    return targetRegister;
    }
 
+TR::Register *
+OMR::Z::TreeEvaluator::bmulEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   // We don't have an instruction which multiplies a source register with a target memory reference, so force the
+   // evaluation of both chlidren here and pass the BAD mnemonic for the register-to-memory operand to the generic
+   // analyzer to ensure it is never generated
+   cg->evaluate(lhsChild);
+   cg->evaluate(rhsChild);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::MSR, TR::InstOpCode::BAD, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
+   }
+
+TR::Register *
+OMR::Z::TreeEvaluator::smulEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsChild = node->getChild(0);
+   TR::Node* rhsChild = node->getChild(1);
+
+   TR_S390BinaryCommutativeAnalyser temp(cg);
+   temp.genericAnalyser(node, TR::InstOpCode::MSR, TR::InstOpCode::MH, TR::InstOpCode::LR);
+
+   cg->decReferenceCount(lhsChild);
+   cg->decReferenceCount(rhsChild);
+
+   return node->getRegister();
+   }
+
 /**
  * imulEvaluator - multiply 2 integers
  */
@@ -2686,26 +2722,6 @@ OMR::Z::TreeEvaluator::lmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       }
 
    return lmulHelper64(node, cg);
-   }
-
-/**
- * bmulEvaluator - multiply 2 bytes
- */
-TR::Register *
-OMR::Z::TreeEvaluator::bmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   TR_UNIMPLEMENTED();
-   return NULL;
-   }
-
-/**
- * smulEvaluator - multiply 2 short integers
- */
-TR::Register *
-OMR::Z::TreeEvaluator::smulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   TR_UNIMPLEMENTED();
-   return NULL;
    }
 
 /**

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -120,8 +120,8 @@
    TR::TreeEvaluator::lmulEvaluator,        // TR::lmul
    TR::TreeEvaluator::fmulEvaluator,        // TR::fmul
    TR::TreeEvaluator::dmulEvaluator,        // TR::dmul
-   TR::TreeEvaluator::unImpOpEvaluator,        // TR::bmul
-   TR::TreeEvaluator::unImpOpEvaluator,        // TR::smul
+   TR::TreeEvaluator::bmulEvaluator,        // TR::bmul
+   TR::TreeEvaluator::smulEvaluator,        // TR::smul
    TR::TreeEvaluator::idivEvaluator,        // TR::idiv
    TR::TreeEvaluator::ldivEvaluator,        // TR::ldiv
    TR::TreeEvaluator::fdivEvaluator,        // TR::fdiv

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3058,8 +3058,8 @@ void generateShiftAndKeepSelected64Bit(TR::Node * node, TR::CodeGenerator *cg,
       }
    else
       {
-      generateRSInstruction(cg, TR::InstOpCode::SRLG, node, aFirstRegister, aSecondRegister, (63 - aToBit) + aShiftAmount);
-      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, aFirstRegister, aFirstRegister, (63 - aToBit) + aShiftAmount + aFromBit);
+      generateRSInstruction(cg, TR::InstOpCode::SRLG, node, aFirstRegister, aSecondRegister, (63 - aToBit) - aShiftAmount);
+      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, aFirstRegister, aFirstRegister, (63 - aToBit) + aFromBit);
       generateRSInstruction(cg, TR::InstOpCode::SRLG, node, aFirstRegister, aFirstRegister, aFromBit);
       }
    }
@@ -3080,8 +3080,8 @@ generateShiftAndKeepSelected31Bit(TR::Node * node, TR::CodeGenerator *cg,
    else
       {
       generateRRInstruction(cg, TR::InstOpCode::LR, node, aFirstRegister, aSecondRegister);
-      generateRSInstruction(cg, TR::InstOpCode::SRL, node, aFirstRegister, (31 - aToBit) + aShiftAmount);
-      generateRSInstruction(cg, TR::InstOpCode::SLL, node, aFirstRegister, (31 - aToBit) + aShiftAmount + aFromBit);
+      generateRSInstruction(cg, TR::InstOpCode::SRL, node, aFirstRegister, (31 - aToBit) - aShiftAmount);
+      generateRSInstruction(cg, TR::InstOpCode::SLL, node, aFirstRegister, (31 - aToBit) + aFromBit);
       generateRSInstruction(cg, TR::InstOpCode::SRL, node, aFirstRegister, aFromBit);
       }
    }

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -317,10 +317,6 @@ TEST_P(UInt64Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int16Arithmetic, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -350,10 +346,6 @@ TEST_P(Int16Arithmetic, UsingConst) {
 }
 
 TEST_P(Int16Arithmetic, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -379,10 +371,6 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int8Arithmetic, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -412,9 +400,6 @@ TEST_P(Int8Arithmetic, UsingConst) {
 }
 
 TEST_P(Int8Arithmetic, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/BitPermuteTest.cpp
+++ b/fvtest/compilertriltest/BitPermuteTest.cpp
@@ -340,9 +340,6 @@ class sBitPermuteTest : public BitPermuteTest<uint16_t> {};
 
 TEST_P(sBitPermuteTest, ConstAddressLengthTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -380,9 +377,6 @@ TEST_P(sBitPermuteTest, ConstAddressLengthTest)
 
 TEST_P(sBitPermuteTest, ConstAddressTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -419,9 +413,6 @@ TEST_P(sBitPermuteTest, ConstAddressTest)
 
 TEST_P(sBitPermuteTest, NoConstTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -459,9 +450,6 @@ class bBitPermuteTest : public BitPermuteTest<uint8_t> {};
 
 TEST_P(bBitPermuteTest, ConstAddressLengthTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -499,9 +487,6 @@ TEST_P(bBitPermuteTest, ConstAddressLengthTest)
 
 TEST_P(bBitPermuteTest, ConstAddressTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -538,9 +523,6 @@ TEST_P(bBitPermuteTest, ConstAddressTest)
 
 TEST_P(bBitPermuteTest, NoConstTest)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -336,10 +336,6 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -366,10 +362,6 @@ TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
 TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -395,10 +387,6 @@ TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
-
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -458,11 +446,7 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -488,11 +472,7 @@ TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -518,11 +498,7 @@ TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -798,10 +774,6 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -828,10 +800,6 @@ TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
 TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -856,10 +824,6 @@ TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -919,11 +883,7 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -949,11 +909,7 @@ TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -979,10 +935,6 @@ TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -1330,10 +1282,6 @@ class UInt16MaskThenShift : public MaskThenShiftArithmetic<uint16_t> {};
 TEST_P(UInt16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -1369,10 +1317,6 @@ class Int16MaskThenShift : public MaskThenShiftArithmetic<int16_t> {};
 
 TEST_P(Int16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
-
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1410,10 +1354,6 @@ class UInt8MaskThenShift : public MaskThenShiftArithmetic<uint8_t> {};
 TEST_P(UInt8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -1449,10 +1389,6 @@ class Int8MaskThenShift : public MaskThenShiftArithmetic<int8_t> {};
 
 TEST_P(Int8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
-
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),

--- a/fvtest/compilertriltest/TernaryTest.cpp
+++ b/fvtest/compilertriltest/TernaryTest.cpp
@@ -112,10 +112,6 @@ static std::vector<std::tuple<T, T>> resultInputs()
 class Int32TernaryInt32CompareTest : public TernaryTest<int32_t, int32_t> {};
 
 TEST_P(Int32TernaryInt32CompareTest, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -144,10 +140,6 @@ TEST_P(Int32TernaryInt32CompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int32TernaryInt32CompareTest, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -188,10 +180,6 @@ INSTANTIATE_TEST_CASE_P(TernaryTest, Int32TernaryInt32CompareTest,
 class Int64TernaryInt64CompareTest : public TernaryTest<int64_t, int64_t> {};
 
 TEST_P(Int64TernaryInt64CompareTest, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -220,10 +208,6 @@ TEST_P(Int64TernaryInt64CompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int64TernaryInt64CompareTest, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -265,10 +249,6 @@ INSTANTIATE_TEST_CASE_P(TernaryTest, Int64TernaryInt64CompareTest,
 class Int64TernaryDoubleCompareTest : public TernaryTest<double, int64_t> {};
 
 TEST_P(Int64TernaryDoubleCompareTest, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -297,10 +277,6 @@ TEST_P(Int64TernaryDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int64TernaryDoubleCompareTest, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -339,10 +315,6 @@ INSTANTIATE_TEST_CASE_P(TernaryTest, Int64TernaryDoubleCompareTest,
 class Int32TernaryDoubleCompareTest : public TernaryTest<double, int32_t> {};
 
 TEST_P(Int32TernaryDoubleCompareTest, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -371,10 +343,6 @@ TEST_P(Int32TernaryDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int32TernaryDoubleCompareTest, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -414,10 +382,6 @@ INSTANTIATE_TEST_CASE_P(TernaryTest, Int32TernaryDoubleCompareTest,
 class ShortTernaryDoubleCompareTest : public TernaryTest<double, int16_t> {};
 
 TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -447,10 +411,6 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(ShortTernaryDoubleCompareTest, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
-        << "The Z code generator implementation is missing currently (see issue #3796)";
-
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -486,5 +446,3 @@ INSTANTIATE_TEST_CASE_P(TernaryTest, ShortTernaryDoubleCompareTest,
             ::testing::ValuesIn(compareInputs<double>()),
             ::testing::ValuesIn(resultInputs<int16_t>()),
             ::testing::Values((xternaryOracle<double, int16_t>))));
-
-

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -100,10 +100,6 @@ TEST_P(Int8ToInt32, UsingConst) {
 }
 
 TEST_P(Int8ToInt32, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -160,10 +156,6 @@ TEST_P(UInt8ToInt32, UsingConst) {
 }
 
 TEST_P(UInt8ToInt32, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -220,10 +212,6 @@ TEST_P(Int8ToInt64, UsingConst) {
 }
 
 TEST_P(Int8ToInt64, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -280,10 +268,6 @@ TEST_P(UInt8ToInt64, UsingConst) {
 }
 
 TEST_P(UInt8ToInt64, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -340,10 +324,6 @@ TEST_P(Int16ToInt32, UsingConst) {
 }
 
 TEST_P(Int16ToInt32, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -400,10 +380,6 @@ TEST_P(UInt16ToInt32, UsingConst) {
 }
 
 TEST_P(UInt16ToInt32, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -460,10 +436,6 @@ TEST_P(Int16ToInt64, UsingConst) {
 }
 
 TEST_P(Int16ToInt64, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -520,10 +492,6 @@ TEST_P(UInt16ToInt64, UsingConst) {
 }
 
 TEST_P(UInt16ToInt64, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =


### PR DESCRIPTION
Now that #4733 has been merged we have fixed the issue which was
preventing us from running various sub-int32 tests because the
incoming arguments were not being loaded correctly. We can now
re-enable all the sub-int32 tests which were disabled as a result.

Fixes: #3525
Fixes: #3796
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>