### PR TITLE
AArch64: Add register allocation order list to linkage property

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -19,6 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <algorithm>
+#include <iterator>
+
 #include "codegen/ARM64SystemLinkage.hpp"
 
 #include "codegen/ARM64Instruction.hpp"
@@ -32,6 +35,75 @@
 #include "il/Node_inlines.hpp"
 #include "il/ParameterSymbol.hpp"
 
+uint32_t TR::ARM64SystemLinkage::_globalRegisterNumberToRealRegisterMap[] =
+   {
+   // GPRs
+   TR::RealRegister::x15,
+   TR::RealRegister::x14,
+   TR::RealRegister::x13,
+   TR::RealRegister::x12,
+   TR::RealRegister::x11,
+   TR::RealRegister::x10,
+   TR::RealRegister::x9,
+   TR::RealRegister::x8, // indirect result location register
+   TR::RealRegister::x18, // platform register
+   // callee-saved registers
+   TR::RealRegister::x28,
+   TR::RealRegister::x27,
+   TR::RealRegister::x26,
+   TR::RealRegister::x25,
+   TR::RealRegister::x24,
+   TR::RealRegister::x23,
+   TR::RealRegister::x22,
+   TR::RealRegister::x21,
+   TR::RealRegister::x20,
+   TR::RealRegister::x19,
+   // parameter registers
+   TR::RealRegister::x7,
+   TR::RealRegister::x6,
+   TR::RealRegister::x5,
+   TR::RealRegister::x4,
+   TR::RealRegister::x3,
+   TR::RealRegister::x2,
+   TR::RealRegister::x1,
+   TR::RealRegister::x0,
+
+   // FPRs
+   TR::RealRegister::v31,
+   TR::RealRegister::v30,
+   TR::RealRegister::v29,
+   TR::RealRegister::v28,
+   TR::RealRegister::v27,
+   TR::RealRegister::v26,
+   TR::RealRegister::v25,
+   TR::RealRegister::v24,
+   TR::RealRegister::v23,
+   TR::RealRegister::v22,
+   TR::RealRegister::v21,
+   TR::RealRegister::v20,
+   TR::RealRegister::v19,
+   TR::RealRegister::v18,
+   TR::RealRegister::v17,
+   TR::RealRegister::v16,
+   // callee-saved registers
+   TR::RealRegister::v15,
+   TR::RealRegister::v14,
+   TR::RealRegister::v13,
+   TR::RealRegister::v12,
+   TR::RealRegister::v11,
+   TR::RealRegister::v10,
+   TR::RealRegister::v9,
+   TR::RealRegister::v8,
+   // parameter registers
+   TR::RealRegister::v7,
+   TR::RealRegister::v6,
+   TR::RealRegister::v5,
+   TR::RealRegister::v4,
+   TR::RealRegister::v3,
+   TR::RealRegister::v2,
+   TR::RealRegister::v1,
+   TR::RealRegister::v0
+   };
 
 TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
@@ -99,6 +171,8 @@ TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    _properties._argumentRegisters[13] = TR::RealRegister::v5;
    _properties._argumentRegisters[14] = TR::RealRegister::v6;
    _properties._argumentRegisters[15] = TR::RealRegister::v7;
+
+   std::copy(std::begin(_globalRegisterNumberToRealRegisterMap), std::end(_globalRegisterNumberToRealRegisterMap), std::begin(_properties._allocationOrder));
 
    _properties._firstIntegerReturnRegister = 0;
    _properties._firstFloatReturnRegister   = 1;

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.hpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.hpp
@@ -145,6 +145,10 @@ class ARM64SystemLinkage : public TR::Linkage
     */
    virtual intptr_t entryPointFromInterpretedMethod();
 
+   private:
+
+   // Tactical GRA
+   static uint32_t _globalRegisterNumberToRealRegisterMap[];
    };
 
 }

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,6 +92,7 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum _returnRegisters[TR::RealRegister::NumRegisters];
    uint8_t _numAllocatableIntegerRegisters;
    uint8_t _numAllocatableFloatRegisters;
+   uint32_t _allocationOrder[TR::RealRegister::NumRegisters];
    uint32_t _preservedRegisterMapForGC;
    TR::RealRegister::RegNum _methodMetaDataRegister;
    TR::RealRegister::RegNum _stackPointerRegister;
@@ -221,6 +222,11 @@ struct ARM64LinkageProperties
    int32_t getNumAllocatableFloatRegisters() const
       {
       return _numAllocatableFloatRegisters;
+      }
+
+   uint32_t *getRegisterAllocationOrder() const
+      {
+      return (uint32_t *) _allocationOrder;
       }
 
    uint32_t getPreservedRegisterMapForGC() const


### PR DESCRIPTION
This commit adds register allocation order list to linkage property
and populates it in the constructor of `ARM64SystemLinkage`.

The intention of this commit is to move `_globalRegisterNumberToRealRegisterMap` from `OMRMachine` to linkage class as ppc codegen does.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>