### PR TITLE
Annotate OMRNode code cleanup with issue number

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5087,6 +5087,8 @@ TR::SymbolReference *
 OMR::Node::getSymbolReference()
    {
 #if !defined(REMOVE_REGLS_SYMREFS_FROM_GETSYMREF)
+   // Issue #4647 was created to track the investigation and removal of this guarded code.
+   //
    // This code is to be removed, once all illegal accesses of _regLoadStoreSymbolReference are removed
    if (self()->hasRegLoadStoreSymbolReference())
       return self()->getRegLoadStoreSymbolReference();
@@ -5100,6 +5102,8 @@ TR::SymbolReference    *
 OMR::Node::setSymbolReference(TR::SymbolReference * p)
    {
 #if !defined(REMOVE_REGLS_SYMREFS_FROM_SETSYMREF)
+   // Issue #4647 was created to track the investigation and removal of this guarded code.
+   //
    if (self()->hasRegLoadStoreSymbolReference())
       {
       p = self()->setRegLoadStoreSymbolReference(p);


### PR DESCRIPTION
Some code in OMRNode.cpp is guarded with `REMOVE_REGLS_SYMREFS_FROM_SETSYMREF`
macros with a comment explaining it should be cleaned up.  Issue #4647 was created
for that purpose.  Document this in the code.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>