### PR TITLE
Cache clear and abandon simplification

### DIFF
--- a/gc/base/MasterGCThread.cpp
+++ b/gc/base/MasterGCThread.cpp
@@ -250,7 +250,8 @@ MM_MasterGCThread::masterThreadEntryPoint()
 
 		/* attachVMThread could have allocated and execute a barrier (until point, this thread acted as a mutator thread.
 		 * Flush GC chaches (like barrier buffers) before turning into the master thread */
-		env->flushGCCaches(true);
+		/* TODO: call plain env->initializeGCThread() once downstream projects are ready (subclass Env::init calls base Env::init)  */
+		env->MM_EnvironmentBase::initializeGCThread();
 
 		env->setThreadType(GC_MASTER_THREAD);
 

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -78,12 +78,6 @@ public:
 	virtual void flushNonAllocationCaches();
 	virtual void flushGCCaches(bool final);
 	
-	virtual void initializeGCThread() {
-		/* before a thread turning into a GC one, it shortly acted as a mutator (during thread attach sequence),
-		 * which means it may have allocated or executed an object access barrier. */
-		flushGCCaches(true);
-	}
-
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(OMR_VMThread *omrVMThread) { return static_cast<MM_EnvironmentStandard*>(omrVMThread->_gcOmrVMThreadExtensions); }
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(MM_EnvironmentBase *env) { return static_cast<MM_EnvironmentStandard*>(env); }
 


### PR DESCRIPTION
When creating remainder or abandoning it, use target environment even if
current thread != from target environment.

This we resolve the problem of occasional waste of abandoned Tenure TLH
remainders for mutator threads. Now, we will be able to re-use them on
next CS cycle.

However, to be able to safely use target's environment, it must be
ensured that target thread is not using the remainder at the same time.
This will be ensured by either target thread not holding VM access, or
if racing to acquire VM access it will serialize by external means (for
example, in OpenJ9, by public flags mutex).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>