### PR TITLE
AArch64: Change OMRLinkage function names

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -64,19 +64,13 @@ TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register
    return result;
    }
 
-TR::Instruction *OMR::ARM64::Linkage::saveArguments(TR::Instruction *cursor)
+TR::Instruction *OMR::ARM64::Linkage::saveParametersToStack(TR::Instruction *cursor)
    {
    TR_UNIMPLEMENTED();
    return cursor;
    }
 
-TR::Instruction *OMR::ARM64::Linkage::loadUpArguments(TR::Instruction *cursor)
-   {
-   TR_UNIMPLEMENTED();
-   return cursor;
-   }
-
-TR::Instruction *OMR::ARM64::Linkage::flushArguments(TR::Instruction *cursor)
+TR::Instruction *OMR::ARM64::Linkage::loadStackParametersToLinkageRegisters(TR::Instruction *cursor)
    {
    TR_UNIMPLEMENTED();
    return cursor;

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -311,20 +311,16 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg);
 
    /**
-    * @brief Saves arguments
+    * @brief Loads parameters from stack
     * @param[in] cursor : instruction cursor
     */
-   virtual TR::Instruction *saveArguments(TR::Instruction *cursor); // may need more parameters
+   virtual TR::Instruction *loadStackParametersToLinkageRegisters(TR::Instruction *cursor);
    /**
-    * @brief Loads up arguments
+    * @brief Saves parameters to stack
     * @param[in] cursor : instruction cursor
     */
-   virtual TR::Instruction *loadUpArguments(TR::Instruction *cursor);
-   /**
-    * @brief Flushes arguments
-    * @param[in] cursor : instruction cursor
-    */
-   virtual TR::Instruction *flushArguments(TR::Instruction *cursor);
+   virtual TR::Instruction *saveParametersToStack(TR::Instruction *cursor);
+
    /**
     * @brief Sets parameter linkage register index
     * @param[in] method : method symbol


### PR DESCRIPTION
This commit renames functions in OMRLinkage.hpp and OMRLinkage.cpp for
AArch64, so that they are consistent with the functions in
ARM64PrivateLinkage.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>