### PR TITLE
Consolidate all trace CG options

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -120,7 +120,7 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
    for (i = 0; i < linkageProperties.getNumFloatArgRegs(); i++)
      _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getFloatArgumentRegister(i)];
 
-   if (self()->comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (self()->comp()->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR));

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -219,7 +219,7 @@ OMR::ARM::CodeGenerator::CodeGenerator()
    for (i=0; i < linkageProperties.getNumFloatArgRegs(); i++)
      _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getFloatArgumentRegister(i)];
 
-   if (self()->comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (self()->comp()->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR));

--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -347,7 +347,7 @@ void TR::ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //
       // This label is the end of the hot instruction stream (i.e., the fallthru path).
       //
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg (comp,"\nOOL: 1. Taking register state snap shot\n");
       cg()->setIsOutOfLineHotPath(true);
       machine->takeRegisterStateSnapShot();
@@ -366,7 +366,7 @@ void TR::ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //
       // Start RA for OOL cold path, restore register state from snap shot
       //
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg (comp, "\nOOL: 1. Restoring Register state from snap shot\n");
       cg()->setIsOutOfLineHotPath(false);
       machine->restoreRegisterStateFromSnapShot();

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -1023,7 +1023,7 @@ OMR::ARM::Machine::takeRegisterStateSnapShot()
       _registerStatesSnapShot[i] = _registerFile[i]->getState();
       _assignedRegisterSnapShot[i] = _registerFile[i]->getAssignedRegister();
       _registerFlagsSnapShot[i] = _registerFile[i]->getFlags();
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg(comp,"OOL: Taking snap shot %d, %x, %x, %x\n", i, _registerStatesSnapShot[i], _assignedRegisterSnapShot[i], _registerFlagsSnapShot[i]);
       }
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
@@ -1033,7 +1033,7 @@ OMR::ARM::Machine::takeRegisterStateSnapShot()
       _registerStatesSnapShot[i] = _registerFile[i]->getState();
       _assignedRegisterSnapShot[i] = _registerFile[i]->getAssignedRegister();
       _registerFlagsSnapShot[i] = _registerFile[i]->getFlags();
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg(comp,"OOL: Taking snap shot %d, %x, %x, %x\n", i, _registerStatesSnapShot[i], _assignedRegisterSnapShot[i], _registerFlagsSnapShot[i]);
       }
 #endif
@@ -1064,7 +1064,7 @@ OMR::ARM::Machine::restoreRegisterStateFromSnapShot()
          {
          _registerFile[i]->getAssignedRegister()->setAssignedRegister(_registerFile[i]);
          }
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg(comp,"OOL: Restoring snap shot %d, %x, %x, %x\n", i, _registerFile[i]->getState(), _registerFile[i]->getAssignedRegister(), _registerFile[i]->getFlags());
       }
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
@@ -1087,7 +1087,7 @@ OMR::ARM::Machine::restoreRegisterStateFromSnapShot()
          {
          _registerFile[i]->getAssignedRegister()->setAssignedRegister(_registerFile[i]);
          }
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg(comp,"OOL: Restoring snap shot %d, %x, %x, %x\n", i, _registerFile[i]->getState(), _registerFile[i]->getAssignedRegister(), _registerFile[i]->getFlags());
       }
 #endif

--- a/compiler/codegen/LiveRegister.cpp
+++ b/compiler/codegen/LiveRegister.cpp
@@ -161,11 +161,6 @@ TR_LiveRegisters::stopUsingRegister(TR::Register *reg)
 void
 TR_LiveRegisters::registerIsDead(TR::Register *reg, bool updateInterferences)
    {
-   if (comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation))
-      {
-      getDebug()->printRegisterKilled(reg);
-      }
-
    if (!reg->isLive())
       return;
 

--- a/compiler/codegen/LiveRegister.hpp
+++ b/compiler/codegen/LiveRegister.hpp
@@ -119,10 +119,6 @@ public:
 
    void setNode(TR::Node *n)
       {
-      if (comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation))
-         {
-         getDebug()->printNodeEvaluation(n, "<- ", _register);
-         }
       _node = n;
       }
 

--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -56,7 +56,6 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
    {
    TR::Register *reg;
 
-   bool trace = self()->comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation);
    TR::ILOpCodes opcode = node->getOpCodeValue();
 
    TR_ASSERT(!self()->comp()->getOption(TR_EnableParanoidRefCountChecks) || node->getOpCode().isTreeTop() || node->getReferenceCount() > 0,
@@ -65,19 +64,9 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
    if (opcode != TR::BBStart && node->getRegister())
       {
       reg = node->getRegister();
-      if (trace)
-         {
-         self()->getDebug()->printNodeEvaluation(node, ":  ", reg);
-         }
       }
    else
       {
-      if (trace)
-         {
-         self()->getDebug()->printNodeEvaluation(node);
-         _indentation += 2;
-         }
-
       // Evaluation of a TR IL tree can be performed by many functions:
       //
       // 1) evaluate(...)
@@ -191,11 +180,6 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
 
       reg = _nodeToInstrEvaluators[opcode](node, self());
 
-      if (self()->comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation))
-         {
-         self()->getDebug()->printNodeEvaluation(node, "<- ", reg, false);
-         _indentation -= 2;
-         }
       if (self()->comp()->getOption(TR_TraceRegisterPressureDetails))
          {
          traceMsg(self()->comp(), "  evaluated %s", self()->getDebug()->getName(node));
@@ -359,10 +343,6 @@ OMR::CodeGenerator::incReferenceCount(TR::Node *node)
 #endif
 
    rcount_t count = node->incReferenceCount();
-   if (self()->comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation))
-      {
-      self()->getDebug()->printNodeEvaluation(node, "++ ", reg);
-      }
    return count;
    }
 
@@ -428,10 +408,6 @@ OMR::CodeGenerator::decReferenceCount(TR::Node * node)
 #endif
 
    rcount_t count = node->decReferenceCount();
-   if (self()->comp()->getOptions()->getTraceCGOption(TR_TraceCGEvaluation))
-      {
-      self()->getDebug()->printNodeEvaluation(node, "-- ", reg);
-      }
    return count;
    }
 

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -360,21 +360,14 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
    if (cg->getDebug())
       cg->getDebug()->roundAddressEnumerationCounters();
 
-     {
+      {
       TR::LexicalMemProfiler mp("RA", comp->phaseMemProfiler());
       LexicalTimer pt("RA", comp->phaseTimer());
 
-      TR_RegisterKinds colourableKindsToAssign;
-      TR_RegisterKinds nonColourableKindsToAssign = cg->prepareRegistersForAssignment();
+      TR_RegisterKinds kindsToAssign = cg->prepareRegistersForAssignment();
 
       cg->jettisonAllSpills(); // Spill temps used before now may lead to conflicts if also used by register assignment
-
-      // Do local register assignment for non-colourable registers.
-      //
-      if(cg->getTraceRAOption(TR_TraceRAListing))
-         if(cg->getDebug()) cg->getDebug()->dumpMethodInstrs(comp->getOutFile(),"Before Local RA",false);
-
-      cg->doRegisterAssignment(nonColourableKindsToAssign);
+      cg->doRegisterAssignment(kindsToAssign);
 
       if (comp->compilationShouldBeInterrupted(AFTER_REGISTER_ASSIGNMENT_CONTEXT))
          {

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -403,7 +403,7 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
    TR::Compilation* comp = cg->comp();
    phase->reportPhase(InstructionSelectionPhase);
 
-   if (comp->getOption(TR_TraceCG) || comp->getOption(TR_TraceTrees) || comp->getOptions()->getTraceCGOption(TR_TraceCGPreInstructionSelection))
+   if (comp->getOption(TR_TraceCG) || comp->getOption(TR_TraceTrees))
       comp->dumpMethodTrees("Pre Instruction Selection Trees");
 
    TR::LexicalMemProfiler mp(phase->getName(), comp->phaseMemProfiler());

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -382,7 +382,7 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
          }
       }
 
-   if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostRegisterAssignment))
+   if (comp->getOption(TR_TraceCG))
       comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Register Assignment Instructions", false, true);
    }
 

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -218,7 +218,7 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
          }
       }
 
-   if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
+   if (comp->getOption(TR_TraceCG))
       {
       const char * title = "Post Relocation Instructions";
       comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), title, false, true);
@@ -255,7 +255,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
       comp->getOSRCompilationData()->compressInstruction2SharedSlotMap();
       }
 
-   if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
+   if (comp->getOption(TR_TraceCG))
       {
       diagnostic("\nbuffer start = %8x, code start = %8x, buffer length = %d", cg->getBinaryBufferStart(), cg->getCodeStart(), cg->getEstimatedCodeLength());
       diagnostic("\n");

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -411,7 +411,7 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
 
    cg->doInstructionSelection();
 
-   if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostInstructionSelection))
+   if (comp->getOption(TR_TraceCG))
       comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Instruction Selection Instructions", false, true);
 
    // check reference counts

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -343,7 +343,7 @@ OMR::CodeGenPhase::performMapStackPhase(TR::CodeGenerator * cg, TR::CodeGenPhase
 
      cg->getLinkage()->mapStack(comp->getJittedMethodSymbol());
 
-     if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceEarlyStackMap))
+     if (comp->getOption(TR_TraceCG))
         comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Stack Map", false);
      }
    cg->setMappingAutomatics();

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -969,7 +969,7 @@ OMR::CodeGenerator::toggleIsInOOLSection()
 
 bool OMR::CodeGenerator::traceBCDCodeGen()
    {
-   return self()->comp()->getOptions()->getTraceCGOption(TR_TraceCGBinaryCodedDecimal);
+   return self()->comp()->getOption(TR_TraceCG);
    }
 
 void OMR::CodeGenerator::traceBCDEntry(char *str, TR::Node *node)

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1207,9 +1207,6 @@ OMR::CodeGenerator::opCodeIsNoOp(TR::ILOpCode &opCode)
    return self()->opCodeIsNoOpOnThisPlatform(opCode);
    }
 
-
-bool OMR::CodeGenerator::getTraceRAOption(uint32_t mask){ return self()->comp()->getOptions()->getTraceRAOption(mask); }
-
 void OMR::CodeGenerator::traceRAInstruction(TR::Instruction *instr)
    {
    const static char * traceEveryInstruction = feGetEnv("TR_traceEveryInstructionDuringRA");

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1045,7 +1045,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Register assignment tracing
    //
-   bool getTraceRAOption(uint32_t mask);
    void traceRAInstruction(TR::Instruction *instr);
    void tracePreRAInstruction(TR::Instruction *instr);
    void tracePostRAInstruction(TR::Instruction *instr);

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -997,7 +997,7 @@ int32_t OMR::Compilation::compile()
       }
 #endif /* defined(AIXPPC) */
 
-   if (self()->getOutFile() != NULL && (self()->getOption(TR_TraceAll) || debug("traceStartCompile") || self()->getOptions()->getAnyTraceCGOption() || self()->getOption(TR_Timing)))
+   if (self()->getOutFile() != NULL && (self()->getOption(TR_TraceAll) || debug("traceStartCompile") || self()->getOption(TR_Timing)))
       {
       self()->getDebug()->printHeader();
       static char *randomExercisePeriodStr = feGetEnv("TR_randomExercisePeriod");

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1115,7 +1115,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceCompactNullChecks",           "L\ttrace compact null checks",                    TR::Options::traceOptimization, compactNullChecks, 0, "P"},
    {"traceDeadTreeElimination",         "L\ttrace dead tree elimination",                  TR::Options::traceOptimization, deadTreesElimination, 0, "P"},
    {"traceDominators",                  "L\ttrace dominators and post-dominators",         SET_OPTION_BIT(TR_TraceDominators), "P" },
-   {"traceEarlyStackMap",               "L\ttrace early stack map",                        SET_TRACECG_BIT(TR_TraceEarlyStackMap), "P"},
    {"traceEscapeAnalysis",              "L\ttrace escape analysis",                        TR::Options::traceOptimization, escapeAnalysis, 0, "P"},
    {"traceEvaluation",                  "L\tdump output of tree evaluation passes",        SET_TRACECG_BIT(TR_TraceCGEvaluation), "P" },
    {"traceExitExtraction",              "L\ttrace extraction of structure nodes that unconditionally exit to outer regions", SET_OPTION_BIT(TR_TraceExitExtraction), "F"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1186,10 +1186,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 #ifdef J9_PROJECT_SPECIFIC
    {"traceProfileGenerator",            "L\ttrace profile generator",                      TR::Options::traceOptimization, profileGenerator, 0, "P"},
 #endif
-   {"traceRA",                          "L\ttrace register assignment (basic)",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _raTrace), TR_TraceRABasic, "F"},
-   {"traceRA=",                         "L{regex}\tlist of additional register assignment traces to enable: deps, details, preRA, states",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _raTrace), 0, "F"},
+   {"traceRA",                          "L\ttrace register assignment",                    SET_OPTION_BIT(TR_TraceRA), "P" },
    {"traceReachability",                "L\ttrace all analyses based on the reachability engine",     SET_OPTION_BIT(TR_TraceReachability), "P"},
    {"traceRecognizedCallTransformer",   "L\ttrace recognized call transformer",            TR::Options::traceOptimization, recognizedCallTransformer, 0, "P"},
    {"traceRedundantAsyncCheckRemoval",  "L\ttrace redundant async check removal",          TR::Options::traceOptimization, redundantAsyncCheckRemoval, 0, "P"},
@@ -2482,7 +2479,6 @@ OMR::Options::jitPreProcess()
    _firstOptTransformationIndex = self()->getMinFirstOptTransformationIndex();
    _lastOptTransformationIndex = self()->getMaxLastOptTransformationIndex();
 
-   _raTrace = 0;
    _storeSinkingLastOpt = -1;
 #ifdef J9_PROJECT_SPECIFIC
    _profilingCount = DEFAULT_PROFILING_COUNT;
@@ -3716,9 +3712,6 @@ OMR::Options::requiresLogFile()
    if (self()->tracingOptimization())
       return true;
 
-   if (self()->getRegisterAssignmentTraceOption(0xffffffff))
-      return true;
-
    return false;
    }
 
@@ -4580,20 +4573,6 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 
 // Debug Enable flags
 { "enableUnneededNarrowIntConversion", TR_EnableUnneededNarrowIntConversion },
-
-// Local RA named trace options
-{ "deps", TR_TraceRADependencies },
-{ "details", TR_TraceRADetails },
-{ "preRA", TR_TraceRAPreAssignmentInstruction },
-{ "spillTemps", TR_TraceRASpillTemps },
-{ "states", TR_TraceRARegisterStates },
-
-
-// Instruction Level GRA named trace Options
-{ "basic", TR_TraceGRABasic},
-
-// Live Register Analysis named trace Options
-{ "results", TR_TraceLRAResults },
 
 // GPU Options
 { "default", TR_EnableGPU},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1171,7 +1171,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceLoopVersioner",               "L\ttrace loop versioner",                          TR::Options::traceOptimization, loopVersioner, 0, "P"},
    {"traceMarkingOfHotFields",          "M\ttrace marking of Hot Fields",                 SET_OPTION_BIT(TR_TraceMarkingOfHotFields), "F"},
    {"traceMethodIndex",                 "L\treport every method symbol that gets created and consumes a methodIndex", SET_OPTION_BIT(TR_TraceMethodIndex), "F"},
-   {"traceMixedModeDisassembly",        "L\tdump generated assembly with bytecodes",       SET_TRACECG_BIT(TR_TraceCGMixedModeDisassembly), "P"},
    {"traceNewBlockOrdering",            "L\ttrace new block ordering",                     TR::Options::traceOptimization, basicBlockOrdering, 0, "P"},
    {"traceNodeFlags",                   "L\ttrace setting/resetting of node flags",        SET_OPTION_BIT(TR_TraceNodeFlags), "F"},
    {"traceNonLinearRA",                 "L\ttrace non-linear RA",                          SET_OPTION_BIT(TR_TraceNonLinearRegisterAssigner), "F"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -60,7 +60,6 @@ using namespace OMR;
 
 #define SET_OPTION_BIT(x)   TR::Options::setBit,   offsetof(OMR::Options,_options[(x)&TR_OWM]), (static_cast<uintptr_t>((x)&~TR_OWM))
 #define RESET_OPTION_BIT(x) TR::Options::resetBit, offsetof(OMR::Options,_options[(x)&TR_OWM]), (static_cast<uintptr_t>((x)&~TR_OWM))
-#define SET_TRACECG_BIT(x)  TR::Options::setBit,   offsetof(OMR::Options, _cgTrace), (static_cast<uintptr_t>(x))
 
 #define NoOptString                     "noOpt"
 #define DisableAllocationInliningString "disableAllocationInlining"
@@ -2488,7 +2487,6 @@ OMR::Options::jitPreProcess()
    _firstOptTransformationIndex = self()->getMinFirstOptTransformationIndex();
    _lastOptTransformationIndex = self()->getMaxLastOptTransformationIndex();
 
-   _cgTrace = 0;
    _raTrace = 0;
    _storeSinkingLastOpt = -1;
 #ifdef J9_PROJECT_SPECIFIC
@@ -3711,6 +3709,7 @@ OMR::Options::requiresLogFile()
    if (self()->getAnyOption(TR_TraceAll) ||
        self()->getAnyOption(TR_TraceBBVA) ||
        self()->getAnyOption(TR_TraceBVA) ||
+       self()->getAnyOption(TR_TraceCG) ||
        self()->getAnyOption(TR_TraceUseDefs) ||
        self()->getAnyOption(TR_TraceNodeFlags) ||
        self()->getAnyOption(TR_TraceValueNumbers) ||
@@ -3719,7 +3718,7 @@ OMR::Options::requiresLogFile()
        self()->getAnyOption(TR_TraceILValidator))
       return true;
 
-   if (self()->tracingOptimization() || self()->getAnyTraceCGOption())
+   if (self()->tracingOptimization())
       return true;
 
    if (self()->getRegisterAssignmentTraceOption(0xffffffff))

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1199,7 +1199,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceRedundantMonitorElimination", "L\ttrace redundant monitor elimination",          TR::Options::traceOptimization, redundantMonitorElimination, 0, "P"},
    {"traceRegDepCopyRemoval",           "L\ttrace register dependency copy removal", TR::Options::traceOptimization, regDepCopyRemoval, 0, "P"},
    {"traceRegisterPressureDetails",     "L\tinclude extra register pressure annotations in register pressure simulation and tree evaluation traces", SET_OPTION_BIT(TR_TraceRegisterPressureDetails), "P" },
-   {"traceRegisterState",               "L\ttrace bit vector denoting assigned registers after register allocation", SET_OPTION_BIT(TR_TraceRegisterState), "P"},
    {"traceRelocatableDataCG",           "L\ttrace relocation data when generating relocatable code", SET_OPTION_BIT(TR_TraceRelocatableDataCG), "P"},
    {"traceRelocatableDataDetailsCG",    "L\ttrace relocation data details when generating relocatable code", SET_OPTION_BIT(TR_TraceRelocatableDataDetailsCG), "P"},
    {"traceRelocatableDataDetailsRT",    "L\ttrace relocation data details when relocating relocatable code", SET_OPTION_BIT(TR_TraceRelocatableDataDetailsRT), "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1191,7 +1191,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"tracePRE",                         "L\ttrace partial redundancy elimination",        TR::Options::traceOptimization, partialRedundancyElimination, 0, "P"},
    {"tracePrefetchInsertion",           "L\ttrace prefetch insertion",                     TR::Options::traceOptimization, prefetchInsertion, 0, "P"},
    {"tracePREForSubNodeReplacement",    "L\ttrace partial redundancy elimination focussed on optimal subnode replacement", SET_OPTION_BIT(TR_TracePREForOptimalSubNodeReplacement), "P" },
-   {"tracePreInstructionSelection",     "L\tdump trees prior to instruction selection",    SET_TRACECG_BIT(TR_TraceCGPreInstructionSelection), "P"},
    {"traceProfiledNodeVersioning",      "L\ttrace profiled node versioning",               TR::Options::traceOptimization, profiledNodeVersioning, 0, "P"},
 #ifdef J9_PROJECT_SPECIFIC
    {"traceProfileGenerator",            "L\ttrace profile generator",                      TR::Options::traceOptimization, profileGenerator, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1118,8 +1118,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceExitExtraction",              "L\ttrace extraction of structure nodes that unconditionally exit to outer regions", SET_OPTION_BIT(TR_TraceExitExtraction), "F"},
    {"traceExplicitNewInitialization",   "L\ttrace explicit new initialization",            TR::Options::traceOptimization, explicitNewInitialization, 0, "P"},
    {"traceFieldPrivatization",          "L\ttrace field privatization",                    TR::Options::traceOptimization, fieldPrivatization, 0, "P"},
-   {"traceForCodeMining=",              "L{regex}\tadd instruction annotations for code mining",
-                                         TR::Options::setRegex, offsetof(OMR::Options, _traceForCodeMining), 0, "P"},
    {"traceFull",                        "L\tturn on all trace options",                    SET_OPTION_BIT(TR_TraceAll), "P"},
    {"traceGeneralStoreSinking",         "L\ttrace general store sinking",                  TR::Options::traceOptimization, generalStoreSinking, 0, "P"},
    {"traceGlobalCopyPropagation",       "L\ttrace global copy propagation",                TR::Options::traceOptimization, globalCopyPropagation, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1233,7 +1233,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceValueNumbers",                "L\ttrace value number info",                      SET_OPTION_BIT(TR_TraceValueNumbers), "F"},
    {"traceVarHandleTransformer",        "L\ttrace VarHandle transformer",                  TR::Options::traceOptimization, varHandleTransformer, 0, "P"},  // Java specific option
    {"traceVFPSubstitution",             "L\ttrace replacement of virtual frame pointer with actual register in memrefs", SET_OPTION_BIT(TR_TraceVFPSubstitution), "F"},
-   {"traceVIP",                         "L\ttrace variable initializer propagation (constant propagation of read-only variables)", SET_OPTION_BIT(TR_TraceVIP), "P" },
    {"traceVirtualGuardHeadMerger",      "L\ttrace virtual head merger",                    TR::Options::traceOptimization, virtualGuardHeadMerger, 0, "P"},
    {"traceVirtualGuardTailSplitter",    "L\ttrace virtual guard tail splitter",            TR::Options::traceOptimization, virtualGuardTailSplitter, 0, "P"},
    {"traceVPConstraints",               "L\ttrace the execution of value propagation merging and intersecting", SET_OPTION_BIT(TR_TraceVPConstraints), "F"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1101,7 +1101,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceBasicBlockPeepHole",          "L\ttrace basic blocks peepHole",                  TR::Options::traceOptimization, basicBlockPeepHole, 0, "P"},
    {"traceBBVA",                        "L\ttrace backward bit vector analysis",           SET_OPTION_BIT(TR_TraceBBVA), "P" },
    {"traceBC",                          "L\tdump bytecodes",                               SET_OPTION_BIT(TR_TraceBC), "P" },
-   {"traceBCDCodeGen",                  "L\ttrace binary coded decimal code generations",  SET_TRACECG_BIT(TR_TraceCGBinaryCodedDecimal), "P"},
    {"traceBlockFrequencyGeneration",    "L\ttrace block frequency generation",             SET_OPTION_BIT(TR_TraceBFGeneration), "P"},
    {"traceBlockShuffling",              "L\ttrace random rearrangement of blocks",         TR::Options::traceOptimization, blockShuffling, 0, "P"},
    {"traceBlockSplitter",               "L\ttrace block splitter",                         TR::Options::traceOptimization, blockSplitter, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1116,7 +1116,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceDeadTreeElimination",         "L\ttrace dead tree elimination",                  TR::Options::traceOptimization, deadTreesElimination, 0, "P"},
    {"traceDominators",                  "L\ttrace dominators and post-dominators",         SET_OPTION_BIT(TR_TraceDominators), "P" },
    {"traceEscapeAnalysis",              "L\ttrace escape analysis",                        TR::Options::traceOptimization, escapeAnalysis, 0, "P"},
-   {"traceEvaluation",                  "L\tdump output of tree evaluation passes",        SET_TRACECG_BIT(TR_TraceCGEvaluation), "P" },
    {"traceExitExtraction",              "L\ttrace extraction of structure nodes that unconditionally exit to outer regions", SET_OPTION_BIT(TR_TraceExitExtraction), "F"},
    {"traceExplicitNewInitialization",   "L\ttrace explicit new initialization",            TR::Options::traceOptimization, explicitNewInitialization, 0, "P"},
    {"traceFieldPrivatization",          "L\ttrace field privatization",                    TR::Options::traceOptimization, fieldPrivatization, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1102,7 +1102,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceBBVA",                        "L\ttrace backward bit vector analysis",           SET_OPTION_BIT(TR_TraceBBVA), "P" },
    {"traceBC",                          "L\tdump bytecodes",                               SET_OPTION_BIT(TR_TraceBC), "P" },
    {"traceBCDCodeGen",                  "L\ttrace binary coded decimal code generations",  SET_TRACECG_BIT(TR_TraceCGBinaryCodedDecimal), "P"},
-   {"traceBin",                         "L\tdump binary instructions",                     SET_TRACECG_BIT(TR_TraceCGPostBinaryEncoding|TR_TraceCGMixedModeDisassembly), "P" },
    {"traceBlockFrequencyGeneration",    "L\ttrace block frequency generation",             SET_OPTION_BIT(TR_TraceBFGeneration), "P"},
    {"traceBlockShuffling",              "L\ttrace random rearrangement of blocks",         TR::Options::traceOptimization, blockShuffling, 0, "P"},
    {"traceBlockSplitter",               "L\ttrace block splitter",                         TR::Options::traceOptimization, blockSplitter, 0, "P"},
@@ -1187,7 +1186,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 #endif
    {"traceOSRLiveRangeAnalysis",        "L\ttrace OSR live range analysis",                TR::Options::traceOptimization, osrLiveRangeAnalysis, 0, "P"},
    {"tracePartialInlining",             "L\ttrace partial inlining heuristics",            SET_OPTION_BIT(TR_TracePartialInlining), "P" },
-   {"tracePostBinaryEncoding",          "L\tdump instructions (code cache addresses, real registers) after binary encoding", SET_TRACECG_BIT(TR_TraceCGPostBinaryEncoding), "P"},
    {"tracePRE",                         "L\ttrace partial redundancy elimination",        TR::Options::traceOptimization, partialRedundancyElimination, 0, "P"},
    {"tracePrefetchInsertion",           "L\ttrace prefetch insertion",                     TR::Options::traceOptimization, prefetchInsertion, 0, "P"},
    {"tracePREForSubNodeReplacement",    "L\ttrace partial redundancy elimination focussed on optimal subnode replacement", SET_OPTION_BIT(TR_TracePREForOptimalSubNodeReplacement), "P" },

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1188,7 +1188,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceOSRLiveRangeAnalysis",        "L\ttrace OSR live range analysis",                TR::Options::traceOptimization, osrLiveRangeAnalysis, 0, "P"},
    {"tracePartialInlining",             "L\ttrace partial inlining heuristics",            SET_OPTION_BIT(TR_TracePartialInlining), "P" },
    {"tracePostBinaryEncoding",          "L\tdump instructions (code cache addresses, real registers) after binary encoding", SET_TRACECG_BIT(TR_TraceCGPostBinaryEncoding), "P"},
-   {"tracePostInstructionSelection",    "L\tdump instructions (virtual registers) after instruction selection", SET_TRACECG_BIT(TR_TraceCGPostInstructionSelection), "P"},
    {"tracePostRegisterAssignment",      "L\tdump instructions (real registers) after register assignment", SET_TRACECG_BIT(TR_TraceCGPostRegisterAssignment), "P"},
    {"tracePRE",                         "L\ttrace partial redundancy elimination",        TR::Options::traceOptimization, partialRedundancyElimination, 0, "P"},
    {"tracePrefetchInsertion",           "L\ttrace prefetch insertion",                     TR::Options::traceOptimization, prefetchInsertion, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4587,12 +4587,10 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 { "preRA", TR_TraceRAPreAssignmentInstruction },
 { "spillTemps", TR_TraceRASpillTemps },
 { "states", TR_TraceRARegisterStates },
-{ "listing", TR_TraceRAListing},
 
 
 // Instruction Level GRA named trace Options
 { "basic", TR_TraceGRABasic},
-{ "listing", TR_TraceGRAListing},
 
 // Live Register Analysis named trace Options
 { "results", TR_TraceLRAResults },

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1231,7 +1231,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceUseDefs",                     "L\ttrace use def info",                           SET_OPTION_BIT(TR_TraceUseDefs), "F"},
    {"traceValueNumbers",                "L\ttrace value number info",                      SET_OPTION_BIT(TR_TraceValueNumbers), "F"},
    {"traceVarHandleTransformer",        "L\ttrace VarHandle transformer",                  TR::Options::traceOptimization, varHandleTransformer, 0, "P"},  // Java specific option
-   {"traceVFPSubstitution",             "L\ttrace replacement of virtual frame pointer with actual register in memrefs", SET_OPTION_BIT(TR_TraceVFPSubstitution), "F"},
    {"traceVirtualGuardHeadMerger",      "L\ttrace virtual head merger",                    TR::Options::traceOptimization, virtualGuardHeadMerger, 0, "P"},
    {"traceVirtualGuardTailSplitter",    "L\ttrace virtual guard tail splitter",            TR::Options::traceOptimization, virtualGuardTailSplitter, 0, "P"},
    {"traceVPConstraints",               "L\ttrace the execution of value propagation merging and intersecting", SET_OPTION_BIT(TR_TraceVPConstraints), "F"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1136,10 +1136,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 #ifdef J9_PROJECT_SPECIFIC
    {"traceIdiomRecognition",            "L\ttrace idiom recognition",                       TR::Options::traceOptimization, idiomRecognition, 0, "P"},
 #endif
-   {"traceILDeadCode",                  "L\ttrace Instruction Level Dead Code (basic)",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _traceILDeadCode), TR_TraceILDeadCodeBasic, "F"},
-   {"traceILDeadCode=",                 "L{regex}\tlist of additional traces to enable: basic, listing, details, live, progress",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _traceILDeadCode), 0, "P"},
    {"traceILGen",                       "L\ttrace IL generator",                           SET_OPTION_BIT(TR_TraceILGen), "F"},
    {"traceILValidator",                 "L\ttrace validation over intermediate language constructs",SET_OPTION_BIT(TR_TraceILValidator), "F" },
    {"traceILWalk",                      "L\tsynonym for traceILWalks",                              SET_OPTION_BIT(TR_TraceILWalks), "P" },
@@ -4623,9 +4619,6 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 
 // Register Spill Costs named trace Options
 { "basic", TR_TraceSpillCostsBasic},
-
-// Instruction Level Dead Code named trace Options
-{ "basic", TR_TraceILDeadCodeBasic},
 
 // GPU Options
 { "default", TR_EnableGPU},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1221,10 +1221,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceScalarizeSSOps",              "L\ttrace scalarization of array/SS ops", SET_OPTION_BIT(TR_TraceScalarizeSSOps), "P"},
    {"traceSEL",                         "L\ttrace sign extension load", SET_OPTION_BIT(TR_TraceSEL), "P"},
    {"traceSequenceSimplification",      "L\ttrace arithmetic sequence simplification",     TR::Options::traceOptimization, expressionsSimplification, 0, "P"},
-   {"traceSpillCosts",                 "L\ttrace spill costs (basic) only show its activation",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _traceSpillCosts), TR_TraceSpillCostsBasic, "F"},
-   {"traceSpillCosts=",                "L{regex}\tlist of additional spill costs options: basic, results, build, details",
-        TR::Options::setBitsFromStringSet, offsetof(OMR::Options, _traceSpillCosts), 0, "P"},
    {"traceStaticFinalFieldFolding",     "L\ttrace generic static final field folding",             TR::Options::traceOptimization, staticFinalFieldFolding, 0, "P"},
    {"traceStringBuilderTransformer",    "L\ttrace StringBuilder tranfsofermer optimization", TR::Options::traceOptimization, stringBuilderTransformer, 0, "P"},
    {"traceStringPeepholes",             "L\ttrace string peepholes",                       TR::Options::traceOptimization, stringPeepholes, 0, "P"},
@@ -4615,10 +4611,6 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 
 // Live Register Analysis named trace Options
 { "results", TR_TraceLRAResults },
-
-
-// Register Spill Costs named trace Options
-{ "basic", TR_TraceSpillCostsBasic},
 
 // GPU Options
 { "default", TR_EnableGPU},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1188,7 +1188,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceOSRLiveRangeAnalysis",        "L\ttrace OSR live range analysis",                TR::Options::traceOptimization, osrLiveRangeAnalysis, 0, "P"},
    {"tracePartialInlining",             "L\ttrace partial inlining heuristics",            SET_OPTION_BIT(TR_TracePartialInlining), "P" },
    {"tracePostBinaryEncoding",          "L\tdump instructions (code cache addresses, real registers) after binary encoding", SET_TRACECG_BIT(TR_TraceCGPostBinaryEncoding), "P"},
-   {"tracePostRegisterAssignment",      "L\tdump instructions (real registers) after register assignment", SET_TRACECG_BIT(TR_TraceCGPostRegisterAssignment), "P"},
    {"tracePRE",                         "L\ttrace partial redundancy elimination",        TR::Options::traceOptimization, partialRedundancyElimination, 0, "P"},
    {"tracePrefetchInsertion",           "L\ttrace prefetch insertion",                     TR::Options::traceOptimization, prefetchInsertion, 0, "P"},
    {"tracePREForSubNodeReplacement",    "L\ttrace partial redundancy elimination focussed on optimal subnode replacement", SET_OPTION_BIT(TR_TracePREForOptimalSubNodeReplacement), "P" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -997,22 +997,6 @@ enum TR_CompilationOptions
    // Debug Enable flags
    TR_EnableUnneededNarrowIntConversion = 0x00000001,
 
-    // Code generation phase trace word
-   //
-   // Available                       = 0x00000001,
-   // Available                       = 0x00000002,
-   // Available                       = 0x00000004,
-   // Available                       = 0x00000008,
-   // Available                       = 0x00000010,
-   // Available                       = 0x00000020,
-   // Available                       = 0x00000040,
-   // Available                       = 0x00000080,
-   // Available                       = 0x00000100,
-   TR_TraceCGEvaluation               = 0x00000200,
-   // Available                       = 0x00000400,
-   // Available                       = 0x00000800,
-   // Available                       = 0x00001000,
-
    // Trace file addresses enumeration option word
    //
    TR_EnumerateBlock                   = 0x00000001,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -872,7 +872,7 @@ enum TR_CompilationOptions
 
    // Option word 27
    TR_ForceIEEEDivideByZeroException                  = 0x00000020 + 27,
-   // Available                                       = 0x00000040 + 27,
+   TR_TraceRA                                         = 0x00000040 + 27,
    TR_DisableDirectStaticAccessOnZ                    = 0x00000080 + 27,
    // Available                                       = 0x00000100 + 27,
    TR_EnableRIEMIT                                    = 0x00000200 + 27,
@@ -1005,40 +1005,6 @@ enum TR_CompilationOptions
    TR_EnumerateRegister                = 0x00000008,
    TR_EnumerateSymbol                  = 0x00000010,
    TR_EnumerateStructure               = 0x00000020,
-   // Available                        = 0x80000000,
-
-   // Register assignment tracing option word
-   //
-   TR_TraceRABasic                      = 0x00000001,
-   TR_TraceRADependencies               = 0x00000002,
-   TR_TraceRADetails                    = 0x00000004,
-   TR_TraceRAPreAssignmentInstruction   = 0x00000008,
-   TR_TraceRARegisterStates             = 0x00000010,
-   TR_TraceRASpillTemps                 = 0x00000020,
-   // Available                         = 0x00000040,
-   // Available                         = 0x00000200,
-
-   // Instruction Level GRA tracing option word
-   //
-   TR_TraceGRABasic                     = 0x00000001,
-   // Available                         = 0x00000400,
-   // Available                         = 0x00000800,
-   // Available                         = 0x00001000,
-   // Available                         = 0x00002000,
-   // Available                         = 0x00004000,
-   // Available                         = 0x00008000,
-
-   // Live Register Analysis tracing option word
-   //
-   TR_TraceLRAResults                   = 0x00000800,
-   // Available                         = 0x00001000,
-
-   // Register ITF tracing option word
-
-   // Available                         = 0x00008000,
-   // Available                         = 0x00010000,
-   // Available                         = 0x00020000,
-   // Available                         = 0x00040000,
 
    // GPU options
    //
@@ -1049,11 +1015,6 @@ enum TR_CompilationOptions
    TR_EnableSafeMT                      = 0x00000010,
    TR_EnableGPUEnableMath               = 0x00000020,
    TR_EnableGPUDisableTransferHoist     = 0x00000040,
-
-   // Instruction Level Dead Code tracing options
-   //
-   TR_TraceILRematBasic                 = TR_TraceGRABasic,
-
    };
 
 enum TR_VerboseFlags
@@ -1498,9 +1459,6 @@ public:
 
    bool      getAddressEnumerationOption(uint32_t mask)   {return (_addressToEnumerate & mask) != 0;}
 
-   bool      getRegisterAssignmentTraceOption(uint32_t mask) {return (_raTrace & mask) != 0;}
-   bool      getTraceRAOption(uint32_t mask);
-   bool      getTraceLRA(uint32_t mask) { return (_traceLRA & mask) != 0; }
    bool      getTraceSimplifier(uint32_t mask) { return (_traceSimplifier & mask) != 0; }
    bool      getDebugEnableFlag(uint32_t mask) { return (_debugEnableFlags & mask) != 0; }
    bool      getEnableGPU(uint32_t mask) { return (_enableGPU & mask) != 0; }
@@ -2292,8 +2250,6 @@ protected:
    int32_t                     _test390StackBuffer;   // Buffer to force a large stack on 390
    int32_t                     _test390LitPoolBuffer; // Buffer to force a large lit pool on 390
    int32_t                     _addressToEnumerate;   // Addresses enumeration option flags
-   int32_t                     _raTrace;              // Register assigner trace flags
-   int32_t                     _traceLRA;             // Live Register Analysis trace flags
    int32_t                     _traceSimplifier;      // Simplifier trace flags
    int32_t                     _debugEnableFlags;     // For miscellaneeous flags used to enable things
    bool                        _optLevelDowngraded;   // this is a flag rather than an option

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1616,7 +1616,6 @@ public:
    TR::SimpleRegex * getDebugOnCreate()                {return _debugOnCreate;}
    TR::SimpleRegex * getBreakOnThrow()                 {return _breakOnThrow;}
    TR::SimpleRegex * getBreakOnPrint()                 {return _breakOnPrint;}
-   TR::SimpleRegex * getTraceForCodeMining()           {return _traceForCodeMining;}
    TR::SimpleRegex * getVerboseOptTransformationsRegex(){return _verboseOptTransformationsRegex;}
    TR::SimpleRegex * getPackedTestRegex()              {return _packedTest;}
    TR::SimpleRegex * getClassesWithFoldableFinalFields(){return _classesWithFolableFinalFields;}
@@ -2206,7 +2205,6 @@ protected:
    int32_t                    *_customStrategy;     // Actually array of TR_OptimizerImpl::Optimizations numbers read from optFileName
    int32_t                     _customStrategySize; // In elements, including endOpts terminator
 
-   TR::SimpleRegex *           _traceForCodeMining;
    // Optimization levels
    //
    int32_t                     _optLevel;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1004,7 +1004,7 @@ enum TR_CompilationOptions
    // Available                       = 0x00000004,
    // Available                       = 0x00000008,
    // Available                       = 0x00000010,
-   TR_TraceCGMixedModeDisassembly     = 0x00000020,
+   // Available                       = 0x00000020,
    // Available                       = 0x00000040,
    // Available                       = 0x00000080,
    TR_TraceCGBinaryCodedDecimal       = 0x00000100,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1001,7 +1001,7 @@ enum TR_CompilationOptions
    //
    TR_TraceCGPreInstructionSelection  = 0x00000001,
    // Available                       = 0x00000002,
-   TR_TraceCGPostRegisterAssignment   = 0x00000004,
+   // Available                       = 0x00000004,
    // Available                       = 0x00000008,
    TR_TraceCGPostBinaryEncoding       = 0x00000010,
    TR_TraceCGMixedModeDisassembly     = 0x00000020,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -599,7 +599,7 @@ enum TR_CompilationOptions
    TR_DisableThunkTupleJ2I                            = 0x00000100 + 17,
    // Available                                       = 0x00000200 + 17,
    // Available                                       = 0x00000400 + 17,
-   TR_TraceVIP                                        = 0x00000800 + 17,
+   // Available                                       = 0x00000800 + 17,
    // Available                                       = 0x00001000 + 17,
    // Available                                       = 0x00002000 + 17,
    // Available                                       = 0x00004000 + 17,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1003,7 +1003,7 @@ enum TR_CompilationOptions
    // Available                       = 0x00000002,
    // Available                       = 0x00000004,
    // Available                       = 0x00000008,
-   TR_TraceCGPostBinaryEncoding       = 0x00000010,
+   // Available                       = 0x00000010,
    TR_TraceCGMixedModeDisassembly     = 0x00000020,
    // Available                       = 0x00000040,
    // Available                       = 0x00000080,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1000,7 +1000,7 @@ enum TR_CompilationOptions
     // Code generation phase trace word
    //
    TR_TraceCGPreInstructionSelection  = 0x00000001,
-   TR_TraceCGPostInstructionSelection = 0x00000002,
+   // Available                       = 0x00000002,
    TR_TraceCGPostRegisterAssignment   = 0x00000004,
    // Available                       = 0x00000008,
    TR_TraceCGPostBinaryEncoding       = 0x00000010,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1011,7 +1011,7 @@ enum TR_CompilationOptions
    TR_TraceCGEvaluation               = 0x00000200,
    // Available                       = 0x00000400,
    // Available                       = 0x00000800,
-   TR_TraceEarlyStackMap              = 0x00001000,
+   // Available                       = 0x00001000,
 
    // Trace file addresses enumeration option word
    //

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1007,7 +1007,7 @@ enum TR_CompilationOptions
    // Available                       = 0x00000020,
    // Available                       = 0x00000040,
    // Available                       = 0x00000080,
-   TR_TraceCGBinaryCodedDecimal       = 0x00000100,
+   // Available                       = 0x00000100,
    TR_TraceCGEvaluation               = 0x00000200,
    // Available                       = 0x00000400,
    // Available                       = 0x00000800,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -999,7 +999,7 @@ enum TR_CompilationOptions
 
     // Code generation phase trace word
    //
-   TR_TraceCGPreInstructionSelection  = 0x00000001,
+   // Available                       = 0x00000001,
    // Available                       = 0x00000002,
    // Available                       = 0x00000004,
    // Available                       = 0x00000008,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1057,10 +1057,6 @@ enum TR_CompilationOptions
    // Available                         = 0x00020000,
    // Available                         = 0x00040000,
 
-   // Register Spill Costs Analysis tracing option word
-   //
-   TR_TraceSpillCostsBasic              = TR_TraceGRABasic,
-
    // GPU options
    //
    TR_EnableGPU                         = 0x00000001,
@@ -1525,7 +1521,6 @@ public:
    bool      getRegisterAssignmentTraceOption(uint32_t mask) {return (_raTrace & mask) != 0;}
    bool      getTraceRAOption(uint32_t mask);
    bool      getTraceLRA(uint32_t mask) { return (_traceLRA & mask) != 0; }
-   bool      getTraceSpillCosts(uint32_t mask) { return (_traceSpillCosts & mask) != 0; }
    bool      getTraceSimplifier(uint32_t mask) { return (_traceSimplifier & mask) != 0; }
    bool      getDebugEnableFlag(uint32_t mask) { return (_debugEnableFlags & mask) != 0; }
    bool      getEnableGPU(uint32_t mask) { return (_enableGPU & mask) != 0; }
@@ -2322,7 +2317,6 @@ protected:
    int32_t                     _addressToEnumerate;   // Addresses enumeration option flags
    int32_t                     _raTrace;              // Register assigner trace flags
    int32_t                     _traceLRA;             // Live Register Analysis trace flags
-   int32_t                     _traceSpillCosts;      // Register Spill Costs trace flags
    int32_t                     _traceSimplifier;      // Simplifier trace flags
    int32_t                     _debugEnableFlags;     // For miscellaneeous flags used to enable things
    bool                        _optLevelDowngraded;   // this is a flag rather than an option

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1497,9 +1497,6 @@ public:
    static bool  isAnyVerboseOptionSet(TR_VerboseFlags op1, TR_VerboseFlags op2, TR_VerboseFlags op3, TR_VerboseFlags op4, TR_VerboseFlags op5, TR_VerboseFlags op6);
    bool isVerboseFileSet();
 
-   bool      getTraceCGOption(uint32_t mask)   {return (_cgTrace & mask) != 0;}
-   bool      getAnyTraceCGOption()             {return (_cgTrace != 0);}
-
    bool      getAddressEnumerationOption(uint32_t mask)   {return (_addressToEnumerate & mask) != 0;}
 
    bool      getRegisterAssignmentTraceOption(uint32_t mask) {return (_raTrace & mask) != 0;}
@@ -2297,7 +2294,6 @@ protected:
    int32_t                     _storeSinkingLastOpt;
    int32_t                     _test390StackBuffer;   // Buffer to force a large stack on 390
    int32_t                     _test390LitPoolBuffer; // Buffer to force a large lit pool on 390
-   int32_t                     _cgTrace;              // Code generator trace flags
    int32_t                     _addressToEnumerate;   // Addresses enumeration option flags
    int32_t                     _raTrace;              // Register assigner trace flags
    int32_t                     _traceLRA;             // Live Register Analysis trace flags

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1016,12 +1016,11 @@ enum TR_CompilationOptions
    TR_TraceRARegisterStates             = 0x00000010,
    TR_TraceRASpillTemps                 = 0x00000020,
    // Available                         = 0x00000040,
-   TR_TraceRAListing                    = 0x00000200,
+   // Available                         = 0x00000200,
 
    // Instruction Level GRA tracing option word
    //
    TR_TraceGRABasic                     = 0x00000001,
-   TR_TraceGRAListing                   = TR_TraceRAListing,
    // Available                         = 0x00000400,
    // Available                         = 0x00000800,
    // Available                         = 0x00001000,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1061,10 +1061,6 @@ enum TR_CompilationOptions
    //
    TR_TraceSpillCostsBasic              = TR_TraceGRABasic,
 
-   // Instruction Level Dead Code tracing options
-   //
-   TR_TraceILDeadCodeBasic              = TR_TraceGRABasic,
-
    // GPU options
    //
    TR_EnableGPU                         = 0x00000001,
@@ -1532,7 +1528,6 @@ public:
    bool      getTraceSpillCosts(uint32_t mask) { return (_traceSpillCosts & mask) != 0; }
    bool      getTraceSimplifier(uint32_t mask) { return (_traceSimplifier & mask) != 0; }
    bool      getDebugEnableFlag(uint32_t mask) { return (_debugEnableFlags & mask) != 0; }
-   bool      getTraceILDeadCode(uint32_t mask) { return (_traceILDeadCode & mask) != 0; }
    bool      getEnableGPU(uint32_t mask) { return (_enableGPU & mask) != 0; }
 
    // If we running at a fixed opt level (non-recomp) then this routine
@@ -2327,7 +2322,6 @@ protected:
    int32_t                     _addressToEnumerate;   // Addresses enumeration option flags
    int32_t                     _raTrace;              // Register assigner trace flags
    int32_t                     _traceLRA;             // Live Register Analysis trace flags
-   int32_t                     _traceILDeadCode;      // Instruction Level Dead Code trace flags
    int32_t                     _traceSpillCosts;      // Register Spill Costs trace flags
    int32_t                     _traceSimplifier;      // Simplifier trace flags
    int32_t                     _debugEnableFlags;     // For miscellaneeous flags used to enable things

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -307,7 +307,7 @@ enum TR_CompilationOptions
    TR_DisableDelayRelocationForAOTCompilations   = 0x00000200 + 7,
    TR_DisableRecompDueToInlinedMethodRedefinition = 0x00000400 + 7,
    TR_DisableLoopReplicatorColdSideEntryCheck = 0x00000800 + 7,
-   TR_TraceVFPSubstitution                = 0x00001000 + 7,
+   // Available                           = 0x00001000 + 7,
    TR_DontDowgradeToColdDuringGracePeriod = 0x00002000 + 7,
    TR_EnableRecompilationPushing          = 0x00004000 + 7,
    TR_EnableJCLInline                     = 0x00008000 + 7, // enable JCL Integer and Long methods inline

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -416,7 +416,7 @@ enum TR_CompilationOptions
    // Available                           = 0x08000000 + 10,
    // Available                           = 0x10000000 + 10,
    // Available                           = 0x20000000 + 10,
-   TR_TraceRegisterState                  = 0x40000000 + 10,
+   // Available                           = 0x40000000 + 10,
    TR_DisableDirectToJNIInline            = 0x80000000 + 10,
 
    // Option word 11

--- a/compiler/control/OMROptions_inlines.hpp
+++ b/compiler/control/OMROptions_inlines.hpp
@@ -87,14 +87,6 @@ OMR::Options::getNumLimitedGRARegsWithheld()
          return regsToWithhold;
       }
 
-
-inline bool
-OMR::Options::getTraceRAOption(uint32_t mask)
-   {
-   return self()->getRegisterAssignmentTraceOption(mask);
-   }
-
-
 inline bool
 OMR::Options::isDisabledForAllMethods (OMR::Optimizations o)
    {

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2653,7 +2653,6 @@ TR_TransformInlinedFunction::TR_TransformInlinedFunction(
      _processingExceptionHandlers(false),
      _treeTopsToRemove(c->trMemory()),
      _blocksWithEdgesToTheEnd(c->trMemory()),
-     _traceVIP(c->getOption(TR_TraceVIP)),
      _favourVftCompare(false),
      findCallNodeRecursionDepth(0),
      onlyMultiRefNodeIsCallNodeRecursionDepth(0)

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -683,8 +683,6 @@ class TR_TransformInlinedFunction
 
       TR_ParameterToArgumentMapper &getParameterMapper(){ return _parameterMapper; }
 
-      bool traceVIP() { return _traceVIP; }
-
 #define MAX_FIND_SIMPLE_CALL_REFERENCE_DEPTH 12
       void setFindCallNodeRecursionDepthToMax() { findCallNodeRecursionDepth = MAX_FIND_SIMPLE_CALL_REFERENCE_DEPTH; }
       void setMultiRefNodeIsCallRecursionDepthToMax() { onlyMultiRefNodeIsCallNodeRecursionDepth = MAX_FIND_SIMPLE_CALL_REFERENCE_DEPTH; }
@@ -729,7 +727,6 @@ class TR_TransformInlinedFunction
       bool                           _processingExceptionHandlers;
       bool                           _favourVftCompare;
       bool                           _determineIfReturnCanBeReplacedWithCallNodeReference;
-      bool                           _traceVIP; // traceValueInitPropagation
       bool                           _crossedBasicBlock;
 
       int32_t findCallNodeRecursionDepth;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -330,7 +330,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    for (i=0; i < linkageProperties.getNumFloatArgRegs(); i++)
      _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getFloatArgumentRegister(i)];
 
-   if (self()->comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (self()->comp()->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR));

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -1998,7 +1998,7 @@ OMR::Power::Machine::decFutureUseCountAndUnlatch(TR::Register *virtualRegister)
    {
    TR::CodeGenerator *cg = self()->cg();
    TR::Compilation   *comp = cg->comp();
-   bool               trace = comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates);
+   bool               trace = comp->getOption(TR_TraceRA);
 
    virtualRegister->decFutureUseCount();
    if (self()->cg()->isOutOfLineColdPath())
@@ -2066,7 +2066,7 @@ OMR::Power::Machine::disassociateUnspilledBackingStorage()
    {
    TR::CodeGenerator *cg = self()->cg();
    TR::Compilation   *comp = cg->comp();
-   bool               trace = comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates);
+   bool               trace = comp->getOption(TR_TraceRA);
 
    TR_ASSERT(!cg->isOutOfLineHotPath() && !cg->isOutOfLineColdPath(), "Should only be called once register assigner is out of OOL control flow region");
    TR_ASSERT(!cg->isFreeSpillListLocked(), "Should only be called once the free spill list is unlocked");

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -68,7 +68,7 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //
       // This label is the end of the hot instruction stream (i.e., the fallthru path).
       //
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg (comp,"\nOOL: 1. Taking register state snap shot\n");
       cg()->setIsOutOfLineHotPath(true);
       machine->takeRegisterStateSnapShot();
@@ -87,7 +87,7 @@ void TR::PPCLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //
       // Start RA for OOL cold path, restore register state from snap shot
       //
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg (comp, "\nOOL: 1. Restoring Register state from snap shot\n");
       cg()->setIsOutOfLineHotPath(false);
       machine->restoreRegisterStateFromSnapShot();

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4560,7 +4560,7 @@ TR_Debug::startTracingRegisterAssignment(const char *direction, TR_RegisterKinds
    {
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    trfprintf(_file, "\n\n<regassign direction=\"%s\" method=\"%s\">\n", direction, jitdCurrentMethodSignature(_comp));
    trfprintf(_file, "<legend>\n"
@@ -4603,7 +4603,7 @@ TR_Debug::stopTracingRegisterAssignment()
    {
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    if (_registerAssignmentTraceCursor)
       trfprintf(_file, "\n");
@@ -4617,7 +4617,7 @@ TR_Debug::traceRegisterAssignment(const char *format, va_list args)
    {
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADetails))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    if (_registerAssignmentTraceCursor)
       {
@@ -4684,14 +4684,12 @@ TR_Debug::traceRegisterAssignment(TR::Instruction *instr, bool insertedByRA, boo
    TR_ASSERT( instr, "cannot trace assignment of NULL instructions\n");
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    if (insertedByRA)
       _registerAssignmentTraceFlags |=  TRACERA_INSTRUCTION_INSERTED;
    else if (postRA)
       _registerAssignmentTraceFlags &= ~TRACERA_INSTRUCTION_INSERTED;
-   else if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRAPreAssignmentInstruction))
-      return;
    print(_file, instr);
    if (_registerAssignmentTraceCursor)
       {
@@ -4699,7 +4697,7 @@ TR_Debug::traceRegisterAssignment(TR::Instruction *instr, bool insertedByRA, boo
       _registerAssignmentTraceCursor = 0;
       if (postRA)
          {
-         if (_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+         if (_comp->getOption(TR_TraceRA))
             {
             trfprintf(_file, "<regstates>\n");
 #if 0
@@ -4761,10 +4759,7 @@ TR_Debug::traceRegisterAssignment(TR::Instruction *instr, bool insertedByRA, boo
                }
             trfprintf(_file, "</regstates>\n");
             }
-         if (_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRAPreAssignmentInstruction))
-            {
-            trfprintf(_file, "\n");
-            }
+         trfprintf(_file, "\n");
          }
       }
    }
@@ -4776,11 +4771,11 @@ TR_Debug::traceRegisterAssigned(TR_RegisterAssignmentFlags flags, TR::Register *
    TR_ASSERT(virtReg, "Cannot trace assignment of NULL Virtual Register\n");
 
    if (_file == NULL ||
-       !_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic))
+       !_comp->getOption(TR_TraceRA))
       return;
    // Avoid superfluous traces, unless the user asks for them.
    if (virtReg->isPlaceholderReg() &&
-       !_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADependencies))
+       !_comp->getOption(TR_TraceRA))
       return;
    char buf[30];
    const char *preCoercionSymbol = flags.testAny(TR_PreDependencyCoercion) ? "!" : "";
@@ -4821,11 +4816,11 @@ TR_Debug::traceRegisterFreed(TR::Register *virtReg, TR::Register *realReg)
    TR_ASSERT(virtReg, "Cannot trace assignment of NULL Virtual Register\n");
 
    if (_file == NULL ||
-       !_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic))
+       !_comp->getOption(TR_TraceRA))
       return;
    // Avoid superfluous traces, unless the user asks for them.
    if (virtReg->isPlaceholderReg() &&
-       !_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADependencies))
+       !_comp->getOption(TR_TraceRA))
       return;
    char buf[30];
    sprintf(buf, "%s(%d/%d)~%s ",
@@ -4851,7 +4846,7 @@ TR_Debug::traceRegisterInterference(TR::Register *virtReg, TR::Register *interfe
    TR_ASSERT( virtReg && interferingVirtual, "cannot trace assignment of NULL registers\n");
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADetails))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    char buf[40];
    sprintf(buf, "%s{%d,%d}? ", getName(interferingVirtual), interferingVirtual->getAssociation(), distance);
@@ -4873,7 +4868,7 @@ TR_Debug::traceRegisterWeight(TR::Register *realReg, uint32_t weight)
    TR_ASSERT( realReg, "cannot trace weight of NULL register\n");
    if (_file == NULL)
       return;
-   if (!_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADetails))
+   if (!_comp->getOption(TR_TraceRA))
       return;
    char buf[30];
    sprintf(buf, "%s[0x%x]? ", getName(realReg), weight);

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2616,49 +2616,6 @@ TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees
 
    }
 
-// Prints info on Register killed (called just before register is to be killed)
-//
-void
-TR_Debug::printRegisterKilled(TR::Register *reg)
-   {
-   TR::FILE *pOutFile = _comp->getOutFile();
-   TR::Node *node;
-   // many nodes can reference one register, so it is misleading to report just the last one set
-   // better to report none.
-   // node = reg->isLive() ? reg->getLiveRegisterInfo()->getNode() : NULL;
-   node = NULL;
-
-   if (node)
-      {
-      trfprintf(pOutFile, " [%s] (%3d)%*s%s   ",
-         getName(node), node->getReferenceCount(),
-         _comp->cg()->_indentation, " ",
-         getName(node->getOpCode()));
-      }
-   else
-      {
-      trfprintf(pOutFile, "  %*s       %*s", addressWidth, " ", _comp->cg()->_indentation, " ");
-      }
-   trfprintf(pOutFile, "%s%s\n",
-      reg->getRegisterName(_comp),
-      reg->isLive() ? " (killed)" : " (killed, already dead)");
-   }
-
-// Prints info on node and register under evaluation
-//
-void
-TR_Debug::printNodeEvaluation(TR::Node *node, const char *relationship, TR::Register *reg, bool printOpCode)
-   {
-   if (!node) return;
-   TR::FILE *pOutFile = _comp->getOutFile();
-   trfprintf(pOutFile, " [%s] (%3d)%*s%s%s%s%s\n",
-      getName(node), node->getReferenceCount(), _comp->cg()->_indentation, " ",
-      (printOpCode) ? getName(node->getOpCode()) : "",
-      relationship,
-      (reg) ? reg->getRegisterName(_comp) : "",
-      (reg) ? (reg->isLive() ? " (live)" : " (dead)") : "");
-   }
-
 void
 TR_Debug::dumpMixedModeDisassembly()
    {

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -407,10 +407,6 @@ TR_Debug::addInstructionComment(TR::Instruction *instr, char * comment, ...)
    if (comment == NULL || _comp->getOutFile() == NULL )
       return;
 
-   TR::SimpleRegex * regex = _comp->getOptions()->getTraceForCodeMining();
-   if (regex && !TR::SimpleRegex::match(regex, comment))
-      return;
-
    CS2::HashIndex hashIndex;
    if (_comp->getToCommentMap().Locate(instr, hashIndex))
       {
@@ -2679,52 +2675,7 @@ TR_Debug::dumpInstructionComments(TR::FILE *pOutFile, TR::Instruction *instr, bo
       for(data=itr.getFirst(); data!=NULL; data= itr.getNext()) trfprintf(pOutFile, " %s", data);
 
       }
-
-   // Print common data mining annotations for all platforms
-   printCommonDataMiningAnnotations(pOutFile, instr, needsStartComment);
-
    }
-
-void
-TR_Debug::printCommonDataMiningAnnotations(TR::FILE *pOutFile, TR::Instruction * inst, bool needsStartComment)
-  {
-  if (inst!=NULL && inst->getNode())
-    {
-    const static char IL_KEY[]  = "IL";
-    const static char FRQ_KEY[] = "FRQ";
-    const static char CLD_KEY[] = "CLD";
-    TR::SimpleRegex * regex = _comp->getOptions()->getTraceForCodeMining();
-    if (regex &&
-        (TR::SimpleRegex::match(regex, "ALL") || TR::SimpleRegex::match(regex, IL_KEY) || TR::SimpleRegex::match(regex, FRQ_KEY)|| TR::SimpleRegex::match(regex, CLD_KEY)))
-       {
-       if (needsStartComment)
-          {
-          trfprintf(pOutFile, " ;");
-          needsStartComment = false;
-          }
-
-       TR::ILOpCode& opcode = inst->getNode()->getOpCode();
-       if (TR::SimpleRegex::match(regex, IL_KEY))
-          {
-          trfprintf(pOutFile, " IL=%s", opcode.getName());
-          }
-       if (inst->getNode()->getOpCodeValue() == TR::BBStart)
-          {
-          _lastFrequency = inst->getNode()->getBlock()->getFrequency();
-          _isCold = inst->getNode()->getBlock()->isCold();
-          }
-       if (TR::SimpleRegex::match(regex, FRQ_KEY))
-          {
-          trfprintf(pOutFile, " FRQ=%d", _lastFrequency);
-          }
-       if (TR::SimpleRegex::match(regex, CLD_KEY))
-          {
-          trfprintf(pOutFile, " CLD=%d", _isCold);
-          }
-       }
-    }
-  }
-
 
 #if !defined(TR_TARGET_POWER) && !defined(TR_TARGET_ARM) && !defined(TR_TARGET_ARM64) && !defined(TR_TARGET_RISCV)
 void

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -539,7 +539,6 @@ public:
    virtual void         dumpMethodInstrs(TR::FILE *, const char *, bool, bool header = false);
    virtual void         dumpMixedModeDisassembly();
    virtual void         dumpInstructionComments(TR::FILE *, TR::Instruction *, bool needsStartComment = true );
-   virtual void         printCommonDataMiningAnnotations(TR::FILE *pOutFile, TR::Instruction * inst, bool needsStartComment = true);
    virtual void         print(TR::FILE *, TR::Instruction *);
    virtual void         print(TR::FILE *, TR::Instruction *, const char *);
    virtual void         print(TR::FILE *, List<TR::Snippet> &, bool isWarm = false);

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -537,8 +537,6 @@ public:
    virtual void         setupToDumpTreesAndInstructions(const char *);
    virtual void         dumpSingleTreeWithInstrs(TR::TreeTop *, TR::Instruction *, bool, bool, bool, bool);
    virtual void         dumpMethodInstrs(TR::FILE *, const char *, bool, bool header = false);
-   virtual void         printRegisterKilled(TR::Register *reg);
-   virtual void         printNodeEvaluation(TR::Node *node, const char *relationship = "", TR::Register *reg = NULL, bool printOpCode = true);
    virtual void         dumpMixedModeDisassembly();
    virtual void         dumpInstructionComments(TR::FILE *, TR::Instruction *, bool needsStartComment = true );
    virtual void         printCommonDataMiningAnnotations(TR::FILE *pOutFile, TR::Instruction * inst, bool needsStartComment = true);

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -112,7 +112,7 @@ OMR::RV::CodeGenerator::CodeGenerator() :
    for (i = 0; i < linkageProperties.getNumFloatArgRegs(); i++)
      _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getFloatArgumentRegister(i)];
 
-   if (self()->comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (self()->comp()->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR));

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1744,7 +1744,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       estimate += (self()->getJitMethodEntryAlignmentBoundary() - 1);
       }
 
-   if (self()->comp()->getOption(TR_TraceVFPSubstitution))
+   if (self()->comp()->getOption(TR_TraceCG))
       traceMsg(self()->comp(), "\n<instructions\n"
                                 "\ttitle=\"VFP Substitution\">");
 
@@ -1835,7 +1835,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       TR_VFPState prevState = _vfpState;
       estimateCursor->adjustVFPState(&_vfpState, self());
 
-      if (self()->comp()->getOption(TR_TraceVFPSubstitution))
+      if (self()->comp()->getOption(TR_TraceCG))
          self()->getDebug()->dumpInstructionWithVFPState(estimateCursor, &prevState);
 
       if (estimateCursor == _vfpResetInstruction)
@@ -1844,7 +1844,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       estimateCursor = estimateCursor->getNext();
       }
 
-   if (self()->comp()->getOption(TR_TraceVFPSubstitution))
+   if (self()->comp()->getOption(TR_TraceCG))
       traceMsg(self()->comp(), "\n</instructions>\n");
 
    estimate = self()->setEstimatedLocationsForSnippetLabels(estimate);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -481,7 +481,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    if (comp->target().cpu.isI386())
       self()->setGenerateMasmListingSyntax();
 
-   if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (comp->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastAssignableGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstXMMR, TR::RealRegister::LastXMMR));

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -218,7 +218,7 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
          {
          int32_t newOffset = stackIndex + pointerSize*(localCursor->getGCMapIndex()-firstLocalGCIndex);
 
-         if (self()->cg()->getTraceRAOption(TR_TraceRASpillTemps))
+         if (self()->cg()->comp()->getOption(TR_TraceRA))
             traceMsg(self()->comp(), "\nmapCompactedStack: changing %s (GC index %d) offset from %d to %d",
                self()->comp()->getDebug()->getName(localCursor), localCursor->getGCMapIndex(), localCursor->getOffset(), newOffset);
 
@@ -524,7 +524,7 @@ void OMR::X86::Linkage::mapSingleAutomatic(TR::AutomaticSymbol *p,
    p->setOffset(stackIndex);
 
 
-   if (self()->cg()->getTraceRAOption(TR_TraceRASpillTemps))
+   if (self()->cg()->comp()->getOption(TR_TraceRA))
       traceMsg(self()->cg()->comp(), "\nmapSingleAutomatic(%s, %d) = %d", self()->cg()->getDebug()->getName(p), size, stackIndex);
    }
 

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -356,7 +356,7 @@ TR_Debug::dumpDependencies(TR::FILE *pOutFile, TR::Instruction  * instr)
    if (pOutFile == NULL || // no dump file
        (_cg->getStackAtlas() // not in instruction selection
         && !(_registerAssignmentTraceFlags & TRACERA_IN_PROGRESS && // not in register assignment...
-          _comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRADependencies)) // or dependencies are not traced
+          _comp->getOption(TR_TraceRA)) // or dependencies are not traced
        ))
       return;
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2514,39 +2514,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
          }
       }
 
-   // Do a pass to tag the basic blocks for Code Mining
-   TR_Debug * debugObj = self()->getDebug();
-   if (debugObj)
-      {
-      TR::SimpleRegex * regex =  self()->comp()->getOptions()->getTraceForCodeMining();
-      if (regex && TR::SimpleRegex::match(regex, "BBN"))
-         {
-         data.cursorInstruction = self()->getFirstInstruction();
-         int32_t currentBlock = -1;
-         int32_t currentBlockFreq = 0;
-         while (data.cursorInstruction)
-            {
-            // Add basic block comment to the current instruction
-            // String will be BBN=###, 11 digits should be enough
-            char *BB_STRING = (char *)self()->trMemory()->allocateHeapMemory(sizeof(char) * 21);
-            TR::Node *node = data.cursorInstruction->getNode();
-
-            if(node && node->getOpCodeValue() == TR::BBStart)
-               {
-               currentBlock = node->getBlock()->getNumber();
-               currentBlockFreq = node->getBlock()->getFrequency();
-               }
-
-            // Add it as a comment
-            sprintf(BB_STRING, "BBN=%d freq=%d", currentBlock, currentBlockFreq);
-            debugObj->addInstructionComment(data.cursorInstruction, BB_STRING);
-            data.cursorInstruction = data.cursorInstruction->getNext();
-            }
-         }
-      }
-
    self()->getLinkage()->performPostBinaryEncoding();
-
    }
 
 /**

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -597,7 +597,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
    _nextAvailableBlockIndex = -1;
    _currentBlockIndex = -1;
 
-   if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (comp->getOption(TR_TraceRA))
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastAssignableGPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR));

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -5678,7 +5678,7 @@ OMR::Z::CodeGenerator::loadOrStoreAddressesMatch(TR::Node *node1, TR::Node *node
 
    if (node1->getSize() != node2->getSize())
       {
-      if (self()->comp()->getOption(TR_TraceVIP))
+      if (self()->comp()->getOption(TR_TraceCG))
          traceMsg(self()->comp(),"\t\tloadOrStoreAddressesMatch = false (sizes differ) : node1 %s (%p) size = %d and node2 %s (%p) size = %d\n",
                node1->getOpCode().getName(),node1,node1->getSize(),node2->getOpCode().getName(),node2,node2->getSize());
       return false;
@@ -5701,7 +5701,7 @@ OMR::Z::CodeGenerator::loadOrStoreAddressesMatch(TR::Node *node1, TR::Node *node
          foundMatch = true;
          }
       }
-   if (self()->comp()->getOption(TR_TraceVIP))
+   if (self()->comp()->getOption(TR_TraceCG))
       traceMsg(self()->comp(),"\t\tloadOrStoreAddressesMatch = %s : node1 %s (%p) and node2 %s (%p)\n",
          foundMatch?"true":"false",node1->getOpCode().getName(),node1,node2->getOpCode().getName(),node2);
    return foundMatch;

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -764,34 +764,6 @@ OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //If the value is set here, the snippet can be handled in an identical fashion to a normal constantdataSnippet
       }
 
-   // trace assigned registers bit vector
-   TR_Debug * debugObj = self()->cg()->getDebug();
-   if (debugObj && comp->getOption(TR_TraceRegisterState))
-      {
-      // determine which GPRs are assigned and the total number of available GPRs
-      uint32_t freeRegs = self()->getBinLocalFreeRegs();
-      uint32_t numRegs  =  TR::RealRegister::LastAssignableGPR - TR::RealRegister::FirstGPR + 1;
-
-      // print freeRegs as a binary number
-      char * strFreeRegs = (char *)self()->cg()->trMemory()->allocateHeapMemory(numRegs+1);
-      for(uint32_t i = 0; i < numRegs; i++)
-         {
-         strFreeRegs[numRegs - i - 1] = (freeRegs & 0x1) ? '1' : '0';
-         freeRegs >>= 1;
-         }
-      strFreeRegs[numRegs] = '\0';
-
-      // format the comment nicely and append it as a comment to the instruction
-      char *commentTemplate = "RegState=[%s]";
-      char *comment = (char *)self()->cg()->trMemory()->allocateHeapMemory(strlen(commentTemplate)+strlen(strFreeRegs)-1);
-      if (comment != NULL)
-         {
-         sprintf(comment, commentTemplate, strFreeRegs);
-         debugObj->addInstructionComment(self(),comment);
-         }
-      }
-
-
    // Modify TBEGIN/TBEGINC's General Register Save Mask (GRSM) to only include
    // live registers.
    if (self()->getOpCodeValue() == TR::InstOpCode::TBEGIN || self()->getOpCodeValue() == TR::InstOpCode::TBEGINC)

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -16612,8 +16612,6 @@ OMR::Z::TreeEvaluator::vconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    generateLoadLiteralPoolAddress(cg, node, litReg);
    size_t offset = node->getLiteralPoolOffset();
    TR::Compilation *comp = cg->comp();
-   if(comp->getOption(TR_TraceCGEvaluation))
-      traceMsg(comp, "vconst codegen, offset=%i\n", offset);
    TR::Register *vecReg = cg->allocateRegister(TR_VRF);
    generateVRXInstruction(cg, TR::InstOpCode::VL, node, vecReg, generateS390MemoryReference(litReg, offset, cg), 0);
    cg->stopUsingRegister(litReg);

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1983,15 +1983,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, TR::Instruction * 
          trfprintf(pOutFile,")");
          }
       }
-   if (strlen(comments) > 0)
-     {
-     TR::SimpleRegex * regex = _comp->getOptions()->getTraceForCodeMining();
-     if (regex && TR::SimpleRegex::match(regex, comments))
-        {
-        trfprintf(pOutFile, "\t ; %s", comments);
-        firstPrint = false;
-        }
-     }
 
    printInstructionComment(pOutFile, 0, instr, firstPrint );
    trfflush(pOutFile);

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -356,7 +356,7 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
          // if (instr->getOpCodeValue() == TR::InstOpCode::ASSOCREGS) break;
 
          if ((instr->getOpCodeValue() == TR::InstOpCode::ASSOCREGS) && /*(debug("traceMsg90RA"))*/
-             (_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRABasic)))
+             (_comp->getOption(TR_TraceRA)))
             {
             if (_comp->cg()->getCodeGeneratorPhase() < TR::CodeGenPhase::BinaryEncodingPhase)
                printAssocRegDirective(pOutFile, instr);

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -619,7 +619,7 @@ TR::S390LabelInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
    if (getLabelSymbol()->isEndOfColdInstructionStream())
       {
       TR::Machine *machine = cg()->machine();
-      if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      if (comp->getOption(TR_TraceRA))
          traceMsg (comp,"\nOOL: taking register state snap shot\n");
       cg()->setIsOutOfLineHotPath(true);
       machine->takeRegisterStateSnapShot();
@@ -694,13 +694,13 @@ TR::S390BranchInstruction::assignRegistersAndDependencies(TR_RegisterKinds kindT
          TR_ASSERT(cg()->getAppendInstruction() == this, "OOL section must have only one branch to the merge point\n");
          // Start RA for OOL cold path, restore register state from snap shot
          TR::Machine *machine = cg()->machine();
-         if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+         if (comp->getOption(TR_TraceRA))
             traceMsg (comp, "\nOOL: Restoring Register state from snap shot\n");
          cg()->setIsOutOfLineHotPath(false);
          machine->restoreRegisterStateFromSnapShot();
          }
       // Reusing the OOL Section merge label for other branches might be unsafe.
-      else if(comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+      else if(comp->getOption(TR_TraceRA))
          traceMsg (comp, "\nOOL: Reusing the OOL Section merge label for other branches might be unsafe.\n");
       }
    }

--- a/compiler/z/codegen/S390Peephole.hpp
+++ b/compiler/z/codegen/S390Peephole.hpp
@@ -38,7 +38,7 @@ protected:
       {
       if (_outFile)
          {
-         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
+         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
             {
             trfprintf(_outFile, info);
             }
@@ -49,7 +49,7 @@ protected:
       {
       if (_outFile)
          {
-         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
+         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
             {
             comp()->getDebug()->print(_outFile, _cursor);
             }

--- a/compiler/z/codegen/S390Peephole.hpp
+++ b/compiler/z/codegen/S390Peephole.hpp
@@ -36,23 +36,17 @@ public:
 protected:
    void printInfo(const char* info)
       {
-      if (_outFile)
+      if (_outFile && comp()->getOption(TR_TraceCG))
          {
-         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
-            {
-            trfprintf(_outFile, info);
-            }
+         trfprintf(_outFile, info);
          }
       }
 
    void printInst()
       {
-      if (_outFile)
+      if (_outFile && comp()->getOption(TR_TraceCG))
          {
-         if ( !( !comp()->getOption(TR_TraceCG) && comp()->getOptions()->getTraceCGOption(TR_TraceCGMixedModeDisassembly) )  )
-            {
-            comp()->getDebug()->print(_outFile, _cursor);
-            }
+         comp()->getDebug()->print(_outFile, _cursor);
          }
       }
 


### PR DESCRIPTION
This PR is a series of commits which consolidates all code generator related tracing options into two options (potentially only one in the future):

- `TR_TraceCG`
- `TR_TraceRA`

People may not be aware but there do exist some sub-options when tracing code generation. In practice however the only option I've found to be used was `TR_TraceCG` and `TR_TraceRA`. Unlike the optimizer the codegen phases are simple and deterministic, and do not require much tracing outside of printing what the instructions look like before and after. The number of messages is sparse and most of them are enabled by default when `TR_TraceCG` is active.

As such to avoid complexity of dealing with different trace options we consolidate them into the above set. Once #3890 is addressed we can discuss potentially only having one trace option for the code generator.

This work is inspired by downstream work in eclipse/openj9#9428 which is an attempt to consolidate much of our tracing infrastructure and to enable us to set tracing of the compiler programmatically, something which the current code generator lacks.