### PR TITLE
Support FMA operations on aarch64

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -418,6 +418,8 @@ static const char *opCodeToNameMap[] =
    "umsubl",
    "smulh",
    "umulh",
+   "fmaddd",
+   "fmadds",
    "crc32x",
    "crc32cx",
    "crc32b",

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -390,6 +390,8 @@
 		umsubl,                                                 	/* 0x9BA08000	UMSUBL    	 */
 		smulh,                                                  	/* 0x9B400000	SMULH     	 */
 		umulh,                                                  	/* 0x9BC00000	UMULH     	 */
+		fmaddd,                                                 	/* 0X1F000000   FMADD        */
+		fmadds,                                                 	/* 0X1F400000   FMADD        */
 	/* Data-processing (2 source) */
 		crc32x,                                                 	/* 0x9AC04C00	CRC32X    	 */
 		crc32cx,                                                	/* 0x9AC05C00	CRC32CX   	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -389,6 +389,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x9BA08000,	/* UMSUBL    	umsubl	 */
 		0x9B400000,	/* SMULH     	smulh	 */
 		0x9BC00000,	/* UMULH     	umulh	 */
+		0X1F400000,	/* FMADD        fmaddd   */
+		0X1F000000,	/* FMADD        fmadds   */
 	/* Data-processing (2 source) */
 		0x9AC04C00,	/* CRC32X    	crc32x	 */
 		0x9AC05C00,	/* CRC32CX   	crc32cx	 */


### PR DESCRIPTION
Adding Instr Opocde `fmaddd` and `fmadds` for supporting FMA operations on aarch64

Issue:eclipse/openj9#7474
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>