### PR TITLE
Add full support for calls on z/OS and enable corresponding tests

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-zos_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-zos_390-64
@@ -30,7 +30,7 @@ pipeline {
                 timestamps {
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DCMAKE_C_COMPILER=/bin/c89 -DCMAKE_CXX_COMPILER=/bin/xlc -DOMR_DDR=OFF -DOMR_THR_FORK_SUPPORT=0 ..'''
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DCMAKE_C_COMPILER=/bin/c89 -DCMAKE_CXX_COMPILER=/bin/xlc -DOMR_DDR=OFF -DOMR_THR_FORK_SUPPORT=0 -DOMR_JITBUILDER_TEST_EXTENDED=1 ..'''
                         echo 'Compile...'
                         sh '''make -j4'''
                     }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-zos_390-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-zos_390-64
@@ -16,7 +16,7 @@ pipeline {
                 timestamps {
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DCMAKE_C_COMPILER=/bin/c89 -DCMAKE_CXX_COMPILER=/bin/xlc -DOMR_DDR=OFF -DOMR_THR_FORK_SUPPORT=0 ..'''
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DCMAKE_C_COMPILER=/bin/c89 -DCMAKE_CXX_COMPILER=/bin/xlc -DOMR_DDR=OFF -DOMR_THR_FORK_SUPPORT=0 -DOMR_JITBUILDER_TEST_EXTENDED=1 ..'''
                         echo 'Compile...'
                         sh '''make -j4'''
                     }

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -180,43 +180,44 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
      }
 
    if (cg->getAheadOfTimeCompile() && (comp->getOption(TR_TraceRelocatableDataCG) || comp->getOption(TR_TraceRelocatableDataDetailsCG) || comp->getOption(TR_TraceReloCG)))
-     {
-     traceMsg(comp, "\n<relocatableDataCG>\n");
-     if (comp->getOption(TR_TraceRelocatableDataDetailsCG)) // verbose output
-        {
-        uint8_t * relocatableMethodCodeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
-        traceMsg(comp, "Code start = %8x, Method start pc = %x, Method start pc offset = 0x%x\n", relocatableMethodCodeStart, cg->getCodeStart(), cg->getCodeStart() - relocatableMethodCodeStart);
-        }
-     cg->getAheadOfTimeCompile()->dumpRelocationData();
-     traceMsg(comp, "</relocatableDataCG>\n");
-     }
+      {
+      traceMsg(comp, "\n<relocatableDataCG>\n");
+      if (comp->getOption(TR_TraceRelocatableDataDetailsCG)) // verbose output
+         {
+         uint8_t * relocatableMethodCodeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
+         traceMsg(comp, "Code start = %8x, Method start pc = %x, Method start pc offset = 0x%x\n", relocatableMethodCodeStart, cg->getCodeStart(), cg->getCodeStart() - relocatableMethodCodeStart);
+         }
+      cg->getAheadOfTimeCompile()->dumpRelocationData();
+      traceMsg(comp, "</relocatableDataCG>\n");
+      }
 
-     if (debug("dumpCodeSizes"))
-        {
-        diagnostic("%08d   %s\n", cg->getCodeLength(), comp->signature());
-        }
+   if (debug("dumpCodeSizes"))
+      {
+      diagnostic("%08d   %s\n", cg->getCodeLength(), comp->signature());
+      }
 
-     TR_ASSERT(cg->getCodeLength() <= cg->getEstimatedCodeLength(),
-               "Method length estimate must be conservatively large\n"
-               "    codeLength = %d, estimatedCodeLength = %d \n",
-               cg->getCodeLength(), cg->getEstimatedCodeLength()
-               );
+   TR_ASSERT(cg->getCodeLength() <= cg->getEstimatedCodeLength(),
+      "Method length estimate must be conservatively large\n"
+      "    codeLength = %d, estimatedCodeLength = %d \n",
+      cg->getCodeLength(), cg->getEstimatedCodeLength()
+   );
 
-     // also trace the interal stack atlas
-     cg->getStackAtlas()->close(cg);
+   // also trace the interal stack atlas
+   cg->getStackAtlas()->close(cg);
 
-     TR::SimpleRegex * regex = comp->getOptions()->getSlipTrap();
-     if (regex && TR::SimpleRegex::match(regex, comp->getCurrentMethod()))
-        {
-        if (cg->comp()->target().is64Bit())
-        {
-        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL64", comp);
-        }
-     else
-        {
-        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL31", comp);
-        }
-     }
+   TR::SimpleRegex * regex = comp->getOptions()->getSlipTrap();
+   if (regex && TR::SimpleRegex::match(regex, comp->getCurrentMethod()))
+      {
+      if (cg->comp()->target().is64Bit())
+         {
+         setDllSlip((char*)cg->getCodeStart(), (char*)cg->getCodeStart() + cg->getCodeLength(), "SLIPDLL64", comp);
+         }
+      else
+         {
+         setDllSlip((char*)cg->getCodeStart(), (char*)cg->getCodeStart() + cg->getCodeLength(), "SLIPDLL31", comp);
+         }
+      }
+
    if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
       {
       const char * title = "Post Relocation Instructions";

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -196,11 +196,6 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         diagnostic("%08d   %s\n", cg->getCodeLength(), comp->signature());
         }
 
-     if (comp->getCurrentMethod() == NULL)
-        {
-        comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
-        }
-
      TR_ASSERT(cg->getCodeLength() <= cg->getEstimatedCodeLength(),
                "Method length estimate must be conservatively large\n"
                "    codeLength = %d, estimatedCodeLength = %d \n",
@@ -303,6 +298,9 @@ OMR::CodeGenPhase::performBinaryEncodingPhase(TR::CodeGenerator * cg, TR::CodeGe
    LexicalTimer pt(phase->getName(), comp->phaseTimer());
 
    cg->doBinaryEncoding();
+
+   // Instructions have been emitted, and now we know what the entry point is, so update the compilation method symbol
+   comp->getMethodSymbol()->setMethodAddress(cg->getCodeStart());
 
    if (debug("verifyFinalNodeReferenceCounts"))
       {

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -379,7 +379,7 @@ compileMethodFromDetails(
          // not ready yet...
          //OMR::MethodMetaDataPOD *metaData = fe.createMethodMetaData(&compiler);
 
-         startPC = compiler.cg()->getCodeStart();
+         startPC = (uint8_t*)compiler.getMethodSymbol()->getMethodAddress();
          uint64_t translationTime = TR::Compiler->vm.getUSecClock() - translationStartTime;
 
          if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompileEnd, TR_VerbosePerformance))

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -2035,14 +2035,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
          argSize += gprSize;
       }
 
-   if (!self()->isFirstParmAtFixedOffset())
-      {
-      stackOffset = argSize;
-      }
-   else
-      {
-      stackOffset = self()->getOffsetToFirstParm();
-      }
+   stackOffset = self()->isFirstParmAtFixedOffset() ? self()->getOffsetToFirstParm() : argSize;
 
    //store env register
    stackOffset = self()->storeExtraEnvRegForBuildArgs(callNode, self(), dependencies, isFastJNI, stackOffset, gprSize, numIntegerArgs);

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -2096,28 +2096,24 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
                if (self()->isSkipGPRsForFloatParms())
                   {
-                  if (numIntegerArgs < self()->getNumIntegerArgumentRegisters())
-                     {
-                     numIntegerArgs++;
-                     }
+                  numIntegerArgs++;
                   }
                break;
                }
          case TR::Double:
 #ifdef J9_PROJECT_SPECIFIC
          case TR::DecimalDouble:
+#endif
             argRegister = self()->pushArg(callNode, child, numIntegerArgs, numFloatArgs, &stackOffset, dependencies);
 
             numFloatArgs++;
 
             if (self()->isSkipGPRsForFloatParms())
                {
-               if (numIntegerArgs < self()->getNumIntegerArgumentRegisters())
-                  {
-                  numIntegerArgs += (self()->cg()->comp()->target().is64Bit()) ? 1 : 2;
-                  }
+               numIntegerArgs += (self()->cg()->comp()->target().is64Bit()) ? 1 : 2;
                }
             break;
+#ifdef J9_PROJECT_SPECIFIC
          case TR::DecimalLongDouble:
             if (numFloatArgs%2 == 1)
                { // need to skip fp arg 'hole' for long double arg

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -2035,7 +2035,6 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
          argSize += gprSize;
       }
 
-   bool isXPLinkToPureOSLinkageCall = false;
    if (!self()->isFirstParmAtFixedOffset())
       {
       stackOffset = argSize;
@@ -2043,23 +2042,6 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
    else
       {
       stackOffset = self()->getOffsetToFirstParm();
-
-      if (isXPLinkToPureOSLinkageCall)
-         {
-         // Load argument list (GPR1) pointer here in XPLink to OS linkage call
-         // The OS linkage argument list is embedded in the XPLink outbound argument area
-         // at offset 8 instead of 0 (to bypass collision with long displacement slot)
-         TR::Register *r1Reg = self()->cg()->allocateRegister();
-         if (stackOffset == self()->getOffsetToLongDispSlot())
-            {
-            stackOffset += 8; // avoid first parm at long displacement slot
-            }
-         TR::RealRegister * stackPtr = self()->getNormalStackPointerRealRegister();
-         generateRXInstruction(self()->cg(), TR::InstOpCode::LA, callNode, r1Reg,
-                   generateS390MemoryReference(stackPtr, stackOffset, self()->cg()));
-         dependencies->addPreCondition(r1Reg, TR::RealRegister::GPR1);
-         self()->cg()->stopUsingRegister(r1Reg);
-         }
       }
 
    //store env register

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -245,9 +245,11 @@ void TR::S390zOSSystemLinkage::createPrologue(TR::Instruction* cursor)
 
    TR::CodeGenerator* cg = self()->cg();
 
+   _xplinkFunctionDescriptorSnippet = new (self()->trHeapMemory()) XPLINKFunctionDescriptorSnippet(cg);
    _ppa1Snippet = new (self()->trHeapMemory()) TR::PPA1Snippet(cg, this);
    _ppa2Snippet = new (self()->trHeapMemory()) TR::PPA2Snippet(cg, this);
 
+   cg->addSnippet(_xplinkFunctionDescriptorSnippet);
    cg->addSnippet(_ppa1Snippet);
    cg->addSnippet(_ppa2Snippet);
 
@@ -527,8 +529,6 @@ TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::R
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
       TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
    {
-   TR::CodeGenerator * codeGen = cg();
-
     // WCode specific
     //
     // There are 4 cases for outgoing branch sequences
@@ -551,40 +551,61 @@ TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::R
     //             a) disp is an offset in the environment (aka ADA) containing the
     //                function descriptor body (i.e. not pointer to function descriptor)
     TR_XPLinkCallTypes callType;
+    
+    TR::Register* aeReg = deps->searchPostConditionRegister(getENVPointerRegister());
+    TR::Register* epReg = deps->searchPostConditionRegister(getEntryPointRegister());
+    TR::Register* raReg = deps->searchPostConditionRegister(getReturnAddressRegister());
 
-    // Find GPR6 (xplink) or GPR15 (os linkage) in post conditions
-    TR::Register * systemEntryPointRegister = deps->searchPostConditionRegister(getEntryPointRegister());
-    // Find GPR7 (xplik) or GPR14 (os linkage) in post conditions
-    TR::Register * systemReturnAddressRegister = deps->searchPostConditionRegister(getReturnAddressRegister());
-
-    TR::RegisterDependencyConditions * preDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, cg());
+    TR::RegisterDependencyConditions* preDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(deps->getPreConditions(), NULL, deps->getAddCursorForPre(), 0, cg());
+    TR::RegisterDependencyConditions* postDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), cg());
 
     if (callNode->getOpCode().isIndirect())
        {
-       generateRRInstruction(cg(), InstOpCode::BASR, callNode, systemReturnAddressRegister, systemEntryPointRegister, preDeps);
+       TR::Register* targetAddress = cg()->evaluate(callNode->getFirstChild());
+
+       generateRSInstruction(cg(), TR::InstOpCode::getLoadMultipleOpCode(), callNode, aeReg, epReg, generateS390MemoryReference(targetAddress, 0, cg()));
+       generateRRInstruction(cg(), InstOpCode::BASR, callNode, raReg, epReg, preDeps);
        callType = TR_XPLinkCallType_BASR;
        }
     else
        {
+       TR::SymbolReference* callSymRef = callNode->getSymbolReference();
+       TR::Symbol* callSymbol = callSymRef->getSymbol();
 
-       TR::SymbolReference *callSymRef = callNode->getSymbolReference();
-       TR::Symbol *callSymbol = callSymRef->getSymbol();
+       if (comp()->isRecursiveMethodTarget(callSymbol))
+          {
+          // No need to load the environment or the entry point for recursive calls because these values are not used
+          // within OMR compiled methods
+          TR::Instruction* callInstr = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, raReg, callSymbol, callSymRef, cg());
+          callInstr->setDependencyConditions(preDeps);
+          }
+       else
+          {
+          struct FunctionDescriptor
+             {
+             void* environment;
+             void* func;
+             };
 
-       TR::Instruction * callInstr = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, systemReturnAddressRegister, callSymbol, callSymRef, cg());
-       callInstr->setDependencyConditions(preDeps);
+          FunctionDescriptor* fd = reinterpret_cast<FunctionDescriptor*>(callSymbol->castToMethodSymbol()->getMethodAddress());
+
+          genLoadAddressConstant(cg(), callNode, reinterpret_cast<uintptrj_t>(fd), epReg);
+          generateRSInstruction(cg(), TR::InstOpCode::getLoadMultipleOpCode(), callNode, aeReg, epReg, generateS390MemoryReference(epReg, 0, cg()));
+
+          TR::Instruction* callInstr = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, raReg, fd->func, callSymRef, cg());
+          callInstr->setDependencyConditions(preDeps);
+          }
+
        callType = TR_XPLinkCallType_BRASL7;
        }
 
-    auto cursor = generateS390LabelInstruction(codeGen, InstOpCode::LABEL, callNode, returnFromJNICallLabel);
+    auto cursor = generateS390LabelInstruction(cg(), InstOpCode::LABEL, callNode, returnFromJNICallLabel);
 
     genCallNOPAndDescriptor(cursor, callNode, callNode, callType);
 
     // Append post-dependencies after NOP
-    TR::LabelSymbol * afterNOP = generateLabelSymbol(cg());
-    TR::RegisterDependencyConditions * postDeps =
-          new (trHeapMemory()) TR::RegisterDependencyConditions(NULL,
-                deps->getPostConditions(), 0, deps->getAddCursorForPost(), cg());
-    generateS390LabelInstruction(codeGen, InstOpCode::LABEL, callNode, afterNOP, postDeps);
+    TR::LabelSymbol* depsLabel = generateLabelSymbol(cg());
+    generateS390LabelInstruction(cg(), InstOpCode::LABEL, callNode, depsLabel, postDeps);
 }
 TR::LabelSymbol*
 TR::S390zOSSystemLinkage::getEntryPointMarkerLabel() const
@@ -1116,4 +1137,52 @@ TR::S390zOSSystemLinkage::XPLINKCallDescriptorRelocation::apply(TR::CodeGenerato
 
    uint8_t* p = getUpdateLocation();
    *reinterpret_cast<int16_t*>(p) = static_cast<int16_t>(offsetToCallDescriptor);
+   }
+
+TR::S390zOSSystemLinkage::XPLINKFunctionDescriptorSnippet::XPLINKFunctionDescriptorSnippet(TR::CodeGenerator* cg)
+   :
+      TR::S390ConstantDataSnippet(cg, NULL, NULL, cg->comp()->target().is32Bit() ? 8 : 16)
+   {
+   if (cg->comp()->target().is32Bit())
+      {
+      *(reinterpret_cast<uint32_t*>(_value) + 0) = 0;
+      *(reinterpret_cast<uint32_t*>(_value) + 1) = 0;
+      }
+   else
+      {
+      *(reinterpret_cast<uint64_t*>(_value) + 0) = 0;
+      *(reinterpret_cast<uint64_t*>(_value) + 1) = 0;
+      }
+   }
+
+uint8_t*
+TR::S390zOSSystemLinkage::XPLINKFunctionDescriptorSnippet::emitSnippetBody()
+   {
+   uint8_t* cursor = cg()->getBinaryBufferCursor();
+
+   // TODO: We should not have to do this here. This should be done by the caller.
+   getSnippetLabel()->setCodeLocation(cursor);
+
+   if (cg()->comp()->target().is32Bit())
+      {
+      // Address of function's environment
+      *reinterpret_cast<uint32_t*>(cursor) = 0;
+      cursor += sizeof(uint32_t);
+
+      // Function of function
+      *reinterpret_cast<uint32_t**>(cursor) = reinterpret_cast<uint32_t*>(cg()->getCodeStart());
+      cursor += sizeof(uint32_t);
+      }
+   else
+      {
+      // Address of function's environment
+      *reinterpret_cast<uint64_t*>(cursor) = 0;
+      cursor += sizeof(uint64_t);
+
+      // Function of function
+      *reinterpret_cast<uint64_t**>(cursor) = reinterpret_cast<uint64_t*>(cg()->getCodeStart());
+      cursor += sizeof(uint64_t);
+      }
+
+   return cursor;
    }

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -1163,6 +1163,9 @@ TR::S390zOSSystemLinkage::XPLINKFunctionDescriptorSnippet::emitSnippetBody()
    // TODO: We should not have to do this here. This should be done by the caller.
    getSnippetLabel()->setCodeLocation(cursor);
 
+   // Update the method symbol address to point to the function descriptor
+   cg()->comp()->getMethodSymbol()->setMethodAddress(cursor);
+
    if (cg()->comp()->target().is32Bit())
       {
       // Address of function's environment

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -589,7 +589,7 @@ TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::R
 
           FunctionDescriptor* fd = reinterpret_cast<FunctionDescriptor*>(callSymbol->castToMethodSymbol()->getMethodAddress());
 
-          genLoadAddressConstant(cg(), callNode, reinterpret_cast<uintptrj_t>(fd), epReg);
+          genLoadAddressConstant(cg(), callNode, reinterpret_cast<uintptr_t>(fd), epReg);
           generateRSInstruction(cg(), TR::InstOpCode::getLoadMultipleOpCode(), callNode, aeReg, epReg, generateS390MemoryReference(epReg, 0, cg()));
 
           TR::Instruction* callInstr = new (cg()->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, raReg, fd->func, callSymRef, cg());

--- a/compiler/z/codegen/SystemLinkagezOS.hpp
+++ b/compiler/z/codegen/SystemLinkagezOS.hpp
@@ -31,6 +31,7 @@
 #include "codegen/SystemLinkage.hpp"
 #include "codegen/snippet/PPA1Snippet.hpp"
 #include "codegen/snippet/PPA2Snippet.hpp"
+#include "codegen/ConstantDataSnippet.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
@@ -105,6 +106,23 @@ class S390zOSSystemLinkage : public TR::SystemLinkage
       TR::Instruction* _nop;
       };
 
+   /** \brief
+    *
+    *  Represents the XPLINK function descriptor which is a data structure that represents the address of a function
+    *  retrieved via the C '&' operator. The data structure holds the actual value of the execution entry point of the
+    *  function it describes.
+    *
+    *  [1] https://www-01.ibm.com/servers/resourcelink/svc00100.nsf/pages/zOSV2R3SA380688/$file/ceev100_v2r3.pdf (page 140)
+    */
+   class XPLINKFunctionDescriptorSnippet : public TR::S390ConstantDataSnippet
+      {
+      public:
+
+         XPLINKFunctionDescriptorSnippet(TR::CodeGenerator* cg);
+
+         virtual uint8_t* emitSnippetBody();
+      };
+
    public:
 
    /** \brief
@@ -174,6 +192,7 @@ class S390zOSSystemLinkage : public TR::SystemLinkage
    TR::LabelSymbol* _entryPointMarkerLabel;
    TR::LabelSymbol* _stackPointerUpdateLabel;
 
+   XPLINKFunctionDescriptorSnippet* _xplinkFunctionDescriptorSnippet;
    TR::PPA1Snippet* _ppa1Snippet;
    TR::PPA2Snippet* _ppa2Snippet;
    };

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -122,6 +122,6 @@ target_link_libraries(compilertest
 
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
-if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos")
+if (NOT OMR_HOST_OS STREQUAL "aix")
 	add_test(NAME CompilerTest COMMAND compilertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
 endif()

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -692,6 +692,20 @@ class SkipHelper
    SKIP_ON(OMRPORT_ARCH_S390, reason)
 
 /*
+ * @brief A macro to allow a test to be conditionally skipped on S390 running under the Linux operating system.
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_S390_LINUX(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_S390_LINUX(reason) \
+   switch (0) case 0: default: /* guard against ambiguous else */ \
+   if (strcmp("Linux", omrsysinfo_get_OS_type()) != 0) { /* allow test to proceed normally */ } \
+   else \
+      SKIP_ON(OMRPORT_ARCH_S390X, reason)
+
+/*
  * @brief A macro to allow a test to be conditionally skipped on S390X
  *
  * The basic syntax for using this macro is:
@@ -702,6 +716,19 @@ class SkipHelper
 #define SKIP_ON_S390X(reason) \
    SKIP_ON(OMRPORT_ARCH_S390X, reason)
 
+/*
+ * @brief A macro to allow a test to be conditionally skipped on S390X running under the Linux operating system.
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_S390X_LINUX(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_S390X_LINUX(reason) \
+   switch (0) case 0: default: /* guard against ambiguous else */ \
+   if (strcmp("Linux", omrsysinfo_get_OS_type()) != 0) { /* allow test to proceed normally */ } \
+   else \
+      SKIP_ON(OMRPORT_ARCH_S390X, reason)
 
 /*
  * @brief A macro to allow a test to be conditionally skipped on AMD64

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -85,10 +85,8 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -117,10 +115,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing1Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -164,10 +160,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -215,10 +209,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -270,10 +262,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -329,10 +319,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -392,10 +380,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -459,10 +445,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -530,10 +514,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -605,10 +587,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -714,10 +694,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -762,10 +740,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -811,10 +787,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -861,10 +835,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -912,10 +884,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -964,10 +934,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1017,10 +985,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1071,10 +1037,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9A
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1414,10 +1378,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing1Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1464,10 +1426,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1518,10 +1478,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1576,10 +1534,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1638,10 +1594,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1704,10 +1658,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1774,10 +1726,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1848,10 +1798,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -1926,10 +1874,8 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2232,10 +2178,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2283,10 +2227,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2335,10 +2277,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2388,10 +2328,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2442,10 +2380,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2497,10 +2433,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2553,10 +2487,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+ SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+ SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -2610,10 +2542,8 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
+ SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+ SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -61,8 +61,10 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -84,8 +86,10 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -126,8 +130,10 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -208,8 +214,10 @@ TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -277,8 +285,10 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -357,8 +367,10 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -424,8 +436,10 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFourArgWithMixedT
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
@@ -466,8 +480,10 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedT
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -41,13 +41,37 @@ template<> const char * TypeToString<int64_t>::prefix = "l";
 template<> const char * TypeToString<float>  ::prefix = "f";
 template<> const char * TypeToString<double> ::prefix = "d";
 
-TEST(TypeToString,TestTemplate) {
+TEST(TypeToString, TestTemplate) {
    EXPECT_STREQ("Int32", TypeToString<int32_t>::type);
    EXPECT_STREQ("Double", TypeToString<double>::type);
 }
 
 template <typename T>
-T passThrough(T x) { return x; }
+T return1stArgument(T a) { return a; }
+
+template <typename T>
+T return2ndArgument(T a, T b) { return b; }
+
+template <typename T>
+T return3rdArgument(T a, T b, T c) { return c; }
+
+template <typename T>
+T return4thArgument(T a, T b, T c, T d) { return d; }
+
+template <typename T>
+T return5thArgument(T a, T b, T c, T d, T e) { return e; }
+
+template <typename T>
+T return6thArgument(T a, T b, T c, T d, T e, T f) { return f; }
+
+template <typename T>
+T return7thArgument(T a, T b, T c, T d, T e, T f, T g) { return g; }
+
+template <typename T>
+T return8thArgument(T a, T b, T c, T d, T e, T f, T g, T h) { return h; }
+
+template <typename T>
+T return9thArgument(T a, T b, T c, T d, T e, T f, T g, T h, T i) { return i; }
 
 template <typename T>
 class LinkageTest : public TRTest::JitTest {};
@@ -69,9 +93,16 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[200] = {0};
-    const auto format_string = "(method return=Int32  args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] linkage=noexist  (iload parm=0)) )  ))";
-    std::snprintf(inputTrees, 200, format_string, reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>)));
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=Int32 args=[Int32]"
+       "  (block"
+       "    (ireturn"
+       "      (icall address=0x%jX args=[Int32] linkage=noexist"
+       "        (iload parm=0) ) ) ) )",
+
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam)>(return1stArgument<TypeParam>)) // address
+    );
 
     auto trees = parseString(inputTrees);
     ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
@@ -80,7 +111,7 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     ASSERT_NE(0, compiler.compile()) << "Compilation succeeded unexpectedly\n" << "Input trees: " << inputTrees;
 }
 
-TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing1Arg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -94,16 +125,22 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[200] = {0};
-    const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=0x%jX args=[%s] linkage=system (%sload parm=0)) )  ))";
-    std::snprintf(inputTrees, 200, format_string, TypeToString<TypeParam>::type, // Return
-                                                  TypeToString<TypeParam>::type, //Args
-                                                  TypeToString<TypeParam>::prefix, //return
-                                                  TypeToString<TypeParam>::prefix, //call
-                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>)),//address
-                                                  TypeToString<TypeParam>::type, //args
-                                                  TypeToString<TypeParam>::prefix //load
-                                                  );
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s] linkage=system"
+       "        (%sload parm=0) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam)>(return1stArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
@@ -121,10 +158,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     }
 }
 
-template <typename T>
-T fourthArg(T a, T b, T c, T d) { return d; }
-
-TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -138,30 +172,26 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[400] = {0};
-    const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
-                                 " (%sload parm=0)"
-                                 " (%sload parm=1)"
-                                 " (%sload parm=2)"
-                                 " (%sload parm=3)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string, TypeToString<TypeParam>::type,   // Return
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::prefix, // return
-                                                  TypeToString<TypeParam>::prefix, // call
-                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>(fourthArg<TypeParam>)),// address
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix  // load
-                                                  );
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam)>(return2ndArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
@@ -170,32 +200,941 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>();
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam)>();
 
     auto inputs = TRTest::const_values<TypeParam>();
     for (auto i = inputs.begin(); i != inputs.end(); ++i) {
         SCOPED_TRACE(*i);
-        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0, *i))  << "Input Trees: " << inputTrees;
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam)>(return3rdArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam)>(return4thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(return5thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(return6thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(return7thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6)"
+       "        (%sload parm=7) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(return8thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6)"
+       "        (%sload parm=7)"
+       "        (%sload parm=8) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(return9thArgument<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, 7, *i))  << "Input Trees: " << inputTrees;
     }
 }
 
 template <typename T>
-T (*get_fourth_arg_from_callee())(T,T,T,T) {
-    char inputTrees[400] = {0};
-    const auto format_string =
-        "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%sload parm=3))))";
-    std::snprintf(inputTrees, 400, format_string,
-        TypeToString<T>::type,   // Return
-        TypeToString<T>::type,   // Args
-        TypeToString<T>::type,   // Args
-        TypeToString<T>::type,   // Args
-        TypeToString<T>::type,   // Args
-        TypeToString<T>::prefix, // return
-        TypeToString<T>::prefix  // load
-        );
+T return2ndArgumentFromMixedTypes(double a, T b) { return b; }
+
+template <typename T>
+T return3rdArgumentFromMixedTypes(double a, int32_t b, T c) { return c; }
+
+template <typename T>
+T return4thArgumentFromMixedTypes(double a, int64_t b, float c, T d) { return d; }
+
+template <typename T>
+T return5thArgumentFromMixedTypes(float a, int32_t b, float c, int64_t d, T e) { return e; }
+
+template <typename T>
+T return6thArgumentFromMixedTypes(float a, int32_t b, double c, int32_t d, int64_t e, T f) { return f; }
+
+template <typename T>
+T return7thArgumentFromMixedTypes(double a, int32_t b, double c, int32_t d, int32_t e, int64_t f, T g) { return g; }
+
+template <typename T>
+T return8thArgumentFromMixedTypes(int64_t a, int64_t b, float c, double d, int32_t e, int64_t f, int32_t g, T h) { return h; }
+
+template <typename T>
+T return9thArgumentFromMixedTypes(double a, int32_t b, float c, int32_t d, int32_t e, float f, int64_t g, int32_t h, T i) { return i; }
+
+template <typename T>
+class LinkageWithMixedTypesTest : public TRTest::JitTest {};
+
+typedef ::testing::Types<int32_t, int64_t, float, double> InputTypes;
+TYPED_TEST_CASE(LinkageWithMixedTypesTest, InputTypes);
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (%sload parm=1) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, TypeParam)>(return2ndArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (%sload parm=2) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, TypeParam)>(return3rdArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int64,Float,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int64,Float,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (lload parm=1)"
+       "        (fload parm=2)"
+       "        (%sload parm=3) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int64_t, float, TypeParam)>(return4thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int64_t, float, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Float,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Float,Int32,Float,Int64,%s] linkage=system"
+       "        (fload parm=0)"
+       "        (iload parm=1)"
+       "        (fload parm=2)"
+       "        (lload parm=3)"
+       "        (%sload parm=4) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, float, int64_t, TypeParam)>(return5thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(float, int32_t, float, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Double,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Float,Int32,Double,Int32,Int64,%s] linkage=system"
+       "        (fload parm=0)"
+       "        (iload parm=1)"
+       "        (dload parm=2)"
+       "        (iload parm=3)"
+       "        (lload parm=4)"
+       "        (%sload parm=5) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, double, int32_t, int64_t, TypeParam)>(return6thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(float, int32_t, double, int32_t, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Double,Int32,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,Double,Int32,Int32,Int64,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (dload parm=2)"
+       "        (iload parm=3)"
+       "        (iload parm=4)"
+       "        (lload parm=5)"
+       "        (%sload parm=6) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, double, int32_t, int32_t, int64_t, TypeParam)>(return7thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, double, int32_t, int32_t, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Int64,Int64,Float,Double,Int32,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Int64,Int64,Float,Double,Int32,Int64,Int32,%s] linkage=system"
+       "        (lload parm=0)"
+       "        (lload parm=1)"
+       "        (fload parm=2)"
+       "        (dload parm=3)"
+       "        (iload parm=4)"
+       "        (lload parm=5)"
+       "        (iload parm=6)"
+       "        (%sload parm=7) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, TypeParam)>(return8thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Float,Int32,Int32,Float,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,Float,Int32,Int32,Float,Int64,Int32,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (fload parm=2)"
+       "        (iload parm=3)"
+       "        (iload parm=4)"
+       "        (fload parm=5)"
+       "        (lload parm=6)"
+       "        (iload parm=7)"
+       "        (%sload parm=8) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, TypeParam)>(return9thArgumentFromMixedTypes<TypeParam>)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, 7, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning1stArgument())(T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=0) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
     if (trees == NULL) {
         return NULL;
     }
@@ -205,10 +1144,270 @@ T (*get_fourth_arg_from_callee())(T,T,T,T) {
         return NULL;
     }
 
-    return compiler.getEntryPoint<T (*)(T,T,T,T)>();
+    return compiler.getEntryPoint<T (*)(T)>();
 }
 
-TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
+template <typename T>
+T (*getJitCompiledMethodReturning2ndArgument())(T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=1) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning3rdArgument())(T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=2) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning4thArgument())(T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=3) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning5thArgument())(T, T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=4) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning6thArgument())(T, T, T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=5) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning7thArgument())(T, T, T, T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=6) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T, T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning8thArgument())(T, T, T, T, T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=7) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T, T, T, T, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning9thArgument())(T, T, T, T, T, T, T, T, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=8) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(T, T, T, T, T, T, T, T, T)>();
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing1Arg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -222,38 +1421,25 @@ TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[400] = {0};
-
-    auto callee_entry_point = get_fourth_arg_from_callee<TypeParam>();
+    auto callee_entry_point = getJitCompiledMethodReturning1stArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
 
-    EXPECT_EQ(static_cast<TypeParam>(1024),    callee_entry_point(0,0,0,static_cast<TypeParam>(1024)));
-    EXPECT_EQ(static_cast<TypeParam>(-1),      callee_entry_point(0,0,0,static_cast<TypeParam>(-1)));
-    EXPECT_EQ(static_cast<TypeParam>(0xf0f0f), callee_entry_point(0,0,0,static_cast<TypeParam>(0xf0f0f)));
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s] linkage=system"
+       "        (%sload parm=0) ) ) ) )",
 
-    const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
-                                 " (%sload parm=0)"
-                                 " (%sload parm=1)"
-                                 " (%sload parm=2)"
-                                 " (%sload parm=3)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string, TypeToString<TypeParam>::type,   // Return
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::prefix, // return
-                                                  TypeToString<TypeParam>::prefix, // call
-                                                  callee_entry_point,              // address
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix  // load
-                                                  );
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
@@ -262,24 +1448,16 @@ TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>();
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam)>();
 
     auto inputs = TRTest::const_values<TypeParam>();
     for (auto i = inputs.begin(); i != inputs.end(); ++i) {
         SCOPED_TRACE(*i);
-        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0, *i))  << "Input Trees: " << inputTrees;
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(*i))  << "Input Trees: " << inputTrees;
     }
 }
 
-template <typename T>
-T fifthArg(T a, T b, T c, T d, T e) { return e; }
-
-/**
- * In accordance with the Microsoft x64 calling convention, only four parameters can be passed in registers (both integer
- * and floating point). Additional arguments are pushed onto the stack (right to left). It is an interesting case when a JITed
- * method calls a method with more than four parameters.
- */
-TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -293,34 +1471,29 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[400] = {0};
-    const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
-                                 " (%sload parm=0)"
-                                 " (%sload parm=1)"
-                                 " (%sload parm=2)"
-                                 " (%sload parm=3)"
-                                 " (%sload parm=4)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string, TypeToString<TypeParam>::type,   // Return
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::prefix, // return
-                                                  TypeToString<TypeParam>::prefix, // call
-                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>(fifthArg<TypeParam>)),// address
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix  // load
-                                                  );
+    auto callee_entry_point = getJitCompiledMethodReturning2ndArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
@@ -329,39 +1502,730 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>();
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam)>();
 
     auto inputs = TRTest::const_values<TypeParam>();
     for (auto i = inputs.begin(); i != inputs.end(); ++i) {
         SCOPED_TRACE(*i);
-        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0,0, *i))  << "Input Trees: " << inputTrees;
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, *i))  << "Input Trees: " << inputTrees;
     }
 }
 
-/*
- * It doesn't matter what this function exactly do. It is requred just to demonstrate what can be expected if a callee
- * actively uses the stack (has a lot of local variables).
- */
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning3rdArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning4thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning5thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning6thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning7thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning8thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6)"
+       "        (%sload parm=7) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning9thArgument<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[%s,%s,%s,%s,%s,%s,%s,%s,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[%s,%s,%s,%s,%s,%s,%s,%s,%s] linkage=system"
+       "        (%sload parm=0)"
+       "        (%sload parm=1)"
+       "        (%sload parm=2)"
+       "        (%sload parm=3)"
+       "        (%sload parm=4)"
+       "        (%sload parm=5)"
+       "        (%sload parm=6)"
+       "        (%sload parm=7)"
+       "        (%sload parm=8) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix, // load
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, 7, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
 template <typename T>
-T stackUser(T a, T b, T c, T d, T e) {
-    volatile T x, y, z, w;
-    for (int32_t i = 0; i < a; i+= b) {
-        w = (c + b) * (i + e);
-        x = a * (i + d + 1);
-        y = b - d + c;
-        z = c * 2 * (i + 1);
+T (*getJitCompiledMethodReturning2ndArgumentFromMixedTypes())(double, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=1) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
     }
-    return x + y + z + w;
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(double, T)>();
 }
 
-/**
- * In the Microsoft x64 calling convention, it is the caller's responsibility to allocate 32 bytes of "shadow space" on
- * the stack right before calling the function (regardless of the actual number of parameters used), and to pop the stack
- * after the call. In the case, when the callee actively uses the stack, the callee can relate on this "shadow space"
- * and save arguments or other nonvolatile registers there. The test demonstrates what can be happen when the callee is
- * an actively stack user.
- */
-TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
+template <typename T>
+T (*getJitCompiledMethodReturning3rdArgumentFromMixedTypes())(double, int32_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=2) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(double, int32_t, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning4thArgumentFromMixedTypes())(double, int64_t, float, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int64,Float,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=3) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(double, int64_t, float, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning5thArgumentFromMixedTypes())(float, int32_t, float, int64_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Float,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=4) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(float, int32_t, float, int64_t, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning6thArgumentFromMixedTypes())(float, int32_t, double, int32_t, int64_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Double,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=5) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(float, int32_t, double, int32_t, int64_t, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning7thArgumentFromMixedTypes())(double, int32_t, double, int32_t, int32_t, int64_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Double,Int32,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=6) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(double, int32_t, double, int32_t, int32_t, int64_t, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning8thArgumentFromMixedTypes())(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Int64,Int64,Float,Double,Int32,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=7) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, T)>();
+}
+
+template <typename T>
+T (*getJitCompiledMethodReturning9thArgumentFromMixedTypes())(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, T) {
+    char inputTrees[400] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Float,Int32,Int32,Float,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%sload parm=8) ) ) )",
+
+       TypeToString<T>::type, // return
+       TypeToString<T>::type, // args
+       TypeToString<T>::prefix, // return
+       TypeToString<T>::prefix  // load
+    );
+
+    auto trees = parseString(inputTrees);
+    if (trees == NULL) {
+        return NULL;
+    }
+
+    Tril::DefaultCompiler compiler(trees);
+    if (compiler.compile() != 0) {
+        return NULL;
+    }
+
+    return compiler.getEntryPoint<T (*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, T)>();
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgWithMixedTypes) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -375,34 +2239,26 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[400] = {0};
-    const auto format_string = "(method return=%s args=[%s,%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s,%s] linkage=system"
-                                 " (%sload parm=0)"
-                                 " (%sload parm=1)"
-                                 " (%sload parm=2)"
-                                 " (%sload parm=3)"
-                                 " (%sload parm=4)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string, TypeToString<TypeParam>::type,   // Return
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::type,   // Args
-                                                  TypeToString<TypeParam>::prefix, // return
-                                                  TypeToString<TypeParam>::prefix, // call
-                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>(stackUser<TypeParam>)),// address
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::type,   // args
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix, // load
-                                                  TypeToString<TypeParam>::prefix  // load
-                                                  );
+    auto callee_entry_point = getJitCompiledMethodReturning2ndArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (%sload parm=1) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
 
@@ -411,70 +2267,16 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>();
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, TypeParam)>();
 
-    // Check the compiled function itself
-    EXPECT_EQ(static_cast<TypeParam>(2053),     stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(3),        stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(0x1e1e23), stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
-
-    // Check the linkage
-    EXPECT_EQ(static_cast<TypeParam>(2053),     entry_point(1,1,1,1,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(3),        entry_point(1,1,1,1,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(0x1e1e23), entry_point(1,1,1,1,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
-}
-
-class LinkageWithMixedTypesTest : public TRTest::JitTest {};
-
-int32_t fourthArgFromMixedTypes(double a, int32_t b, double c, int32_t d) { return d; }
-
-typedef int32_t (*FourMixedArgumentFunction)(double,int32_t,double,int32_t);
-
-TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFourArgWithMixedTypes) {
-    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
-
-    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
-    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-    if ("z/OS" != omrsysinfo_get_OS_type()) {
-       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
-    }
-    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
-    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-
-    char inputTrees[400] = {0};
-    const auto format_string = "(method return=Int32 args=[Double,Int32,Double,Int32]"
-                               "  (block (ireturn (icall address=0x%jX args=[Double,Int32,Double,Int32] linkage=system"
-                                 " (dload parm=0)"
-                                 " (iload parm=1)"
-                                 " (dload parm=2)"
-                                 " (iload parm=3)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string,
-        reinterpret_cast<uintmax_t>(static_cast<FourMixedArgumentFunction>(fourthArgFromMixedTypes)));
-
-    auto trees = parseString(inputTrees);
-    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
-
-    Tril::DefaultCompiler compiler(trees);
-    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<FourMixedArgumentFunction>();
-
-    auto inputs = TRTest::const_values<int32_t>();
+    auto inputs = TRTest::const_values<TypeParam>();
     for (auto i = inputs.begin(); i != inputs.end(); ++i) {
         SCOPED_TRACE(*i);
-        EXPECT_EQ(*i, entry_point(0.0,0,0.0, *i))  << "Input Trees: " << inputTrees;
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, *i))  << "Input Trees: " << inputTrees;
     }
 }
 
-double fifthArgFromMixedTypes(double a, int32_t b, double c, int32_t d, double e) { return e; }
-
-typedef double (*FiveMixedArgumentFunction)(double,int32_t,double,int32_t,double);
-
-TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedTypes) {
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgWithMixedTypes) {
     OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
@@ -488,29 +2290,373 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedT
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
-    char inputTrees[400] = {0};
-    const auto format_string = "(method return=Double args=[Double,Int32,Double,Int32,Double]"
-                               "  (block (dreturn (dcall address=0x%jX args=[Double,Int32,Double,Int32,Double] linkage=system"
-                                 " (dload parm=0)"
-                                 " (iload parm=1)"
-                                 " (dload parm=2)"
-                                 " (iload parm=3)"
-                                 " (dload parm=4)"
-                                 ") )  ))";
-    std::snprintf(inputTrees, 400, format_string,
-        reinterpret_cast<uintmax_t>(static_cast<FiveMixedArgumentFunction>(fifthArgFromMixedTypes)));
+    auto callee_entry_point = getJitCompiledMethodReturning3rdArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (%sload parm=2) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
 
     auto trees = parseString(inputTrees);
+
     ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
 
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<FiveMixedArgumentFunction>();
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, TypeParam)>();
 
-    auto inputs = TRTest::const_values<double>();
+    auto inputs = TRTest::const_values<TypeParam>();
     for (auto i = inputs.begin(); i != inputs.end(); ++i) {
         SCOPED_TRACE(*i);
-        EXPECT_DOUBLE_EQ(*i, entry_point(0.0,0,0.0,0, *i))  << "Input Trees: " << inputTrees;
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning4thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int64,Float,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int64,Float,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (lload parm=1)"
+       "        (fload parm=2)"
+       "        (%sload parm=3) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int64_t, float, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int64_t, float, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning5thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Float,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Float,Int32,Float,Int64,%s] linkage=system"
+       "        (fload parm=0)"
+       "        (iload parm=1)"
+       "        (fload parm=2)"
+       "        (lload parm=3)"
+       "        (%sload parm=4) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, float, int64_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(float, int32_t, float, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning6thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Float,Int32,Double,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Float,Int32,Double,Int32,Int64,%s] linkage=system"
+       "        (fload parm=0)"
+       "        (iload parm=1)"
+       "        (dload parm=2)"
+       "        (iload parm=3)"
+       "        (lload parm=4)"
+       "        (%sload parm=5) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, double, int32_t, int64_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(float, int32_t, double, int32_t, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning7thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Double,Int32,Int32,Int64,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,Double,Int32,Int32,Int64,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (dload parm=2)"
+       "        (iload parm=3)"
+       "        (iload parm=4)"
+       "        (lload parm=5)"
+       "        (%sload parm=6) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, double, int32_t, int32_t, int64_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, double, int32_t, int32_t, int64_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning8thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Int64,Int64,Float,Double,Int32,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Int64,Int64,Float,Double,Int32,Int64,Int32,%s] linkage=system"
+       "        (lload parm=0)"
+       "        (lload parm=1)"
+       "        (fload parm=2)"
+       "        (dload parm=3)"
+       "        (iload parm=4)"
+       "        (lload parm=5)"
+       "        (iload parm=6)"
+       "        (%sload parm=7) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, *i))  << "Input Trees: " << inputTrees;
+    }
+}
+
+TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgWithMixedTypes) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
+
+    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    if ("z/OS" != omrsysinfo_get_OS_type()) {
+       SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+       SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+    }
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+
+    auto callee_entry_point = getJitCompiledMethodReturning9thArgumentFromMixedTypes<TypeParam>();
+    ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
+
+    char inputTrees[600] = { 0 };
+    std::snprintf(inputTrees, sizeof(inputTrees),
+       "(method return=%s args=[Double,Int32,Float,Int32,Int32,Float,Int64,Int32,%s]"
+       "  (block"
+       "    (%sreturn"
+       "      (%scall address=0x%jX args=[Double,Int32,Float,Int32,Int32,Float,Int64,Int32,%s] linkage=system"
+       "        (dload parm=0)"
+       "        (iload parm=1)"
+       "        (fload parm=2)"
+       "        (iload parm=3)"
+       "        (iload parm=4)"
+       "        (fload parm=5)"
+       "        (lload parm=6)"
+       "        (iload parm=7)"
+       "        (%sload parm=8) ) ) ) )",
+
+       TypeToString<TypeParam>::type, // return
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix, // return
+       TypeToString<TypeParam>::prefix, //call
+       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, TypeParam)>(callee_entry_point)), // address
+       TypeToString<TypeParam>::type, // args
+       TypeToString<TypeParam>::prefix // load
+    );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, TypeParam)>();
+
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.begin(); i != inputs.end(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0, 1, 2, 3, 4, 5, 6, 7, *i))  << "Input Trees: " << inputTrees;
     }
 }

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -600,6 +600,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
 }
 
 TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
+    OMRPORT_ACCESS_FROM_OMRPORT(TRTest::TestWithPortLib::privateOmrPortLibrary);
 
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -1437,7 +1437,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing1Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -1489,7 +1489,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // load
@@ -1545,7 +1545,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1605,7 +1605,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1669,7 +1669,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1737,7 +1737,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1809,7 +1809,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1885,7 +1885,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -1965,7 +1965,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::type, // args
@@ -2256,7 +2256,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2308,7 +2308,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2361,7 +2361,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int64_t, float, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2415,7 +2415,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, float, int64_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2470,7 +2470,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(float, int32_t, double, int32_t, int64_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2526,7 +2526,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, double, int32_t, int32_t, int64_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2583,7 +2583,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(int64_t, int64_t, float, double, int32_t, int64_t, int32_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );
@@ -2641,7 +2641,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix, // return
        TypeToString<TypeParam>::prefix, //call
-       reinterpret_cast<uintmax_t>(static_cast<TypeParam(*)(double, int32_t, float, int32_t, int32_t, float, int64_t, int32_t, TypeParam)>(callee_entry_point)), // address
+       reinterpret_cast<uintmax_t>(callee_entry_point), // address
        TypeToString<TypeParam>::type, // args
        TypeToString<TypeParam>::prefix // load
     );

--- a/fvtest/compilertriltest/MinimalTest.cpp
+++ b/fvtest/compilertriltest/MinimalTest.cpp
@@ -316,8 +316,10 @@ TEST_F(MinimalTest, MeaningOfLife)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -331,8 +333,10 @@ TEST_F(MinimalTest, ReturnArgI32)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -348,8 +352,10 @@ TEST_F(MinimalTest, MaxIfThen)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -366,8 +372,10 @@ TEST_F(MinimalTest, AddArgConst)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -382,8 +390,10 @@ TEST_F(MinimalTest, SubArgArg)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -400,8 +410,10 @@ TEST_F(MinimalTest, Factorial)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
@@ -423,8 +435,10 @@ TEST_F(MinimalTest, RecursiveFibonnaci)
    SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
-   SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   if ("z/OS" != omrsysinfo_get_OS_type()) {
+      SKIP_ON_S390(MissingImplementation) << "Test is skipped on S390 because calls are not currently supported (see issue #1645)";
+      SKIP_ON_S390X(MissingImplementation) << "Test is skipped on S390x because calls are not currently supported (see issue #1645)";
+   }
    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 

--- a/fvtest/tril/test/IlGenTest.cpp
+++ b/fvtest/tril/test/IlGenTest.cpp
@@ -40,9 +40,9 @@
 
 class IlGenTest : public Tril::Test::JitTest {};
 
-// TODO (#4719): This test is currently broken on AIX and z/OS, since it is not valid to use the return value of
+// TODO (#4719): This test is currently broken on AIX, since it is not valid to use the return value of
 // compileMethodFromDetails as a function pointer.
-#if !defined(AIXPPC) && !defined(J9ZOS390)
+#if !defined(AIXPPC)
 TEST_F(IlGenTest, Return3) {
     auto trees = parseString("(block (ireturn (iconst 3)))");
 

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -83,19 +83,7 @@ int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     // if compilation was successful, set the entry point for the compiled body
     if (rc == 0)
        {
-#if defined(J9ZOS390)
-       struct FunctionDescriptor
-       {
-          uint64_t environment;
-          void* func;
-       };
-
-       FunctionDescriptor* fd = new FunctionDescriptor();
-       fd->environment = 0;
-       fd->func = entry_point;
-
-       entry_point = (uint8_t*) fd;
-#elif defined(AIXPPC)
+#if defined(AIXPPC)
        struct FunctionDescriptor
           {
           void* func;

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -189,19 +189,7 @@ internal_compileMethodBuilder(TR::MethodBuilder *m, void **entry)
    {
    auto rc = m->Compile(entry);
 
-#if defined(J9ZOS390)
-   struct FunctionDescriptor
-   {
-      uint64_t environment;
-      void* func;
-   };
-
-   FunctionDescriptor* fd = new FunctionDescriptor();
-   fd->environment = 0;
-   fd->func = *entry;
-
-   *entry = (void*) fd;
-#elif defined(AIXPPC)
+#if defined(AIXPPC)
    struct FunctionDescriptor
       {
       void* func;

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -74,6 +74,5 @@ endif()
 
 
 # Additional Tests: These may not run properly on all platforms
-# Mandelbrot takes arguments for its test
-# so will require we enhance create_jitbuilder_target.
-#create_jitbuilder_target(mandelbrot   cpp/samples/Mandelbrot.cpp)
+# Mandelbrot takes arguments for its test so will require we enhance create_jitbuilder_test
+#create_jitbuilder_test(mandelbrot cpp/samples/Mandelbrot.cpp)

--- a/jitbuilder/release/cpp/samples/Call.cpp
+++ b/jitbuilder/release/cpp/samples/Call.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/cpp/samples/Call.cpp
+++ b/jitbuilder/release/cpp/samples/Call.cpp
@@ -27,29 +27,32 @@
 
 #include "Call.hpp"
 
+static CallFunctionType2Arg *nativeToJitMethod = NULL;
+
 static int32_t
-doublesum(int32_t first, int32_t second)
+nativeMethod(int32_t x, int32_t y)
    {
-   #define DOUBLESUM_LINE LINETOSTR(__LINE__)
-   int32_t result = 2 * (first + second);
-   fprintf(stderr,"doublesum(%d, %d) == %d\n", first, second, result);
+   #define NATIVE_METHOD_LINE LINETOSTR(__LINE__)
+   int32_t result = nativeToJitMethod(x, y);
+   fprintf(stderr,"(%d + %d) * 2 == %d\n", x, y, result);
    return result;
    }
 
-CallMethod::CallMethod(OMR::JitBuilder::TypeDictionary *types)
+JitToNativeCallMethod::JitToNativeCallMethod(OMR::JitBuilder::TypeDictionary *types)
    : OMR::JitBuilder::MethodBuilder(types)
    {
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
 
-   DefineName("test_calls");
-   DefineParameter("n", Int32);
+   DefineName("test_jit_to_native");
+   DefineParameter("x", Int32);
+   DefineParameter("y", Int32);
    DefineReturnType(Int32);
 
-   DefineFunction((char *)"doublesum",
+   DefineFunction((char *)"nativeMethod",
                   (char *)__FILE__,
-                  (char *)DOUBLESUM_LINE,
-                  (void *)&doublesum,
+                  (char *)NATIVE_METHOD_LINE,
+                  (void *)&nativeMethod,
                   Int32,
                   2,
                   Int32,
@@ -57,19 +60,117 @@ CallMethod::CallMethod(OMR::JitBuilder::TypeDictionary *types)
    }
 
 bool
-CallMethod::buildIL()
+JitToNativeCallMethod::buildIL()
+   {
+   Store("doublesum",
+      Call("nativeMethod", 2,
+         Load("x"),
+         Load("y")));
+
+   Return(
+      Load("doublesum"));
+
+   return true;
+   }
+
+JitToNativeComputedCallMethod::JitToNativeComputedCallMethod(OMR::JitBuilder::TypeDictionary *types)
+   : OMR::JitBuilder::MethodBuilder(types)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("test_jit_to_native_computed");
+   DefineParameter("x", Int32);
+   DefineParameter("y", Int32);
+   DefineReturnType(Int32);
+
+   DefineFunction((char *)"nativeMethod",
+                  (char *)__FILE__,
+                  (char *)NATIVE_METHOD_LINE,
+                  (void *)&nativeMethod,
+                  Int32,
+                  2,
+                  Int32,
+                  Int32);
+   }
+
+bool
+JitToNativeComputedCallMethod::buildIL()
+   {
+   Store("doublesum",
+      ComputedCall("nativeMethod", 3,
+         ConstAddress((void*) &nativeMethod),
+         Load("x"),
+         Load("y")));
+
+   Return(
+      Load("doublesum"));
+
+   return true;
+   }
+
+NativeToJitCallMethod::NativeToJitCallMethod(OMR::JitBuilder::TypeDictionary *types)
+   : OMR::JitBuilder::MethodBuilder(types)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("test_native_to_jit");
+   DefineParameter("x", Int32);
+   DefineParameter("y", Int32);
+   DefineReturnType(Int32);
+   }
+
+bool
+NativeToJitCallMethod::buildIL()
+   {
+   Store("doublesum",
+      Mul(
+         Add(
+            Load("x"),
+            Load("y")),
+         ConstInt32(2)));
+
+   Return(
+      Load("doublesum"));
+
+   return true;
+   }
+
+JitToJitCallMethod::JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, const char *jitMethodName, void *entry)
+   : OMR::JitBuilder::MethodBuilder(types), jitMethodName(jitMethodName)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("test_jit_to_jit");
+   DefineParameter("n", Int32);
+   DefineReturnType(Int32);
+
+   DefineFunction((char *)jitMethodName,
+                  (char *)"",
+                  (char *)"",
+                  (void *)entry,
+                  Int32,
+                  2,
+                  Int32,
+                  Int32);
+   }
+
+bool
+JitToJitCallMethod::buildIL()
    {
    Store("sum",
       ConstInt32(0));
 
-   IlBuilder *loop=NULL;
+   IlBuilder *loop = NULL;
    ForLoopUp("i", &loop,
              ConstInt32(0),
              Load("n"),
              ConstInt32(1));
 
    loop->Store("sum",
-   loop->   Call("doublesum", 2,
+   loop->   Call(jitMethodName, 2,
    loop->      Load("sum"),
    loop->      Load("i")));
 
@@ -79,50 +180,7 @@ CallMethod::buildIL()
    return true;
    }
 
-ComputedCallMethod::ComputedCallMethod(OMR::JitBuilder::TypeDictionary *types)
-   : OMR::JitBuilder::MethodBuilder(types)
-   {
-   DefineLine(LINETOSTR(__LINE__));
-   DefineFile(__FILE__);
-
-   DefineName("test_computed_call");
-   DefineParameter("n", Int32);
-   DefineReturnType(Int32);
-
-   DefineFunction((char *)"doublesum",
-                  (char *)__FILE__,
-                  (char *)DOUBLESUM_LINE,
-                  (void *)&doublesum,
-                  Int32,
-                  2,
-                  Int32,
-                  Int32);
-   }
-#undef DOUBLESUM_LINE
-
-bool
-ComputedCallMethod::buildIL()
-   {
-   Store("sum",
-      ConstInt32(0));
-
-   IlBuilder *loop=NULL;
-   ForLoopUp("i", &loop,
-             ConstInt32(0),
-             Load("n"),
-             ConstInt32(1));
-
-   loop->Store("sum",
-   loop->   ComputedCall("doublesum", 3,
-   loop->      ConstAddress((void*) &doublesum),
-   loop->      Load("sum"),
-   loop->      Load("i")));
-
-   Return(
-      Load("sum"));
-
-   return true;
-   }
+#undef NATIVE_METHOD_LINE
 
 int
 main(int argc, char *argv[])
@@ -138,36 +196,72 @@ main(int argc, char *argv[])
    printf("Step 2: define type dictionary\n");
    OMR::JitBuilder::TypeDictionary types;
 
-   printf("Step 3: compile Call method builder\n");
-   CallMethod method(&types);
-   void *entry=0;
-   int32_t rc = compileMethodBuilder(&method, &entry);
+   void *entry = 0;
+
+   printf("Step 3: compile JitToNativeCall method builder\n");
+   JitToNativeCallMethod jitToNativeCallMethod(&types);
+   int32_t rc = compileMethodBuilder(&jitToNativeCallMethod, &entry);
    if (rc != 0)
       {
       fprintf(stderr,"FAIL: compilation error %d\n", rc);
       exit(-2);
       }
 
-   printf("Step 4: invoke compiled Call method\n");
-   CallFunctionType *call=(CallFunctionType *)entry;
-   for (int32_t n=0;n < 10;n++)
-      printf("call(%2d) = %d\n", n, call(n));
+   CallFunctionType2Arg *jitToNativeMethod = (CallFunctionType2Arg*)entry;
 
-   printf("Step 5: compile ComputedCall method builder\n");
-   ComputedCallMethod computedCallMethod(&types);
-   rc = compileMethodBuilder(&computedCallMethod, &entry);
+   printf("Step 4: compile JitToNativeComputedCall method builder\n");
+   JitToNativeComputedCallMethod jitToNativeComputedCallMethod(&types);
+   rc = compileMethodBuilder(&jitToNativeComputedCallMethod, &entry);
    if (rc != 0)
       {
       fprintf(stderr,"FAIL: compilation error %d\n", rc);
       exit(-2);
       }
 
-   printf("Step 6: invoke compiled ComputedCall method\n");
-   call=(CallFunctionType *)entry;
-   for (int32_t n=0;n < 10;n++)
-      printf("call(%2d) = %d\n", n, call(n));
+   CallFunctionType2Arg *jitToNativeComputedMethod = (CallFunctionType2Arg*)entry;
 
-   printf ("Step 7: shutdown JIT\n");
+   printf("Step 5: compile NativeToJitCall method builder\n");
+   NativeToJitCallMethod nativeToJitCallMethod(&types);
+   rc = compileMethodBuilder(&nativeToJitCallMethod, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   nativeToJitMethod = (CallFunctionType2Arg*)entry;
+
+   printf("Step 6: compile JitToJitCall (direct call to native) method builder\n");
+   JitToJitCallMethod jitToJitCallMethod(&types, "test_jit_to_native", (void *)jitToNativeMethod);
+   rc = compileMethodBuilder(&jitToJitCallMethod, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   CallFunctionType1Arg *jitToJitMethod = (CallFunctionType1Arg *)entry;
+
+   printf("Step 7: invoke compiled JitToJitCall (direct call to native) method\n");
+   for (int32_t n = 0;n < 10; n++)
+      printf("jitToJitMethod(%d) = %d\n", n, jitToJitMethod(n));
+
+   printf("Step 8: compile JitToJitCall (computed/indirect call to native) method builder\n");
+   JitToJitCallMethod jitToJitComputedCallMethod(&types, "test_jit_to_native_computed", (void *)jitToNativeComputedMethod);
+   rc = compileMethodBuilder(&jitToJitComputedCallMethod, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   CallFunctionType1Arg *jitToJitComputedMethod = (CallFunctionType1Arg *)entry;
+
+   printf("Step 9: invoke compiled JitToJitCall (computed/indirect call to native) method\n");
+   for (int32_t n = 0;n < 10; n++)
+      printf("jitToJitComputedMethod(%d) = %d\n", n, jitToJitComputedMethod(n));
+
+   printf ("Step 10: shutdown JIT\n");
    shutdownJit();
 
    printf("PASS\n");

--- a/jitbuilder/release/cpp/samples/Call.hpp
+++ b/jitbuilder/release/cpp/samples/Call.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/cpp/samples/Call.hpp
+++ b/jitbuilder/release/cpp/samples/Call.hpp
@@ -26,20 +26,37 @@
 
 #include "JitBuilder.hpp"
 
-typedef int32_t (CallFunctionType)(int32_t);
+typedef int32_t (CallFunctionType1Arg)(int32_t);
+typedef int32_t (CallFunctionType2Arg)(int32_t, int32_t);
 
-class CallMethod : public OMR::JitBuilder::MethodBuilder
+class JitToNativeCallMethod : public OMR::JitBuilder::MethodBuilder
    {
    public:
-   CallMethod(OMR::JitBuilder::TypeDictionary *types);
+   JitToNativeCallMethod(OMR::JitBuilder::TypeDictionary *types);
    virtual bool buildIL();
    };
 
-class ComputedCallMethod : public OMR::JitBuilder::MethodBuilder
+class JitToNativeComputedCallMethod : public OMR::JitBuilder::MethodBuilder
    {
    public:
-   ComputedCallMethod(OMR::JitBuilder::TypeDictionary *types);
+   JitToNativeComputedCallMethod(OMR::JitBuilder::TypeDictionary *types);
    virtual bool buildIL();
+   };
+
+class NativeToJitCallMethod : public OMR::JitBuilder::MethodBuilder
+   {
+   public:
+   NativeToJitCallMethod(OMR::JitBuilder::TypeDictionary *types);
+   virtual bool buildIL();
+   };
+
+class JitToJitCallMethod : public OMR::JitBuilder::MethodBuilder
+   {
+   public:
+   JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, const char *jitMethodName, void *entry);
+   virtual bool buildIL();
+
+   const char *jitMethodName;
    };
 
 #endif // !defined(CALL_INCL)

--- a/jitbuilder/release/cpp/samples/Mandelbrot.cpp
+++ b/jitbuilder/release/cpp/samples/Mandelbrot.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/cpp/samples/Mandelbrot.cpp
+++ b/jitbuilder/release/cpp/samples/Mandelbrot.cpp
@@ -294,7 +294,6 @@ MandelbrotMethod::buildIL()
    return true;
    }
 
-
 #define max(a,b) ((a)>(b)?(a):(b))
 
 int
@@ -302,10 +301,10 @@ main(int argc, char *argv[])
    {
    if (argc < 2)
       {
-      fprintf(stderr, "Usage: mandelbrot <N> [output file name]\n");
+      fprintf(stderr, "Usage: mandelbrot <N> [output file name in PPM format]\n");
       exit(-1);
       }
-   const int N=max(0, (argc > 1) ? atoi(argv[1]) : 0);
+   const int N = max(0, (argc > 1) ? atoi(argv[1]) : 0);
 
    printf("Step 1: initialize JIT\n");
    bool initialized = initializeJit();
@@ -320,7 +319,7 @@ main(int argc, char *argv[])
 
    printf("Step 3: compile method builder\n");
    MandelbrotMethod mandelbrotMethod(&types);
-   void *entry=0;
+   void *entry = 0;
    int32_t rc = compileMethodBuilder(&mandelbrotMethod, &entry);
    if (rc != 0)
       {
@@ -340,6 +339,12 @@ main(int argc, char *argv[])
 
    printf("Step 5: output result buffer\n");
    FILE *out = (argc == 3) ? fopen(argv[2], "wb") : stdout;
+
+   // The file we generate here is in the PPM image format which has a simple header describing how to interpret the
+   // buffer. This string needs to be encoded as ASCII in the file generated, however on platforms such as z/OS whose
+   // native encoding is not ASCII this is problematic.
+   //
+   // TODO (#4901): Use the port library to output the header bytes for PPM image file format
    fprintf(out, "P4\n%u %u\n", max_x, height);
    fwrite(buffer, size, 1, out);
 


### PR DESCRIPTION
This PR contains a series of commits which enables full support for JIT <-> native calls on z/OS. The change appears rather large due to the amount of test code that was enhanced to validate the support. There was also other issues encountered during development which were fixed. Please see the commit descriptions for details on what each change does and why.

The "meat" of the support can be found in the two commits titled:

- "Create the XPLINK Function Descriptor for OMR compiled bodies on z/OS"
- "Use method symbol address to get the entry point in Tril and JitBuilder"

These two commits give us the support and are not very large changes all in all.

Issue: #4719