### PR TITLE
Refactor TR_PrexArgInfo to reduce coupling with TR_InlinerTracer

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -6446,7 +6446,8 @@ OMR_InlinerUtil::clearArgInfoForNonInvariantArguments(TR_CallTarget *target, TR_
       {
       if (tracePrex)
          traceMsg(comp(), "ARGS PROPAGATION: argInfo %p after clear arg info for non-invariant arguments", argInfo);
-      tracer->dumpPrexArgInfo(argInfo);
+      if (tracer->heuristicLevel())
+         argInfo->dumpTrace();
       }
    }
 

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,3 +64,23 @@ TR_PrexArgument::TR_PrexArgument(
       }
 #endif
    }
+
+void TR_PrexArgInfo::dumpTrace() {
+   TR::Compilation *comp = TR::comp();
+   traceMsg(comp,  "<argInfo address = %p numArgs = %d>\n", this, getNumArgs());
+   for (int i = 0 ; i < getNumArgs(); i++)
+      {
+      TR_PrexArgument* arg = get(i);
+      if (arg && arg->getClass())
+         {
+         char* className = TR::Compiler->cls.classSignature(comp, arg->getClass(), comp->trMemory());
+         traceMsg(comp,  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d argIsKnownObject=%d koi=%d class=%p className= %s/>\n",
+         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->hasKnownObjectIndex(), arg->getKnownObjectIndex(), arg->getClass(), className);
+         }
+      else
+         {
+         traceMsg(comp,  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d/>\n", i, arg, arg ? arg->classIsFixed() : 0, arg ? arg->classIsPreexistent() : 0);
+         }
+      }
+   traceMsg(comp,  "</argInfo>\n");
+}

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,10 @@
 #include <string.h>
 #include "env/KnownObjectTable.hpp"
 #include "env/TRMemory.hpp"
+
+// Temporary macro to coordinate changes between omr and openj9.
+// This will eventually be changed to TR_LogTracer.
+#define TR_PREXARGINFO_TRACER_CLASS TR_InlinerTracer
 
 class TR_CallSite;
 class TR_InlinerTracer;
@@ -109,15 +113,15 @@ class TR_PrexArgInfo
    static TR_PrexArgInfo* enhance(TR_PrexArgInfo *dest, TR_PrexArgInfo *source, TR::Compilation *comp);
 
    static void propagateReceiverInfoIfAvailable (TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-                                              TR_PrexArgInfo * argInfo, TR_InlinerTracer *tracer);
+                                              TR_PrexArgInfo * argInfo, TR_PREXARGINFO_TRACER_CLASS *tracer);
 
    static void propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-      TR_PrexArgInfo * argInfo, TR_InlinerTracer *tracer);
+      TR_PrexArgInfo * argInfo, TR_PREXARGINFO_TRACER_CLASS *tracer);
 
-   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_InlinerTracer *tracer);
+   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_PREXARGINFO_TRACER_CLASS *tracer);
 
-   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
-   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
+   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_PREXARGINFO_TRACER_CLASS* tracer);
+   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_PREXARGINFO_TRACER_CLASS* tracer);
    /**
     * \brief
     *    Get arg info for arguments of callNode that are parameters of the caller
@@ -140,13 +144,15 @@ class TR_PrexArgInfo
 
    int32_t getNumArgs() { return _numArgs; }
 
+   void dumpTrace();
+
    private:
 
    int32_t _numArgs;
    TR_PrexArgument **_args;
    //
 #ifdef J9_PROJECT_SPECIFIC
-   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_InlinerTracer* tracer);
+   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_PREXARGINFO_TRACER_CLASS* tracer);
    static bool hasArgInfoForChild (TR::Node *child, TR_PrexArgInfo * argInfo);
    static TR_PrexArgument* getArgForChild(TR::Node *child, TR_PrexArgInfo* argInfo);
 #endif


### PR DESCRIPTION
I originally submitted these changes in #4779. However, I have made modifications so that this PR does not need to be merged at the same time as a PR in openj9.

This PR is a step towards making the TR_PrexArgInfo class more reusable by decoupling it from the TR_InlinerTracer class. The next step is here https://github.com/eclipse/openj9/pull/8759

- Duplicate functionality from `TR_InlinerTracer::dumpPrexArgInfo` into the new method `TR_PrexArgInfo::dumpTrace`.
  - Once all callsites in openj9 are updated to use the new method, the old method can be removed.

- Define the macro `TR_PREXARGINFO_TRACER_CLASS` and update `TR_PrexArgInfo` method signatures to use this macro
  - This is done so that we can eventually modify `TR_PrexArgInfo` method signatures to accept a `TR_LogTracer` argument instead of a `TR_InlinerTracer` argument since `TR_LogTracer` is a less specialized class.
  - Method definitions need to be changed in openj9 before we can update this macro to `TR_LogTracer`

See https://github.com/eclipse/openj9/issues/7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>