### PR TITLE
CMake: Overhaul split debug handling

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -103,6 +103,7 @@ function(_omr_toolchain_separate_debug_symbols tgt)
 			COMMAND "${CMAKE_OBJCOPY}" "--add-gnu-debuglink=${dbg_file}" "${exe_file}"
 		)
 	endif()
+	set_target_properties(${tgt} PROPERTIES OMR_DEBUG_FILE "${dbg_file}")
 endfunction()
 
 function(_omr_toolchain_process_exports TARGET_NAME)

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -219,5 +219,6 @@ else()
 			COMMAND "${CMAKE_COMMAND}" -E copy ${exe_file} ${dbg_file}
 			COMMAND "${CMAKE_STRIP}" -X32_64 -t ${exe_file}
 		)
+		set_target_properties(${tgt} PROPERTIES OMR_DEBUG_FILE "${dbg_file}")
 	endfunction()
 endif()


### PR DESCRIPTION
- Update logic omr_split_debug/omr_process_split_debug. It is now safe to
call on all targets. Checks on library type and config options are now
handled internally.

- Rename omr_split_debug() -> omr_process_split_debug to reflect new
behaviour.

- Toochain debug info splitter functions are now responsible for setting
the OMR_DEBUG_FILE property on a target, which points to the file where
the debug info is stored.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>