### PR TITLE
Remove TR_PREXARGINFO_TRACER_CLASS macro

### DIFF
--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -28,9 +28,6 @@
 #include "env/TRMemory.hpp"
 #include "ras/LogTracer.hpp"
 
-// Temporary macro to coordinate changes between omr and openj9.
-#define TR_PREXARGINFO_TRACER_CLASS TR_LogTracer
-
 class TR_CallSite;
 class TR_InlinerTracer;
 class TR_OpaqueClassBlock;


### PR DESCRIPTION
This is the next PR in a sequence of steps to refactor the TR_PrexArgInfo class.
The previous PR was here: https://github.com/eclipse/openj9/pull/9163

This macro was used temporarily to coordinate changes with openj9. Now that the
necessary changes have been made in openj9, this macro can be removed.

See: https://github.com/eclipse/openj9/issues/7936

Signed-off-by: Ryan Shukla <ryans@ibm.com>