### PR TITLE
Create relocation records of type TR_BlockFrequency and TR_RecompQueuedFlag

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1087,6 +1087,12 @@ OMR::CodeGenerator::needRelocationsForPersistentInfoData()
    }
 
 bool
+OMR::CodeGenerator::needRelocationsForPersistentProfileInfoData()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
 OMR::CodeGenerator::needRelocationsForCurrentMethodPC()
    {
    return self()->comp()->compileRelocatableCode();

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1174,6 +1174,7 @@ public:
    bool needRelocationsForStatics();
    bool needRelocationsForBodyInfoData();
    bool needRelocationsForPersistentInfoData();
+   bool needRelocationsForPersistentProfileInfoData();
    bool needRelocationsForLookupEvaluationData();
    bool needRelocationsForCurrentMethodPC();
 

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -330,7 +330,8 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    TR_ExternalRelocationTargetKind kind = getTargetKind();
 
    if (comp->target().cpu.isPower() &&
-          (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethod || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress || kind == TR_DebugCounter))
+          (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethod || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
+           || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();
@@ -362,7 +363,8 @@ void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
    uint8_t *codeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
    TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
    if (comp->target().cpu.isPower() &&
-      (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethodSequence || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress || kind == TR_DebugCounter))
+      (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethodSequence || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
+       || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1932,6 +1932,18 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          TR::DebugCounter::generateRelocation(comp, firstInstruction, node, counter, seqKind);
          return;
          }
+
+      case TR_BlockFrequency:
+	 {
+         TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof(TR_RelocationRecordInformation), heapAlloc);
+         recordInfo->data1 = (uintptr_t)node->getSymbolReference();
+         recordInfo->data2 = (uintptr_t)seqKind;
+         relo = new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+            firstInstruction,
+            (uint8_t *)recordInfo,
+            TR_BlockFrequency, self());
+         break;
+         }
       }
 
    if (comp->getOption(TR_UseSymbolValidationManager) && !relo)
@@ -2086,6 +2098,17 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
          }
 
       TR::DebugCounter::generateRelocation(comp, firstInstruction, secondInstruction, node, counter, orderedPairSequence2);
+      }
+   else if (typeAddress == TR_BlockFrequency)
+      {
+      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+      recordInfo->data1 = (uintptr_t)node->getSymbolReference();
+      recordInfo->data2 = orderedPairSequence2;
+      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
+                                                                                          (uint8_t *)secondInstruction,
+                                                                                          (uint8_t *)recordInfo,
+                                                                                          (TR_ExternalRelocationTargetKind)typeAddress, self()),
+                                                                                          __FILE__, __LINE__, node);
       }
    else if (typeAddress != -1)
       {

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1621,6 +1621,18 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, (intptr_t)ref, reg, NULL, false, TR_ClassAddress);
          return;
          }
+      else if (symbol->isBlockFrequency() && cg->needRelocationsForPersistentProfileInfoData())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_BlockFrequency);
+         return;
+         }
+      else if (symbol->isRecompQueuedFlag() && cg->needRelocationsForPersistentProfileInfoData())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RecompQueuedFlag);
+         return;
+         }
       else
          {
          TR_ASSERT_FATAL(!comp->getOption(TR_UseSymbolValidationManager) || ref->isUnresolved(), "SVM relocation unhandled");
@@ -1753,6 +1765,19 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
          return;
          }
+      else if (cg->needRelocationsForPersistentProfileInfoData() && symbol->isBlockFrequency())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_BlockFrequency);
+         return;
+         }
+      else if (cg->needRelocationsForPersistentProfileInfoData() && symbol->isRecompQueuedFlag())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RecompQueuedFlag);
+         return;
+         }
+
       else if (refIsUnresolved || useUnresSnippetToAvoidRelo)
          {
          self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, isStore, false));

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -185,7 +185,8 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
             (cg->needRelocationsForStatics()            ||
              cg->needClassAndMethodPointerRelocations() ||
              cg->needRelocationsForBodyInfoData()       ||
-             cg->needRelocationsForPersistentInfoData()))
+             cg->needRelocationsForPersistentInfoData() ||
+             cg->needRelocationsForPersistentProfileInfoData()))
       {
       mightNeedAddressRegister = true;
       }
@@ -290,6 +291,8 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
    else if (sr.getSymbol() && sr.getSymbol()->isRecompilationCounter() && cg->needRelocationsForBodyInfoData())
       return true;
    else if (sr.getSymbol() && sr.getSymbol()->isCountForRecompile() && cg->needRelocationsForPersistentInfoData())
+      return true;
+   else if (sr.getSymbol() && (sr.getSymbol()->isBlockFrequency() || sr.getSymbol()->isRecompQueuedFlag()) && cg->needRelocationsForPersistentProfileInfoData())
       return true;
    else if (cg->comp()->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject())
       return true; // If a class gets replaced, it may no longer fit in an immediate

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1146,6 +1146,14 @@ TR::X86RegImmSymInstruction::autoSetReloKind()
       {
       setReloKind(TR_DebugCounter);
       }
+   else if (symbol->isBlockFrequency())
+      {
+      setReloKind(TR_BlockFrequency);
+      }
+   else if (symbol->isRecompQueuedFlag())
+      {
+      setReloKind(TR_RecompQueuedFlag);
+      }
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3915,6 +3923,10 @@ TR::AMD64RegImm64SymInstruction::autoSetReloKind()
       setReloKind(TR_ConstantPool);
    else if (symbol->isStatic() && !getSymbolReference()->isUnresolved() && !symbol->isClassObject() && !symbol->isNotDataAddress())
       setReloKind(TR_DataAddress);
+   else if (symbol->isBlockFrequency())
+      setReloKind(TR_BlockFrequency);
+   else if (symbol->isRecompQueuedFlag())
+      setReloKind(TR_RecompQueuedFlag);
    else
       setReloKind(-1);
    }

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1189,10 +1189,25 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                                     getNode(),
                                                     counter);
                }
+            else if (sym->isBlockFrequency())
+               {
+               TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+               recordInfo->data1 = (uintptr_t)getSymbolReference();
+               recordInfo->data2 = 0; // seqKind
+               TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
+               cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+               }
+            else if (sym->isRecompQueuedFlag())
+               {
+               TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
+               cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+               }
             else
+               {
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                    (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)(uintptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
                                        __FILE__, __LINE__, getNode());
+               }
             }
 
          }
@@ -1760,6 +1775,23 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          }
          break;
 
+      case TR_BlockFrequency:
+         {
+         TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+         recordInfo->data1 = (uintptr_t)getSymbolReference();
+         recordInfo->data2 = 0; // seqKind
+         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
+         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         }
+         break;
+
+      case TR_RecompQueuedFlag:
+         {
+         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
+         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         }
+         break;
+
       default:
          TR_ASSERT(0, "invalid relocation kind for TR::X86RegImmSymInstruction");
       }
@@ -2174,6 +2206,19 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                            cursor,
                                            getNode(),
                                            counter);
+      }
+   else if (symbol->isBlockFrequency())
+      {
+      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+      recordInfo->data1 = (uintptr_t)getSymbolReference();
+      recordInfo->data2 = 0; // seqKind
+      TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
+      cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+      }
+   else if (symbol->isRecompQueuedFlag())
+      {
+      TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
+      cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
       }
    else
       {
@@ -2865,6 +2910,21 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                                  cursor,
                                                  getNode(),
                                                  counter);
+            }
+            break;
+         case TR_BlockFrequency:
+            {
+            TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+            recordInfo->data1 = (uintptr_t)getSymbolReference();
+            recordInfo->data2 = 0; // seqKind
+            TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
+            cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+            }
+            break;
+         case TR_RecompQueuedFlag:
+            {
+            TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
+            cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
             }
             break;
 

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -251,6 +251,25 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          }
          break;
 
+      case TR_BlockFrequency:
+         {
+         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
+         TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+         recordInfo->data1 = (uintptr_t)getNode()->getSymbolReference();
+         recordInfo->data2 = 0; // seqKind
+         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
+         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         }
+         break;
+
+      case TR_RecompQueuedFlag:
+         {
+         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
+         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
+         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         }
+         break;
+
       default:
          TR_ASSERT( 0,"relocation type not handled yet");
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -167,6 +167,10 @@ generateLoad32BitConstant(TR::CodeGenerator* cg, TR::Node* node, int32_t value, 
             return generateRegLitRefInstruction(cg, TR::InstOpCode::L, node, targetRegister, value, TR_GlobalValue, dependencies, cursor, literalPoolRegister);
          if (sym->isRecompilationCounter())
             return generateRegLitRefInstruction(cg, TR::InstOpCode::L, node, targetRegister, value, TR_BodyInfoAddress, dependencies, cursor, literalPoolRegister);
+         if (cg->needRelocationsForPersistentProfileInfoData() && sym->isBlockFrequency())
+            return generateRegLitRefInstruction(cg, TR::InstOpCode::L, node, targetRegister, value, TR_BlockFrequency, dependencies, cursor, literalPoolRegister);
+         if (cg->needRelocationsForPersistentProfileInfoData() && sym->isRecompQueuedFlag())
+            return generateRegLitRefInstruction(cg, TR::InstOpCode::L, node, targetRegister, value, TR_RecompQueuedFlag, dependencies, cursor, literalPoolRegister);
          }
       }
 
@@ -212,6 +216,14 @@ genLoadLongConstant(TR::CodeGenerator * cg, TR::Node * node, int64_t value, TR::
       {
       TR::Instruction * temp = cursor;
       cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::LG, node, targetRegister, value, TR_DataAddress, cond, cursor, base);
+      }
+   else if (cg->needRelocationsForPersistentProfileInfoData() && sym && sym->isBlockFrequency())
+      {
+      cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::LG, node, targetRegister, value, TR_BlockFrequency, cond, cursor, base);
+      }
+   else if (cg->needRelocationsForPersistentProfileInfoData() && sym && sym->isRecompQueuedFlag())
+      {
+      cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::LG, node, targetRegister, value, TR_RecompQueuedFlag, cond, cursor, base);
       }
    else if (value >= MIN_IMMEDIATE_VAL && value <= MAX_IMMEDIATE_VAL && !comp->compileRelocatableCode())
       {
@@ -6234,6 +6246,14 @@ OMR::Z::TreeEvaluator::checkAndSetMemRefDataSnippetRelocationType(TR::Node * nod
       {
       reloType = TR_DataAddress;
       }
+   else if (cg->needRelocationsForPersistentProfileInfoData() && isStatic && node->getSymbol()->isBlockFrequency())
+      {
+      reloType = TR_BlockFrequency;
+      }
+   else if (cg->needRelocationsForPersistentProfileInfoData() && isStatic && node->getSymbol()->isRecompQueuedFlag())
+      {
+      reloType = TR_RecompQueuedFlag;
+      }
 
    if (reloType != 0)
       {
@@ -9424,6 +9444,18 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
                cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister,
                                                      (uintptr_t) node->getSymbol()->getStaticSymbol()->getStaticAddress(),
                                                      TR_MethodObject, NULL, NULL, NULL);
+               }
+            else if (cg->needRelocationsForPersistentProfileInfoData() && sym && sym->isBlockFrequency())
+               {
+               cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister,
+                                                        (uintptr_t) node->getSymbol()->getStaticSymbol()->getStaticAddress(),
+                                                        TR_BlockFrequency, NULL, NULL, NULL);
+               }
+            else if (cg->needRelocationsForPersistentProfileInfoData() && sym && sym->isRecompQueuedFlag())
+               {
+               cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister,
+                                                        (uintptr_t) node->getSymbol()->getStaticSymbol()->getStaticAddress(),
+                                                        TR_RecompQueuedFlag, NULL, NULL, NULL);
                }
             else
                {


### PR DESCRIPTION
In OpenJ9 the JProfiling framework is used to create profiled code
which contains references to internal data structures like block
frequencies stored in `TR_BlockFrequencInfo` class, or the flag for
checking if the method is already in recompilation queue.
To support AOT compilation for such code, we need to generate relocation
records for such data structures referenced by the compiled code.
This commit adds the code for generating the relocation records
for block frequency and the recompilation queued flag.
Currently it only handles x and p architectures.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>