### PR TITLE
Added constants for Unix Implementations in OMRSOCK API

### DIFF
--- a/fvtest/porttest/omrsockTest.cpp
+++ b/fvtest/porttest/omrsockTest.cpp
@@ -116,9 +116,9 @@ TEST(PortSockTest, create_hints_and_element_extraction)
 	int32_t sockType = 0;
 	int32_t protocol = 0;
 
-	int32_t hintsFamily = 0;
-	int32_t hintsSockType = 1;
-	int32_t hintsProtocol = 1;
+	int32_t hintsFamily = OMRSOCK_AF_UNSPEC;
+	int32_t hintsSockType = OMRSOCK_STREAM;
+	int32_t hintsProtocol = OMRSOCK_IPPROTO_TCP;
 	int32_t hintsFlags = 0;
 
 	OMRPORTLIB->sock_getaddrinfo_create_hints(OMRPORTLIB, &hints, hintsFamily, hintsSockType, hintsProtocol, hintsFlags);
@@ -174,7 +174,7 @@ TEST(PortSockTest, create_hints_and_element_extraction)
 
 	/* Recreate hints with different parameters, see if hints elements are overwriten properly. */
 
-	hintsProtocol = 0;
+	hintsProtocol = OMRSOCK_IPPROTO_DEFAULT;
 	hintsFlags = 6;
 
 	OMRPORTLIB->sock_getaddrinfo_create_hints(OMRPORTLIB, &hints, hintsFamily, hintsSockType, hintsProtocol, hintsFlags);
@@ -236,9 +236,9 @@ TEST(PortSockTest, getaddrinfo_and_freeaddrinfo)
 	int32_t sockType = 0;
 	int32_t protocol = 0;
 
-	int32_t hintsFamily = 2;
-	int32_t hintsSockType = 1;
-	int32_t hintsProtocol = 0;
+	int32_t hintsFamily = OMRSOCK_AF_INET;
+	int32_t hintsSockType = OMRSOCK_STREAM;
+	int32_t hintsProtocol = OMRSOCK_IPPROTO_DEFAULT;
 	int32_t hintsFlags = 0;
 
 	rc = OMRPORTLIB->sock_getaddrinfo_create_hints(OMRPORTLIB, &hints, hintsFamily, hintsSockType, hintsProtocol, hintsFlags);

--- a/include_core/omrportsock.h
+++ b/include_core/omrportsock.h
@@ -34,4 +34,19 @@ typedef struct OMRSockAddrStorage *omrsock_sockaddr_t;
 /* Pointer to OMRSocket, a struct that contains socket descriptor. */
 typedef struct OMRSocket *omrsock_socket_t;
 
+/* Address Family */
+#define OMRSOCK_AF_UNSPEC 0
+#define OMRSOCK_AF_INET 1
+#define OMRSOCK_AF_INET6 2
+
+/* Socket types */
+#define OMRSOCK_ANY 0
+#define OMRSOCK_STREAM 1
+#define OMRSOCK_DGRAM 2
+
+/* Protocol Family */
+#define OMRSOCK_IPPROTO_DEFAULT 0
+#define OMRSOCK_IPPROTO_TCP 1
+#define OMRSOCK_IPPROTO_UDP 2
+
 #endif /* !defined(OMRPORTSOCK_H_) */

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -31,6 +31,7 @@
 
 #include "omrcfg.h"
 #if defined(OMR_PORT_SOCKET_SUPPORT)
+#include "omrsock.h"
 #include "omrport.h"
 #include "omrporterror.h"
 #include "omrsockptb.h"
@@ -196,12 +197,12 @@ omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_add
 	memset(ptbHints, 0, sizeof(omr_os_addrinfo));
 
 	ptbHints->ai_flags = flags;
-	ptbHints->ai_family = family;
-	ptbHints->ai_socktype = socktype;
-	ptbHints->ai_protocol = protocol;
+	ptbHints->ai_family = get_os_family(family);
+	ptbHints->ai_socktype = get_os_socktype(socktype);
+	ptbHints->ai_protocol = get_os_protocol(protocol);
 
-	(ptBuffer->addrInfoHints).addrInfo = ptbHints;
-	(ptBuffer->addrInfoHints).length = 1;
+	ptBuffer->addrInfoHints.addrInfo = ptbHints;
+	ptBuffer->addrInfoHints.length = 1;
 	*hints = &ptBuffer->addrInfoHints;
 	return 0;
 }
@@ -271,7 +272,7 @@ omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
 		}
 	}
 
-	*family = info->ai_family;
+	*family = get_omr_family(info->ai_family);
 	return 0;
 }
 
@@ -294,7 +295,7 @@ omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinf
 		}
 	}
 
-	*socktype = info->ai_socktype;
+	*socktype = get_omr_socktype(info->ai_socktype);
 	return 0;
 }
 
@@ -317,7 +318,7 @@ omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinf
 		}
 	}
 
-	*protocol = info->ai_protocol;
+	*protocol = get_omr_protocol(info->ai_protocol);
 	return 0;
 }
 

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -101,6 +101,72 @@ get_os_protocol(int32_t omrProtocol)
 	return OS_SOCK_IPPROTO_DEFAULT;
 }
 
+/* Internal: OS dependent constants TO OMRSOCK user interface constants mapping. */
+
+/**
+ * @internal Map OS address family to OMRSOCK API user interface address
+ * family names. 
+ *
+ * @param osFamily The OS address family to be converted.
+ *
+ * @return OMR address family, or OMRSOCK_AF_UNSPEC if none exists.
+
+ */
+static int32_t
+get_omr_family(int32_t osFamily)
+{
+	switch(osFamily)
+	{
+		case OS_SOCK_AF_INET:
+			return OMRSOCK_AF_INET;
+		case OS_SOCK_AF_INET6:
+			return OMRSOCK_AF_INET6;
+	}
+	return OMRSOCK_AF_UNSPEC;
+}
+
+/**
+ * @internal Map OS socket type to OMRSOCK API user interface socket 
+ * types.
+ *
+ * @param osSockType The OS socket type to be converted.
+ *
+ * @return OMR socket type on success, or OMRSOCK_ANY if none exists.
+ */
+static int32_t
+get_omr_socktype(int32_t osSockType)
+{
+	switch(osSockType)
+	{
+		case OMRSOCK_STREAM:
+			return OS_SOCK_STREAM;
+		case OMRSOCK_DGRAM:
+			return OS_SOCK_DGRAM;
+	}
+	return OMRSOCK_ANY;
+}
+
+/**
+ * @internal Map OS protocol to OMRSOCK API user interface protocol.  
+ *
+ * @param osProtocol The OS protocol to be converted.
+ *
+ * @return OMRSOCK user interface protocol on success, or 
+ * OMRSOCK_IPPROTO_DEFAULT if none exists.
+ */
+static int32_t
+get_omr_protocol(int32_t osProtocol)
+{
+	switch(osProtocol)
+	{
+		case OS_SOCK_IPPROTO_TCP:
+			return OMRSOCK_IPPROTO_TCP;
+		case OS_SOCK_IPPROTO_UDP:
+			return OMRSOCK_IPPROTO_UDP;
+	}
+	return OMRSOCK_IPPROTO_DEFAULT;
+}
+
 int32_t
 omrsock_startup(struct OMRPortLibrary *portLibrary)
 {

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -35,6 +35,72 @@
 #include "omrporterror.h"
 #include "omrsockptb.h"
 
+/* Internal: OMRSOCK user interface constants TO OS dependent constants mapping. */
+
+/**
+ * @internal Map OMRSOCK API user interface address family names to the OS address 
+ * family, which may be defined differently depending on operating system. 
+ *
+ * @param omrFamily The OMR address family to be converted.
+ *
+ * @return OS address family, or OS_SOCK_AF_UNSPEC if none exists.
+ */
+static int32_t
+get_os_family(int32_t omrFamily)
+{
+	switch(omrFamily)
+	{
+		case OMRSOCK_AF_INET:
+			return OS_SOCK_AF_INET;
+		case OMRSOCK_AF_INET6:
+			return OS_SOCK_AF_INET6;
+	}
+	return OS_SOCK_AF_UNSPEC;
+}
+
+/**
+ * @internal Map OMRSOCK API user interface socket type to the OS socket type, 
+ * which may be defined differently depending on operating system. 
+ *
+ * @param omrSockType The OMR socket type to be converted.
+ *
+ * @return OS socket type on success, or OS_SOCK_ANY if none exists.
+ */
+static int32_t
+get_os_socktype(int32_t omrSockType)
+{
+	switch(omrSockType)
+	{
+		case OMRSOCK_STREAM:
+			return OS_SOCK_STREAM;
+		case OMRSOCK_DGRAM:
+			return OS_SOCK_DGRAM;
+	}
+	return OS_SOCK_ANY;
+}
+
+/**
+ * @internal Map OMRSOCK API user interface protocol to the OS protocols, 
+ * which may be defined differently depending on operating system. 
+ *
+ * @param omrProtocol The OMR protocol to be converted.
+ *
+ * @return OS protocol on success, or OS_SOCK_IPPROTO_DEFAULT 
+ * if none exists.
+ */
+static int32_t
+get_os_protocol(int32_t omrProtocol)
+{
+	switch(omrProtocol)
+	{
+		case OMRSOCK_IPPROTO_TCP:
+			return OS_SOCK_IPPROTO_TCP;
+		case OMRSOCK_IPPROTO_UDP:
+			return OS_SOCK_IPPROTO_UDP;
+	}
+	return OS_SOCK_IPPROTO_DEFAULT;
+}
+
 int32_t
 omrsock_startup(struct OMRPortLibrary *portLibrary)
 {

--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMRSOCK_H_)
+#define OMRSOCK_H_
+
+/* According to AIX documentation, this file is needed. */
+#if defined(OMR_OS_AIX)
+#include <sys/socketvar.h>
+#endif
+
+/* According to ZOS documentation, this definition is needed. */
+#if defined(OMR_OS_ZOS) && !defined(_OE_SOCKETS)
+#define _OE_SOCKETS
+#endif
+
+#include <sys/types.h> /* Some historical implementations need this file, POSIX.1-2001 does not. */
+#include <sys/socket.h>
+
+/* Address Family */
+#define OS_SOCK_AF_UNSPEC AF_UNSPEC
+#define OS_SOCK_AF_INET AF_INET
+#define OS_SOCK_AF_INET6 AF_INET6
+
+/* Socket types */
+#define OS_SOCK_ANY 0
+#define OS_SOCK_STREAM SOCK_STREAM
+#define OS_SOCK_DGRAM SOCK_DGRAM
+
+/* Protocol */
+#define OS_SOCK_IPPROTO_DEFAULT 0
+#define OS_SOCK_IPPROTO_TCP IPPROTO_TCP
+#define OS_SOCK_IPPROTO_UDP IPPROTO_UDP
+
+#endif /* !defined(OMRSOCK_H_) */


### PR DESCRIPTION
- Added defintions for constants for OMRSOCK API
- Added OS definitions for constants needed by OMRSOCK API
- Added OMR to OS dependent constants mapping
- Added OS to OMR constants mapping
- Fixed current implementations to accept constants
- Change current test cases to use the new constants

Depends on PR: #4832

Issue: #4795 