### PR TITLE
Remove definitions of deprecated unsigned IL Opcodes of Equality Compare and branch

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -468,14 +468,14 @@ OMR::ARM64::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *c
    return icmpHelper(node, TR::CC_HI, false, cg);
    }
 
-// also handles lucmpeq, acmpeq
+// also handles  acmpeq
 TR::Register *
 OMR::ARM64::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_EQ, true, cg);
    }
 
-// also handles lucmpne, acmpne
+// also handles acmpne
 TR::Register *
 OMR::ARM64::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -285,7 +285,7 @@ OMR::ARM64::TreeEvaluator::ifiucmpleEvaluator(TR::Node *node, TR::CodeGenerator 
    return NULL;
    }
 
-// also handles iflucmpeq, ifacmpeq
+// also handles ifacmpeq
 TR::Register *
 OMR::ARM64::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -263,8 +263,6 @@ public:
 	static TR::Register *icmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *icmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *icmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -388,8 +388,6 @@ public:
 	static TR::Register *ifbcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifbucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifbucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -398,8 +398,6 @@ public:
 	static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifsucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -348,8 +348,6 @@ public:
 	static TR::Register *iflcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iflucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iflucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -317,8 +317,6 @@ public:
 	static TR::Register *bcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -273,8 +273,6 @@ public:
 	static TR::Register *lcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -338,8 +338,6 @@ public:
 	static TR::Register *ificmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ificmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ificmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifiucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifiucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -323,8 +323,6 @@ public:
 	static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -370,8 +370,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifscmpgeEvaluator ,	// TR::ifscmpge		// short integer compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifscmpgtEvaluator ,	// TR::ifscmpgt		// short integer compare and branch if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifscmpleEvaluator ,	// TR::ifscmple		// short integer compare and branch if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifsucmpeqEvaluator ,	// TR::ifsucmpeq		// char compare and branch if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifsucmpneEvaluator ,	// TR::ifsucmpne		// char compare and branch if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifsucmpltEvaluator ,	// TR::ifsucmplt		// char compare and branch if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifsucmpgeEvaluator ,	// TR::ifsucmpge		// char compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifsucmpgtEvaluator ,	// TR::ifsucmpgt		// char compare and branch if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -289,8 +289,6 @@
     TR::TreeEvaluator::icmpgeEvaluator, // TR::bcmpge		// byte compare if greater than or equal
     TR::TreeEvaluator::icmpgtEvaluator, // TR::bcmpgt		// byte compare if greater than
     TR::TreeEvaluator::icmpleEvaluator, // TR::bcmple		// byte compare if less than or equal
-    TR::TreeEvaluator::icmpeqEvaluator, // TR::bucmpeq		// unsigned byte compare if equal
-    TR::TreeEvaluator::icmpneEvaluator, // TR::bucmpne		// unsigned byte compare if not equal
     TR::TreeEvaluator::iucmpltEvaluator, // TR::bucmplt		// unsigned byte compare if less than
     TR::TreeEvaluator::iucmpgeEvaluator, // TR::bucmpge		// unsigned byte compare if greater than or equal
     TR::TreeEvaluator::iucmpgtEvaluator, // TR::bucmpgt		// unsigned byte compare if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -310,8 +310,6 @@
     TR::TreeEvaluator::ificmpgeEvaluator, // TR::ificmpge		// integer compare and branch if greater than or equal
     TR::TreeEvaluator::ificmpgtEvaluator, // TR::ificmpgt		// integer compare and branch if greater than
     TR::TreeEvaluator::ificmpleEvaluator, // TR::ificmple		// integer compare and branch if less than or equal
-    TR::TreeEvaluator::ificmpeqEvaluator, // TR::ifiucmpeq		// unsigned integer compare and branch if equal
-    TR::TreeEvaluator::ificmpneEvaluator, // TR::ifiucmpne		// unsigned integer compare and branch if not equal
     TR::TreeEvaluator::ifiucmpltEvaluator, // TR::ifiucmplt		// unsigned integer compare and branch if less than
     TR::TreeEvaluator::ifiucmpgeEvaluator, // TR::ifiucmpge		// unsigned integer compare and branch if greater than or equal
     TR::TreeEvaluator::ifiucmpgtEvaluator, // TR::ifiucmpgt		// unsigned integer compare and branch if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -245,8 +245,6 @@
     TR::TreeEvaluator::lcmpgeEvaluator, // TR::lcmpge		// long compare if greater than or equal
     TR::TreeEvaluator::lcmpgtEvaluator, // TR::lcmpgt		// long compare if greater than
     TR::TreeEvaluator::lcmpleEvaluator, // TR::lcmple		// long compare if less than or equal
-    TR::TreeEvaluator::lcmpeqEvaluator, // TR::lucmpeq		// unsigned long compare if equal
-    TR::TreeEvaluator::lcmpneEvaluator, // TR::lucmpne		// unsigned long compare if not equal
     TR::TreeEvaluator::lucmpltEvaluator, // TR::lucmplt		// unsigned long compare if less than
     TR::TreeEvaluator::lucmpgeEvaluator, // TR::lucmpge		// unsigned long compare if greater than or equal
     TR::TreeEvaluator::lucmpgtEvaluator, // TR::lucmpgt		// unsigned long compare if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -295,8 +295,6 @@
     TR::TreeEvaluator::icmpgeEvaluator, // TR::scmpge		// short integer compare if greater than or equal
     TR::TreeEvaluator::icmpgtEvaluator, // TR::scmpgt		// short integer compare if greater than
     TR::TreeEvaluator::icmpleEvaluator, // TR::scmple		// short integer compare if less than or equal
-    TR::TreeEvaluator::icmpeqEvaluator, // TR::sucmpeq		// char compare if equal
-    TR::TreeEvaluator::icmpneEvaluator, // TR::sucmpne		// char compare if not equal
     TR::TreeEvaluator::iucmpltEvaluator, // TR::sucmplt		// char compare if less than
     TR::TreeEvaluator::iucmpgeEvaluator, // TR::sucmpge		// char compare if greater than or equal
     TR::TreeEvaluator::iucmpgtEvaluator, // TR::sucmpgt		// char compare if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -360,8 +360,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbcmpgeEvaluator ,	// TR::ifbcmpge		// byte compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbcmpgtEvaluator ,	// TR::ifbcmpgt		// byte compare and branch if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbcmpleEvaluator ,	// TR::ifbcmple		// byte compare and branch if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbucmpeqEvaluator ,	// TR::ifbucmpeq		// unsigned byte compare and branch if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbucmpneEvaluator ,	// TR::ifbucmpne		// unsigned byte compare and branch if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbucmpltEvaluator ,	// TR::ifbucmplt		// unsigned byte compare and branch if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbucmpgeEvaluator ,	// TR::ifbucmpge		// unsigned byte compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ifbucmpgtEvaluator ,	// TR::ifbucmpgt		// unsigned byte compare and branch if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -235,8 +235,6 @@
     TR::TreeEvaluator::icmpgeEvaluator, // TR::icmpge		// integer compare if greater than or equal
     TR::TreeEvaluator::icmpgtEvaluator, // TR::icmpgt		// integer compare if greater than
     TR::TreeEvaluator::icmpleEvaluator, // TR::icmple		// integer compare if less than or equal
-    TR::TreeEvaluator::icmpeqEvaluator, // TR::iucmpeq		// unsigned integer compare if equal
-    TR::TreeEvaluator::icmpneEvaluator, // TR::iucmpne		// unsigned integer compare if not equal
     TR::TreeEvaluator::iucmpltEvaluator, // TR::iucmplt		// unsigned integer compare if less than
     TR::TreeEvaluator::iucmpgeEvaluator, // TR::iucmpge		// unsigned integer compare if greater than or equal
     TR::TreeEvaluator::iucmpgtEvaluator, // TR::iucmpgt		// unsigned integer compare if greater than

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -320,8 +320,6 @@
     TR::TreeEvaluator::iflcmpgeEvaluator, // TR::iflcmpge		// long compare and branch if greater than or equal
     TR::TreeEvaluator::iflcmpgtEvaluator, // TR::iflcmpgt		// long compare and branch if greater than
     TR::TreeEvaluator::iflcmpleEvaluator, // TR::iflcmple		// long compare and branch if less than or equal
-    TR::TreeEvaluator::iflcmpeqEvaluator, // TR::iflucmpeq		// unsigned long compare and branch if equal
-    TR::TreeEvaluator::iflcmpneEvaluator, // TR::iflucmpne		// unsigned long compare and branch if not equal
     TR::TreeEvaluator::iflucmpltEvaluator, // TR::iflucmplt		// unsigned long compare and branch if less than
     TR::TreeEvaluator::iflucmpgeEvaluator, // TR::iflucmpge		// unsigned long compare and branch if greater than or equal
     TR::TreeEvaluator::iflucmpgtEvaluator, // TR::iflucmpgt		// unsigned long compare and branch if greater than

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -279,7 +279,6 @@ public:
    static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -347,7 +347,6 @@ public:
    static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -471,8 +471,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbcmpge
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbcmpgt
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbcmple
-   TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbucmpeq
-   TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbucmpne
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbucmplt
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbucmpge
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifbucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -406,8 +406,6 @@
    TR::TreeEvaluator::iflcmpgeEvaluator,    // TR::iflcmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,    // TR::iflcmpgt
    TR::TreeEvaluator::iflcmpleEvaluator,    // TR::iflcmple
-   TR::TreeEvaluator::iflcmpeqEvaluator,    // TR::iflucmpeq
-   TR::TreeEvaluator::iflcmpeqEvaluator,    // TR::iflucmpne
    TR::TreeEvaluator::iflucmpltEvaluator,   // TR::iflucmplt
    TR::TreeEvaluator::iflucmpgeEvaluator,   // TR::iflucmpge
    TR::TreeEvaluator::iflucmpgtEvaluator,   // TR::iflucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -374,8 +374,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::scmpge
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::scmpgt
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::scmple
-   TR::TreeEvaluator::unImpOpEvaluator,      // TR::sucmpeq
-   TR::TreeEvaluator::unImpOpEvaluator,      // TR::sucmpne
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::sucmplt
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::sucmpge
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::sucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -300,8 +300,6 @@
    TR::TreeEvaluator::lcmpgeEvaluator,      // TR::lcmpge
    TR::TreeEvaluator::lcmpgtEvaluator,      // TR::lcmpgt
    TR::TreeEvaluator::lcmpleEvaluator,      // TR::lcmple
-   TR::TreeEvaluator::lcmpeqEvaluator,      // TR::lucmpeq
-   TR::TreeEvaluator::lcmpneEvaluator,      // TR::lucmpne
    TR::TreeEvaluator::lucmpltEvaluator,     // TR::lucmplt
    TR::TreeEvaluator::lucmpgeEvaluator,     // TR::lucmpge
    TR::TreeEvaluator::lucmpgtEvaluator,     // TR::lucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -481,8 +481,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifscmpge
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifscmpgt
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifscmple
-   TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifsucmpeq
-   TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifsucmpne
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifsucmplt
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifsucmpge
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::ifsucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -395,8 +395,6 @@
    TR::TreeEvaluator::ificmpgeEvaluator,    // TR::ificmpge
    TR::TreeEvaluator::ificmpgtEvaluator,    // TR::ificmpgt
    TR::TreeEvaluator::ificmpleEvaluator,    // TR::ificmple
-   TR::TreeEvaluator::ificmpeqEvaluator,    // TR::ifiucmpeq
-   TR::TreeEvaluator::ificmpeqEvaluator,    // TR::ifiucmpne
    TR::TreeEvaluator::ifiucmpltEvaluator,   // TR::ifiucmplt
    TR::TreeEvaluator::ifiucmpgeEvaluator,   // TR::ifiucmpge
    TR::TreeEvaluator::ifiucmpgtEvaluator,   // TR::ifiucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -289,8 +289,6 @@
    TR::TreeEvaluator::icmpgeEvaluator,      // TR::icmpge
    TR::TreeEvaluator::icmpgtEvaluator,      // TR::icmpgt
    TR::TreeEvaluator::icmpleEvaluator,      // TR::icmple
-   TR::TreeEvaluator::icmpeqEvaluator,      // TR::iucmpeq
-   TR::TreeEvaluator::icmpneEvaluator,      // TR::iucmpne
    TR::TreeEvaluator::iucmpltEvaluator,     // TR::iucmplt
    TR::TreeEvaluator::iucmpgeEvaluator,     // TR::iucmpge
    TR::TreeEvaluator::iucmpgtEvaluator,     // TR::iucmpgt

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -368,8 +368,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bcmpge
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bcmpgt
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bcmple
-   TR::TreeEvaluator::unImpOpEvaluator,      // TR::bucmpeq
-   TR::TreeEvaluator::unImpOpEvaluator,      // TR::bucmpne
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bucmplt
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bucmpge
    TR::TreeEvaluator::unImpOpEvaluator,      // TR::bucmpgt

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -4630,38 +4630,6 @@
    },
 
    {
-   /* .opcode               = */ TR::ifiucmpeq,
-   /* .name                 = */ "ifiucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int32),
-   /* .swapChildrenOpCode   = */ TR::ifiucmpeq,
-   /* .reverseBranchOpCode  = */ TR::ifiucmpne,
-   /* .booleanCompareOpCode = */ TR::iucmpeq,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
-   /* .opcode               = */ TR::ifiucmpne,
-   /* .name                 = */ "ifiucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int32),
-   /* .swapChildrenOpCode   = */ TR::ifiucmpne,
-   /* .reverseBranchOpCode  = */ TR::ifiucmpeq,
-   /* .booleanCompareOpCode = */ TR::iucmpne,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::ifiucmplt,
    /* .name                 = */ "ifiucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -3590,38 +3590,6 @@
    },
 
    {
-   /* .opcode               = */ TR::lucmpeq,
-   /* .name                 = */ "lucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int64),
-   /* .swapChildrenOpCode   = */ TR::lucmpeq,
-   /* .reverseBranchOpCode  = */ TR::lucmpne,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::iflucmpeq,
-   },
-
-   {
-   /* .opcode               = */ TR::lucmpne,
-   /* .name                 = */ "lucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int64),
-   /* .swapChildrenOpCode   = */ TR::lucmpne,
-   /* .reverseBranchOpCode  = */ TR::lucmpeq,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::iflucmpne,
-   },
-
-   {
    /* .opcode               = */ TR::lucmplt,
    /* .name                 = */ "lucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -3430,38 +3430,6 @@
    },
 
    {
-   /* .opcode               = */ TR::iucmpeq,
-   /* .name                 = */ "iucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int32),
-   /* .swapChildrenOpCode   = */ TR::iucmpeq,
-   /* .reverseBranchOpCode  = */ TR::iucmpne,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifiucmpeq,
-   },
-
-   {
-   /* .opcode               = */ TR::iucmpne,
-   /* .name                 = */ "iucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int32),
-   /* .swapChildrenOpCode   = */ TR::iucmpne,
-   /* .reverseBranchOpCode  = */ TR::iucmpeq,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifiucmpne,
-   },
-
-   {
    /* .opcode               = */ TR::iucmplt,
    /* .name                 = */ "iucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -4790,38 +4790,6 @@
    },
 
    {
-   /* .opcode               = */ TR::iflucmpeq,
-   /* .name                 = */ "iflucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int64),
-   /* .swapChildrenOpCode   = */ TR::iflucmpeq,
-   /* .reverseBranchOpCode  = */ TR::iflucmpne,
-   /* .booleanCompareOpCode = */ TR::lucmpeq,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
-   /* .opcode               = */ TR::iflucmpne,
-   /* .name                 = */ "iflucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int64),
-   /* .swapChildrenOpCode   = */ TR::iflucmpne,
-   /* .reverseBranchOpCode  = */ TR::iflucmpeq,
-   /* .booleanCompareOpCode = */ TR::lucmpne,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::iflucmplt,
    /* .name                 = */ "iflucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -4294,38 +4294,6 @@
    },
 
    {
-   /* .opcode               = */ TR::bucmpeq,
-   /* .name                 = */ "bucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int8),
-   /* .swapChildrenOpCode   = */ TR::bucmpeq,
-   /* .reverseBranchOpCode  = */ TR::bucmpne,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifbucmpeq,
-   },
-
-   {
-   /* .opcode               = */ TR::bucmpne,
-   /* .name                 = */ "bucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer | ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int8),
-   /* .swapChildrenOpCode   = */ TR::bucmpne,
-   /* .reverseBranchOpCode  = */ TR::bucmpeq,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifbucmpne,
-   },
-
-   {
    /* .opcode               = */ TR::bucmplt,
    /* .name                 = */ "bucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -5590,38 +5590,6 @@
    },
 
    {
-   /* .opcode               = */ TR::ifsucmpeq,
-   /* .name                 = */ "ifsucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int16),
-   /* .swapChildrenOpCode   = */ TR::ifsucmpeq,
-   /* .reverseBranchOpCode  = */ TR::ifsucmpne,
-   /* .booleanCompareOpCode = */ TR::sucmpeq,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
-   /* .opcode               = */ TR::ifsucmpne,
-   /* .name                 = */ "ifsucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int16),
-   /* .swapChildrenOpCode   = */ TR::ifsucmpne,
-   /* .reverseBranchOpCode  = */ TR::ifsucmpeq,
-   /* .booleanCompareOpCode = */ TR::sucmpne,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::ifsucmplt,
    /* .name                 = */ "ifsucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -5430,38 +5430,6 @@
    },
 
    {
-   /* .opcode               = */ TR::ifbucmpeq,
-   /* .name                 = */ "ifbucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int8),
-   /* .swapChildrenOpCode   = */ TR::ifbucmpeq,
-   /* .reverseBranchOpCode  = */ TR::ifbucmpne,
-   /* .booleanCompareOpCode = */ TR::bucmpeq,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
-   /* .opcode               = */ TR::ifbucmpne,
-   /* .name                 = */ "ifbucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,
-   /* .properties2          = */ ILProp2::UnsignedCompare,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::NoType,
-   /* .typeProperties       = */ ILTypeProp::Unsigned,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int8),
-   /* .swapChildrenOpCode   = */ TR::ifbucmpne,
-   /* .reverseBranchOpCode  = */ TR::ifbucmpeq,
-   /* .booleanCompareOpCode = */ TR::bucmpne,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::ifbucmplt,
    /* .name                 = */ "ifbucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare | ILProp1::Branch | ILProp1::TreeTop,

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -4390,38 +4390,6 @@
    },
 
    {
-   /* .opcode               = */ TR::sucmpeq,
-   /* .name                 = */ "sucmpeq",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ ILProp3::CompareTrueIfEqual,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int16),
-   /* .swapChildrenOpCode   = */ TR::sucmpeq,
-   /* .reverseBranchOpCode  = */ TR::sucmpne,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifsucmpeq,
-   },
-
-   {
-   /* .opcode               = */ TR::sucmpne,
-   /* .name                 = */ "sucmpne",
-   /* .properties1          = */ ILProp1::BooleanCompare,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
-   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int16),
-   /* .swapChildrenOpCode   = */ TR::sucmpne,
-   /* .reverseBranchOpCode  = */ TR::sucmpeq,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::ifsucmpne,
-   },
-
-   {
    /* .opcode               = */ TR::sucmplt,
    /* .name                 = */ "sucmplt",
    /* .properties1          = */ ILProp1::BooleanCompare,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -284,8 +284,6 @@
    icmpge,   // integer compare if greater than or equal
    icmpgt,   // integer compare if greater than
    icmple,   // integer compare if less than or equal
-   iucmpeq,   // unsigned integer compare if equal
-   iucmpne,   // unsigned integer compare if not equal
    iucmplt,   // unsigned integer compare if less than
    iucmpge,   // unsigned integer compare if greater than or equal
    iucmpgt,   // unsigned integer compare if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -419,8 +419,6 @@
    ifscmpge, // short integer compare and branch if greater than or equal
    ifscmpgt, // short integer compare and branch if greater than
    ifscmple, // short integer compare and branch if less than or equal
-   ifsucmpeq, // char compare and branch if equal
-   ifsucmpne, // char compare and branch if not equal
    ifsucmplt, // char compare and branch if less than
    ifsucmpge, // char compare and branch if greater than or equal
    ifsucmpgt, // char compare and branch if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -344,8 +344,6 @@
    scmpge,   // short integer compare if greater than or equal
    scmpgt,   // short integer compare if greater than
    scmple,   // short integer compare if less than or equal
-   sucmpeq,   // char compare if equal
-   sucmpne,   // char compare if not equal
    sucmplt,   // char compare if less than
    sucmpge,   // char compare if greater than or equal
    sucmpgt,   // char compare if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -409,8 +409,6 @@
    ifbcmpge, // byte compare and branch if greater than or equal
    ifbcmpgt, // byte compare and branch if greater than
    ifbcmple, // byte compare and branch if less than or equal
-   ifbucmpeq, // unsigned byte compare and branch if equal
-   ifbucmpne, // unsigned byte compare and branch if not equal
    ifbucmplt, // unsigned byte compare and branch if less than
    ifbucmpge, // unsigned byte compare and branch if greater than or equal
    ifbucmpgt, // unsigned byte compare and branch if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -369,8 +369,6 @@
    iflcmpge, // long compare and branch if greater than or equal
    iflcmpgt, // long compare and branch if greater than
    iflcmple, // long compare and branch if less than or equal
-   iflucmpeq, // unsigned long compare and branch if equal
-   iflucmpne, // unsigned long compare and branch if not equal
    iflucmplt, // unsigned long compare and branch if less than
    iflucmpge, // unsigned long compare and branch if greater than or equal
    iflucmpgt, // unsigned long compare and branch if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -338,8 +338,6 @@
    bcmpge,   // byte compare if greater than or equal
    bcmpgt,   // byte compare if greater than
    bcmple,   // byte compare if less than or equal
-   bucmpeq,  // unsigned byte compare if equal
-   bucmpne,  // unsigned byte compare if not equal
    bucmplt,  // unsigned byte compare if less than
    bucmpge,  // unsigned byte compare if greater than or equal
    bucmpgt,  // unsigned byte compare if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -359,8 +359,6 @@
    ificmpge, // integer compare and branch if greater than or equal
    ificmpgt, // integer compare and branch if greater than
    ificmple, // integer compare and branch if less than or equal
-   ifiucmpeq, // unsigned integer compare and branch if equal
-   ifiucmpne, // unsigned integer compare and branch if not equal
    ifiucmplt, // unsigned integer compare and branch if less than
    ifiucmpge, // unsigned integer compare and branch if greater than or equal
    ifiucmpgt, // unsigned integer compare and branch if greater than

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -294,8 +294,6 @@
    lcmpge,   // long compare if greater than or equal
    lcmpgt,   // long compare if greater than
    lcmple,   // long compare if less than or equal
-   lucmpeq,   // unsigned long compare if equal
-   lucmpne,   // unsigned long compare if not equal
    lucmplt,   // unsigned long compare if less than
    lucmpge,   // unsigned long compare if greater than or equal
    lucmpgt,   // unsigned long compare if greater than

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -373,10 +373,6 @@ private:
       {
       switch (opvalue) 
          {
-         //Equality compare  
-         case TR::sucmpeq:
-         case TR::sucmpne:
-         
          //Equality compare and branch
          case TR::ifiucmpeq:
          case TR::ifiucmpne:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,8 +374,6 @@ private:
       switch (opvalue) 
          {
          //Equality compare and branch
-         case TR::ifbucmpeq:
-         case TR::ifbucmpne:
          case TR::ifsucmpeq:
          case TR::ifsucmpne:
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,8 +374,6 @@ private:
       switch (opvalue) 
          {
          //Equality compare  
-         case TR::iucmpeq:
-         case TR::iucmpne:
          case TR::lucmpeq:
          case TR::lucmpne:
          case TR::sucmpeq:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,8 +374,6 @@ private:
       switch (opvalue) 
          {
          //Equality compare and branch
-         case TR::iflucmpeq:
-         case TR::iflucmpne:
          case TR::ifbucmpeq:
          case TR::ifbucmpne:
          case TR::ifsucmpeq:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,8 +374,6 @@ private:
       switch (opvalue) 
          {
          //Equality compare and branch
-         case TR::ifiucmpeq:
-         case TR::ifiucmpne:
          case TR::iflucmpeq:
          case TR::iflucmpne:
          case TR::ifbucmpeq:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -373,9 +373,7 @@ private:
       {
       switch (opvalue) 
          {
-         //Equality compare
-         case TR::bucmpeq:
-         case TR::bucmpne:   
+         //Equality compare  
          case TR::iucmpeq:
          case TR::iucmpne:
          case TR::lucmpeq:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -373,10 +373,6 @@ private:
       {
       switch (opvalue) 
          {
-         //Equality compare and branch
-         case TR::ifsucmpeq:
-         case TR::ifsucmpne:
-
          //Constant
          case TR::buconst:
          case TR::iuconst:

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,8 +374,6 @@ private:
       switch (opvalue) 
          {
          //Equality compare  
-         case TR::lucmpeq:
-         case TR::lucmpne:
          case TR::sucmpeq:
          case TR::sucmpne:
          

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1765,7 +1765,7 @@ TR_Arraytranslate::checkStore(TR::Node * storeNode)
 
 //Break tree should look as follows:
 //
-//ifsucmpeq --> block <no-stop>
+//ifscmpeq --> block <no-stop>
 //  ==>icload at <translate-char>
 //  cconst <termination char>
 //-or-
@@ -2455,7 +2455,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //                    iconst -16
    //            iconst 2
    //          iconst -16
-   //ifsucmpne --> block <no-stop>
+   //ifscmpne --> block <no-stop>
    //  ==>icload at <translate-char>
    //  cconst <termination char>
    //BBEnd <load-char>
@@ -2505,7 +2505,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //                    iconst -16
    //            iconst 2
    //          iconst -16
-   //ifsucmpeq --> block <escape-block>
+   //ifscmpeq --> block <escape-block>
    //  ==>icload at <translate-char>
    //  cconst <termination char>
    //BBEnd <load-char>

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15426,48 +15426,6 @@ TR::Node *scmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
    return node;
    }
 
-TR::Node *sucmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
-   {
-   simplifyChildren(node, block, s);
-
-   TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
-
-   if (firstChild == secondChild)
-      {
-      foldIntConstant(node, 1, s, true /* anchorChildren */);
-      return node;
-      }
-   if (firstChild->getOpCode().isLoadConst() && secondChild->getOpCode().isLoadConst())
-      {
-      foldIntConstant(node, firstChild->getConst<uint16_t>()==secondChild->getConst<uint16_t>(), s, false /* !anchorChildren*/);
-      return node;
-      }
-
-   orderChildren(node, firstChild, secondChild, s);
-   return node;
-   }
-
-TR::Node *sucmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
-   {
-   simplifyChildren(node, block, s);
-
-   TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
-
-   if (firstChild == secondChild)
-      {
-      foldIntConstant(node, 0, s, true /* anchorChildren */);
-      return node;
-      }
-   if (firstChild->getOpCode().isLoadConst() && secondChild->getOpCode().isLoadConst())
-      {
-      foldIntConstant(node, firstChild->getConst<uint16_t>()!=secondChild->getConst<uint16_t>(), s, false /* !anchorChildren*/);
-      return node;
-      }
-
-   orderChildren(node, firstChild, secondChild, s);
-   return node;
-   }
-
 TR::Node *sucmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
    simplifyChildren(node, block, s);

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -196,8 +196,6 @@ TR::Node * scmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 TR::Node * scmpleSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * scmpgtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * scmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * sucmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * sucmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * sucmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * sucmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * sucmpgtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -258,8 +258,6 @@
    lcmpgeSimplifier,        // TR::lcmpge
    lcmpgtSimplifier,        // TR::lcmpgt
    lcmpleSimplifier,        // TR::lcmple
-   lcmpeqSimplifier,        // TR::lucmpeq
-   lcmpneSimplifier,        // TR::lucmpne
    lucmpltSimplifier,       // TR::lucmplt
    lucmpgeSimplifier,       // TR::lucmpge
    lucmpgtSimplifier,       // TR::lucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -373,8 +373,6 @@
    ifCmpWithEqualitySimplifier,     // TR::ifbcmpge
    ifCmpWithoutEqualitySimplifier,  // TR::ifbcmpgt
    ifCmpWithEqualitySimplifier,     // TR::ifbcmple
-   ifCmpWithEqualitySimplifier,     // TR::ifbucmpeq
-   ifCmpWithoutEqualitySimplifier,  // TR::ifbucmpne
    ifCmpWithoutEqualitySimplifier,  // TR::ifbucmplt
    ifCmpWithEqualitySimplifier,     // TR::ifbucmpge
    ifCmpWithoutEqualitySimplifier,  // TR::ifbucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -308,8 +308,6 @@
    scmpgeSimplifier,        // TR::scmpge
    scmpgtSimplifier,        // TR::scmpgt
    scmpleSimplifier,        // TR::scmple
-   sucmpeqSimplifier,        // TR::sucmpeq
-   sucmpneSimplifier,        // TR::sucmpne
    sucmpltSimplifier,        // TR::sucmplt
    sucmpgeSimplifier,        // TR::sucmpge
    sucmpgtSimplifier,        // TR::sucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -383,8 +383,6 @@
    ifCmpWithEqualitySimplifier,     // TR::ifscmpge
    ifCmpWithoutEqualitySimplifier,  // TR::ifscmpgt
    ifCmpWithEqualitySimplifier,     // TR::ifscmple
-   ifCmpWithEqualitySimplifier,     // TR::ifsucmpeq
-   ifCmpWithoutEqualitySimplifier,  // TR::ifsucmpne
    ifCmpWithoutEqualitySimplifier,  // TR::ifsucmplt
    ifCmpWithEqualitySimplifier,     // TR::ifsucmpge
    ifCmpWithoutEqualitySimplifier,  // TR::ifsucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -323,8 +323,6 @@
    ificmpgeSimplifier,      // TR::ificmpge
    ificmpgtSimplifier,      // TR::ificmpgt
    ificmpleSimplifier,      // TR::ificmple
-   ificmpeqSimplifier,      // TR::ifiucmpeq
-   ificmpneSimplifier,      // TR::ifiucmpne
    ificmpltSimplifier,      // TR::ifiucmplt
    ificmpgeSimplifier,      // TR::ifiucmpge
    ificmpgtSimplifier,      // TR::ifiucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -302,8 +302,6 @@
    bcmpgeSimplifier,        // TR::bcmpge
    bcmpgtSimplifier,        // TR::bcmpgt
    bcmpleSimplifier,        // TR::bcmple
-   bcmpeqSimplifier,        // TR::bucmpeq
-   bcmpneSimplifier,        // TR::bucmpne
    bcmpltSimplifier,        // TR::bucmplt
    bcmpgeSimplifier,        // TR::bucmpge
    bcmpgtSimplifier,        // TR::bucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -333,8 +333,6 @@
    iflcmpgeSimplifier,      // TR::iflcmpge
    iflcmpgtSimplifier,      // TR::iflcmpgt
    iflcmpleSimplifier,      // TR::iflcmple
-   iflcmpeqSimplifier,      // TR::iflucmpeq
-   iflcmpneSimplifier,      // TR::iflucmpne
    iflcmpltSimplifier,      // TR::iflucmplt
    iflcmpgeSimplifier,      // TR::iflucmpge
    iflcmpgtSimplifier,      // TR::iflucmpgt

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -248,8 +248,6 @@
    icmpgeSimplifier,        // TR::icmpge
    icmpgtSimplifier,        // TR::icmpgt
    icmpleSimplifier,        // TR::icmple
-   dftSimplifier,           // TR::iucmpeq
-   dftSimplifier,           // TR::iucmpne
    dftSimplifier,           // TR::iucmplt
    dftSimplifier,           // TR::iucmpge
    dftSimplifier,           // TR::iucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -395,8 +395,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCmpge,           // TR::lcmpge
    constrainCmpgt,           // TR::lcmpgt
    constrainCmple,           // TR::lcmple
-   constrainCmpeq,           // TR::lucmpeq
-   constrainCmpne,           // TR::lucmpne
    constrainCmp,             // TR::lucmplt
    constrainCmp,             // TR::lucmpge
    constrainCmp,             // TR::lucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -385,8 +385,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCmpge,           // TR::icmpge
    constrainCmpgt,           // TR::icmpgt
    constrainCmple,           // TR::icmple
-   constrainCmpeq,           // TR::iucmpeq
-   constrainCmpne,           // TR::iucmpne
    constrainCmp,             // TR::iucmplt
    constrainCmp,             // TR::iucmpge
    constrainCmp,             // TR::iucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -462,8 +462,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainIfcmpge,         // TR::ificmpge
    constrainIfcmpgt,         // TR::ificmpgt
    constrainIfcmple,         // TR::ificmple
-   constrainIfcmpeq,         // TR::ifiucmpeq
-   constrainIfcmpne,         // TR::ifiucmpne
    constrainCondBranch,      // TR::ifiucmplt
    constrainCondBranch,      // TR::ifiucmpge
    constrainCondBranch,      // TR::ifiucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -524,8 +524,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCondBranch,      // TR::ifscmpge
    constrainCondBranch,      // TR::ifscmpgt
    constrainCondBranch,      // TR::ifscmple
-   constrainCondBranch,      // TR::ifsucmpeq
-   constrainCondBranch,      // TR::ifsucmpne
    constrainCondBranch,      // TR::ifsucmplt
    constrainCondBranch,      // TR::ifsucmpge
    constrainCondBranch,      // TR::ifsucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -472,8 +472,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainIfcmpge,         // TR::iflcmpge
    constrainIfcmpgt,         // TR::iflcmpgt
    constrainIfcmple,         // TR::iflcmple
-   constrainIfcmpeq,         // TR::iflucmpeq
-   constrainIfcmpne,         // TR::iflucmpne
    constrainIfcmplt,         // TR::iflucmplt
    constrainIfcmpge,         // TR::iflucmpge
    constrainIfcmpgt,         // TR::iflucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -441,8 +441,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCmpge,           // TR::bcmpge
    constrainCmpgt,           // TR::bcmpgt
    constrainCmple,           // TR::bcmple
-   constrainCmpeq,           // TR::bucmpeq
-   constrainCmpne,           // TR::bucmpne
    constrainCmp,             // TR::bucmplt
    constrainCmp,             // TR::bucmpge
    constrainCmp,             // TR::bucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -447,8 +447,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCmpge,           // TR::scmpge
    constrainCmpgt,           // TR::scmpgt
    constrainCmple,           // TR::scmple
-   constrainCmpeq,           // TR::sucmpeq
-   constrainCmpne,           // TR::sucmpne
    constrainCmplt,           // TR::sucmplt
    constrainCmpge,           // TR::sucmpge
    constrainCmpgt,           // TR::sucmpgt

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -514,8 +514,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCondBranch,      // TR::ifbcmpge
    constrainCondBranch,      // TR::ifbcmpgt
    constrainCondBranch,      // TR::ifbcmple
-   constrainCondBranch,      // TR::ifbucmpeq
-   constrainCondBranch,      // TR::ifbucmpne
    constrainCondBranch,      // TR::ifbucmplt
    constrainCondBranch,      // TR::ifbucmpge
    constrainCondBranch,      // TR::ifbucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -265,7 +265,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -326,7 +326,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -294,8 +294,6 @@
    TR::TreeEvaluator::icmpgeEvaluator,                  // TR::scmpge
    TR::TreeEvaluator::icmpgtEvaluator,                  // TR::scmpgt
    TR::TreeEvaluator::icmpleEvaluator,                  // TR::scmple
-   TR::TreeEvaluator::icmpeqEvaluator,                  // TR::sucmpeq
-   TR::TreeEvaluator::icmpneEvaluator,                  // TR::sucmpne
    TR::TreeEvaluator::iucmpltEvaluator,                 // TR::sucmplt
    TR::TreeEvaluator::iucmpgeEvaluator,                 // TR::sucmpge
    TR::TreeEvaluator::iucmpgtEvaluator,                 // TR::sucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -319,8 +319,6 @@
    TR::TreeEvaluator::iflcmpgeEvaluator,                // TR::iflcmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,                // TR::iflcmpgt
    TR::TreeEvaluator::iflcmpleEvaluator,                // TR::iflcmple
-   TR::TreeEvaluator::iflcmpeqEvaluator,                // TR::iflucmpeq
-   TR::TreeEvaluator::iflcmpeqEvaluator,                // TR::iflucmpne
    TR::TreeEvaluator::iflucmpltEvaluator,               // TR::iflucmplt
    TR::TreeEvaluator::iflucmpgeEvaluator,               // TR::iflucmpge
    TR::TreeEvaluator::iflucmpgtEvaluator,               // TR::iflucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -369,8 +369,6 @@
    TR::TreeEvaluator::ificmpgeEvaluator,                // TR::ifscmpge
    TR::TreeEvaluator::ificmpgtEvaluator,                // TR::ifscmpgt
    TR::TreeEvaluator::ificmpleEvaluator,                // TR::ifscmple
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifsucmpeq
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifsucmpne
    TR::TreeEvaluator::ifiucmpltEvaluator,               // TR::ifsucmplt
    TR::TreeEvaluator::ifiucmpgeEvaluator,               // TR::ifsucmpge
    TR::TreeEvaluator::ifiucmpgtEvaluator,               // TR::ifsucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -288,8 +288,6 @@
    TR::TreeEvaluator::icmpgeEvaluator,                  // TR::bcmpge
    TR::TreeEvaluator::icmpgtEvaluator,                  // TR::bcmpgt
    TR::TreeEvaluator::icmpleEvaluator,                  // TR::bcmple
-   TR::TreeEvaluator::icmpeqEvaluator,                  // TR::bucmpeq
-   TR::TreeEvaluator::icmpneEvaluator,                  // TR::bucmpne
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::bucmplt
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::bucmpge
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::bucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -234,8 +234,6 @@
    TR::TreeEvaluator::icmpgeEvaluator,                  // TR::icmpge
    TR::TreeEvaluator::icmpgtEvaluator,                  // TR::icmpgt
    TR::TreeEvaluator::icmpleEvaluator,                  // TR::icmple
-   TR::TreeEvaluator::icmpeqEvaluator,                  // TR::iucmpeq
-   TR::TreeEvaluator::icmpneEvaluator,                  // TR::iucmpne
    TR::TreeEvaluator::iucmpltEvaluator,                 // TR::iucmplt
    TR::TreeEvaluator::iucmpgeEvaluator,                 // TR::iucmpge
    TR::TreeEvaluator::iucmpgtEvaluator,                 // TR::iucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -244,8 +244,6 @@
    TR::TreeEvaluator::lcmpgeEvaluator,                  // TR::lcmpge
    TR::TreeEvaluator::lcmpgtEvaluator,                  // TR::lcmpgt
    TR::TreeEvaluator::lcmpleEvaluator,                  // TR::lcmple
-   TR::TreeEvaluator::lcmpeqEvaluator,                  // TR::lucmpeq
-   TR::TreeEvaluator::lcmpneEvaluator,                  // TR::lucmpne
    TR::TreeEvaluator::lucmpltEvaluator,                 // TR::lucmplt
    TR::TreeEvaluator::lucmpgeEvaluator,                 // TR::lucmpge
    TR::TreeEvaluator::lucmpgtEvaluator,                 // TR::lucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -309,8 +309,6 @@
    TR::TreeEvaluator::ificmpgeEvaluator,                // TR::ificmpge
    TR::TreeEvaluator::ificmpgtEvaluator,                // TR::ificmpgt
    TR::TreeEvaluator::ificmpleEvaluator,                // TR::ificmple
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifiucmpeq
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifiucmpne
    TR::TreeEvaluator::ifiucmpltEvaluator,               // TR::ifiucmplt
    TR::TreeEvaluator::ifiucmpgeEvaluator,               // TR::ifiucmpge
    TR::TreeEvaluator::ifiucmpgtEvaluator,               // TR::ifiucmpgt

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -359,8 +359,6 @@
    TR::TreeEvaluator::ificmpgeEvaluator,                // TR::ifbcmpge
    TR::TreeEvaluator::ificmpgtEvaluator,                // TR::ifbcmpgt
    TR::TreeEvaluator::ificmpleEvaluator,                // TR::ifbcmple
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifbucmpeq
-   TR::TreeEvaluator::ificmpeqEvaluator,                // TR::ifbucmpne
    TR::TreeEvaluator::ifiucmpltEvaluator,               // TR::ifbucmplt
    TR::TreeEvaluator::ifiucmpgeEvaluator,               // TR::ifbucmpge
    TR::TreeEvaluator::ifiucmpgtEvaluator,               // TR::ifbucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2581,8 +2581,6 @@ int32_t childTypes[] =
    TR::Int64,                     // TR::iflcmpge
    TR::Int64,                     // TR::iflcmpgt
    TR::Int64,                     // TR::iflcmple
-   TR::Int64,                     // TR::iflucmpeq
-   TR::Int64,                     // TR::iflucmpne
    TR::Int64,                     // TR::iflucmplt
    TR::Int64,                     // TR::iflucmpge
    TR::Int64,                     // TR::iflucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2494,8 +2494,6 @@ int32_t childTypes[] =
    TR::Int32,                     // TR::icmpge
    TR::Int32,                     // TR::icmpgt
    TR::Int32,                     // TR::icmple
-   TR::Int32,                     // TR::iucmpeq
-   TR::Int32,                     // TR::iucmpne
    TR::Int32,                     // TR::iucmplt
    TR::Int32,                     // TR::iucmpge
    TR::Int32,                     // TR::iucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2550,8 +2550,6 @@ int32_t childTypes[] =
    TR::Int8,                      // TR::bcmpge
    TR::Int8,                      // TR::bcmpgt
    TR::Int8,                      // TR::bcmple
-   TR::Int8,                      // TR::bucmpeq
-   TR::Int8,                      // TR::bucmpne
    TR::Int8,                      // TR::bucmplt
    TR::Int8,                      // TR::bucmpge
    TR::Int8,                      // TR::bucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2571,8 +2571,6 @@ int32_t childTypes[] =
    TR::Int32,                     // TR::ificmpge
    TR::Int32,                     // TR::ificmpgt
    TR::Int32,                     // TR::ificmple
-   TR::Int32,                     // TR::ifiucmpeq
-   TR::Int32,                     // TR::ifiucmpne
    TR::Int32,                     // TR::ifiucmplt
    TR::Int32,                     // TR::ifiucmpge
    TR::Int32,                     // TR::ifiucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2633,8 +2633,6 @@ int32_t childTypes[] =
    TR::Int16,                     // TR::ifscmpge
    TR::Int16,                     // TR::ifscmpgt
    TR::Int16,                     // TR::ifscmple
-   TR::Int16,                     // TR::ifsucmpeq
-   TR::Int16,                     // TR::ifsucmpne
    TR::Int16,                     // TR::ifsucmplt
    TR::Int16,                     // TR::ifsucmpge
    TR::Int16,                     // TR::ifsucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2556,8 +2556,6 @@ int32_t childTypes[] =
    TR::Int16,                     // TR::scmpge
    TR::Int16,                     // TR::scmpgt
    TR::Int16,                     // TR::scmple
-   TR::Int16,                     // TR::sucmpeq
-   TR::Int16,                     // TR::sucmpne
    TR::Int16,                     // TR::sucmplt
    TR::Int16,                     // TR::sucmpge
    TR::Int16,                     // TR::sucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2504,8 +2504,6 @@ int32_t childTypes[] =
    TR::Int64,                     // TR::lcmpge
    TR::Int64,                     // TR::lcmpgt
    TR::Int64,                     // TR::lcmple
-   TR::Int64,                     // TR::lucmpeq
-   TR::Int64,                     // TR::lucmpne
    TR::Int64,                     // TR::lucmplt
    TR::Int64,                     // TR::lucmpge
    TR::Int64,                     // TR::lucmpgt

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2623,8 +2623,6 @@ int32_t childTypes[] =
    TR::Int8,                      // TR::ifbcmpge
    TR::Int8,                      // TR::ifbcmpgt
    TR::Int8,                      // TR::ifbcmple
-   TR::Int8,                      // TR::ifbucmpeq
-   TR::Int8,                      // TR::ifbucmpne
    TR::Int8,                      // TR::ifbucmplt
    TR::Int8,                      // TR::ifbucmpge
    TR::Int8,                      // TR::ifbucmpgt

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -198,7 +198,7 @@ OMR::RV::TreeEvaluator::ifiucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg
    return NULL;
    }
 
-// also handles iflucmpeq, ifacmpeq
+// also handles ifacmpeq
 TR::Register *
 OMR::RV::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -206,7 +206,7 @@ OMR::RV::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return NULL;
    }
 
-// also handles iflucmpne, ifacmpne
+// also handles ifacmpne
 TR::Register *
 OMR::RV::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -387,7 +387,6 @@ OMR::RV::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return icmpHelper(TR::InstOpCode::_sltu, TR::InstOpCode::bad, 0, node, true, cg);
    }
 
-// also handles lucmpeq
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -395,7 +394,6 @@ OMR::RV::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return icmpeqEvaluator(node, cg);
    }
 
-// also handles lucmpne
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -128,7 +128,6 @@ static TR::Instruction *ificmpHelper(TR::InstOpCode::Mnemonic op, TR::Node *node
    return result;
    }
 
-// also handles ifiucmpeq
 TR::Register *
 OMR::RV::TreeEvaluator::ificmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -136,7 +135,6 @@ OMR::RV::TreeEvaluator::ificmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return NULL;
    }
 
-// also handles ifiucmpne
 TR::Register *
 OMR::RV::TreeEvaluator::ificmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -340,8 +340,6 @@ public:
 	static TR::Register *ificmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ificmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ificmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifiucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifiucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifiucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -350,8 +350,6 @@ public:
 	static TR::Register *iflcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iflucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iflucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iflucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -265,8 +265,6 @@ public:
 	static TR::Register *icmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *icmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *icmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -319,8 +319,6 @@ public:
 	static TR::Register *bcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -275,8 +275,6 @@ public:
 	static TR::Register *lcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -325,8 +325,6 @@ public:
 	static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -400,8 +400,6 @@ public:
 	static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifsucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -390,8 +390,6 @@ public:
 	static TR::Register *ifbcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifbucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *ifbucmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ifbucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -310,8 +310,6 @@
     TR::TreeEvaluator::ificmpgeEvaluator, // TR::ificmpge		// integer compare and branch if greater than or equal
     TR::TreeEvaluator::ificmpgtEvaluator, // TR::ificmpgt		// integer compare and branch if greater than
     TR::TreeEvaluator::ificmpleEvaluator, // TR::ificmple		// integer compare and branch if less than or equal
-    TR::TreeEvaluator::ificmpeqEvaluator, // TR::ifiucmpeq		// unsigned integer compare and branch if equal
-    TR::TreeEvaluator::ificmpneEvaluator, // TR::ifiucmpne		// unsigned integer compare and branch if not equal
     TR::TreeEvaluator::ifiucmpltEvaluator, // TR::ifiucmplt		// unsigned integer compare and branch if less than
     TR::TreeEvaluator::ifiucmpgeEvaluator, // TR::ifiucmpge		// unsigned integer compare and branch if greater than or equal
     TR::TreeEvaluator::ifiucmpgtEvaluator, // TR::ifiucmpgt		// unsigned integer compare and branch if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -245,8 +245,6 @@
     TR::TreeEvaluator::lcmpgeEvaluator, // TR::lcmpge		// long compare if greater than or equal
     TR::TreeEvaluator::lcmpgtEvaluator, // TR::lcmpgt		// long compare if greater than
     TR::TreeEvaluator::lcmpleEvaluator, // TR::lcmple		// long compare if less than or equal
-    TR::TreeEvaluator::lcmpeqEvaluator, // TR::lucmpeq		// unsigned long compare if equal
-    TR::TreeEvaluator::lcmpneEvaluator, // TR::lucmpne		// unsigned long compare if not equal
     TR::TreeEvaluator::lucmpltEvaluator, // TR::lucmplt		// unsigned long compare if less than
     TR::TreeEvaluator::lucmpgeEvaluator, // TR::lucmpge		// unsigned long compare if greater than or equal
     TR::TreeEvaluator::lucmpgtEvaluator, // TR::lucmpgt		// unsigned long compare if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -235,8 +235,6 @@
     TR::TreeEvaluator::icmpgeEvaluator, // TR::icmpge		// integer compare if greater than or equal
     TR::TreeEvaluator::icmpgtEvaluator, // TR::icmpgt		// integer compare if greater than
     TR::TreeEvaluator::icmpleEvaluator, // TR::icmple		// integer compare if less than or equal
-    TR::TreeEvaluator::icmpeqEvaluator, // TR::iucmpeq		// unsigned integer compare if equal
-    TR::TreeEvaluator::icmpneEvaluator, // TR::iucmpne		// unsigned integer compare if not equal
     TR::TreeEvaluator::iucmpltEvaluator, // TR::iucmplt		// unsigned integer compare if less than
     TR::TreeEvaluator::iucmpgeEvaluator, // TR::iucmpge		// unsigned integer compare if greater than or equal
     TR::TreeEvaluator::iucmpgtEvaluator, // TR::iucmpgt		// unsigned integer compare if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -360,8 +360,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbcmpgeEvaluator ,	// TR::ifbcmpge		// byte compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbcmpgtEvaluator ,	// TR::ifbcmpgt		// byte compare and branch if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbcmpleEvaluator ,	// TR::ifbcmple		// byte compare and branch if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbucmpeqEvaluator ,	// TR::ifbucmpeq		// unsigned byte compare and branch if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbucmpneEvaluator ,	// TR::ifbucmpne		// unsigned byte compare and branch if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbucmpltEvaluator ,	// TR::ifbucmplt		// unsigned byte compare and branch if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbucmpgeEvaluator ,	// TR::ifbucmpge		// unsigned byte compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifbucmpgtEvaluator ,	// TR::ifbucmpgt		// unsigned byte compare and branch if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -295,8 +295,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::scmpgeEvaluator ,	// TR::scmpge		// short integer compare if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::scmpgtEvaluator ,	// TR::scmpgt		// short integer compare if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::scmpleEvaluator ,	// TR::scmple		// short integer compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sucmpeqEvaluator ,	// TR::sucmpeq		// char compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sucmpneEvaluator ,	// TR::sucmpne		// char compare if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sucmpltEvaluator ,	// TR::sucmplt		// char compare if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sucmpgeEvaluator ,	// TR::sucmpge		// char compare if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sucmpgtEvaluator ,	// TR::sucmpgt		// char compare if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -289,8 +289,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bcmpgeEvaluator ,	// TR::bcmpge		// byte compare if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bcmpgtEvaluator ,	// TR::bcmpgt		// byte compare if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bcmpleEvaluator ,	// TR::bcmple		// byte compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bucmpeqEvaluator ,	// TR::bucmpeq		// unsigned byte compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bucmpneEvaluator ,	// TR::bucmpne		// unsigned byte compare if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bucmpltEvaluator ,	// TR::bucmplt		// unsigned byte compare if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bucmpgeEvaluator ,	// TR::bucmpge		// unsigned byte compare if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bucmpgtEvaluator ,	// TR::bucmpgt		// unsigned byte compare if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -320,8 +320,6 @@
     TR::TreeEvaluator::iflcmpgeEvaluator, // TR::iflcmpge		// long compare and branch if greater than or equal
     TR::TreeEvaluator::iflcmpgtEvaluator, // TR::iflcmpgt		// long compare and branch if greater than
     TR::TreeEvaluator::iflcmpleEvaluator, // TR::iflcmple		// long compare and branch if less than or equal
-    TR::TreeEvaluator::iflcmpeqEvaluator, // TR::iflucmpeq		// unsigned long compare and branch if equal
-    TR::TreeEvaluator::iflcmpneEvaluator, // TR::iflucmpne		// unsigned long compare and branch if not equal
     TR::TreeEvaluator::iflucmpltEvaluator, // TR::iflucmplt		// unsigned long compare and branch if less than
     TR::TreeEvaluator::iflucmpgeEvaluator, // TR::iflucmpge		// unsigned long compare and branch if greater than or equal
     TR::TreeEvaluator::iflucmpgtEvaluator, // TR::iflucmpgt		// unsigned long compare and branch if greater than

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -370,8 +370,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifscmpgeEvaluator ,	// TR::ifscmpge		// short integer compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifscmpgtEvaluator ,	// TR::ifscmpgt		// short integer compare and branch if greater than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifscmpleEvaluator ,	// TR::ifscmple		// short integer compare and branch if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifsucmpeqEvaluator ,	// TR::ifsucmpeq		// char compare and branch if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifsucmpneEvaluator ,	// TR::ifsucmpne		// char compare and branch if not equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifsucmpltEvaluator ,	// TR::ifsucmplt		// char compare and branch if less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifsucmpgeEvaluator ,	// TR::ifsucmpge		// char compare and branch if greater than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::ifsucmpgtEvaluator ,	// TR::ifsucmpgt		// char compare and branch if greater than

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -235,8 +235,6 @@
    TR::TreeEvaluator::integerCmpgeEvaluator,                           // TR::icmpge
    TR::TreeEvaluator::integerCmpgtEvaluator,                           // TR::icmpgt
    TR::TreeEvaluator::integerCmpleEvaluator,                           // TR::icmple
-   TR::TreeEvaluator::integerCmpeqEvaluator,                           // TR::iucmpeq
-   TR::TreeEvaluator::integerCmpneEvaluator,                           // TR::iucmpne
    TR::TreeEvaluator::unsignedIntegerCmpltEvaluator,                   // TR::iucmplt
    TR::TreeEvaluator::unsignedIntegerCmpgeEvaluator,                   // TR::iucmpge
    TR::TreeEvaluator::unsignedIntegerCmpgtEvaluator,                   // TR::iucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -320,8 +320,6 @@
    TR::TreeEvaluator::integerIfCmpgeEvaluator,                         // TR::iflcmpge
    TR::TreeEvaluator::integerIfCmpgtEvaluator,                         // TR::iflcmpgt
    TR::TreeEvaluator::integerIfCmpleEvaluator,                         // TR::iflcmple
-   TR::TreeEvaluator::integerIfCmpeqEvaluator,                         // TR::iflucmpeq
-   TR::TreeEvaluator::integerIfCmpneEvaluator,                         // TR::iflucmpne
    TR::TreeEvaluator::unsignedIntegerIfCmpltEvaluator,                 // TR::iflucmplt
    TR::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator,                 // TR::iflucmpge
    TR::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator,                 // TR::iflucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -289,8 +289,6 @@
    TR::TreeEvaluator::bcmpgeEvaluator,                                 // TR::bcmpge
    TR::TreeEvaluator::bcmpgtEvaluator,                                 // TR::bcmpgt
    TR::TreeEvaluator::bcmpleEvaluator,                                 // TR::bcmple
-   TR::TreeEvaluator::bcmpeqEvaluator,                                 // TR::bucmpeq (zPDT)
-   TR::TreeEvaluator::bcmpeqEvaluator,                                 // TR::bucmpne (zPDT)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmplt
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmpge
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -360,8 +360,6 @@
    TR::TreeEvaluator::ifbcmpgeEvaluator,                               // TR::ifbcmpge
    TR::TreeEvaluator::ifbcmpgtEvaluator,                               // TR::ifbcmpgt
    TR::TreeEvaluator::ifbcmpleEvaluator,                               // TR::ifbcmple
-   TR::TreeEvaluator::ifbcmpeqEvaluator,                               // TR::ifbucmpeq
-   TR::TreeEvaluator::ifbcmpeqEvaluator,                               // TR::ifbucmpne
    TR::TreeEvaluator::ifbucmpltEvaluator,                              // TR::ifbucmplt
    TR::TreeEvaluator::ifbucmpgeEvaluator,                              // TR::ifbucmpge
    TR::TreeEvaluator::ifbucmpgtEvaluator,                              // TR::ifbucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -370,8 +370,6 @@
    TR::TreeEvaluator::ifscmpgeEvaluator,                               // TR::ifscmpge
    TR::TreeEvaluator::ifscmpgtEvaluator,                               // TR::ifscmpgt
    TR::TreeEvaluator::ifscmpleEvaluator,                               // TR::ifscmple
-   TR::TreeEvaluator::ifsucmpeqEvaluator,                              // TR::ifsucmpeq
-   TR::TreeEvaluator::ifsucmpeqEvaluator,                              // TR::ifsucmpne
    TR::TreeEvaluator::ifsucmpltEvaluator,                              // TR::ifsucmplt
    TR::TreeEvaluator::ifsucmpgeEvaluator,                              // TR::ifsucmpge
    TR::TreeEvaluator::ifsucmpgtEvaluator,                              // TR::ifsucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -245,8 +245,6 @@
    TR::TreeEvaluator::integerCmpgeEvaluator,                           // TR::lcmpge
    TR::TreeEvaluator::integerCmpgtEvaluator,                           // TR::lcmpgt
    TR::TreeEvaluator::integerCmpleEvaluator,                           // TR::lcmple
-   TR::TreeEvaluator::integerCmpeqEvaluator,                           // TR::lucmpeq
-   TR::TreeEvaluator::integerCmpneEvaluator,                           // TR::lucmpne
    TR::TreeEvaluator::unsignedIntegerCmpltEvaluator,                   // TR::lucmplt
    TR::TreeEvaluator::unsignedIntegerCmpgeEvaluator,                   // TR::lucmpge
    TR::TreeEvaluator::unsignedIntegerCmpgtEvaluator,                   // TR::lucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -295,8 +295,6 @@
    TR::TreeEvaluator::scmpgeEvaluator,                                 // TR::scmpge
    TR::TreeEvaluator::scmpgtEvaluator,                                 // TR::scmpgt
    TR::TreeEvaluator::scmpleEvaluator,                                 // TR::scmple
-   TR::TreeEvaluator::sucmpeqEvaluator,                                // TR::sucmpeq
-   TR::TreeEvaluator::sucmpeqEvaluator,                                // TR::sucmpne
    TR::TreeEvaluator::sucmpltEvaluator,                                // TR::sucmplt
    TR::TreeEvaluator::sucmpgeEvaluator,                                // TR::sucmpge
    TR::TreeEvaluator::sucmpgtEvaluator,                                // TR::sucmpgt

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -310,8 +310,6 @@
    TR::TreeEvaluator::integerIfCmpgeEvaluator,                         // TR::ificmpge
    TR::TreeEvaluator::integerIfCmpgtEvaluator,                         // TR::ificmpgt
    TR::TreeEvaluator::integerIfCmpleEvaluator,                         // TR::ificmple
-   TR::TreeEvaluator::integerIfCmpeqEvaluator,                         // TR::ifiucmpeq
-   TR::TreeEvaluator::integerIfCmpneEvaluator,                         // TR::ifiucmpne
    TR::TreeEvaluator::unsignedIntegerIfCmpltEvaluator,                 // TR::ifiucmplt
    TR::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator,                 // TR::ifiucmpge
    TR::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator,                 // TR::ifiucmpgt

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2198,52 +2198,6 @@ TR::Register *OMR::X86::TreeEvaluator::scmpleEvaluator(TR::Node *node, TR::CodeG
    return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETLE1Reg, cg);
    }
 
-
-TR::Register *OMR::X86::TreeEvaluator::sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Register *targetRegister = cg->allocateRegister();
-   TR::Node     *secondChild    = node->getSecondChild();
-
-   if (secondChild->getOpCode().isLoadConst() &&
-       secondChild->getRegister() == NULL)
-      {
-      int32_t      value            = secondChild->getShortInt();
-      TR::Node     *firstChild       = node->getFirstChild();
-      TR::Register *testRegister     = cg->evaluate(firstChild);
-      if (value >= -128 && value <= 127)
-         {
-         if (value == 0)
-            {
-            generateRegRegInstruction(TEST2RegReg, node, testRegister, testRegister, cg);
-            }
-         else
-            {
-            generateRegImmInstruction(CMP2RegImms, node, testRegister, value, cg);
-            }
-         }
-      else
-         {
-         ///generateRegImmInstruction(CMP2RegImm2, node, testRegister, value, cg);
-         generateWiderCompare(node, testRegister, value, cg);
-         }
-      cg->decReferenceCount(firstChild);
-      cg->decReferenceCount(secondChild);
-      }
-   else
-      {
-      TR_X86CompareAnalyser  temp(cg);
-      temp.integerCompareAnalyser(node, CMP2RegReg, CMP2RegMem, CMP2MemReg);
-      }
-   node->setRegister(targetRegister);
-
-   if (cg->enableRegisterInterferences())
-      cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
-
-   generateRegInstruction(node->getOpCodeValue() == TR::sucmpeq ? SETE1Reg : SETNE1Reg, node, targetRegister, cg);
-   generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
-   return targetRegister;
-   }
-
 TR::Register *OMR::X86::TreeEvaluator::sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::cmp2BytesEvaluator(node, SETB1Reg, cg);

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1914,15 +1914,6 @@ TR::Register *OMR::X86::TreeEvaluator::ifscmpleEvaluator(TR::Node *node, TR::Cod
    return NULL;
    }
 
-
-TR::Register *OMR::X86::TreeEvaluator::ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::TreeEvaluator::compareIntegersForEquality(node, cg);
-   generateConditionalJumpInstruction(node->getOpCodeValue() == TR::ifsucmpeq ? JE4 : JNE4,
-                                      node, cg, true);
-   return NULL;
-   }
-
 TR::Register *OMR::X86::TreeEvaluator::ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compare2BytesForOrder(node, cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -183,7 +183,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -198,7 +198,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -235,8 +235,6 @@
    TR::TreeEvaluator::integerCmpgeEvaluator,                           // TR::icmpge
    TR::TreeEvaluator::integerCmpgtEvaluator,                           // TR::icmpgt
    TR::TreeEvaluator::integerCmpleEvaluator,                           // TR::icmple
-   TR::TreeEvaluator::integerCmpeqEvaluator,                           // TR::iucmpeq
-   TR::TreeEvaluator::integerCmpneEvaluator,                           // TR::iucmpne
    TR::TreeEvaluator::unsignedIntegerCmpltEvaluator,                   // TR::iucmplt
    TR::TreeEvaluator::unsignedIntegerCmpgeEvaluator,                   // TR::iucmpge
    TR::TreeEvaluator::unsignedIntegerCmpgtEvaluator,                   // TR::iucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -289,8 +289,6 @@
    TR::TreeEvaluator::bcmpgeEvaluator,                                 // TR::bcmpge
    TR::TreeEvaluator::bcmpgtEvaluator,                                 // TR::bcmpgt
    TR::TreeEvaluator::bcmpleEvaluator,                                 // TR::bcmple
-   TR::TreeEvaluator::bcmpeqEvaluator,                                 // TR::bucmpeq (zPDT)
-   TR::TreeEvaluator::bcmpeqEvaluator,                                 // TR::bucmpne (zPDT)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmplt
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmpge
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::bucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -360,8 +360,6 @@
    TR::TreeEvaluator::ifbcmpgeEvaluator,                               // TR::ifbcmpge
    TR::TreeEvaluator::ifbcmpgtEvaluator,                               // TR::ifbcmpgt
    TR::TreeEvaluator::ifbcmpleEvaluator,                               // TR::ifbcmple
-   TR::TreeEvaluator::ifbcmpeqEvaluator,                               // TR::ifbucmpeq
-   TR::TreeEvaluator::ifbcmpeqEvaluator,                               // TR::ifbucmpne
    TR::TreeEvaluator::ifbucmpltEvaluator,                              // TR::ifbucmplt
    TR::TreeEvaluator::ifbucmpgeEvaluator,                              // TR::ifbucmpge
    TR::TreeEvaluator::ifbucmpgtEvaluator,                              // TR::ifbucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -370,8 +370,6 @@
    TR::TreeEvaluator::ifscmpgeEvaluator,                               // TR::ifscmpge
    TR::TreeEvaluator::ifscmpgtEvaluator,                               // TR::ifscmpgt
    TR::TreeEvaluator::ifscmpleEvaluator,                               // TR::ifscmple
-   TR::TreeEvaluator::ifsucmpeqEvaluator,                              // TR::ifsucmpeq
-   TR::TreeEvaluator::ifsucmpeqEvaluator,                              // TR::ifsucmpne
    TR::TreeEvaluator::ifsucmpltEvaluator,                              // TR::ifsucmplt
    TR::TreeEvaluator::ifsucmpgeEvaluator,                              // TR::ifsucmpge
    TR::TreeEvaluator::ifsucmpgtEvaluator,                              // TR::ifsucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -245,8 +245,6 @@
    TR::TreeEvaluator::lcmpgeEvaluator,                                 // TR::lcmpge
    TR::TreeEvaluator::lcmpgtEvaluator,                                 // TR::lcmpgt
    TR::TreeEvaluator::lcmpleEvaluator,                                 // TR::lcmple
-   TR::TreeEvaluator::lcmpeqEvaluator,                                 // TR::lucmpeq
-   TR::TreeEvaluator::lcmpneEvaluator,                                 // TR::lucmpne
    TR::TreeEvaluator::lucmpltEvaluator,                                // TR::lucmplt
    TR::TreeEvaluator::lucmpgeEvaluator,                                // TR::lucmpge
    TR::TreeEvaluator::lucmpgtEvaluator,                                // TR::lucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -320,8 +320,6 @@
    TR::TreeEvaluator::iflcmpgeEvaluator,                               // TR::iflcmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,                               // TR::iflcmpgt
    TR::TreeEvaluator::iflcmpleEvaluator,                               // TR::iflcmple
-   TR::TreeEvaluator::iflcmpeqEvaluator,                               // TR::iflucmpeq
-   TR::TreeEvaluator::iflcmpneEvaluator,                               // TR::iflucmpne
    TR::TreeEvaluator::iflcmpltEvaluator,                               // TR::iflucmplt
    TR::TreeEvaluator::iflcmpgeEvaluator,                               // TR::iflucmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,                               // TR::iflucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -295,8 +295,6 @@
    TR::TreeEvaluator::scmpgeEvaluator,                                 // TR::scmpge
    TR::TreeEvaluator::scmpgtEvaluator,                                 // TR::scmpgt
    TR::TreeEvaluator::scmpleEvaluator,                                 // TR::scmple
-   TR::TreeEvaluator::sucmpeqEvaluator,                                // TR::sucmpeq
-   TR::TreeEvaluator::sucmpeqEvaluator,                                // TR::sucmpne
    TR::TreeEvaluator::sucmpltEvaluator,                                // TR::sucmplt
    TR::TreeEvaluator::sucmpgeEvaluator,                                // TR::sucmpge
    TR::TreeEvaluator::sucmpgtEvaluator,                                // TR::sucmpgt

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -310,8 +310,6 @@
    TR::TreeEvaluator::integerIfCmpgeEvaluator,                         // TR::ificmpge
    TR::TreeEvaluator::integerIfCmpgtEvaluator,                         // TR::ificmpgt
    TR::TreeEvaluator::integerIfCmpleEvaluator,                         // TR::ificmple
-   TR::TreeEvaluator::integerIfCmpeqEvaluator,                         // TR::ifiucmpeq
-   TR::TreeEvaluator::integerIfCmpneEvaluator,                         // TR::ifiucmpne
    TR::TreeEvaluator::unsignedIntegerIfCmpltEvaluator,                 // TR::ifiucmplt
    TR::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator,                 // TR::ifiucmpge
    TR::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator,                 // TR::ifiucmpgt

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1266,23 +1266,6 @@ OMR::Z::TreeEvaluator::ifscmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
    }
 
 /**
- * Char compare and branch if equal
- *    - also handles ifsucmpne (char compare and branch if not equal)
- */
-TR::Register *
-OMR::Z::TreeEvaluator::ifsucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   if (node->getOpCodeValue() == TR::ifsucmpeq)
-      {
-      return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
-      }
-   else
-      {
-      return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, TR::InstOpCode::COND_BNE);
-      }
-   }
-
-/**
  * Char compare and branch if less than
  */
 TR::Register *

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1629,16 +1629,6 @@ OMR::Z::TreeEvaluator::scmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    }
 
 /**
- * Char compare if equal
- * - also handles sucmpne (char compare if not equal)
- */
-TR::Register *
-OMR::Z::TreeEvaluator::sucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-      return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, TR::InstOpCode::COND_BNE);
-   }
-
-/**
  * Char compare if less than
  */
 TR::Register *

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -12681,8 +12681,8 @@ TR::InstOpCode::S390BranchCondition getButestBranchCondition(TR::ILOpCodes opCod
          {
                                  /* Condition Code Value */
     /* branch opcode*/  /*        0            1            2            3       */
-    /* TR::ifiucmpeq */     { TR::InstOpCode::COND_MASK8 , TR::InstOpCode::COND_MASK6 , TR::InstOpCode::COND_MASK0 ,  TR::InstOpCode::COND_MASK1  },
-    /* TR::ifiucmpne */     { TR::InstOpCode::COND_MASK7 , TR::InstOpCode::COND_MASK9 , TR::InstOpCode::COND_MASK15,  TR::InstOpCode::COND_MASK14 },
+    /* TR::ificmpeq */      { TR::InstOpCode::COND_MASK8 , TR::InstOpCode::COND_MASK6 , TR::InstOpCode::COND_MASK0 ,  TR::InstOpCode::COND_MASK1  },
+    /* TR::ificmpne */      { TR::InstOpCode::COND_MASK7 , TR::InstOpCode::COND_MASK9 , TR::InstOpCode::COND_MASK15,  TR::InstOpCode::COND_MASK14 },
     /* TR::ifiucmpgt */     { TR::InstOpCode::COND_MASK7 , TR::InstOpCode::COND_MASK1 , TR::InstOpCode::COND_MASK1 ,  TR::InstOpCode::COND_MASK0  },
     /* TR::ifiucmpge */     { TR::InstOpCode::COND_MASK15, TR::InstOpCode::COND_MASK7 , TR::InstOpCode::COND_MASK1 ,  TR::InstOpCode::COND_MASK1  },
     /* TR::ifiucmplt */     { TR::InstOpCode::COND_MASK0 , TR::InstOpCode::COND_MASK8 , TR::InstOpCode::COND_MASK14,  TR::InstOpCode::COND_MASK14 },

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -348,7 +348,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *ifscmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifscmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ifsucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ifsucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -399,7 +399,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *scmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *scmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *sucmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -320,8 +320,6 @@
    TR::TreeEvaluator::scmpgeEvaluator,      // TR::scmpge
    TR::TreeEvaluator::scmpgtEvaluator,      // TR::scmpgt
    TR::TreeEvaluator::scmpleEvaluator,      // TR::scmple
-   TR::TreeEvaluator::sucmpeqEvaluator,      // TR::sucmpeq
-   TR::TreeEvaluator::sucmpeqEvaluator,      // TR::sucmpne
    TR::TreeEvaluator::sucmpltEvaluator,      // TR::sucmplt
    TR::TreeEvaluator::sucmpgeEvaluator,      // TR::sucmpge
    TR::TreeEvaluator::sucmpgtEvaluator,      // TR::sucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -256,8 +256,6 @@
    TR::TreeEvaluator::icmpgeEvaluator,      // TR::icmpge
    TR::TreeEvaluator::icmpgtEvaluator,      // TR::icmpgt
    TR::TreeEvaluator::icmpleEvaluator,      // TR::icmple
-   TR::TreeEvaluator::icmpeqEvaluator,      // TR::iucmpeq
-   TR::TreeEvaluator::icmpeqEvaluator,      // TR::iucmpne
    TR::TreeEvaluator::icmpltEvaluator,      // TR::iucmplt
    TR::TreeEvaluator::icmpgeEvaluator,      // TR::iucmpge
    TR::TreeEvaluator::icmpgtEvaluator,      // TR::iucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -267,8 +267,6 @@
    TR::TreeEvaluator::lcmpgeEvaluator,      // TR::lcmpge
    TR::TreeEvaluator::lcmpgtEvaluator,      // TR::lcmpgt
    TR::TreeEvaluator::lcmpleEvaluator,      // TR::lcmple
-   TR::TreeEvaluator::lcmpeqEvaluator,      // TR::lucmpeq
-   TR::TreeEvaluator::lcmpneEvaluator,      // TR::lucmpne
    TR::TreeEvaluator::lcmpltEvaluator,      // TR::lucmplt
    TR::TreeEvaluator::lcmpgeEvaluator,      // TR::lucmpge
    TR::TreeEvaluator::lcmpgtEvaluator,      // TR::lucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -314,8 +314,6 @@
    TR::TreeEvaluator::bcmpgeEvaluator,      // TR::bcmpge
    TR::TreeEvaluator::bcmpgtEvaluator,      // TR::bcmpgt
    TR::TreeEvaluator::bcmpleEvaluator,      // TR::bcmple
-   TR::TreeEvaluator::bcmpeqEvaluator,      // TR::bucmpeq
-   TR::TreeEvaluator::bcmpeqEvaluator,      // TR::bucmpne
    TR::TreeEvaluator::badILOpEvaluator,     // TR::bucmplt
    TR::TreeEvaluator::badILOpEvaluator,     // TR::bucmpge
    TR::TreeEvaluator::badILOpEvaluator,     // TR::bucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -335,8 +335,6 @@
    TR::TreeEvaluator::ificmpgeEvaluator,    // TR::ificmpge
    TR::TreeEvaluator::ificmpgtEvaluator,    // TR::ificmpgt
    TR::TreeEvaluator::ificmpleEvaluator,    // TR::ificmple
-   TR::TreeEvaluator::ificmpeqEvaluator,    // TR::ifiucmpeq
-   TR::TreeEvaluator::ificmpeqEvaluator,    // TR::ifiucmpne : todo
    TR::TreeEvaluator::ificmpltEvaluator,    // TR::ifiucmplt : Temporary place holders till unsigned opcodes are implemented
    TR::TreeEvaluator::ificmpgeEvaluator,    // TR::ifiucmpge
    TR::TreeEvaluator::ificmpgtEvaluator,    // TR::ifiucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -399,8 +399,6 @@
    TR::TreeEvaluator::ifscmpgeEvaluator,    // TR::ifscmpge
    TR::TreeEvaluator::ifscmpgtEvaluator,    // TR::ifscmpgt
    TR::TreeEvaluator::ifscmpleEvaluator,    // TR::ifscmple
-   TR::TreeEvaluator::ifsucmpeqEvaluator,    // TR::ifsucmpeq
-   TR::TreeEvaluator::ifsucmpeqEvaluator,    // TR::ifsucmpne
    TR::TreeEvaluator::ifsucmpltEvaluator,    // TR::ifsucmplt
    TR::TreeEvaluator::ifsucmpgeEvaluator,    // TR::ifsucmpge
    TR::TreeEvaluator::ifsucmpgtEvaluator,    // TR::ifsucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -389,8 +389,6 @@
    TR::TreeEvaluator::ifbcmpgeEvaluator,    // TR::ifbcmpge
    TR::TreeEvaluator::ifbcmpgtEvaluator,    // TR::ifbcmpgt
    TR::TreeEvaluator::ifbcmpleEvaluator,    // TR::ifbcmple
-   TR::TreeEvaluator::ifbcmpeqEvaluator,    // TR::ifbucmpeq
-   TR::TreeEvaluator::ifbcmpeqEvaluator,    // TR::ifbucmpne
    TR::TreeEvaluator::ifbcmpltEvaluator,    // TR::ifbucmplt
    TR::TreeEvaluator::ifbcmpgeEvaluator,    // TR::ifbucmpge
    TR::TreeEvaluator::ifbcmpgtEvaluator,    // TR::ifbucmpgt

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -346,8 +346,6 @@
    TR::TreeEvaluator::iflcmpgeEvaluator,    // TR::iflcmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,    // TR::iflcmpgt
    TR::TreeEvaluator::iflcmpleEvaluator,    // TR::iflcmple
-   TR::TreeEvaluator::iflcmpeqEvaluator,    // TR::iflucmpeq
-   TR::TreeEvaluator::iflcmpneEvaluator,    // TR::iflucmpne
    TR::TreeEvaluator::iflcmpltEvaluator,    // TR::iflucmplt
    TR::TreeEvaluator::iflcmpgeEvaluator,    // TR::iflucmpge
    TR::TreeEvaluator::iflcmpgtEvaluator,    // TR::iflucmpgt


### PR DESCRIPTION
Removed definitions, declarations, properties and all other lists/enums that define the behavior of the unsigned IL Opcodes in `Equality compare` and `Equality compare and branch`. The above ILOpcodes will be completely removed from OMR after this PR.

Note that this PR need to be merged simultaneously with https://github.com/eclipse/openj9/pull/8939

Issue:#2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>