### PR TITLE
Fix pervasive warnings on z/OS and AIX

### DIFF
--- a/compiler/infra/OMRMonitor.hpp
+++ b/compiler/infra/OMRMonitor.hpp
@@ -47,14 +47,14 @@ class Monitor
    static TR::Monitor *create(char *name);
    static void destroy(TR::Monitor *monitor);
    void enter();
-   int32_t try_enter() { TR_UNIMPLEMENTED(); }
+   int32_t try_enter() { TR_UNIMPLEMENTED(); return 0; }
    int32_t exit(); // returns 0 on success
    void destroy();
    void wait() { TR_UNIMPLEMENTED(); }
-   intptr_t wait_timed(int64_t millis, int32_t nanos) { TR_UNIMPLEMENTED(); }
+   intptr_t wait_timed(int64_t millis, int32_t nanos) { TR_UNIMPLEMENTED(); return 0; }
    void notify() { TR_UNIMPLEMENTED(); }
    void notifyAll() { TR_UNIMPLEMENTED(); }
-   int32_t num_waiting() { TR_UNIMPLEMENTED(); }
+   int32_t num_waiting() { TR_UNIMPLEMENTED(); return 0; }
    char const *getName();
    bool init(char *name);
 

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -51,7 +51,6 @@ void initializeJitRuntimeHelperTable(char jvmpi);
 
 enum TR_CCPreLoadedCode
    {
-#if !defined(TR_TARGET_S390)
    TR_AllocPrefetch = 0,
 #if defined(TR_TARGET_POWER)
    TR_ObjAlloc,
@@ -63,7 +62,6 @@ enum TR_CCPreLoadedCode
    TR_arrayStoreCHK,
 #endif // TR_TARGET_POWER
    TR_NonZeroAllocPrefetch,
-#endif // !defined(TR_TARGET_S390)
    TR_numCCPreLoadedCode
    };
 


### PR DESCRIPTION
The following warning is emitted when compiling a compilation unit
which includes the OMRCodeCache.hpp file:

```
"omr/compiler/runtime/OMRCodeCache.hpp", line 450.14: CCN8891 (W) The
array member "void *_CCPreLoadedCode[]" may only be followed by members
of consistent type.
```

The reason this warning is emitted is because `TR_numCCPreLoadedCode`
evaluates to 0 on S390 due to an ifdef and so we have a zero length
array on z/OS. It is emitting a warning because we have types declared
after the zero length array which are not of the same type as the array
elements.

To fix this issue we simply omit an ifdef which forces the value of
`TR_numCCPreLoadedCode` to be non-zero on S390. This is reasonable, as
this enum is not used at all in the S390 codegen.

When a compilation unit including the OMRMonitor.hpp is compiled xlC
will emit the following warnings:

```
"omr/compiler/infra/OMRMonitor.hpp", line 50.46: CCN6101 (W) A return
value of type "int" is expected.
"omr/compiler/infra/OMRMonitor.hpp", line 54.77: CCN6101 (W) A return
value of type "long" is expected.
"omr/compiler/infra/OMRMonitor.hpp", line 57.48: CCN6101 (W) A return
value of type "int" is expected.
```

It appears that xlC is unable to deduce that the function will not
return and as such it emits a warning saying that there is no return
value. To fix this we just return default values. It doesn't matter
what we return really because at runtime we will never execute the
return statement.

Fixes: #3703
Fixes: #4548