### PR TITLE
Remove obsolete APIs in known object table

### DIFF
--- a/compiler/env/OMRKnownObjectTable.cpp
+++ b/compiler/env/OMRKnownObjectTable.cpp
@@ -49,25 +49,6 @@ OMR::KnownObjectTable::getEndIndex()
    }
 
 TR::KnownObjectTable::Index
-OMR::KnownObjectTable::getIndex(uintptr_t objectPointer)
-   {
-   TR_UNIMPLEMENTED();
-   return -1;
-   }
-
-TR::KnownObjectTable::Index
-OMR::KnownObjectTable::getIndex(uintptr_t objectPointer, bool isArrayWithConstantElements)
-   {
-   TR_ASSERT(TR::Compiler->vm.hasAccess(self()->comp()), "Getting KnownObjectTable index requires VM access");
-   TR::KnownObjectTable::Index index = self()->getIndex(objectPointer);
-   if (isArrayWithConstantElements)
-      {
-      self()->addArrayWithConstantElements(index);
-      }
-   return index;
-   }
-
-TR::KnownObjectTable::Index
 OMR::KnownObjectTable::getOrCreateIndex(uintptr_t objectPointer)
    {
    TR_UNIMPLEMENTED();
@@ -123,26 +104,6 @@ void
 OMR::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
    {
    TR_UNIMPLEMENTED();
-   }
-
-TR::KnownObjectTable::Index
-OMR::KnownObjectTable::getIndexAt(uintptr_t *objectReferenceLocation)
-   {
-#ifdef J9_PROJECT_SPECIFIC
-   TR::VMAccessCriticalSection getIndexCriticalSection(self()->comp());
-#endif
-   uintptr_t objectPointer = *objectReferenceLocation; // Note: object references held as uintptr_t must never be compressed refs
-   Index result = self()->getIndex(objectPointer);
-   return result;
-   }
-
-TR::KnownObjectTable::Index
-OMR::KnownObjectTable::getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements)
-   {
-   Index result = self()->getIndexAt(objectReferenceLocation);
-   if (isArrayWithConstantElements)
-      self()->addArrayWithConstantElements(result);
-   return result;
    }
 
 TR::KnownObjectTable::Index

--- a/compiler/env/OMRKnownObjectTable.hpp
+++ b/compiler/env/OMRKnownObjectTable.hpp
@@ -75,8 +75,6 @@ public:
    void setComp(TR::Compilation *comp) { _comp = comp; }
 
    Index getEndIndex();                      // Highest index assigned so far + 1
-   Index getIndex(uintptr_t objectPointer); // Must hold vm access for this
-   Index getIndex(uintptr_t objectPointer, bool isArrayWithConstantElements); // Must hold vm access for this
    Index getOrCreateIndex(uintptr_t objectPointer); // Must hold vm access for this
    Index getOrCreateIndex(uintptr_t objectPointer, bool isArrayWithConstantElements); // Must hold vm access for this
    uintptr_t *getPointerLocation(Index index);
@@ -89,8 +87,6 @@ public:
    // API for checking if an known object is an array with immutable elements
    bool isArrayWithConstantElements(Index index);
 
-   Index getIndexAt(uintptr_t *objectReferenceLocation);
-   Index getIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
    Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation);
    Index getOrCreateIndexAt(uintptr_t *objectReferenceLocation, bool isArrayWithConstantElements);
    Index getExistingIndexAt(uintptr_t *objectReferenceLocation);


### PR DESCRIPTION
Remove `getIndex()` and `getIndex()` and they have been replaced by `getOrCreateIndex()` and
`getOrCreateIndexAt()`.

This is the last commit for this cleanup. The previous related PRs are:
- #5004
- #4930
- eclipse/openj9#8931
- eclipse/openj9#9075

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>