### PR TITLE
Fix OMROptions_includes.hpp missing from OMRCPU on Z

### DIFF
--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -28,6 +28,7 @@
 #pragma csect(TEST,"OMRZCPUBase#T")
 
 #include "control/Options.hpp"
+#include "control/Options_inlines.hpp"
 #include "env/CPU.hpp"
 
 TR::CPU


### PR DESCRIPTION
Downstream projects which are using the newly introduced APIs here are
failing to compile with undefined symbols to `getOptions` since we
forgot to include the inlines file to resolve these symbols.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>