### PR TITLE
AArch64: Add OMR_ARCH_AARCH64 to omrcfg.h.in

### DIFF
--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -124,6 +124,11 @@
 #undef OMR_ARCH_ARM
 
 /**
+ * This spec targets AARCH64 processors.
+ */
+#undef OMR_ARCH_AARCH64
+
+/**
  * This spec targets x86 processors.
  */
 #undef OMR_ARCH_X86


### PR DESCRIPTION
Add `OMR_ARCH_AARCH64` to omrcfg.h.in.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>