### PR TITLE
Write out newline character after the message in verbose output

### DIFF
--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -301,8 +301,7 @@ compileMethodFromDetails(
       {
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileExclude))
          {
-         TR_VerboseLog::write("<JIT: %s cannot be translated>\n",
-                              compilee.signature(&trMemory));
+         TR_VerboseLog::writeLine(TR_Vlog_INFO, "%s cannot be translated", compilee.signature(&trMemory));
          }
       return 0;
       }
@@ -313,8 +312,7 @@ compileMethodFromDetails(
       // so that we don't have to deal with OOM ugliness below
       if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileExclude))
          {
-         TR_VerboseLog::write("<JIT: %s out-of-memory allocating optimization plan>\n",
-                              compilee.signature(&trMemory));
+         TR_VerboseLog::writeLine(TR_Vlog_INFO, "%s out-of-memory allocating optimization plan", compilee.signature(&trMemory));
          }
       return 0;
       }
@@ -386,7 +384,7 @@ compileMethodFromDetails(
             {
             const char *signature = compilee.signature(&trMemory);
             TR_VerboseLog::vlogAcquire();
-            TR_VerboseLog::writeLine(TR_Vlog_COMP,"(%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
+            TR_VerboseLog::write(TR_Vlog_COMP, "(%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
                                            compiler.getHotnessName(compiler.getMethodHotness()),
                                            signature,
                                            startPC,
@@ -401,6 +399,7 @@ compileMethodFromDetails(
                   );
                }
 
+            TR_VerboseLog::writeLine("");
             TR_VerboseLog::vlogRelease();
             trfflush(jitConfig->options.vLogFile);
             }

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1533,7 +1533,7 @@ OMR::Options::setRegex(char *option, void *base, TR::OptionTable *entry)
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
    *((TR::SimpleRegex**)((char*)base+entry->parm1)) = regex;
    if (!regex)
-      TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+      TR_VerboseLog::writeLine("Bad regular expression at --> '%s'", option);
    return option;
    }
 
@@ -1544,7 +1544,7 @@ OMR::Options::setStaticRegex(char *option, void *base, TR::OptionTable *entry)
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
    *((TR::SimpleRegex**)entry->parm1) = regex;
    if (!regex)
-      TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+      TR_VerboseLog::writeLine("Bad regular expression at --> '%s'", option);
    return option;
    }
 
@@ -2224,7 +2224,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
       if (self()->getOption(TR_MimicInterpreterFrameShape))
          {
          if (self()->getFixedOptLevel() != -1 && self()->getFixedOptLevel() != noOpt)
-            TR_VerboseLog::write("<JIT: FullSpeedDebug: ignoring user specified optLevel>\n");
+            TR_VerboseLog::writeLine(TR_Vlog_FSD, "Ignoring user specified optLevel");
          if (_countString)
             {
             //if quickstart is enabled, then message saying it is incompatable with fsdb
@@ -2232,11 +2232,11 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
                {
                if (TR::Options::isQuickstartDetected())
                   {
-                  TR_VerboseLog::write("<JIT: FullSpeedDebug: ignoring -Xquickstart option>\n");
+                  TR_VerboseLog::writeLine(TR_Vlog_FSD, "Ignoring -Xquickstart option");
                   }
                else
                   {
-                  TR_VerboseLog::write("<JIT: FullSpeedDebug: ignoring countString>\n");
+                  TR_VerboseLog::writeLine(TR_Vlog_FSD, "Ignoring countString");
                   }
                }
             }
@@ -2294,11 +2294,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          }
       else if (self()->requiresLogFile())
          {
-         if (this == TR::Options::getAOTCmdLineOptions())
-            TR_VerboseLog::write("<AOT");
-         else
-            TR_VerboseLog::write("<JIT");
-         TR_VerboseLog::write(": trace options require a log file to be specified: log=<filename>)>\n");
+         TR_VerboseLog::writeLine(TR_Vlog_INFO, "Trace options require a log file to be specified: log=<filename>");
          return false;
          }
 
@@ -2311,7 +2307,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          fej9->compileMethods(optionSet, jitConfig);
          if (self()->getOption(TR_WaitBit))
             {
-            TR_VerboseLog::write("Will call waitOnCompiler\n");
+            TR_VerboseLog::writeLine("Will call waitOnCompiler");
             fej9->waitOnCompiler(jitConfig);
             }
          }
@@ -2696,7 +2692,7 @@ OMR::Options::jitPreProcess()
             if (_aggressivenessLevel != -1) // -1 means not set
                {
                if (OMR::Options::isAnyVerboseOptionSet())
-                  TR_VerboseLog::write("\n<JIT: _aggressivenessLevel=%d; must be between 0 and 5; Option ignored\n", _aggressivenessLevel);
+                  TR_VerboseLog::writeLine(TR_Vlog_INFO, "_aggressivenessLevel=%d; must be between 0 and 5; Option ignored", _aggressivenessLevel);
                _aggressivenessLevel = -1;
                }
             }
@@ -3092,10 +3088,10 @@ OMR::Options::validateOptionsTables(void *feBase, TR_FrontEnd *fe)
          }
       if (_numJitEntries > 0 && stricmp_ignore_locale((opt-1)->name, opt->name) >= 0)
          {
-         TR_VerboseLog::writeLine(TR_Vlog_FAILURE,"JIT option table entries out of order: ");
+         TR_VerboseLog::write(TR_Vlog_FAILURE, "JIT option table entries out of order: ");
          TR_VerboseLog::write((opt-1)->name);
          TR_VerboseLog::write(", ");
-         TR_VerboseLog::write(opt->name);
+         TR_VerboseLog::writeLine(opt->name);
          return false;
          }
 #endif
@@ -3253,7 +3249,7 @@ OMR::Options::processOptionSet(
             methodRegex = TR::SimpleRegex::create(endOpt);
             if (!methodRegex)
                {
-               TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", endOpt);
+               TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", endOpt);
                return options;
                }
 
@@ -3264,7 +3260,7 @@ OMR::Options::processOptionSet(
                optLevelRegex = TR::SimpleRegex::create(endOpt);
                if (!optLevelRegex)
                   {
-                  TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", endOpt);
+                  TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", endOpt);
                   return options;
                   }
                }
@@ -3406,7 +3402,7 @@ OMR::Options::processOptionSet(
 
          if (!endOpt)
             {
-            TR_VerboseLog::write("<JIT: Unable to allocate option string>\n");
+            TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Unable to allocate option string");
             return options;
             }
 
@@ -3414,7 +3410,7 @@ OMR::Options::processOptionSet(
 
          if (!feEndOpt)
             {
-            TR_VerboseLog::write("<JIT: Unable to allocate option string>\n");
+            TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Unable to allocate option string");
             return options;
             }
 
@@ -3424,7 +3420,7 @@ OMR::Options::processOptionSet(
          //
          if (feEndOpt != options && optionSet)
             {
-            TR_VerboseLog::write("<JIT: Option not allowed in option subset>\n");
+            TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Option not allowed in option subset");
             return options;
             }
 
@@ -3540,7 +3536,7 @@ OMR::Options::processOption(
       {
       if (opt->msgInfo & NOT_IN_SUBSET)
          {
-         TR_VerboseLog::write("<JIT: option not allowed in option subset>\n");
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Option not allowed in option subset");
          opt->msgInfo = 0;
          return startOption;
          }
@@ -3564,7 +3560,7 @@ OMR::Options::processOption(
       processingMethod = TR::Options::negateProcessingMethod(opt->fcn);
       if (!processingMethod)
          {
-         TR_VerboseLog::write("<JIT: '!' is not supported for this option>\n");
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "'!' is not supported for this option");
          opt->msgInfo = 0;
          return startOption;
          }
@@ -3608,7 +3604,7 @@ OMR::Options::jitPostProcess()
       }
    else if (self()->requiresLogFile())
       {
-      TR_VerboseLog::write("<JIT: the log file option must be specified when a trace options is used: log=<filename>)>\n");
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Log file option must be specified when a trace options is used: log=<filename>");
       return false;
       }
 
@@ -3627,7 +3623,7 @@ OMR::Options::jitPostProcess()
             }
          else
             {
-            TR_VerboseLog::write("<JIT: WARNING: ignoring optFile option; unable to read opts from '%s'\n", _optFileName);
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Ignoring optFile option; unable to read opts from '%s'", _optFileName);
             }
          }
       }
@@ -3833,7 +3829,7 @@ OMR::Options::printOptions(char *options, char *envOptions)
       optionsType = "AOT";
    TR_Debug::dumpOptions(optionsType, options, envOptions, self(), _jitOptions, TR::Options::_feOptions, _feBase, _fe);
    if (_aggressivenessLevel > 0)
-       TR_VerboseLog::write("\naggressivenessLevel=%u\n", _aggressivenessLevel);
+       TR_VerboseLog::writeLine("aggressivenessLevel=%u", _aggressivenessLevel);
    }
 
 
@@ -4237,13 +4233,13 @@ OMR::Options::setCounts()
 
    if (!_countString)
       {
-      TR_VerboseLog::write("<JIT: Count string could not be allocated>\n");
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Count string could not be allocated");
       return dummy_string;
       }
 
    if (_initialCount == -1 || _initialBCount == -1 || _initialMILCount == -1)
       {
-      TR_VerboseLog::write("<JIT: Bad string count: %s>\n", _countString);
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad string count: '%s'", _countString);
       return _countString;
       }
 
@@ -4550,7 +4546,7 @@ OMR::Options::setAddressEnumerationBits(char *option, void *base, TR::OptionTabl
 
       TR::SimpleRegex * regex = _debug ? TR::SimpleRegex::create(option) : 0;
       if (!regex)
-         TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", option);
       else
          {
          if (TR::SimpleRegex::matchIgnoringLocale(regex, "block"))
@@ -4578,7 +4574,7 @@ OMR::Options::setAddressEnumerationBits(char *option, void *base, TR::OptionTabl
             *((int32_t*)((char*)base+entry->parm1)) |= TR_EnumerateStructure;
             }
          if (*((int32_t*)((char*)base+entry->parm1)) == 0x00000000)
-            TR_VerboseLog::write("<JIT: Address enumeration option not found.  No address enumeration option was set.>");
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Address enumeration option not found. No address enumeration option was set.");
          }
       }
 
@@ -4626,7 +4622,7 @@ OMR::Options::setBitsFromStringSet(char *option, void *base, TR::OptionTable *en
 
       TR::SimpleRegex * regex = _debug ? TR::SimpleRegex::create(option) : 0;
       if (!regex)
-         TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", option);
       else
          {
          for(i=0;_optionStringToBitMapping[i].bitValue != 0;i++)
@@ -4637,7 +4633,7 @@ OMR::Options::setBitsFromStringSet(char *option, void *base, TR::OptionTable *en
              }
            }
          if (*((int32_t*)((char*)base+entry->parm1)) == 0x00000000)
-            TR_VerboseLog::write("<JIT: Register assignment tracing options not found.  No additional tracing option was set.>");
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Register assignment tracing options not found. No additional tracing option was set.");
          }
       }
 
@@ -4657,7 +4653,7 @@ char *OMR::Options::clearBitsFromStringSet(char *option, void *base, TR::OptionT
       {
       TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
       if (!regex)
-         TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", option);
       else
          {
          for(i=0;_optionStringToBitMapping[i].bitValue != 0;i++)
@@ -4668,7 +4664,7 @@ char *OMR::Options::clearBitsFromStringSet(char *option, void *base, TR::OptionT
              }
            }
          if (*((int32_t*)((char*)base+entry->parm1)) == 0x00000000)
-            TR_VerboseLog::write("<JIT: Register assignment tracing options not found.  No additional tracing option was set.>");
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Register assignment tracing options not found. No additional tracing option was set.");
          }
       }
 
@@ -4694,7 +4690,7 @@ OMR::Options::configureOptReporting(char *option, void *base, TR::OptionTable *e
          options->setOption(TR_CountOptTransformations);
          TR::SimpleRegex * regex = _debug ? TR::SimpleRegex::create(option) : 0;
          if (!regex)
-            TR_VerboseLog::write("<JIT: Bad regular expression --> '%s'>\n", option);
+            TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression --> '%s'", option);
          else
             options->_verboseOptTransformationsRegex = regex;
          break;
@@ -4799,7 +4795,7 @@ OMR::Options::setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verbose
       {
       TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
       if (!regex)
-         TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", option);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", option);
       else
          {
          bool foundMatch = false;
@@ -4815,7 +4811,7 @@ OMR::Options::setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verbose
             }
 
          if (!foundMatch)
-            TR_VerboseLog::write("<JIT: Verbose option not found.  No verbose option was set.>");
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Verbose option not found. No verbose option was set.");
          }
       }
       return option;

--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -99,14 +99,14 @@ public:
          if (TR::Options::getVerboseOption(TR_VerbosePerformance))
             {
             TR_VerboseLog::vlogAcquire();
-            TR_VerboseLog::write("\nProfiling %s compile time with:", comp->signature());
+            TR_VerboseLog::write("Profiling %s compile time with:", comp->signature());
             char **iter = options;
             while (*iter)
                {
                TR_VerboseLog::write(" %s", *iter);
                iter++;
                }
-            TR_VerboseLog::write("\n");
+            TR_VerboseLog::writeLine("");
             TR_VerboseLog::vlogRelease();
             }
 

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -70,10 +70,10 @@ void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)
    TR_ASSERT(tag != TR_Vlog_null, "TR_Vlog_null is not a valid Vlog tag");
    va_list args;
    va_start(args, format);
-   write("\n");
    writeTimeStamp();
    write(_vlogTable[tag]);
    vwrite(format,args);
+   write("\n");
    va_end(args);
    }
 
@@ -83,10 +83,10 @@ void TR_VerboseLog::writeLineLocked(TR_VlogTag tag, const char *format, ...)
    vlogAcquire();
    va_list args;
    va_start(args, format);
-   write("\n");
    writeTimeStamp();
    write(_vlogTable[tag]);
    vwrite(format,args);
+   write("\n");
    va_end(args);
    vlogRelease();
    }

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -63,6 +63,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#PROFILING: ",
    "#JITServer: ",
    "#AOTCOMPRESSION: ",
+   "#FSD: ",
    };
 
 void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)
@@ -72,7 +73,16 @@ void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)
    va_start(args, format);
    writeTimeStamp();
    write(_vlogTable[tag]);
-   vwrite(format,args);
+   vwrite(format, args);
+   write("\n");
+   va_end(args);
+   }
+
+void TR_VerboseLog::writeLine(const char *format, ...)
+   {
+   va_list args;
+   va_start(args, format);
+   vwrite(format, args);
    write("\n");
    va_end(args);
    }
@@ -85,7 +95,7 @@ void TR_VerboseLog::writeLineLocked(TR_VlogTag tag, const char *format, ...)
    va_start(args, format);
    writeTimeStamp();
    write(_vlogTable[tag]);
-   vwrite(format,args);
+   vwrite(format, args);
    write("\n");
    va_end(args);
    vlogRelease();
@@ -95,7 +105,18 @@ void TR_VerboseLog::write(const char *format, ...)
    {
    va_list args;
    va_start(args, format);
-   vwrite(format,args);
+   vwrite(format, args);
+   va_end(args);
+   }
+
+void TR_VerboseLog::write(TR_VlogTag tag, const char *format, ...)
+   {
+   TR_ASSERT_FATAL(tag != TR_Vlog_null, "TR_Vlog_null is not a valid Vlog tag");
+   va_list args;
+   va_start(args, format);
+   writeTimeStamp();
+   write(_vlogTable[tag]);
+   vwrite(format, args);
    va_end(args);
    }
 

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -71,6 +71,7 @@ enum TR_VlogTag
    TR_Vlog_PROFILING,
    TR_Vlog_JITServer,
    TR_Vlog_AOTCOMPRESSION,
+   TR_Vlog_FSD,
    TR_Vlog_numTags
    };
 
@@ -84,7 +85,9 @@ class TR_VerboseLog
    //writeLine and write provide multi line write capabilities, and are to be used with vlogAcquire() and vlogRelease(),
    //this ensures nice formatted verbose logs
    static void write(const char *format, ...);
+   static void write(TR_VlogTag tag, const char *format, ...);
    static void writeLine(TR_VlogTag tag, const char *format, ...);
+   static void writeLine(const char *format, ...);
    //writeLineLocked is a single line print function, it provides the locks for you
    static void writeLineLocked(TR_VlogTag tag, const char *format, ...);
    static void vlogAcquire(); //defined in each front end

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -123,7 +123,7 @@ TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t opti
       TR::SimpleRegex *regex = TR::SimpleRegex::create(filterCursor);
       if (!regex)
          {
-         TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", filterCursor);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", filterCursor);
          return 0;
          }
       nameLength = filterCursor - filterString;
@@ -318,7 +318,7 @@ TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::Compila
 
       if (includeFlag == '[')
          {
-         //TR_VerboseLog::write("<JIT: sub inline file entry start --> '%s'>\n", limitReadBuffer);
+         //TR_VerboseLog::writeLine(TR_Vlog_INFO, "Sub inline file entry start --> '%s'", limitReadBuffer);
 
          if (filter)
             {
@@ -330,7 +330,7 @@ TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::Compila
          }
       else if (includeFlag == ']')
          {
-         //TR_VerboseLog::write("<JIT: sub inline file entry end --> '%s'>\n", limitReadBuffer);
+         //TR_VerboseLog::writeLine(TR_Vlog_INFO, "Sub inline file entry end --> '%s'", limitReadBuffer);
          // always return true (success)
          // this will ignore the rest of the filters if no matching open bracket.
          return true;
@@ -371,7 +371,7 @@ TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::Compila
          if (!filter)
             {
             inlineFileError = true;
-            TR_VerboseLog::write("<JIT: bad inline file entry --> '%s'>\n", limitReadBuffer);
+            TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad inline file entry --> '%s'", limitReadBuffer);
             break;
             }
          }
@@ -445,7 +445,7 @@ TR_Debug::inlinefileOption(char *option, void *base, TR::OptionTable *entry, TR:
 
    if (!success)
       {
-      TR_VerboseLog::write("<JIT: fatal: unable to read inline file --> '%s'>\n", inlineFileName);
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Unable to read inline file --> '%s'", inlineFileName);
       return fail; // We want to fail if we can't read the file because it is too easy to miss that the file wasn't picked up
       }
    return endOpt;
@@ -687,14 +687,14 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
          }
       if (limitFileError)
          {
-         TR_VerboseLog::write("<JIT: fatal: bad limit file entry --> '%s'>\n", limitReadBuffer);
+         TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad limit file entry --> '%s'", limitReadBuffer);
          return fail;
          }
       fclose(limitFile);
       }
    else
       {
-      TR_VerboseLog::write("<JIT: fatal: unable to read limit file --> '%s'>\n", limitFileName);
+      TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Unable to read limit file --> '%s'", limitFileName);
       return fail; //We want to fail if we can't read the file because it is too easy to miss that the file wasn't picked up
       }
    return endOpt;
@@ -732,7 +732,7 @@ TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Opti
          if (!optLevelRegex || *p != '(')
             {
             if (!optLevelRegex)
-               TR_VerboseLog::write("<JIT: Bad regular expression at --> '%s'>\n", p);
+               TR_VerboseLog::writeLine(TR_Vlog_FAILURE, "Bad regular expression at --> '%s'", p);
             return option;
             }
          }
@@ -980,17 +980,17 @@ TR_Debug::printFilters(TR::CompilationFilters * filters)
 void
 TR_Debug::printFilters()
    {
-   TR_VerboseLog::write("<compilationFilters>\n");
+   TR_VerboseLog::writeLine("<compilationFilters>");
    printFilters(_compilationFilters);
-   TR_VerboseLog::write("</compilationFilters>\n");
+   TR_VerboseLog::writeLine("</compilationFilters>");
 
-   TR_VerboseLog::write("<relocationFilters>\n");
+   TR_VerboseLog::writeLine("<relocationFilters>");
    printFilters(_relocationFilters);
-   TR_VerboseLog::write("</relocationFilters>\n");
+   TR_VerboseLog::writeLine("</relocationFilters>");
 
-   TR_VerboseLog::write("<inlineFilters>\n");
+   TR_VerboseLog::writeLine("<inlineFilters>");
    printFilters(_inlineFilters);
-   TR_VerboseLog::write("</inlineFilters>\n");
+   TR_VerboseLog::writeLine("</inlineFilters>");
    }
 
 void
@@ -1010,7 +1010,7 @@ TR_Debug::printSamplingPoints()
    {
       if (filter->getFilterType() == TR_FILTER_SAMPLE_INTERPRETED)
       {
-         TR_VerboseLog::write("(%d)\tInterpreted %s.%s%s\tcount=%d\n",
+         TR_VerboseLog::writeLine("(%d)\tInterpreted %s.%s%s\tcount=%d",
             filter->getTickCount(),
             filter->getClass(), filter->getName(), filter->getSignature(),
             filter->getSampleCount()
@@ -1018,7 +1018,7 @@ TR_Debug::printSamplingPoints()
       }
       else
       {
-         TR_VerboseLog::write("(%d)\tCompiled %s.%s%s\tlevel=%d%s\n",
+         TR_VerboseLog::writeLine("(%d)\tCompiled %s.%s%s\tlevel=%d%s",
             filter->getTickCount(),
             filter->getClass(), filter->getName(), filter->getSignature(),
             filter->getSampleLevel(),
@@ -1038,7 +1038,7 @@ TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
 
    // Walk the filter to determine the type.
    //
-   //TR_VerboseLog::write("filterName: %s\n", string);
+   //TR_VerboseLog::writeLine("filterName: %s", string);
    char *nameChars = NULL;
    int32_t nameLen = 0;
    char *classChars = NULL;
@@ -1365,7 +1365,7 @@ TR_Debug::loadCustomStrategy(char *fileName)
          {
          if (optCount >= (sizeof(optNumBuffer)/sizeof(optNumBuffer[0])))
             {
-            TR_VerboseLog::write("<JIT: WARNING: reached limit of %d optFile lines; ignoring subsequent lines\n", optCount);
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Reached limit of %d optFile lines; ignoring subsequent lines", optCount);
             break;
             }
 
@@ -1390,7 +1390,7 @@ TR_Debug::loadCustomStrategy(char *fileName)
                }
             }
          if (optNum == OMR::numOpts)
-            TR_VerboseLog::write("<JIT: WARNING: ignoring optFile line; no matching opt name for '%s'\n", name);
+            TR_VerboseLog::writeLine(TR_Vlog_INFO, "Ignoring optFile line; no matching opt name for '%s'", name);
 
          }
 
@@ -1403,12 +1403,12 @@ TR_Debug::loadCustomStrategy(char *fileName)
          }
       else
          {
-         TR_VerboseLog::write("<JIT: WARNING: ignoring optFile; contains no suitable opt names\n");
+         TR_VerboseLog::writeLine(TR_Vlog_INFO, "Ignoring optFile; contains no suitable opt names");
          }
       }
    else
       {
-      TR_VerboseLog::write("<JIT: WARNING: optFile not found: %s\n", fileName);
+      TR_VerboseLog::writeLine(TR_Vlog_INFO, "optFile not found: '%s'", fileName);
       }
    return customStrategy;
    }

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -219,7 +219,7 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
          //
          if (!entry->length)
             entry->length = strlen(entry->name);
-         TR_VerboseLog::write("%*s%s",OPTION_NAME_INDENT," ",entry->name);
+         TR_VerboseLog::write("%*s%s", OPTION_NAME_INDENT, " ", entry->name);
          int32_t currentColumn = entry->length+OPTION_NAME_INDENT;
 
          // Set up the argument text
@@ -237,7 +237,8 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
             TR_VerboseLog::write("%*s", DESCRIPTION_START_COLUMN-currentColumn, " ");
          else
             {
-            TR_VerboseLog::writeLine(TR_Vlog_INFO,"%*s", DESCRIPTION_START_COLUMN, " ");
+            TR_VerboseLog::writeLine("");
+            TR_VerboseLog::write(TR_Vlog_INFO, "%*s", DESCRIPTION_START_COLUMN, " ");
             }
          currentColumn = DESCRIPTION_START_COLUMN;
 
@@ -258,9 +259,10 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
                {
                if (lastWordBreak == start)
                   lastWordBreak = i;
-               TR_VerboseLog::write("%.*s",lastWordBreak-start,entry->helpText+start);
+               TR_VerboseLog::write("%.*s", lastWordBreak-start, entry->helpText+start);
                currentColumn = DESCRIPTION_START_COLUMN + DESCRIPTION_TEXT_INDENT;
-               TR_VerboseLog::writeLine(TR_Vlog_INFO,"%*s", currentColumn, " ");
+               TR_VerboseLog::writeLine("");
+               TR_VerboseLog::write(TR_Vlog_INFO, "%*s", currentColumn, " ");
                start = i = ++lastWordBreak;
                continue;
                }
@@ -269,10 +271,11 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
             i++;
             }
 
-         TR_VerboseLog::write("%s",entry->helpText+start);
+         TR_VerboseLog::write("%s", entry->helpText+start);
          }
       }
-   TR_VerboseLog::writeLine(TR_Vlog_INFO,"");
+   TR_VerboseLog::writeLine("");
+   TR_VerboseLog::writeLine(TR_Vlog_INFO, "");
    }
 
 void
@@ -472,7 +475,7 @@ TR_Debug::dumpOptions(
 
       if (printIt && (entry->msg[0]=='F'|| extendCheck))
          {
-         TR_VerboseLog::writeLine(TR_Vlog_INFO,"     %s", entry->name);
+         TR_VerboseLog::write(TR_Vlog_INFO,"     %s", entry->name);
 
          if (regex)
             regex->print(false);
@@ -495,16 +498,17 @@ TR_Debug::dumpOptions(
                }
             TR_VerboseLog::write("}");
             }
+
+         TR_VerboseLog::writeLine("");
          }
       }
 
 #ifdef J9_PROJECT_SPECIFIC
    if (fej9->generateCompressedPointers())
       {
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"     ");
-      TR_VerboseLog::write("compressedRefs shiftAmount=%d", TR::Compiler->om.compressedReferenceShift());
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"     ");
-      TR_VerboseLog::write("compressedRefs isLowMemHeap=%d", (TR::Compiler->vm.heapBaseAddress() == 0));
+      TR_VerboseLog::writeLine("");
+      TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs shiftAmount=%d", TR::Compiler->om.compressedReferenceShift());
+      TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs isLowMemHeap=%d", (TR::Compiler->vm.heapBaseAddress() == 0));
       }
 #endif
    }


### PR DESCRIPTION
The `TR_VerboseLog::writeLine*` APIs currently write the newline
character before the message being printed which is non-conventional.
Typically the expectation of a user is that any API that outputs
newline characters outputs them at the end, examples from various
languages in [1] [2] [3], and there are numerous other examples.

The reason we are making this change is because other components in OMR
will expect to be writing at the start of a newline, whether that be
stdout, stderr, or a file. The verbose log not adhering to this
expectation yields in messages getting printed one after another which
is not desirable.

[1] https://docs.python.org/3/library/functions.html#print
[2] https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#println-java.lang.String-
[3] https://docs.microsoft.com/en-us/dotnet/api/system.console.writeline?view=netframework-4.8#System_Console_WriteLine_System_String_

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>