### PR TITLE
Fix ILGen GPF if last block is malformed

### DIFF
--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -286,7 +286,12 @@ OMR::CFG::addSuccessorEdges(TR::Block * block)
             addEdge(block, block->getExit()->getNextTreeTop()->getNode()->getBlock());
          break;
       default:
-         addEdge(block, block->getExit()->getNextTreeTop()->getNode()->getBlock());
+         {
+         if (block->getExit()->getNextTreeTop())
+            addEdge(block, block->getExit()->getNextTreeTop()->getNode()->getBlock());
+         else
+            addEdge(block, getEnd());
+         }
       }
    }
 


### PR DESCRIPTION
When generating code, if the last block being generated does not end in
a control-flow statement a GPF can occur in the CFG trying to add an
appropriate exit edge. While such an unterminated block is ilformed, the
block may be unreachable and will be cleaned up by the optimizer. This
change is to prevent the compiler crashing - an edge from the last block
is added to the end of the CFG.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>