### PR TITLE
Refactor processor version check for branch hints

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -269,7 +269,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mne
       TR::Node *thirdChild = node->getChild(2);
       TR_ASSERT(thirdChild->getOpCodeValue() == TR::GlRegDeps, "The third child of a compare is assumed to be a TR::GlRegDeps, but wasn't");
       cg->evaluate(thirdChild);
-      if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+      if (isHint)
          generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                generateRegisterDependencyConditions(cg, thirdChild, 0));
       else
@@ -279,7 +279,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mne
       }
    else
       {
-      if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+      if (isHint)
          generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
       else
          generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -448,14 +448,14 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label1);
       if (deps)
          {
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, destinationLabel, condReg, deps);
          else
             generateDepConditionalBranchInstruction(cg, branchOp, node, destinationLabel, condReg, deps);
          }
       else
          {
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, destinationLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, destinationLabel, condReg);
@@ -535,7 +535,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
          TR::Node *thirdChild = node->getChild(2);
          TR_ASSERT(thirdChild->getOpCodeValue() == TR::GlRegDeps, "The third child of a compare is assumed to be a TR::GlRegDeps, but wasn't");
          cg->evaluate(thirdChild);
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                   generateRegisterDependencyConditions(cg, thirdChild, 0));
          else
@@ -545,7 +545,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
          }
       else
          {
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -1333,7 +1333,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
        {
        TR::Node *thirdChild = node->getChild(2);
        cg->evaluate(thirdChild);
-       if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+       if (isHint)
           generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                 generateRegisterDependencyConditions(cg, thirdChild, 0));
        else
@@ -1344,7 +1344,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
        }
     else
        {
-       if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+       if (isHint)
           generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
        else
           generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -1539,7 +1539,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
          {
          thirdChild = node->getChild(2);
          cg->evaluate(thirdChild);
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                   generateRegisterDependencyConditions(cg, thirdChild, 0));
          else
@@ -1549,7 +1549,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
          }
       else
          {
-         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
+         if (isHint)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -3582,11 +3582,7 @@ OMR::Power::TreeEvaluator::generateNullTestInstructions(
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli8, node, condReg, trgReg, NULLVALUE);
       else
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, condReg, trgReg, NULLVALUE);
-      if (cg->comp()->target().cpu.id() >= TR_PPCgp)
-         // use PPC AS branch hint
-         gcPoint = generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beql, PPCOpProp_BranchUnlikely, node, snippetLabel, condReg, conditions);
-      else
-         gcPoint = generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beql, node, snippetLabel, condReg, conditions);
+      gcPoint = generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beql, PPCOpProp_BranchUnlikely, node, snippetLabel, condReg, conditions);
 
       gcPoint->setExceptBranchOp();
       cg->stopUsingRegister(condReg);
@@ -3689,10 +3685,7 @@ TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::Co
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi8, node, condReg, value, 0);
       else
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, value, 0);
-      if (cg->comp()->target().cpu.id() >= TR_PPCgp) // Use PPC AS branch hint.
-         generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, node, slowPathLabel, condReg);
-      else
-         generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, slowPathLabel, condReg);
+      generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, node, slowPathLabel, condReg);
 
       cg->decReferenceCount(node->getFirstChild());
       cg->stopUsingRegister(condReg);

--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -314,6 +314,10 @@ TR::Instruction *generateDepLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCo
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, bool likeliness, TR::Node * n,
    TR::LabelSymbol *sym, TR::Register *cr, TR::Instruction *preced)
    {
+   // if processor does not support branch hints
+   if (cg->comp()->target().cpu.id() < TR_PPCgp)   
+      return generateConditionalBranchInstruction(cg, op, n, sym, cr, preced);
+
    if (cr->isFlippedCCR())
       op = flipBranch(cg, op);
 
@@ -325,6 +329,10 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
 TR::Instruction *generateDepConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,  bool likeliness, TR::Node * n,
    TR::LabelSymbol *sym, TR::Register *cr, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
    {
+   // if processor does not support branch hints
+   if (cg->comp()->target().cpu.id() < TR_PPCgp)   
+      return generateDepConditionalBranchInstruction(cg, op, n, sym, cr, cond, preced);
+   
    if (cr->isFlippedCCR())
       op = flipBranch(cg, op);
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5252,14 +5252,7 @@ static TR::Register *inlineSimpleAtomicUpdate(TR::Node *node, bool isAddOp, bool
          newValueReg);
 
    // We expect this store is usually successful, i.e., the following branch will not be taken
-   if (cg->comp()->target().cpu.id() >= TR_PPCgp)
-      {
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, PPCOpProp_BranchUnlikely, node, loopLabel, cndReg);
-      }
-   else
-      {
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, loopLabel, cndReg);
-      }
+   generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, PPCOpProp_BranchUnlikely, node, loopLabel, cndReg);
 
    // We deviate from the VM helper here: no-store-no-barrier instead of always-barrier
    generateInstruction(cg, TR::InstOpCode::sync, node);
@@ -5914,15 +5907,9 @@ TR::Register *OMR::Power::TreeEvaluator::cmpsetEvaluator(
    generateTrg1ImmInstruction             (cg, TR::InstOpCode::li,     node, result, 1);
    generateTrg1MemInstruction             (cg, ldrOp,        node, tmpReg, ldMemRef);
    generateTrg1Src2Instruction            (cg, cmpOp,        node, condReg, tmpReg, cmpReg);
-   if (cg->comp()->target().cpu.id() >= TR_PPCgp)
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne,    PPCOpProp_BranchUnlikely, node, endLabel, condReg);
-   else
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne,    node, endLabel, condReg);
+   generateConditionalBranchInstruction   (cg, TR::InstOpCode::bne,    PPCOpProp_BranchUnlikely, node, endLabel, condReg);
    generateMemSrc1Instruction             (cg, stcOp,        node, stMemRef, repReg);
-   if (cg->comp()->target().cpu.id() >= TR_PPCgp)
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne,    PPCOpProp_BranchUnlikely, node, endLabel, cr0);
-   else
-      generateConditionalBranchInstruction(cg, TR::InstOpCode::bne,    node, endLabel, cr0);
+   generateConditionalBranchInstruction   (cg, TR::InstOpCode::bne,    PPCOpProp_BranchUnlikely, node, endLabel, cr0);
    generateTrg1ImmInstruction             (cg, TR::InstOpCode::li,     node, result, 0);
    generateDepLabelInstruction            (cg, TR::InstOpCode::label,  node, endLabel, deps);
 


### PR DESCRIPTION
For a better encapsulation of codegen
`generateConditionalBranchInstruction` helper functions.
The caller passes branch hints when possible and the
function checks if the processor supports it.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>