### PR TITLE
Consolidating getMethodFromBCInfo type routines

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3359,6 +3359,60 @@ OMR::Node::getOwningMethod()
 
 
 
+/** \brief
+ *  Used to get the ram method from the Bytecode Info.
+ * 
+ *  \param *comp
+ *  _compilation of type TR::Compilation 
+ *  
+ *  @return 
+ *  Returns the ram method (TR_OpaqueMethodBlock) from function call getOwningMethod(TR::Compilation *comp, TR_ByteCodeInfo &bcInfo)
+ */
+TR_OpaqueMethodBlock* 
+OMR::Node::getOwningMethod(TR::Compilation *comp)
+   {
+   return TR::Node::getOwningMethod(comp, self()->getByteCodeInfo());
+   }
+
+
+
+/** \brief
+ *  Used to get the ram method from the Bytecode Info.
+ * 
+ *  \param *comp
+ *  _compilation of type TR::Compilation
+ * 
+ *  \param &bcInfo 
+ *  _byteCodeInfo of a node of type TR::Node  
+ *  
+ *  @return 
+ *  Returns the ram method (TR_OpaqueMethodBlock)
+ */
+TR_OpaqueMethodBlock* 
+OMR::Node::getOwningMethod(TR::Compilation *comp, TR_ByteCodeInfo &bcInfo)
+   {
+   TR_OpaqueMethodBlock *method = NULL; 
+  
+   if (comp->compileRelocatableCode()) 
+      { 
+      if (0 <= bcInfo.getCallerIndex()) 
+         method = (TR_OpaqueMethodBlock *)(((TR_AOTMethodInfo *)comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo)->resolvedMethod->getPersistentIdentifier()); 
+      else 
+         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getPersistentIdentifier()); 
+      } 
+   else  
+      { 
+      if (0 <= bcInfo.getCallerIndex()) 
+         method = (TR_OpaqueMethodBlock *)(comp->getInlinedCallSite(bcInfo.getCallerIndex())._vmMethodInfo); 
+      else 
+         method = (TR_OpaqueMethodBlock *)(comp->getCurrentMethod()->getNonPersistentIdentifier()); 
+      } 
+  
+   return method; 
+   }
+
+
+
 void *
 OMR::Node::getAOTMethod()
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -673,6 +673,31 @@ public:
 
    TR_OpaqueMethodBlock * getOwningMethod();
 
+   /** \brief
+    *  Used to get the ram method from the Bytecode Info.
+    * 
+    *  \param *comp
+    *  _compilation of type TR::Compilation
+    * 
+    *  @return 
+    *  Returns the ram method (TR_OpaqueMethodBlock)  from function call getOwningMethod(TR::Compilation *comp, TR_ByteCodeInfo &bcInfo)
+    */
+   TR_OpaqueMethodBlock* getOwningMethod(TR::Compilation *comp);
+
+   /** \brief
+    *  Used to get the ram method from the Bytecode Info.
+    * 
+    *  \param *comp
+    *  _compilation of type TR::Compilation
+    * 
+    *  \param &bcInfo 
+    *  _byteCodeInfo of a node of type TR::Node  
+    * 
+    *  @return 
+    *  Returns the ram method (TR_OpaqueMethodBlock)
+    */
+   static TR_OpaqueMethodBlock* getOwningMethod(TR::Compilation *comp, TR_ByteCodeInfo &bcInfo);
+
    inline TR::DataType    getType();
 
    // TODO: Sink into J9. Depends on OMR::Compilation::getMethodFromNode


### PR DESCRIPTION
- getMethodFromBCInfo is removed from CompilerThread.cpp, IProfiler.cpp
 and HWProfiler.cpp
- getMethodFromNode is removed from IProfiler.cpp
- getMethodFromBCInfo is added to OMRNode.cpp
- fej9->isAOT_DEPRECATED_DO_NOT_USE() in getMethodFromBCInfo is
replaced with compileRelocatableCode()
- This routine is renamed to getOwningMethod and declared as static.

Issue: eclipse/openj9#5257

Signed-off-by: Siri Sahithi Ponangi <sahithi.ponangi@unb.ca>