### PR TITLE
Fix missing omrsysinfo_get_x86_description on Windows

### DIFF
--- a/port/common/omrsysinfo_helpers.c
+++ b/port/common/omrsysinfo_helpers.c
@@ -33,7 +33,7 @@
 
 #include <string.h>
 
-#if (defined(J9X86) || defined(J9HAMMER))
+#if defined(OMR_OS_WINDOWS) || defined(J9X86) || defined(J9HAMMER)
 #if defined(OMR_OS_WINDOWS)
 #include <intrin.h>
 #define cpuid(CPUInfo, EAXValue)             __cpuid(CPUInfo, EAXValue)
@@ -224,4 +224,4 @@ omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorD
 
 	return 0;
 }
-#endif /* (defined(J9X86) || defined(J9HAMMER)) */
+#endif /* defined(OMR_OS_WINDOWS) || defined(J9X86) || defined(J9HAMMER) */

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -30,9 +30,9 @@
 
 #include "omrport.h"
 
-#if (defined(J9X86) || defined(J9HAMMER))
+#if defined(OMR_OS_WINDOWS) || defined(J9X86) || defined(J9HAMMER)
 extern intptr_t
 omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
-#endif
+#endif /* defined(OMR_OS_WINDOWS) || defined(J9X86) || defined(J9HAMMER) */
 
 #endif /* SYSINFOHELPERS_H_ */


### PR DESCRIPTION
Signed-off-by: Harry Yu <harryyu1994@gmail.com>