### PR TITLE
Remove method with definate return value

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4239,13 +4239,6 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
    return;
    }
 
-//return true if the call is dominated hot call
-bool TR_InlinerBase::callMustBeInlinedRegardlessOfSize(TR_CallSite *callsite)
-   {
-
-   return false;
-   }
-
 static bool traceIfMatchesPattern(TR::Compilation* comp)
    {
    static char* cRegex = feGetEnv ("TR_printIfRegex");
@@ -5485,7 +5478,7 @@ OMR_InlinerPolicy::callMustBeInlined(TR_CallTarget *calltarget)
 bool
 TR_InlinerBase::forceInline(TR_CallTarget *calltarget)
    {
-   if (getPolicy()->callMustBeInlined(calltarget) || callMustBeInlinedRegardlessOfSize(calltarget->_myCallSite))
+   if (getPolicy()->callMustBeInlined(calltarget))
       return true;
 
    return false;

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -319,7 +319,6 @@ class TR_InlinerBase: public TR_HasRandomGenerator
       void getSymbolAndFindInlineTargets(TR_CallStack *, TR_CallSite *, bool findNewTargets=true);
 
       void applyPolicyToTargets(TR_CallStack *, TR_CallSite *);
-      bool callMustBeInlinedRegardlessOfSize(TR_CallSite *callsite);
 
       bool forceInline(TR_CallTarget *calltarget);
       bool forceVarInitInlining(TR_CallTarget *calltarget);


### PR DESCRIPTION
method not refererenced in other places except Inliner.cpp and return a definate false so remove it.

Signed-off-by: James Guan jamesgua@ca.ibm.com