### PR TITLE
Fix printing of instruction prefixes before binary encoding

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -727,7 +727,8 @@ TR_Debug::printInstrDumpHeader(const char * title)
 uint8_t *
 TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction *instr, uint8_t *cursor, uint8_t size)
    {
-   if (cursor != NULL)
+   // Code start is unknown until after the binary encoding phase
+   if (_comp->cg()->getCodeGeneratorPhase() >= TR::CodeGenPhase::BinaryEncodingPhase && cursor >= _comp->cg()->getCodeStart())
       {
       uint32_t offset = cursor - _comp->cg()->getCodeStart();
 


### PR DESCRIPTION
If one attempts to print an instruction prefix before binary encoding
we need to ensure that the cursor value is valid, otherwise we need to
fall back to printing the generic string.

More specifically, if one attempts to print the contents of a snippet
before it is binary encoded, the cursor value may be `NULL` or a small
positive value, since we are incrementing the cursor as we print the
snippet contents. We do not want to try dereferencing such cursor
pointers since they are not valid and would lead to segmentation faults.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>