### PR TITLE
Fix X86 MemoryReference copy constructor for constant data snippets

### DIFF
--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -355,6 +355,10 @@ OMR::X86::MemoryReference::MemoryReference(
       _dataSnippet = TR::UnresolvedDataSnippet::create(cg, _baseNode, &_symbolReference, false, _symbolReference.canCauseGC());
       cg->addSnippet(_dataSnippet);
       }
+   else if (mr.getDataSnippet() != NULL)
+      {
+      _dataSnippet = mr.getDataSnippet();
+      }
    else
       {
       _dataSnippet = NULL;


### PR DESCRIPTION
The X86 MemoryReference copy constructor does not copy the constant data
snippet field if there is one.  Make it so.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>