### PR TITLE
Refactor ternary to select cleanup

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1495,7 +1495,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsArrayTranslateTRxx() {return _flags2.testAny(SupportsArrayTranslate);}
    void setSupportsArrayTranslateTRxx() {_flags2.set(SupportsArrayTranslate);}
 
-   bool getSupportsTernary() {return _flags2.testAny(SupportsSelect);}
    bool getSupportsSelect() {return _flags2.testAny(SupportsSelect);}
    void setSupportsSelect() {_flags2.set(SupportsSelect);}
 

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -658,14 +658,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
    }
 
 TR::ILOpCodes
-OMR::IL::opCodeForTernarySelect(TR::DataType dt)
-   {
-   TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
-
-   return OMR::IL::opCodesForSelect[dt];
-   }
-
-TR::ILOpCodes
 OMR::IL::opCodeForSelect(TR::DataType dt)
    {
    TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");

--- a/compiler/il/OMRIL.hpp
+++ b/compiler/il/OMRIL.hpp
@@ -73,7 +73,6 @@ class OMR_EXTENSIBLE IL
    TR::ILOpCodes opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode);
    TR::ILOpCodes opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode);
 
-   TR::ILOpCodes opCodeForTernarySelect(TR::DataType dt);
    TR::ILOpCodes opCodeForSelect(TR::DataType dt);
    TR::ILOpCodes opCodeForConst(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectLoad(TR::DataType dt);

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -462,7 +462,6 @@
    bselect,   //
    sselect,   //
    aselect,   //
-   aternary = aselect,   //
    fselect,   //
    dselect,   //
    treetop,  // tree top to anchor subtrees with side-effects

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -228,7 +228,6 @@ public:
    bool isRotate()                   const { return properties2().testAny(ILProp2::LeftRotate); }
    bool isUnsignedCompare()          const { return properties2().testAny(ILProp2::UnsignedCompare); }
    bool isOverflowCompare()          const { return properties2().testAny(ILProp2::OverflowCompare); }
-   bool isTernary()                  const { return properties2().testAny(ILProp2::Select); }
    bool isSelect()                   const { return properties2().testAny(ILProp2::Select); }
    bool isSelectAdd()                const { return properties2().testAny(ILProp2::SelectAdd); }
    bool isSelectSub()                const { return properties2().testAny(ILProp2::SelectSub); }

--- a/compiler/il/OMRILProps.hpp
+++ b/compiler/il/OMRILProps.hpp
@@ -216,7 +216,6 @@ namespace ILProp2
       LeftRotate                   = 0x00001000,
       UnsignedCompare              = 0x00002000,
       OverflowCompare              = 0x00004000,
-      Ternary                      = 0x00008000,
       Select                       = 0x00008000,
       SelectAdd                    = 0x00010000,
       SelectSub                    = 0x00020000,


### PR DESCRIPTION
Cleaning up duplicated code

Removed deprecated functions (i.e. `getSupportsTernary` etc.)
which were introduced by the PR #4578.

Closes: #681 and #4847 