### PR TITLE
Disable code cache reclamation if perfTool option is enabled

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1998,11 +1998,13 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
    self()->setOption(TR_DisableNextGenHCR);
 #endif
 
-   static const char *ccr = feGetEnv("TR_DisableCCR");
-   if (ccr)
+   static const bool disableCCREnv = feGetEnv("TR_DisableCCR") != NULL;
+   if (self()->getOption(TR_PerfTool) || disableCCREnv)
       {
+      fprintf(stderr, "WARNING: Disabling code cache reclamation due to due to -Xjit:perfTool or TR_DisableCCR environment variable\n");
       self()->setOption(TR_DisableCodeCacheReclamation);
       }
+
    static const char *disableCCCF = feGetEnv("TR_DisableClearCodeCacheFullFlag");
    if (disableCCCF)
       {


### PR DESCRIPTION
When the perfTool option is enabled the user is likely profiling JIT
generated code which means we would want to disable code cache
reclamation to avoid the profiling tool from mapping ticks to
overlapping JIT methods. We spit out a warning message to stderr so it
is obvious to the user that this is happening.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>