### PR TITLE
Fix incorrect spelling of J9_PROJECT_SPECIFIC

### DIFF
--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -289,7 +289,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
          {
          trgReg = cg->allocateRegister();
          TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
-#ifdef J9_ProjectSpecific
+#ifdef J9_PROJECT_SPECIFIC
          if (node->getFirstChild()->getOpCodeValue() == TR::irsload)
             {
             tempMR->forceIndexedForm(node->getFirstChild(), cg);


### PR DESCRIPTION
It seems that previously, there was code in the Power codegen guarded by
the definition of a J9_ProjectSpecific macro. This was a misspelling of
the J9_PROJECT_SPECIFIC macro, so this code was never actually used.
This could cause incorrect behaviour in OpenJ9 if an irsload node
appeared under an s2i node. The spelling of this check has been
corrected so that the code should now be enabled correctly.

Fixed: #5137
Signed-off-by: Ben Thomas <ben@benthomas.ca>