### PR TITLE
Remove remnants of LM from the Power codegen

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1569,9 +1569,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsTM() { return _flags4.testAny(SupportsTM);}
    void setSupportsTM() { _flags4.set(SupportsTM);}
 
-   bool getSupportsLM() { return _flags4.testAny(SupportsLM);}
-   void setSupportsLM() { _flags4.set(SupportsLM);}
-
    virtual bool getSupportsTLE();
 
    virtual bool getSupportsIbyteswap();
@@ -1850,7 +1847,7 @@ class OMR_EXTENSIBLE CodeGenerator
       // AVAILABLE                                        = 0x04000000,
       // AVAILABLE                                        = 0x08000000,
       // AVAILABLE                                        = 0x10000000,
-      SupportsLM                                          = 0x20000000,
+      // AVAILABLE                                        = 0x20000000,
 
       DummyLastEnum4
       };

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -271,7 +271,6 @@ const char * objectName[] =
    "TR_ZHWProfiler",
    "TR_PPCHWProfiler",
    "TR_ZGuardedStorage",
-   "TR_PPCLMGuardedStorage",
 
    "CatchTable",
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -417,7 +417,6 @@ public:
       ZHWProfiler,
       PPCHWProfiler,
       ZGuardedStorage,
-      PPCLMGuardedStorage,
 
       CatchTable,
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -282,10 +282,6 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    if (self()->comp()->target().cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM) && TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
       self()->setSupportsTM();
 
-   // enable LM if hardware supports instructions and running the reduced-pause GC policy
-   if (self()->comp()->target().cpu.getPPCSupportsLM())
-      self()->setSupportsLM();
-
    if (self()->comp()->target().cpu.getPPCSupportsVMX() && self()->comp()->target().cpu.getPPCSupportsVSX())
       self()->setSupportsAutoSIMD();
 

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -234,8 +234,6 @@
    lbzx,             // Load byte and zero extend indexed
    ld,               // Load dword
    ldarx,            // Load dword and reserve indexed
-   ldmx,             // Load dword monitored indexed
-   lwzmx,            // Load word and zero monitored indexed
    ldu,              // Load dword with update
    ldux,             // Load dword with update indexed
    ldx,              // Load dword indexed

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -2363,28 +2363,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::ldmx,
-   /* .name        = */ "ldmx",
-   /* .description =    "Load dword monitored indexed", */
-   /* .opcode      = */ 0x7C00026A,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsLoad |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::lwzmx,
-   /* .name        = */ "lwzmx",
-   /* .description =    "Load word and zero monitored indexed", */
-   /* .opcode      = */ 0x7C000268,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsLoad |
-                        PPCOpProp_AltFormat,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::ldu,
    /* .name        = */ "ldu",
    /* .description =    "Load dword with update", */

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -398,16 +398,7 @@ TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::Code
       }
    else
       {
-      // For compr refs caseL if monitored loads is supported and we are loading an address, use monitored loads instruction
-      if (node->getOpCodeValue() == TR::iloadi && cg->getSupportsLM() && node->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
-         {
-         tempMR->forceIndexedForm(node, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwzmx, node, tempReg, tempMR);
-         }
-      else
-         {
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-         }
+      generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
       }
 
    cg->insertPrefetchIfNecessary(node, tempReg);
@@ -553,37 +544,12 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
          }
       else
          {
-	     // if monitored loads is supported and we are loading an address, use monitored loads instruction
-	     if (node->getOpCodeValue() == TR::aloadi && cg->getSupportsLM() && node->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
-		    {
-		    tempMR->forceIndexedForm(node, cg);
-		    generateTrg1MemInstruction(cg, TR::InstOpCode::ldmx, node, tempReg, tempMR);
-		    }
-	     else
-		    {
-	    	generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, tempReg, tempMR);
-		    }
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, tempReg, tempMR);
          }
       }
    else
       {
-      if (node->getSymbol()->isClassObject() || (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()))
-		 {
-    	 generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-		 }
-      else
-         {
-	     // if monitored loads is supported and we are loading an address, use monitored loads instruction
-	     if (node->getOpCodeValue() == TR::aloadi && cg->getSupportsLM() && node->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
-		    {
-		    tempMR->forceIndexedForm(node, cg);
-		    generateTrg1MemInstruction(cg, TR::InstOpCode::lwzmx, node, tempReg, tempMR);
-		    }
-	     else
-		    {
-	    	 generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-		    }
-         }
+      generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
       }
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -62,7 +62,6 @@ public:
    bool getPPCSupportsVSX() { return false; }
    bool getPPCSupportsAES() { return false; }
    bool getPPCSupportsTM()  { return false; }
-   bool getPPCSupportsLM()  { return false; }
 
    /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
     *         Alias of getPPCSupportsTM() as a platform agnostic query.


### PR DESCRIPTION
Previously, a half-implemented feature called LM guarded storage was
present in the Power codegen. This code was never used since the
necessary hardware support was never added for it to work. Since it's
unlikely that the necessary support will ever be added, all associated
code has been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>