### PR TITLE
Update AIX builds with version appropriate copy of CreateExportList

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -36,7 +36,7 @@ pipeline {
 
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
+                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/opt/IBM/xlC/13.1.3/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
 
                         echo 'Compile...'
                         sh '''export CCACHE_EXTRAFILES="$PWD/omrcfg.h" && make -j8'''

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
@@ -22,7 +22,7 @@ pipeline {
 
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
+                        sh '''cmake -Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/opt/IBM/xlC/13.1.3/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
 
                         echo 'Compile...'
                         sh '''export CCACHE_EXTRAFILES="$PWD/omrcfg.h" && make -j4'''

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -29,7 +29,7 @@ def SPECS = [
         'builds' : [
             [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake',
+                'configureArgs' : '-Wdev -DCMAKE_C_COMPILER=xlc_r -DCMAKE_CXX_COMPILER=xlC_r -DCMAKE_XL_CreateExportList="/opt/IBM/xlC/13.1.3/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake',
                 'compile' : 'export CCACHE_EXTRAFILES="$PWD/omrcfg.h" && make -j8'
             ]
         ],


### PR DESCRIPTION
* related eclipse/omr#5016
* /usr/vac is the location of xlc12 which new machines do not have installed

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>