### PR TITLE
Remove NULL check for Self() in TreeTop::join

### DIFF
--- a/compiler/il/OMRTreeTop_inlines.hpp
+++ b/compiler/il/OMRTreeTop_inlines.hpp
@@ -80,8 +80,8 @@ OMR::TreeTop::unlink(bool decRefCountRecursively)
 inline void
 OMR::TreeTop::join(TR::TreeTop * p)
    {
-   if (self())
-      self()->setNextTreeTop(p);
+   self()->setNextTreeTop(p);
+   
    if (p)
       p->setPrevTreeTop(self());
    }


### PR DESCRIPTION
`OMR::TreeTop::join()` checks if self() is NULL [1], which is odd
because it never makes sense to call a member function on a NULL
object. Such calls are undefined behaviour.

Closes: #4835
Signed-off-by: Tucker <tuckermiles70@gmail.com>