### PR TITLE
Fix typo in function name containesZeroOrOneConcreteClass

### DIFF
--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -61,7 +61,7 @@ OMR::ClassEnv::classUnloadAssumptionNeedsRelocation(TR::Compilation *comp)
    }
 
 bool 
-OMR::ClassEnv::containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses)
+OMR::ClassEnv::containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses)
    {
    TR_UNIMPLEMENTED();
    return false;

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -167,7 +167,7 @@ public:
     * @return Returns 'true' if the given list of classes contains less than 
     * 2 concrete classes and false otherwise.
     */
-   bool containesZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
+   bool containsZeroOrOneConcreteClass(TR::Compilation *comp, List<TR_PersistentClassInfo>* subClasses);
    };
 
 }

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -9830,7 +9830,7 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
                       the method test is insufficient for the devirtualizations done by invariantargumentpreexisence
                       */
 
-                      if (TR::Compiler->cls.containesZeroOrOneConcreteClass(vp->comp(), &subClasses))
+                      if (TR::Compiler->cls.containsZeroOrOneConcreteClass(vp->comp(), &subClasses))
                          {
                          TR::ResolvedMethodSymbol* cMethodSymbol = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(
                          symRef->getOwningMethodIndex(), -1, rvm, methodKind)->getSymbol()->castToResolvedMethodSymbol();


### PR DESCRIPTION
Correct typo in new added function name `containsZeroOrOneConcreteClass`.

Reference: https://github.com/eclipse/omr/issues/5037
Depends on: https://github.com/eclipse/openj9/pull/9166

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>