### PR TITLE
Redundant CS transition

### DIFF
--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -199,7 +199,7 @@ TraceEvent=Trc_MM_concurrentClassMarkStart Overhead=1 Level=1 Template="Concurre
 TraceEvent=Trc_MM_concurrentClassMarkEnd Overhead=1 Level=1 Template="Concurrent class mark end, traced %zu"
 TraceEntry=Trc_MM_ParallelHeapWalker_allObjectsDoParallel_Entry Overhead=1 Level=1 Template="Trc_MM_ParallelHeapWalker_allObjectsDoParallel_Entry"
 TraceExit=Trc_MM_ParallelHeapWalker_allObjectsDoParallel_Exit Overhead=1 Level=1 Template="Trc_MM_ParallelHeapWalker_allObjectsDoParallel_Exit: heapChunkFactor=%zu, parallelChunkSize=0x%zx, objects walked by this thread=%zu"
-TraceExit=Trc_MM_MemorySubSpace_garbageCollect_Exit4 Overhead=9 Level=9 Template="MM_MemorySubSpace_garbageCollect Exit4 Concurrent kickoff forced"
+TraceExit=Trc_MM_MemorySubSpace_garbageCollect_Exit4 Overhead=1 Level=1 Template="MM_MemorySubSpace_garbageCollect Exit4 Concurrent kickoff forced"
 
 TraceEntry=Trc_MM_Scavenger_masterThreadGarbageCollect_Entry Overhead=1 Level=1 Template="Scavenger start"
 TraceEvent=Trc_MM_Scavenger_masterThreadGarbageCollect_setFailedTenureFlag Overhead=1 Level=1 Group=percolate Template="Setting failed tenure flag. _failedTenureLargest = %zu"
@@ -258,11 +258,11 @@ TraceEvent=Trc_MM_ConcurrentHaltedState Overhead=1 Level=1 Group=gclogger Templa
 // Assert that the thread has exclusive VM access
 TraceAssert=Assert_MM_mustHaveExclusiveVMAccess noEnv Overhead=1 Level=1 Assert="(P1)->exclusiveCount != 0"
 
-TraceEntry=Trc_MM_GlobalCollector_isTimeForClassUnloading_Entry noEnv Overhead=1 Level=9 Template="MM_GlobalCollector_isTimeForClassUnloading. dynamicClassUnloading:%zu classLoaderBlocks:%zu dynamicClassUnloadingThreshold:%zu lastUnloadNumOfClassLoaders:%zu"
-TraceExit=Trc_MM_GlobalCollector_isTimeForClassUnloading_Exit noEnv Overhead=1 Level=9 Template="MM_GlobalCollector_isTimeForClassUnloading result = %s"
+TraceEntry=Trc_MM_GlobalCollector_isTimeForClassUnloading_Entry noEnv Overhead=1 Level=2 Template="MM_GlobalCollector_isTimeForClassUnloading. dynamicClassUnloading:%zu classLoaderBlocks:%zu dynamicClassUnloadingThreshold:%zu lastUnloadNumOfClassLoaders:%zu"
+TraceExit=Trc_MM_GlobalCollector_isTimeForClassUnloading_Exit noEnv Overhead=1 Level=2 Template="MM_GlobalCollector_isTimeForClassUnloading result = %s"
 
-TraceEntry=Trc_MM_GlobalCollector_isTimeForGlobalGCKickoff_Entry noEnv Overhead=1 Level=9 Template="MM_GlobalCollector_isTimeForGlobalGCKickoff. dynamicClassUnloading:%zu classLoaderBlocks:%zu dynamicClassUnloadingKickoffThreshold:%zu lastUnloadNumOfClassLoaders:%zu"
-TraceExit=Trc_MM_GlobalCollector_isTimeForGlobalGCKickoff_Exit noEnv Overhead=1 Level=9 Template="MM_GlobalCollector_isTimeForGlobalGCKickoff result = %s"
+TraceEntry=Trc_MM_GlobalCollector_isTimeForGlobalGCKickoff_Entry noEnv Overhead=1 Level=1 Template="MM_GlobalCollector_isTimeForGlobalGCKickoff. dynamicClassUnloading:%zu classLoaderBlocks:%zu dynamicClassUnloadingKickoffThreshold:%zu lastUnloadNumOfClassLoaders:%zu"
+TraceExit=Trc_MM_GlobalCollector_isTimeForGlobalGCKickoff_Exit noEnv Overhead=1 Level=1 Template="MM_GlobalCollector_isTimeForGlobalGCKickoff result = %s"
 TraceEvent=Trc_MM_Oracle_setupForCollect Obsolete Overhead=1 Level=1 Group=oracle Template="Oracle received setup call"
 TraceEvent=Trc_MM_Oracle_cleanupAfterCollect Obsolete Overhead=1 Level=1 Group=oracle Template="Oracle received cleanup call"
 
@@ -328,8 +328,8 @@ TraceEvent=Trc_MM_StandardAccessBarrier_treatObjectAsRecentlyAllocated Overhead=
 TraceEntry=Trc_MM_ConcurrentGC_determineInitWork_Entry Overhead=1 Level=1 Group=concurrent Template="MM_ConcurrentGC_determineInitWork"
 TraceExit=Trc_MM_ConcurrentGC_determineInitWork_Exit Overhead=1 Level=1 Group=concurrent Template="MM_ConcurrentGC_determineInitWork"
 
-TraceEntry=Trc_MM_ConcurrentGC_getInitRange_Entry Overhead=1 Level=2 Group=concurrent Template="MM_ConcurrentGC_getInitRange"
-TraceExit=Trc_MM_ConcurrentGC_getInitRange_Succeed Overhead=1 Level=2 Group=concurrent Template="MM_ConcurrentGC_getInitRange from %p to %p type=%zx concurrentCollectible=%s"
+TraceEntry=Trc_MM_ConcurrentGC_getInitRange_Entry Overhead=1 Level=3 Group=concurrent Template="MM_ConcurrentGC_getInitRange"
+TraceExit=Trc_MM_ConcurrentGC_getInitRange_Succeed Overhead=1 Level=3 Group=concurrent Template="MM_ConcurrentGC_getInitRange from %p to %p type=%zx concurrentCollectible=%s"
 TraceExit=Trc_MM_ConcurrentGC_getInitRange_Fail Overhead=1 Level=2 Group=concurrent Template="MM_ConcurrentGC_getInitRange return false"
 
 TraceEntry=Trc_MM_ConcurrentGC_tuneToHeap_Entry Overhead=1 Level=1 Group=concurrent Template="MM_ConcurrentGC_tuneToHeap"
@@ -923,3 +923,5 @@ TraceEntry=Trc_MM_double_map_Entry Overhead=1 Level=3 Group=arraylet Template="M
 TraceException=Trc_MM_double_map_TraverseLeavesNULLPointer Overhead=1 Level=1 Group=arraylet Template="Found a NULL pointer as the last leaf in arraylet spine"
 TraceException=Trc_MM_double_map_Failed Overhead=1 Level=1 Group=arraylet Template="Failed to double map arraylets"
 TraceExit=Trc_MM_double_map_Exit Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::doubleMapArraylets. result=%p"
+
+TraceEvent=Trc_MM_Scavenger_percolate_delegate Overhead=1 Level=1 Group=percolate Template="Percolating due to language specific reason"


### PR DESCRIPTION
Remove the Concurrent Scavenger transition at the begining of
Scavenger's percolate, since we will attempt it anyway before really
percolating as part of
MM_ParallelGlobalGC::completeExternalConcurrentCycle().

Having both attempts can cause problems if first one aborts and then
instead of directly percolating, the second one may trigger another STW
increment seeing the previous one did not complete cycle (not knowing it
aborted).

For a few trace points adjusted priorities, based on how important they
are vs how frequently they occur.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>