### PR TITLE
Remove definition of deprecated IL const Opcodes

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -573,7 +573,6 @@ public:
 	static TR::Register *luRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iuRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *luRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -548,7 +548,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::luRegLoadEvaluator ,	// TR::luRegLoad		// Load unsigned long integer global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iuRegStoreEvaluator ,	// TR::iuRegStore	// Store unsigned integer global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::luRegStoreEvaluator ,	// TR::luRegStore	// Store long integer global register 
-    TR::TreeEvaluator::cconstEvaluator, // TR::cconst		// load unicode constant (16-bit unsigned)
     TR::TreeEvaluator::cloadEvaluator, // TR::cload		// load short unsigned integer
     TR::TreeEvaluator::cloadEvaluator, // TR::cloadi		// load indirect unsigned short integer
     TR::TreeEvaluator::sstoreEvaluator, // TR::cstore		// store unsigned short integer

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -49,11 +49,6 @@ TR::Register *OMR::ARM64::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::Cod
    return commonConstEvaluator(node, node->getByte(), cg);
    }
 
-TR::Register *OMR::ARM64::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return commonConstEvaluator(node, node->getConst<uint16_t>(), cg);
-   }
-
 TR::Register *OMR::ARM64::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (cg->profiledPointersRequireRelocation() &&

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -61,7 +61,6 @@ public:
    static TR::Register *unImpOpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -672,7 +672,6 @@
    TR::TreeEvaluator::lRegLoadEvaluator,    // TR::luRegLoad
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::iuRegStore
    TR::TreeEvaluator::lRegStoreEvaluator,   // TR::luRegStore
-   TR::TreeEvaluator::cconstEvaluator,      // TR::cconst
    TR::TreeEvaluator::cloadEvaluator,       // TR::cload
    TR::TreeEvaluator::cloadEvaluator,       // TR::cloadi
    TR::TreeEvaluator::sstoreEvaluator,      // TR::cstore

--- a/compiler/arm/codegen/UnaryEvaluator.cpp
+++ b/compiler/arm/codegen/UnaryEvaluator.cpp
@@ -55,11 +55,6 @@ TR::Register *OMR::ARM::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::CodeG
    return commonConstEvaluator(node, node->getByte(), cg);
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return commonConstEvaluator(node, node->getConst<uint16_t>(), cg);
-   }
-
 TR::Register *OMR::ARM::TreeEvaluator::commonConstEvaluator(TR::Node *node, int32_t value, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg = node->setRegister(cg->allocateRegister());

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -8460,22 +8460,6 @@
    },
 
    {
-   /* .opcode               = */ TR::cconst,
-   /* .name                 = */ "cconst",
-   /* .properties1          = */ ILProp1::LoadConst,
-   /* .properties2          = */ ILProp2::ValueNumberShare,
-   /* .properties3          = */ ILProp3::LikeUse,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int16,
-   /* .typeProperties       = */ ILTypeProp::Size_2 | ILTypeProp::Unsigned,
-   /* .childProperties      = */ ILChildProp::NoChildren,
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::cload,
    /* .name                 = */ "cload",
    /* .properties1          = */ ILProp1::LoadVar | ILProp1::HasSymbolRef,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -610,7 +610,6 @@
    luRegLoad, // Load unsigned long integer global register
    iuRegStore,// Store unsigned integer global register
    luRegStore,// Store long integer global register
-   cconst,   // load unicode constant (16-bit unsigned)
    cload,    // load short unsigned integer
    cloadi,   // load indirect unsigned short integer
    cstore,   // store unsigned short integer

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -373,9 +373,6 @@ private:
       {
       switch (opvalue) 
          {
-         //Constant
-         case TR::cconst:
-
          //Add and Subtract
          case TR::aiuadd: 
          case TR::aluadd: 

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1767,7 +1767,7 @@ TR_Arraytranslate::checkStore(TR::Node * storeNode)
 //
 //ifscmpeq --> block <no-stop>
 //  ==>icload at <translate-char>
-//  cconst <termination char>
+//  sconst <termination char>
 //-or-
 //ifXcmpYY --> block <no-stop>
 //  ==>icload at <translate-char>
@@ -2457,7 +2457,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //          iconst -16
    //ifscmpne --> block <no-stop>
    //  ==>icload at <translate-char>
-   //  cconst <termination char>
+   //  sconst <termination char>
    //BBEnd <load-char>
    //BBStart <escape>
    //   goto <escape-block>
@@ -2507,7 +2507,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //          iconst -16
    //ifscmpeq --> block <escape-block>
    //  ==>icload at <translate-char>
-   //  cconst <termination char>
+   //  sconst <termination char>
    //BBEnd <load-char>
    //
    //BBStart <store-char>

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -2609,12 +2609,12 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                      }
                   if (reportCompareDemotions)
                      {
-                     dumpOptDetails(s->comp(), "Long Compare Narrower: found child 1 c2l and child 2 lconst in cconst range in method %s\n", s->comp()->signature());
+                     dumpOptDetails(s->comp(), "Long Compare Narrower: found child 1 c2l and child 2 lconst in sconst range in method %s\n", s->comp()->signature());
                      }
                   }
                else if (reportCompareDemotions)
                   {
-                  dumpOptDetails(s->comp(), "Long Compare Narrower: found child 1 c2l and child 2 cconst in method %s\n", s->comp()->signature());
+                  dumpOptDetails(s->comp(), "Long Compare Narrower: found child 1 c2l and child 2 sconst in method %s\n", s->comp()->signature());
                   }
                }
             }
@@ -4440,12 +4440,12 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
                   }
                if (reportCompareDemotions)
                   {
-                  dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 iconst in cconst range in method %s\n", s->comp()->signature());
+                  dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 iconst in sconst range in method %s\n", s->comp()->signature());
                   }
                }
             else if (reportCompareDemotions)
                {
-               dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 cconst in method %s\n", s->comp()->signature());
+               dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 sconst in method %s\n", s->comp()->signature());
                }
             }
          }
@@ -4582,12 +4582,12 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   }
                if (reportCompareDemotions)
                   {
-                  dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 iconst in cconst range in method %s\n", s->comp()->signature());
+                  dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 iconst in sconst range in method %s\n", s->comp()->signature());
                   }
                }
             else if (reportCompareDemotions)
                {
-               dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 cconst in method %s\n", s->comp()->signature());
+               dumpOptDetails(s->comp(), "Integer Compare Narrower: found child 1 c2i and child 2 sconst in method %s\n", s->comp()->signature());
                }
             }
          }

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -572,7 +572,6 @@
    dftSimplifier,           // TR::luRegLoad
    dftSimplifier,           // TR::iuRegStore
    dftSimplifier,           // TR::luRegStore
-   constSimplifier,         // TR::cconst
    directLoadSimplifier,    // TR::cload
    indirectLoadSimplifier,  // TR::cloadi
    dftSimplifier,           // TR::cstore

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -715,7 +715,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::luRegLoad
    constrainChildren,        // TR::iuRegStore
    constrainChildren,        // TR::luRegStore
-   constrainShortConst,      // TR::cconst
    constrainIntLoad,         // TR::cload
    constrainIntLoad,         // TR::cloadi
    constrainIntStore,        // TR::cstore

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -555,7 +555,6 @@
    TR::TreeEvaluator::gprRegLoadEvaluator,              // TR::luRegLoad
    TR::TreeEvaluator::gprRegStoreEvaluator,             // TR::iuRegStore
    TR::TreeEvaluator::gprRegStoreEvaluator,             // TR::luRegStore
-   TR::TreeEvaluator::iconstEvaluator,                  // TR::cconst
    TR::TreeEvaluator::cloadEvaluator,                   // TR::cload
    TR::TreeEvaluator::cloadEvaluator,                   // TR::cloadi
    TR::TreeEvaluator::cstoreEvaluator,                  // TR::cstore

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2821,7 +2821,6 @@ int32_t childTypes[] =
    TR::Int64,                     // TR::luRegLoad
    TR::Int32,                     // TR::iuRegStore
    TR::Int64,                     // TR::luRegStore
-   TR::Int16,                     // TR::cconst
    TR::Int16,                     // TR::cload
    TR::Int16 | (TR::Address<<8),   // TR::cloadi
    TR::Int16,                     // TR::cstore

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -580,7 +580,6 @@ public:
 	static TR::Register *luRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iuRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *luRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -548,7 +548,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::luRegLoadEvaluator ,	// TR::luRegLoad		// Load unsigned long integer global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::iuRegStoreEvaluator ,	// TR::iuRegStore	// Store unsigned integer global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::luRegStoreEvaluator ,	// TR::luRegStore	// Store long integer global register
-    TR::TreeEvaluator::cconstEvaluator, // TR::cconst		// load unicode constant (16-bit unsigned)
     TR::TreeEvaluator::cloadEvaluator, // TR::cload		// load short unsigned integer
     TR::TreeEvaluator::cloadEvaluator, // TR::cloadi		// load indirect unsigned short integer
     TR::TreeEvaluator::sstoreEvaluator, // TR::cstore		// store unsigned short integer

--- a/compiler/riscv/codegen/UnaryEvaluator.cpp
+++ b/compiler/riscv/codegen/UnaryEvaluator.cpp
@@ -49,11 +49,6 @@ TR::Register *OMR::RV::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::CodeGe
    return commonConstEvaluator(node, node->getByte(), cg);
    }
 
-TR::Register *OMR::RV::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return commonConstEvaluator(node, node->getConst<uint16_t>(), cg);
-   }
-
 TR::Register *OMR::RV::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg = cg->allocateRegister();

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -551,7 +551,6 @@
    TR::TreeEvaluator::integerRegLoadEvaluator,                         // TR::luRegLoad <- (Uses iRegLoad intentionally)
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::iuRegStore
    TR::TreeEvaluator::lRegStoreEvaluator,                              // TR::luRegStore
-   TR::TreeEvaluator::cconstEvaluator,                                 // TR::cconst
    TR::TreeEvaluator::sloadEvaluator,                                  // TR::cload
    TR::TreeEvaluator::sloadEvaluator,                                  // TR::cloadi
    TR::TreeEvaluator::cstoreEvaluator,                                 // TR::cstore

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -70,7 +70,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *floadEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -54,13 +54,6 @@ TR::Register *OMR::X86::TreeEvaluator::sconstEvaluator(TR::Node *node, TR::CodeG
    return reg;
    }
 
-TR::Register *OMR::X86::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableChar, cg);
-   node->setRegister(reg);
-   return reg;
-   }
-
 TR::Register *OMR::X86::TreeEvaluator::iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *reg = TR::TreeEvaluator::loadConstant(node, node->getInt(), TR_RematerializableInt, cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -551,7 +551,6 @@
    TR::TreeEvaluator::lRegLoadEvaluator,                               // TR::luRegLoad (OBSOLETE?)
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::iuRegStore (OBSOLETE?)
    TR::TreeEvaluator::lRegStoreEvaluator,                              // TR::luRegStore (OBSOLETE?)
-   TR::TreeEvaluator::cconstEvaluator,                                 // TR::cconst
    TR::TreeEvaluator::sloadEvaluator,                                  // TR::cload
    TR::TreeEvaluator::sloadEvaluator,                                  // TR::cloadi
    TR::TreeEvaluator::cstoreEvaluator,                                 // TR::cstore

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -93,7 +93,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *branchEvaluator(TR::Node * node, TR::CodeGenerator * cg);
    static TR::Register *ibranchEvaluator(TR::Node * node, TR::CodeGenerator * cg);
    static TR::Register *mbranchEvaluator(TR::Node * node, TR::CodeGenerator * cg);

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -586,7 +586,6 @@
    TR::TreeEvaluator::lRegLoadEvaluator,    // TR::luRegLoad
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::iuRegStore
    TR::TreeEvaluator::lRegStoreEvaluator,   // TR::luRegStore
-   TR::TreeEvaluator::cconstEvaluator,      // TR::cconst
    TR::TreeEvaluator::sloadEvaluator,       // TR::cload
    TR::TreeEvaluator::sloadEvaluator,       // TR::cloadi
    TR::TreeEvaluator::cstoreEvaluator,      // TR::cstore

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -134,17 +134,6 @@ OMR::Z::TreeEvaluator::sconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    }
 
 /**
- * cconst Evaluator: load unicode integer constant (16-bit unsigned)
- */
-TR::Register *
-OMR::Z::TreeEvaluator::cconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   generateLoad32BitConstant(cg, node, node->getConst<uint16_t>(), tempReg, true);
-   return tempReg;
-   }
-
-/**
  * labsEvaluator -
  */
 TR::Register *


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `constant` category listed in #2657.

_Note that this PR needs to be merged simultaneously with https://github.com/eclipse/openj9/pull/9118_

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com