### PR TITLE
New Inline function areAnyLiveObjectsInCard

### DIFF
--- a/gc/base/HeapMap.hpp
+++ b/gc/base/HeapMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,6 +128,7 @@ public:
 	MMINLINE void *getHeapBase() { return _heapBase; }
 
 	MMINLINE uintptr_t *getHeapMapBits() { return _heapMapBits; }
+	MMINLINE const uintptr_t *getHeapMapBits() const { return _heapMapBits; }
 
 	MMINLINE uintptr_t getObjectGrain() { return ((uintptr_t)1) << _heapMapBitShift; };
 		
@@ -154,7 +155,7 @@ public:
 	}
 	
 	MMINLINE uintptr_t 
-	getSlotIndex(omrobjectptr_t objectPtr)
+	getSlotIndex(omrobjectptr_t objectPtr) const
 	{
 		uintptr_t slotIndex = ((uintptr_t)objectPtr) - _heapMapBaseDelta;
 		slotIndex >>= _heapMapIndexShift;
@@ -255,6 +256,30 @@ public:
 		return false;
 	}
 	
+	MMINLINE uintptr_t *
+	getSlotPtr(uintptr_t index)
+	{
+		return &(getHeapMapBits()[index]);
+	}
+
+	MMINLINE const uintptr_t *
+	getSlotPtr(uintptr_t index) const
+	{
+		return &(getHeapMapBits()[index]);
+	}
+
+	MMINLINE uintptr_t *
+	getSlotPtrForAddress(omrobjectptr_t address)
+	{
+		return getSlotPtr(getSlotIndex(address));
+	}
+
+	MMINLINE const uintptr_t *
+	getSlotPtrForAddress(omrobjectptr_t address) const
+	{
+		return getSlotPtr(getSlotIndex(address));
+	}
+
 	uintptr_t numberBitsInRange(MM_EnvironmentBase *env, void *lowAddress, void *highAddress);
 
 	/**

--- a/gc/base/MarkMap.hpp
+++ b/gc/base/MarkMap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@
 
 #include "omrcfg.h"
 #include "omr.h"
+#include "omrmodroncore.h"
 
 #include "HeapMap.hpp"
 
@@ -100,6 +101,20 @@ public:
 	getFirstCellByMarkSlotIndex(uintptr_t slotIndex)
 	{
 		return _heapMapBaseDelta + (slotIndex << _heapMapIndexShift);
+	}
+
+	/**
+	 * check MarkMap if there is any liveObjects in the Card
+	 * this function assumes that card covers exactly 512 bytes.
+	 * @param heapAddress has to be card size aligned
+	 */
+	MMINLINE bool
+	areAnyLiveObjectsInCard(void* heapAddress) const
+	{
+#if (8 != BITS_PER_BYTE) || (9 != CARD_SIZE_SHIFT)
+#error Card size has to be exactly 512 bytes
+#endif
+		return 0 != *(uint64_t*)getSlotPtrForAddress((omrobjectptr_t) heapAddress);
 	}
 
 	/**


### PR DESCRIPTION
	base on current MarkMap, verify if there are any liveObjects
	in the card. it is helper function for card flushing or
	card pruning.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>