### PR TITLE
Replace CPU APIs on x86

### DIFF
--- a/compiler/arm/env/OMRCompilerEnv.hpp
+++ b/compiler/arm/env/OMRCompilerEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,8 +48,8 @@ class OMR_EXTENSIBLE CompilerEnv : public OMR::CompilerEnv
    {
 public:
 
-   CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit) :
-         OMR::CompilerEnv(raw, persistentAllocatorKit)
+   CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit, OMRPortLibrary * const portLib=NULL) :
+         OMR::CompilerEnv(raw, persistentAllocatorKit, portLib)
       {}
 
    // Initialize 'target' environment for this compilation

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -297,7 +297,6 @@ OMR::Compilation::Compilation(
    _target(TR::Compiler->target),
    _tlsManager(*self())
    {
-
    //Avoid expensive initialization and uneeded option checking if we are doing AOT Loads
    if (_optimizationPlan && _optimizationPlan->getIsAotLoad())
       {

--- a/compiler/env/OMRCPU.cpp
+++ b/compiler/env/OMRCPU.cpp
@@ -29,24 +29,15 @@
 #include "env/defines.h"
 #include "omrcfg.h"
 
-TR::CPU *
-OMR::CPU::self()
+OMR::CPU::CPU() :
+   _processor(TR_NullProcessor),
+   _endianness(TR::endian_unknown),
+   _majorArch(TR::arch_unknown),
+   _minorArch(TR::m_arch_none)
    {
-   return static_cast<TR::CPU*>(this);
-   }
-
-TR::CPU
-OMR::CPU::detect(OMRPortLibrary * const omrPortLib)
-   {
-   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
-   OMRProcessorDesc processorDescription;
-   omrsysinfo_get_processor_description(&processorDescription);
-   return TR::CPU(processorDescription);
-   }
-
-void
-OMR::CPU::initializeByHostQuery()
-   {
+   _processorDescription.processor = OMR_PROCESSOR_UNDEFINED;
+   _processorDescription.physicalProcessor = OMR_PROCESSOR_UNDEFINED;
+   memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
 
 #ifdef OMR_ENV_LITTLE_ENDIAN
    _endianness = TR::endian_little;
@@ -71,9 +62,60 @@ OMR::CPU::initializeByHostQuery()
 #if defined(TR_HOST_X86)
    _majorArch = TR::arch_x86;
    #if defined (TR_HOST_64BIT)
-   _minorArch = TR::m_arch_amd64;
+      _minorArch = TR::m_arch_amd64;
    #else
-   _minorArch = TR::m_arch_i386;
+      _minorArch = TR::m_arch_i386;
+#endif
+
+#elif defined (TR_HOST_POWER)
+   _majorArch = TR::arch_power;
+#elif defined(TR_HOST_ARM)
+   _majorArch = TR::arch_arm;
+#elif defined(TR_HOST_S390)
+   _majorArch = TR::arch_z;
+#elif defined(TR_HOST_ARM64)
+   _majorArch = TR::arch_arm64;
+#elif defined(TR_HOST_RISCV)
+   _majorArch = TR::arch_riscv;
+   #if defined (TR_HOST_64BIT)
+      _minorArch = TR::m_arch_riscv64;
+   #else
+      _minorArch = TR::m_arch_riscv32;
+   #endif
+#else
+   TR_ASSERT(0, "unknown host architecture");
+#endif
+   }
+
+OMR::CPU::CPU(const OMRProcessorDesc& processorDescription) : 
+   _processorDescription(processorDescription)
+   {
+#ifdef OMR_ENV_LITTLE_ENDIAN
+   _endianness = TR::endian_little;
+#else
+   _endianness = TR::endian_big;
+#endif
+
+   // Validate host endianness #define with an additional compile-time test
+   //
+   char SwapTest[2] = { 1, 0 };
+   bool isHostLittleEndian = (*(short *)SwapTest == 1);
+
+   if (_endianness == TR::endian_little)
+      {
+      TR_ASSERT(isHostLittleEndian, "expecting host to be little endian");
+      }
+   else
+      {
+      TR_ASSERT(!isHostLittleEndian, "expecting host to be big endian");
+      }
+
+#if defined(TR_HOST_X86)
+   _majorArch = TR::arch_x86;
+   #if defined (TR_HOST_64BIT)
+      _minorArch = TR::m_arch_amd64;
+   #else
+      _minorArch = TR::m_arch_i386;
    #endif
 #elif defined (TR_HOST_POWER)
    _majorArch = TR::arch_power;
@@ -86,20 +128,45 @@ OMR::CPU::initializeByHostQuery()
 #elif defined(TR_HOST_RISCV)
    _majorArch = TR::arch_riscv;
    #if defined (TR_HOST_64BIT)
-   _minorArch = TR::m_arch_riscv64;
+      _minorArch = TR::m_arch_riscv64;
    #else
-   _minorArch = TR::m_arch_riscv32;
+      _minorArch = TR::m_arch_riscv32;
    #endif
 #else
-   TR_ASSERT(0, "unknown host architecture");
-   _majorArch = TR::arch_unknown;
+      TR_ASSERT(0, "unknown host architecture");
 #endif
+   }
 
+
+TR::CPU *
+OMR::CPU::self()
+   {
+   return static_cast<TR::CPU*>(this);
+   }
+
+TR::CPU
+OMR::CPU::detect(OMRPortLibrary * const omrPortLib)
+   {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
+   OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
+   OMRProcessorDesc processorDescription;
+   omrsysinfo_get_processor_description(&processorDescription);
+   return TR::CPU(processorDescription);
+   }
+
+bool
+OMR::CPU::is(OMRProcessorArchitecture p)
+   {
+   TR_ASSERT_FATAL(TR::Compiler->omrPortLib != NULL, "Should not be calling this OMR level API without a valid port library pointer. Perhaps we did not initialize the port library properly?\n");
+   return _processorDescription.processor == p;
    }
 
 bool
 OMR::CPU::supportsFeature(uint32_t feature)
    {
+   TR_ASSERT_FATAL(TR::Compiler->omrPortLib != NULL, "Should not be calling this OMR level API without a valid port library pointer. Perhaps we did not initialize the port library properly?\n");
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    BOOLEAN supported = omrsysinfo_processor_has_feature(&_processorDescription, feature);
    return (TRUE == supported);

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -88,22 +88,13 @@ protected:
    /** 
     * @brief Default constructor that defaults down to OMR minimum supported CPU and features
     */
-   CPU() :
-         _processor(TR_NullProcessor),
-         _endianness(TR::endian_unknown),
-         _majorArch(TR::arch_unknown),
-         _minorArch(TR::m_arch_none)
-      {
-      _processorDescription.processor = OMR_PROCESSOR_UNDEFINED;
-      _processorDescription.physicalProcessor = OMR_PROCESSOR_UNDEFINED;
-      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
-      }
+   CPU();
 
    /** 
     * @brief Constructor that initializes the cpu from processor description provided by user
     * @param[in] OMRProcessorDesc : the input processor description
     */
-   CPU(const OMRProcessorDesc& processorDescription) : _processorDescription(processorDescription) {}
+   CPU(const OMRProcessorDesc& processorDescription);
 
 public:
 
@@ -116,21 +107,11 @@ public:
     */
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
-   // Initialize CPU info by querying the host processor at compile-time
-   //
-   void initializeByHostQuery();
-
    TR_Processor setProcessor(TR_Processor p) { return(_processor = p); }
 
    // Processor identity and generation comparisons
    //
    TR_Processor id() { return _processor; }
-   bool is(TR_Processor p) { return _processor == p; }
-   bool isNot(TR_Processor p) { return _processor != p; }
-   bool isAtLeast(TR_Processor p) { return _processor >= p; }
-   bool isLaterThan(TR_Processor p) { return _processor > p; }
-   bool isEarlierThan(TR_Processor p) { return _processor < p; }
-   bool isAtMost(TR_Processor p) { return _processor <= p; }
 
    bool getSupportsHardwareSQRT() { return false; }
    bool getSupportsHardwareRound() { return false; }
@@ -169,7 +150,7 @@ public:
     * @param[in] p : the input processor type
     * @return true when current processor is the same as the input processor type
     */
-   bool is(OMRProcessorArchitecture p) const { return _processorDescription.processor == p; }
+   bool is(OMRProcessorArchitecture p);
 
    /**
     * @brief Determines whether current processor is equal or newer than the input processor type

--- a/compiler/env/OMRCompilerEnv.cpp
+++ b/compiler/env/OMRCompilerEnv.cpp
@@ -27,13 +27,14 @@
 
 OMR::CompilerEnv::CompilerEnv(
    TR::RawAllocator raw,
-   const TR::PersistentAllocatorKit &persistentAllocatorKit
+   const TR::PersistentAllocatorKit &persistentAllocatorKit,
+   OMRPortLibrary * const portLib
    ) :
       rawAllocator(raw),
       _initialized(false),
       _persistentAllocator(persistentAllocatorKit),
       regionAllocator(_persistentAllocator),
-      omrPortLib(NULL)
+      omrPortLib(portLib)
    {
    }
 
@@ -73,7 +74,7 @@ OMR::CompilerEnv::initializeHostEnvironment()
 
    // Initialize the host CPU by querying the host processor
    //
-   host.cpu.initializeByHostQuery();
+   host.cpu = TR::CPU::detect(TR::Compiler->omrPortLib);
 
    // Host major operating system
    //
@@ -118,7 +119,7 @@ OMR::CompilerEnv::initializeTargetEnvironment()
 
    // Initialize the target CPU by querying the host processor
    //
-   target.cpu.initializeByHostQuery();
+   target.cpu = TR::CPU::detect(TR::Compiler->omrPortLib);
 
    // Target major operating system
    //

--- a/compiler/env/OMRCompilerEnv.hpp
+++ b/compiler/env/OMRCompilerEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ class OMR_EXTENSIBLE CompilerEnv
 
 public:
 
-   CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit);
+   CompilerEnv(TR::RawAllocator raw, const TR::PersistentAllocatorKit &persistentAllocatorKit, OMRPortLibrary* const omrPortLib=NULL);
 
    TR::CompilerEnv *self();
 

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1040,11 +1040,15 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
    startLabel->setStartInternalControlFlow();
    reStartLabel->setEndInternalControlFlow();
 
+
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE) == cg->getX86ProcessorInfo().supportsSSE(), "supportsSSE() failed\n");
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) == cg->getX86ProcessorInfo().supportsSSE2(), "supportsSSE2() failed\n");
+   
    bool optimizeF2IWithSSE = ( node->getOpCodeValue() == TR::f2i &&
-                               cg->getX86ProcessorInfo().supportsSSE() );
+                               cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE) );
 
    bool optimizeD2IWithSSE2 = ( node->getOpCodeValue() == TR::d2i &&
-                                cg->getX86ProcessorInfo().supportsSSE2() );
+                                cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) );
 
    if (!optimizeF2IWithSSE && !optimizeD2IWithSSE2)
       {
@@ -2205,7 +2209,9 @@ bool OMR::X86::TreeEvaluator::canUseFCOMIInstructions(TR::Node *node, TR::CodeGe
    {
    TR::ILOpCodes cmpOp = node->getOpCodeValue();
 
-   return (!cg->getX86ProcessorInfo().supportsFCOMIInstructions() ||
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFCOMIInstructions() == cg->getX86ProcessorInfo().supportsFCOMIInstructions(), "supportsFCOMIInstuctions() failed\n");
+
+   return (!cg->comp()->target().cpu.supportsFCOMIInstructions() ||
            cmpOp == TR::iffcmpneu ||
            cmpOp == TR::iffcmpeq  ||
            cmpOp == TR::ifdcmpneu ||

--- a/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
+++ b/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
@@ -98,14 +98,21 @@ TR::Register *TR_X86IntegerMultiplyDecomposer::decomposeIntegerMultiplier(int32_
          const integerMultiplyComposition& composition = _integerMultiplySolutions[decompositionIndex];
          if (composition._subsequentShiftTooExpensive == false)
             {
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) == cg()->getX86ProcessorInfo().isIntelCore2(), "isIntelCore2 failed\n");
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_INTELNEHALEM) == cg()->getX86ProcessorInfo().isIntelNehalem(), "isIntelNehalem failed\n");
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_INTELWESTMERE) == cg()->getX86ProcessorInfo().isIntelWestmere(), "isIntelWestmere failed\n");
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_INTELSANDYBRIDGE) == cg()->getX86ProcessorInfo().isIntelSandyBridge(), "isIntelSandyBridge failed\n");
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H) == cg()->getX86ProcessorInfo().isAMD15h(), "isAMD15h failed\n");
+            TR_ASSERT_FATAL(comp->target().cpu.is(OMR_PROCESSOR_X86_AMDOPTERON) == cg()->getX86ProcessorInfo().isAMDOpteron(), "isAMDOpteron failed\n");
+
             target = generateDecompositionInstructions(decompositionIndex, tempRegArraySize, tempRegArray);
             if (shiftAmount < 3 &&
-               !cg()->getX86ProcessorInfo().isIntelCore2() &&
-               !cg()->getX86ProcessorInfo().isIntelNehalem() &&
-               !cg()->getX86ProcessorInfo().isIntelWestmere() &&
-               !cg()->getX86ProcessorInfo().isIntelSandyBridge() &&
-               !cg()->getX86ProcessorInfo().isAMD15h() &&
-               !cg()->getX86ProcessorInfo().isAMDOpteron()) // TODO:: P3 should go straight to else and use shift always
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_INTELCORE2) &&
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_INTELNEHALEM) &&
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_INTELWESTMERE) &&
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_INTELSANDYBRIDGE) &&
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H) &&
+               !comp->target().cpu.is(OMR_PROCESSOR_X86_AMDOPTERON)) // TODO:: P3 should go straight to else and use shift always
                {
                for (; shiftAmount > 0; --shiftAmount)
                   {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2723,7 +2723,8 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
    bool isShortConstantArrayWithZero = false;
 
    static bool isConstArraysetEnabled = (NULL == feGetEnv("TR_DisableConstArrayset"));
-   if (isConstArraysetEnabled && cg->getX86ProcessorInfo().supportsSSSE3() && cg->comp()->target().is64Bit())
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) == cg->getX86ProcessorInfo().supportsSSSE3(), "supportsSSSE3() failed!\n");
+   if (isConstArraysetEnabled && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSSE3) && cg->comp()->target().is64Bit())
       {
       if (valueNode->getOpCode().isLoadConst() && !valueNode->getOpCode().isFloat() && !valueNode->getOpCode().isDouble())
          {
@@ -4241,7 +4242,8 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
    TR::Node* operandNode0 = node->getChild(0);
    TR::Node* operandNode1 = node->getChild(1);
 
-   bool useRegMemForm = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX();
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsAVX() == TR::CodeGenerator::getX86ProcessorInfo().supportsAVX(), "supportsAVX() failed\n");
+   bool useRegMemForm = cg->comp()->target().cpu.supportsAVX();
 
    if (useRegMemForm)
       {
@@ -4262,7 +4264,7 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
    TR_X86OpCodes opCode = useRegMemForm ? BinaryArithmeticOpCodesForMem[type][arithmetic] : BinaryArithmeticOpCodesForReg[type][arithmetic];
    TR_ASSERT(opCode != BADIA32Op, "FloatingPointAndVectorBinaryArithmeticEvaluator: unsupported data type or arithmetic.");
 
-   if (TR::CodeGenerator::getX86ProcessorInfo().supportsAVX())
+   if (cg->comp()->target().cpu.supportsAVX())
       {
       if (useRegMemForm)
          generateRegRegMemInstruction(opCode, node, resultReg, operandReg0, generateX86MemoryReference(operandNode1, cg), cg);

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1460,6 +1460,8 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
       TR_X86OpCode fenceOp;
       bool is5ByteFence = false;
 
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(), "requiresLFence() failed\n");
+
       if (barrier & LockOR)
          {
          fenceOp.setOpCodeValue(LOR4MemImms);
@@ -1467,7 +1469,7 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
          }
       else if ((barrier & kMemoryFence) == kMemoryFence)
          fenceOp.setOpCodeValue(MFENCE);
-      else if ((barrier & kLoadFence) && cg->getX86ProcessorInfo().requiresLFENCE())
+      else if ((barrier & kLoadFence) && cg->comp()->target().cpu.requiresLFence())
          fenceOp.setOpCodeValue(LFENCE);
       else if (barrier & kStoreFence)
          fenceOp.setOpCodeValue(SFENCE);

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -37,7 +37,10 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    TR::Instruction::REX rex(rexbits);
    rex.W = rex_w;
    // Use AVX if possible
-   if (supportsAVX() && TR::CodeGenerator::getX86ProcessorInfo().supportsAVX())
+
+   TR_ASSERT_FATAL(TR::comp()->target().cpu.supportsAVX() == TR::CodeGenerator::getX86ProcessorInfo().supportsAVX(), "supportsAVX() failed\n");
+
+   if (supportsAVX() && TR::comp()->target().cpu.supportsAVX())
       {
       TR::Instruction::VEX<3> vex(rex, modrm_opcode);
       vex.m = escape;

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -22,20 +22,25 @@
 #include <stdlib.h>
 #include <string.h>
 #include "env/CPU.hpp"
+#include "env/CompilerEnv.hpp"
 #include "env/JitConfig.hpp"
 #include "env/ProcessorInfo.hpp"
 #include "infra/Flags.hpp"
 #include "x/runtime/X86Runtime.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 TR::CPU
 OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
-   {   
+   {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
    // Only enable the features that compiler currently uses
    uint32_t enabledFeatures [] = {OMR_FEATURE_X86_FPU, OMR_FEATURE_X86_CX8, OMR_FEATURE_X86_CMOV,
                                   OMR_FEATURE_X86_MMX, OMR_FEATURE_X86_SSE, OMR_FEATURE_X86_SSE2,
                                   OMR_FEATURE_X86_SSSE3, OMR_FEATURE_X86_SSE4_1, OMR_FEATURE_X86_POPCNT,
                                   OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_OSXSAVE, OMR_FEATURE_X86_AVX,
-                                  OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM};
+                                  OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM};
 
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
    OMRProcessorDesc featureMasks;
@@ -50,6 +55,15 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
    for (size_t i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)
       {
       processorDescription.features[i] &= featureMasks.features[i];
+      }
+
+   if (TRUE == omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE))
+      {
+      if (((6 & _xgetbv(0)) != 6) || feGetEnv("TR_DisableAVX")) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
+         {
+         // Unset OSXSAVE if not enabled via CR0
+         omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE, FALSE);
+         }
       }
 
    return TR::CPU(processorDescription);
@@ -120,31 +134,34 @@ OMR::X86::CPU::getX86ProcessorSignature()
 uint32_t
 OMR::X86::CPU::getX86ProcessorFeatureFlags()
    {
-   return self()->queryX86TargetCPUID()->_featureFlags;
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->queryX86TargetCPUID()->_featureFlags;
+
+   return self()->_processorDescription.features[0];
    }
 
 uint32_t
 OMR::X86::CPU::getX86ProcessorFeatureFlags2()
    {
-   return self()->queryX86TargetCPUID()->_featureFlags2;
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->queryX86TargetCPUID()->_featureFlags2;
+
+   return self()->_processorDescription.features[1];
    }
 
 uint32_t
 OMR::X86::CPU::getX86ProcessorFeatureFlags8()
    {
-   return self()->queryX86TargetCPUID()->_featureFlags8;
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->queryX86TargetCPUID()->_featureFlags8;
+
+   return self()->_processorDescription.features[3];
    }
 
 bool
 OMR::X86::CPU::getSupportsHardwareSQRT()
    {
    return true;
-   }
-
-bool
-OMR::X86::CPU::testOSForSSESupport()
-   {
-   return false;
    }
 
 bool
@@ -157,12 +174,18 @@ OMR::X86::CPU::supportsTransactionalMemoryInstructions()
 bool
 OMR::X86::CPU::isGenuineIntel()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().isGenuineIntel();
+
    return self()->isAtLeast(OMR_PROCESSOR_X86_INTEL_FIRST) && self()->isAtMost(OMR_PROCESSOR_X86_INTEL_LAST);
    }
 
 bool
 OMR::X86::CPU::isAuthenticAMD()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().isAuthenticAMD();
+   
    return self()->isAtLeast(OMR_PROCESSOR_X86_AMD_FIRST) && self()->isAtMost(OMR_PROCESSOR_X86_AMD_LAST);
    }
 
@@ -175,30 +198,395 @@ OMR::X86::CPU::requiresLFence()
 bool
 OMR::X86::CPU::supportsFCOMIInstructions()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().supportsFCOMIInstructions();
+
    return self()->supportsFeature(OMR_FEATURE_X86_FPU) || self()->supportsFeature(OMR_FEATURE_X86_CMOV);
    }
 
 bool
 OMR::X86::CPU::supportsMFence()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().supportsMFence();
+
    return self()->supportsFeature(OMR_FEATURE_X86_SSE2);
    }
 
 bool
 OMR::X86::CPU::supportsLFence()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().supportsLFence();
+
    return self()->supportsFeature(OMR_FEATURE_X86_SSE2);
    }
 
 bool
 OMR::X86::CPU::supportsSFence()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().supportsSFence();
+
    return self()->supportsFeature(OMR_FEATURE_X86_SSE2) || self()->supportsFeature(OMR_FEATURE_X86_MMX);
    }
 
 bool
 OMR::X86::CPU::prefersMultiByteNOP()
    {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().prefersMultiByteNOP();
+   TR_ASSERT_FATAL(TR::CodeGenerator::getX86ProcessorInfo().prefersMultiByteNOP() == (self()->isGenuineIntel() && !self()->is(OMR_PROCESSOR_X86_INTELPENTIUM)), "prefersMultiByteNOP");
+
    return self()->isGenuineIntel() && !self()->is(OMR_PROCESSOR_X86_INTELPENTIUM);
+   }
+
+bool
+OMR::X86::CPU::supportsAVX()
+   {
+   if (TR::Compiler->omrPortLib == NULL)
+      return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX();
+   TR_ASSERT_FATAL(TR::CodeGenerator::getX86ProcessorInfo().supportsAVX() == (self()->supportsFeature(OMR_FEATURE_X86_AVX) && self()->supportsFeature(OMR_FEATURE_X86_OSXSAVE)), "supportsAVX");
+
+   return self()->supportsFeature(OMR_FEATURE_X86_AVX) && self()->supportsFeature(OMR_FEATURE_X86_OSXSAVE);
+   }
+
+bool
+OMR::X86::CPU::is(OMRProcessorArchitecture p)
+   {
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->is_old_api(p);
+   TR_ASSERT_FATAL(self()->is_test(p), "old api and new api did not match, processor %d", p);
+
+   return _processorDescription.processor == p;
+   }
+
+bool
+OMR::X86::CPU::supportsFeature(uint32_t feature)
+   {
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->supports_feature_old_api(feature);
+   TR_ASSERT_FATAL(self()->supports_feature_test(feature), "old api and new api did not match, feature %d", feature);
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   return TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature);
+   }
+
+bool
+OMR::X86::CPU::is_test(OMRProcessorArchitecture p)
+   {
+   switch(p)
+      {
+      case OMR_PROCESSOR_X86_INTELWESTMERE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelWestmere() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELNEHALEM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelNehalem() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELP6:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelP6() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium4() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELCORE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelCore2() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELTULSA:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelTulsa() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSandyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelIvyBridge() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELHASWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelHaswell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELBROADWELL:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelBroadwell() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+         return TR::CodeGenerator::getX86ProcessorInfo().isIntelSkylake() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDAthlonDuron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDOPTERON:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron() == (_processorDescription.processor == p);
+      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+         return TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == (_processorDescription.processor == p);
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
+OMR::X86::CPU::supports_feature_test(uint32_t feature)
+   {
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
+
+   switch(feature)
+      {
+      case OMR_FEATURE_X86_OSXSAVE:
+         return TR::CodeGenerator::getX86ProcessorInfo().enabledXSAVE() == ans;
+      case OMR_FEATURE_X86_FPU:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasBuiltInFPU() == ans;
+      case OMR_FEATURE_X86_VME:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsVirtualModeExtension() == ans;
+      case OMR_FEATURE_X86_DE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebuggingExtension() == ans;
+      case OMR_FEATURE_X86_PSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_TSC:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsRDTSCInstruction() == ans;
+      case OMR_FEATURE_X86_MSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasModelSpecificRegisters() == ans;
+      case OMR_FEATURE_X86_PAE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPhysicalAddressExtension() == ans;
+      case OMR_FEATURE_X86_MCE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMachineCheckException() == ans;
+      case OMR_FEATURE_X86_CX8:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG8BInstruction() == ans;
+      case OMR_FEATURE_X86_CMPXCHG16B:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG16BInstruction() == ans;
+      case OMR_FEATURE_X86_APIC:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasAPICHardware() == ans;
+      case OMR_FEATURE_X86_MTRR:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMemoryTypeRangeRegisters() == ans;
+      case OMR_FEATURE_X86_PGE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPageGlobalFlag() == ans;
+      case OMR_FEATURE_X86_MCA:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasMachineCheckArchitecture() == ans;
+      case OMR_FEATURE_X86_CMOV:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCMOVInstructions() == ans;
+      case OMR_FEATURE_X86_PAT:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasPageAttributeTable() == ans;
+      case OMR_FEATURE_X86_PSE_36:
+         return TR::CodeGenerator::getX86ProcessorInfo().has36BitPageSizeExtension() == ans;
+      case OMR_FEATURE_X86_PSN:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber() == ans;
+      case OMR_FEATURE_X86_CLFSH:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction() == ans;
+      case OMR_FEATURE_X86_DS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore() == ans;
+      case OMR_FEATURE_X86_ACPI:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasACPIRegisters() == ans;
+      case OMR_FEATURE_X86_MMX:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsMMXInstructions() == ans;
+      case OMR_FEATURE_X86_FXSR:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsFastFPSavesRestores() == ans;
+      case OMR_FEATURE_X86_SSE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE() == ans;
+      case OMR_FEATURE_X86_SSE2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE2() == ans;
+      case OMR_FEATURE_X86_SSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE3() == ans;
+      case OMR_FEATURE_X86_SSSE3:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSSE3() == ans;
+      case OMR_FEATURE_X86_SSE4_1:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() == ans;
+      case OMR_FEATURE_X86_SSE4_2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_2() == ans;
+      case OMR_FEATURE_X86_PCLMULQDQ:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLMUL() == ans;
+      case OMR_FEATURE_X86_AESNI:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() == ans;
+      case OMR_FEATURE_X86_POPCNT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsPOPCNT() == ans;
+      case OMR_FEATURE_X86_SS:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsSelfSnoop() == ans;
+      case OMR_FEATURE_X86_RTM:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsTM() == ans;
+      case OMR_FEATURE_X86_HTT:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHyperThreading() == ans;
+      case OMR_FEATURE_X86_HLE:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsHLE() == ans;
+      case OMR_FEATURE_X86_TM:
+         return TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor() == ans;
+      case OMR_FEATURE_X86_AVX:
+         return true;
+      default:
+         return false;
+      }
+   return false;
+   }
+
+bool
+OMR::X86::CPU::is_old_api(OMRProcessorArchitecture p)
+   {
+   bool ans = false;
+   switch(p)
+      {
+      case OMR_PROCESSOR_X86_INTELWESTMERE:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelWestmere();
+         break;
+      case OMR_PROCESSOR_X86_INTELNEHALEM:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelNehalem();
+         break;
+      case OMR_PROCESSOR_X86_INTELPENTIUM:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium();
+         break;
+      case OMR_PROCESSOR_X86_INTELP6:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelP6();
+         break;
+      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelPentium4();
+         break;
+      case OMR_PROCESSOR_X86_INTELCORE2:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelCore2();
+         break;
+      case OMR_PROCESSOR_X86_INTELTULSA:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelTulsa();
+         break;
+      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelSandyBridge();
+         break;
+      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelIvyBridge();
+         break;
+      case OMR_PROCESSOR_X86_INTELHASWELL:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelHaswell();
+         break;
+      case OMR_PROCESSOR_X86_INTELBROADWELL:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelBroadwell();
+         break;
+      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isIntelSkylake();
+         break;
+      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isAMDAthlonDuron();
+         break;
+      case OMR_PROCESSOR_X86_AMDOPTERON:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron();
+         break;
+      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+         ans = TR::CodeGenerator::getX86ProcessorInfo().isAMD15h();
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Unknown processor %d", p);
+         break;
+      }
+   return ans;
+   }
+
+bool
+OMR::X86::CPU::supports_feature_old_api(uint32_t feature)
+   {
+   bool supported = false;
+   switch(feature)
+      {
+      case OMR_FEATURE_X86_OSXSAVE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().enabledXSAVE();
+         break;
+      case OMR_FEATURE_X86_FPU:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasBuiltInFPU();
+         break;
+      case OMR_FEATURE_X86_VME:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsVirtualModeExtension();
+         break;
+      case OMR_FEATURE_X86_DE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsDebuggingExtension();
+         break;
+      case OMR_FEATURE_X86_PSE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsPageSizeExtension();
+         break;
+      case OMR_FEATURE_X86_TSC:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsRDTSCInstruction();
+         break;
+      case OMR_FEATURE_X86_MSR:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasModelSpecificRegisters();
+         break;
+      case OMR_FEATURE_X86_PAE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsPhysicalAddressExtension();
+         break;
+      case OMR_FEATURE_X86_MCE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsMachineCheckException();
+         break;
+      case OMR_FEATURE_X86_CX8:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG8BInstruction();
+         break;
+      case OMR_FEATURE_X86_CMPXCHG16B:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG16BInstruction();
+         break;
+      case OMR_FEATURE_X86_APIC:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasAPICHardware();
+         break;
+      case OMR_FEATURE_X86_MTRR:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasMemoryTypeRangeRegisters();
+         break;
+      case OMR_FEATURE_X86_PGE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsPageGlobalFlag();
+         break;
+      case OMR_FEATURE_X86_MCA:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasMachineCheckArchitecture();
+         break;
+      case OMR_FEATURE_X86_CMOV:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsCMOVInstructions();
+         break;
+      case OMR_FEATURE_X86_PAT:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasPageAttributeTable();
+         break;
+      case OMR_FEATURE_X86_PSE_36:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().has36BitPageSizeExtension();
+         break;
+      case OMR_FEATURE_X86_PSN:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber();
+         break;
+      case OMR_FEATURE_X86_CLFSH:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction();
+         break;
+      case OMR_FEATURE_X86_DS:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore();
+         break;
+      case OMR_FEATURE_X86_ACPI:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasACPIRegisters();
+         break;
+      case OMR_FEATURE_X86_MMX:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsMMXInstructions();
+         break;
+      case OMR_FEATURE_X86_FXSR:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsFastFPSavesRestores();
+         break;
+      case OMR_FEATURE_X86_SSE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSE();
+         break;
+      case OMR_FEATURE_X86_SSE2:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSE2();
+         break;
+      case OMR_FEATURE_X86_SSE3:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSE3();
+         break;
+      case OMR_FEATURE_X86_SSSE3:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSSE3();
+         break;
+      case OMR_FEATURE_X86_SSE4_1:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1();
+         break;
+      case OMR_FEATURE_X86_SSE4_2:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_2();
+         break;
+      case OMR_FEATURE_X86_PCLMULQDQ:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsCLMUL();
+         break;
+      case OMR_FEATURE_X86_AESNI:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI();
+         break;
+      case OMR_FEATURE_X86_POPCNT:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsPOPCNT();
+         break;
+      case OMR_FEATURE_X86_SS:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsSelfSnoop();
+         break;
+      case OMR_FEATURE_X86_RTM:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsTM();
+         break;
+      case OMR_FEATURE_X86_HTT:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsHyperThreading();
+         break;
+      case OMR_FEATURE_X86_HLE:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsHLE();
+         break;
+      case OMR_FEATURE_X86_TM:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor();
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Unknown feature %d", feature);
+         break;
+      }
+   return supported;
    }
 

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -68,9 +68,6 @@ public:
 
    bool getSupportsHardwareSQRT();
 
-   bool testOSForSSESupport();
-
-
    /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
     *
     *  @return true if TM is available, false otherwise.
@@ -101,6 +98,17 @@ public:
    bool supportsLFence();
    bool supportsSFence();
    bool prefersMultiByteNOP();
+   bool supportsAVX();
+   bool testOSForSSESupport() { return false; }
+   
+   // Will be removed once we no longer need the old processor detection apis
+   bool is(OMRProcessorArchitecture p);
+   bool is_old_api(OMRProcessorArchitecture p);
+   bool is_test(OMRProcessorArchitecture p);
+
+   bool supportsFeature(uint32_t feature);
+   bool supports_feature_old_api(uint32_t feature);
+   bool supports_feature_test(uint32_t feature);
    };
 }
 

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -465,7 +465,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
                }
             else
                {
-               TR_ASSERT( cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "Assumption of support of the CMPXCHG8B instruction failed in lstoreEvaluator()" );
+               TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8), "Assumption of support of the CMPXCHG8B instruction failed in lstoreEvaluator()" );
 
                eaxReg = cg->allocateRegister();
                edxReg = cg->allocateRegister();
@@ -500,7 +500,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
             }
          else if(symRef && symRef->isUnresolved() && symRef->getSymbol()->isVolatile() && (!comp->getOption(TR_DisableNewX86VolatileSupport) && cg->comp()->target().is32Bit()) )
             {
-            TR_ASSERT( cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "Assumption of support of the CMPXCHG8B instruction failed in lstoreEvaluator()" );
+            TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8), "Assumption of support of the CMPXCHG8B instruction failed in lstoreEvaluator()" );
             eaxReg = cg->allocateRegister();
             edxReg = cg->allocateRegister();
             ecxReg = cg->allocateRegister();
@@ -3101,7 +3101,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::performLload(TR::Node *node, TR::Me
          {
          TR_X86ProcessorInfo &p = cg->getX86ProcessorInfo();
 
-         if (p.isGenuineIntel())
+         if (cg->comp()->target().cpu.isGenuineIntel())
             {
             TR::Register *xmmReg = cg->allocateRegister(TR_FPR);
             generateRegMemInstruction(cg->getXMMDoubleLoadOpCode(), node, xmmReg, sourceMR, cg);
@@ -3147,7 +3147,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::performLload(TR::Node *node, TR::Me
          }
       else
          {
-         TR_ASSERT( cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "Assumption of support of the CMPXCHG8B instruction failed in performLload()" );
+         TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8), "Assumption of support of the CMPXCHG8B instruction failed in performLload()" );
 
          TR::Register *ecxReg=NULL, *ebxReg=NULL;
          TR::RegisterDependencyConditions  *deps = NULL;

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -34,6 +34,9 @@
 TR::CPU
 OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
    {
+   if (omrPortLib == NULL)
+      return TR::CPU();
+
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
    OMRProcessorDesc processorDescription;
    omrsysinfo_get_processor_description(&processorDescription);


### PR DESCRIPTION
- Replace old processor APIs with new APIs from the CPU class
- Replace global TR::Compiler target with per comp target so that each compilation can either use target or relocatableTarget depending on the type of the compilation (JIT or AOT)
- When there is no port lib available, continue to use old APIs

Issue: #4339

Signed-off-by: Harry Yu <harryyu1994@gmail.com>