### PR TITLE
Define new UnsupportedValueTypeOperation exception

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -66,6 +66,17 @@ struct ILGenFailure : public virtual CompilationException
    };
 
 /**
+ * Unsupported value type operation exception type.
+ *
+ * Thrown if an unsupported value type operation is encountered that requires
+ * compilation to be aborted.
+ */
+struct UnsupportedValueTypeOperation : public virtual CompilationException
+   {
+   virtual const char* what() const throw() { return "Unsupported value type operation"; }
+   };
+
+/**
  * Recoverable IL Generation Failure exception type.
  *
  * Thrown on an IL Generation Failure condition which the compiler can


### PR DESCRIPTION
Initial prototype support in the JIT compiler for identity classes (value types) will not generally handle the case where the class of a value type is unresolved.  For now the JIT compiler should abort the compilation with an `UnsupportedValueTypeOperation` exception, to allow such unsupported operations to be more easily kept track of.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>