### PR TITLE
CMake: Update split  debug info handling

### DIFF
--- a/cmake/caches/Travis.cmake
+++ b/cmake/caches/Travis.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@ set(OMR_GC_MODRON_CONCURRENT_MARK ON CACHE BOOL "")
 set(OMR_GC_VLHGC ON CACHE BOOL "")
 set(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD ON CACHE BOOL "")
 set(OMR_PORT_SOCKET_SUPPORT ON CACHE BOOL "")
+set(OMR_SEPARATE_DEBUG_INFO ON CACHE BOOL "")
 
 set(OMR_NOTIFY_POLICY_CONTROL ON CACHE BOOL "")
 set(OMR_THR_CUSTOM_SPIN_OPTIONS ON CACHE BOOL "")

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -218,3 +218,12 @@ set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GN
 if(OMR_HOST_OS STREQUAL "win")
 	set(OMR_WINDOWS_NOMINMAX ON CACHE BOOL "Define NOMINMAX in every compilation unit; prevents Windows headers from polluting the global namespace with 'min' and 'max' macros.")
 endif()
+
+set(OMR_SEPARATE_DEBUG_INFO OFF CACHE BOOL "Maintain debug info in a separate file")
+set(OMR_FLATTEN_DEBUG_INFO OFF CACHE BOOL "Enable generation of flattened debug info on osx")
+if(OMR_OS_OSX)
+	set(default_debug_ext ".dSYM")
+else()
+	set(default_debug_ext ".debuginfo")
+endif()
+set(OMR_DEBUG_INFO_OUTPUT_EXTENSION "${default_debug_ext}" CACHE STRING "Extension to use for separate debug info")

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -34,7 +34,6 @@ include(OmrPlatform)
 set(OMR_MODULES_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(DDR_INFO_DIR "${CMAKE_BINARY_DIR}/ddr_info")
 
-set(OMR_SEPARATE_DEBUG_INFO OFF CACHE BOOL "Maintain debug info in a separate file")
 
 function(make_ddr_set set_name)
 	set(DDR_TARGET_NAME "${set_name}")
@@ -153,6 +152,11 @@ function(target_enable_ddr tgt)
 		# if no value is present, assume the debug info lives in the target file
 		if(NOT debug_file)
 			set(debug_file "$<TARGET_FILE:${tgt}>")
+		else()
+			# For non flattened debug on osx, the debug "file" is actually a folder
+			if(OMR_OS_OSX AND NOT OMR_FLATTEN_DEBUG_INFO)
+				set(debug_file "${debug_file}/Contents/Resources/DWARF/$<TARGET_FILE_NAME:${tgt}>")
+			endif()
 		endif()
 
 		set(MAGIC_TEMPLATE "OUTPUT_FILE\n${debug_file}\n${MAGIC_TEMPLATE}")

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -88,15 +88,20 @@ endif()
 function(_omr_toolchain_separate_debug_symbols tgt)
 	set(exe_file "$<TARGET_FILE:${tgt}>")
 	if(OMR_OS_OSX)
-		set(dbg_file "${exe_file}.dSYM")
+		set(dbg_file "${exe_file}${OMR_DEBUG_INFO_OUTPUT_EXTENSION}")
+		if(OMR_FLATTEN_DEBUG_INFO)
+			set(flatten_arg "-f")
+		else()
+			set(flatten_arg)
+		endif()
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD
-			COMMAND dsymutil -o "${dbg_file}" "${exe_file}"
+			COMMAND dsymutil ${flatten_arg} -o "${dbg_file}" "${exe_file}"
 		)
 	else()
-		omr_get_target_path(target_path ${tgt})
-		omr_replace_suffix(dbg_file "${target_path}" ".debuginfo")
+		omr_get_target_output_genex(${tgt} output_name)
+		set(dbg_file "${output_name}${OMR_DEBUG_INFO_OUTPUT_EXTENSION}")
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -212,8 +212,8 @@ else()
 
 	function(_omr_toolchain_separate_debug_symbols tgt)
 		set(exe_file "$<TARGET_FILE:${tgt}>")
-		omr_get_target_path(target_path ${tgt})
-		omr_replace_suffix(dbg_file "${target_path}" ".debuginfo")
+		omr_get_target_output_genex(${tgt} output_name)
+		set(dbg_file "${output_name}${OMR_DEBUG_INFO_OUTPUT_EXTENSION}")
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD


### PR DESCRIPTION
Fix the handling of how we determine the name of the split debug file.
Also enable split debug info in the CI builds, so it hopefully catches these issues
in the future.