### PR TITLE
Fix use of uintptrj_t guarded by J9_PROJECT_SPECIFIC

### DIFF
--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -738,11 +738,11 @@ TR::S390zOSSystemLinkage::generateCallDescriptorValue(TR::Node* callNode)
          // JNI Calls include a JNIEnv* pointer that is not included in list of children nodes.
          // For FastJNI, certain calls do not require us to pass the JNIEnv.
          if (!cg()->fej9()->jniDoNotPassThread(resolvedMethod))
-            parmAreaOffset += sizeof(uintptrj_t);
+            parmAreaOffset += sizeof(uintptr_t);
 
          // For FastJNI, certain calls do not have to pass in receiver object.
          if (cg()->fej9()->jniDoNotPassReceiver(resolvedMethod))
-            parmAreaOffset -= sizeof(uintptrj_t);
+            parmAreaOffset -= sizeof(uintptr_t);
          }
 #endif
 


### PR DESCRIPTION
A merge conflict caused us to miss this case which is guarded by the
`J9_PROJECT_SPECIFIC` ifdef which is why the OMR testing did not catch
it.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>