### PR TITLE
Add support for recognizing fma on x86

### DIFF
--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,7 +141,8 @@ inline uint32_t getFeatureFlags2Mask()
          | TR_POPCNT
          | TR_AESNI
          | TR_OSXSAVE
-         | TR_AVX;
+         | TR_AVX
+         | TR_FMA;
    }
 
 enum TR_X86ProcessorFeatures8

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -169,6 +169,8 @@ inline TR_X86OpCodes SizeParameterizedOpCode(bool is64Bit =
 // Floating-point
 #define MOVSMemReg     SizeParameterizedOpCode<MOVSDMemReg     , MOVSSMemReg     >
 #define MOVSRegMem     SizeParameterizedOpCode<MOVSDRegMem     , MOVSSRegMem     >
+// FMA
+#define VFMADD231SRegRegReg  SizeParameterizedOpCode<VFMADD231SDRegRegReg, VFMADD231SSRegRegReg>
 
 // Size and carry-parameterized opcodes
 //


### PR DESCRIPTION
1. Set up `SizeParameterizedOpCode` for `VFMADD231SRegRegReg`. 
2. Add TR_FMA feature mask to `ProcessorInfo.hpp` so that FMA feature detection is supported on the processor.

This commit will support recognizing fma on x86 https://github.com/eclipse/openj9/pull/8573

Issue:eclipse/openj9#7474
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>