### PR TITLE
Prepare compiled MethodBuilder for use in later Call()

### DIFF
--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -705,7 +705,17 @@ OMR::MethodBuilder::Compile(void **entry)
 
    int32_t rc=0;
    *entry = (void *) compileMethodFromDetails(NULL, details, warm, rc);
+
+   // let TypeDictionary know to clear out sym refs used in this compilation so
+   // no dangling pointers
    typeDictionary()->NotifyCompilationDone();
+
+   // in case this MethodBuilder object is used in another Call()
+   // clear out symrefs allocated in this compilation (no dangling pointers)
+   // and reset _connectedTrees so MethodBuilder can be inlined if needed
+   _symbols.clear();
+   _connectedTrees = false;
+
    return rc;
    }
 


### PR DESCRIPTION
The `Call()` JitBuilder service can take a `MethodBuilder` object
as the target, which currently chooses to always inline that
`MethodBuilder`. It only works properly for `MethodBuilder` objects
that haven't been previously compiled. Previously compiled
`MethodBuilder` objects retain some state that cause problems
when the object is passed `Call`. In particular:
    - there are dangling `SymbolReference`s stored in `_symbols`
    - `_connectedTrees` is true so `connectTrees()` skips the
      inlined method code as it stitches the caller's trees
      together

These are readily fixed by clearing the `_symbols` map and
clearing the `_connectedTrees` flag.

Fixes: #4909

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>