### PR TITLE
Make UnsupportedValueTypeOperation a recoverable exception

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -66,17 +66,6 @@ struct ILGenFailure : public virtual CompilationException
    };
 
 /**
- * Unsupported value type operation exception type.
- *
- * Thrown if an unsupported value type operation is encountered that requires
- * compilation to be aborted.
- */
-struct UnsupportedValueTypeOperation : public virtual CompilationException
-   {
-   virtual const char* what() const throw() { return "Unsupported value type operation"; }
-   };
-
-/**
  * Recoverable IL Generation Failure exception type.
  *
  * Thrown on an IL Generation Failure condition which the compiler can
@@ -98,6 +87,17 @@ struct RecoverableILGenException : public virtual CompilationException
 struct NoRecompilationRecoverableILGenException: public RecoverableILGenException
    {
    virtual const char* what() const throw() { return "Recoverable IL Gen Exception with no recompilation if failing method is outermost"; }
+   };
+
+/**
+ * Unsupported value type operation exception type.
+ *
+ * Thrown if an unsupported value type operation is encountered that requires
+ * compilation to be aborted.
+ */
+struct UnsupportedValueTypeOperation : public virtual RecoverableILGenException
+   {
+   virtual const char* what() const throw() { return "Unsupported value type operation"; }
    };
 
 /**


### PR DESCRIPTION
The `UnsupportedValueTypeOperation` exception extended `CompilationException`, which meant that, if it was thrown, compilation would be aborted.  However, it should be considered a recoverable exception - if an unsupported operation is encountered during inlining, only the inlining of that particular method should be aborted while compilation of the outermost method continues.

Fixed this by having `UnsupportedValueTypeOperation` extend `RecoverableILGenException` instead.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>