### PR TITLE
AArch64: Move copyParametersToHomeLocation to OMRLinkage

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.hpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.hpp
@@ -145,6 +145,12 @@ class ARM64SystemLinkage : public TR::Linkage
     */
    virtual intptr_t entryPointFromInterpretedMethod();
 
+   /**
+    * @brief Sets parameter linkage register index
+    * @param[in] method : method symbol
+    */
+   virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method);
+
    private:
 
    // Tactical GRA

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,14 @@
 #include <stdint.h>
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/MemoryReference.hpp"
+#include "compile/Compilation.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
+#include "il/ParameterSymbol.hpp"
 
 void OMR::ARM64::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
@@ -157,4 +160,48 @@ OMR::ARM64::Linkage::numArgumentRegisters(TR_RegisterKinds kind)
       default:
          return 0;
       }
+   }
+
+TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored)
+   {
+   TR::Machine *machine = cg()->machine();
+   const TR::ARM64LinkageProperties& properties = getProperties();
+   TR::RealRegister *stackPtr = machine->getRealRegister(properties.getStackPointerRegister());
+
+   TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
+   ListIterator<TR::ParameterSymbol> parmIterator(&(bodySymbol->getParameterList()));
+   TR::ParameterSymbol *parmCursor;
+
+   // Store to stack all parameters passed in linkage registers
+   //
+   for (parmCursor = parmIterator.getFirst();
+        parmCursor != NULL;
+        parmCursor = parmIterator.getNext())
+      {
+      if (parmCursor->isParmPassedInRegister())
+         {
+         if (!parmsHaveBeenStored)
+            {
+            int8_t lri = parmCursor->getLinkageRegisterIndex();
+            TR::RealRegister *linkageReg;
+            TR::InstOpCode::Mnemonic op;
+
+            if (parmCursor->getDataType() == TR::Double || parmCursor->getDataType() == TR::Float)
+               {
+               linkageReg = machine->getRealRegister(properties.getFloatArgumentRegister(lri));
+               op = (parmCursor->getDataType() == TR::Double) ? TR::InstOpCode::vstrimmd : TR::InstOpCode::vstrimms;
+               }
+            else
+               {
+               linkageReg = machine->getRealRegister(properties.getIntegerArgumentRegister(lri));
+               op = (parmCursor->getSize() == 8) ? TR::InstOpCode::strimmx : TR::InstOpCode::strimmw;
+               }
+
+            TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, parmCursor->getParameterOffset(), cg());
+            cursor = generateMemSrc1Instruction(cg(), op, NULL, stackMR, linkageReg, cursor);
+            }
+         }
+      }
+
+   return cursor;
    }

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -399,6 +399,16 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     */
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode) = 0;
 
+   /**
+    * @brief Stores parameters passed in linkage registers to the stack where the
+    *        method body expects to find them.
+    *
+    * @param[in] cursor : the instruction cursor to begin inserting copy instructions
+    * @param[in] parmsHaveBeenStored : true if the parameters have been stored to the stack
+    *
+    * @return The instruction cursor after copies inserted.
+    */
+   TR::Instruction *copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored = false);
    };
 } // ARM64
 } // TR


### PR DESCRIPTION
- Move `copyParametersToHomeLocation` to OMRLinkage class. We will use this function from both system linkage and private linkage.
- Change `ARM64SystemLinkage::createPrologue` to use `copyParametersToHomeLocation`.
- Implement `ARM64SystemLinkage::setParameterLinkageRegisterIndex`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>