### PR TITLE
Fix max open file limits on OSX

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -860,10 +860,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 	{
 		OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 		const char *testName = "omrsysinfo_test_sysinfo_set_limit_FILE_DESCRIPTORS";
-#if defined(OSX)
-		portTestEnv->log("Skipping test: sysinfo_test_sysinfo_set_limit_FILE_DESCRIPTORS: resource limits unsupported on macOS, see issue #4990 for more details\n");
-		reportTestExit(OMRPORTLIB, testName);
-#else /* defined(OSX) */
 		uint32_t rc = OMRPORT_LIMIT_UNKNOWN;
 		uint64_t originalSoftLimit = 0;
 		uint64_t finalSoftLimit = 0;
@@ -1027,7 +1023,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 	}
 
 	reportTestExit(OMRPORTLIB, testName);
-#endif /* defined(OSX) */
 }
 
 #if defined(AIXPPC)


### PR DESCRIPTION
on OSX, there are two mechanisms for reporting the limits of the system.
The first is getrlimit/setrlimit, and the second is through sysctl.

Sysctl will report the maximum number of open files that the kernel will
allow a process to have. This is a global property that affects all
processes.

getrlimit/setrlimit, on the other hand, will report the limits set on a
given process.

These two limits do not have to match.

The true soft limit for open files is the minimum between the current
rlimit and the sysctl limit.  The true hard limit is the minimum between
the max rlimit and the sysctl limit.

With this PR, this is what we report and enforce on OSX.

Fixes: #4990
Signed-off-by: Robert Young <rwy0717@gmail.com>