### PR TITLE
Add TR::getMax/MinFloat/Double features

### DIFF
--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -318,3 +318,41 @@ OMR::DataType::getPrefix(TR::DataType dt)
    TR_ASSERT(dt < TR::NumOMRTypes, "Prefix requested for unknown datatype");
    return OMRDataTypePrefixes[dt];
    }
+
+void FloatingPointLimits::setMaxFloat()
+   {
+   int32_t f = FLOAT_POS_INFINITY;
+   _maxFloat = 0.0f;
+   memcpy(&_maxFloat, &f, sizeof(f));
+   }
+
+void  FloatingPointLimits::setMinFloat()
+   {
+   int32_t f = FLOAT_NEG_INFINITY;
+   _minFloat = 0.0f;
+   memcpy(&_minFloat, &f, sizeof(f));
+   }
+void  FloatingPointLimits::setMaxDouble()
+   {
+   uint64_t d = DOUBLE_POS_INFINITY;
+   _maxDouble = 0.0;
+   memcpy(&_maxDouble, &d, sizeof(d));
+   }
+
+void  FloatingPointLimits::setMinDouble()
+   {
+   int64_t d = DOUBLE_NEG_INFINITY;
+   _minDouble = 0.0;
+   memcpy(&_minDouble, &d, sizeof(d));
+   }
+
+namespace TR{
+   static FloatingPointLimits fpLimits;
+
+   float getMaxFloat() { return fpLimits.getMaxFloat(); }
+   float getMinFloat() { return fpLimits.getMinFloat(); }
+   double getMaxDouble() { return fpLimits.getMaxDouble(); }
+   double getMinDouble() { return fpLimits.getMinDouble(); }
+}
+
+

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -253,6 +253,33 @@ enum DataTypes
  * @{
  */
 
+class FloatingPointLimits
+   {
+   float _maxFloat;
+   float _minFloat;
+   double _maxDouble;
+   double _minDouble;
+
+   void setMaxFloat();
+   void setMinFloat();
+   void setMaxDouble();
+   void setMinDouble();
+
+public:
+   FloatingPointLimits()
+      {
+      setMinFloat();
+      setMaxFloat();
+      setMinDouble();
+      setMaxDouble();
+      }
+
+   float getMaxFloat() { return _maxFloat; }
+   float getMinFloat() { return _minFloat; }
+   double getMaxDouble() { return _maxDouble; }
+   double getMinDouble() { return _minDouble; }
+   };
+
 namespace TR
 {
 
@@ -292,6 +319,13 @@ namespace TR
    template <> inline int32_t getMaxUnsignedPrecision<TR::Int16>() { return 5; }
    template <> inline int32_t getMaxUnsignedPrecision<TR::Int32>() { return 10; }
    template <> inline int32_t getMaxUnsignedPrecision<TR::Int64>() { return 20; }
+
+   // The constructor of the FloatLimits class is run only once
+   // The query functions below just return the cached copies of the float limits.
+   float getMaxFloat();
+   float getMinFloat();
+   double getMaxDouble();
+   double getMinDouble();
 
 } // namespace TR
 


### PR DESCRIPTION
Add functions to get INF or -INF values of float/double.
There has been some previously defined hex values for max/min
float/double but cannot use it directly because the values are defined in
hex, e.g. [1]. The TR::getMax/MinFloat/Double functions reinterpret the hex
representations to their floating point values and return a floating
point type.

[1] https://github.com/eclipse/omr/blob/92e2fea39ad35c44d9d0c3428ea54118e4510d90/compiler/il/OMRDataTypes.hpp#L62
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>