### PR TITLE
Override CPU::detect() on Z and X86

### DIFF
--- a/compiler/env/OMRCPU.cpp
+++ b/compiler/env/OMRCPU.cpp
@@ -29,21 +29,20 @@
 #include "env/defines.h"
 #include "omrcfg.h"
 
-
-TR::CPU TR::detect(OMRPortLibrary * const omrPortLib)
-   {
-   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
-   OMRProcessorDesc processorDescription;
-   omrsysinfo_get_processor_description(&processorDescription);
-   return TR::CPU(processorDescription);
-   }
-
 TR::CPU *
 OMR::CPU::self()
    {
    return static_cast<TR::CPU*>(this);
    }
 
+TR::CPU
+OMR::CPU::detect(OMRPortLibrary * const omrPortLib)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc processorDescription;
+   omrsysinfo_get_processor_description(&processorDescription);
+   return TR::CPU(processorDescription);
+   }
 
 void
 OMR::CPU::initializeByHostQuery()
@@ -105,3 +104,4 @@ OMR::CPU::supportsFeature(uint32_t feature)
    BOOLEAN supported = omrsysinfo_processor_has_feature(&_processorDescription, feature);
    return (TRUE == supported);
    }
+

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -75,14 +75,6 @@ enum MinorArchitecture
    m_arch_riscv64
    };
 
-
-/** 
- * @brief Detects the underlying processor type and features using the port library and constructs a TR::CPU object 
- * @param[in] omrPortLib : the port library
- * @return TR::CPU
- */
-TR::CPU detect(OMRPortLibrary * const omrPortLib);
-
 }
 
 
@@ -116,6 +108,13 @@ protected:
 public:
 
    TR::CPU *self();
+
+   /** 
+    * @brief Detects the underlying processor type and features using the port library and constructs a TR::CPU object 
+    * @param[in] omrPortLib : the port library
+    * @return TR::CPU
+    */
+   static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
    // Initialize CPU info by querying the host processor at compile-time
    //

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -27,6 +27,34 @@
 #include "infra/Flags.hpp"
 #include "x/runtime/X86Runtime.hpp"
 
+TR::CPU
+OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
+   {   
+   // Only enable the features that compiler currently uses
+   uint32_t enabledFeatures [] = {OMR_FEATURE_X86_FPU, OMR_FEATURE_X86_CX8, OMR_FEATURE_X86_CMOV,
+                                  OMR_FEATURE_X86_MMX, OMR_FEATURE_X86_SSE, OMR_FEATURE_X86_SSE2,
+                                  OMR_FEATURE_X86_SSSE3, OMR_FEATURE_X86_SSE4_1, OMR_FEATURE_X86_POPCNT,
+                                  OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_OSXSAVE, OMR_FEATURE_X86_AVX,
+                                  OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM};
+
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc featureMasks;
+   memset(featureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+   for (size_t i = 0; i < sizeof(enabledFeatures)/sizeof(uint32_t); i++)
+      {
+      omrsysinfo_processor_set_feature(&featureMasks, enabledFeatures[i], TRUE);
+      }
+
+   OMRProcessorDesc processorDescription;
+   omrsysinfo_get_processor_description(&processorDescription);
+   for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
+      {
+      processorDescription.features[i] &= featureMasks.features[i];
+      }
+
+   return TR::CPU(processorDescription);
+   }
+
 TR_X86CPUIDBuffer *
 OMR::X86::CPU::queryX86TargetCPUID()
    {

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -57,6 +57,8 @@ protected:
 
 public:
 
+   static TR::CPU detect(OMRPortLibrary * const omrPortLib);
+
    TR_X86CPUIDBuffer *queryX86TargetCPUID();
    const char *getX86ProcessorVendorId();
    uint32_t getX86ProcessorSignature();

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -27,7 +27,67 @@
 #pragma csect(STATIC,"OMRZCPUBase#S")
 #pragma csect(TEST,"OMRZCPUBase#T")
 
+#include "control/Options.hpp"
 #include "env/CPU.hpp"
+
+TR::CPU
+OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc processorDescription;
+   omrsysinfo_get_processor_description(&processorDescription);
+
+   if (processorDescription.processor >= OMR_PROCESSOR_S390_Z10 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ10))
+      processorDescription.processor = OMR_PROCESSOR_S390_FIRST;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_Z196 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ196))
+      processorDescription.processor = OMR_PROCESSOR_S390_Z10;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_ZEC12 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZEC12))
+      processorDescription.processor = OMR_PROCESSOR_S390_Z196;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_Z13 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ13))
+      processorDescription.processor = OMR_PROCESSOR_S390_ZEC12;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_Z14 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ14))
+      processorDescription.processor = OMR_PROCESSOR_S390_Z13;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_Z15 && TR::Options::getCmdLineOptions()->getOption(TR_DisableZ15))
+      processorDescription.processor = OMR_PROCESSOR_S390_Z14;
+   else if (processorDescription.processor >= OMR_PROCESSOR_S390_ZNEXT && TR::Options::getCmdLineOptions()->getOption(TR_DisableZNext))
+      processorDescription.processor = OMR_PROCESSOR_S390_Z15;
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z10)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_DFP, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z196)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_HIGH_WORD, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_ZEC12)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_TE, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_RI, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z13)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z14)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_GUARDED_STORAGE, FALSE);
+      }
+
+   if (processorDescription.processor < OMR_PROCESSOR_S390_Z15)
+      {
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_FACILITY_ENHANCEMENT_2, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY, FALSE);
+      }
+
+   return TR::CPU(processorDescription);
+   }
 
 const char*
 OMR::Z::CPU::getProcessorName(int32_t machineId)
@@ -107,12 +167,6 @@ OMR::Z::CPU::getProcessorName(int32_t machineId)
 
    return result;
    }
-
-OMR::Z::CPU::CPU()
-   :
-   OMR::CPU(),
-   _supportedArch(z9)
-   {}
 
 bool
 OMR::Z::CPU::getSupportsArch(Architecture arch)
@@ -403,3 +457,4 @@ OMR::Z::CPU::isTargetWithinBranchRelativeRILRange(intptrj_t targetAddress, intpt
    return (targetAddress == sourceAddress + ((intptrj_t)((int32_t)((targetAddress - sourceAddress) / 2))) * 2) &&
             (targetAddress % 2 == 0);
    }
+

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -69,6 +69,8 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
     */
    static const char* getProcessorName(int32_t machineId);
 
+   static TR::CPU detect(OMRPortLibrary * const omrPortLib);
+
    public:
 
    bool getSupportsArch(Architecture arch);
@@ -260,7 +262,7 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
 
    protected:
 
-   CPU();
+   CPU() : OMR::CPU(), _supportedArch(z9) {}
    CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
    enum


### PR DESCRIPTION
On Z, modifications to the processor description are needed
due to command line options and other factors. On X, unused
features are masked out (may come in handy for processor
compatibility tests)

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>