### PR TITLE
Improve handling of 'aiadd' and 'aladd'

### DIFF
--- a/compiler/ras/ILValidationRules.cpp
+++ b/compiler/ras/ILValidationRules.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -494,5 +494,26 @@ void TR::Validate_ireturnReturnType::validate(TR::Node *node)
                               comp(),"ireturn has an invalid child type %s (expected Int{8,16,32})",
                               childTypeName);
          }
+      }
+   }
+
+/**
+ * Validate_axaddEnvironment (a TR::NodeValidationRule):
+ */
+TR::Validate_axaddEnvironment::Validate_axaddEnvironment(TR::Compilation *comp)
+   : TR::NodeValidationRule(comp, OMR::validate_axaddEnvironment)
+   {
+   }
+
+void TR::Validate_axaddEnvironment::validate(TR::Node *node)
+   {
+   const auto opcode = node->getOpCode().getOpCodeValue();
+   if (opcode == TR::aiadd)
+      {
+      TR::checkILCondition(node, comp()->target().is32Bit(), comp(), "aiadd should not be seen on 64-bit");
+      }
+   if (opcode == TR::aladd)
+      {
+      TR::checkILCondition(node, comp()->target().is64Bit(), comp(), "aladd should not be seen on 32-bit");
       }
    }

--- a/compiler/ras/ILValidationRules.hpp
+++ b/compiler/ras/ILValidationRules.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -220,6 +220,13 @@ class Validate_ireturnReturnType : public NodeValidationRule
    void validate(TR::Node *node);
    };
 
+class Validate_axaddEnvironment : public NodeValidationRule
+   {
+   public:
+   Validate_axaddEnvironment(TR::Compilation *comp);
+
+   void validate(TR::Node *node);
+   };
 /* NOTE: Please add any new NodeValidationRules here */
 
 } //namespace TR

--- a/compiler/ras/ILValidationStrategies.hpp
+++ b/compiler/ras/ILValidationStrategies.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ enum ILValidationRule
    validateLivenessBoundaries,
    validateNodeRefCountWithinBlock,
    validate_ireturnReturnType,
+   validate_axaddEnvironment,
    /**
     * NOTE: Please add `id`s for any new ILValidationRule here!
     *       This needs to match the implementation of said *ILValidationRule.

--- a/compiler/ras/ILValidator.cpp
+++ b/compiler/ras/ILValidator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,7 @@ const OMR::ILValidationStrategy OMR::postILgenValidatonStrategy[] =
    { OMR::validateChildTypes              },
    { OMR::validateLivenessBoundaries      },
    { OMR::validateNodeRefCountWithinBlock },
+   { OMR::validate_axaddEnvironment       },
    { OMR::endRules                        }
    };
 
@@ -130,7 +131,8 @@ TR::ILValidator::ILValidator(TR::Compilation *comp)
         { 
           new  (comp->trHeapMemory()) TR::ValidateChildCount(_comp),
           new  (comp->trHeapMemory()) TR::ValidateChildTypes(_comp),
-          new  (comp->trHeapMemory()) TR::Validate_ireturnReturnType(_comp)
+          new  (comp->trHeapMemory()) TR::Validate_ireturnReturnType(_comp),
+          new  (comp->trHeapMemory()) TR::Validate_axaddEnvironment(_comp)
         };
      /**
       * NOTE: Please initialize any new *ValidationRule here!

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5828,68 +5828,28 @@ OMR::Z::TreeEvaluator::aloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::aiaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   TR::Register * targetRegister = cg->allocateRegister();
-   TR::Node * firstChild = node->getFirstChild();
-   TR::MemoryReference * aiaddMR = generateS390MemoryReference(cg);
-   TR::Compilation *comp = cg->comp();
-
-   aiaddMR->populateAddTree(node, cg);
-   aiaddMR->eliminateNegativeDisplacement(node, cg);
-   aiaddMR->enforceDisplacementLimit(node, cg, NULL);
-
-   if (node->getOpCodeValue() == TR::aiadd && node->isInternalPointer())
-      {
-      if (node->getPinningArrayPointer())
-         {
-         targetRegister->setContainsInternalPointer();
-         targetRegister->setPinningArrayPointer(node->getPinningArrayPointer());
-         }
-      else if (firstChild->getOpCodeValue() == TR::aload &&
-         firstChild->getSymbolReference()->getSymbol()->isAuto() &&
-         firstChild->getSymbolReference()->getSymbol()->isPinningArrayPointer())
-         {
-         targetRegister->setContainsInternalPointer();
-         if (!firstChild->getSymbolReference()->getSymbol()->isInternalPointer())
-            {
-            targetRegister->setPinningArrayPointer(firstChild->getSymbolReference()->getSymbol()->castToAutoSymbol());
-            }
-         else
-            {
-            targetRegister->setPinningArrayPointer(firstChild->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
-            }
-         }
-      else if (firstChild->getRegister() != NULL && firstChild->getRegister()->containsInternalPointer())
-         {
-         targetRegister->setContainsInternalPointer();
-         targetRegister->setPinningArrayPointer(firstChild->getRegister()->getPinningArrayPointer());
-         }
-      }
-
-   generateRXInstruction(cg, TR::InstOpCode::LA, node, targetRegister, aiaddMR);
-   node->setRegister(targetRegister);
-
-   return targetRegister;
+   return OMR::Z::TreeEvaluator::axaddEvaluator(node, cg);
    }
 
-/**
- * Handles TR_Aladd on 64-bit
- */
 TR::Register *
 OMR::Z::TreeEvaluator::aladdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
+   return OMR::Z::TreeEvaluator::axaddEvaluator(node, cg);
+   }
+
+TR::Register *
+OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
+   {
    TR::Compilation *comp = cg->comp();
-   TR_ASSERT(cg->comp()->target().is64Bit(), "aladd should not be seen on 32-bit");
-
    TR::Register * targetRegister = cg->allocateRegister();
-
    TR::Node * firstChild = node->getFirstChild();
-   TR::MemoryReference * aladdMR = generateS390MemoryReference(cg);
+   TR::MemoryReference * axaddMR = generateS390MemoryReference(cg);
 
-   aladdMR->populateAddTree(node, cg);
-   aladdMR->eliminateNegativeDisplacement(node, cg);
-   aladdMR->enforceDisplacementLimit(node, cg, NULL);
+   axaddMR->populateAddTree(node, cg);
+   axaddMR->eliminateNegativeDisplacement(node, cg);
+   axaddMR->enforceDisplacementLimit(node, cg, NULL);
 
-   if (node->getOpCodeValue() == TR::aladd && node->isInternalPointer())
+   if (node->isInternalPointer())
       {
       if (node->getPinningArrayPointer())
          {
@@ -5917,7 +5877,7 @@ OMR::Z::TreeEvaluator::aladdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          }
       }
 
-   generateRXInstruction(cg, TR::InstOpCode::LA, node, targetRegister, aladdMR);
+   generateRXInstruction(cg, TR::InstOpCode::LA, node, targetRegister, axaddMR);
    node->setRegister(targetRegister);
 
    return targetRegister;

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -130,6 +130,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aiaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aladdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *axaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *laddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *faddEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -22,7 +22,6 @@
 #include "JitTest.hpp"
 #include "default_compiler.hpp"
 #include "compile/OMRCompilation.hpp"
-
 #include <string>
 
 class IllformedTrees : public TRTest::JitTest, public ::testing::WithParamInterface<std::string> {};
@@ -39,6 +38,7 @@ TEST_P(IllformedTrees, FailCompilation) {
             << "Compilation did not fail due to ill-formed input trees";
 }
 
+#ifdef OMR_ENV_DATA64
 INSTANTIATE_TEST_CASE_P(ILValidatorTest, IllformedTrees, ::testing::Values(
     "(method return=Int32 (block (ireturn (iadd (iconst 1) (sconst 3)))))",
     "(method return=Int32 (block (ireturn (sadd (iconst 1) (iconst 3)))))",
@@ -46,6 +46,7 @@ INSTANTIATE_TEST_CASE_P(ILValidatorTest, IllformedTrees, ::testing::Values(
     "(method return=Address (block (areturn (aladd (aconst 4) (iconst 1)))))",
     "(method return=Address (block (areturn (aiadd (iconst 1) (aconst 4)))))",
     "(method return=Address (block (areturn (aladd (lconst 1) (aconst 4)))))",
+    "(method return=Address (block (areturn (aiadd (aconst 1) (iconst 4)))))",
     "(method return=Int32 (block (ireturn (acmpeq (iconst 4) (aconst 4)))))",
     "(method return=Int32 (block (ireturn (acmpge (lconst 4) (aconst 4)))))",
     "(method return=NoType (block (return (GlRegDeps))))",
@@ -56,6 +57,28 @@ INSTANTIATE_TEST_CASE_P(ILValidatorTest, IllformedTrees, ::testing::Values(
     "(method return=Int64 (block (lreturn (sshl (sconst 1) (iconst 1)))))", // lreturn incorrect type. 
     "(method return=Int64 (block (lreturn (sconst 1) )))"                   // lreturn incorrect type. 
     ));
+#endif
+
+#ifdef OMR_ENV_DATA32
+INSTANTIATE_TEST_CASE_P(ILValidatorTest, IllformedTrees, ::testing::Values(
+    "(method return=Int32 (block (ireturn (iadd (iconst 1) (sconst 3)))))",
+    "(method return=Int32 (block (ireturn (sadd (iconst 1) (iconst 3)))))",
+    "(method return=Address (block (areturn (aiadd (aconst 4) (lconst 1)))))",
+    "(method return=Address (block (areturn (aladd (aconst 4) (iconst 1)))))",
+    "(method return=Address (block (areturn (aiadd (iconst 1) (aconst 4)))))",
+    "(method return=Address (block (areturn (aladd (lconst 1) (aconst 4)))))",
+    "(method return=Address (block (areturn (aladd (aconst 1) (lconst 4)))))",
+    "(method return=Int32 (block (ireturn (acmpeq (iconst 4) (aconst 4)))))",
+    "(method return=Int32 (block (ireturn (acmpge (lconst 4) (aconst 4)))))",
+    "(method return=NoType (block (return (GlRegDeps))))",
+    "(method return=Int32 (block (ireturn (GlRegDeps) (iconst 3))))",
+    "(method return=Int32 (block (ireturn (GlRegDeps) (iadd (iconst 1) (iconst 3)))))",
+    "(method return=Int32 (block (ireturn (iconst 3 (GlRegDeps)))))",
+    "(method return=Int32 (block (ireturn (iadd (GlRegDeps) (iconst 1) (iconst 3)))))"
+    "(method return=Int64 (block (lreturn (sshl (sconst 1) (iconst 1)))))", // lreturn incorrect type. 
+    "(method return=Int64 (block (lreturn (sconst 1) )))"                   // lreturn incorrect type. 
+    ));
+#endif
 
 class WellformedTrees : public TRTest::JitTest, public ::testing::WithParamInterface<std::string> {};
 


### PR DESCRIPTION
- Implement `axaddEvaluator` on Z which combine the code of current 'aiaddEvaluator' and 'aladdEvaluator', because they have almost the same codes. 

- Add tril tests for `aiadd` and `aladd`. Ideally, `aiadd` should be only used on 32 bit platforms and `aladd` should be used on 64 bit platforms. So their tril tests will be guarded by `OMR_ENV_DATA64`. Also, add an verifiers for 'aiadd' and 'aladd' to ensure the data types of their pass-in arguments are correct.