### PR TITLE
Fix localCSE where it does not common the eligible node

### DIFF
--- a/compiler/optimizer/OMRLocalCSE.hpp
+++ b/compiler/optimizer/OMRLocalCSE.hpp
@@ -137,6 +137,7 @@ class LocalCSE : public TR::Optimization
    bool doCopyPropagationIfPossible(TR::Node *, TR::Node *, int32_t, TR::Node *, TR::SymbolReference *, vcount_t, bool &);
    void doCommoningIfAvailable(TR::Node *, TR::Node *, int32_t, bool &);
    void doCommoningAgainIfPreviouslyCommoned(TR::Node *, TR::Node *, int32_t);
+   bool canCommonNodeInVolatilePass(TR::Node*);
 
    TR::Node *getNode(TR::Node *node);
 


### PR DESCRIPTION
For the optimization level hot and above, we run two passes in localCSE. First one for the volatiles only and second one for non volatiles only. In case of the volatiles only pass, to make sure we common the volatile which are based on an indirection non volatile finals or non global autos/parm it marks such node available for commoning in volatile pass. Issue occurs, where it encounters first reference of such non volatile nodes and just adds it to the list of replaced nodes without replacing it. This causes an issue with the subsequent reference of such non volatiles which will be replaced with the available expression as node is already in the list of replaced nodes. 

This commit fixes the issue so that if it encounters finals or autos or parms in volatile pass which are candidate for commoning, it will replace it with available expression and then add it to replaced list.

Fixes: eclipse/openj9#8637

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>