### PR TITLE
Move function numConcreteClasses into OpenJ9 ClassEnv

### DIFF
--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -59,3 +59,10 @@ OMR::ClassEnv::classUnloadAssumptionNeedsRelocation(TR::Compilation *comp)
    {
    return comp->compileRelocatableCode();
    }
+
+bool 
+OMR::ClassEnv::containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses)
+   {
+   TR_UNIMPLEMENTED();
+   return false;
+   }

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -43,6 +43,8 @@ namespace TR { class TypeLayout; }
 namespace TR { class Region; }
 class TR_ResolvedMethod;
 class TR_Memory;
+class TR_PersistentClassInfo;
+template <typename ListKind> class List;
 
 namespace OMR
 {
@@ -142,6 +144,16 @@ public:
     */
    const TR::TypeLayout* enumerateFields(TR::Region& region, TR_OpaqueClassBlock * clazz, TR::Compilation *comp) { return NULL; }
 
+   /**
+    * @brief Determine if a list of classes contains less than two concrete classes.
+    * A class is considered concrete if it is not an interface or an abstract class
+    * 
+    * @param subClasses List of subclasses to be checked.
+    * 
+    * @return Returns 'true' if the given list of classes contains less than 
+    * 2 concrete classes and false otherwise.
+    */
+   bool containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
    };
 
 }


### PR DESCRIPTION
This PR removes an OMR function `numConcreteClasses`. and added a frontend calling corresponding OpenJ9 function. 

This function takes a list of subclasses and count the number of concrete classes. It is called only once in the code base and compare number of concrete class with two. Thus it is safe to modify this function and return a boolean value once number of concrete class reaches two. This is also included in the change.

This change reduces JITServer messages between client and server. Since this function can be now executed on the server instead of sending messages to client. 

This change contains two PRs, one in OpenJ9 and one in OMR. The OMR PR depends on this PR, thus this should be merged after OpenJ9 or it will break the build. 

Reference: https://github.com/eclipse/openj9/issues/8699
Depend on: https://github.com/eclipse/openj9/pull/8933

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>