### PR TITLE
Jb call inline sample

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2035,7 +2035,9 @@ OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue *
    calleeMB->setReturnBuilder(returnBuilder);
 
    // get calleeMB ready to be part of this compilation
-   // MUST be the OMR::IlBuilder implementation, not the OMR::MethodBuilder one
+   // call initialize on calleeMB in case it has earlier been used outside of this compilation
+   calleeMB->initialize(_details, _methodSymbol, _fe, _symRefTab);
+   // setupBuilderForIL MUST be the OMR::IlBuilder implementation, not the OMR::MethodBuilder one
    calleeMB->OMR::IlBuilder::setupForBuildIL();
 
    // store arguments into parameter values

--- a/jitbuilder/release/cpp/samples/Call.cpp
+++ b/jitbuilder/release/cpp/samples/Call.cpp
@@ -137,8 +137,8 @@ NativeToJitCallMethod::buildIL()
    return true;
    }
 
-JitToJitCallMethod::JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, const char *jitMethodName, void *entry)
-   : OMR::JitBuilder::MethodBuilder(types), jitMethodName(jitMethodName)
+JitToJitCallMethod::JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, OMR::JitBuilder::MethodBuilder *jitMethodBuilder)
+   : OMR::JitBuilder::MethodBuilder(types), jitMethodBuilder(jitMethodBuilder)
    {
    DefineLine(LINETOSTR(__LINE__));
    DefineFile(__FILE__);
@@ -146,15 +146,6 @@ JitToJitCallMethod::JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, c
    DefineName("test_jit_to_jit");
    DefineParameter("n", Int32);
    DefineReturnType(Int32);
-
-   DefineFunction((char *)jitMethodName,
-                  (char *)"",
-                  (char *)"",
-                  (void *)entry,
-                  Int32,
-                  2,
-                  Int32,
-                  Int32);
    }
 
 bool
@@ -170,7 +161,7 @@ JitToJitCallMethod::buildIL()
              ConstInt32(1));
 
    loop->Store("sum",
-   loop->   Call(jitMethodName, 2,
+   loop->   Call(jitMethodBuilder, 2,
    loop->      Load("sum"),
    loop->      Load("i")));
 
@@ -232,7 +223,7 @@ main(int argc, char *argv[])
    nativeToJitMethod = (CallFunctionType2Arg*)entry;
 
    printf("Step 6: compile JitToJitCall (direct call to native) method builder\n");
-   JitToJitCallMethod jitToJitCallMethod(&types, "test_jit_to_native", (void *)jitToNativeMethod);
+   JitToJitCallMethod jitToJitCallMethod(&types, &jitToNativeCallMethod);
    rc = compileMethodBuilder(&jitToJitCallMethod, &entry);
    if (rc != 0)
       {
@@ -247,7 +238,7 @@ main(int argc, char *argv[])
       printf("jitToJitMethod(%d) = %d\n", n, jitToJitMethod(n));
 
    printf("Step 8: compile JitToJitCall (computed/indirect call to native) method builder\n");
-   JitToJitCallMethod jitToJitComputedCallMethod(&types, "test_jit_to_native_computed", (void *)jitToNativeComputedMethod);
+   JitToJitCallMethod jitToJitComputedCallMethod(&types, &jitToNativeComputedCallMethod);
    rc = compileMethodBuilder(&jitToJitComputedCallMethod, &entry);
    if (rc != 0)
       {

--- a/jitbuilder/release/cpp/samples/Call.hpp
+++ b/jitbuilder/release/cpp/samples/Call.hpp
@@ -53,10 +53,10 @@ class NativeToJitCallMethod : public OMR::JitBuilder::MethodBuilder
 class JitToJitCallMethod : public OMR::JitBuilder::MethodBuilder
    {
    public:
-   JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, const char *jitMethodName, void *entry);
+   JitToJitCallMethod(OMR::JitBuilder::TypeDictionary *types, OMR::JitBuilder::MethodBuilder *jitMethodBuilder);
    virtual bool buildIL();
 
-   const char *jitMethodName;
+   OMR::JitBuilder::MethodBuilder *jitMethodBuilder;
    };
 
 #endif // !defined(CALL_INCL)


### PR DESCRIPTION
Re-initialize method builder objects before inlining

When using the JitBuilder `Call` service and passing a `MethodBuilder` object, we do not know the origin of that object before we begin to inline it. In most code samples, that object is a "fresh" `MethodBuilder` that hasn't been compiled itself. When it has been compiled previously, there are some TR objects cached in it that cause problems during inlining, such as the compilation object, the method symbol, etc. These should be re-initialized to the current `MethodBuilder` being compiled before the callee `MethodBuilder` is inlined. While `setupForBuildIL()` is called, we also need to call `initialize()` to re-initialize these fields. I missed this in my earlier attempt to address #4909 .

Included in this fix is an update to the `Call` code sample from @fjeremic that causes that sample to test this exact scenario (inlining a `MethodBuilder` object that has previously been compiled) so we won't regress it again.