### PR TITLE
Fix segfault in omrvmemtest

### DIFF
--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4078,6 +4078,7 @@ TEST(PortVmemTest, vmem_testOverlappingSegments)
 
 	reportTestEntry(OMRPORTLIB, testName);
 	memset(keepCycles, 0, CYCLES);
+	memset(vmemID, 0, sizeof(*vmemID) * CYCLES);
 	srand(10);
 
 	portTestEnv->log("Cycles: %d\n\n", CYCLES);
@@ -4135,6 +4136,9 @@ exit:
 	freed = 0;
 	for (j = 0; j < CYCLES; j++) {
 		if (keepCycles[j] >= i) {
+			if (vmemID[j].address == 0) {
+				continue;
+			}
 			int32_t rc = omrvmem_free_memory(vmemID[j].address, vmemParams[j].byteAmount, &vmemID[j]);
 			if (0 == rc) {
 				freed++;


### PR DESCRIPTION
As part ofr cleanup testOverlappingSegments deallocates all its memory
descriptrors. However if one of the allocations in the first pass fails,
the remaining portion of the array of descriptors remains uninitialized.
Attempting to later deallocate them causes a segfault. To solve the
issue, all descriptors are initialized to 0, and empty descriptors are
skipped during deallocation cleanup.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>