### PR TITLE
Replace the obsolete known object table APIs

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1003,7 +1003,7 @@ OMR::SymbolReferenceTable::findOrCreateSymRefWithKnownObject(TR::SymbolReference
    if (!knot)
       return original;
 
-   TR::KnownObjectTable::Index objectIndex = knot->getIndexAt(referenceLocation, isArrayWithConstantElements);
+   TR::KnownObjectTable::Index objectIndex = knot->getOrCreateIndexAt(referenceLocation, isArrayWithConstantElements);
    return findOrCreateSymRefWithKnownObject(original, objectIndex);
    }
 

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1159,7 +1159,7 @@ TR::VPConstraint *TR::VPClass::create(OMR::ValuePropagation *vp, TR::VPClassType
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(vp->comp()->fe());
       uintptr_t objRefOffs = fej9->getOffsetOfJavaLangClassFromClassField();
       uintptr_t *objRef = (uintptr_t*)(type->getClass() + objRefOffs);
-      TR::KnownObjectTable::Index index = knot->getIndexAt(objRef);
+      TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt(objRef);
       type = TR::VPKnownObject::createForJavaLangClass(vp, index);
       }
 #endif
@@ -3559,7 +3559,7 @@ TR::VPConstraint *TR::VPKnownObject::intersect1(TR::VPConstraint *other, OMR::Va
       // - known object should be more specific (though it allows null).
       TR::KnownObjectTable *knot = vp->comp()->getKnownObjectTable();
       TR_ASSERT(knot, "Can't create a TR::VPKnownObject without a known-object table");
-      if (getIndex() == knot->getIndexAt((uintptr_t*)otherConstString->getSymRef()->getSymbol()->castToStaticSymbol()->getStaticAddress()))
+      if (getIndex() == knot->getOrCreateIndexAt((uintptr_t*)otherConstString->getSymRef()->getSymbol()->castToStaticSymbol()->getStaticAddress()))
          return other; // A const string constraint is more specific than known object
       else
          return NULL; // Two different objects

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -423,7 +423,7 @@ static bool tryFoldCompileTimeLoad(
          else if (knot && constraint->isConstString())
             {
             baseExpression  = curNode;
-            baseKnownObject = knot->getIndexAt((uintptr_t*)constraint->getConstString()->getSymRef()->getSymbol()->castToStaticSymbol()->getStaticAddress());
+            baseKnownObject = knot->getOrCreateIndexAt((uintptr_t*)constraint->getConstString()->getSymRef()->getSymbol()->castToStaticSymbol()->getStaticAddress());
             if (vp->trace())
                traceMsg(vp->comp(), "  - %s %p is string obj%d\n", baseExpression->getOpCode().getName(), baseExpression, baseKnownObject);
             break;
@@ -1529,7 +1529,7 @@ static const char *getFieldSignature(OMR::ValuePropagation *vp, TR::Node *node, 
  */
 static bool addKnownObjectConstraints(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   // Access to VM for multiple operations including KnownObjectTable::getIndex()
+   // Access to VM for multiple operations including KnownObjectTable::getOrCreateIndex()
    // is not supported at the server for OMR.
    if (vp->comp()->isOutOfProcessCompilation())
       return false;
@@ -1570,7 +1570,7 @@ static bool addKnownObjectConstraints(OMR::ValuePropagation *vp, TR::Node *node)
             //
             clazz = TR::Compiler->cls.classFromJavaLangClass(vp->comp(), objectReference);
             }
-         knownObjectIndex = knot->getIndex(objectReference);
+         knownObjectIndex = knot->getOrCreateIndex(objectReference);
          }
 
 
@@ -2259,7 +2259,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
                         if(!TR::Compiler->cls.isClassArray(vp->comp(), fieldObjectClazz))
                            {
                            traceMsg(vp->comp(), "Recognized known object field node %p \n", node);
-                           TR::KnownObjectTable::Index fieldObjectKnotIndex = knot->getIndex(fieldObject);
+                           TR::KnownObjectTable::Index fieldObjectKnotIndex = knot->getOrCreateIndex(fieldObject);
                            // Global constraints should work here, as field loads get fresh value numbers
                            constraint = TR::VPClass::create(vp,
                                  TR::VPKnownObject::create(vp, fieldObjectKnotIndex),
@@ -2346,7 +2346,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
          if (knot && symRef == vp->comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef())
             {
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(vp->comp()->fe());
-            TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptr_t*)(base->getClass() + fej9->getOffsetOfJavaLangClassFromClassField()));
+            TR::KnownObjectTable::Index knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(base->getClass() + fej9->getOffsetOfJavaLangClassFromClassField()));
             vp->addBlockOrGlobalConstraint(node,
                   TR::VPClass::create(vp,
                      TR::VPKnownObject::createForJavaLangClass(vp, knownObjectIndex),


### PR DESCRIPTION

Replace `getIndex()` and `getIndexAt()` with `getOrCreateIndex()` and `getOrCreateIndexAt()`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>