### PR TITLE
Reduce counts when running without SCC and many CPUs are available

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4073,7 +4073,7 @@ OMR::Options::setCounts()
             }
          else // Use higher count
             {
-            _initialCount = TR_DEFAULT_INITIAL_COUNT;
+            _initialCount = TR::Compiler->target.numberOfProcessors() >= TR_NUMPROC_FOR_LARGE_SMP ? TR_LARGE_SMP_INITIAL_COUNT : TR_DEFAULT_INITIAL_COUNT;
             }
          }
       else
@@ -4096,7 +4096,7 @@ OMR::Options::setCounts()
                }
             else
                {
-               _initialBCount = TR_DEFAULT_INITIAL_BCOUNT;
+               _initialBCount = TR::Compiler->target.numberOfProcessors() >= TR_NUMPROC_FOR_LARGE_SMP ? TR_LARGE_SMP_INITIAL_BCOUNT: TR_DEFAULT_INITIAL_BCOUNT;
                }
             _initialBCount = std::min(_initialBCount, _initialCount);
             }

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1192,6 +1192,10 @@ enum TR_ProcessOptionsFlags
 #define TR_DEFAULT_INITIAL_BCOUNT        3000
 #define TR_DEFAULT_INITIAL_MILCOUNT       250
 
+#define TR_LARGE_SMP_INITIAL_COUNT       2000
+#define TR_LARGE_SMP_INITIAL_BCOUNT      1000
+#define TR_NUMPROC_FOR_LARGE_SMP            4 // Minimum number of CPUs to declare this environment as a "large SMP"
+
 #define TR_QUICKSTART_INITIAL_COUNT      1000
 #define TR_QUICKSTART_INITIAL_BCOUNT      250
 #define TR_QUICKSTART_INITIAL_MILCOUNT      1


### PR DESCRIPTION
When the shared class cache feature is not used, the default invocation counts
are count=3000,bcount=3000. They are rather large to allow for enough interpreter
profiling information to be collected. However, this affects the rampup of
Java applications because the transition from interpreter to jitted code is delayed.
Recent experiments have shown that it is possible to reduce the counts from
(3000,3000) to (2000,1000) without affecting the long term throughput.
Because lower invocation counts means more compilations, we can afford to lower the
counts only when we have enough computing power. In this PR the default
invocation counts will be lowered to (2000,1000) only when there are 4 CPUs
or more available.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>