### PR TITLE
Initialize OptTestDriver's members

### DIFF
--- a/fvtest/compilertest/tests/OptTestDriver.cpp
+++ b/fvtest/compilertest/tests/OptTestDriver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,10 @@
 #include "ilgen/IlInjector.hpp"
 #include "ras/IlVerifierHelpers.hpp"
 #include "ilgen/MethodInfo.hpp"
+
+TestCompiler::OptTestDriver::OptTestDriver() : _compiledMethod(NULL), _methodInfo(NULL), _ilVer(NULL)
+   {
+   }
 
 TestCompiler::OptTestDriver::~OptTestDriver()
    {

--- a/fvtest/compilertest/tests/OptTestDriver.hpp
+++ b/fvtest/compilertest/tests/OptTestDriver.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,7 @@ namespace TestCompiler
 class OptTestDriver : public TestDriver, public ::testing::Test
    {
    public:
+   OptTestDriver();
    ~OptTestDriver();
 
    void setMethodInfo(TestCompiler::MethodInfo *methodInfo) { _methodInfo = methodInfo; }


### PR DESCRIPTION
The `_ilVer` member specifically needs to be initialized because it is optional. If the user doesn't set one we'll dereference an uninitialized pointer in `OMR::Compilation::compile()`.