### PR TITLE
Expand omrvmemtest on Z/OS

### DIFF
--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -3792,6 +3792,84 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 									  requestedPageSize, requestedPageFlags, isSizeSupported);
 	}
 
+	portTestEnv->log("\nCase %d: Default large page when pageable is preferred. \n", caseIndex++);
+	if (0 == defaultLargePageSize) {
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
+	} else {
+		mode = 0;
+		requestedPageSize = 0;
+		requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE;
+		PRINT_FIND_VALID_PAGE_SIZE_INPUT(mode, requestedPageSize, requestedPageFlags);
+
+		omrvmem_default_large_page_size_ex(mode, &requestedPageSize, &requestedPageFlags);
+
+		expectedPageSize = ONE_MB;
+		expectedPageFlags = oneMBPageable ? OMRPORT_VMEM_PAGE_FLAG_PAGEABLE : OMRPORT_VMEM_PAGE_FLAG_FIXED;
+
+		verifyFindValidPageSizeOutput(
+			portLibrary, testName, expectedPageSize, expectedPageFlags,
+			FALSE, requestedPageSize, requestedPageFlags, FALSE);
+	}
+
+	portTestEnv->log("\nCase %d: Default large page when mode is OMRPORT_VMEM_MEMORY_MODE_EXECUTE.\n", caseIndex++);
+	if (0 == defaultLargePageSize) {
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
+	} else {
+		mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
+		requestedPageSize = 0;
+		requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE;
+		PRINT_FIND_VALID_PAGE_SIZE_INPUT(mode, requestedPageSize, requestedPageFlags);
+
+		omrvmem_default_large_page_size_ex(mode, &requestedPageSize, &requestedPageFlags);
+
+		expectedPageSize = oneMBPageable ? ONE_MB : 0;
+		expectedPageFlags = oneMBPageable ? OMRPORT_VMEM_PAGE_FLAG_PAGEABLE : OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
+
+		verifyFindValidPageSizeOutput(
+			portLibrary, testName, expectedPageSize, expectedPageFlags,
+			FALSE, requestedPageSize, requestedPageFlags, FALSE);
+	}
+
+	portTestEnv->log("\nCase %d: Verify 1M large pages when pageable is preferred.\n", caseIndex++);
+	if (0 == defaultLargePageSize) {
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
+	} else {
+		mode = 0;
+		requestedPageSize = ONE_MB;
+		requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE;
+		PRINT_FIND_VALID_PAGE_SIZE_INPUT(mode, requestedPageSize, requestedPageFlags);
+
+		omrvmem_find_valid_page_size(mode, &requestedPageSize, &requestedPageFlags, &isSizeSupported);
+
+		expectedPageSize = ONE_MB;
+		expectedPageFlags = oneMBPageable ? OMRPORT_VMEM_PAGE_FLAG_PAGEABLE : OMRPORT_VMEM_PAGE_FLAG_FIXED;
+		expectedIsSizeSupported = TRUE;
+
+		verifyFindValidPageSizeOutput(
+			portLibrary, testName, expectedPageSize, expectedPageFlags,
+			expectedIsSizeSupported, requestedPageSize, requestedPageFlags, isSizeSupported);
+	}
+
+	portTestEnv->log("\nCase %d: Verify 1M large pages when mode is OMRPORT_VMEM_MEMORY_MODE_EXECUTE.\n", caseIndex++);
+	if (0 == defaultLargePageSize) {
+		portTestEnv->log("Skip this test as the configuration does not support default large page size\n");
+	} else {
+		mode = OMRPORT_VMEM_MEMORY_MODE_EXECUTE;
+		requestedPageSize = ONE_MB;
+		requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE;
+		PRINT_FIND_VALID_PAGE_SIZE_INPUT(mode, requestedPageSize, requestedPageFlags);
+
+		omrvmem_find_valid_page_size(mode, &requestedPageSize, &requestedPageFlags, &isSizeSupported);
+
+		expectedPageSize = oneMBPageable ? ONE_MB : FOUR_KB;
+		expectedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
+		expectedIsSizeSupported = oneMBPageable;
+
+		verifyFindValidPageSizeOutput(
+			portLibrary, testName, expectedPageSize, expectedPageFlags,
+			expectedIsSizeSupported, requestedPageSize, requestedPageFlags, isSizeSupported);
+	}
+
 #endif /* defined(OMR_ENV_DATA64) */
 
 _exit:


### PR DESCRIPTION
Expand omrvmemtest on Z/OS

Expanding the current tests to add cases where `OMRPORT_VMEM_PAGE_FLAG_PREFER_PAGEABLE` may be used.

These test cases include:

1) Default large page when `pageable` is preferred
This test will return a `pageable 1M` default large page when available, and 1M fixed pages otherwise.
If no large pages are configured an invalid large page state will be set.

2) Default large page when `pageable` is preferred, and mode is `OMRPORT_VMEM_MEMORY_MODE_EXECUTE`
This test will return a `pageable 1M` default large page when available, otherwise an invalid large page state will be set.

3) Verify 1M large pages when `pageable` is preferred
This test will verify that 1M large pages are supported if there exists a `pageable`, or fixed `1M pages` are available.

4) Verify 1M large pages when `pageable` is preferred, and mode is `OMRPORT_VMEM_MEMORY_MODE_EXECUTE`
This test will verify that 1M large pages are supported only if `1M pageable` is configured.

For more info on `OMRPORT_VMEM_PAGE_FLAG_PREFER_PAGEABLE`, see Pull Request https://github.com/eclipse/omr/pull/4762.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>