### PR TITLE
Inactive copy caches for Concurrent Scavenger

### DIFF
--- a/example/glue/EnvironmentDelegate.hpp
+++ b/example/glue/EnvironmentDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,6 +178,11 @@ public:
 	 * Release shared VM acccess.
 	 */
 	void releaseVMAccess();
+	
+	/**
+	 * Returns true if a mutator threads entered native code without releasing VM access
+	 */
+	bool inNative() { return false; }
 
 	/**
 	 * Check whether another thread is requesting exclusive VM access. This method must be
@@ -228,9 +233,7 @@ public:
 
 	void reacquireCriticalHeapAccess(uintptr_t data) {}
 
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	void forceOutOfLineVMAccess() {}
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	/**

--- a/gc/base/MasterGCThread.cpp
+++ b/gc/base/MasterGCThread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -248,9 +248,9 @@ MM_MasterGCThread::masterThreadEntryPoint()
 		/* thread attached successfully */
 		MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 
-		/* attachVMThread could allocate an execute a barrier (since it that point, this thread acted as a mutator thread.
+		/* attachVMThread could have allocated and execute a barrier (until point, this thread acted as a mutator thread.
 		 * Flush GC chaches (like barrier buffers) before turning into the master thread */
-		env->flushGCCaches();
+		env->flushGCCaches(true);
 
 		env->setThreadType(GC_MASTER_THREAD);
 

--- a/gc/base/OMRVMThreadInterface.cpp
+++ b/gc/base/OMRVMThreadInterface.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ GC_OMRVMThreadInterface::flushCachesForWalk(MM_EnvironmentBase *env)
 	env->_objectAllocationInterface->flushCache(env);
 	/* If we are in a middle of a concurrent GC, we want to flush GC caches, typically for mutator threads doing GC work.
 	 * (GC threads are  smart enough to do it themselves, before they let the walk occur) */
-	env->flushGCCaches();
+	env->flushGCCaches(true);
 }
 
 void

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ void
 MM_EnvironmentStandard::tearDown(MM_GCExtensionsBase *extensions)
 {
 	/* If we are in a middle of a concurrent GC, we may want to flush GC caches (if thread happens to do GC work) */
-	flushGCCaches();
+	flushGCCaches(true);
 	/* tearDown base class */
 	MM_EnvironmentBase::tearDown(extensions);
 }
@@ -93,13 +93,13 @@ MM_EnvironmentStandard::flushNonAllocationCaches()
 }
 
 void
-MM_EnvironmentStandard::flushGCCaches()
+MM_EnvironmentStandard::flushGCCaches(bool final)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (getExtensions()->concurrentScavenger) {
 		if (MUTATOR_THREAD == getThreadType()) {
 			if (NULL != getExtensions()->scavenger) {
-				getExtensions()->scavenger->threadReleaseCaches(this, true);
+				getExtensions()->scavenger->threadReleaseCaches(this, true, final);
 			}
 		}
 	}

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -930,6 +930,68 @@ MM_Scavenger::calculateOptimumCopyScanCacheSize(MM_EnvironmentStandard *env)
     return cacheSize;
 }
 
+
+MMINLINE bool
+MM_Scavenger::activateSurvivorCopyScanCache(MM_EnvironmentStandard *env)
+{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)env->_inactiveSurvivorCopyScanCache;
+	if (NULL != cache) {
+		Assert_MM_true(MUTATOR_THREAD == env->getThreadType());
+		/* racing with a GC thread that detected work queue depletion, which may try to flush the cache to generate more concurrent work */
+		if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&env->_inactiveSurvivorCopyScanCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+			/* succeded activating */
+			Assert_MM_true(NULL == env->_survivorCopyScanCache);
+			env->_survivorCopyScanCache = cache;
+			activateDeferredCopyScanCache(env);
+			/* Force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */
+			env->forceOutOfLineVMAccess();
+			return true;
+		}
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	return false;
+}
+
+MMINLINE bool
+MM_Scavenger::activateTenureCopyScanCache(MM_EnvironmentStandard *env)
+{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)env->_inactiveTenureCopyScanCache;
+	if (NULL != cache) {
+		Assert_MM_true(MUTATOR_THREAD == env->getThreadType());
+		/* racing with a GC thread that detected work queue depletion, which may try to flush the cache to generate more concurrent work */
+		if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&env->_inactiveTenureCopyScanCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+			/* succeded activating */
+			Assert_MM_true(NULL == env->_tenureCopyScanCache);
+			env->_tenureCopyScanCache = cache;
+			activateDeferredCopyScanCache(env);
+			/* Force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */
+			env->forceOutOfLineVMAccess();
+			return true;
+		}
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	return false;
+}
+
+
+void
+MM_Scavenger::activateDeferredCopyScanCache(MM_EnvironmentStandard *env)
+{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)env->_inactiveDeferredCopyCache;
+	if (NULL != cache) {
+		/* TODO: investigate if atomic us really necessary */
+		if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&env->_inactiveDeferredCopyCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+			Assert_MM_true(NULL == env->_deferredCopyCache);
+			env->_deferredCopyCache = cache;
+		}
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+}
+
+
 MMINLINE MM_CopyScanCacheStandard *
 MM_Scavenger::reserveMemoryForAllocateInSemiSpace(MM_EnvironmentStandard *env, omrobjectptr_t objectToEvacuate, uintptr_t objectReserveSizeInBytes)
 {
@@ -944,6 +1006,7 @@ MM_Scavenger::reserveMemoryForAllocateInSemiSpace(MM_EnvironmentStandard *env, o
 	 * Please note that condition like (top >= start + size) might cause wrong functioning due overflow
 	 * so to be safe (top - start >= size) must be used
 	 */
+retry:
 	if ((NULL != env->_survivorCopyScanCache) && (((uintptr_t)env->_survivorCopyScanCache->cacheTop - (uintptr_t)env->_survivorCopyScanCache->cacheAlloc) >= cacheSize)) {
 		/* A survivor copy scan cache exists and there is a room, use the current copy cache */
 		copyCache = env->_survivorCopyScanCache;
@@ -952,14 +1015,19 @@ MM_Scavenger::reserveMemoryForAllocateInSemiSpace(MM_EnvironmentStandard *env, o
 		/* Try and allocate room for the copy - if successful, flush the old cache */
 		bool allocateResult = false;
 		if (objectReserveSizeInBytes < _minSemiSpaceFailureSize) {
+			if (activateSurvivorCopyScanCache(env)) {
+				goto retry;
+			}
 			/* try to use TLH remainder from previous discard */
 			if (((uintptr_t)env->_survivorTLHRemainderTop - (uintptr_t)env->_survivorTLHRemainderBase) >= cacheSize) {
 				Assert_MM_true(NULL != env->_survivorTLHRemainderBase);
+				Assert_MM_true(NULL != env->_survivorTLHRemainderTop);
 				allocateResult = true;
 				addrBase = env->_survivorTLHRemainderBase;
 				addrTop = env->_survivorTLHRemainderTop;
 				env->_survivorTLHRemainderBase = NULL;
 				env->_survivorTLHRemainderTop = NULL;
+				activateDeferredCopyScanCache(env);
 			} else if (_extensions->tlhSurvivorDiscardThreshold < cacheSize) {
 				MM_AllocateDescription allocDescription(cacheSize, 0, false, true);
 
@@ -980,8 +1048,14 @@ MM_Scavenger::reserveMemoryForAllocateInSemiSpace(MM_EnvironmentStandard *env, o
 			}
 		}
 
-		if(allocateResult) {
+		if (allocateResult) {
 			/* A new chunk has been allocated - refresh the copy cache */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+			if (isConcurrentInProgress() && (MUTATOR_THREAD == env->getThreadType())) {
+				/* For CS, force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */
+				env->forceOutOfLineVMAccess();
+			}
+#endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 			/* release local cache first. along the path we may realize that a cache structure can be re-used */
 			MM_CopyScanCacheStandard *cacheToReuse = releaseLocalCopyCache(env, env->_survivorCopyScanCache);
@@ -1044,6 +1118,7 @@ MM_Scavenger::reserveMemoryForAllocateInTenureSpace(MM_EnvironmentStandard *env,
 	 * Please note that condition like (top >= start + size) might cause wrong functioning due overflow
 	 * so to be safe (top - start >= size) must be used
 	 */
+retry:
 	if ((NULL != env->_tenureCopyScanCache) && (((uintptr_t)env->_tenureCopyScanCache->cacheTop - (uintptr_t)env->_tenureCopyScanCache->cacheAlloc) >= cacheSize)) {
 		/* A tenure copy scan cache exists and there is a room, use the current copy cache */
 		copyCache = env->_tenureCopyScanCache;
@@ -1052,9 +1127,13 @@ MM_Scavenger::reserveMemoryForAllocateInTenureSpace(MM_EnvironmentStandard *env,
 		/* Try and allocate room for the copy - if successful, flush the old cache */
 		bool allocateResult = false;
 		if (cacheSize < _minTenureFailureSize) {
+			if (activateTenureCopyScanCache(env)) {
+				goto retry;
+			}
 			/* try to use TLH remainder from previous discard. */
 			if (((uintptr_t)env->_tenureTLHRemainderTop - (uintptr_t)env->_tenureTLHRemainderBase) >= cacheSize) {
 				Assert_MM_true(NULL != env->_tenureTLHRemainderBase);
+				Assert_MM_true(NULL != env->_tenureTLHRemainderTop);
 				allocateResult = true;
 				addrBase = env->_tenureTLHRemainderBase;
 				addrTop = env->_tenureTLHRemainderTop;
@@ -1062,6 +1141,7 @@ MM_Scavenger::reserveMemoryForAllocateInTenureSpace(MM_EnvironmentStandard *env,
 				env->_tenureTLHRemainderBase = NULL;
 				env->_tenureTLHRemainderTop = NULL;
 				env->_loaAllocation = false;
+				activateDeferredCopyScanCache(env);
 			} else if (_extensions->tlhTenureDiscardThreshold < cacheSize) {
 				MM_AllocateDescription allocDescription(cacheSize, 0, false, true);
 				allocDescription.setCollectorAllocateExpandOnFailure(true);
@@ -1094,8 +1174,14 @@ MM_Scavenger::reserveMemoryForAllocateInTenureSpace(MM_EnvironmentStandard *env,
 			}
 		}
 
-		if(allocateResult) {
+		if (allocateResult) {
 			/* A new chunk has been allocated - refresh the copy cache */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+			if (isConcurrentInProgress() && (MUTATOR_THREAD == env->getThreadType())) {
+				/* For CS, force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */
+				env->forceOutOfLineVMAccess();
+			}
+#endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 			/* release local cache first. along the path we may realize that a cache structure can be re-used */
 			MM_CopyScanCacheStandard *cacheToReuse = releaseLocalCopyCache(env, env->_tenureCopyScanCache);
@@ -3101,8 +3187,8 @@ MM_Scavenger::clearCache(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *
 				remainderCreated = true;
 				env->_scavengerStats._tenureTLHRemainderCount += 1;
 				Assert_MM_true(NULL == env->_tenureTLHRemainderBase);
-				Assert_MM_true(NULL == env->_tenureTLHRemainderTop);
 				env->_tenureTLHRemainderBase = cache->cacheAlloc;
+				Assert_MM_true(NULL == env->_tenureTLHRemainderTop);
 				env->_tenureTLHRemainderTop = cache->cacheTop;
 				env->_loaAllocation = (OMR_SCAVENGER_CACHE_TYPE_LOA == (cache->flags & OMR_SCAVENGER_CACHE_TYPE_LOA));
 			}
@@ -3115,8 +3201,8 @@ MM_Scavenger::clearCache(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *
 				remainderCreated = true;
 				env->_scavengerStats._survivorTLHRemainderCount += 1;
 				Assert_MM_true(NULL == env->_survivorTLHRemainderBase);
-				Assert_MM_true(NULL == env->_survivorTLHRemainderTop);
 				env->_survivorTLHRemainderBase = cache->cacheAlloc;
+				Assert_MM_true(NULL == env->_survivorTLHRemainderTop);
 				env->_survivorTLHRemainderTop = cache->cacheTop;
 			}
 		} else {
@@ -3327,7 +3413,7 @@ MM_Scavenger::checkAndSetShouldYieldFlag(MM_EnvironmentStandard *env) {
 	 * But since that request in the thread is not cleared even when implicit master GC thread enters STW phase, and since this yield check is invoked
 	 * in common code that can run both during STW and concurrent phase, we have to additionally check we are indeed in concurrent phase before deciding to yield.
 	 * Most of the time we could rely on being in 'concurrent_state_scan' but it's more reliable to actually check if exclusive access
-	 * is indeed being requested (hence scavenger_shouldYield() call too).
+	 * is indeed being requested (hence shouldYield() call to delegate, too).
 	 */
 	if (!_shouldYield && env->isExclusiveAccessRequestWaiting() && _delegate.shouldYield()) {
 		_shouldYield = true;
@@ -4786,7 +4872,7 @@ MM_Scavenger::isConcurrentWorkAvailable(MM_EnvironmentBase *env)
 
 	Assert_MM_true(!concurrentWorkAvailable || isConcurrentInProgress());
 
-	return concurrent_state_scan == _concurrentState;
+	return concurrentWorkAvailable;
 }
 
 bool
@@ -4866,58 +4952,251 @@ MM_Scavenger::mutatorSetupForGC(MM_EnvironmentBase *envBase)
 	}
 }
 
-void
-MM_Scavenger::threadReleaseCaches(MM_EnvironmentBase *envBase, bool final)
+MMINLINE void
+MM_Scavenger::handleInactiveSurvivorCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
 {
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)targetEnv->_inactiveSurvivorCopyScanCache;
+	if (NULL != cache) {
+		/* TODO: this path is to become active once mutator threads starts creating inactive caches on VM Access release */
+		Assert_MM_unreachable();
+		/* either we are explicitly instructed to flush, or we are observing suboptimal parallelism in background threads */
+		if (flushCaches || (_waitingCount > 0)) {
+			/* Racing with mutator trying to activate cache */
+			if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&targetEnv->_inactiveSurvivorCopyScanCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+				Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+				cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+				currentEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+				if (final) {
+					/* Even if currentEnv != targetEnv, at this final point it should be safe to use target thread env,
+					 * since the mutator thread does not have VM access and we won't race it
+					 */
+					clearCache(targetEnv, cache);
+				} else {
+					clearCache(currentEnv, cache);
+					if (flushCaches) {
+						/* it's unfortunate, but we cannot preserve remainders */
+						abandonSurvivorTLHRemainder(currentEnv);
+					}
+				}
+				/* notify is only needed by the end of concurrent phase */
+				addCacheEntryToScanListAndNotify(targetEnv, cache);
+			}
+		}
+		/* else thread has had back-to-back VM access release without any barriers in between to activate this copy cache */
+	}
+}
+
+MMINLINE void
+MM_Scavenger::handleSurvivorCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
+{
+	MM_CopyScanCacheStandard *cache = targetEnv->_survivorCopyScanCache;
+	if (NULL != cache) {
+		if ((currentEnv == targetEnv) || final || targetEnv->inNative()) {
+			/* Race between a calling GC thread and target thread (potentially refreshing cache) is not expected:
+			 * 1) if currentEnv == targetEnv, it's obvious
+			 * 2) if final, then we are at the start of STW, while all target threads have already blocked
+			 * 3) if inNative, target thread cannot be executing barrier (and GC code); if it races to exit native,
+			 *    it will block since a) it's forced to reacquire VM access through slow path and b) caller holds thread public mutex what prevents reacquire
+			 */
+			targetEnv->_survivorCopyScanCache = NULL;
+			Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+			/* either we are explicitly instructed to flush, or we are observing suboptimal parallelism in background threads */
+			if (flushCaches || (_waitingCount > 0)) {
+				cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+				targetEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+				clearCache(targetEnv, cache);
+				addCacheEntryToScanListAndNotify(targetEnv, cache);
+			} else {
+				/* If it's an intermediate release (mutator threads releasing VM access in a middle of concurrent cycle), and high parallelism,
+				 * we'll keep the cache around, but tag it inactive, so it can be safely flushed at a later point (toward the end of concurrent phase)
+				 * by another thread.
+				 */
+				Assert_MM_true(NULL == targetEnv->_inactiveSurvivorCopyScanCache);
+				targetEnv->_inactiveSurvivorCopyScanCache = cache;
+			}
+		}
+	}
+
+}
+
+MMINLINE void
+MM_Scavenger::handleInactiveTenureCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
+{
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)targetEnv->_inactiveTenureCopyScanCache;
+	if (NULL != cache) {
+		/* TODO: this path is to become active once mutator threads starts creating inactive caches on VM Access release */
+		Assert_MM_unreachable();
+		/* either we are explicitly instructed to flush, or we are observing suboptimal parallelism in background threads */
+		if (flushCaches || (_waitingCount > 0)) {
+			/* Racing with mutator trying to activate cache */
+			if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&targetEnv->_inactiveTenureCopyScanCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+				Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+				cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+				targetEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+				if (final) {
+					/* Even if currentEnv != targetEnv, at this final point it should be safe to use target thread env,
+					 * since the mutator thread does not have VM access and we won't race it
+					 */
+					clearCache(targetEnv, cache);
+				} else {
+					clearCache(currentEnv, cache);
+					if (flushCaches) {
+						/* it's unfortunate, but we cannot preserve remainders */
+						abandonTenureTLHRemainder(currentEnv, false);
+					}
+				}
+				addCacheEntryToScanListAndNotify(targetEnv, cache);
+			}
+			/* else we failed to push inactive cache since mutator thread reactivacted it -> concurrent cycle continues */
+		}
+		/* else thread has had consecutive VM access release without any barriers in between to activate this copy cache */
+	}
+}
+
+MMINLINE void
+MM_Scavenger::handleTenureCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
+{
+	MM_CopyScanCacheStandard *cache = targetEnv->_tenureCopyScanCache;
+	if (NULL != cache) {
+		if ((currentEnv == targetEnv) || final || targetEnv->inNative()) {
+			/* Race between a calling GC thread and target thread (potentially refreshing cache) is not expected:
+			 * 1) if currentEnv == targetEnv, it's obvious
+			 * 2) if final, then we are at the start of STW, while all target threads have already blocked
+			 * 3) if inNative, target thread cannot be executing barrier (and GC code); if it races to exit native,
+			 *    it will block since a) it's forced to reacquire VM access through slow path and b) caller holds thread public mutex what prevents reacquire
+			 */
+			targetEnv->_tenureCopyScanCache = NULL;
+			Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+			/* either we are explicitly instructed to flush, or we are observing suboptimal parallelism in background threads */
+			if (flushCaches || (_waitingCount > 0)) {
+				cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+				targetEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+				clearCache(targetEnv, cache);
+				addCacheEntryToScanListAndNotify(targetEnv, cache);
+			} else {
+				/* If it's an intermediate release (mutator threads releasing VM access in a middle of concurrent phase), and high parallelism,
+				 * we'll keep the cache around, but tag it inactive, so it can be safely flushed at a later point (toward the end of concurrent phase)
+				 * by another thread.
+				 */
+				Assert_MM_true(NULL == targetEnv->_inactiveTenureCopyScanCache);
+				targetEnv->_inactiveTenureCopyScanCache = cache;
+			}
+		}
+	}
+}
+
+
+MMINLINE void
+MM_Scavenger::handleInactiveDeferredCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
+{
+	MM_CopyScanCacheStandard *cache = (MM_CopyScanCacheStandard *)targetEnv->_inactiveDeferredCopyCache;
+	if (NULL != cache) {
+		/* TODO: this path is to become active once mutator threads starts creating inactive caches on VM Access release */
+		Assert_MM_unreachable();
+		/* either we are explicitly instructed to flush, or we are observing suboptimal parallelism in background threads */
+		if (flushCaches || (_waitingCount > 0)) {
+			/* Racing with mutator trying to activate cache */
+			if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&targetEnv->_inactiveDeferredCopyCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+				Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+				cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+				targetEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+				addCacheEntryToScanListAndNotify(targetEnv, cache);
+			}
+			/* else we failed to push inactive cache since mutator thread reactivacted it -> concurrent cycle continues */
+		}
+		/* else thread has had consecutive VM access release without any barriers in between to activate this copy cache */
+	}
+}
+
+MMINLINE void
+MM_Scavenger::handleDeferredCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final)
+{
+	MM_CopyScanCacheStandard *cache = targetEnv->_deferredCopyCache;
+	if (NULL != cache) {
+		/* We cannot allow dangling deferred copy cache - if we just pushed survivor or tenure copy cache we should push deferred, too. */
+		if ((currentEnv == targetEnv) || final || targetEnv->inNative()
+				|| (NULL == targetEnv->_survivorCopyScanCache) || (NULL == targetEnv->_tenureCopyScanCache)) {
+			/* Race between mutator thread actual owner and another mutator thread that helps with concurrent termination */
+			if ((uintptr_t)cache == MM_AtomicOperations::lockCompareExchange((volatile uintptr_t *)&targetEnv->_deferredCopyCache, (uintptr_t)cache, (uintptr_t)NULL)) {
+				targetEnv->_deferredCopyCache = NULL;
+				Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+				Assert_MM_true(cache->flags & OMR_SCAVENGER_CACHE_TYPE_CLEARED);
+				if (flushCaches || (_waitingCount > 0) || (NULL == targetEnv->_survivorCopyScanCache) || (NULL == targetEnv->_tenureCopyScanCache)) {
+					/* Master thread in STW is MUTATOR type and can trigger this as well */
+					cache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+					targetEnv->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+					addCacheEntryToScanListAndNotify(targetEnv, cache);
+				} else {
+					Assert_MM_true(NULL == targetEnv->_inactiveDeferredCopyCache);
+					targetEnv->_inactiveDeferredCopyCache = cache;
+				}
+			}
+		}
+	}
+}
+
+/* TODO: remove once threadReleaseCaches gets currentEnv from callers */
+static OMR_VMThread *
+getCurrentOMRVMThread(OMR_VM *vm)
+{
+	OMR_VMThread *currentThread = NULL;
+	omrthread_t self = omrthread_self();
+	if (NULL != self) {
+		if (vm->_vmThreadKey > 0) {
+			currentThread = (OMR_VMThread *)omrthread_tls_get(self, vm->_vmThreadKey);
+		}
+	}
+	return currentThread;
+}
+
+void
+MM_Scavenger::threadReleaseCaches(MM_EnvironmentBase *targetEnvBase, bool flushCaches, bool final)
+{
+	MM_EnvironmentStandard *targetEnv = MM_EnvironmentStandard::getEnvironment(targetEnvBase);
+
+	Assert_MM_true(flushCaches >= final);
 
 	if (isConcurrentInProgress()) {
-		if (NULL != env->_deferredScanCache) {
-			Assert_MM_true(MUTATOR_THREAD != env->getThreadType());
+		/* TODO: have callers pass currentEnv */
+	    MM_EnvironmentStandard *currentEnv = MM_EnvironmentStandard::getEnvironment(getCurrentOMRVMThread(targetEnvBase->getOmrVM()));
+
+		if (NULL != targetEnv->_deferredScanCache) {
+			Assert_MM_true(MUTATOR_THREAD != targetEnv->getThreadType());
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
+			targetEnv->_scavengerStats._releaseScanListCount += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			_scavengeCacheScanList.pushCache(env, env->_deferredScanCache);
-			env->_deferredScanCache = NULL;
+			_scavengeCacheScanList.pushCache(targetEnv, targetEnv->_deferredScanCache);
+			targetEnv->_deferredScanCache = NULL;
 		}
 
-		if (NULL != env->_survivorCopyScanCache) {
-			Assert_MM_true(env->_survivorCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			env->_survivorCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
-#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
-#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			clearCache(env, env->_survivorCopyScanCache);
-			_scavengeCacheScanList.pushCache(env, env->_survivorCopyScanCache);
-			env->_survivorCopyScanCache = NULL;
-		}
-		if (NULL != env->_deferredCopyCache) {
-			Assert_MM_true(env->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_CLEARED);
-			Assert_MM_true(env->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			env->_deferredCopyCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
-#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
-#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			_scavengeCacheScanList.pushCache(env, env->_deferredCopyCache);
-			env->_deferredCopyCache = NULL;
-		}
-		if (NULL != env->_tenureCopyScanCache) {
-			Assert_MM_true(env->_tenureCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			env->_tenureCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
-#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
-#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			clearCache(env, env->_tenureCopyScanCache);
-			_scavengeCacheScanList.pushCache(env, env->_tenureCopyScanCache);
-			env->_tenureCopyScanCache = NULL;
-		}
+		handleInactiveSurvivorCopyScanCache(currentEnv, targetEnv, flushCaches, final);
+		handleSurvivorCopyScanCache(currentEnv, targetEnv, flushCaches, final);
+		handleInactiveTenureCopyScanCache(currentEnv, targetEnv, flushCaches, final);
+		handleTenureCopyScanCache(currentEnv, targetEnv, flushCaches, final);
+		handleInactiveDeferredCopyScanCache(currentEnv, targetEnv, flushCaches, final);
+		handleDeferredCopyScanCache(currentEnv, targetEnv, flushCaches, final);
 
 		if (final) {
-			/* If it's an intermediate release (for example mutator threads releasing VM access in a middle of Concurrent Scavenger cycle,
+			/* If it's an intermediate release (mutator threads releasing VM access in a middle of Concurrent Scavenger cycle),
 			 * keep copy cache remainders around (do not abandon yet), to be reused if the threads re-acquires VM access during the same CS cycle.
+			 * For final release, we abondon ever remainders.
 			 */
-			abandonSurvivorTLHRemainder(env);
-			abandonTenureTLHRemainder(env, true);
+			abandonSurvivorTLHRemainder(targetEnv);
+			abandonTenureTLHRemainder(targetEnv, true);
 		}
 	}
 }
@@ -5017,7 +5296,7 @@ MM_Scavenger::workThreadProcessRoots(MM_EnvironmentStandard *env)
 	 * This is important to do only for GC threads that will not be used in concurrent phase, but at this point
 	 * we don't know which threads Scheduler will not use, so we do it for every thread.
 	 */
-	threadReleaseCaches(env, true);
+	threadReleaseCaches(env, true, true);
 
 	mergeThreadGCStats(env);
 }
@@ -5038,7 +5317,7 @@ MM_Scavenger::workThreadScan(MM_EnvironmentStandard *env)
 	 * Most of the time, STW phase will have a superset of GC threads, so they could just resume the work on their own caches,
 	 * but this is not 100% guarantied (the control of what threads are inolved is in Dispatcher's domain).
 	 */
-	threadReleaseCaches(env, true);
+	threadReleaseCaches(env, true, true);
 
 	mergeThreadGCStats(env);
 }
@@ -5047,6 +5326,9 @@ void
 MM_Scavenger::workThreadComplete(MM_EnvironmentStandard *env)
 {
 	Assert_MM_true(_extensions->concurrentScavenger);
+
+	/* record that this thread is participating in this cycle */
+	env->_scavengerStats._gcCount = _extensions->scavengerStats._gcCount;
 
 	clearThreadGCStats(env, false);
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -335,6 +335,13 @@ public:
 	
 	void scavengeRememberedSetListIndirect(MM_EnvironmentStandard *env);
 	void scavengeRememberedSetListDirect(MM_EnvironmentStandard *env);
+
+	MMINLINE void handleInactiveSurvivorCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
+	MMINLINE void handleSurvivorCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
+	MMINLINE void handleInactiveTenureCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
+	MMINLINE void handleTenureCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
+	MMINLINE void handleInactiveDeferredCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
+	MMINLINE void handleDeferredCopyScanCache(MM_EnvironmentStandard *currentEnv, MM_EnvironmentStandard *targetEnv, bool flushCaches, bool final);
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/**
@@ -443,6 +450,10 @@ public:
 	 */
 	void abandonSurvivorTLHRemainder(MM_EnvironmentStandard *env);
 	void abandonTenureTLHRemainder(MM_EnvironmentStandard *env, bool preserveRemainders = false);
+	
+	MMINLINE bool activateSurvivorCopyScanCache(MM_EnvironmentStandard *env);
+	MMINLINE bool activateTenureCopyScanCache(MM_EnvironmentStandard *env);
+	void activateDeferredCopyScanCache(MM_EnvironmentStandard *env);
 
 	void reportGCStart(MM_EnvironmentStandard *env);
 	void reportGCEnd(MM_EnvironmentStandard *env);
@@ -662,9 +673,10 @@ public:
 	/**
 	 * All open copy caches (even if not full) are pushed onto scan queue. Unused memory is abondoned.
 	 * @param env Invoking thread, for which copy caches are to be released. Could be either GC or mutator thread.
+	 * @param flushCaches If true, really push caches to scan queue, otherwise just deactivate them for possible near future use
 	 * @param final If true (typically at the end of a cycle), abandon TLH remainders, too. Otherwise keep them for possible future copy cache refresh.
 	 */
-	void threadReleaseCaches(MM_EnvironmentBase *env, bool final);
+	void threadReleaseCaches(MM_EnvironmentBase *env, bool flushCaches, bool final);
 	
 	/**
 	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 
@@ -859,6 +871,7 @@ public:
 		, _concurrentState(concurrent_state_idle)
 		, _concurrentScavengerSwitchCount(0)
 		, _shouldYield(false)
+		, _concurrentPhaseStats()
 #endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 		, _omrVM(env->getOmrVM())


### PR DESCRIPTION
Introducing inactive survivor and tenure copy caches for mutator
threads. A copy cache during VM access release/acquire will move copy
caches to inactive/active. When inactive, they will be eligible for
pushing to scan queue by a third thread (one that senses it's almost end
of concurrent phase).

Cache is deactivated by setting a special inactive cache pointer and
setting null to active one (as opposed to setting an explicit boolean or
a low tag bit in existing cache pointer). This is friendly with existing
object allocation code that checks first thing if copy cache is null or
not. We don't have to do any extra checks to determine that cache is to
be activated.

During VM access release, if there are idle GC threads, the copy cache
will not be deactivated but pushed right away to help with finishing the
cycle sooner.

When a third thread tries to push inactive copy cache to the
queue, it may race with the target (owner) mutator thread trying to
activate it. Atomics are used to serialize. One that wins setting null
to inactive cache proceeds.

Flushing code assumes that a mutator thread cannot suddenly change from
inactive to active (acquire VM access or exit native code) and start
using copy cache. If a third thread calls flush (in OpenJ9) it must hold
target's thread public mutex flags. Whenever copy cache is
created/reactivated we will force slow path acquire VM access what will
ensure that target thread blocks on its own public flags mutex, while
flushing is in progress.

Flushing method has two arguments now:
1) flushCaches (new) - most of the time during concurrent phase (when a
thread releases VM access) it's false, what means we prefer to just
deactivate the cache. It's true when we sense that we
are close to the end of the cycle (all GC threads idling and a third
thread force all inactive ones to flush caches).
2) final (existing) - what also means 'make heap walkable'. It's true
only during the final thread iteration that occurs at the start of STW
increment. During intermediate VM access release it will be false.

This change is a building block of
#4787


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>