### PR TITLE
Change TR_PREXARGINFO_TRACER_CLASS macro definition to TR_LogTracer

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3862,8 +3862,6 @@ TR_IndirectCallSite::addTargetIfThereIsSingleImplementer (TR_InlinerBase* inline
 
 bool TR_IndirectCallSite::findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner)
    {
-   //inliner->tracer()->dumpPrexArgInfo(_ecsPrexArgInfo);
-
    if (addTargetIfMethodIsNotOverriden(inliner) ||
        addTargetIfMethodIsNotOverridenInReceiversHierarchy(inliner) ||
        addTargetIfThereIsSingleImplementer(inliner) ||
@@ -6278,30 +6276,6 @@ TR_InlinerDelimiter::TR_InlinerDelimiter(TR_InlinerTracer *tracer, char * tag)
 TR_InlinerDelimiter::~TR_InlinerDelimiter()
    {
    debugTrace(_tracer,"</%s>",_tag);
-   }
-
-void TR_InlinerTracer::dumpPrexArgInfo(TR_PrexArgInfo* argInfo)
-   {
-   if (!argInfo || !heuristicLevel())
-      return;
-
-   traceMsg( comp(),  "<argInfo address = %p numArgs = %d>\n", argInfo, argInfo->getNumArgs());
-   for (int i = 0 ; i < argInfo->getNumArgs(); i++)
-
-      {
-      TR_PrexArgument* arg = argInfo->get(i);
-      if (arg && arg->getClass())
-         {
-         char* className = TR::Compiler->cls.classSignature(comp(), arg->getClass(), trMemory());
-         traceMsg( comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d argIsKnownObject=%d koi=%d class=%p className= %s/>\n",
-         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->hasKnownObjectIndex(), arg->getKnownObjectIndex(), arg->getClass(), className);
-         }
-      else
-         {
-         traceMsg( comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d/>\n", i, arg, arg ? arg->classIsFixed() : 0, arg ? arg->classIsPreexistent() : 0);
-         }
-      }
-      traceMsg( comp(),  "</argInfo>\n");
    }
 
 bool

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -129,7 +129,6 @@ class TR_InlinerTracer : public TR_LogTracer
       void dumpCallTarget (TR_CallTarget *, const char *fmt, ...);
       void dumpInline (TR_LinkHead<TR_CallTarget> *targets, const char *fmt, ...);
       void dumpPartialInline (TR_InlineBlocks *partialInline);
-      void dumpPrexArgInfo(TR_PrexArgInfo* argInfo);
 
       void dumpDeadCalls(TR_LinkHead<TR_CallSite> *sites);
 

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -26,10 +26,10 @@
 #include <string.h>
 #include "env/KnownObjectTable.hpp"
 #include "env/TRMemory.hpp"
+#include "ras/LogTracer.hpp"
 
 // Temporary macro to coordinate changes between omr and openj9.
-// This will eventually be changed to TR_LogTracer.
-#define TR_PREXARGINFO_TRACER_CLASS TR_InlinerTracer
+#define TR_PREXARGINFO_TRACER_CLASS TR_LogTracer
 
 class TR_CallSite;
 class TR_InlinerTracer;
@@ -113,15 +113,15 @@ class TR_PrexArgInfo
    static TR_PrexArgInfo* enhance(TR_PrexArgInfo *dest, TR_PrexArgInfo *source, TR::Compilation *comp);
 
    static void propagateReceiverInfoIfAvailable (TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-                                              TR_PrexArgInfo * argInfo, TR_PREXARGINFO_TRACER_CLASS *tracer);
+                                              TR_PrexArgInfo* argInfo, TR_LogTracer* tracer);
 
    static void propagateArgsFromCaller(TR::ResolvedMethodSymbol* methodSymbol, TR_CallSite* callsite,
-      TR_PrexArgInfo * argInfo, TR_PREXARGINFO_TRACER_CLASS *tracer);
+      TR_PrexArgInfo* argInfo, TR_LogTracer* tracer);
 
-   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_PREXARGINFO_TRACER_CLASS *tracer);
+   static bool validateAndPropagateArgsFromCalleeSymbol(TR_PrexArgInfo* argsFromSymbol, TR_PrexArgInfo* argsFromTarget, TR_LogTracer* tracer);
 
-   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_PREXARGINFO_TRACER_CLASS* tracer);
-   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_PREXARGINFO_TRACER_CLASS* tracer);
+   static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_LogTracer* tracer);
+   void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_LogTracer* tracer);
    /**
     * \brief
     *    Get arg info for arguments of callNode that are parameters of the caller
@@ -152,7 +152,7 @@ class TR_PrexArgInfo
    TR_PrexArgument **_args;
    //
 #ifdef J9_PROJECT_SPECIFIC
-   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_PREXARGINFO_TRACER_CLASS* tracer);
+   static TR::Node* getCallNode (TR::ResolvedMethodSymbol* methodSymbol, class TR_CallSite* callsite, class TR_LogTracer* tracer);
    static bool hasArgInfoForChild (TR::Node *child, TR_PrexArgInfo * argInfo);
    static TR_PrexArgument* getArgForChild(TR::Node *child, TR_PrexArgInfo* argInfo);
 #endif


### PR DESCRIPTION
This macro was introduced in #4903.

The original issue is here: https://github.com/eclipse/openj9/issues/7936

This is a step towards refactoring the `TR_PrexArgInfo` class so that it is
decoupled from the `TR_InlinerTracer` class.

- Change `TR_PrexArgInfo` method declarations to accept arguments of type
  `TR_LogTracer` instead of `TR_InlinerTracer`.
- Change the definition of `TR_PREXARGINFO_TRACER_CLASS` to TR_LogTracer so that
  the corresponding method definitions in openj9 are also updated.
- Remove method `TR_InlinerTracer::dumpPrexArgInfo` since it is no longer called
  anywhere.

See: https://github.com/eclipse/openj9/issues/7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>