### PR TITLE
Implement dmin/dmax and fmin/fmax on Z 

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -367,21 +367,19 @@ imaximinHelper(TR::Node* node, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic c
       TR::Node* lhsNode = node->getChild(0);
       TR::Node* rhsNode = node->getChild(1);
 
-      TR::Register* lhsReg = cg->allocateRegister();
+      TR::Register* resultReg = cg->allocateRegister();
+      TR::Register* lhsReg = cg->evaluate(lhsNode);
       TR::Register* rhsReg = cg->evaluate(rhsNode);
 
-      // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
-      TR::Register* tmpRegister = cg->evaluate(lhsNode);
+      generateRRInstruction(cg, TR::InstOpCode::CR, node, lhsReg, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::SELR, node, resultReg, rhsReg, lhsReg, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
 
-      generateRRInstruction(cg, TR::InstOpCode::CR, node, tmpRegister, rhsReg);
-      generateRRFInstruction(cg, TR::InstOpCode::SELR, node, lhsReg, rhsReg, tmpRegister, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
-
-      node->setRegister(lhsReg);
+      node->setRegister(resultReg);
 
       cg->decReferenceCount(lhsNode);
       cg->decReferenceCount(rhsNode);
 
-      return lhsReg;
+      return resultReg;
       }
    else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
@@ -415,21 +413,19 @@ lmaxlminHelper(TR::Node* node, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic c
       TR::Node* lhsNode = node->getChild(0);
       TR::Node* rhsNode = node->getChild(1);
 
-      TR::Register* lhsReg = cg->allocateRegister();
+      TR::Register* resultReg = cg->allocateRegister();
+      TR::Register* lhsReg = cg->evaluate(lhsNode);
       TR::Register* rhsReg = cg->evaluate(rhsNode);
 
-      // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
-      TR::Register* tmpRegister = cg->evaluate(lhsNode);
+      generateRREInstruction(cg, TR::InstOpCode::CGR, node, lhsReg, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::SELGR, node, resultReg, rhsReg, lhsReg, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
 
-      generateRREInstruction(cg, TR::InstOpCode::CGR, node, tmpRegister, rhsReg);
-      generateRRFInstruction(cg, TR::InstOpCode::SELGR, node, lhsReg, rhsReg, tmpRegister, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
-
-      node->setRegister(lhsReg);
+      node->setRegister(resultReg);
 
       cg->decReferenceCount(lhsNode);
       cg->decReferenceCount(rhsNode);
 
-      return lhsReg;
+      return resultReg;
       }
    else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -323,130 +323,33 @@ generateS390Compare(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mne
    return branchOpCond;
    }
 
-/**
- *  \brief
- *     Compares two values are returns the max/min of the two.
- *     ONLY SUPPORTS imax, imin, lmax, lmin
- *
- *  \param node
- *     The node representing a call to max or min.
- *
- *  \param cg
- *     The code generator used to generate the instructions.
- *
- *  \param isMax
- *     Determines the type of function, either a max or min call.
- *
- *  \return
- *     The register containing the max/min value.
- */
-static TR::Register* maxMinHelper(TR::Node* node, TR::CodeGenerator* cg, bool isMax)
+static TR::Register*
+xmaxxminHelper(TR::Node* node, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic compareRROp, TR::InstOpCode::S390BranchCondition branchCond, TR::InstOpCode::Mnemonic moveRROp)
    {
    TR::Node* lhsNode = node->getChild(0);
    TR::Node* rhsNode = node->getChild(1);
 
-   TR::Register* lhsReg = NULL;
+   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
    TR::Register* rhsReg = cg->evaluate(rhsNode);
 
-   // Mask is 4 to pick rhs when lhs is less for max, 2 to pick rhs when lhs is greater for min
-   const uint8_t mask = isMax ? 0x4 : 0x2;
+   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
 
-   if (node->getOpCodeValue() == TR::imax || node->getOpCodeValue() == TR::imin)
-      {
-      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15))
-         {
-         lhsReg = cg->allocateRegister();
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
 
-         // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
-         TR::Register* tmpRegister = cg->evaluate(lhsNode);
+   generateRREInstruction(cg, compareRROp, node, lhsReg, rhsReg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, branchCond, node, cFlowRegionEnd);
 
-         generateRRInstruction(cg, TR::InstOpCode::CR, node, tmpRegister, rhsReg);
-         generateRRFInstruction(cg, TR::InstOpCode::SELR, node, lhsReg, rhsReg, tmpRegister, mask);
-         }
-      else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
-         {
-         lhsReg = cg->gprClobberEvaluate(lhsNode);
+   generateRREInstruction(cg, moveRROp, node, lhsReg, rhsReg);
 
-         generateRRInstruction(cg, TR::InstOpCode::CR, node, lhsReg, rhsReg);
-         generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, lhsReg, rhsReg, mask, true);
-         }
-      else
-         {
-         lhsReg = cg->gprClobberEvaluate(lhsNode);
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
 
-         TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-         TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
+   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
 
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-         cFlowRegionStart->setStartInternalControlFlow();
-
-         auto bc = isMax ?
-            TR::InstOpCode::COND_BHR :
-            TR::InstOpCode::COND_BLR;
-
-         generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CR, node, lhsReg, rhsReg, bc, cFlowRegionEnd, false);
-
-         generateRRInstruction(cg, TR::InstOpCode::LR, node, lhsReg, rhsReg);
-
-         TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-         deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-         deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-         cFlowRegionEnd->setEndInternalControlFlow();
-         }
-      }
-   else if (node->getOpCodeValue() == TR::lmax || node->getOpCodeValue() == TR::lmin)
-      {
-      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15))
-         {
-         lhsReg = cg->allocateRegister();
-
-         // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
-         TR::Register* tmpRegister = cg->evaluate(lhsNode);
-
-         generateRREInstruction(cg, TR::InstOpCode::CGR, node, tmpRegister, rhsReg);
-         generateRRFInstruction(cg, TR::InstOpCode::SELGR, node, lhsReg, rhsReg, tmpRegister, mask);
-         }
-      else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
-         {
-         lhsReg = cg->gprClobberEvaluate(lhsNode);
-
-         generateRREInstruction(cg, TR::InstOpCode::CGR, node, lhsReg, rhsReg);
-         generateRRFInstruction(cg, TR::InstOpCode::LOCGR, node, lhsReg, rhsReg, mask, true);
-         }
-      else
-         {
-         lhsReg = cg->gprClobberEvaluate(lhsNode);
-
-         TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-         TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
-
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-         cFlowRegionStart->setStartInternalControlFlow();
-
-         auto bc = isMax ?
-            TR::InstOpCode::COND_BHR :
-            TR::InstOpCode::COND_BLR;
-
-         generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CGR, node, lhsReg, rhsReg, bc, cFlowRegionEnd, false);
-
-         generateRRInstruction(cg, TR::InstOpCode::LGR, node, lhsReg, rhsReg);
-
-         TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-         deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-         deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-         cFlowRegionEnd->setEndInternalControlFlow();
-         }
-      }
-   else
-      {
-      TR_ASSERT_FATAL(node->getOpCodeValue(), "Opcode %s cannot be evaluated by maxMinHelper\n", node->getOpCode().getName());
-      }
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
+   cFlowRegionEnd->setEndInternalControlFlow();
 
    node->setRegister(lhsReg);
 
@@ -456,160 +359,148 @@ static TR::Register* maxMinHelper(TR::Node* node, TR::CodeGenerator* cg, bool is
    return lhsReg;
    }
 
-TR::Register *
-OMR::Z::TreeEvaluator::maxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+static TR::Register*
+imaximinHelper(TR::Node* node, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic compareRROp, TR::InstOpCode::S390BranchCondition branchCond, TR::InstOpCode::Mnemonic moveRROp)
    {
-   return maxMinHelper(node, cg, true);
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15))
+      {
+      TR::Node* lhsNode = node->getChild(0);
+      TR::Node* rhsNode = node->getChild(1);
+
+      TR::Register* lhsReg = cg->allocateRegister();
+      TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+      // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
+      TR::Register* tmpRegister = cg->evaluate(lhsNode);
+
+      generateRRInstruction(cg, TR::InstOpCode::CR, node, tmpRegister, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::SELR, node, lhsReg, rhsReg, tmpRegister, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
+
+      node->setRegister(lhsReg);
+
+      cg->decReferenceCount(lhsNode);
+      cg->decReferenceCount(rhsNode);
+
+      return lhsReg;
+      }
+   else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
+      {
+      TR::Node* lhsNode = node->getChild(0);
+      TR::Node* rhsNode = node->getChild(1);
+
+      TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+      TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+      generateRRInstruction(cg, TR::InstOpCode::CR, node, lhsReg, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, lhsReg, rhsReg, getMaskForBranchCondition(getReverseBranchCondition(branchCond)), true);
+
+      node->setRegister(lhsReg);
+
+      cg->decReferenceCount(lhsNode);
+      cg->decReferenceCount(rhsNode);
+
+      return lhsReg;
+      }
+   else
+      {
+      return xmaxxminHelper(node, cg, compareRROp, branchCond, moveRROp);
+      }
+   }
+
+static TR::Register*
+lmaxlminHelper(TR::Node* node, TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic compareRROp, TR::InstOpCode::S390BranchCondition branchCond, TR::InstOpCode::Mnemonic moveRROp)
+   {
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15))
+      {
+      TR::Node* lhsNode = node->getChild(0);
+      TR::Node* rhsNode = node->getChild(1);
+
+      TR::Register* lhsReg = cg->allocateRegister();
+      TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+      // Load into a tmp instead of clobberEvaluating into lhsReg to avoid an extra register shuffle
+      TR::Register* tmpRegister = cg->evaluate(lhsNode);
+
+      generateRREInstruction(cg, TR::InstOpCode::CGR, node, tmpRegister, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::SELGR, node, lhsReg, rhsReg, tmpRegister, getMaskForBranchCondition(getReverseBranchCondition(branchCond)));
+
+      node->setRegister(lhsReg);
+
+      cg->decReferenceCount(lhsNode);
+      cg->decReferenceCount(rhsNode);
+
+      return lhsReg;
+      }
+   else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
+      {
+      TR::Node* lhsNode = node->getChild(0);
+      TR::Node* rhsNode = node->getChild(1);
+
+      TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+      TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+      generateRREInstruction(cg, TR::InstOpCode::CGR, node, lhsReg, rhsReg);
+      generateRRFInstruction(cg, TR::InstOpCode::LOCGR, node, lhsReg, rhsReg, getMaskForBranchCondition(getReverseBranchCondition(branchCond)), true);
+
+      node->setRegister(lhsReg);
+
+      cg->decReferenceCount(lhsNode);
+      cg->decReferenceCount(rhsNode);
+
+      return lhsReg;
+      }
+   else
+      {
+      return xmaxxminHelper(node, cg, compareRROp, branchCond, moveRROp);
+      }
+   }
+
+TR::Register*
+OMR::Z::TreeEvaluator::imaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   return imaximinHelper(node, cg, TR::InstOpCode::CR, TR::InstOpCode::COND_BHR, TR::InstOpCode::LR);
+   }
+
+TR::Register*
+OMR::Z::TreeEvaluator::lmaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   return lmaxlminHelper(node, cg, TR::InstOpCode::CGR, TR::InstOpCode::COND_BHR, TR::InstOpCode::LGR);
    }
 
 TR::Register*
 OMR::Z::TreeEvaluator::fmaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR::Node* lhsNode = node->getChild(0);
-   TR::Node* rhsNode = node->getChild(1);
-
-   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
-   TR::Register* rhsReg = cg->evaluate(rhsNode);
-
-   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-   cFlowRegionStart->setStartInternalControlFlow();
-
-   generateRRInstruction(cg, TR::InstOpCode::CEBR, node, lhsReg, rhsReg);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BHR, node, cFlowRegionEnd);
-
-   generateRRInstruction(cg, TR::InstOpCode::LER, node, lhsReg, rhsReg);
-
-   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-   cFlowRegionEnd->setEndInternalControlFlow();
-
-   node->setRegister(lhsReg);
-
-   cg->decReferenceCount(lhsNode);
-   cg->decReferenceCount(rhsNode);
-
-   return lhsReg;
+   return xmaxxminHelper(node, cg, TR::InstOpCode::CEBR, TR::InstOpCode::COND_BHR, TR::InstOpCode::LER);
    }
 
 TR::Register*
 OMR::Z::TreeEvaluator::dmaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR::Node* lhsNode = node->getChild(0);
-   TR::Node* rhsNode = node->getChild(1);
-
-   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
-   TR::Register* rhsReg = cg->evaluate(rhsNode);
-
-   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-   cFlowRegionStart->setStartInternalControlFlow();
-
-   generateRRInstruction(cg, TR::InstOpCode::CDBR, node, lhsReg, rhsReg);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BHR, node, cFlowRegionEnd);
-
-   generateRRInstruction(cg, TR::InstOpCode::LDR, node, lhsReg, rhsReg);
-
-   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-   cFlowRegionEnd->setEndInternalControlFlow();
-
-   node->setRegister(lhsReg);
-
-   cg->decReferenceCount(lhsNode);
-   cg->decReferenceCount(rhsNode);
-
-   return lhsReg;
+   return xmaxxminHelper(node, cg, TR::InstOpCode::CDBR, TR::InstOpCode::COND_BHR, TR::InstOpCode::LDR);
    }
 
 TR::Register *
-OMR::Z::TreeEvaluator::minEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+OMR::Z::TreeEvaluator::iminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return maxMinHelper(node, cg, false);
+   return imaximinHelper(node, cg, TR::InstOpCode::CR, TR::InstOpCode::COND_BLR, TR::InstOpCode::LR);
+   }
+
+TR::Register *
+OMR::Z::TreeEvaluator::lminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return lmaxlminHelper(node, cg, TR::InstOpCode::CGR, TR::InstOpCode::COND_BLR, TR::InstOpCode::LGR);
    }
 
 TR::Register*
 OMR::Z::TreeEvaluator::fminEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR::Node* lhsNode = node->getChild(0);
-   TR::Node* rhsNode = node->getChild(1);
-
-   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
-   TR::Register* rhsReg = cg->evaluate(rhsNode);
-
-   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-   cFlowRegionStart->setStartInternalControlFlow();
-
-   generateRRInstruction(cg, TR::InstOpCode::CEBR, node, lhsReg, rhsReg);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BLR, node, cFlowRegionEnd);
-
-   generateRRInstruction(cg, TR::InstOpCode::LER, node, lhsReg, rhsReg);
-
-   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-   cFlowRegionEnd->setEndInternalControlFlow();
-
-   node->setRegister(lhsReg);
-
-   cg->decReferenceCount(lhsNode);
-   cg->decReferenceCount(rhsNode);
-
-   return lhsReg;
+   return xmaxxminHelper(node, cg, TR::InstOpCode::CEBR, TR::InstOpCode::COND_BLR, TR::InstOpCode::LER);
    }
 
 TR::Register*
 OMR::Z::TreeEvaluator::dminEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR::Node* lhsNode = node->getChild(0);
-   TR::Node* rhsNode = node->getChild(1);
-
-   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
-   TR::Register* rhsReg = cg->evaluate(rhsNode);
-
-   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
-   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
-   cFlowRegionStart->setStartInternalControlFlow();
-
-   generateRRInstruction(cg, TR::InstOpCode::CDBR, node, lhsReg, rhsReg);
-   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BLR, node, cFlowRegionEnd);
-
-   generateRRInstruction(cg, TR::InstOpCode::LDR, node, lhsReg, rhsReg);
-
-   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
-
-   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
-   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
-
-   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
-   cFlowRegionEnd->setEndInternalControlFlow();
-
-   node->setRegister(lhsReg);
-
-   cg->decReferenceCount(lhsNode);
-   cg->decReferenceCount(rhsNode);
-
-   return lhsReg;
+   return xmaxxminHelper(node, cg, TR::InstOpCode::CDBR, TR::InstOpCode::COND_BLR, TR::InstOpCode::LDR);
    }
 
 /**

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -462,12 +462,155 @@ OMR::Z::TreeEvaluator::maxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return maxMinHelper(node, cg, true);
    }
 
+TR::Register*
+OMR::Z::TreeEvaluator::fmaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsNode = node->getChild(0);
+   TR::Node* rhsNode = node->getChild(1);
+
+   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+   TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+
+   generateRRInstruction(cg, TR::InstOpCode::CEBR, node, lhsReg, rhsReg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BHR, node, cFlowRegionEnd);
+
+   generateRRInstruction(cg, TR::InstOpCode::LER, node, lhsReg, rhsReg);
+
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
+
+   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
+   cFlowRegionEnd->setEndInternalControlFlow();
+
+   node->setRegister(lhsReg);
+
+   cg->decReferenceCount(lhsNode);
+   cg->decReferenceCount(rhsNode);
+
+   return lhsReg;
+   }
+
+TR::Register*
+OMR::Z::TreeEvaluator::dmaxEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsNode = node->getChild(0);
+   TR::Node* rhsNode = node->getChild(1);
+
+   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+   TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+
+   generateRRInstruction(cg, TR::InstOpCode::CDBR, node, lhsReg, rhsReg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BHR, node, cFlowRegionEnd);
+
+   generateRRInstruction(cg, TR::InstOpCode::LDR, node, lhsReg, rhsReg);
+
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
+
+   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
+   cFlowRegionEnd->setEndInternalControlFlow();
+
+   node->setRegister(lhsReg);
+
+   cg->decReferenceCount(lhsNode);
+   cg->decReferenceCount(rhsNode);
+
+   return lhsReg;
+   }
+
 TR::Register *
 OMR::Z::TreeEvaluator::minEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return maxMinHelper(node, cg, false);
    }
 
+TR::Register*
+OMR::Z::TreeEvaluator::fminEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsNode = node->getChild(0);
+   TR::Node* rhsNode = node->getChild(1);
+
+   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+   TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+
+   generateRRInstruction(cg, TR::InstOpCode::CEBR, node, lhsReg, rhsReg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BLR, node, cFlowRegionEnd);
+
+   generateRRInstruction(cg, TR::InstOpCode::LER, node, lhsReg, rhsReg);
+
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
+
+   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
+   cFlowRegionEnd->setEndInternalControlFlow();
+
+   node->setRegister(lhsReg);
+
+   cg->decReferenceCount(lhsNode);
+   cg->decReferenceCount(rhsNode);
+
+   return lhsReg;
+   }
+
+TR::Register*
+OMR::Z::TreeEvaluator::dminEvaluator(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   TR::Node* lhsNode = node->getChild(0);
+   TR::Node* rhsNode = node->getChild(1);
+
+   TR::Register* lhsReg = cg->gprClobberEvaluate(lhsNode);
+   TR::Register* rhsReg = cg->evaluate(rhsNode);
+
+   TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol* cFlowRegionEnd = generateLabelSymbol(cg);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+
+   generateRRInstruction(cg, TR::InstOpCode::CDBR, node, lhsReg, rhsReg);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BLR, node, cFlowRegionEnd);
+
+   generateRRInstruction(cg, TR::InstOpCode::LDR, node, lhsReg, rhsReg);
+
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
+
+   deps->addPostConditionIfNotAlreadyInserted(lhsReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(rhsReg, TR::RealRegister::AssignAny);
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, deps);
+   cFlowRegionEnd->setEndInternalControlFlow();
+
+   node->setRegister(lhsReg);
+
+   cg->decReferenceCount(lhsNode);
+   cg->decReferenceCount(rhsNode);
+
+   return lhsReg;
+   }
 
 /**
  * 64bit version lcmpEvaluator Helper: long compare (1 if child1 > child2, 0 if child1 == child2,

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -736,7 +736,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *GlRegDepsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *minEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *maxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool needsResolve, TR::CodeGenerator * cg);
 

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -734,11 +734,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *GlRegDepsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-
-   static TR::Register *minEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   
+   static TR::Register *iminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *lminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *maxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *imaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *lmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -790,17 +790,17 @@
    TR::TreeEvaluator::setpmEvaluator,       // TR::setpm
    TR::TreeEvaluator::loadAutoOffsetEvaluator,// TR::loadAutoOffset
 
-   TR::TreeEvaluator::maxEvaluator,         // TR::imax
-   TR::TreeEvaluator::maxEvaluator,         // TR::iumax
-   TR::TreeEvaluator::maxEvaluator,         // TR::lmax
-   TR::TreeEvaluator::maxEvaluator,         // TR::lumax
+   TR::TreeEvaluator::imaxEvaluator,         // TR::imax
+   TR::TreeEvaluator::imaxEvaluator,         // TR::iumax
+   TR::TreeEvaluator::lmaxEvaluator,         // TR::lmax
+   TR::TreeEvaluator::lmaxEvaluator,         // TR::lumax
    TR::TreeEvaluator::fmaxEvaluator,     // TR::fmax
    TR::TreeEvaluator::dmaxEvaluator,     // TR::dmax
 
-   TR::TreeEvaluator::minEvaluator,         // TR::imin
-   TR::TreeEvaluator::minEvaluator,         // TR::iumin
-   TR::TreeEvaluator::minEvaluator,         // TR::lmin
-   TR::TreeEvaluator::minEvaluator,         // TR::lumin
+   TR::TreeEvaluator::iminEvaluator,         // TR::imin
+   TR::TreeEvaluator::iminEvaluator,         // TR::iumin
+   TR::TreeEvaluator::lminEvaluator,         // TR::lmin
+   TR::TreeEvaluator::lminEvaluator,         // TR::lumin
    TR::TreeEvaluator::fminEvaluator,     // TR::fmin
    TR::TreeEvaluator::dminEvaluator,     // TR::dmin
    TR::TreeEvaluator::trtEvaluator,         // TR::trt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -794,15 +794,15 @@
    TR::TreeEvaluator::maxEvaluator,         // TR::iumax
    TR::TreeEvaluator::maxEvaluator,         // TR::lmax
    TR::TreeEvaluator::maxEvaluator,         // TR::lumax
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::fmax
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dmax
+   TR::TreeEvaluator::fmaxEvaluator,     // TR::fmax
+   TR::TreeEvaluator::dmaxEvaluator,     // TR::dmax
 
    TR::TreeEvaluator::minEvaluator,         // TR::imin
    TR::TreeEvaluator::minEvaluator,         // TR::iumin
    TR::TreeEvaluator::minEvaluator,         // TR::lmin
    TR::TreeEvaluator::minEvaluator,         // TR::lumin
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::fmin
-   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dmin
+   TR::TreeEvaluator::fminEvaluator,     // TR::fmin
+   TR::TreeEvaluator::dminEvaluator,     // TR::dmin
    TR::TreeEvaluator::trtEvaluator,         // TR::trt
    TR::TreeEvaluator::trtEvaluator,         // TR::trtSimple
 

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,7 +190,7 @@ class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
 
 TEST_P(FloatMaxMin, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
         << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
     auto param = TRTest::to_struct(GetParam());
     char inputTrees[1024] = {0};
@@ -219,7 +219,7 @@ TEST_P(FloatMaxMin, UsingConst) {
 
 TEST_P(FloatMaxMin, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
         << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
     auto param = TRTest::to_struct(GetParam());
 
@@ -257,7 +257,7 @@ class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
 
 TEST_P(DoubleMaxMin, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
         << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
     auto param = TRTest::to_struct(GetParam());
 
@@ -287,7 +287,7 @@ TEST_P(DoubleMaxMin, UsingConst) {
 
 TEST_P(DoubleMaxMin, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
         << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
     auto param = TRTest::to_struct(GetParam());
 


### PR DESCRIPTION
Provide naive implementations of these two evaluators with internal
control flow regions. We also take this opportunity to refactor and
reduce duplication in the evaluators.

Much of the code between the max/min evaluators for different datatypes
is shared. We minimize the duplication by moving code into helpers and
using parameters to pass in mnemonics which to generate.

Issue: #4276
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>