### PR TITLE
Return SCM variables for Github statuses

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -299,8 +299,8 @@ timestamps {
                                             ]
                                         ]
                                     } else {
-                                        checkout scm
-                                        setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
+                                        scmVars = checkout scm
+                                        setBuildStatus("In Progress","PENDING","${scmVars.GIT_COMMIT}")
                                     }
                                 }
                                 stage('Build') {
@@ -359,7 +359,7 @@ timestamps {
                         }
                     } finally {
                         if (!params.ghprbPullId) {
-                            setBuildStatus("Complete", currentBuild.currentResult, "${env.GIT_COMMIT}")
+                            setBuildStatus("Complete", currentBuild.currentResult, "${scmVars.GIT_COMMIT}")
                         }
                         cleanWs()
                     }


### PR DESCRIPTION
- In declarative syntax, the SCM variables were
  exposed in the env variable. In scripted syntax
  this is not the case. We must capture the SCM
  variables in order to access them.

Related #4992

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>