### PR TITLE
Enable invariant argument prex only when recompilation supported

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -6773,7 +6773,7 @@ int32_t TR_InvariantArgumentPreexistence::perform()
       }
 
    static const char *disablePREX = feGetEnv("TR_disablePREX");
-   if (disablePREX || comp()->getOptions()->realTimeGC())
+   if (!comp()->isRecompilationEnabled() || disablePREX || comp()->getOptions()->realTimeGC())
       return 0;
 
    {


### PR DESCRIPTION
Add an explicit check for supported recompilation to enable this optimization.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>