### PR TITLE
Document uses of function 'generateShiftAndKeepSelected(64|31)Bit'

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -857,7 +857,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
                }
             else
                {
-               generateShiftAndKeepSelected64Bit(node, cg, firstRegister, firstRegister, 64-shiftAmnt, 63, 0, true, false);
+               generateShiftThenKeepSelected64Bit(node, cg, firstRegister, firstRegister, 64-shiftAmnt, 63, 0);
                }
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, done, deps);
             }
@@ -2966,7 +2966,7 @@ OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             }
          else
             {
-            generateShiftAndKeepSelected31Bit(node, cg, targetRegister, targetRegister, 0x3f & (32 - shftAmnt), 31, 0, true, false);
+            generateShiftThenKeepSelected31Bit(node, cg, targetRegister, targetRegister, 0x3f & (32 - shftAmnt), 31, 0);
             }
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, done, deps);
          }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -10292,9 +10292,9 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          // Index into helper table - Each entry in table is 16 bytes.
          //   Actual index to helper table is the remaining length (8-byte) * 16.
          if (cg->comp()->target().is64Bit())
-            generateShiftAndKeepSelected64Bit(node, cg, tmpReg, tmpReg, 52, 59, 4, true, false);
+            generateShiftThenKeepSelected64Bit(node, cg, tmpReg, tmpReg, 52, 59, 4);
          else
-            generateShiftAndKeepSelected31Bit(node, cg, tmpReg, tmpReg, 20, 27, 4, true, false);
+            generateShiftThenKeepSelected31Bit(node, cg, tmpReg, tmpReg, 20, 27, 4);
 
          // Helper table address is stored in raReg.  Branch to helper to execute TRT and return.
          TR::MemoryReference * targetMR = new (cg->trHeapMemory()) TR::MemoryReference(raReg, tmpReg, 0, cg);
@@ -11218,7 +11218,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
             case 3:
                {
                TR::Register *tmpByteConstReg = cg->allocateRegister();
-               generateShiftAndKeepSelected31Bit(node, cg, tmpByteConstReg, tmpConstExprRegister, 24, 31, -8, true, false);
+               generateShiftThenKeepSelected31Bit(node, cg, tmpByteConstReg, tmpConstExprRegister, 24, 31, -8);
                generateRSInstruction(cg, TR::InstOpCode::SRL, node, tmpConstExprRegister, 16); //0x0000aabb
                generateRXInstruction(cg, TR::InstOpCode::STH, node, tmpConstExprRegister, new (cg->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, offset, cg));
                offset += 2;
@@ -12185,12 +12185,12 @@ OMR::Z::TreeEvaluator::bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg
             // This will generate a RISBG instruction (if it's supported, otherwise two shift instructions).
             // A RISBG instruction is equivalent to doing a `(tmpReg & 0x1) << x`. But for a 64-bit value we would have to use
             // two AND immediate instructions and a shift instruction to do this. So instead we use a single RISBG instruction.
-            generateShiftAndKeepSelected64Bit(node, cg, tmpReg, tmpReg, 63 - x, 63 - x, x, true, false);
+            generateShiftThenKeepSelected64Bit(node, cg, tmpReg, tmpReg, 63 - x, 63 - x, x);
             }
          else
             {
             // Same as above, but generate a RISBLG instead of RISBG for 32, 16, and 8-bit integers
-            generateShiftAndKeepSelected31Bit(node, cg, tmpReg, tmpReg, 31 - x, 31 - x, x, true, false);
+            generateShiftThenKeepSelected31Bit(node, cg, tmpReg, tmpReg, 31 - x, 31 - x, x);
             }
 
          // Now OR the result into the resultReg
@@ -12297,7 +12297,7 @@ OMR::Z::TreeEvaluator::bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg
          // This will generate a RISBG instruction (if supported).
          // This is equivalent to doing a `tmpReg & 0x1`. But on 64-bit we would have to use
          // two AND immediate instructions. So instead we use a single RISBG instruction.
-         generateShiftAndKeepSelected64Bit(node, cg, tmpReg, tmpReg, 63, 63, 0, true, false);
+         generateShiftThenKeepSelected64Bit(node, cg, tmpReg, tmpReg, 63, 63, 0);
          }
       else
          {

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -1019,9 +1019,9 @@ MemToMemVarLenMacroOp::generateRemainder()
       {
       TR::LabelSymbol *remainderDoneLabel = generateLabelSymbol(_cg);
       if (_cg->comp()->target().is64Bit())
-         generateShiftAndKeepSelected64Bit(_rootNode, _cg, _regLen, _regLen, 52, 59, 4, true, false);
+         generateShiftThenKeepSelected64Bit(_rootNode, _cg, _regLen, _regLen, 52, 59, 4);
       else
-         generateShiftAndKeepSelected31Bit(_rootNode, _cg, _regLen, _regLen, 20, 27, 4, true, false);
+         generateShiftThenKeepSelected31Bit(_rootNode, _cg, _regLen, _regLen, 20, 27, 4);
 
       TR::MemoryReference * targetMR = new (_cg->trHeapMemory()) TR::MemoryReference(_raReg, _regLen, 0, _cg);
       generateRXInstruction(_cg, TR::InstOpCode::BAS, _rootNode, _raReg, targetMR);

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -1511,15 +1511,76 @@ TR::Instruction *
 generateReplicateNodeInVectorReg(TR::Node * node, TR::CodeGenerator *cg, TR::Register * targetVRF, TR::Node * srcElementNode,
                                  int elementSize, TR::Register *zeroReg=NULL, TR::Instruction * preced=NULL);
 
-void generateShiftAndKeepSelected64Bit(
+/**
+ * \param node
+ *    The node being evaluated.
+ *
+ * \param cg
+ *    The code generator used to generate the instructions.
+ * 
+ * \param targetRegister
+ *    The register where the specific shifted bits from sourceRegister will be placed to the corresponding 
+ *    location. The remaining bits will be zeroed out.
+ * 
+ * \param sourceRegister
+ *    The register which will be shifted. The selected shifted bits in sourceRegister will be placed to 
+ *    targetRegister, and the sourceRegister itself will stay unchanged. 
+ * 
+ * \param fromBit
+ *    Indicates the starting bit position of the selected range of bits in targetRegister and in sourceRegister after shifting. 
+ * 
+ * \param toBit
+ *    Indicates the ending bit position of the selected range of bits in targetRegister and in sourceRegister after shifting. 
+ * 
+ * \param shiftAmount
+ *    Indicates the amount of bits that sourceRegister is shifted to the left. 
+ * 
+ * \example
+ *    fromBit = 10;   toBit = 20;   shiftAmount = 15;
+ * 
+ *                              Bit 10    Bit 20
+ *    Before:                     |          |
+ *                     0          V          V                                               63
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *    sourceRegister: |10010000 00100011 01001000 11000100 00011010 00111000 00101011 00010000|
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
+ *      
+ *                     0                                                                     63
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *    targetRegister: |10000110 01101010 00111000 11011110 11000011 01111000 00100011 00000000|
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
+ *    
+ *    The function first makes a copy of sourceRegister into the targetRegister and then shifts the targetRegister left
+ *    by the shiftAmount (15 bits):
+ * 
+ *                              Bit 10    Bit 20
+ *                                |          |
+ *                     0          V          V                                               63
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *    targetRegister: |10100100 01100010 00001101 00011100 00010101 10001000 00000000 00000000|
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
+ * 
+ *    The function then selects the bits in rage [fromBit, toBit] inclusive of the shifted value and all other non-
+ *    selected bits are zeroed out:
+ * 
+ *                              Bit 10    Bit 20
+ *    After:                      |          |
+ *                     0          V          V                                               63
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+     
+ *    targetRegister: |00000000 00100010 00001000 00000000 00000000 00000000 00000000 00000000|
+ *                    +--------+--------+--------+--------+--------+--------+--------+--------+
+ *
+ *    Note the value of sourceRegister will remain unchanged.
+*/
+void generateShiftThenKeepSelected64Bit(
       TR::Node * node, TR::CodeGenerator *cg,
-      TR::Register * aFirstRegister, TR::Register * aSecondRegister, int aFromBit,
-      int aToBit, int aShiftAmount, bool aClearOtherBits, bool aSetConditionCode);
+      TR::Register * targetRegister, TR::Register * sourceRegister, int fromBit,
+      int toBit, int shiftAmount);
 
-void generateShiftAndKeepSelected31Bit(
+void generateShiftThenKeepSelected31Bit(
       TR::Node * node, TR::CodeGenerator *cg,
-      TR::Register * aFirstRegister, TR::Register * aSecondRegister, int aFromBit,
-      int aToBit, int aShiftAmount, bool aClearOtherBits, bool aSetConditionCode);
+      TR::Register * targetRegister, TR::Register * sourceRegister, int fromBit,
+      int toBit, int shiftAmount);
 
 TR::Instruction *generateZeroVector(TR::Node *node, TR::CodeGenerator *cg, TR::Register *vecZeroReg);
 


### PR DESCRIPTION
- Document the uses of function `generateShiftAndKeepSelected(64|31)Bit`. And provide corresponding example. 
- Remove the redundant arguments.
- Add assertions to restrict the values of arguments.

Issue: #3814
Signed-off-by: simonameng <simonameng97@gmail.com>