### PR TITLE
AArch64: Add OMR_ARCH_AARCH64 to omrcfg.cmake.h.in

### DIFF
--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -126,6 +126,11 @@
 #cmakedefine OMR_ARCH_ARM
 
 /**
+ * This spec targets AARCH64 processors.
+ */
+#cmakedefine OMR_ARCH_AARCH64
+
+/**
  * This spec targets x86 processors.
  */
 #cmakedefine OMR_ARCH_X86


### PR DESCRIPTION
Add `OMR_ARCH_AARCH64` to `omrcfg.cmake.h.in`.

`OMR_ARCH_AARCH64` is added to `omrcfg.h.in` in https://github.com/eclipse/omr/pull/4982,
but it must be also added to `omrcfg.cmake.h.in` for CMake builds.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>