### PR TITLE
CMake: Exclude third party code from the `all` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ add_subdirectory(thread)
 add_subdirectory(port)
 add_subdirectory(util)
 add_subdirectory(omr)
-add_subdirectory(third_party)
+add_subdirectory(third_party EXCLUDE_FROM_ALL)
 add_subdirectory(omrsigcompat)
 
 if(OMR_RAS_TDF_TRACE)


### PR DESCRIPTION
This means that `make all` will not build any of the third party code,
unless it is required  by other targets given your configuration

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>