### PR TITLE
TGC Parallel Flush Copy/Scan Updates

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -148,12 +148,13 @@ public:
 	 */
 private:
 	/**
-	 * Flush the threads reference and remembered set caches before waiting in getNextScanCache.
+	 * Flush copy/scan count updates, the threads reference and remembered set caches before waiting in getNextScanCache.
 	 * This removes the requirement of a synchronization point after calls to completeScan when
 	 * it is followed by reference or remembered set processing.
 	 * @param env - current thread environment
+	 * @param finalFlush - lets the copy/scan flush know if it's the last thread performing the flush
 	 */
-	void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env);
+	void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env, bool finalFlush = false);
 	
 	void saveMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
 	void restoreMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
@@ -250,7 +251,11 @@ public:
 	MMINLINE bool copyAndForward(MM_EnvironmentStandard *env, volatile omrobjectptr_t *objectPtrIndirect);
 
 	MMINLINE omrobjectptr_t copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHeader);
-
+	
+	/* Flush remaining Copy Scan updates which would otherwise be discarded 
+	 * @param majorFlush last thread to flush updates should perform a major flush (push accumulated updates to history record) 
+	 */ 
+	MMINLINE void flushCopyScanCounts(MM_EnvironmentBase* env, bool majorFlush);
 	MMINLINE void updateCopyScanCounts(MM_EnvironmentBase* env, uint64_t slotsScanned, uint64_t slotsCopied);
 	bool splitIndexableObjectScanner(MM_EnvironmentStandard *env, GC_ObjectScanner *objectScanner, uintptr_t startIndex, omrobjectptr_t *rememberedSetSlot);
 

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -64,6 +64,7 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_totalDeepStructures(0)
 	,_totalObjsDeepScanned(0)
 	,_depthDeepestStructure(0)
+	,_copyScanUpdates(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	,_avgInitialFree(0)
 	,_avgTenureBytes(0)
@@ -169,6 +170,7 @@ MM_ScavengerStats::clear(bool firstIncrement)
 	_totalDeepStructures = 0;
 	_totalObjsDeepScanned = 0;
 	_depthDeepestStructure = 0;
+	_copyScanUpdates = 0;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	/* NOTE: _startTime and _endTime are also not cleared
 	 * as they are recorded before/after all stat clearing/gathering.

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -95,6 +95,7 @@ public:
 	uintptr_t _totalDeepStructures; /**<  The number of deep structures that are scanned with priority (number of deepScanOutline function calls) */
 	uintptr_t _totalObjsDeepScanned; /**< The total number of deep structure objects that are special treated (number of copyAndForward with priority)*/
 	uintptr_t _depthDeepestStructure; /**< Length of longest deep structure that is special treated */
+	uintptr_t _copyScanUpdates;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
 	/* Average (weighted) number of bytes free after a collection and


### PR DESCRIPTION
For background see https://github.com/eclipse/omr/issues/4825

A thread's copy/scan update will be discarded and reset if it finishes
scanning with less than 512 slots scanned
(SCAVENGER_SLOTS_SCANNED_PER_THREAD_UPDATE). Furthermore, if the
accumulator has gathered updates, but doesn't reach the 32 update
threshold (SCAVENGER_THREAD_UPDATES_PER_MAJOR_UPDATE), the updates will
never be pushed to history table and will be discarded/reset.

- Flush implemented
   - After complete scan routine but prior to blocking, thread will
flush it's update to the accumulator (minor update)
   - Last thread to block will flush the accumulator to update history
table (major update)
   - ~~Recording to the history table takes scan cache metrics. This is
problematic during a major flush. To get around this, a snapshot of Scan
List metrics is taken during minor updates, used in the case where the
update would of triggered a major update had it reached the threshold,
but doesn't, and is part of major flush~~
- _copyScanUpdates thread local scavenger stat added to count the number
of total updates (incremented each time a thread does an update before
it is contended in any way), this can be compared with history table updates 
to get number of missed updates.

Signed-off-by: Salman Rana <salman.rana@ibm.com>