### PR TITLE
AArch64: Change the default JIT option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3053,7 +3053,7 @@ void OMR::Options::setOptionInAllOptionSets(uint32_t mask, bool b)
 char *
 OMR::Options::getDefaultOptions()
    {
-   if (TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM())
+   if (TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM() || TR::Compiler->target.cpu.isARM64())
       return (char *) ("samplingFrequency=2");
 
    if (TR::Compiler->target.cpu.isZ())


### PR DESCRIPTION
This commit changes the default JIT option for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>