### PR TITLE
Remove mention of dead PPCHeapAllocSnippet class

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -201,7 +201,6 @@ namespace TR { class PPCHelperCallSnippet; }
 namespace TR { class PPCMonitorEnterSnippet; }
 namespace TR { class PPCMonitorExitSnippet; }
 namespace TR { class PPCReadMonitorSnippet; }
-namespace TR { class PPCHeapAllocSnippet; }
 
 namespace TR { class PPCAllocPrefetchSnippet; }
 
@@ -930,7 +929,6 @@ public:
    void print(TR::FILE *, TR::PPCMonitorEnterSnippet *);
    void print(TR::FILE *, TR::PPCMonitorExitSnippet *);
    void print(TR::FILE *, TR::PPCReadMonitorSnippet *);
-   void print(TR::FILE *, TR::PPCHeapAllocSnippet *);
    void print(TR::FILE *, TR::PPCAllocPrefetchSnippet *);
 
 


### PR DESCRIPTION
This snippet class is dead and being removed from OpenJ9 ([PR 9548](https://github.com/eclipse/openj9/pull/9548))

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>