### PR TITLE
Fix canGCAndExcept flag for TR_monitorExit helper

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1081,7 +1081,7 @@ OMR::SymbolReferenceTable::createTempSymRefWithKnownObject(TR::Symbol *symbol, m
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateMonitorExitSymbolRef(TR::ResolvedMethodSymbol *)
    {
-   return findOrCreateRuntimeHelper(TR_monitorExit, true, false, true);
+   return findOrCreateRuntimeHelper(TR_monitorExit, true /* canGCandReturn */, true /* canGCandExcept */, true /* preservesAllRegisters */);
    }
 
 


### PR DESCRIPTION
MonitorExit helper can throw exception so set canGCandExcept to true

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>