### PR TITLE
WIP: No freeSpill when doing local RA for ICF

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -457,7 +457,7 @@ OMR::CodeGenerator::allocateSpill(int32_t dataSize, bool containsCollectedRefere
    TR_ASSERT_FATAL(!containsCollectedReference || (dataSize == TR::Compiler->om.sizeofReferenceAddress()), "assertion failure");
 
    if (self()->getTraceRAOption(TR_TraceRASpillTemps))
-      traceMsg(self()->comp(), "\nallocateSpill(%d, %s, %s)", dataSize, containsCollectedReference? "collected":"uncollected", offset? "offset":"NULL");
+      traceMsg(self()->comp(), "\nallocateSpill(%d, %s, %s)\n", dataSize, containsCollectedReference? "collected":"uncollected", offset? "offset":"NULL");
 
    if (offset && self()->comp()->getOption(TR_DisableHalfSlotSpills))
       {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1449,12 +1449,9 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
    bool dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && comp->getOutFile() != NULL;
 #endif
 
-   if (self()->getUseNonLinearRegisterAssigner())
+   if (!self()->getSpilledRegisterList())
       {
-      if (!self()->getSpilledRegisterList())
-         {
-         self()->setSpilledRegisterList(new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
-         }
+      self()->setSpilledRegisterList(new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
       }
 
    if (self()->getDebug())

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -302,8 +302,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR_GlobalRegisterNumber getLastGlobalFPRRegisterNumber()
       {return _numGlobalGPRs + _numGlobalFPRs - 1;}
 
-   TR::RegisterDependencyConditions  *createDepCondForLiveGPRs();
-   TR::RegisterDependencyConditions  *createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<TR::Register*> *spilledRegisterList = NULL);
+   TR::RegisterDependencyConditions  *createDepCondForLiveGPRs(TR::list<TR::Register*> *spilledRegisterList = NULL);
 
 #if defined(DEBUG)
    void printGPRegisterStatus(TR_FrontEnd *, TR::RealRegister **registerFile, TR::FILE *pOutFile);

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -737,8 +737,6 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
       //
       if (dependentRegNum == TR::RealRegister::SpilledReg)
          {
-         if (cg->getUseNonLinearRegisterAssigner())
-            {
             if (virtReg->getAssignedRegister())
                {
                TR_ASSERT(virtReg->getBackingStorage(), "should have a backing store for spilled reg virtuals");
@@ -778,7 +776,6 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
                {
                cg->getSpilledRegisterList()->push_front(virtReg);
                }
-            }
          }
       }
 
@@ -1036,8 +1033,6 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          }
       }
 
-   if (cg->getUseNonLinearRegisterAssigner())
-      {
       for (i=0; i<numberOfRegisters; i++)
          {
          virtReg = _dependencies[i].getRegister();
@@ -1050,8 +1045,6 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
             virtReg->decFutureUseCount();
             }
          }
-      }
-
    }
 
 

--- a/compiler/x/codegen/OutlinedInstructions.cpp
+++ b/compiler/x/codegen/OutlinedInstructions.cpp
@@ -245,8 +245,10 @@ void TR_OutlinedInstructions::assignRegisters(TR_RegisterKinds kindsToBeAssigned
    // current real register associations.  This is necessary to get the register assigner
    // back into its original state before the helper stream was processed.
    //
-   TR::RegisterDependencyConditions *liveRealRegDeps = _cg->machine()->createDepCondForLiveGPRs();
+   TR::RegisterDependencyConditions *liveRealRegDeps = _cg->machine()->createDepCondForLiveGPRs(_cg->getSpilledRegisterList());
    _firstInstruction->setDependencyConditions(liveRealRegDeps);
+   traceMsg(_cg->comp(), "\nblocking spill for OutlinedInstructions _firstInstruction %p\n", _firstInstruction);
+   _cg->lockFreeSpillList();
 
    // TODO:AMD64: Fix excessive register assignment exchanges in outlined instruction dispatch.
 
@@ -266,6 +268,7 @@ void TR_OutlinedInstructions::assignRegisters(TR_RegisterKinds kindsToBeAssigned
 
    // Returning to mainline, reset this counter
    _cg->setInternalControlFlowSafeNestingDepth(0);
+   _cg->unlockFreeSpillList();
 
    setHasBeenRegisterAssigned(true);
    }


### PR DESCRIPTION
Currently RA records the register states for mainline code when starts
assigning registers to out-of-line instructions so that out-of-line
instructions respects the register assignments in the mainline code.
This change makes RA respect the state of spills as well by blocking
`freeSpill`.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>