### PR TITLE
Remove non-existent VSX load/store with update instructions

### DIFF
--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -830,7 +830,6 @@
    vmrglw,           // vector merge low word
 // lxsd,             // Load VSX scalar Dword
    lxsdx,            // Load VSX Scalar Doubleword Indexed
-   lxsdux,           // Load VSX Scalar Doubleword with Update Indexed
 // lxssp,            // Load VSX scalar single
 // lxsibzx,          // Load VSX scalar as integer byte & zero indexed
 // lxsihzx,          // Load VSX scalar as integer Hword & zero indexed
@@ -843,16 +842,11 @@
 // lxvx,             // Load VSX vector indexed
 // stxsd,            // Store VSX Scalar Dword
    stxsdx,           // Store VSX Scalar Doubleword Indexed
-   stxsdux,          // Store VSX Scalar Doubleword with Update Indexed
    lxvd2x,           // Load VSX Vector Doubleword*2 Indexed
-   lxvd2ux,          // Load VSX Vector Doubleword*2 with Update Indexed
    lxvdsx,           // Load VSX Vector Doubleword & Splat Indexed
    lxvw4x,           // Load VSX Vector Word*4 Indexed
-   lxvw4ux,          // Load VSX Vector Word*4 with Update Indexed
    stxvd2x,          // store VSX Vector Doubleword*2 Indexed
-   stxvd2ux,         // store VSX Vector Doubleword*2 with Update Indexed
    stxvw4x,          // store VSX Vector Word*4 Indexed
-   stxvw4ux,         // store VSX Vector Word*4 with Update Indexed
 // stxssp,           // Store VSX Scalar SP
    xsabsdp,          // VSX Scalar Absolute Value Double-Precision
    xsadddp,          // VSX Scalar Add Double-Precision

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9051,20 +9051,6 @@
                         PPCOpProp_AltFormat,
    },
 
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::lxsdux,
-   /* .name        = */ "lxsdux",
-   /* .description =    "Load VSX Scalar Doubleword with Update Indexed", */
-   /* .opcode      = */ 0x7C0004D8,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_DoubleFP |
-                        PPCOpProp_IsLoad |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
-                        PPCOpProp_AltFormat,
-   },
-
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::lxssp, */
    /* .name        =    "lxssp", */
@@ -9208,20 +9194,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::stxsdux,
-   /* .name        = */ "stxsdux",
-   /* .description =    "Store VSX Scalar Doubleword with Update Indexed", */
-   /* .opcode      = */ 0x7C0005D8,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_DoubleFP |
-                        PPCOpProp_IsStore |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::lxvd2x,
    /* .name        = */ "lxvd2x",
    /* .description =    "Load VSX Vector Doubleword*2 Indexed", */
@@ -9230,19 +9202,6 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp7,
    /* .properties  = */ PPCOpProp_IsLoad |
                         PPCOpProp_IsVSX |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::lxvd2ux,
-   /* .name        = */ "lxvd2ux",
-   /* .description =    "Load VSX Vector Doubleword*2 with Update Indexed", */
-   /* .opcode      = */ 0x7C0006D8,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsLoad |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
                         PPCOpProp_AltFormat,
    },
 
@@ -9271,19 +9230,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::lxvw4ux,
-   /* .name        = */ "lxvw4ux",
-   /* .description =    "Load VSX Vector Word*4 with Update Indexed", */
-   /* .opcode      = */ 0x7C000658,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsLoad |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::stxvd2x,
    /* .name        = */ "stxvd2x",
    /* .description =    "store VSX Vector Doubleword*2 Indexed", */
@@ -9296,19 +9242,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::stxvd2ux,
-   /* .name        = */ "stxvd2ux",
-   /* .description =    "store VSX Vector Doubleword*2 with Update Indexed", */
-   /* .opcode      = */ 0x7C0007D8,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsStore |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::stxvw4x,
    /* .name        = */ "stxvw4x",
    /* .description =    "store VSX Vector Word*4 Indexed", */
@@ -9317,19 +9250,6 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp7,
    /* .properties  = */ PPCOpProp_IsStore |
                         PPCOpProp_IsVSX |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::stxvw4ux,
-   /* .name        = */ "stxvw4ux",
-   /* .description =    "store VSX Vector Word*4 with Update Indexed", */
-   /* .opcode      = */ 0x7C000758,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsStore |
-                        PPCOpProp_IsVSX |
-                        PPCOpProp_UpdateForm |
                         PPCOpProp_AltFormat,
    },
 

--- a/compiler/p/runtime/ppcasmdefines.inc
+++ b/compiler/p/runtime/ppcasmdefines.inc
@@ -1,5 +1,5 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! Copyright (c) 2000, 2016 IBM Corp. and others
+!! Copyright (c) 2000, 2020 IBM Corp. and others
 !!
 !! This program and the accompanying materials are made available under
 !! the terms of the Eclipse Public License 2.0 which accompanies this
@@ -302,9 +302,6 @@
         .endm
         .macro stxvw4x  xt, ra, rb
         .int 0x7c000718 | (\xt & 31) << 21 | \ra << 16 | \rb << 11 | (\xt & 32) >> 5
-        .endm
-        .macro stxvw4ux xt, ra, rb
-        .int 0x7c000758 | (\xt & 31) << 21 | \ra << 16 | \rb << 11 | (\xt & 32) >> 5
         .endm
         .macro stxsdx   xs, ra, rb
         .int 0x7c000598 | (\xs & 31) << 21 | \ra << 16 | \rb << 11 | (\xs & 32) >> 5


### PR DESCRIPTION
Previously, the list of Power opcodes included a number of VSX
load/store indexed with update instructions that do not actually exist.
These have been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>