### PR TITLE
Update omrsl_open_shared library behaviour on unix platforms

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -67,6 +67,13 @@ macro(omr_find_semaphore_implementation)
 	endif()
 endmacro()
 
+function(omr_check_dladdr)
+	list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
+	list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
+	check_symbol_exists(dladdr "dlfcn.h" OMR_HAS_DLADDR)
+endfunction()
+
+
 # Translate from CMake's view of the system to the OMR view of the system.
 # Exports a number of variables indicicating platform, os, endianness, etc.
 # - OMR_ARCH_{AARCH64,X86,ARM,S390} # TODO: Add POWER
@@ -205,6 +212,7 @@ macro(omr_detect_system_information)
 	message(STATUS "OMR: The target data size is ${OMR_ENV_TARGET_DATASIZE}")
 
 	omr_find_semaphore_implementation()
+	omr_check_dladdr()
 
 	# Check if we are a multi config generator
 	# CMake 3.10 adds GENERATOR_IS_MULTI_CONFIG property

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -248,6 +248,7 @@
 #cmakedefine OMR_USE_POSIX_SEMAPHORES
 #cmakedefine OMR_USE_OSX_SEMAPHORES
 #cmakedefine OMR_USE_ZOS_SEMAPHORES
+#cmakedefine OMR_HAS_DLADDR
 
 /**
  * This flag enables the usage of OMR socket API. The API contains functions for

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -265,6 +265,10 @@
 #define OMR_USE_OSX_SEMAPHORES
 #elif defined(J9ZOS390)
 #define OMR_USE_ZOS_SEMAPHORES
+#endif
+
+#if defined(LINUX) || defined(OSX)
+#define OMR_HAS_DLADDR
 #endif
 
 /**

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -162,7 +162,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 	/* dlopen(2) called with NULL filename opens a handle to current executable. */
 	handle = dlopen(openExec ? NULL : openName, lazyOrNow);
 
-#if defined(LINUX) || defined(OSX)
+#if defined(OMR_HAS_DLADDR)
 	if ((NULL == handle) && !openExec) {
 		/* last ditch, try dir port lib DLL is in */
 		char portLibDir[MAX_STRING_LENGTH];
@@ -197,7 +197,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 			}
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* defined(OMR_HAS_DLADDR) */
 
 	if (NULL == handle) {
 		getDLError(portLibrary, errBuf, sizeof(errBuf));


### PR DESCRIPTION
Rather than gating behaviour on platform, instead base on availabilty of
the dladdr function

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>