### PR TITLE
CopyScanCache pool size

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -201,6 +201,11 @@ private:
 		return shouldAbort;
 	}
 
+	/** 
+	 * A simple heuristic that projects the need for copy-scan cache size pool, based on heap size that Scavenger operates with)
+	 */	
+	uintptr_t calculateMaxCacheCount(uintptr_t activeMemorySize);
+
 public:
 	/**
 	 * Hook callback. Called when a global collect has started


### PR DESCRIPTION
Reduce max and increment size of the pool by factor of 3.4x

This is effectively fixing a regression where this pool increased due to
decrease of minimum copy cache size from 32K to 8K about a couple of
years ago.

The heuristic for the size of the pool is now based on both min and max
size of copy cache. Relying on just min size was too conservative. If GC
dynamically decided to use small copy caches it means that parallelism
is low, what in turn means that scan queue is mostly empty, hence the
need for the caches is low.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>