### PR TITLE
Rename OMR_HAS_DLADDR to OMR_HAVE_DLADDR

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -70,7 +70,7 @@ endmacro()
 function(omr_check_dladdr)
 	list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
 	list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
-	check_symbol_exists(dladdr "dlfcn.h" OMR_HAS_DLADDR)
+	check_symbol_exists(dladdr "dlfcn.h" OMR_HAVE_DLADDR)
 endfunction()
 
 

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -242,7 +242,7 @@
 #cmakedefine OMR_USE_POSIX_SEMAPHORES
 #cmakedefine OMR_USE_OSX_SEMAPHORES
 #cmakedefine OMR_USE_ZOS_SEMAPHORES
-#cmakedefine OMR_HAS_DLADDR
+#cmakedefine OMR_HAVE_DLADDR
 
 /**
  * This flag enables the usage of OMR socket API. The API contains functions for

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -256,7 +256,7 @@
 #endif
 
 #if defined(LINUX) || defined(OSX)
-#define OMR_HAS_DLADDR
+#define OMR_HAVE_DLADDR
 #endif
 
 /**

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -162,7 +162,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 	/* dlopen(2) called with NULL filename opens a handle to current executable. */
 	handle = dlopen(openExec ? NULL : openName, lazyOrNow);
 
-#if defined(OMR_HAS_DLADDR)
+#if defined(OMR_HAVE_DLADDR)
 	if ((NULL == handle) && !openExec) {
 		/* last ditch, try dir port lib DLL is in */
 		char portLibDir[MAX_STRING_LENGTH];


### PR DESCRIPTION
Change to be inline with autoconf convention

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>