### PR TITLE
Prevent TR_X86ProcessorInfo::initialize from re-initializing

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -111,6 +111,8 @@ TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
 void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
    {
+   if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))
+      return;
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
    //


### PR DESCRIPTION
The static variable TR_X86ProcessorInfo should only be initialized
once. Initializing it repeatly caused a race condition in the code.
Technically we may still have syncronization issues without a lock,
but the chances will be much lower with this change. Note that this
implementation of processor detection will be replaced soon. This
change is only needed to test out the new processor detection APIs.

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>