### PR TITLE
AArch64: Make registerBitMask function available to outside of code generator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -417,7 +417,8 @@ TR::Register *OMR::ARM64::CodeGenerator::gprClobberEvaluate(TR::Node *node)
       }
    }
 
-static uint32_t registerBitMask(int32_t reg)
+uint32_t
+OMR::ARM64::CodeGenerator::registerBitMask(int32_t reg)
    {
    return 1 << (reg-1);
    }
@@ -445,7 +446,7 @@ void OMR::ARM64::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
                atlas->addPinningArrayPtrForInternalPtrReg(virtReg->getPinningArrayPointer());
                }
             else if (virtReg->containsCollectedReference())
-               map->setRegisterBits(registerBitMask(i));
+               map->setRegisterBits(self()->registerBitMask(i));
             }
          }
       }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -400,6 +400,14 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *preced = 0);
 
+   /**
+    * @brief Returns bit mask for real register
+    * @param[in] reg: real register number
+    * 
+    * @return bit mask for real register
+    */
+   static uint32_t registerBitMask(int32_t reg);
+
    private:
 
    enum // flags


### PR DESCRIPTION
This commit makes `registerBitMask` function available to
outside of `OMRCodeGenerator.cpp`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>