### PR TITLE
AArch64: Initialize global register table from linkage property

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -59,11 +59,11 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    // Tactical GRA settings
    //
-   self()->setGlobalRegisterTable(TR::Machine::getGlobalRegisterTable());
+   self()->setGlobalRegisterTable(_linkageProperties->getRegisterAllocationOrder());
    _numGPR = _linkageProperties->getNumAllocatableIntegerRegisters();
    _numFPR = _linkageProperties->getNumAllocatableFloatRegisters();
-   self()->setLastGlobalGPR(TR::Machine::getLastGlobalGPRRegisterNumber());
-   self()->setLastGlobalFPR(TR::Machine::getLastGlobalFPRRegisterNumber());
+   self()->setLastGlobalGPR(_numGPR - 1);
+   self()->setLastGlobalFPR(_numGPR + _numFPR - 1);
 
    self()->getLinkage()->initARM64RealRegisterLinkage();
 

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1146,73 +1146,3 @@ OMR::ARM64::Machine::restoreRegisterStateFromSnapShot()
          }
       }
    }
-
-uint32_t OMR::ARM64::Machine::_globalRegisterNumberToRealRegisterMap[] =
-   {
-   // GPRs
-   TR::RealRegister::x15,
-   TR::RealRegister::x14,
-   TR::RealRegister::x13,
-   TR::RealRegister::x12,
-   TR::RealRegister::x11,
-   TR::RealRegister::x10,
-   TR::RealRegister::x9,
-   TR::RealRegister::x8, // indirect result location register
-   TR::RealRegister::x18, // platform register
-   // callee-saved registers
-   TR::RealRegister::x28,
-   TR::RealRegister::x27,
-   TR::RealRegister::x26,
-   TR::RealRegister::x25,
-   TR::RealRegister::x24,
-   TR::RealRegister::x23,
-   TR::RealRegister::x22,
-   TR::RealRegister::x21,
-   TR::RealRegister::x20,
-   TR::RealRegister::x19,
-   // parameter registers
-   TR::RealRegister::x7,
-   TR::RealRegister::x6,
-   TR::RealRegister::x5,
-   TR::RealRegister::x4,
-   TR::RealRegister::x3,
-   TR::RealRegister::x2,
-   TR::RealRegister::x1,
-   TR::RealRegister::x0,
-
-   // FPRs
-   TR::RealRegister::v31,
-   TR::RealRegister::v30,
-   TR::RealRegister::v29,
-   TR::RealRegister::v28,
-   TR::RealRegister::v27,
-   TR::RealRegister::v26,
-   TR::RealRegister::v25,
-   TR::RealRegister::v24,
-   TR::RealRegister::v23,
-   TR::RealRegister::v22,
-   TR::RealRegister::v21,
-   TR::RealRegister::v20,
-   TR::RealRegister::v19,
-   TR::RealRegister::v18,
-   TR::RealRegister::v17,
-   TR::RealRegister::v16,
-   // callee-saved registers
-   TR::RealRegister::v15,
-   TR::RealRegister::v14,
-   TR::RealRegister::v13,
-   TR::RealRegister::v12,
-   TR::RealRegister::v11,
-   TR::RealRegister::v10,
-   TR::RealRegister::v9,
-   TR::RealRegister::v8,
-   // parameter registers
-   TR::RealRegister::v7,
-   TR::RealRegister::v6,
-   TR::RealRegister::v5,
-   TR::RealRegister::v4,
-   TR::RealRegister::v3,
-   TR::RealRegister::v2,
-   TR::RealRegister::v1,
-   TR::RealRegister::v0
-   };

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,11 +41,6 @@ namespace OMR { typedef OMR::ARM64::Machine MachineConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
-
-#define NUM_ARM64_GPR 32
-#define MAX_ARM64_GLOBAL_GPRS 27 // excluding IP0, IP1, FP, LR, and SP
-#define NUM_ARM64_FPR 32
-#define MAX_ARM64_GLOBAL_FPRS 32
 
 #define NUM_ARM64_MAXR 32
 
@@ -145,25 +140,6 @@ public:
     */
    void restoreRegisterStateFromSnapShot();
 
-   /**
-    * @brief Answers global register table
-    * @return global register table
-    */
-   static uint32_t *getGlobalRegisterTable()
-      { return _globalRegisterNumberToRealRegisterMap; }
-   /**
-    * @brief Answers global register number of last GPR
-    * @return global register number
-    */
-   static TR_GlobalRegisterNumber getLastGlobalGPRRegisterNumber()
-      { return MAX_ARM64_GLOBAL_GPRS - 1; }
-   /**
-    * @brief Answers global register number of last FPR
-    * @return global register number
-    */
-   static TR_GlobalRegisterNumber getLastGlobalFPRRegisterNumber()
-      { return MAX_ARM64_GLOBAL_GPRS + MAX_ARM64_GLOBAL_FPRS - 1; }
-
 private:
 
    // For register snap shot
@@ -172,10 +148,6 @@ private:
    TR::Register               *_assignedRegisterSnapShot[TR::RealRegister::NumRegisters];
 
    void initializeRegisterFile();
-
-   // Tactical GRA
-   static uint32_t _globalRegisterNumberToRealRegisterMap[MAX_ARM64_GLOBAL_GPRS + MAX_ARM64_GLOBAL_FPRS];
-
    };
 }
 }


### PR DESCRIPTION
- Change code generator to initialize global register table
from linkage property instead of `OMRMachine`.
- Remove unused members from `OMRMacine`.

Depends on 
- https://github.com/eclipse/omr/pull/5109
- https://github.com/eclipse/openj9/pull/9337

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>