### PR TITLE
CMake: Add omr_add_library, omr_add_executable functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ include(OmrHookgen)
 include(OmrOption)
 include(OmrPlatform)
 include(OmrTracegen)
+include(OmrTargetSupport)
 include(OmrSanitizerSupport)
 
 ###
@@ -75,7 +76,7 @@ enable_testing()
 ### omr_base: basic includes and definitions needed everywhere
 ###
 
-add_library(omr_base INTERFACE)
+omr_add_library(omr_base INTERFACE)
 
 target_include_directories(omr_base
 	INTERFACE

--- a/cmake/modules/OmrTargetSupport.cmake
+++ b/cmake/modules/OmrTargetSupport.cmake
@@ -1,0 +1,86 @@
+###############################################################################
+# Copyright (c) 2020, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#############################################################################
+
+if(OMR_TARGET_SUPPORT)
+	return()
+endif()
+set(OMR_TARGET_SUPPORT 1)
+
+include(OmrAssert)
+include(OmrUtility)
+
+# omr_add_library(name <sources> ...)
+#   STATIC | SHARED | OBJECT  - same meanings as for standard add_library
+# At present, a thin wrapper around add_library, but it ensures that exports
+# and split debug info are handled
+function(omr_add_library name)
+	set(options SHARED STATIC OBJECT INTERFACE)
+	set(oneValueArgs )
+	set(multiValueArgs )
+
+	foreach(var IN LISTS options oneValueArgs multiValueArgs)
+		set(opt_${var} "")
+	endforeach()
+	cmake_parse_arguments(opt "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+
+	omr_count_true(num_types VARIABLES opt_SHARED opt_STATIC opt_OBJECT opt_INTERFACE)
+	omr_assert(TEST num_types LESS 2 MESSAGE "Only one of STATIC | SHARED | OBJECT | INTERFACE may be given")
+
+	# if no target type given, fall back to STATIC|SHARED depending on BUILD_SHARED_LIBS
+	# (same behavior as CMake)
+	if(num_types EQUAL 0)
+		if(BUILD_SHARED_LIBS)
+			set(opt_SHARED True)
+		else()
+			set(opt_STATIC True)
+		endif()
+	endif()
+
+	if(opt_SHARED)
+		set(lib_type "SHARED")
+	elseif(opt_STATIC)
+		set(lib_type "STATIC")
+	elseif(opt_OBJECT)
+		set(lib_type "OBJECT")
+	elseif(opt_INTERFACE)
+		set(lib_type "INTERFACE")
+	else()
+		omr_assert(TEST "False" MESSAGE "Unreachable")
+	endif()
+
+	add_library(${name} ${lib_type} ${opt_UNPARSED_ARGUMENTS})
+
+	if(opt_SHARED)
+		# split debug info if applicable. Note: omr_split_debug is responsible for checking OMR_SEPARATE_DEBUG_INFO
+		omr_process_split_debug(${name})
+		omr_process_exports(${name})
+	endif()
+endfunction()
+
+
+# omr_add_executable(name <sources> ...)
+# At present, a thin wrapper around add_executable, but it ensures that
+# split debug info is handled
+function(omr_add_executable name)
+	add_executable(${name} ${ARGN})
+	omr_process_split_debug(${name})
+endfunction()

--- a/ddr/CMakeLists.txt
+++ b/ddr/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ if(NOT OMR_DDR)
 	message(FATAL_ERROR ddr disabled)
 endif(NOT OMR_DDR)
 
-add_library(omr_ddr_base INTERFACE)
+omr_add_library(omr_ddr_base INTERFACE)
 
 target_link_libraries(omr_ddr_base
 	INTERFACE

--- a/ddr/lib/ddr-blobgen/CMakeLists.txt
+++ b/ddr/lib/ddr-blobgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omr_ddr_blobgen
+omr_add_library(omr_ddr_blobgen
 	java/genBinaryBlob.cpp
 	java/genBlobJava.cpp
 	java/genSuperset.cpp

--- a/ddr/lib/ddr-ir/CMakeLists.txt
+++ b/ddr/lib/ddr-ir/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omr_ddr_ir
+omr_add_library(omr_ddr_ir
 	ClassType.cpp
 	ClassUDT.cpp
 	EnumMember.cpp

--- a/ddr/lib/ddr-macros/CMakeLists.txt
+++ b/ddr/lib/ddr-macros/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omr_ddr_macros
+omr_add_library(omr_ddr_macros
 	MacroInfo.cpp
 	MacroTool.cpp
 )

--- a/ddr/lib/ddr-scanner/CMakeLists.txt
+++ b/ddr/lib/ddr-scanner/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omr_ddr_scanner
+omr_add_library(omr_ddr_scanner
 	Scanner.cpp
 )
 

--- a/ddr/tools/blob_reader/CMakeLists.txt
+++ b/ddr/tools/blob_reader/CMakeLists.txt
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omr_blob_reader
+omr_add_executable(omr_blob_reader
 	blob_reader.cpp
 )
 

--- a/ddr/tools/ddrgen/CMakeLists.txt
+++ b/ddr/tools/ddrgen/CMakeLists.txt
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omr_ddrgen
+omr_add_executable(omr_ddrgen
 	ddrgen.cpp
 )
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@ include(OmrAssert)
 
 omr_assert(TEST OMR_EXAMPLE)
 
-add_library(omr_example_base INTERFACE)
+omr_add_library(omr_example_base INTERFACE)
 
 target_include_directories(omr_example_base
 	INTERFACE
@@ -37,7 +37,7 @@ target_link_libraries(omr_example_base
 
 # The GC example shows how to use OMR's GC component
 if(OMR_GC)
-	add_executable(gcexample
+	omr_add_executable(gcexample
 		gcmain.cpp
 	)
 

--- a/example/glue/CMakeLists.txt
+++ b/example/glue/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ set(OMR_UTIL_GLUE_TARGET "omr_example_util_glue" CACHE STRING "The util glue tar
 set(OMR_RAS_GLUE_TARGET "omr_example_ras_glue" CACHE STRING "The ras glue target, must be interface library" FORCE)
 set(OMR_CORE_GLUE_TARGET "omr_example_core_glue" CACHE STRING "The core glue target, must be and interface library" FORCE)
 
-add_library(omr_example_gc_glue INTERFACE)
+omr_add_library(omr_example_gc_glue INTERFACE)
 
 target_sources(omr_example_gc_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/CollectorLanguageInterfaceImpl.cpp
@@ -52,7 +52,7 @@ target_link_libraries(omr_example_gc_glue
 		omr_example_base
 )
 
-add_library(omr_example_util_glue INTERFACE)
+omr_add_library(omr_example_util_glue INTERFACE)
 
 target_sources(omr_example_util_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/UtilGlue.c
@@ -63,7 +63,7 @@ target_link_libraries(omr_example_util_glue
 		omr_example_base
 )
 
-add_library(omr_example_ras_glue INTERFACE)
+omr_add_library(omr_example_ras_glue INTERFACE)
 
 target_sources(omr_example_ras_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/Profiling.c
@@ -74,7 +74,7 @@ target_link_libraries(omr_example_ras_glue
 		omr_example_base
 )
 
-add_library(omr_example_core_glue INTERFACE)
+omr_add_library(omr_example_core_glue INTERFACE)
 
 target_sources(omr_example_core_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/LanguageVMGlue.c

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 
 omr_add_hookgen(INPUT hooksample.hdf)
 
-add_executable(omralgotest
+omr_add_executable(omralgotest
 	algoTest.cpp
 	algorithm_test_internal.h
 	avltest.c

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -67,7 +67,7 @@ create_omr_compiler_library(
 # Export paths for dependent objects
 make_compiler_target(testcompiler INTERFACE COMPILER testcompiler)
 
-add_executable(compilertest
+omr_add_executable(compilertest
 	tests/main.cpp
 	tests/BuilderTest.cpp
 	tests/FooBarTest.cpp

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
-add_executable(comptest
+omr_add_executable(comptest
 	main.cpp
 	JitTestUtilitiesTest.cpp
 	ILValidatorTest.cpp

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -38,7 +38,7 @@ if(OMR_ARCH_POWER)
 	)
 endif()
 
-add_executable(compunittest ${COMPCGTEST_FILES})
+omr_add_executable(compunittest ${COMPCGTEST_FILES})
 
 # For the time being, link against Tril even though we don't really need Tril itself. This is done
 # to avoid needing to duplicate the boilerplate in Tril's CMakeLists.txt.

--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ###############################################################################
 
 function(omr_add_core_test testname)
-	add_executable("${testname}"
+	omr_add_executable("${testname}"
 		"${testname}.cpp"
 		main.cpp
 	)

--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,7 @@ include(OmrAssert)
 omr_assert(TEST OMR_GC_API AND OMR_FVTEST)
 
 function(omr_add_gc_test testname)
-	add_executable("${testname}"
+	omr_add_executable("${testname}"
 		"${testname}.cpp"
 		main.cpp
 	)

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ omr_assert(
 	MESSAGE "The fv gctest component relies on the example glue"
 )
 
-add_executable(omrgctest
+omr_add_executable(omrgctest
 	GCConfigObjectTable.cpp
 	GCConfigTest.cpp
 	gcTestHelpers.cpp

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(jitbuildertest
+omr_add_executable(jitbuildertest
 	main.cpp
 	selftest.cpp
 	UnionTest.cpp

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omrGtest STATIC
+omr_add_library(omrGtest STATIC
 	omrGtest.cpp
 )
 
@@ -39,7 +39,7 @@ if(OMR_OS_ZOS)
 	endif()
 endif()
 
-add_library(omrGtestGlue INTERFACE)
+omr_add_library(omrGtestGlue INTERFACE)
 
 target_include_directories(omrGtestGlue
 	INTERFACE

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -49,7 +49,7 @@ if((OMR_PORT_SOCKET_SUPPORT) AND (NOT OMR_HOST_OS STREQUAL "win"))
 	)
 endif()
 
-add_executable(omrporttest
+omr_add_executable(omrporttest
 	fileTest.cpp
 	heapTest.cpp
 	omrportTest.cpp
@@ -97,7 +97,7 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrporttest j9a2e)
 endif()
 
-add_library(sltestlib SHARED
+omr_add_library(sltestlib SHARED
 	sltestlib/sltest.c
 )
 
@@ -111,7 +111,7 @@ target_compile_options(sltestlib
 )
 
 if(OMR_HOST_OS STREQUAL "aix")
-	add_library(aixbaddep SHARED
+	omr_add_library(aixbaddep SHARED
 		aixbaddep/sltest.c
 	)
 

--- a/fvtest/rastest/CMakeLists.txt
+++ b/fvtest/rastest/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 add_tracegen(omr_test.tdf)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(bindthreadagent SHARED
+omr_add_library(bindthreadagent SHARED
 	bindthreadagent.c
 	omragent.def
 )
@@ -40,7 +40,7 @@ omr_add_exports(bindthreadagent
 	OMRAgent_OnUnload
 )
 
-add_library(memorycategoriesagent SHARED
+omr_add_library(memorycategoriesagent SHARED
 	memorycategoriesagent.c
 	omragent.def
 )
@@ -52,7 +52,7 @@ omr_add_exports(memorycategoriesagent
 	OMRAgent_OnUnload
 )
 
-add_library(traceagent SHARED
+omr_add_library(traceagent SHARED
 	traceagent.c
 	omragent.def
 )
@@ -64,7 +64,7 @@ omr_add_exports(traceagent
 	OMRAgent_OnUnload
 )
 
-add_library(traceNotStartedAgent SHARED
+omr_add_library(traceNotStartedAgent SHARED
 	traceNotStartedAgent.c
 	omragent.def
 )
@@ -76,7 +76,7 @@ omr_add_exports(traceNotStartedAgent
 	OMRAgent_OnUnload
 )
 
-add_library(cpuLoadAgent SHARED
+omr_add_library(cpuLoadAgent SHARED
 	cpuLoadAgent.c
 	omragent.def
 )
@@ -88,7 +88,7 @@ omr_add_exports(cpuLoadAgent
 	OMRAgent_OnUnload
 )
 
-add_library(invalidAgentMissingOnLoad SHARED
+omr_add_library(invalidAgentMissingOnLoad SHARED
 	invalidAgentMissingOnLoad.c
 	invalidAgentMissingOnLoad.def
 )
@@ -99,7 +99,7 @@ omr_add_exports(invalidAgentMissingOnLoad
 	OMRAgent_OnUnload
 )
 
-add_library(invalidAgentMissingOnUnload SHARED
+omr_add_library(invalidAgentMissingOnUnload SHARED
 	invalidAgentMissingOnUnload.c
 	invalidAgentMissingOnUnload.def
 )
@@ -110,7 +110,7 @@ omr_add_exports(invalidAgentMissingOnUnload
 	OMRAgent_OnLoad
 )
 
-add_library(invalidAgentReturnError SHARED
+omr_add_library(invalidAgentReturnError SHARED
 	invalidAgentReturnError.c
 	omragent.def
 )
@@ -122,7 +122,7 @@ omr_add_exports(invalidAgentReturnError
 	OMRAgent_OnUnload
 )
 
-add_library(sampleSubscriber SHARED
+omr_add_library(sampleSubscriber SHARED
 	sampleSubscriber.c
 	omragent.def
 )
@@ -134,7 +134,7 @@ omr_add_exports(sampleSubscriber
 	OMRAgent_OnUnload
 )
 
-add_library(subscriberAgent SHARED
+omr_add_library(subscriberAgent SHARED
 	subscriberAgent.c
 	omragent.def
 )
@@ -145,7 +145,7 @@ omr_add_exports(subscriberAgent
 	OMRAgent_OnUnload
 )
 
-add_library(subscriberAgentWithJ9thread SHARED
+omr_add_library(subscriberAgentWithJ9thread SHARED
 	subscriberAgentWithJ9thread.c
 	omragent.def
 )
@@ -156,7 +156,7 @@ omr_add_exports(subscriberAgentWithJ9thread
 	OMRAgent_OnUnload
 )
 
-add_library(traceOptionAgent SHARED
+omr_add_library(traceOptionAgent SHARED
 	traceOptionAgent.c
 	omragent.def
 )
@@ -171,7 +171,7 @@ omr_add_exports(traceOptionAgent
 	OMRAgent_OnUnload
 )
 
-add_executable(omrrastest
+omr_add_executable(omrrastest
 	agentNegativeTest.cpp
 	agentTest.cpp
 	main.cpp
@@ -204,7 +204,7 @@ add_dependencies(omrrastest
 	traceNotStartedAgent
 )
 
-add_executable(omrsubscribertest
+omr_add_executable(omrsubscribertest
 	main.cpp
 	rasTestHelpers.cpp
 	subscriberTest.cpp
@@ -226,7 +226,7 @@ add_dependencies(omrsubscribertest
 	subscriberAgentWithJ9thread
 )
 
-add_executable(omrtraceoptiontest
+omr_add_executable(omrtraceoptiontest
 	main.cpp
 	rasTestHelpers.cpp
 	traceOptionTest.cpp

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omrsigtest
+omr_add_executable(omrsigtest
 	sigTest.cpp
 	sigTestHelpers.cpp
 	main.cpp

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omrthreadextendedtest
+omr_add_executable(omrthreadextendedtest
 	processTimeTest.cpp
 	threadCpuTimeTest.cpp
 	threadExtendedTestHelpers.cpp

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omrthreadtest
+omr_add_executable(omrthreadtest
 	abortTest.cpp
 	CEnterExit.cpp
 	CMonitor.cpp

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(incordec
+omr_add_executable(incordec
 	main.cpp
 )
 

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(mandelbrot
+omr_add_executable(mandelbrot
 	main.cpp
 )
 

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-add_executable(triltest
+omr_add_executable(triltest
 	main.cpp
 	ASTTest.cpp
 	ParserTest.cpp

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(TRIL_BACKEND_LIB      testcompiler)
 
-add_library(tril STATIC
+omr_add_library(tril STATIC
 	ast.cpp
 	parser.cpp
 	ilgen.cpp
@@ -62,10 +62,10 @@ if(NOT OMR_HOST_OS STREQUAL "win")
 endif()
 
 
-add_executable(tril_dumper compiler.cpp)
+omr_add_executable(tril_dumper compiler.cpp)
 target_link_libraries(tril_dumper tril)
 
-add_executable(tril_compiler compiler.cpp)
+omr_add_executable(tril_compiler compiler.cpp)
 target_link_libraries(tril_compiler tril)
 
 # The platform specific ${TR_CXX_COMPILE_OPTIONS} and ${TR_C_COMPILE_OPTIONS} compile options

--- a/fvtest/util/CMakeLists.txt
+++ b/fvtest/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omrtestutil STATIC
+omr_add_library(omrtestutil STATIC
 	printerrorhelper.cpp
 	testvmhelper.cpp
 )

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omrutiltest
+omr_add_executable(omrutiltest
 	main.cpp
 )
 

--- a/fvtest/vmtest/CMakeLists.txt
+++ b/fvtest/vmtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(omrvmtest
+omr_add_executable(omrvmtest
 	main.cpp
 )
 if(OMR_THR_FORK_SUPPORT)

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -50,7 +50,7 @@ add_tracegen(verbose/j9vgc.tdf)
 
 # Ideally We would handle the tracegen stuff like the hookgen stuff above
 # But for whatever reason that breaks the ninja builds
-add_library(omrgc_tracegen OBJECT
+omr_add_library(omrgc_tracegen OBJECT
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9mm.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_omrmm.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9vgc.c
@@ -66,7 +66,7 @@ target_compile_definitions(omrgc_tracegen
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-add_library(omrgc STATIC
+omr_add_library(omrgc STATIC
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp
 	base/AllocationInterfaceGeneric.cpp

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 macro(create_jitbuilder_test target)
-	add_executable(${target} ${ARGN})
+	omr_add_executable(${target} ${ARGN})
 	target_include_directories(${target} PUBLIC cpp/include)
 	target_link_libraries(${target}
 		jitbuilder

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ omr_assert(
 	MESSAGE "OMR_RAS_GLUE_TARGET must be set. Try using the example with OMR_EXAMPLE=ON"
 )
 
-add_library(omrcore STATIC
+omr_add_library(omrcore STATIC
 	OMR_Agent.cpp
 	OMR_MethodDictionary.cpp
 	OMR_Profiler.cpp

--- a/omr/startup/CMakeLists.txt
+++ b/omr/startup/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omrvmstartup STATIC
+omr_add_library(omrvmstartup STATIC
 	omrvmstartup.cpp
 	omrrasinit.c
 	omrtrcinit.c

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 include(OmrMsvcRuntime)
 
-add_library(omrsig SHARED
+omr_add_library(omrsig SHARED
 	omrsig.cpp
 )
 

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omrtrace STATIC
+omr_add_library(omrtrace STATIC
 	omrtraceapi.cpp
 	omrtracecomponent.cpp
 	omrtraceformatter.cpp

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -39,7 +39,7 @@ add_tracegen(common/omrport.tdf)
 
 # Logic below will set the target_includes, and supplement the
 # target_sources
-add_library(omrport_obj OBJECT
+omr_add_library(omrport_obj OBJECT
 	${CMAKE_CURRENT_BINARY_DIR}/ut_omrport.c
 )
 
@@ -428,7 +428,7 @@ ddr_set_add_targets(omrddr omrport_obj)
 ### omrport static lib
 ###
 
-add_library(omrport STATIC
+omr_add_library(omrport STATIC
 	$<TARGET_OBJECTS:omrport_obj>
 )
 

--- a/third_party/pugixml-1.5/CMakeLists.txt
+++ b/third_party/pugixml-1.5/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(pugixml STATIC
+omr_add_library(pugixml STATIC
 	pugixml.cpp
 )
 

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,7 @@ include_directories(common)
 
 #TODO also should be able to build dynamic lib
 
-add_library(j9thr_obj OBJECT
+omr_add_library(j9thr_obj OBJECT
 	${resolvedPaths}
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9thr.c
 )
@@ -143,7 +143,7 @@ ddr_add_headers(j9thr_obj
 )
 ddr_set_add_targets(omrddr j9thr_obj)
 
-add_library(j9thrstatic STATIC
+omr_add_library(j9thrstatic STATIC
 	$<TARGET_OBJECTS:j9thr_obj>
 )
 

--- a/tools/hookgen/CMakeLists.txt
+++ b/tools/hookgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,7 @@
 ###############################################################################
 
 
-add_executable(hookgen
+omr_add_executable(hookgen
 	HookGen.cpp
 	main.cpp
 )

--- a/tools/tracegen/CMakeLists.txt
+++ b/tools/tracegen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(tracegen
+omr_add_executable(tracegen
 	main.cpp
 )
 
@@ -31,7 +31,7 @@ target_link_libraries(tracegen
 
 # TODO: Move libtrace to it's own home
 # NOTE: trace is static so we don't futz with RPATHs to run the tools.
-add_library(trace STATIC
+omr_add_library(trace STATIC
 	ArgParser.cpp
 	CFileWriter.cpp
 	DATFileWriter.cpp

--- a/tools/tracemerge/CMakeLists.txt
+++ b/tools/tracemerge/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_executable(tracemerge
+omr_add_executable(tracemerge
 	DATMerge.cpp
 	main.cpp
 )

--- a/util/a2e/CMakeLists.txt
+++ b/util/a2e/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(j9a2e SHARED
+omr_add_library(j9a2e SHARED
 	sysTranslate.c
 	atoe.c
 	atoe_utils.c

--- a/util/avl/CMakeLists.txt
+++ b/util/avl/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ set(j9avl_public_headers
 	"${omr_SOURCE_DIR}/include_core/avl_api.h"
 )
 
-add_library(j9avl STATIC
+omr_add_library(j9avl STATIC
 	avlsup.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_avl.c
 )

--- a/util/hashtable/CMakeLists.txt
+++ b/util/hashtable/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_tracegen(hashtable.tdf)
 
-add_library(j9hashtable STATIC
+omr_add_library(j9hashtable STATIC
 	hash.c
 	hashtable.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_hashtable.c

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 #TODO there is a bunch of stuff with vpaths, presumably for some extensibility reasons
 # need to figure out if its actually needed and implement properly if required
-add_library(j9hook_obj OBJECT
+omr_add_library(j9hook_obj OBJECT
 	${CMAKE_CURRENT_SOURCE_DIR}/hookable.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9hook.c
 )
@@ -52,7 +52,7 @@ omr_add_exports(j9hook_obj
 target_enable_ddr(j9hook_obj)
 ddr_set_add_targets(omrddr j9hook_obj)
 
-add_library(j9hookstatic STATIC
+omr_add_library(j9hookstatic STATIC
 	$<TARGET_OBJECTS:j9hook_obj>
 )
 # Duplicate the export list onto the static library version

--- a/util/main_function/CMakeLists.txt
+++ b/util/main_function/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omr_main_function INTERFACE)
+omr_add_library(omr_main_function INTERFACE)
 
 target_sources(omr_main_function
 	INTERFACE

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ set(VPATH "")
 
 add_tracegen(utilcore.tdf j9utilcore)
 
-add_library(omrutil_obj OBJECT
+omr_add_library(omrutil_obj OBJECT
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9utilcore.c
 )
 
@@ -159,7 +159,7 @@ target_include_directories(omrutil_obj PUBLIC $<TARGET_PROPERTY:${OMR_UTIL_GLUE_
 target_enable_ddr(omrutil_obj)
 ddr_set_add_targets(omrddr omrutil_obj)
 
-add_library(omrutil STATIC
+omr_add_library(omrutil STATIC
 	$<TARGET_OBJECTS:omrutil_obj>
 )
 

--- a/util/pool/CMakeLists.txt
+++ b/util/pool/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_tracegen(pool.tdf)
 
-add_library(j9pool STATIC
+omr_add_library(j9pool STATIC
 	pool.c
 	pool_cap.c
 	${CMAKE_CURRENT_BINARY_DIR}/ut_pool.c


### PR DESCRIPTION
At present, these functions are thin wrappers around add_library/executable, but they ensure that exports and split debug info are handled.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>