### PR TITLE
Fix marking of failed tests in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,13 +28,12 @@ jobs:
           ctest -V -C Debug
         displayName: "Test"
         workingDirectory: 'build'
-        continueOnError: true
  
       - task: PublishTestResults@2
+        condition: succeededOrFailed()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/*results.xml'
-          failTaskOnFailedTests: true
         displayName: 'Publish results'
  
   - job:
@@ -86,13 +85,12 @@ jobs:
           ctest -V -j$NUMBER_OF_PROCESSORS
         displayName: "Test"
         workingDirectory: 'build'
-        continueOnError: true
  
       - task: PublishTestResults@2
+        condition: succeededOrFailed()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/*results.xml'
-          failTaskOnFailedTests: true
         displayName: 'Publish results'
  
   - job:
@@ -148,11 +146,10 @@ jobs:
           ctest -V -j$NUMBER_OF_PROCESSORS
         displayName: "Test"
         workingDirectory: 'build'
-        continueOnError: true
  
       - task: PublishTestResults@2
+        condition: succeededOrFailed()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/*results.xml'
-          failTaskOnFailedTests: true
         displayName: 'Publish results'


### PR DESCRIPTION
When a test fails we want the job to be marked as failed as well,
however we still wish to run the "Publish results" job so that the test
output can be parsed and test results published. We modify the pipeline
so if there are failures we fail the "Test" job, but still continue to
run the "Publish results" job.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>