### PR TITLE
Clean-up support for Known Object Table in JITServer

### DIFF
--- a/compiler/env/OMRKnownObjectTable.cpp
+++ b/compiler/env/OMRKnownObjectTable.cpp
@@ -67,6 +67,25 @@ OMR::KnownObjectTable::getIndex(uintptr_t objectPointer, bool isArrayWithConstan
    return index;
    }
 
+TR::KnownObjectTable::Index
+OMR::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer)
+   {
+   TR_UNIMPLEMENTED();
+   return -1;
+   }
+
+TR::KnownObjectTable::Index
+OMR::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer, bool isArrayWithConstantElements)
+   {
+   TR_ASSERT(TR::Compiler->vm.hasAccess(self()->comp()), "Getting KnownObjectTable index requires VM access");
+   TR::KnownObjectTable::Index index = self()->getOrCreateIndex(objectPointer);
+   if (isArrayWithConstantElements)
+      {
+      self()->addArrayWithConstantElements(index);
+      }
+   return index;
+   }
+
 void
 OMR::KnownObjectTable::addArrayWithConstantElements(Index index)
    {
@@ -121,6 +140,26 @@ TR::KnownObjectTable::Index
 OMR::KnownObjectTable::getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
    {
    Index result = self()->getIndexAt(objectReferenceLocation);
+   if (isArrayWithConstantElements)
+      self()->addArrayWithConstantElements(result);
+   return result;
+   }
+
+TR::KnownObjectTable::Index
+OMR::KnownObjectTable::getOrCreateIndexAt(uintptr_t *objectReferenceLocation)
+   {
+#ifdef J9_PROJECT_SPECIFIC
+   TR::VMAccessCriticalSection getIndexCriticalSection(self()->comp());
+#endif
+   uintptr_t objectPointer = *objectReferenceLocation; // Note: object references held as uintptr_t must never be compressed refs
+   Index result = self()->getOrCreateIndex(objectPointer);
+   return result;
+   }
+
+TR::KnownObjectTable::Index
+OMR::KnownObjectTable::getOrCreateIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
+   {
+   Index result = self()->getOrCreateIndexAt(objectReferenceLocation);
    if (isArrayWithConstantElements)
       self()->addArrayWithConstantElements(result);
    return result;

--- a/compiler/env/OMRKnownObjectTable.hpp
+++ b/compiler/env/OMRKnownObjectTable.hpp
@@ -74,13 +74,15 @@ public:
    TR::Compilation *comp() const { return _comp; }
    void setComp(TR::Compilation *comp) { _comp = comp; }
 
-   virtual Index getEndIndex();                      // Highest index assigned so far + 1
-   virtual Index getIndex(uintptr_t objectPointer); // Must hold vm access for this
+   Index getEndIndex();                      // Highest index assigned so far + 1
+   Index getIndex(uintptr_t objectPointer); // Must hold vm access for this
    Index getIndex(uintptr_t objectPointer, bool isArrayWithConstantElements); // Must hold vm access for this
-   virtual uintptr_t *getPointerLocation(Index index);
-   virtual bool isNull(Index index);
+   Index getOrCreateIndex(uintptr_t objectPointer); // Must hold vm access for this
+   Index getOrCreateIndex(uintptr_t objectPointer, bool isArrayWithConstantElements); // Must hold vm access for this
+   uintptr_t *getPointerLocation(Index index);
+   bool isNull(Index index);
 
-   virtual void dumpTo(TR::FILE *file, TR::Compilation *comp);
+   void dumpTo(TR::FILE *file, TR::Compilation *comp);
 
    // Handy wrappers
 
@@ -89,6 +91,8 @@ public:
 
    Index getIndexAt(uintptr_t *objectReferenceLocation);
    Index getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
+   Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation);
+   Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
    Index getExistingIndexAt(uintptr_t *objectReferenceLocation);
 
    uintptr_t getPointer(Index index);


### PR DESCRIPTION
This is the first step of the clean-up:
- Add `getOrCreateIndex()` and `getOrCreateIndexAt`() which
will be used to replace `getIndex()` and `getIndexAt()` in
the second clean-up phase.
- Remove `virtual` declaration of the methods since `KnownObjectTable`
is an extensible class.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>