### PR TITLE
Removed deprecated FrontEnd:getObjectAlignmentInBytes

### DIFF
--- a/compiler/env/FrontEnd.cpp
+++ b/compiler/env/FrontEnd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,14 +126,6 @@ uintptrj_t TR_FrontEnd::getOffsetOfContiguousArraySizeField()     { TR_UNIMPLEME
 uintptrj_t TR_FrontEnd::getOffsetOfDiscontiguousArraySizeField()  { TR_UNIMPLEMENTED(); return 0; }
 
 uintptrj_t TR_FrontEnd::getOffsetOfIndexableSizeField()           { TR_UNIMPLEMENTED(); return 0; }
-
-
-int32_t
-TR_FrontEnd::getObjectAlignmentInBytes()
-   {
-   TR_UNIMPLEMENTED();
-   return 0;
-   }
 
 
 char *

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -194,7 +194,6 @@ public:
    virtual int32_t getArraySpineShift(int32_t);
    virtual int32_t getArrayletMask(int32_t);
    virtual int32_t getArrayletLeafIndex(int32_t, int32_t);
-   virtual int32_t getObjectAlignmentInBytes();
    virtual uintptrj_t getOffsetOfContiguousArraySizeField();
    virtual uintptrj_t getOffsetOfDiscontiguousArraySizeField();
    virtual uintptrj_t getObjectHeaderSizeInBytes();


### PR DESCRIPTION
Removed deprecated FrontEnd getObjectAlignmentInBytes method.

https://github.com/eclipse/openj9/pull/8606 needs to be merged before.
Closes: https://github.com/eclipse/openj9/issues/5904

Signed-off-by: Sean Moffatt <sean.moffatt@unb.ca>