### PR TITLE
Use correct RegImm64 constructor for insertLoadConstant

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -254,7 +254,7 @@ TR::Instruction *OMR::X86::TreeEvaluator::insertLoadConstant(TR::Node           
          if (cg->constantAddressesCanChangeSize(node) && node && node->getOpCodeValue() == TR::aconst &&
              (node->isClassPointerConstant() || node->isMethodPointerConstant()))
             {
-            movInstruction = generateRegImm64Instruction(MOV8RegImm64, node, target, value, cg, reloKind);
+            movInstruction = generateRegImm64Instruction(currentInstruction, MOV8RegImm64, target, value, cg, reloKind);
             }
          else if (IS_32BIT_UNSIGNED(value))
             {


### PR DESCRIPTION
On one path where a preceding instruction was provided, the wrong instruction
constructor was being used that will lead to the instruction being inserted in
the wrong place.  Use the correct constructor when a preceding instruction is
provided.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>