### PR TITLE
AArch64: Implement select evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -69,6 +69,8 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    self()->setSupportsVirtualGuardNOPing();
 
+   self()->setSupportsSelect();
+
    _numberBytesReadInaccessible = 0;
    _numberBytesWriteInaccessible = 0;
 

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -408,13 +408,13 @@
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::sRegStore		// Store short global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::bRegStore		// Store byte global register
     TR::TreeEvaluator::GlRegDepsEvaluator, // TR::GlRegDeps		// Global Register Dependency List
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iselectEvaluator ,	// TR::iselect		// Select Operator:  Based on the result of the first child; take the value of the
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lselectEvaluator ,	// TR::lselect		//   second (first child evaluates to true) or third(first child evaluates to false) child
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bselectEvaluator ,	// TR::bselect   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sselectEvaluator ,	// TR::sselect   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::aselectEvaluator ,	// TR::aselect   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fselectEvaluator ,	// TR::fselect   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dselectEvaluator ,	// TR::dselect   
+    TR::TreeEvaluator::iselectEvaluator, // TR::iselect		// Select Operator:  Based on the result of the first child; take the value of the
+    TR::TreeEvaluator::iselectEvaluator, // TR::lselect		//   second (first child evaluates to true) or third(first child evaluates to false) child
+    TR::TreeEvaluator::iselectEvaluator, // TR::bselect
+    TR::TreeEvaluator::iselectEvaluator, // TR::sselect
+    TR::TreeEvaluator::iselectEvaluator, // TR::aselect
+    TR::TreeEvaluator::fselectEvaluator, // TR::fselect
+    TR::TreeEvaluator::fselectEvaluator, // TR::dselect
     TR::TreeEvaluator::treetopEvaluator, // TR::treetop		// tree top to anchor subtrees with side-effects
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::MethodEnterHookEvaluator ,	// TR::MethodEnterHook	// called after a frame is built; temps initialized; and monitor acquired (if necessary)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::MethodExitHookEvaluator ,	// TR::MethodExitHook	// called immediately before returning; frame not yet collapsed; monitor released (if necessary)

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -245,7 +245,6 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectInt64CompareTest,
             ::testing::ValuesIn(resultInputs<int64_t>()),
             ::testing::Values(xselectOracle<int64_t, int64_t>)));
 
-
 class Int64SelectDoubleCompareTest : public SelectTest<double, int64_t> {};
 
 TEST_P(Int64SelectDoubleCompareTest, UsingLoadParam) {
@@ -315,6 +314,8 @@ INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectDoubleCompareTest,
 class Int32SelectDoubleCompareTest : public SelectTest<double, int32_t> {};
 
 TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
+    SKIP_ON_AARCH64(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -343,6 +344,8 @@ TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
 }
 
 TEST_P(Int32SelectDoubleCompareTest, UsingConst) {
+    SKIP_ON_AARCH64(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -453,7 +456,6 @@ TEST_P(FloatSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
     SKIP_ON_HAMMER(MissingImplementation);
     SKIP_ON_ARM(MissingImplementation);
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = to_struct(GetParam());
 
@@ -526,7 +528,6 @@ TEST_P(DoubleSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
     SKIP_ON_HAMMER(MissingImplementation);
     SKIP_ON_ARM(MissingImplementation);
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = to_struct(GetParam());
 


### PR DESCRIPTION
This commit implements iselectEvaluator() and fselectEvaluator() for
AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>