### PR TITLE
Add non-helper symbol for working with value types

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -206,6 +206,13 @@ class SymbolReferenceTable
       startPCLinkageInfoSymbol,
       instanceShapeFromROMClassSymbol,
 
+      /** \brief Performs an equality comparison between two objects.
+       *
+       * The comparison takes two references to objects as arguments.
+       * It is up to users to define to define and implement the semantics of this operation.
+       */
+      objectEqualityComparisonSymbol,
+
       /** \brief
        *
        *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -138,6 +138,10 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             {
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
             }
+         if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
+            {
+            return &symRefTab->aliasBuilder.defaultMethodUseAliases();
+            }
 
          if (!methodSymbol->isHelper())
             {
@@ -183,6 +187,7 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             case TR_transactionExit:
             case TR_newObject:
             case TR_newObjectNoZeroInit:
+            case TR_acmpHelper:
             case TR_newValue:
             case TR_newValueNoZeroInit:
             case TR_newArray:
@@ -322,7 +327,8 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::arraySetSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::osrFearPointHelperSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol) ||
-             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol))
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
             {
             return &symRefTab->aliasBuilder.defaultMethodDefAliases();
             }
@@ -368,6 +374,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             case TR_writeBarrierClassStoreRealTimeGC:
             case TR_writeBarrierStoreRealTimeGC:
             case TR_aNewArray:
+            case TR_acmpHelper:
             case TR_newValue:
             case TR_newValueNoZeroInit:
             case TR_newObject:

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2109,6 +2109,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<j9methodConstantPoolField>",
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
+   "<objectEqualityComparison>",
    "<synchronizedFieldLoad>",
    "<atomicAdd>",
    "<atomicFetchAndAdd>",


### PR DESCRIPTION
The new `objectEqualityComparison` non-helper represents an object equality comparison that is more complex than a simple reference comparison.

This new symbol, along with `acmpHelper`, is also added to appropriate alias sets.