### PR TITLE
Add omrsysinfo_processor_disable_feature API

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1285,8 +1285,8 @@ typedef enum OMRProcessorArchitecture {
 
 } OMRProcessorArchitecture;
 
-/* Holds processor type and features used with omrsysinfo_get_processor_description
- * and omrsysinfo_processor_has_feature
+/* Holds processor type and features used with omrsysinfo_get_processor_description,
+ * omrsysinfo_processor_has_feature and omrsysinfo_processor_disable_feature
  */
 #define OMRPORT_SYSINFO_FEATURES_SIZE 5
 typedef struct OMRProcessorDesc {
@@ -1658,6 +1658,8 @@ typedef struct OMRPortLibrary {
 	intptr_t  ( *sysinfo_get_processor_description)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_processor_has_feature "omrsysinfo_processor_has_feature"*/
 	BOOLEAN  ( *sysinfo_processor_has_feature)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_processor_disable_feature "omrsysinfo_processor_disable_feature"*/
+	intptr_t  ( *sysinfo_processor_disable_feature)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_OS_type "omrsysinfo_get_OS_type"*/
 	const char *(*sysinfo_get_OS_type)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_executable_name "omrsysinfo_get_executable_name"*/
@@ -2371,6 +2373,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_get_CPU_architecture() privateOmrPortLibrary->sysinfo_get_CPU_architecture(privateOmrPortLibrary)
 #define omrsysinfo_get_processor_description(param1) privateOmrPortLibrary->sysinfo_get_processor_description(privateOmrPortLibrary,param1)
 #define omrsysinfo_processor_has_feature(param1,param2) privateOmrPortLibrary->sysinfo_processor_has_feature(privateOmrPortLibrary,param1,param2)
+#define omrsysinfo_processor_disable_feature(param1,param2) privateOmrPortLibrary->sysinfo_processor_disable_feature(privateOmrPortLibrary,param1,param2)
 #define omrsysinfo_get_OS_type() privateOmrPortLibrary->sysinfo_get_OS_type(privateOmrPortLibrary)
 #define omrsysinfo_get_executable_name(param1,param2) privateOmrPortLibrary->sysinfo_get_executable_name(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_username(param1,param2) privateOmrPortLibrary->sysinfo_get_username(privateOmrPortLibrary, (param1), (param2))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -74,6 +74,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_CPU_architecture, /* sysinfo_get_CPU_architecture */
 	omrsysinfo_get_processor_description, /* omrsysinfo_get_processor_description */
 	omrsysinfo_processor_has_feature, /* omrsysinfo_processor_has_feature */
+	omrsysinfo_processor_disable_feature, /* omrsysinfo_processor_disable_feature */
 	omrsysinfo_get_OS_type, /* sysinfo_get_OS_type */
 	omrsysinfo_get_executable_name, /* sysinfo_get_executable_name */
 	omrsysinfo_get_username, /* sysinfo_get_username */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1102,8 +1102,11 @@ TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_parseDashFa
 TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_parseSecondAddressFailed Group=mem Overhead=1 Level=5 NoEnv Template="findAvailableMemoryBlockNoMalloc parser failed to get second address from line (%s)"
 TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_addressesMismatch Group=mem Overhead=1 Level=5 NoEnv Template="findAvailableMemoryBlockNoMalloc parser found addresses mismatch from line (%s)"
 
-TraceEntry=Trc_PRT_sysinfo_get_processor_description_Entered Group=j9sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: desc = %p"
-TraceExit=Trc_PRT_sysinfo_get_processor_description_Exit Group=j9sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: returning with %zd"
+TraceEntry=Trc_PRT_sysinfo_get_processor_description_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: desc = %p"
+TraceExit=Trc_PRT_sysinfo_get_processor_description_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: returning with %zd"
 
 TraceEntry=Trc_PRT_sysinfo_processor_has_feature_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_has_feature: desc = %p, feature = %d"
-TraceExit=Trc_PRT_sysinfo_processor_has_feature_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_has_feature: returning with %zu."
+TraceExit=Trc_PRT_sysinfo_processor_has_feature_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_has_feature: returning with %zu"
+
+TraceEntry=Trc_PRT_sysinfo_processor_disable_feature_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_disable_feature: desc = %p, feature = %d"
+TraceExit=Trc_PRT_sysinfo_processor_disable_feature_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_disable_feature: returning with %zd"

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -115,7 +115,7 @@ omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProc
  *
  * @param[in] portLibrary The port library.
  * @param[in] desc The struct that will contain the CPU type and features.
- * @param[in] feature The feature to check (see j9port.h for list of features J9PORT_{PPC,S390,PPC}_FEATURE_*)
+ * @param[in] feature The feature to check (see omrport.h for list of features OMRPORT_FEATURE_{PPC,S390,PPC}_*)
  *
  * @return TRUE if feature is present, FALSE otherwise.
  */
@@ -125,6 +125,24 @@ omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcesso
 	Trc_PRT_sysinfo_processor_has_feature_Entered(desc, feature);
 	BOOLEAN rc = FALSE;
 	Trc_PRT_sysinfo_processor_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}
+
+/**
+ * Disable provided CPU feature.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] desc The struct that will contain the CPU type and features.
+ * @param[in] feature The feature to check (see omrport.h for list of features OMRPORT_FEATURE_{PPC,S390,PPC}_*)
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+omrsysinfo_processor_disable_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature)
+{
+	Trc_PRT_sysinfo_processor_disable_feature_Entered(desc, feature);
+	intptr_t rc = OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+	Trc_PRT_sysinfo_processor_disable_feature_Exit(rc);
 	return rc;
 }
 /**
@@ -877,7 +895,7 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift);
 	}
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -482,6 +482,8 @@ extern J9_CFUNC intptr_t
 omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
 extern J9_CFUNC BOOLEAN
 omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature);
+extern J9_CFUNC intptr_t
+omrsysinfo_processor_disable_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature);
 extern J9_CFUNC const char *
 omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -647,10 +647,30 @@ omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcesso
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift);
 	}
 
 	Trc_PRT_sysinfo_processor_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}
+
+intptr_t
+omrsysinfo_processor_disable_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature)
+{
+	intptr_t rc = -1;
+	Trc_PRT_sysinfo_processor_disable_feature_Entered(desc, feature);
+
+	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
+		uint32_t featureIndex = feature / 32;
+		uint32_t featureShift = feature % 32;
+
+		if (OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift)) {
+			desc->features[featureIndex] -= (1u << featureShift);
+			rc = 0;
+		}
+	}
+
+	Trc_PRT_sysinfo_processor_disable_feature_Exit(rc);
 	return rc;
 }
 
@@ -670,7 +690,7 @@ omrsysinfo_set_feature(OMRProcessorDesc *desc, uint32_t feature)
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		desc->features[featureIndex] = (desc->features[featureIndex] | (1 << (featureShift)));
+		desc->features[featureIndex] = (desc->features[featureIndex] | (1u << (featureShift)));
 	}
 }
 #endif /* defined(AIXPPC) || defined(S390) || defined(J9ZOS390) */
@@ -4717,7 +4737,7 @@ setOSFeature(struct OMROSDesc *desc, uint32_t feature)
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		desc->features[featureIndex] = (desc->features[featureIndex] | (1 << (featureShift)));
+		desc->features[featureIndex] = (desc->features[featureIndex] | (1u << (featureShift)));
 	}
 }
 
@@ -4774,7 +4794,7 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift);
 	}
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -116,10 +116,30 @@ omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcesso
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift);
 	}
 
 	Trc_PRT_sysinfo_processor_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}
+
+intptr_t
+omrsysinfo_processor_disable_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature)
+{
+	intptr_t rc = -1;
+	Trc_PRT_sysinfo_processor_disable_feature_Entered(desc, feature);
+
+	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
+		uint32_t featureIndex = feature / 32;
+		uint32_t featureShift = feature % 32;
+
+		if (OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift)) {
+			desc->features[featureIndex] -= (1u << featureShift);
+			rc = 0;
+		}
+	}
+
+	Trc_PRT_sysinfo_processor_disable_feature_Exit(rc);
 	return rc;
 }
 
@@ -1739,7 +1759,7 @@ omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *
 		uint32_t featureIndex = feature / 32;
 		uint32_t featureShift = feature % 32;
 
-		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1u << featureShift);
 	}
 
 	Trc_PRT_sysinfo_os_has_feature_Exit((uintptr_t)rc);


### PR DESCRIPTION
This API is used for disabling features in OMRProcessorDesc.

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>