### PR TITLE
Use '-static-libstdc++' when linking ddrgen and blob_reader

### DIFF
--- a/ddr/tools/blob_reader/CMakeLists.txt
+++ b/ddr/tools/blob_reader/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,4 +38,14 @@ target_link_libraries(omr_blob_reader
 
 if(OMRPORT_OMRSIG_SUPPORT)
 	target_link_libraries(omr_blob_reader omrsig)
+endif()
+
+if((OMR_TOOLCONFIG STREQUAL "gnu") AND (NOT OMR_OS_OSX))
+	include(CheckCXXCompilerFlag)
+	check_cxx_compiler_flag("-static-libstdc++" ALLOWS_STATIC_LIBCPP)
+	if(ALLOWS_STATIC_LIBCPP)
+		set_property(
+			TARGET omr_blob_reader
+			APPEND_STRING PROPERTY LINK_FLAGS " -static-libstdc++")
+	endif()
 endif()

--- a/ddr/tools/blob_reader/Makefile
+++ b/ddr/tools/blob_reader/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@ MODULE_INCLUDES += \
 
 ifeq (gcc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += -frtti -D__STDC_LIMIT_MACROS -std=c++0x
+  MODULE_LDFLAGS += -static-libstdc++
 endif
 
 ifeq (msvc,$(OMR_TOOLCHAIN))

--- a/ddr/tools/ddrgen/CMakeLists.txt
+++ b/ddr/tools/ddrgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,4 +40,14 @@ target_link_libraries(omr_ddrgen
 
 if(OMRPORT_OMRSIG_SUPPORT)
 	target_link_libraries(omr_ddrgen omrsig)
+endif()
+
+if((OMR_TOOLCONFIG STREQUAL "gnu") AND (NOT OMR_OS_OSX))
+	include(CheckCXXCompilerFlag)
+	check_cxx_compiler_flag("-static-libstdc++" ALLOWS_STATIC_LIBCPP)
+	if(ALLOWS_STATIC_LIBCPP)
+		set_property(
+			TARGET omr_ddrgen
+			APPEND_STRING PROPERTY LINK_FLAGS " -static-libstdc++")
+	endif()
 endif()

--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,7 @@ endif
 
 ifeq (gcc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += -frtti -D__STDC_LIMIT_MACROS -std=c++0x
+  MODULE_LDFLAGS += -static-libstdc++
 else ifeq (msvc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += /EHsc
 endif


### PR DESCRIPTION
Using g++ 7.5 requires a version of libstdc++ that is newer than what is available on CentOS. Statically linking that library allows these tools to run on CentOS.