### PR TITLE
AArch64: Implement TR_Debug::getGlobalRegisterName

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -3117,6 +3117,10 @@ const char *TR_Debug::getGlobalRegisterName(TR_GlobalRegisterNumber regNum, TR_R
    if (_comp->target().cpu.isARM())
       return getName(realRegNum, size);
 #endif
+#if defined(TR_TARGET_ARM64)
+   if (_comp->target().cpu.isARM64())
+      return getARM64RegisterName(realRegNum, size);
+#endif
    return "???";
    }
 


### PR DESCRIPTION
Implement `TR_Debug::getGlobalRegisterName` for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>