### PR TITLE
WIP: Scavenger Parallelism/Sync Stats

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -446,6 +446,11 @@ MM_Scavenger::workerSetupForGC(MM_EnvironmentStandard *env)
 {
 	clearThreadGCStats(env, true);
 
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	env->_scavengerStats.intervalStart(omrtime_hires_clock());
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+
 	/* Clear local language-specific stats */
 	_delegate.workerSetupForGC_clearEnvironmentLangStats(env);
 
@@ -689,6 +694,7 @@ MM_Scavenger::mergeGCStatsBase(MM_EnvironmentBase *env, MM_ScavengerStats *final
 	finalGCStats->_totalObjsDeepScanned += scavStats->_totalObjsDeepScanned;
 	finalGCStats->_depthDeepestStructure = scavStats->_depthDeepestStructure;
 	finalGCStats->_copyScanUpdates += scavStats->_copyScanUpdates;
+	finalGCStats->_aggregatedIntervalSpan += scavStats->_aggregatedIntervalSpan;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
 	finalGCStats->_flipDiscardBytes += scavStats->_flipDiscardBytes;
@@ -2016,6 +2022,11 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 		if(!doneFlag) {
 			_waitingCount -= 1;
 		}
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+		else {
+			env->_scavengerStats.intervalStart(omrtime_hires_clock());
+		}
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
 		omrthread_monitor_exit(_scanCacheMonitor);
 	}

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -65,6 +65,8 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_totalObjsDeepScanned(0)
 	,_depthDeepestStructure(0)
 	,_copyScanUpdates(0)
+	,_intervalStartTime(0)
+	,_aggregatedIntervalSpan(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	,_avgInitialFree(0)
 	,_avgTenureBytes(0)
@@ -171,6 +173,8 @@ MM_ScavengerStats::clear(bool firstIncrement)
 	_totalObjsDeepScanned = 0;
 	_depthDeepestStructure = 0;
 	_copyScanUpdates = 0;
+	_intervalStartTime = 0;
+	_aggregatedIntervalSpan = 0;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	/* NOTE: _startTime and _endTime are also not cleared
 	 * as they are recorded before/after all stat clearing/gathering.


### PR DESCRIPTION
Scavenger Stat gathering for busyness/idleness related to
synchronization. Currently, we rely on a waiting count for this, however
this is only valid for completeScan phase of Scavenger.

For a broader measure of busyness, we must gather the following:
1) Total amount of time threads are stalled outside of completeScan
phase (i.e by task synchronization APIs)
2) Total amount of time threads spend outside of completeScan phase

Signed-off-by: Salman Rana <salman.rana@ibm.com>