### PR TITLE
Fix for ZOS linkage

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -286,6 +286,11 @@ public:
 	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
+	/**
+	 * Notify any (concurrent) collector that might block and hold VM access
+	 * that an Exclusive VM Access is to be requested so that VM access can be released
+	 */
+	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env) {}
 	virtual bool isDisabled(MM_EnvironmentBase *env) { return _disableGC; }
 	/**
 	 * @return pointer to collector/phase specific concurrent stats structure

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -518,12 +518,6 @@ public:
 	bool exclusiveAccessBeatenByOtherThread() { return _exclusiveAccessBeatenByOtherThread; }
 	
 	/**
-	 * Notify any (concurrent) collector that might block and hold VM access
-	 * that an Exclusive VM Access is to be requested so that VM access can be released
-	 */
-	void collectorNotifyAcquireExclusiveVMAccess();
-
-	/**
 	 * Force thread to use out-of-line request for VM access. This may be required if there
 	 * is there is an event waiting to be hooked the next time the thread acquires VM access.
 	 */

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -324,6 +324,11 @@ public:
 #endif /* OMR_GC_MODRON_COMPACTION */
 
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env);
+	/**
+	 * Notify any (concurrent) collector (like Concurrent Scavenger) that might block and hold VM access
+	 * that an Exclusive VM Access is to be requested so that VM access can be released
+	 */	
+	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env);
 
 	MM_ParallelGlobalGC(MM_EnvironmentBase *env)
 		: MM_GlobalCollector()


### PR DESCRIPTION
https://github.com/eclipse/omr/pull/4905 causing Verbose GC lib linkage
failure on ZOS

EnvironmentBase cannot call Scavenger directly (which is in
standard dir).
Using indirection: EnvironmentBase will call base Collector and through
virtual dispatch effectively call ParallelGlobalGC (which is in standard
dir) that will call Scavenger.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>