### PR TITLE
AArch64: Fix instruction for add with sign-extension

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -915,7 +915,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
             *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::movkw) | ((upper | TR::MOV_LSL16) << 5);
             immreg->setRegisterFieldRD(wcursor);
             wcursor++;
-            *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::addx) | (TR::EXT_SXTW << 13);
+            *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::addextx) | (TR::EXT_SXTW << 13);
             base->setRegisterFieldRN(wcursor);
             immreg->setRegisterFieldRM(wcursor);
             treg->setRegisterFieldRD(wcursor);


### PR DESCRIPTION
This commit fixes the instruction used in generating a memory address.
You need to use addextx instead of addx when you use the SXTW option.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>