### PR TITLE
Remove isTimeForGlobalGCKickoff() from base Collector class

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -538,13 +538,6 @@ MM_Collector::setThreadFailAllocFlag(MM_EnvironmentBase* env, bool flag)
 	}
 }
 
-bool
-MM_Collector::isTimeForGlobalGCKickoff()
-{
-	Assert_MM_unreachable();
-	return false;
-}
-
 /**
  * Abort any currently active garbage collection activity.
  * The abort consists of halting any activity related to garbage collection, and resetting/releasing said

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -68,12 +68,6 @@ protected:
 	uint64_t _masterThreadCpuTimeStart; /**< slot to store the master CPU time at the beginning of the collection */
 
 public:
-	/*
-	 * Determine if a collector (some parent, typically the global collector) wishes to usurp any minor collection.
-	 * @return boolean indicating if the parent collector should be invoked in place of a child.
-	 */
-	virtual bool isTimeForGlobalGCKickoff();
-
 	/**
  	 * Perform any collector-specific initialization.
  	 * @return TRUE if startup completes OK, FALSE otherwise

--- a/gc/base/GlobalCollector.hpp
+++ b/gc/base/GlobalCollector.hpp
@@ -52,6 +52,11 @@ protected:
 public:
 	MM_GlobalCollectorDelegate *getGlobalCollectorDelegate() { return &_delegate; }
 
+
+	/*
+	 * Determine if a collector (some parent, typically the global collector) wishes to usurp any minor collection.
+	 * @return boolean indicating if the parent collector should be invoked in place of a child.
+	 */
 	virtual bool isTimeForGlobalGCKickoff();
 
 	virtual bool condYield(MM_EnvironmentBase *env, uint64_t timeSlackNanoSec)


### PR DESCRIPTION
Fixes: eclipse/omr#5178
moving isTimeForGlobalGCKickoff() from MM_Collector(base) to MM_GlobalCollector (subclass) so downstream projects will not invoke isTimeForGlobalGCKickoff against MM_Collector.
Signed-off-by: Enson <enson.guo@ibm.com>