### PR TITLE
RISC-V: enable compiler tests in CI pipeline

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-linux_riscv64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_riscv64
@@ -45,6 +45,17 @@ pipeline {
                 }
             }
         }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                        junit '**/*results.xml'
+                    }
+                }
+            }
+        }
     }
     post {
         success {

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_riscv64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_riscv64
@@ -30,6 +30,17 @@ pipeline {
                 }
             }
         }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                        junit '**/*results.xml'
+                    }
+                }
+            }
+        }
     }
     post {
         always {

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -144,6 +144,7 @@ TEST_P(UInt32Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support iudiv/iurem (see issue #3673)";
+    SKIP_ON_RISCV(MissingImplementation);
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -177,6 +178,7 @@ TEST_P(UInt32Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support iudiv/iurem (see issue #3673)";
+    SKIP_ON_RISCV(MissingImplementation);
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -260,6 +262,7 @@ TEST_P(UInt64Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "ludiv" && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support ludiv (see issue #2227)";
+    SKIP_ON_RISCV(MissingImplementation);
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -293,6 +296,7 @@ TEST_P(UInt64Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "ludiv" && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support ludiv (see issue #2227)";
+    SKIP_ON_RISCV(MissingImplementation);
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -317,6 +321,7 @@ TEST_P(UInt64Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int16Arithmetic, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -346,6 +351,7 @@ TEST_P(Int16Arithmetic, UsingConst) {
 }
 
 TEST_P(Int16Arithmetic, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -371,6 +377,7 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int8Arithmetic, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -400,6 +407,8 @@ TEST_P(Int8Arithmetic, UsingConst) {
 }
 
 TEST_P(Int8Arithmetic, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+    
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -937,6 +937,8 @@ int32_t iffcmpgt(float l, float r) {
 class FloatIfCompare : public TRTest::OpCodeTest<int32_t, float, float> {};
 
 TEST_P(FloatIfCompare, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[256] = {0};
@@ -965,6 +967,8 @@ TEST_P(FloatIfCompare, UsingConst) {
 }
 
 TEST_P(FloatIfCompare, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[256] = {0};
@@ -1031,6 +1035,8 @@ int32_t ifdcmpgt(double l, double r) {
 class DoubleIfCompare : public TRTest::OpCodeTest<int32_t, double, double> {};
 
 TEST_P(DoubleIfCompare, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -1059,6 +1065,8 @@ TEST_P(DoubleIfCompare, UsingConst) {
 }
 
 TEST_P(DoubleIfCompare, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[256] = {0};

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,8 @@ INSTANTIATE_TEST_CASE_P(ILValidatorTest, IllformedTrees, ::testing::Values(
 class WellformedTrees : public TRTest::JitTest, public ::testing::WithParamInterface<std::string> {};
 
 TEST_P(WellformedTrees, CompileOnly) {
+    SKIP_ON_RISCV(MissingImplementation) << "Skipped in RISC-V because of missing implementation of acmpge";
+
     auto inputTrees = GetParam();
     auto trees = parseString(inputTrees.c_str());
 

--- a/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
+++ b/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@
 
 // C++11 upgrade (Issue #1916).
 template <typename ValType>
-class IfxcmpgeReductionTest : public ::testing::TestWithParam<std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)>>
+class IfxcmpgeReductionTest : public TRTest::TestWithPortLib, public ::testing::WithParamInterface<std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)>>
    {
    public:
 
@@ -92,6 +92,8 @@ class Int8ReductionTest : public IfxcmpgeReductionTest<int8_t> {};
 
 TEST_P(Int8ReductionTest, Reduction)
    {
+   SKIP_ON_RISCV(MissingImplementation);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[600] = {0};
@@ -136,6 +138,8 @@ class UInt8ReductionTest : public IfxcmpgeReductionTest<uint8_t> {};
 
 TEST_P(UInt8ReductionTest, Reduction)
    {
+   SKIP_ON_RISCV(MissingImplementation);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[600] = {0};
@@ -180,6 +184,8 @@ class Int16ReductionTest : public IfxcmpgeReductionTest<int16_t> {};
 
 TEST_P(Int16ReductionTest, Reduction)
    {
+   SKIP_ON_RISCV(MissingImplementation);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[600] = {0};
@@ -224,6 +230,8 @@ class UInt16ReductionTest : public IfxcmpgeReductionTest<uint16_t> {};
 
 TEST_P(UInt16ReductionTest, Reduction)
    {
+   SKIP_ON_RISCV(MissingImplementation);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[600] = {0};

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include <stdexcept>
 #include <iostream>
+#include <cstring>
 #include "control/Options.hpp"
 #include "optimizer/Optimizer.hpp"
 #include "ilgen/MethodBuilder.hpp"
@@ -606,7 +607,7 @@ class SkipHelper
  * anywhere within the scope of a test, it is best to only use at at the beginning,
  * before the main body of a test.
  *
- * To skip a test, a condition aswell as a "reason" for skipping must be specified.
+ * To skip a test, a condition as well as a "reason" for skipping must be specified.
  * The condition may be any boolean expression. The "reason" must be a value from
  * the `SkipReason` enum (see its documentation for further details). Optionally,
  * a more detailed message can also be specified using the `<<` stream operator;
@@ -623,5 +624,127 @@ class SkipHelper
    if (!(condition)) { /* allow test to proceed normally */ } \
    else \
       return SkipHelper(SkipReason::reason) = ::testing::Message()
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on given platform
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON(<OMRPORT_ARCH_*>, <reason>) << <message>;
+ *
+ */
+#define SKIP_ON(arch, reason) \
+   SKIP_IF(!strcmp(arch, omrsysinfo_get_CPU_architecture()), reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on X86
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_X86(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_X86(reason) \
+   SKIP_ON(OMRPORT_ARCH_X86, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on POWER
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_PPC(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_PPC(reason) \
+   SKIP_ON(OMRPORT_ARCH_PPC, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on POWER 64
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_PPC64(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_PPC64(reason) \
+   SKIP_ON(OMRPORT_ARCH_PPC64, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on POWER 64le
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_PPC64LE(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_PPC64LE(reason) \
+   SKIP_ON(OMRPORT_ARCH_PPC64LE, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on S390
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_S390(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_S390(reason) \
+   SKIP_ON(OMRPORT_ARCH_S390, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on S390X
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_S390X(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_S390X(reason) \
+   SKIP_ON(OMRPORT_ARCH_S390X, reason)
+
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on AMD64
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_HAMMER(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_HAMMER(reason) \
+   SKIP_ON(OMRPORT_ARCH_HAMMER, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on ARM (AArch32)
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_ARM(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_ARM(reason) \
+   SKIP_ON(OMRPORT_ARCH_ARM, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on AArch64
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_AARCH64(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_AARCH64(reason) \
+   SKIP_ON(OMRPORT_ARCH_AARCH64, reason)
+
+/*
+ * @brief A macro to allow a test to be conditionally skipped on RISC-V
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_RISCV(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_RISCV(reason) \
+   SKIP_ON(OMRPORT_ARCH_RISCV, reason)
 
 #endif // JITTEST_HPP

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,9 +57,14 @@ TYPED_TEST_CASE(LinkageTest, InputTypes);
 
 TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=Int32  args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] linkage=noexist  (iload parm=0)) )  ))";
@@ -74,9 +79,14 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
 
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=0x%jX args=[%s] linkage=system (%sload parm=0)) )  ))";
@@ -110,9 +120,14 @@ T fourthArg(T a, T b, T c, T d) { return d; }
 
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
@@ -186,9 +201,14 @@ T (*get_fourth_arg_from_callee())(T,T,T,T) {
 
 TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
 
@@ -249,9 +269,14 @@ T fifthArg(T a, T b, T c, T d, T e) { return e; }
  */
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
@@ -323,9 +348,14 @@ T stackUser(T a, T b, T c, T d, T e) {
  */
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
@@ -384,9 +414,14 @@ typedef int32_t (*FourMixedArgumentFunction)(double,int32_t,double,int32_t);
 
 TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFourArgWithMixedTypes) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=Int32 args=[Double,Int32,Double,Int32]"
@@ -420,9 +455,14 @@ typedef double (*FiveMixedArgumentFunction)(double,int32_t,double,int32_t,double
 
 TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedTypes) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=Double args=[Double,Int32,Double,Int32,Double]"

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -65,6 +65,7 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=Int32  args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] linkage=noexist  (iload parm=0)) )  ))";
@@ -87,6 +88,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=0x%jX args=[%s] linkage=system (%sload parm=0)) )  ))";
@@ -128,6 +130,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
@@ -209,6 +212,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
 
@@ -277,6 +281,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
@@ -356,6 +361,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
@@ -422,6 +428,7 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFourArgWithMixedT
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=Int32 args=[Double,Int32,Double,Int32]"
@@ -463,6 +470,7 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedT
     SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[400] = {0};
     const auto format_string = "(method return=Double args=[Double,Int32,Double,Int32,Double]"

--- a/fvtest/compilertriltest/LongAndAsRotateTest.cpp
+++ b/fvtest/compilertriltest/LongAndAsRotateTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ uint64_t lconstInput_onesAroundZeros [] = {0x0, 0x8000000000000001, 0xE000000000
 uint64_t lconstInput_invalidPatterns [] = {0x4000000000000001, 0xF0F0F0F0F0F0F0F0, 0x8000000000000002};
 
 template <typename VarType, typename ConstType>
-class LongAndAsRotateTest : public ::testing::TestWithParam<std::tuple<VarType, ConstType, ConstType (*) (VarType, ConstType)>>
+class LongAndAsRotateTest : public TRTest::TestWithPortLib, public ::testing::WithParamInterface<std::tuple<VarType, ConstType, ConstType (*) (VarType, ConstType)>>
    {
    public:
 
@@ -110,6 +110,8 @@ class i2lLongAndAsRotateTest : public LongAndAsRotateTest<int32_t, uint64_t> {};
 
 TEST_P(i2lLongAndAsRotateTest, SimpleTest)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[512] = {0};
@@ -138,6 +140,8 @@ TEST_P(i2lLongAndAsRotateTest, SimpleTest)
 
 TEST_P(i2lLongAndAsRotateTest, iConstTest)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // this is an arbitrary value that will be used to create
@@ -180,6 +184,8 @@ TEST_P(i2lLongAndAsRotateTest, iConstTest)
 
 TEST_P(i2lLongAndAsRotateTest, GreaterThanOneRefCount1)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // this is an arbitrary value that will be used to create
@@ -228,6 +234,8 @@ TEST_P(i2lLongAndAsRotateTest, GreaterThanOneRefCount1)
 
 TEST_P(i2lLongAndAsRotateTest, GreaterThanOneRefCount2)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // these are arbitrary values that will be used to create
@@ -291,6 +299,8 @@ class iu2lLongAndAsRotateTest : public LongAndAsRotateTest<uint32_t, uint64_t> {
 
 TEST_P(iu2lLongAndAsRotateTest, SimpleTest)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    char inputTrees[512] = {0};
@@ -319,6 +329,8 @@ TEST_P(iu2lLongAndAsRotateTest, SimpleTest)
 
 TEST_P(iu2lLongAndAsRotateTest, iConstTest)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // this is an arbitrary value that will be used to create
@@ -360,6 +372,8 @@ TEST_P(iu2lLongAndAsRotateTest, iConstTest)
 
 TEST_P(iu2lLongAndAsRotateTest, GreaterThanOneRefCount1)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // this is an arbitrary value that will be used to create
@@ -407,6 +421,8 @@ TEST_P(iu2lLongAndAsRotateTest, GreaterThanOneRefCount1)
 
 TEST_P(iu2lLongAndAsRotateTest, GreaterThanOneRefCount2)
    {
+   SKIP_ON_RISCV(KnownBug);
+
    auto param = to_struct(GetParam());
 
    // these are arbitrary values that will be used to create

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -189,9 +189,9 @@ INSTANTIATE_TEST_CASE_P(MaxMin, Int64MaxMin, ::testing::Combine(
 class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
 
 TEST_P(FloatMaxMin, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
-        << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    
     auto param = TRTest::to_struct(GetParam());
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -218,9 +218,9 @@ TEST_P(FloatMaxMin, UsingConst) {
 }
 
 TEST_P(FloatMaxMin, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
-        << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+ 
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -256,9 +256,9 @@ INSTANTIATE_TEST_CASE_P(MaxMin, FloatMaxMin, ::testing::Combine(
 class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
 
 TEST_P(DoubleMaxMin, UsingConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
-        << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
+    SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -286,9 +286,9 @@ TEST_P(DoubleMaxMin, UsingConst) {
 }
 
 TEST_P(DoubleMaxMin, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
-        << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
+    SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -67,6 +67,7 @@ bool smallFp_filter(std::tuple<T, T> a)
 class Int32MaxMin : public TRTest::BinaryOpTest<int32_t> {};
 
 TEST_P(Int32MaxMin, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[150] = {0};
@@ -94,6 +95,8 @@ TEST_P(Int32MaxMin, UsingConst) {
 }
 
 TEST_P(Int32MaxMin, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[150] = {0};
@@ -128,6 +131,8 @@ INSTANTIATE_TEST_CASE_P(MaxMin, Int32MaxMin, ::testing::Combine(
 class Int64MaxMin : public TRTest::BinaryOpTest<int64_t> {};
 
 TEST_P(Int64MaxMin, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[150] = {0};
@@ -155,6 +160,8 @@ TEST_P(Int64MaxMin, UsingConst) {
 }
 
 TEST_P(Int64MaxMin, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[150] = {0};
@@ -191,6 +198,7 @@ class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
 TEST_P(FloatMaxMin, UsingConst) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_RISCV(MissingImplementation) << "The RISC-V code generator currently doesn't support fmax/fmin (see issue #4276)";
     
     auto param = TRTest::to_struct(GetParam());
     char inputTrees[1024] = {0};
@@ -220,6 +228,7 @@ TEST_P(FloatMaxMin, UsingConst) {
 TEST_P(FloatMaxMin, UsingLoadParam) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_RISCV(MissingImplementation) << "The RISC-V code generator currently doesn't support fmax/fmin (see issue #4276)";
  
     auto param = TRTest::to_struct(GetParam());
 
@@ -258,6 +267,7 @@ class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
 TEST_P(DoubleMaxMin, UsingConst) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_RISCV(MissingImplementation) << "The RISC-V code generator currently doesn't support fmax/fmin (see issue #4276)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -288,6 +298,7 @@ TEST_P(DoubleMaxMin, UsingConst) {
 TEST_P(DoubleMaxMin, UsingLoadParam) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_RISCV(MissingImplementation) << "The RISC-V code generator currently doesn't support fmax/fmin (see issue #4276)";
 
     auto param = TRTest::to_struct(GetParam());
 

--- a/fvtest/compilertriltest/MinimalTest.cpp
+++ b/fvtest/compilertriltest/MinimalTest.cpp
@@ -313,9 +313,13 @@ typename M::FunctionPtr compile()
 
 TEST_F(MinimalTest, MeaningOfLife)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<MeaningOfLifeMethod>();
 
@@ -324,9 +328,13 @@ TEST_F(MinimalTest, MeaningOfLife)
 
 TEST_F(MinimalTest, ReturnArgI32)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<ReturnArgI32Method>();
 
@@ -337,8 +345,13 @@ TEST_F(MinimalTest, ReturnArgI32)
 TEST_F(MinimalTest, MaxIfThen)
    {
    std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<MaxIfThenMethod>();
 
@@ -350,9 +363,13 @@ TEST_F(MinimalTest, MaxIfThen)
 
 TEST_F(MinimalTest, AddArgConst)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<AddArgConstMethod>();
 
@@ -362,9 +379,13 @@ TEST_F(MinimalTest, AddArgConst)
 
 TEST_F(MinimalTest, SubArgArg)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<SubArgArgMethod>();
 
@@ -376,9 +397,13 @@ TEST_F(MinimalTest, SubArgArg)
 
 TEST_F(MinimalTest, Factorial)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<FactorialMethod>();
 
@@ -395,9 +420,13 @@ RecursiveFibonnaci(int32_t n)
 
 TEST_F(MinimalTest, RecursiveFibonnaci)
    {
-   std::string arch = omrsysinfo_get_CPU_architecture();
-   SKIP_IF(OMRPORT_ARCH_HAMMER != arch, MissingImplementation)
-        << "Test is skipped on non-x86-64 platforms because calls are not currently supported on other platforms (see issue #1645)";
+   SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+   SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
    auto entry = compile<RecursiveFibonnaciMethod>();
 

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -112,6 +112,7 @@ static std::vector<std::tuple<T, T>> resultInputs()
 class Int32SelectInt32CompareTest : public SelectTest<int32_t, int32_t> {};
 
 TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -140,6 +141,7 @@ TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int32SelectInt32CompareTest, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -180,6 +182,7 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectInt32CompareTest,
 class Int64SelectInt64CompareTest : public SelectTest<int64_t, int64_t> {};
 
 TEST_P(Int64SelectInt64CompareTest, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -208,6 +211,7 @@ TEST_P(Int64SelectInt64CompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int64SelectInt64CompareTest, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -249,6 +253,7 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectInt64CompareTest,
 class Int64SelectDoubleCompareTest : public SelectTest<double, int64_t> {};
 
 TEST_P(Int64SelectDoubleCompareTest, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -277,6 +282,7 @@ TEST_P(Int64SelectDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int64SelectDoubleCompareTest, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -315,6 +321,7 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectDoubleCompareTest,
 class Int32SelectDoubleCompareTest : public SelectTest<double, int32_t> {};
 
 TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -343,6 +350,7 @@ TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int32SelectDoubleCompareTest, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -382,6 +390,7 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectDoubleCompareTest,
 class ShortSelectDoubleCompareTest : public SelectTest<double, int16_t> {};
 
 TEST_P(ShortSelectDoubleCompareTest, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -411,6 +420,7 @@ TEST_P(ShortSelectDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(ShortSelectDoubleCompareTest, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -307,6 +307,8 @@ INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int64ShiftAndRotate, ::testing::Comb
 class Int8ShiftAndRotate : public ShiftAndRotateArithmetic<int8_t> {};
 
 TEST_P(Int8ShiftAndRotate, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -334,6 +336,8 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -360,6 +364,8 @@ TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -386,6 +392,8 @@ TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -419,6 +427,8 @@ INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int8ShiftAndRotate, ::testing::Combi
 class Int16ShiftAndRotate : public ShiftAndRotateArithmetic<int16_t> {};
 
 TEST_P(Int16ShiftAndRotate, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -446,6 +456,7 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -472,6 +483,7 @@ TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -498,6 +510,7 @@ TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -745,6 +758,8 @@ INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt64ShiftAndRotate, ::testing::Com
 class UInt8ShiftAndRotate : public ShiftAndRotateArithmetic<uint8_t> {};
 
 TEST_P(UInt8ShiftAndRotate, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -772,6 +787,8 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -798,6 +815,8 @@ TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -824,6 +843,7 @@ TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -856,6 +876,8 @@ INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt8ShiftAndRotate, ::testing::Comb
 class UInt16ShiftAndRotate : public ShiftAndRotateArithmetic<uint16_t> {};
 
 TEST_P(UInt16ShiftAndRotate, UsingConst) {
+    SKIP_ON_RISCV(MissingImplementation);
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -883,6 +905,7 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -909,6 +932,7 @@ TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -935,6 +959,7 @@ TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
+    SKIP_ON_RISCV(MissingImplementation);
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[300] = {0};
@@ -1282,6 +1307,7 @@ class UInt16MaskThenShift : public MaskThenShiftArithmetic<uint16_t> {};
 TEST_P(UInt16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_RISCV(MissingImplementation);
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -1318,6 +1344,7 @@ class Int16MaskThenShift : public MaskThenShiftArithmetic<int16_t> {};
 TEST_P(Int16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_RISCV(MissingImplementation);
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -1354,6 +1381,7 @@ class UInt8MaskThenShift : public MaskThenShiftArithmetic<uint8_t> {};
 TEST_P(UInt8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_RISCV(MissingImplementation);
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -1390,6 +1418,7 @@ class Int8MaskThenShift : public MaskThenShiftArithmetic<int8_t> {};
 TEST_P(Int8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_RISCV(MissingImplementation);
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -100,6 +100,7 @@ TEST_P(Int8ToInt32, UsingConst) {
 }
 
 TEST_P(Int8ToInt32, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -156,6 +157,7 @@ TEST_P(UInt8ToInt32, UsingConst) {
 }
 
 TEST_P(UInt8ToInt32, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -212,6 +214,7 @@ TEST_P(Int8ToInt64, UsingConst) {
 }
 
 TEST_P(Int8ToInt64, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -268,6 +271,7 @@ TEST_P(UInt8ToInt64, UsingConst) {
 }
 
 TEST_P(UInt8ToInt64, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -324,6 +328,7 @@ TEST_P(Int16ToInt32, UsingConst) {
 }
 
 TEST_P(Int16ToInt32, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -380,6 +385,7 @@ TEST_P(UInt16ToInt32, UsingConst) {
 }
 
 TEST_P(UInt16ToInt32, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -436,6 +442,7 @@ TEST_P(Int16ToInt64, UsingConst) {
 }
 
 TEST_P(Int16ToInt64, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -492,6 +499,7 @@ TEST_P(UInt16ToInt64, UsingConst) {
 }
 
 TEST_P(UInt16ToInt64, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -604,6 +612,8 @@ TEST_P(UInt32ToInt64, UsingConst) {
 }
 
 TEST_P(UInt32ToInt64, UsingLoadParam) {
+    SKIP_ON_RISCV(KnownBug);
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -1402,9 +1412,9 @@ class NormalizeNanTest : public TRTest::JitTest, public ::testing::WithParamInte
 class FloatNormalizeNan : public NormalizeNanTest<uint32_t> {};
 
 TEST_P(FloatNormalizeNan, UsingLoadIndirect) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     char *inputTrees =
         "(method return=Int32 args=[Address]"
@@ -1427,9 +1437,9 @@ TEST_P(FloatNormalizeNan, UsingLoadIndirect) {
 }
 
 TEST_P(FloatNormalizeNan, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     char *inputTrees =
         "(method return=Int32 args=[Int32]"
@@ -1453,9 +1463,9 @@ TEST_P(FloatNormalizeNan, UsingLoadParam) {
 }
 
 TEST_P(FloatNormalizeNan, UsingLoadConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     uint32_t value = GetParam();
 
@@ -1485,9 +1495,9 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatNormalizeNan, ::testing::Values
 class DoubleNormalizeNan : public NormalizeNanTest<uint64_t> {};
 
 TEST_P(DoubleNormalizeNan, UsingLoadIndirect) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     char *inputTrees =
         "(method return=Int64 args=[Address]"
@@ -1510,9 +1520,9 @@ TEST_P(DoubleNormalizeNan, UsingLoadIndirect) {
 }
 
 TEST_P(DoubleNormalizeNan, UsingLoadParam) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     char *inputTrees =
         "(method return=Int64 args=[Int64]"
@@ -1536,9 +1546,9 @@ TEST_P(DoubleNormalizeNan, UsingLoadParam) {
 }
 
 TEST_P(DoubleNormalizeNan, UsingLoadConst) {
-    std::string arch = omrsysinfo_get_CPU_architecture();
-    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
-        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+    SKIP_ON_RISCV(KnownBug);
 
     uint64_t value = GetParam();
 

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,8 @@ TEST_F(VectorTest, VDoubleAdd) {
     // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -45,7 +45,8 @@ TEST_F(VectorTest, VDoubleAdd) {
     // have vector support. Determining whether a specific platform has the support
     // at runtime is currently not possible in tril. So the test is being disabled altogether
     // on Z for now.
-#ifndef TR_TARGET_S390
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -61,5 +62,4 @@ TEST_F(VectorTest, VDoubleAdd) {
     entry_point(output,inputA,inputB); 
     EXPECT_DOUBLE_EQ(inputA[0] + inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary? 
     EXPECT_DOUBLE_EQ(inputA[1] + inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary? 
-#endif
 }

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,4 +56,8 @@ target_link_libraries(jitbuildertest
 
 set_property(TARGET jitbuildertest PROPERTY FOLDER fvtest)
 
-add_test(NAME JitBuilderTest COMMAND jitbuildertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
+# Disable JitBuilder tests on RISC-V. This is essentially a workaround
+# until #4764 is addressed. Once done, tests should be properly skipped.
+if(NOT OMR_HOST_ARCH STREQUAL "riscv")
+	add_test(NAME JitBuilderTest COMMAND jitbuildertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
+endif()


### PR DESCRIPTION
This PR enables compiler tests on RISC-V native build CI pipelines. Tests known to fail are disabled and will be dealt with in subsequent PRs.