### PR TITLE
Set OMR_ENV_GCC in gnu.cmake (except on OSX)

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -187,6 +187,8 @@ macro(omr_detect_system_information)
 	else()
 		if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 			set(_OMR_TOOLCONFIG "gnu")
+			# This should go away shortly - see https://github.com/eclipse/omr/issues/5107.
+			set(OMR_ENV_GCC ON CACHE INTERNAL "")
 		elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 			set(_OMR_TOOLCONFIG "msvc")
 		elseif(CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")


### PR DESCRIPTION
OpenJ9 depends on `OMR_ENV_GCC` being defined (or not) appropriately.