### PR TITLE
AArch64: Call redoTrampolineReservationIfNecessary()

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -95,6 +95,12 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
       else
          {
          TR::MethodSymbol *method = symRef->getSymbol()->getMethodSymbol();
+
+         if (cg()->hasCodeCacheSwitched())
+            {
+            cg()->redoTrampolineReservationIfNecessary(this, symRef);
+            }
+
          if (method && method->isHelper())
             {
             intptr_t destination = (intptr_t)symRef->getMethodAddress();


### PR DESCRIPTION
This commit adds a call to redoTrampolineReservationIfNecessary()
upon hasCodeCacheSwitched() in generateBinaryEncoding() for
ARM64ImmSymInstruction.

Fixes: eclipse/openj9#9214

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>