### PR TITLE
AArch64: Remove `hasToBeOnStack` from OMRLinkage

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,11 +47,6 @@ void OMR::ARM64::Linkage::initARM64RealRegisterLinkage()
 void OMR::ARM64::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    /* do nothing */
-   }
-
-bool OMR::ARM64::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
-   {
-   return(false);
    }
 
 TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -288,12 +288,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    Linkage (TR::CodeGenerator *cg) : OMR::Linkage(cg) {}
 
    /**
-    * @brief Parameter has to be on stack or not
-    * @param[in] parm : parameter symbol
-    * @return true if the parameter has to be on stack, false otherwise
-    */
-   virtual bool hasToBeOnStack(TR::ParameterSymbol *parm);
-   /**
     * @brief Maps symbols to locations on stack
     * @param[in] method : method for which symbols are mapped on stack
     */


### PR DESCRIPTION
Remove `OMR::ARM64::Linkage::hasToBeOnStack` so that the common
implementation `OMR::Linkage::hasToBeOnStack` is used.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>