### PR TITLE
Add knn-k as a code owner for ARM code generators

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 IBM Corp. and others
+# Copyright (c) 2018, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,8 +40,8 @@
 /compiler/ @0xdaryl @mstoodle
 /compiler/optimizer/ @vijaysun-omr @andrewcraik
 /compiler/il/ @vijaysun-omr @Leonardo2718
-/compiler/arm/ @0xdaryl
-/compiler/aarch64/ @0xdaryl
+/compiler/arm/ @0xdaryl @knn-k
+/compiler/aarch64/ @0xdaryl @knn-k
 /compiler/z/ @fjeremic
 
 # JitBuilder


### PR DESCRIPTION
Signed-off-by: Daryl Maier <maier@ca.ibm.com>