### PR TITLE
Changed dependency list overflow assert to fatal

### DIFF
--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -410,7 +410,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          // Printf added so it triggers some output even in prod build.
          // If this failure is triggered in a prod build, you might
          // not get a SEGV nor any meaningful error msg.
-         TR_ASSERT(0,"ERROR: addPostCondition list overflow\n");
+         TR_ASSERT_FATAL(0,"ERROR: addPostCondition list overflow\n");
          _cg->comp()->failCompilation<TR::CompilationException>("addPostCondition list overflow, abort compilation\n");
          }
       _postConditions->setDependencyInfo(_addCursorForPost++, vr, rr, flag);

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -362,14 +362,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
       // dont add dependencies if reg is real register
       if (vr && vr->getRealRegister()!=NULL) return;
 
-      if (_addCursorForPre >= _numPreConditions)
-         {
-         // Printf added so it triggers some output even in prod build.
-         // If this failure is triggered in a prod build, you might
-         // not get a SEGV nor any meaningful error msg.
-         TR_ASSERT(0,"ERROR: addPreCondition list overflow\n");
-         _cg->comp()->failCompilation<TR::CompilationException>("addPreCondition list overflow, abort compilation\n");
-         }
+      TR_ASSERT_FATAL(_addCursorForPre < _numPreConditions,"addPreCondition list overflow. addCursorForPre(%d), numPreConditions(%d), virtual register name(%s) and pointer(%p)\n",_addCursorForPre, _numPreConditions,vr->getRegisterName(_cg->comp()),vr);
       _preConditions->setDependencyInfo(_addCursorForPre++, vr, rr, flag);
       }
 
@@ -405,14 +398,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
       // dont add dependencies if reg is real register
       if (vr && vr->getRealRegister()!=NULL) return;
-      if (_addCursorForPost >= _numPostConditions)
-         {
-         // Printf added so it triggers some output even in prod build.
-         // If this failure is triggered in a prod build, you might
-         // not get a SEGV nor any meaningful error msg.
-         TR_ASSERT_FATAL(0,"ERROR: addPostCondition list overflow\n");
-         _cg->comp()->failCompilation<TR::CompilationException>("addPostCondition list overflow, abort compilation\n");
-         }
+      TR_ASSERT_FATAL(_addCursorForPost < _numPostConditions,"addPostCondition list overflow. addCursorForPost(%d), numPostConditions(%d), virtual register name(%s) and pointer(%p)\n",_addCursorForPost, _numPostConditions,vr->getRegisterName(_cg->comp()),vr);
       _postConditions->setDependencyInfo(_addCursorForPost++, vr, rr, flag);
       }
 


### PR DESCRIPTION
With initial implementation, using a fallback such as an interpreter to execute method for which compilation failed due to dependency list overflow could result in silent performance issues.

Changing the assert to fatal helps avoid any potential silent performance issues by ensuring initialization of dependency list with correct capacity.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>