### PR TITLE
Add empty definition for endOutlinedInstructionSequence

### DIFF
--- a/compiler/x/codegen/OutlinedInstructions.cpp
+++ b/compiler/x/codegen/OutlinedInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -377,6 +377,12 @@ TR_OutlinedInstructionsGenerator::TR_OutlinedInstructionsGenerator(TR::LabelSymb
    cg->getOutlinedInstructionsList().push_front(_oi);
    _oi->swapInstructionListsWithCompilation();
    generateLabelInstruction(LABEL, node, entryLabel, cg);
+   }
+
+void
+TR_OutlinedInstructionsGenerator::endOutlinedInstructionSequence()
+   {
+   /// TODO: Move cleanup code from destrdductor here
    }
 
 TR_OutlinedInstructionsGenerator::~TR_OutlinedInstructionsGenerator()

--- a/compiler/x/codegen/OutlinedInstructions.hpp
+++ b/compiler/x/codegen/OutlinedInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -167,6 +167,16 @@ class TR_OutlinedInstructionsGenerator
       @brief Switch back to mainline code generation.
    */
    ~TR_OutlinedInstructionsGenerator();
+
+   /**
+    * @brief Performs post outlined instruction generation cleanup
+    *
+    * This function *must* be called after an outline instruction sequence
+    * is generated.
+    *
+    */
+   void endOutlinedInstructionSequence();
+
    /**
       @brief Obtain the underlying TR_OutlinedInstructions.
    */


### PR DESCRIPTION
TR_OutlinedInstructionsGenerator::endOutlinedInstructionSequence() will
eventually do the cleanup necessary after generating an outlined
instruction sequence in the x86 codegen. For now, an empty
implementation is provided for the purpose of coordinating changes
with downstream projects.

Issue: #4846

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>