### PR TITLE
AArch64: Enable Global Register Allocation

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -66,6 +66,7 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
    self()->setLastGlobalFPR(TR::Machine::getLastGlobalFPRRegisterNumber());
 
    self()->getLinkage()->initARM64RealRegisterLinkage();
+   self()->setSupportsGlRegDeps();
 
    self()->setSupportsVirtualGuardNOPing();
 


### PR DESCRIPTION
This commit enables Global Register Allocation for aarch64.

- Add call to `setSupportsGlRegDeps` to constructor of CodeGenerator.

Depends on:
- https://github.com/eclipse/omr/pull/5091
- https://github.com/eclipse/omr/pull/5092
- https://github.com/eclipse/omr/pull/5093
- https://github.com/eclipse/omr/pull/5094

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>