### PR TITLE
Add query method for class whose instances are zero initializable

### DIFF
--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -83,6 +83,20 @@ public:
    bool isPrimitiveClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return false; }
    bool isAnonymousClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return false; }
    bool isValueTypeClass(TR_OpaqueClassBlock *) { return false; }
+
+   /**
+    * \brief
+    *    Checks whether instances of the specified class can be trivially initialized by
+    *    "zeroing" their fields
+    *
+    * \param clazz
+    *    The class that is to be checked
+    *
+    * \return
+    *    `true` if instances of the specified class can be initialized by zeroing their fields;
+    *    `false` otherwise (if some special initialization is required for some fields)
+    */
+   bool isZeroInitializable(TR_OpaqueClassBlock *clazz) { return true; }
    bool isPrimitiveArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
    bool isReferenceArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
    bool isClassArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }


### PR DESCRIPTION
~Classes with value type fields might have those fields flattened (that is, expanded into their components).  `hasUnflattenedValueTypeFields` checks whether a class has any such fields that have not been flattened.~

Define an `isZeroInitializable` method that indicates whether a class's instances have fields that can be trivially initialized by zeroing memory.

The default implementation returns true unconditionally, but can be overridden by downstream projects.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>