### PR TITLE
Collector STW flag

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -477,6 +477,7 @@ void*
 MM_Collector::garbageCollect(MM_EnvironmentBase* env, MM_MemorySubSpace* callingSubSpace, MM_AllocateDescription* allocateDescription, uint32_t gcCode, MM_ObjectAllocationInterface* objectAllocationInterface, MM_MemorySubSpace* baseSubSpace, MM_AllocationContext* context)
 {
 	Assert_MM_mustHaveExclusiveVMAccess(env->getOmrVMThread());
+	_stwCollectionInProgress = true;
 
 	Assert_MM_true(NULL == env->_cycleState);
 	preCollect(env, callingSubSpace, allocateDescription, gcCode);
@@ -515,6 +516,9 @@ MM_Collector::garbageCollect(MM_EnvironmentBase* env, MM_MemorySubSpace* calling
 	postCollect(env, callingSubSpace);
 	Assert_MM_true(NULL != env->_cycleState);
 	env->_cycleState = NULL;
+
+	Assert_MM_true(_stwCollectionInProgress);
+	_stwCollectionInProgress = false;
 
 	return postCollectAllocationResult;
 }

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 1991, 2018 IBM Corp. and others
+ * (c) Copyright 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,6 +60,7 @@ protected:
 	bool _gcCompleted;
 	bool _isRecursiveGC;
 	bool _disableGC;
+	bool _stwCollectionInProgress;  /**< if set, the whole or partial STW phase is in progress (mutators not running) */
 
 	uintptr_t _collectorExpandedSize;
 	uintptr_t _cycleType;
@@ -90,6 +91,15 @@ public:
 	 * @return boolean indicating if the last GC completed successfully.
 	 */
 	bool gcCompleted() { return _gcCompleted; }
+	
+	/*
+	 * Return value of _stwCollectionInProgress flag
+	 */
+	bool isStwCollectionInProgress()
+	{
+		return _stwCollectionInProgress;
+	}
+	
 
 private:
 	void setThreadFailAllocFlag(MM_EnvironmentBase *env, bool flag);
@@ -305,6 +315,7 @@ public:
 		, _gcCompleted(false)
 		, _isRecursiveGC(false)
 		, _disableGC(false)
+		, _stwCollectionInProgress(false)
 		, _collectorExpandedSize(0)
 		, _cycleType(OMR_GC_CYCLE_TYPE_DEFAULT)
 		, _masterThreadCpuTimeStart(0)

--- a/gc/base/GlobalCollector.hpp
+++ b/gc/base/GlobalCollector.hpp
@@ -65,11 +65,6 @@ public:
 	}
 
 	virtual void yield(MM_EnvironmentBase *env) {};
-	
-	virtual bool isStwCollectionInProgress()
-	{
-		return false;
-	}
 
 	/**
  	 * Perform any collector-specific initialization.

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1294,7 +1294,7 @@ MM_ConcurrentGC::tuneToHeap(MM_EnvironmentBase *env)
 	 */
 	if(0 == heapSize) {
 		Trc_MM_ConcurrentGC_tuneToHeap_Exit1(env->getLanguageVMThread());
-		assume0(!_stwCollectionInProgress);
+		Assert_MM_true(!_stwCollectionInProgress);
 		return;
 	}
 
@@ -2922,11 +2922,7 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 
 	/* Ensure caller acquired exclusive VM access before calling */
 	Assert_MM_mustHaveExclusiveVMAccess(env->getOmrVMThread());
-
-	/* Set flag to show STW collector is active; some operations need to know if they
-	 * are called during a global collect or not, eg heapAddRange
-	 */
-	_stwCollectionInProgress = true;
+	Assert_MM_true(_stwCollectionInProgress);
 
 	/* Assume for now we will need to initialize the mark map. If we subsequenly find
 	 * we got far enough through the concurrent mark cycle then we will reset this flag
@@ -3155,7 +3151,6 @@ MM_ConcurrentGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace 
 	}
 
 	/* Collection is complete so reset flags */
-	_stwCollectionInProgress = false;
 	_forcedKickoff  = false;
 	_stats.clearKickoffReason();
 

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -200,7 +200,6 @@ private:
 	volatile uint32_t _conHelpersShutdownCount;
 	omrthread_monitor_t _conHelpersActivationMonitor;
 
-	bool _stwCollectionInProgress;  /**< if set, the final STW phase is in progress (mutators not running) */
 	bool _initializeMarkMap;
 	omrthread_monitor_t _initWorkMonitor;
 	omrthread_monitor_t _initWorkCompleteMonitor;
@@ -460,14 +459,6 @@ public:
 		}	
 	}
 
-	/*
-	 * Return value of _stwCollectionInProgress flag
-	 */
-	virtual bool isStwCollectionInProgress()
-	{
-		return _stwCollectionInProgress;
-	}
-
 	/**
 	 * Return reference to Card Table
 	 */
@@ -494,7 +485,6 @@ public:
 		,_conHelpersStarted(0)
 		,_conHelpersShutdownCount(0)
 		,_conHelpersActivationMonitor(NULL)
-		,_stwCollectionInProgress(false)
 		,_initializeMarkMap(false)
 		,_initWorkMonitor(NULL)
 		,_initWorkCompleteMonitor(NULL)


### PR DESCRIPTION
Generalize the existing flag that was being set only in Concurrent
Global GC to being maintained by base Collector, so that can be used
for any STW Collector.

Specifically, it was needed in an unusual combination when Concurrent
Scavenger was enabled, but Concurrent Mark disabled (so Global GC was
not MM_ConcurrentGC, but MM_ParallelGlobalGC which would not set STW
flag), and when CS would abort and Global Marking would miss to fixup
forwarded slots (during STW phase).

In future, the flag might be useful for other code in CS & Balanced to
determine if GC threads running in STW or concurrent phase. But for that
we have to properly set it for cases when Master Threads is explicit.
This is better to do in a separate change, if/when it becomes important.
For now, this flag is reliable only any STW GC with implicit Master
Thread.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>