### PR TITLE
WIP: AArch64: Enable OutOfLineCodeSection

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -373,6 +373,12 @@ class ARM64LabelInstruction : public TR::Instruction
       }
 
    /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */

--- a/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
+++ b/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,12 +31,52 @@ TR_ARM64OutOfLineCodeSection::TR_ARM64OutOfLineCodeSection(TR::Node *callNode,
                             TR::CodeGenerator *cg) :
                             TR_OutOfLineCodeSection(callNode, callOp, targetReg, entryLabel, restartLabel, cg)
    {
+   if(callNode->isPreparedForDirectJNI())
+      {
+      _callNode->setPreparedForDirectJNI();
+      }
    generateARM64OutOfLineCodeSectionDispatch();
    }
 
 void TR_ARM64OutOfLineCodeSection::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   TR_UNIMPLEMENTED();
+   TR::Compilation* comp = _cg->comp();
+   if (hasBeenRegisterAssigned())
+     return;
+
+   // nested internal control flow assert:
+   _cg->setInternalControlFlowSafeNestingDepth(_cg->internalControlFlowNestingDepth());
+
+   // Create a dependency list on the first instruction in this stream that captures all current real register associations.
+   // This is necessary to get the register assigner back into its original state before the helper stream was processed.
+   _cg->incOutOfLineColdPathNestedDepth();
+
+   // This prevents the OOL entry label from resetting all register's startOfranges during RA
+   _cg->toggleIsInOOLSection();
+   TR::RegisterDependencyConditions  *liveRealRegDeps = _cg->machine()->createCondForLiveAndSpilledGPRs(true, _cg->getSpilledRegisterList());
+
+   if (liveRealRegDeps)
+      _firstInstruction->setDependencyConditions(liveRealRegDeps);
+   _cg->toggleIsInOOLSection(); // toggle it back because swapInstructionListsWithCompilation() also calls toggle...
+
+   // Register assign the helper dispatch instructions.
+   swapInstructionListsWithCompilation();
+   _cg->doRegisterAssignment(kindsToBeAssigned);
+   swapInstructionListsWithCompilation();
+
+   _cg->decOutOfLineColdPathNestedDepth();
+
+   // Returning to mainline, reset this counter
+   _cg->setInternalControlFlowSafeNestingDepth(0);
+
+   // Link in the helper stream into the mainline code.
+   // We will end up with the OOL items attached at the bottom of the instruction stream
+   TR::Instruction *appendInstruction = _cg->getAppendInstruction();
+   appendInstruction->setNext(_firstInstruction);
+   _firstInstruction->setPrev(appendInstruction);
+   _cg->setAppendInstruction(_appendInstruction);
+
+   setHasBeenRegisterAssigned(true);
    }
 
 void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -543,3 +543,16 @@ OMR::ARM64::CodeGenerator::generateNop(TR::Node *node, TR::Instruction *preced)
    else
       return new (self()->trHeapMemory()) TR::Instruction(TR::InstOpCode::nop, node, self());
    }
+
+TR_ARM64OutOfLineCodeSection *OMR::ARM64::CodeGenerator::findOutLinedInstructionsFromLabel(TR::LabelSymbol *label)
+   {
+   auto oiIterator = self()->getARM64OutOfLineCodeSectionList().begin();
+   while (oiIterator != self()->getARM64OutOfLineCodeSectionList().end())
+      {
+      if ((*oiIterator)->getEntryLabel() == label)
+         return *oiIterator;
+      ++oiIterator;
+      }
+
+   return NULL;
+   }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -370,7 +370,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    // OutOfLineCodeSection List functions
    TR::list<TR_ARM64OutOfLineCodeSection*> &getARM64OutOfLineCodeSectionList() {return _outOfLineCodeSectionList;}
-
+   TR_ARM64OutOfLineCodeSection *findOutLinedInstructionsFromLabel(TR::LabelSymbol *label);
    // We need to provide an implementation to avoid an unimplemented assert. See issue #4446.
    int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget) { return 8; }
    // We need to provide an implementation to avoid an unimplemented assert. See issue #4446.

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ namespace OMR { typedef OMR::ARM64::Machine MachineConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
 
 #define NUM_ARM64_GPR 32
 #define MAX_ARM64_GLOBAL_GPRS 27 // excluding IP0, IP1, FP, LR, and SP
@@ -144,6 +145,11 @@ public:
     * @brief Restore the register file from snapshot
     */
    void restoreRegisterStateFromSnapShot();
+
+
+   TR::RegisterDependencyConditions  *createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<TR::Register*> *spilledRegisterList = NULL);
+
+   void disassociateUnspilledBackingStorage();
 
    /**
     * @brief Answers global register table


### PR DESCRIPTION
Implement `assignRegisters` method of `TR_ARM64OutOfLineCodeSection`
to enable generating binary for instructions of outlined cold path.

`ZEROCHKEvaluator` is the only user of `TR_ARM64OutOfLineCodeSection` for the moment.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>