### PR TITLE
Disable CFG simplifier patterns related to conditional stores

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -369,6 +369,10 @@ static bool containsIndirectOperation(TR::Compilation *comp, TR::TreeTop *treeto
 
 bool OMR::CFGSimplifier::simplifyCondStoreSequence(bool needToDuplicateTree)
    {
+   static char *enableSimplifyCondStoreSequence = feGetEnv("TR_enableSimplifyCondStoreSequence");
+   if (enableSimplifyCondStoreSequence == NULL)
+      return false;
+
    if (!(comp()->cg()->getSupportsSelect()))
       return false;
 
@@ -474,6 +478,10 @@ bool OMR::CFGSimplifier::simplifyCondStoreSequence(bool needToDuplicateTree)
 
 bool OMR::CFGSimplifier::simplifySimpleStore(bool needToDuplicateTree)
    {
+   static char *enableSimplifySimpleStore = feGetEnv("TR_enableSimplifySimpleStore");
+   if (enableSimplifySimpleStore == NULL)
+      return false;
+
    if (!(comp()->cg()->getSupportsSelect()))
       return false;
 
@@ -777,6 +785,10 @@ static bool checkEquivalentIndirectLoadChain(TR::Node *lhs, TR::Node *rhs)
 //
 bool OMR::CFGSimplifier::simplifyBooleanStore(bool needToDuplicateTree)
    {
+   static char *enableSimplifyBooleanStore = feGetEnv("TR_enableSimplifyBooleanStore");
+   if (enableSimplifyBooleanStore == NULL)
+      return false;
+
    if (!(comp()->cg()->getSupportsSelect()))
       return false;
 


### PR DESCRIPTION
There are bugs in these patterns. Disabling them allows CFG simplification to
be enabled while the root causes of these problems are investigated.

See: https://github.com/eclipse/openj9/issues/8397

Signed-off-by: Ryan Shukla <ryans@ibm.com>