### PR TITLE
 Concurrent Scavenger Async Handler triggering

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -516,6 +516,12 @@ public:
 	 * @return true if we were beaten, false otherwise.
 	 */
 	bool exclusiveAccessBeatenByOtherThread() { return _exclusiveAccessBeatenByOtherThread; }
+	
+	/**
+	 * Notify any (concurrent) collector that might block and hold VM access
+	 * that an Exclusive VM Access is to be requested so that VM access can be released
+	 */
+	void collectorNotifyAcquireExclusiveVMAccess();
 
 	/**
 	 * Force thread to use out-of-line request for VM access. This may be required if there

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -276,7 +276,7 @@ MM_GCExtensionsBase::isConcurrentScavengerInProgress()
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (NULL != scavenger) {
-		return scavenger->isConcurrentInProgress();
+		return scavenger->isConcurrentCycleInProgress();
 	} else {
 		return false;
 	}

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -465,6 +465,7 @@ public:
 	bool concurrentScavengerBackgroundThreadsForced; /**< true if concurrentScavengerBackgroundThreads set via command line option */
 	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
 	float concurrentScavengerAllocDeviationBoost; /**< boost factor for allocate rate and its deviation, used for tilt calcuation in Concurrent Scavenger */
+	bool concurrentScavengeExhaustiveTermination; /**< control flag to enable/disable concurrent phase termination optimization using involing async mutator callbacks */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1521,6 +1522,7 @@ public:
 		, concurrentScavengerBackgroundThreadsForced(false)
 		, concurrentScavengerSlack(0)
 		, concurrentScavengerAllocDeviationBoost(2.0)
+		, concurrentScavengeExhaustiveTermination(false)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)

--- a/gc/base/standard/CopyScanCacheStandard.hpp
+++ b/gc/base/standard/CopyScanCacheStandard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,23 @@ public:
 	isSplitArray() const
 	{
 		return (OMR_SCAVENGER_CACHE_TYPE_SPLIT_ARRAY == (flags & OMR_SCAVENGER_CACHE_TYPE_SPLIT_ARRAY));
+	}
+	
+	/**
+	 * reinitializes the cache with the given base and top addresses.
+	 * @param base base address of cache
+	 * @param top top address of cache
+	 */
+	void reinitCache(void *base, void *top) {
+		cacheBase = base;
+		cacheAlloc = base;
+		scanCurrent = base;
+		cacheTop = top;
+		_arraySplitIndex = 0;
+		_arraySplitAmountToScan = 0;
+		_arraySplitRememberedSlot = NULL;
+		_hasPartiallyScannedObject = false;
+		_shouldBeRemembered = false;
 	}
 
 	/**

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -99,7 +99,7 @@ MM_EnvironmentStandard::flushGCCaches(bool final)
 	if (getExtensions()->concurrentScavenger) {
 		if (MUTATOR_THREAD == getThreadType()) {
 			if (NULL != getExtensions()->scavenger) {
-				getExtensions()->scavenger->threadReleaseCaches(this, true, final);
+				getExtensions()->scavenger->threadReleaseCaches(NULL, this, true, final);
 			}
 		}
 	}

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -59,6 +59,8 @@ class MM_SublistPool;
 
 struct OMR_VM;
 
+extern "C" void concurrentScavengerAsyncCallbackHandler(OMR_VMThread *omrVMThread);
+
 /**
  * @todo Provide class documentation
  * @ingroup GC_Modron_Standard
@@ -123,12 +125,14 @@ private:
 	MM_MasterGCThread _masterGCThread; /**< An object which manages the state of the master GC thread */
 	
 	volatile enum ConcurrentState {
-		concurrent_state_idle,
-		concurrent_state_init,
-		concurrent_state_roots,
-		concurrent_state_scan,
-		concurrent_state_complete
-	} _concurrentState;
+		concurrent_phase_idle,
+		concurrent_phase_init,
+		concurrent_phase_roots,
+		concurrent_phase_scan,
+		concurrent_phase_complete
+	} _concurrentPhase;
+	
+	bool _currentPhaseConcurrent;
 	
 	uint64_t _concurrentScavengerSwitchCount; /**< global counter of cycle start and cycle end transitions */
 	volatile bool _shouldYield; /**< Set by the first GC thread that observes that a criteria for yielding is met. Reset only when the concurrent phase is finished. */
@@ -183,7 +187,7 @@ private:
 					 
 			shouldAbort = _shouldYield;
 			if (shouldAbort) {
-				Assert_MM_true(concurrent_state_scan == _concurrentState);
+				Assert_MM_true(concurrent_phase_scan == _concurrentPhase);
 				/* Since we are aborting the scan loop without synchornizing with other GC threads (before which we flush buffers),
 				 * we have to do it now. 
 				 * There should be no danger in not synchonizing with other threads, since we can only abort/yield in main scan loop
@@ -383,28 +387,27 @@ public:
 	MMINLINE uintptr_t copyCacheDistanceMetric(MM_CopyScanCacheStandard* cache);
 
 	MMINLINE MM_CopyScanCacheStandard *getNextScanCacheFromList(MM_EnvironmentStandard *env);
-	void addCopyCachesToFreeList(MM_EnvironmentStandard *env);
+	/**
+	 * Called at the end of a task to return empty caches to the global free pool
+	 */
+	void finalReturnCopyCachesToFreeList(MM_EnvironmentStandard *env);
+	/* 
+	 * Used by CS to return empty caches during intermediate blocks, to aid with more precise counting of free/empty cache in the pool
+	 */
+	void returnEmptyCopyCachesToFreeList(MM_EnvironmentStandard *env);
 	MMINLINE void addCacheEntryToScanListAndNotify(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *newCacheEntry);
-
-	MMINLINE bool
-	isWorkAvailableInCache(MM_CopyScanCacheStandard *cache)
-	{
-		return (cache->scanCurrent < cache->cacheAlloc);
-	}
 
 	MMINLINE bool
 	isWorkAvailableInCacheWithCheck(MM_CopyScanCacheStandard *cache)
 	{
-		return ((NULL != cache) && isWorkAvailableInCache(cache));
+		return ((NULL != cache) && cache->isScanWorkAvailable());
 	}
 
-	/**
-	 * reinitializes the cache with the given base and top addresses.
-	 * @param cache cache to be reinitialized.
-	 * @param base base address of cache
-	 * @param top top address of cache
-	 */
-	MMINLINE void reinitCache(MM_CopyScanCacheStandard *cache, void *base, void *top);
+	MMINLINE bool
+	isEmptyCacheWithCheck(MM_CopyScanCacheStandard *cache)
+	{
+		return ((NULL != cache) && !cache->isScanWorkAvailable());
+	}
 
 	/**
 	 * An attempt to get a preallocated scan cache header, free list will be locked
@@ -609,6 +612,21 @@ public:
 
 	/* API used by ParallelScavengeTask to set _waitingCountAliasThreshold. */
 	void setAliasThreshold(uintptr_t waitingCountAliasThreshold) { _waitingCountAliasThreshold = waitingCountAliasThreshold; }
+	
+	/**
+	 * Notify Collector that a thread is about to acquire Exclusive VM access.
+	 * This can be useful in scenario when GC is concurrent, and currently in progress.
+	 * env invoking thread that is about to acquire Exclusive VM access
+	 */
+	void externalNotifyToYield(MM_EnvironmentBase* env);
+	
+	/**
+	 * For CS, last thread to block, before notifying other threads to unblock 
+	 * will check if all caches are returned to the free global pool. If not,
+	 * it will activate Async Handler to force mutators to flush caches, 
+	 * and go back to scanning and eventually getting to this point again.
+	 */
+	bool shouldDoFinalNotify(MM_EnvironmentStandard *env);
 
 protected:
 	virtual void setupForGC(MM_EnvironmentBase *env);
@@ -682,11 +700,12 @@ public:
 	/* methods used by either mutator or GC threads */
 	/**
 	 * All open copy caches (even if not full) are pushed onto scan queue. Unused memory is abondoned.
-	 * @param env Invoking thread, for which copy caches are to be released. Could be either GC or mutator thread.
+	 * @param currentEnvBase Current thread in which context this is invoked from. Could be either GC or mutator thread.
+	 * @param targetEnvBase  Thread for which copy caches are to be released. Could be either GC or mutator thread.
 	 * @param flushCaches If true, really push caches to scan queue, otherwise just deactivate them for possible near future use
 	 * @param final If true (typically at the end of a cycle), abandon TLH remainders, too. Otherwise keep them for possible future copy cache refresh.
 	 */
-	void threadReleaseCaches(MM_EnvironmentBase *env, bool flushCaches, bool final);
+	void threadReleaseCaches(MM_EnvironmentBase *currentEnvBase, MM_EnvironmentBase *targetEnvBase, bool flushCaches, bool final);
 	
 	/**
 	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 
@@ -702,8 +721,25 @@ public:
 	void workThreadScan(MM_EnvironmentStandard *env);
 	void workThreadComplete(MM_EnvironmentStandard *env);
 
+	/**
+	 * GC threads may call it to determine if running in a context of 
+	 * concurrent or STW task
+	 */
+	bool isCurrentPhaseConcurrent() {
+		return _currentPhaseConcurrent;
+	}
+	
+	/**
+	 * True if CS cycle is active at any point (STW or concurrent task active,
+	 * or even short gaps between STW and concurrent tasks)
+	 */
+	bool isConcurrentCycleInProgress() {
+		return concurrent_phase_idle != _concurrentPhase;
+	}
+	
+	/* TODO: remove once downstream projects start using isConcurrentCycleInProgress/isCurrentPhaseConcurrent */
 	bool isConcurrentInProgress() {
-		return concurrent_state_idle != _concurrentState;
+		return concurrent_phase_idle != _concurrentPhase;
 	}
 	
 	bool isMutatorThreadInSyncWithCycle(MM_EnvironmentBase *env) {
@@ -878,7 +914,8 @@ public:
 		, _regionManager(regionManager)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, _masterGCThread(env)
-		, _concurrentState(concurrent_state_idle)
+		, _concurrentPhase(concurrent_phase_idle)
+		, _currentPhaseConcurrent(false)
 		, _concurrentScavengerSwitchCount(0)
 		, _shouldYield(false)
 		, _concurrentPhaseStats()


### PR DESCRIPTION
Once all GC threads run out of work, the last thread (that would
normally notify all other threads that the scan loop is terminating)
will activate Async Handler to force mutator threads to flush their copy
caches. Then, it (as any other GC thread) would wait till new caches
occur on the scan queue and scan them and eventually again all meet at
the same termination point.

This process may repeat several (typically 1-3) times, until all
copy-scan caches have been returned to the global free cache pool. It is
guaranteed to converge since live set in evacuate is finite, and
mutators are forced to flush caches through either Async Handler or when
they release VM access.

While waiting for caches to occur, the thread that triggered Async
Handling can be also be awaken to yield VM access to incoming Exclusive
VM access request by GC.

For now, requests to external Exclusive VM access request (such as JVMTI
etc) are handled by 1ms timeout on the wait.

Some more background: #4787

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>