### PR TITLE
WIP: Add IL TreeInterpreter for enabling further compiler optimizations

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -798,6 +798,13 @@ public:
    bool hasClassExtendAssumptions() { return _flags.testAny(HasClassExtendAssumptions); }
 
    // ==========================================================================
+   // Interpreter
+   //
+   
+   void setInterpreterResult(int64_t result) {_interpreterResult = result;}
+   int64_t getInterpreterResult() { return _interpreterResult;}
+
+   // ==========================================================================
    // Compilation
    //
 
@@ -1155,6 +1162,7 @@ private:
    TR_ArenaAllocator                 _arenaAllocator;
    const char *                      _allocatorName;
    TR::Region                        _aliasRegion;
+   int64_t                           _interpreterResult;
 
 
    TR_IlGenerator                    *_ilGenerator;

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -709,6 +709,18 @@ OMR::MethodBuilder::Compile(void **entry)
    return rc;
    }
 
+int32_t
+OMR::MethodBuilder::Interpret()
+   {
+   TR::ResolvedMethod resolvedMethod(static_cast<TR::MethodBuilder *>(this));
+   TR::IlGeneratorMethodDetails details(&resolvedMethod);
+   int32_t rc=0;
+   compileMethodFromDetails(NULL, details, noOpt, rc);
+   TR_ASSERT(rc == 1, "Interpretater returned error code %d, which should return 1 for CompilationInterrupted\n", rc);
+   typeDictionary()->NotifyCompilationDone();
+   return comp()->getInterpreterResult();
+   }
+
 void *
 OMR::MethodBuilder::client()
    {

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -137,6 +137,7 @@ class MethodBuilder : public TR::IlBuilder
                        TR::IlType     ** parmTypes);
 
    int32_t Compile(void **entry);
+   int32_t Interpret();
 
    /**
     * @brief will be called if a Call is issued to a function that has not yet been defined, provides a

--- a/compiler/optimizer/CMakeLists.txt
+++ b/compiler/optimizer/CMakeLists.txt
@@ -70,6 +70,7 @@ compiler_library(optimizer
 	${CMAKE_CURRENT_LIST_DIR}/OMROptimizationManager.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRTransformUtil.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMROptimizer.cpp
+	${CMAKE_CURRENT_LIST_DIR}/Operation.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OrderBlocks.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OSRDefAnalysis.cpp
 	${CMAKE_CURRENT_LIST_DIR}/PartialRedundancy.cpp
@@ -87,6 +88,7 @@ compiler_library(optimizer
 	${CMAKE_CURRENT_LIST_DIR}/Structure.cpp
 	${CMAKE_CURRENT_LIST_DIR}/SwitchAnalyzer.cpp
 	${CMAKE_CURRENT_LIST_DIR}/TranslateTable.cpp
+	${CMAKE_CURRENT_LIST_DIR}/TreeInterpreter.cpp
 	${CMAKE_CURRENT_LIST_DIR}/UnionBitVectorAnalysis.cpp
 	${CMAKE_CURRENT_LIST_DIR}/UseDefInfo.cpp
 	${CMAKE_CURRENT_LIST_DIR}/ValueNumberInfo.cpp

--- a/compiler/optimizer/OMROptimizations.enum
+++ b/compiler/optimizer/OMROptimizations.enum
@@ -26,6 +26,7 @@
 
    OPTIMIZATION_ENUM_ONLY(endOpts = 0x00) // Marks the end of a list of optimizations
 
+   OPTIMIZATION(treeInterpreter)
    OPTIMIZATION(inlining)
    OPTIMIZATION(targetedInlining)
    OPTIMIZATION(trivialInlining)

--- a/compiler/optimizer/Operation.cpp
+++ b/compiler/optimizer/Operation.cpp
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-// #include "optimizer/Operation.hpp"
 #include "optimizer/TreeInterpreter.hpp"
 #include <cstring>
 

--- a/compiler/optimizer/Operation.cpp
+++ b/compiler/optimizer/Operation.cpp
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+// #include "optimizer/Operation.hpp"
+#include "optimizer/TreeInterpreter.hpp"
+#include <cstring>
+
+void
+TR::TreeInterpreter::performOp(TR::Node * node){
+   VALUE operand1, operand2, result;
+   memset(&result, 0, sizeof(VALUE));
+
+   switch (node->getOpCodeValue()){
+      case TR::BBStart:
+         break;
+      case TR::BBEnd:
+         break;
+      case TR::treetop:
+         break;
+
+      // long operations
+      case TR::lconst:
+      {
+         result.type = Int64;
+         result.data.lconst = node->getLongInt();
+         break;
+      }
+      case TR::lload:
+      {
+         result = symbolTable[node->getSymbol()];
+         break;
+      }
+      case TR::lloadi:
+      {
+         result.type = TR::TreeInterpreter::DATATYPE::Address;
+         result.data.aconst = (uintptrj_t)&(symbolTable[node->getSymbol()]);
+         break;
+      }
+      case TR::lstore:
+      {
+         symbolTable[node->getSymbol()] = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         break;
+      }
+      case TR::ladd:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst + operand2.data.lconst;
+         break;
+      }
+      case TR::lsub:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst - operand2.data.lconst;
+         break;
+      }
+      case TR::lmul:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst * operand2.data.lconst;
+         break;
+      }
+      case TR::ldiv:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst / operand2.data.lconst;
+         break;
+      }
+      case TR::lrem:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst % operand2.data.lconst;
+         break;
+      }
+      case TR::lneg:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = ~operand1.data.lconst;
+         break;
+      }
+      case TR::labs:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int64;
+         if (operand1.data.lconst >= 0)
+            result.data.lconst = operand1.data.lconst;
+         else
+            result.data.lconst = -(operand1.data.lconst);
+         break;
+      }
+      case TR::lshl:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst << operand2.data.lconst;
+         break;
+      }
+      case TR::lshr:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst >> operand2.data.lconst;
+         break;
+      }
+      case TR::lrol:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = (operand1.data.lconst << operand2.data.lconst) 
+                              | (operand1.data.lconst >> (64 - operand2.data.lconst));
+         break;
+      }
+      case TR::land:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst & operand2.data.lconst;
+         break;
+      }
+      case TR::lor:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst | operand2.data.lconst;
+         break;
+      }
+      case TR::lxor:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.lconst ^ operand2.data.lconst;
+         break;
+      }
+      case TR::l2i:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int32;
+         result.data.iconst = (int32_t)operand1.data.lconst;
+         break;
+      }
+      case TR::l2f:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Float;
+         result.data.fconst = (float_t)operand1.data.lconst;
+         break;
+      }
+      case TR::l2d:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Double;
+         result.data.dconst = (double_t)operand1.data.lconst;
+         break;
+      }
+      case TR::l2b:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int8;
+         result.data.bconst = (int8_t)operand1.data.lconst;
+         break;
+      }
+      case TR::l2s:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int16;
+         result.data.sconst = (int16_t)operand1.data.lconst;
+         break;
+      }
+      case TR::l2a:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Address;
+         result.data.aconst = (uintptrj_t)operand1.data.lconst;
+         break;
+      }
+      case TR::lcmpeq:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst == operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmpne:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst != operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmplt:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst <  operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmpge:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst >= operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmpgt:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst >  operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmple:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Boolean;
+         result.data.lconst = operand1.data.lconst <= operand2.data.lconst ? true : false;
+         break;
+      }
+      case TR::lcmp:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int8;
+         result.data.lconst = operand1.data.lconst >  operand2.data.lconst ? 1 :
+                              operand1.data.lconst == operand2.data.lconst ? 0 : -1;
+         break;
+      }
+      case TR::lternary:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = operand1.data.boolean
+                                 ? nodeValueMap[node->getChild(1)->getGlobalIndex()].data.lconst
+                                 : nodeValueMap[node->getChild(2)->getGlobalIndex()].data.lconst;
+         break;
+      }
+      case TR::lmulh:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = (((__int128_t)operand1.data.lconst) * ((__int128_t)operand2.data.lconst))>>64;
+         break;
+      }
+      case TR::lbits2d:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         result.type = Double;
+         result.data.lconst = operand1.data.lconst;
+         break;
+      }
+      case TR::lcmpset:
+      {
+         int64_t * pointer = (int64_t *)&nodeValueMap[node->getChild(0)->getGlobalIndex()].data.lconst;
+         operand1 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(2)->getGlobalIndex()];
+         result.type = Boolean;
+         if (*pointer == operand1.data.lconst){
+            *pointer = operand2.data.lconst;
+            result.data.boolean = false;
+         }
+         else{
+            result.data.boolean = true;
+         }
+         break;
+      }
+      case TR::lexp:
+      {
+         operand1 = nodeValueMap[node->getChild(0)->getGlobalIndex()];
+         operand2 = nodeValueMap[node->getChild(1)->getGlobalIndex()];
+         result.type = Int64;
+         result.data.lconst = pow(operand1.data.lconst,operand2.data.lconst);
+         break;
+      }
+      case TR::lmax:
+      {
+         int64_t max, temp;
+         max = (nodeValueMap[node->getChild(0)->getGlobalIndex()]).data.lconst;
+         for (int i = 1; i < node->getNumChildren(); ++i){
+            temp = (nodeValueMap[node->getChild(i)->getGlobalIndex()]).data.lconst;
+            if (temp > max)
+               max = temp;
+         }
+         result.type = Int64;
+         result.data.lconst = max;
+         break;
+      }
+      case TR::lmin:
+      {
+         int64_t min, temp;
+         min = nodeValueMap[node->getChild(0)->getGlobalIndex()].data.lconst;
+         for (int i = 1; i < node->getNumChildren(); ++i){
+            int64_t temp = nodeValueMap[node->getChild(i)->getGlobalIndex()].data.lconst;
+            if (min > temp)
+               min = temp;
+         }
+         result.type = Int64;
+         result.data.lconst = min;
+         break;
+      }
+      default:
+         TR_ASSERT_FATAL(1, "Unexpected opcode for n%dn [%p]\n", node->getGlobalIndex(), node);
+   }
+   if (node->getReferenceCount() != 0){
+      nodeValueMap[node->getGlobalIndex()] = result;
+   }
+   return;
+}

--- a/compiler/optimizer/TreeInterpreter.cpp
+++ b/compiler/optimizer/TreeInterpreter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,4 +118,34 @@ TR::TreeInterpreter::process(TR::Node *node)
    traceMsg(comp(), "\tprocessing node n%dn [%p], evaluating\n", node->getGlobalIndex(), node);
    performOp(node);
    return;
+}
+
+void
+TR::TreeInterpreter::dumpNodeToValueMap()
+{
+   char mapString[2048];
+   char *stringp = mapString;
+   stringp += sprintf(stringp, "  nodeToValueMap DUMP:\n");
+   for(auto e : nodeValueMap){
+      stringp += sprintf(stringp, "\tnodeGlobalIndex: n%dn;  ", e.first);
+      stringp += sprintf(stringp, "VALUE: {type = %5s, data = 0x%.8X}\n",
+         VALUETYPE_NAME[e.second.type], e.second.data);
+    }
+    traceMsg(comp(), "%s\n", mapString);
+    return;
+}
+
+void
+TR::TreeInterpreter::dumpSymbolTable()
+{
+   char symTableString[2048];
+   char *stringp = symTableString;
+   stringp += sprintf(stringp, "  symbolTable DUMP:\n");
+   for(auto e : symbolTable){
+      stringp += sprintf(stringp, "\tTR::Symbol *: 0x%p;  ", e.first);
+      stringp += sprintf(stringp, "VALUE: {type = %5s, data = 0x%.8X, rc = %2d}\n",
+         VALUETYPE_NAME[e.second.type], e.second.data);
+    }
+    traceMsg(comp(), "%s\n", symTableString);
+    return;
 }

--- a/compiler/optimizer/TreeInterpreter.cpp
+++ b/compiler/optimizer/TreeInterpreter.cpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "optimizer/TreeInterpreter.hpp"
+#include <stddef.h>
+#include <stdint.h>
+#include "infra/forward_list.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "env/FrontEnd.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Options.hpp"
+#include "control/Options_inlines.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/IO.hpp"
+#include "env/StackMemoryRegion.hpp"
+#include "env/jittypes.h"
+#include "il/AutomaticSymbol.hpp"
+#include "il/Block.hpp"
+#include "il/DataTypes.hpp"
+#include "il/ILOpCodes.hpp"
+#include "il/ILOps.hpp"
+#include "il/MethodSymbol.hpp"
+#include "il/Node.hpp"
+#include "il/NodePool.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/ResolvedMethodSymbol.hpp"
+#include "il/Symbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/ILWalk.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Optimization_inlines.hpp"
+#include "optimizer/OptimizationManager.hpp"
+#include "optimizer/Optimizations.hpp"
+#include "optimizer/Optimizer.hpp"
+#include "optimizer/TransformUtil.hpp"
+#include "ras/Debug.hpp"
+
+
+TR::Optimization *
+TR::TreeInterpreter::create(TR::OptimizationManager *manager)
+   {
+   return new (manager->allocator()) TR::TreeInterpreter(manager);
+   }
+
+
+TR::TreeInterpreter::TreeInterpreter(TR::OptimizationManager *manager)
+   : TR::Optimization(manager),
+   nodeValueMap(std::less<ncount_t>(), comp()->trMemory()->currentStackRegion()),
+   symbolTable(std::less<TR::Symbol *>(), comp()->trMemory()->currentStackRegion())
+{
+}
+
+int32_t
+TR::TreeInterpreter::perform()
+{
+   TR::TreeTop *firstTree = comp()->getStartTree();
+   VALUE treeTopValue;
+   for ( TR::TreeTop * treeTop = firstTree; treeTop != NULL; treeTop = treeTop->getNextTreeTop()){
+      TR::Node *treeTopNode = treeTop->getNode();
+      traceMsg(comp(), "walking treeTop n%dn\n", treeTopNode->getGlobalIndex());
+      process(treeTopNode);
+      dumpNodeToValueMap();
+      if (treeTopNode->getOpCodeValue() == TR::treetop){
+         treeTopValue = nodeValueMap[treeTopNode->getChild(0)->getGlobalIndex()];
+         traceMsg(comp(), "treeTop n%dn VALUE(%s) = 0x%.8X\n",
+            treeTopNode->getGlobalIndex(), VALUETYPE_NAME[treeTopValue.type], treeTopValue.data);
+      }
+      traceMsg(comp(), "------------------------\n");
+   }
+   // interpretation finished, interrupt compiler
+   comp()->setInterpreterResult(treeTopValue.data.lconst);
+   comp()->failCompilation<TR::CompilationInterrupted>("IL interpretation finsihed");
+   return 1;
+}
+
+const char *
+TR::TreeInterpreter::optDetailString() const throw()
+   {
+   return "O^O TreeInterpreter: ";
+   }
+
+void
+TR::TreeInterpreter::process(TR::Node *node)
+{
+   if (nodeValueMap.find(node->getGlobalIndex()) != nodeValueMap.end()){
+      traceMsg(comp(), "\tprocessing node n%dn [%p], value found in map\n", node->getGlobalIndex(), node);
+      return;
+   }
+
+   int numChildren = node->getNumChildren();
+   for (int i = 0; i < numChildren; i++){
+      process(node->getChild(i));
+   }
+   traceMsg(comp(), "\tprocessing node n%dn [%p], evaluating\n", node->getGlobalIndex(), node);
+   performOp(node);
+   return;
+}

--- a/compiler/optimizer/TreeInterpreter.hpp
+++ b/compiler/optimizer/TreeInterpreter.hpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_TREEINTERPRETER_INCL
+#define TR_TREEINTERPRETER_INCL
+
+#include <stdint.h>
+#include "env/TRMemory.hpp"
+#include "infra/List.hpp"
+#include "optimizer/Optimization.hpp"
+#include "optimizer/Operation.hpp"
+#include <stack>
+#include <string>
+
+
+namespace TR { class Block; }
+namespace TR { class OptimizationManager; }
+namespace TR { class TreeTop; }
+
+namespace TR
+{
+
+
+class TreeInterpreter : public TR::Optimization
+{
+   public:
+   // aconst - address constant (zero value means NULL)
+   // iconst - integer constant (32-bit signed 2's complement)
+   // lconst - long integer constant (64-bit signed 2's complement)
+   // fconst - float constant (32-bit ieee fp)
+   // dconst - double constant (64-bit ieee fp)
+   // bconst - byte integer constant (8-bit signed 2's complement)
+   // sconst - short integer constant (16-bit signed 2's complement)
+   char VALUETYPE_NAME[9][10] = {
+      "NoType",
+      "Int8",
+      "Int16",
+      "Int32",
+      "Int64",
+      "Float",
+      "Double",
+      "Address",
+      "Boolean"
+   };
+   typedef enum {
+      NoType=0,
+      Int8,
+      Int16,
+      Int32,
+      Int64,
+      Float,
+      Double,
+      Address,
+      Boolean
+   } DATATYPE;
+   typedef union{
+      uintptrj_t  aconst;
+      int8_t      bconst;
+      int16_t     sconst;
+      int32_t     iconst;
+      int64_t     lconst;
+      float_t     fconst;
+      double_t    dconst;
+      bool        boolean;
+   } DATA;
+   
+   typedef struct {
+      DATATYPE type;
+      DATA data;
+   } VALUE;
+
+
+   typedef std::pair<ncount_t const, VALUE> NodeToValueMapEntry;
+   typedef TR::typed_allocator<NodeToValueMapEntry, TR::Region&> NodeToValueMapAlloc;
+   typedef std::map<ncount_t, VALUE, std::less<ncount_t>, NodeToValueMapAlloc> NodeToValueMap;
+   NodeToValueMap nodeValueMap;
+
+   typedef std::pair<TR::Symbol * const, VALUE> SymbolTableEntry;
+   typedef TR::typed_allocator<SymbolTableEntry, TR::Region&> SymbolTableAlloc;
+   typedef std::map<TR::Symbol *, VALUE, std::less<TR::Symbol *>, SymbolTableAlloc> SymbolTable;
+   SymbolTable symbolTable;
+
+   TreeInterpreter(TR::OptimizationManager *manager);
+   static TR::Optimization *create(TR::OptimizationManager *manager);
+   virtual int32_t perform();
+   virtual const char * optDetailString() const throw();
+
+   private:
+   void process(TR::Node *node);
+
+   // operations
+   void performOp(TR::Node * node);
+};
+}
+
+#endif

--- a/compiler/optimizer/TreeInterpreter.hpp
+++ b/compiler/optimizer/TreeInterpreter.hpp
@@ -108,6 +108,8 @@ class TreeInterpreter : public TR::Optimization
 
    // operations
    void performOp(TR::Node * node);
+   void dumpNodeToValueMap();
+   void dumpSymbolTable();
 };
 }
 

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -30,6 +30,14 @@
             {"name":"entryPoint","type":"ppointer"}
             ]
         },
+        { "name": "interpretMethodBuilder"
+            , "overloadsuffix": ""
+            , "flags": []
+            , "return": "int32"
+            , "parms": [
+                {"name":"methodBuilder","type":"MethodBuilder"}
+                ]
+        },
         { "name": "shutdownJit"
         , "overloadsuffix": ""
         , "flags": []

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -222,6 +222,44 @@ internal_compileMethodBuilder(TR::MethodBuilder *m, void **entry)
    return rc;
    }
 
+int32_t
+internal_interpretMethodBuilder(TR::MethodBuilder *m)
+   {
+   auto result = m->Interpret();
+
+#if defined(J9ZOS390)
+   struct FunctionDescriptor
+   {
+      uint64_t environment;
+      void* func;
+   };
+
+   FunctionDescriptor* fd = new FunctionDescriptor();
+   fd->environment = 0;
+   fd->func = *entry;
+
+   *entry = (void*) fd;
+#elif defined(AIXPPC)
+   struct FunctionDescriptor
+      {
+      void* func;
+      void* toc;
+      void* environment;
+      };
+
+   FunctionDescriptor* fd = new FunctionDescriptor();
+   fd->func = *entry;
+   // TODO: There should really be a better way to get this. Usually, we would use
+   // cg->getTOCBase(), but the code generator has already been destroyed by now...
+   fd->toc = toPPCTableOfConstants(TR_PersistentMemory::getNonThreadSafePersistentInfo()->getPersistentTOC())->getTOCBase();
+   fd->environment = NULL;
+
+   *entry = (uint8_t*) fd;
+#endif
+
+   return result;
+   }
+
 void
 internal_shutdownJit()
    {

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -61,6 +61,7 @@
 #include "optimizer/RegDepCopyRemoval.hpp"
 #include "optimizer/Simplifier.hpp"
 #include "optimizer/SinkStores.hpp"
+#include "optimizer/TreeInterpreter.hpp"
 #include "optimizer/TrivialDeadBlockRemover.hpp"
 #include "optimizer/GlobalValuePropagation.hpp"
 #include "optimizer/LocalValuePropagation.hpp"
@@ -144,6 +145,11 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::endOpts                                                                  },
    };
 
+static const OptimizationStrategy TreeInterpreterOpts[] =
+   {
+   { OMR::treeInterpreter                                                          },
+   { OMR::endOpts                                                                  },
+   };
 
 namespace JitBuilder
 {
@@ -153,6 +159,8 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
    : OMR::Optimizer(comp, methodSymbol, isIlGen, strategy, VNType)
    {
    // Initialize individual optimizations
+   _opts[OMR::treeInterpreter] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::TreeInterpreter::create, OMR::treeInterpreter);
    _opts[OMR::trivialDeadBlockRemover] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialDeadBlockRemover::create, OMR::trivialDeadBlockRemover);
    _opts[OMR::deadTreesElimination] =
@@ -210,7 +218,7 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
    self()->setRequestOptimization(OMR::tacticalGlobalRegisterAllocator, true);
 
 
-   omrCompilationStrategies[noOpt] = JBwarmStrategyOpts;
+   omrCompilationStrategies[noOpt] = TreeInterpreterOpts;
    omrCompilationStrategies[cold]  = JBwarmStrategyOpts;
    omrCompilationStrategies[warm]  = JBwarmStrategyOpts;
    omrCompilationStrategies[hot]   = JBwarmStrategyOpts;


### PR DESCRIPTION
The project is aimed at making an IL interpreter that uses value constraint propagation to 
enable the compiler to use more advanced inline optimizations.

This PR adds a basic interpreter for the IL tree. The interpreter is implemented as a compiler optimization, and is inserted as the noOpt strategy for now, which is currently unused.

This serves as a prototype to build upon for future work. Some current limitations include being unable to pass parameters to methods, and the only type of instructions supported are a subset of long integer operations. Further work needs to be done to add value constraint propagation.

This is a project done by University of Alberta students under CANOSP.