### PR TITLE
CMake: Ensure that split debug info is processed in  target_enable_ddr

### DIFF
--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -146,11 +146,12 @@ function(target_enable_ddr tgt)
 		"$<JOIN:$<TARGET_PROPERTY:${tgt},DDR_PREINCLUDES>,\n>"
 	)
 	if((target_type MATCHES "EXECUTABLE|SHARED_LIBRARY") AND (NOT opt_NO_DEBUG_INFO))
-
+		# Ensure that debug info has been processed
+		omr_process_split_debug(${tgt})
 		get_target_property(debug_file "${tgt}" OMR_DEBUG_FILE)
 
 		# if no value is present, assume the debug info lives in the target file
-		if(debug_file STREQUAL "")
+		if(NOT debug_file)
 			set(debug_file "$<TARGET_FILE:${tgt}>")
 		endif()
 


### PR DESCRIPTION
We need to make sure that the split debug info is procesed before we
start handling the ddr side of things, otherwise calls to
omr_process_split_debug after target_enable_ddr will cause ddr to fail to
extract the debug info from the target.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>