### PR TITLE
Fix addrinfo element extraction function name in OMRSOCK API

### DIFF
--- a/fvtest/porttest/omrsockTest.cpp
+++ b/fvtest/porttest/omrsockTest.cpp
@@ -78,10 +78,10 @@ TEST(PortSockTest, library_function_pointers_not_null)
 
 	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo_create_hints, (void *)NULL);
 	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo, (void *)NULL);
-	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo_length, (void *)NULL);
-	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo_family, (void *)NULL);
-	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo_socktype, (void *)NULL);
-	EXPECT_NE(OMRPORTLIB->sock_getaddrinfo_protocol, (void *)NULL);
+	EXPECT_NE(OMRPORTLIB->sock_addrinfo_length, (void *)NULL);
+	EXPECT_NE(OMRPORTLIB->sock_addrinfo_family, (void *)NULL);
+	EXPECT_NE(OMRPORTLIB->sock_addrinfo_socktype, (void *)NULL);
+	EXPECT_NE(OMRPORTLIB->sock_addrinfo_protocol, (void *)NULL);
 	EXPECT_NE(OMRPORTLIB->sock_freeaddrinfo, (void *)NULL);
 	EXPECT_NE(OMRPORTLIB->sock_socket, (void *)NULL);
 	EXPECT_NE(OMRPORTLIB->sock_bind, (void *)NULL);
@@ -128,47 +128,47 @@ TEST(PortSockTest, create_hints_and_element_extraction)
 	/* Testing invalid arguments: Pointer to OMRAddrInfoNode that is NULL */
 
 	int32_t rc;
-	rc = OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, NULL, &length);
+	rc = OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, NULL, &length);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, NULL, &family, 0);
+	rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, NULL, 0, &family);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, NULL, &sockType, 0);
+	rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, NULL, 0, &sockType);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, NULL, &protocol, 0);
+	rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, NULL, 0, &protocol);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
 	/* Testing invalid arguments: Index is bigger than the length when querying */
 
-	rc = OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, hints, &length);
+	rc = OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, hints, &length);
 	EXPECT_EQ(rc, 0);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, hints, &family, length);
+	rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, hints, length, &family);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, hints, &sockType, length);
+	rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, hints, length, &sockType);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, hints, &protocol, length);
+	rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, hints, length, &protocol);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
 	/* Get and verify elements of the newly created hints. */
 
-	rc = OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, hints, &length);
+	rc = OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, hints, &length);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(length, 1);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, hints, &family, 0);
+	rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, hints, 0, &family);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(family, hintsFamily);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, hints, &sockType, 0);
+	rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, hints, 0, &sockType);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(sockType, hintsSockType);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, hints, &protocol, 0);
+	rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, hints, 0, &protocol);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(protocol, hintsProtocol);
 
@@ -179,19 +179,19 @@ TEST(PortSockTest, create_hints_and_element_extraction)
 
 	OMRPORTLIB->sock_getaddrinfo_create_hints(OMRPORTLIB, &hints, hintsFamily, hintsSockType, hintsProtocol, hintsFlags);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, hints, &length);
+	rc = OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, hints, &length);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(length, 1);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, hints, &family, 0);
+	rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, hints, 0, &family);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(family, hintsFamily);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, hints, &sockType, 0);
+	rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, hints, 0, &sockType);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(sockType, hintsSockType);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, hints, &protocol, 0);
+	rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, hints, 0, &protocol);
 	EXPECT_EQ(rc, 0);
 	EXPECT_EQ(protocol, hintsProtocol);
 
@@ -199,13 +199,13 @@ TEST(PortSockTest, create_hints_and_element_extraction)
 
 	hints->length = 5;
 
-	rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, hints, &family, 3);
+	rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, hints, 3, &family);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, hints, &sockType, 3);
+	rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, hints, 3, &sockType);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 
-	rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, hints, &protocol, 3);
+	rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, hints, 3, &protocol);
 	EXPECT_EQ(rc, OMRPORT_ERROR_INVALID_ARGUMENTS);
 }
 
@@ -258,19 +258,19 @@ TEST(PortSockTest, getaddrinfo_and_freeaddrinfo)
 	rc = OMRPORTLIB->sock_getaddrinfo(OMRPORTLIB, (char *)"localhost", NULL, hints, &result);
 	ASSERT_EQ(rc, 0);
 
-	OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, &result, &length);
+	OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, &result, &length);
 	ASSERT_NE(length, 0);
 
 	for (uint32_t i = 0; i < length; i++) {
-		rc = OMRPORTLIB->sock_getaddrinfo_family(OMRPORTLIB, &result, &family, i);
+		rc = OMRPORTLIB->sock_addrinfo_family(OMRPORTLIB, &result, i, &family);
 		EXPECT_EQ(rc, 0);
 		EXPECT_EQ(family, hintsFamily);
 
-		rc = OMRPORTLIB->sock_getaddrinfo_socktype(OMRPORTLIB, &result, &sockType, i);
+		rc = OMRPORTLIB->sock_addrinfo_socktype(OMRPORTLIB, &result, i, &sockType);
 		EXPECT_EQ(rc, 0);
 		EXPECT_EQ(sockType, hintsSockType);
 
-		rc = OMRPORTLIB->sock_getaddrinfo_protocol(OMRPORTLIB, &result, &protocol, i);
+		rc = OMRPORTLIB->sock_addrinfo_protocol(OMRPORTLIB, &result, i, &protocol);
 		EXPECT_EQ(rc, 0);
 	}
 	
@@ -280,7 +280,7 @@ TEST(PortSockTest, getaddrinfo_and_freeaddrinfo)
 	rc = OMRPORTLIB->sock_getaddrinfo(OMRPORTLIB, (char *)"localhost", NULL, NULL, &result);
 	ASSERT_EQ(rc, 0);
 
-	OMRPORTLIB->sock_getaddrinfo_length(OMRPORTLIB, &result, &length);
+	OMRPORTLIB->sock_addrinfo_length(OMRPORTLIB, &result, &length);
 	ASSERT_NE(length, 0);
 
 	OMRPORTLIB->sock_freeaddrinfo(OMRPORTLIB, &result);

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -2115,14 +2115,14 @@ typedef struct OMRPortLibrary {
 	int32_t (*sock_getaddrinfo_create_hints)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int32_t family, int32_t socktype, int32_t protocol, int32_t flags) ;
 	/** see @ref omrsock.c::omrsock_getaddrinfo "omrsock_getaddrinfo"*/
 	int32_t (*sock_getaddrinfo)(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result) ;
-	/** see @ref omrsock.c::omrsock_getaddrinfo_length "omrsock_getaddrinfo_length"*/
-	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length) ;
-	/** see @ref omrsock.c::omrsock_getaddrinfo_family "omrsock_getaddrinfo_family"*/
-	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, uint32_t index) ;
-	/** see @ref omrsock.c::omrsock_getaddrinfo_socktype "omrsock_getaddrinfo_socktype"*/
-	int32_t (*sock_getaddrinfo_socktype)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, uint32_t index) ;
-	/** see @ref omrsock.c::omrsock_getaddrinfo_protocol "omrsock_getaddrinfo_protocol"*/
-	int32_t (*sock_getaddrinfo_protocol)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, uint32_t index) ;
+	/** see @ref omrsock.c::omrsock_addrinfo_length "omrsock_addrinfo_length"*/
+	int32_t (*sock_addrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *result) ;
+	/** see @ref omrsock.c::omrsock_addrinfo_family "omrsock_addrinfo_family"*/
+	int32_t (*sock_addrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result) ;
+	/** see @ref omrsock.c::omrsock_addrinfo_socktype "omrsock_addrinfo_socktype"*/
+	int32_t (*sock_addrinfo_socktype)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result) ;
+	/** see @ref omrsock.c::omrsock_addrinfo_protocol "omrsock_addrinfo_protocol"*/
+	int32_t (*sock_addrinfo_protocol)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result) ;
 	/** see @ref omrsock.c::omrsock_freeaddrinfo "omrsock_freeaddrinfo"*/
 	int32_t (*sock_freeaddrinfo)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle) ;
 	/** see @ref omrsock.c::omrsock_socket "omrsock_socket"*/
@@ -2596,10 +2596,10 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsock_startup() privateOmrPortLibrary->sock_startup(privateOmrPortLibrary)
 #define omrsock_getaddrinfo_create_hints(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_getaddrinfo_create_hints(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
 #define omrsock_getaddrinfo(param1,param2,param3,param4) privateOmrPortLibrary->sock_getaddrinfo(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
-#define omrsock_getaddrinfo_length(param1,param2) privateOmrPortLibrary->sock_getaddrinfo_length(privateOmrPortLibrary, (param1), (param2))
-#define omrsock_getaddrinfo_family(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_family(privateOmrPortLibrary, (param1), (param2), (param3))
-#define omrsock_getaddrinfo_socktype(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_socktype(privateOmrPortLibrary, (param1), (param2), (param3))
-#define omrsock_getaddrinfo_protocol(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_protocol(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_addrinfo_length(param1,param2) privateOmrPortLibrary->sock_addrinfo_length(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_addrinfo_family(param1,param2,param3) privateOmrPortLibrary->sock_addrinfo_family(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_addrinfo_socktype(param1,param2,param3) privateOmrPortLibrary->sock_addrinfo_socktype(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_addrinfo_protocol(param1,param2,param3) privateOmrPortLibrary->sock_addrinfo_protocol(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsock_freeaddrinfo(param1) privateOmrPortLibrary->sock_freeaddrinfo(privateOmrPortLibrary, (param1))
 #define omrsock_socket(param1, param2, param3, param4) privateOmrPortLibrary->sock_socket(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
 #define omrsock_bind(param1,param2) privateOmrPortLibrary->sock_bind(privateOmrPortLibrary, (param1), (param2))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -307,10 +307,10 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsock_startup, /* sock_startup */
 	omrsock_getaddrinfo_create_hints, /* sock_getaddrinfo_create_hints */
 	omrsock_getaddrinfo, /* sock_getaddrinfo */
-	omrsock_getaddrinfo_length, /* sock_getaddrinfo_length */
-	omrsock_getaddrinfo_family, /* sock_getaddrinfo_family */
-	omrsock_getaddrinfo_socktype, /* sock_getaddrinfo_socktype */
-	omrsock_getaddrinfo_protocol, /* sock_getaddrinfo_protocol */
+	omrsock_addrinfo_length, /* sock_addrinfo_length */
+	omrsock_addrinfo_family, /* sock_addrinfo_family */
+	omrsock_addrinfo_socktype, /* sock_addrinfo_socktype */
+	omrsock_addrinfo_protocol, /* sock_addrinfo_protocol */
 	omrsock_freeaddrinfo, /* sock_freeaddrinfo */
 	omrsock_socket, /* sock_socket */
 	omrsock_bind, /* sock_bind */

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -73,10 +73,10 @@ omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_add
  * Answers a list of addresses as an opaque struct in "result".
  * 
  * Use the following functions to extract the details:
- * @arg @ref omrsock_getaddrinfo_length
- * @arg @ref omrsock_getaddrinfo_family
- * @arg @ref omrsock_getaddrinfo_socktype
- * @arg @ref omrsock_getaddrinfo_protocol
+ * @arg @ref omrsock_addrinfo_length
+ * @arg @ref omrsock_addrinfo_family
+ * @arg @ref omrsock_addrinfo_socktype
+ * @arg @ref omrsock_addrinfo_protocol
  * @param[in] portLibrary The port library.
  * @param[in] node The name of the host in either host name format or in IPv4 or IPv6 accepted 
  * notations.
@@ -102,13 +102,13 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
  *
  * @param[in] portLibrary The port library.
  * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
- * @param[out] length The number of results.
+ * @param[out] result The number of results.
  *
  * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
  * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
+omrsock_addrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
@@ -119,14 +119,14 @@ omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
  *
  * @param[in] portLibrary The port library.
  * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
- * @param[out] family The family at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] result The family at "index".
  *
  * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
  * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, uint32_t index)
+omrsock_addrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
@@ -137,14 +137,14 @@ omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
  *
  * @param[in] portLibrary The port library.
  * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
- * @param[out] socktype The socket type at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] result The socket type at "index".
  *
  * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
  * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
-omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, uint32_t index)
+omrsock_addrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
@@ -155,14 +155,14 @@ omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinf
  *
  * @param[in] portLibrary The port library.
  * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
- * @param[out] protocol The protocol family at "index".
  * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] result The protocol family at "index".
  *
  * @return 0, if no errors occurred, otherwise return an error. Error code values returned are
  * \arg OMRPORT_ERROR_INVALID_ARGUMENTS when handle or index arguments are invalid.
  */
 int32_t
-omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, uint32_t index)
+omrsock_addrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -622,13 +622,13 @@ omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_add
 extern J9_CFUNC int32_t
 omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length);
+omrsock_addrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *result);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, uint32_t index);
+omrsock_addrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index,int32_t *result);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, uint32_t index);
+omrsock_addrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, uint32_t index);
+omrsock_addrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index,int32_t *result);
 extern J9_CFUNC int32_t
 omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -243,18 +243,18 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 }
 
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
+omrsock_addrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *result)
 {
 	if (NULL == handle) {
 		return OMRPORT_ERROR_INVALID_ARGUMENTS;
 	}
 
-	*length = handle->length;
+	*result = handle->length;
 	return 0;
 }
 
 int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, uint32_t index)
+omrsock_addrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {	
 	omr_os_addrinfo *info = NULL;
 	uint32_t i = 0;
@@ -272,12 +272,12 @@ omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
 		}
 	}
 
-	*family = get_omr_family(info->ai_family);
+	*result = get_omr_family(info->ai_family);
 	return 0;
 }
 
 int32_t
-omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, uint32_t index)
+omrsock_addrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	omr_os_addrinfo *info = NULL;
 	uint32_t i = 0;
@@ -295,12 +295,12 @@ omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinf
 		}
 	}
 
-	*socktype = get_omr_socktype(info->ai_socktype);
+	*result = get_omr_socktype(info->ai_socktype);
 	return 0;
 }
 
 int32_t
-omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, uint32_t index)
+omrsock_addrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	omr_os_addrinfo *info = NULL;
 	uint32_t i = 0;
@@ -318,7 +318,7 @@ omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinf
 		}
 	}
 
-	*protocol = get_omr_protocol(info->ai_protocol);
+	*result = get_omr_protocol(info->ai_protocol);
 	return 0;
 }
 

--- a/port/win32/omrsock.c
+++ b/port/win32/omrsock.c
@@ -51,25 +51,25 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 }
 
 int32_t
-omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *length)
+omrsock_addrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
 
 int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, uint32_t index)
+omrsock_addrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
 
 int32_t
-omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, uint32_t index)
+omrsock_addrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
 
 int32_t
-omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, uint32_t index)
+omrsock_addrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, uint32_t index, int32_t *result)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }


### PR DESCRIPTION
- Small fix to change element extraction function name in OMRSOCK API. The reason for change is to clarify what these function do: to access elements of addrinfo stuct within OMRAddrInfoNode.
- The commits are grouped by groups of related files.

Issue: #4102  