### PR TITLE
Fix Select Evaluators for Double and Float

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -442,7 +442,7 @@
    TR::TreeEvaluator::selectEvaluator,      // TR::bselect
    TR::TreeEvaluator::selectEvaluator,      // TR::sselect
    TR::TreeEvaluator::selectEvaluator,      // TR::aselect
-   TR::TreeEvaluator::selectEvaluator,      // TR::fselect
+   TR::TreeEvaluator::dselectEvaluator,      // TR::fselect
    TR::TreeEvaluator::dselectEvaluator,     // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,     // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodEnterHook

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -452,8 +452,6 @@ class FloatSelectInt32CompareTest : public SelectTest<int32_t, float> {};
 TEST_P(FloatSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
     SKIP_ON_HAMMER(MissingImplementation);
-    SKIP_ON_S390(KnownBug);
-    SKIP_ON_S390X(KnownBug);
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_AARCH64(MissingImplementation);
 
@@ -527,8 +525,6 @@ class DoubleSelectInt32CompareTest : public SelectTest<int32_t, double> {};
 TEST_P(DoubleSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
     SKIP_ON_HAMMER(MissingImplementation);
-    SKIP_ON_S390(KnownBug);
-    SKIP_ON_S390X(KnownBug);
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_AARCH64(MissingImplementation);
 


### PR DESCRIPTION
Fix Select Evaluators for Double and Float on Z.

Fixes: #4953

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>