### PR TITLE
AArch64: Enable SupportsGlRegDepOnFirstBlock

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -67,6 +67,7 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    self()->getLinkage()->initARM64RealRegisterLinkage();
    self()->setSupportsGlRegDeps();
+   self()->setSupportsGlRegDepOnFirstBlock();
 
    self()->setSupportsVirtualGuardNOPing();
 


### PR DESCRIPTION
This commit turns on `SupportsGlRegDepOnFirstBlock` for aarch64.

Depends on:
- https://github.com/eclipse/omr/pull/5161
- https://github.com/eclipse/omr/pull/5162
- https://github.com/eclipse/omr/pull/5163

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>