### PR TITLE
RISC-V: rename `vselectEvaluator()` to `vbitselectEvaluator()`

### DIFF
--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -476,7 +476,7 @@ public:
 	static TR::Register *vicmpanyltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vicmpanyleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *vbitselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vpermEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vdmergelEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
This commit fixes broken compilation on RISC-V after a merge of
66aae968.