### PR TITLE
Recognizes patterns like BNDCHK and simplifies them

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.hpp
+++ b/compiler/optimizer/OMRCFGSimplifier.hpp
@@ -121,6 +121,18 @@ class CFGSimplifier : public TR::Optimization
     */
    bool simplifyInstanceOfTestToCheckcast(bool needToDuplicateTree);
 
+   /**
+    * \brief
+    *    This function tries to match ificmplt/iflcmplt, followed by another ificmplt/ificmpge/iflcmplt/iflcmpge
+    *    that either throws or branches and replace with a BNDCHK.
+    *
+    * \parm needToDuplicateTree
+    *    Boolean to indicate whether or not to duplicate node.
+    *
+    * \return Boolean that indicates true if tranformation is performed based on a matched pattern.
+    */
+   bool simplifyBoundCheckWithThrowException(bool needToDuplicateTree); 
+
    TR::TreeTop *getNextRealTreetop(TR::TreeTop *treeTop);
    TR::TreeTop *getLastRealTreetop(TR::Block *block);
    TR::Block   *getFallThroughBlock(TR::Block *block);


### PR DESCRIPTION
Patterns similar to BNDCHK but throws different exceptions is matched
and simplified with a BNDCHK that branches to appropriate exception
block.

This essentially checks for array index bound check patterns, which
starts with a ificmp followed by another ificmp and either branches to
a block that throws exception or executes the non-exception behavior.

Upon matching such pattern, it replaces the two ificmp checks with a
BNDCHK with a catch-all block that jumps to the exception block. This
ensures the returned exceptions are correct, while simplifies the
pattern for non-exception cases (BNDCHK -> non-exception case).

Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>