### PR TITLE
Remove unnecessary indentation in jitbuilder.api.json.

### DIFF
--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -1464,27 +1464,27 @@
                 , "parms": [ {"name":"value","type":"IlValue"} ]
                 },
                 { "name": "Switch"
-                    , "overloadsuffix": "WithArgArray"
-                    , "flags": []
-                    , "return": "none"
-                    , "parms": [
-                        {"name":"selectorValue","type":"IlValue"},
-                        {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
-                        {"name":"numCases","type":"int32"},
-                        {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
-                        ]
+                , "overloadsuffix": "WithArgArray"
+                , "flags": []
+                , "return": "none"
+                , "parms": [
+                    {"name":"selectorValue","type":"IlValue"},
+                    {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
+                    {"name":"numCases","type":"int32"},
+                    {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
+                    ]
                 },
                 { "name": "TableSwitch"
-                    , "overloadsuffix": "WithArgArray"
-                    , "flags": []
-                    , "return": "none"
-                    , "parms": [
-                        {"name":"selectorValue","type":"IlValue"},
-                        {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
-                        {"name": "generateBoundsCheck", "type": "boolean"},
-                        {"name":"numCases","type":"int32"},
-                        {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
-                        ]
+                , "overloadsuffix": "WithArgArray"
+                , "flags": []
+                , "return": "none"
+                , "parms": [
+                    {"name":"selectorValue","type":"IlValue"},
+                    {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
+                    {"name": "generateBoundsCheck", "type": "boolean"},
+                    {"name":"numCases","type":"int32"},
+                    {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
+                    ]
                 },
                 { "name": "MakeCase"
                 , "overloadsuffix": ""


### PR DESCRIPTION
A change in jitbuilder.api.json introduced unnecessary indentation in #4340 

[skip ci] since this is just whitespace modifications

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>