### PR TITLE
CMake: Generate libX.debuginfo instead of libX.so.dbg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2019 IBM Corp. and others
+# Copyright (c) 2014, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,13 +112,12 @@ Testing/
 *.lo
 *.o
 *.obj
-*.dbg
+*.debuginfo
 
 # Compiled Dynamic libraries
 *.so
-*.so.dbg
 *.dylib
-*.dylib.dbg
+*.dSYM
 *.def
 *.dll
 *.exp

--- a/cmake/modules/OmrTargetSupport.cmake
+++ b/cmake/modules/OmrTargetSupport.cmake
@@ -33,14 +33,13 @@ include(OmrUtility)
 # and split debug info are handled
 function(omr_add_library name)
 	set(options SHARED STATIC OBJECT INTERFACE)
-	set(oneValueArgs )
-	set(multiValueArgs )
+	set(oneValueArgs)
+	set(multiValueArgs)
 
 	foreach(var IN LISTS options oneValueArgs multiValueArgs)
 		set(opt_${var} "")
 	endforeach()
 	cmake_parse_arguments(opt "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
 
 	omr_count_true(num_types VARIABLES opt_SHARED opt_STATIC opt_OBJECT opt_INTERFACE)
 	omr_assert(TEST num_types LESS 2 MESSAGE "Only one of STATIC | SHARED | OBJECT | INTERFACE may be given")
@@ -74,7 +73,6 @@ function(omr_add_library name)
 		omr_process_split_debug(${name})
 	endif()
 endfunction()
-
 
 # omr_add_executable(name <sources> ...)
 # At present, a thin wrapper around add_executable, but it ensures that

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -87,20 +87,22 @@ endif()
 
 function(_omr_toolchain_separate_debug_symbols tgt)
 	set(exe_file "$<TARGET_FILE:${tgt}>")
-	set(dbg_file "$<TARGET_FILE:${tgt}>.dbg")
 	if(OMR_OS_OSX)
+		set(dbg_file "${exe_file}.dSYM")
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD
-			COMMAND dsymutil -f ${exe_file} -o ${dbg_file}
+			COMMAND dsymutil -o "${dbg_file}" "${exe_file}"
 		)
 	else()
+		omr_get_target_path(target_path ${tgt})
+		omr_replace_suffix(dbg_file "${target_path}" ".debuginfo")
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD
 			COMMAND "${CMAKE_OBJCOPY}" --only-keep-debug "${exe_file}" "${dbg_file}"
 			COMMAND "${CMAKE_OBJCOPY}" --strip-debug "${exe_file}"
-			COMMAND "${CMAKE_OBJCOPY}" "--add-gnu-debuglink=${dbg_file}" "${exe_file}"
+			COMMAND "${CMAKE_OBJCOPY}" --add-gnu-debuglink="${dbg_file}" "${exe_file}"
 		)
 	endif()
 	set_target_properties(${tgt} PROPERTIES OMR_DEBUG_FILE "${dbg_file}")

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -189,9 +189,9 @@ if(OMR_OS_ZOS)
 		endif()
 		add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
 			COMMAND "${CMAKE_COMMAND}"
-			"-DLIBRARY_FILE_NAME=$<TARGET_FILE_NAME:${TARGET_NAME}>"
-			"-DLIBRARY_FOLDER=$<TARGET_FILE_DIR:${TARGET_NAME}>"
-			-P "${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/zos_rename_exports.cmake"
+				"-DLIBRARY_FILE_NAME=$<TARGET_FILE_NAME:${TARGET_NAME}>"
+				"-DLIBRARY_FOLDER=$<TARGET_FILE_DIR:${TARGET_NAME}>"
+				-P "${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/zos_rename_exports.cmake"
 		)
 	endfunction()
 else()
@@ -212,7 +212,8 @@ else()
 
 	function(_omr_toolchain_separate_debug_symbols tgt)
 		set(exe_file "$<TARGET_FILE:${tgt}>")
-		set(dbg_file "$<TARGET_FILE:${tgt}>.dbg")
+		omr_get_target_path(target_path ${tgt})
+		omr_replace_suffix(dbg_file "${target_path}" ".debuginfo")
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD

--- a/doc/ddr.md
+++ b/doc/ddr.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2018 IBM Corp. and others
+Copyright (c) 2016, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,8 +62,8 @@ Make sure that OMR was configured to output debug information (Enabled by
 default, or pass --enable-debug as above)
 
 ```sh
-find -name "*.dbg" >filelist
-make -f ddr_artifacts.mk TOP_SRCDIR=. DBG_FILE_LIST=./filelist
+find -name "*.debuginfo" >filelist
+make -f ddr_artifacts.mk TOP_SRCDIR=. DBG_FILE_LIST=filelist
 ```
 
 ## Using DDR for other projects
@@ -75,5 +75,5 @@ other artifacts, such as libraries, you will need to add them as well.
 You need to call a special makefile, which will run ddrgen on your project.
 
 ```sh
-make -f omr/ddr_artifacts.mk TOP_SRCDIR=. DBG_FILE_LIST=./<filelist>
+make -f omr/ddr_artifacts.mk TOP_SRCDIR=. DBG_FILE_LIST=filelist
 ```


### PR DESCRIPTION
Rework computation of debug info filenames for consistency with makefile behavior.