### PR TITLE
AArch64: Add check before using register of node in memory reference

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -326,23 +326,20 @@ void OMR::ARM64::MemoryReference::addToOffset(TR::Node *node, intptr_t amount, T
 
       if (_baseRegister != NULL)
          {
-         if (node->getOpCode().isLoadConst() && node->getRegister())
+         if (constantIsUnsignedImm12(displacement))
+            {
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, newBase, _baseRegister, displacement);
+            }
+         else if (node->getOpCode().isLoadConst() && node->getRegister() && (node->getLongInt() == displacement))
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister, node->getRegister());
             }
          else
             {
-            if (constantIsUnsignedImm12(displacement))
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, newBase, _baseRegister, displacement);
-               }
-            else
-               {
-               TR::Register *tempReg = cg->allocateRegister();
-               loadConstant64(cg, node, displacement, tempReg);
-               generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister, tempReg);
-               cg->stopUsingRegister(tempReg);
-               }
+            TR::Register *tempReg = cg->allocateRegister();
+            loadConstant64(cg, node, displacement, tempReg);
+            generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister, tempReg);
+            cg->stopUsingRegister(tempReg);
             }
          }
       else


### PR DESCRIPTION
`OMR::ARM64::MemoryReference::addToOffset` uses node's register as displacement
if node is `const` node. It uses the node associated with the last instruction
if `NULL` is passed to `addToOffset` as `node` argument. Unfortunately,
the node chosen is irrelevant in some cases.
This commit adds value check before using the node's register to avoid using
incorrect register for displacement.
This commit also moves if-block for the case where const value can be encoded
in `addimmx` instruction before the if-block for the case where node's register
can be reused.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>