### PR TITLE
AArch64: Add entries in TR_Debug::getRuntimeHelperName()

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4218,7 +4218,11 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          case TR_ARM64interpreterSyncDoubleStaticGlue:             return "_interpreterSyncDoubleStaticGlue";
          case TR_ARM64nativeStaticHelper:                          return "_nativeStaticHelper";
          case TR_ARM64interfaceDispatch:                           return "_interfaceDispatch";
+         case TR_ARM64samplingRecompileMethod:                     return "_samplingRecompileMethod";
          case TR_ARM64countingRecompileMethod:                     return "_countingRecompileMethod";
+         case TR_ARM64samplingPatchCallSite:                       return "_samplingPatchCallSite";
+         case TR_ARM64countingPatchCallSite:                       return "_countingPatchCallSite";
+         case TR_ARM64induceRecompilation:                         return "_induceRecompilation";
          case TR_ARM64revertToInterpreterGlue:                     return "_revertToInterpreterGlue";
          case TR_ARM64doubleRemainder:                             return "doubleRemainder";
          case TR_ARM64floatRemainder:                              return "floatRemainder";


### PR DESCRIPTION
This commit adds some entries for AArch64 in TR_Debug::getRuntimeHelperName().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>