### PR TITLE
Fix binary encoding template for ldux

### DIFF
--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -2400,7 +2400,7 @@
    /* .mnemonic    = */ OMR::InstOpCode::ldux,
    /* .name        = */ "ldux",
    /* .description =    "Load dword with update indexed", */
-   /* .opcode      = */ 0x7C00006C,
+   /* .opcode      = */ 0x7C00006A,
    /* .format      = */ FORMAT_UNKNOWN,
    /* .minimumALS  = */ TR_Processor::TR_PPCpwr630,
    /* .properties  = */ PPCOpProp_UpdateForm |


### PR DESCRIPTION
The current binary encoding template used for Power ldux instructions is
incorrect, instead encoding a dcbst instruction which would not perform
the requisite load or update the base register. This has now been
corrected and ldux instructions should encode correctly.

Signed-off-by: Ben Thomas <ben@benthomas.ca>