### PR TITLE
Change realTimeGC field to an internal option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1027,6 +1027,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"randomSeedRaw",      "R\tUses the supplied random seed as-is; see also randomSeedSignatureHash", RESET_OPTION_BIT(TR_RandomSeedSignatureHash),  "F" },
    {"randomSeedSignatureHash","R\tSet random seed value based on a hash of the method's signature, in order to get varying seeds while maintaining reproducibility", SET_OPTION_BIT(TR_RandomSeedSignatureHash),  "F" },
    {"reduceCountsForMethodsCompiledDuringStartup", "M\tNeeds SCC compilation hints\t", SET_OPTION_BIT(TR_ReduceCountsForMethodsCompiledDuringStartup), "F", NOT_IN_SUBSET },
+   {"realTimeGC",         "I\tSupport the real time GC", SET_OPTION_BIT(TR_RealTimeGC), "F" },
    {"regmap",             "C\tgenerate GC maps with register maps", SET_OPTION_BIT(TR_RegisterMaps), NULL, NOT_IN_SUBSET},
    {"reportEvents",       "C\tcompile event reporting hooks into code", SET_OPTION_BIT(TR_ReportMethodEnter | TR_ReportMethodExit)},
    {"reportMethodEnterExit", "D\treport method enter and exit",                   SET_OPTION_BIT(TR_ReportMethodEnter | TR_ReportMethodExit), "F"},
@@ -1654,8 +1655,6 @@ int32_t       OMR::Options::_numUsableCompilationThreads = -1; // -1 means not i
 
 int32_t       OMR::Options::_trampolineSpacePercentage = 0; // 0 means no change from default
 
-bool          OMR::Options::_realTimeGC=false;
-
 bool          OMR::Options::_countsAreProvidedByUser = false;
 TR_YesNoMaybe OMR::Options::_startupTimeMatters = TR_maybe;
 
@@ -1902,6 +1901,17 @@ OMR::Options::Options(TR::Options &other) :
       _logFile = NULL;
    }
 
+void
+OMR::Options::setRealTimeGC(bool m)
+   {
+   self()->setOption(TR_RealTimeGC, m);
+   }
+
+bool
+OMR::Options::realTimeGC()
+   {
+   return self()->getOption(TR_RealTimeGC);
+   }
 
 char *
 OMR::Options::latePostProcessJIT(void *jitConfig)

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -325,7 +325,7 @@ enum TR_CompilationOptions
    TR_DisableTOC                          = 0x08000000 + 7,
    TR_UseLowPriorityQueueDuringCLP        = 0x10000000 + 7,
    TR_DisableVectorBCD                    = 0x20000000 + 7,
-   // Available                           = 0x40000000 + 7,
+   TR_RealTimeGC                          = 0x40000000 + 7,
    TR_DisableTraps                        = 0x80000000 + 7,
 
    // Option word 8
@@ -1909,8 +1909,8 @@ public:
    void setActiveCardTableBase(uintptr_t b) { _activeCardTableBase = b; }
    uintptr_t getActiveCardTableBase() { return _activeCardTableBase; }
 
-   void setRealTimeGC(bool m)            { _realTimeGC = m; }
-   inline bool realTimeGC()              { return _realTimeGC; }
+   void setRealTimeGC(bool m);
+   bool realTimeGC();
 
    static void setSharedClassCache(bool c){ _sharedClassCache = c; }
    inline static bool sharedClassCache()  { return _sharedClassCache; }
@@ -2298,8 +2298,6 @@ protected:
    bool                        _isVariableHeapBaseForBarrierRange0;
    bool                        _isVariableHeapSizeForBarrierRange0;
    bool                        _isVariableActiveCardTableBase;
-
-   static bool                 _realTimeGC;
 
    static bool                 _sharedClassCache;
 


### PR DESCRIPTION
This change is to support the JITServer to send the option flag from the client to the Compilation object at the server.

Related to issue eclipse/openj9#8707

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>