### PR TITLE
RISC-V: define OMR_GC_FULL_POINTERS in CI scripts when compiling nati…

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-linux_riscv64_cross
+++ b/buildenv/jenkins/jobs/builds/Build-linux_riscv64_cross
@@ -40,6 +40,7 @@ pipeline {
                                     -DOMR_OMRSIG=OFF \
                                     -DOMR_GC=OFF \
                                     -DOMR_FVTEST=OFF \
+                                    -DOMR_GC_FULL_POINTERS=ON \
                                     .."""
 
 

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_riscv64_cross
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_riscv64_cross
@@ -25,6 +25,7 @@ pipeline {
                                     -DOMR_OMRSIG=OFF \
                                     -DOMR_GC=OFF \
                                     -DOMR_FVTEST=OFF \
+                                    -DOMR_GC_FULL_POINTERS=ON \
                                     .."""
 
                         echo 'Compile...'


### PR DESCRIPTION
…ve tools

Since commit cb146bd9, OMR requires OMR_GC_FULL_POINTERS or OMR_GC_COMPRESSED_POINTERS
to be defined. This commit defines OMR_GC_FULL_POINTERS when compiling native
tools for cross-compilation in CI scripts so the compilation proceeds.

This commit fixes broken cross-compilation CI job.