### PR TITLE
Add support for miscellaneous-instruction-extensions facility 2 in OMR::Z::CPU

### DIFF
--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -245,8 +245,11 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
 
    bool isLoadNodeNested = false;
 
+   // All of the memToRegOpCodes (MGH, MSGC and MSC) used in the if block below
+   // rely on the miscellaneous-instruction-extension facility 2 being installed
+
    // TODO: add MH and MHY here; outside of the z14 if check.
-   if(cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z14))
+   if(cg()->comp()->target().cpu.getSupportsMiscellaneousInstructionExtensions2Facility())
       {
       bool isSetReg2Mem1 = false;
 

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -314,6 +314,25 @@ OMR::Z::CPU::setSupportsGuardedStorageFacility(bool value)
    }
 
 bool
+OMR::Z::CPU::getSupportsMiscellaneousInstructionExtensions2Facility()
+   {
+   return _flags.testAny(S390SupportsMIE2);
+   }
+
+bool
+OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensions2Facility(bool value)
+   {
+   if (value)
+      {
+      _flags.set(S390SupportsMIE2);
+      }
+   else
+      {
+      _flags.reset(S390SupportsMIE2);
+      }
+   }
+
+bool
 OMR::Z::CPU::getSupportsMiscellaneousInstructionExtensions3Facility()
    {
    return _flags.testAny(S390SupportsMIE3);

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -177,6 +177,23 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
    bool setSupportsVectorPackedDecimalFacility(bool value);
    
    /** \brief
+    *     Determines whether the Miscellaneous Instruction Extensions 2 (MIE2) facility is available on the current
+    *     processor.
+    */
+   bool getSupportsMiscellaneousInstructionExtensions2Facility();
+
+   /** \brief
+    *     Determines whether the Miscellaneous Instruction Extensions 2 (MIE2) facility is available on the current
+    *     processor.
+    *
+    *  \param value
+    *     Determines whether the Miscellaneous Instruction Extensions 2 facility is available (if \c true) or not (if
+    *     \c false).
+    */
+   bool setSupportsMiscellaneousInstructionExtensions2Facility(bool value);
+
+
+   /** \brief
     *     Determines whether the Miscellaneous Instruction Extensions 3 (MIE3) facility is available on the current
     *     processor.
     */
@@ -279,10 +296,11 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
       S390SupportsVectorPackedDecimalFacility  = 0x00080000,
       S390SupportsGuardedStorageFacility       = 0x00100000,
       S390SupportsSideEffectAccessFacility     = 0x00200000,
-      S390SupportsMIE3                         = 0x00400000,
-      S390SupportsVectorFacilityEnhancement2   = 0x00800000,
-      S390SupportsVectorPDEnhancementFacility  = 0x01000000,
-      S390SupportsVectorFacilityEnhancement1   = 0x02000000,
+      S390SupportsMIE2                         = 0x00400000,
+      S390SupportsMIE3                         = 0x00800000,
+      S390SupportsVectorFacilityEnhancement2   = 0x01000000,
+      S390SupportsVectorPDEnhancementFacility  = 0x02000000,
+      S390SupportsVectorFacilityEnhancement1   = 0x04000000,
       };
 
    Architecture _supportedArch;


### PR DESCRIPTION
This commit adds a flag for miscellaneous-instruction-extensions facility 2
within OMR::Z::CPU. It also adds the relevant methods to retrieve/toggle
this flag.

Lastly, it guards the emission of `MGH`, `MSGC` and `MSC` instructions within `z/codegen/BinaryCommutativeAnalyzer.cpp` with a check for this facility.

Signed-off-by: Pushkar Bettadpur <pushkar.bettadpur@ibm.com>