### PR TITLE
AArch64 Add IsHeapAlloc to enum for Snippet kind

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1432,6 +1432,9 @@ TR_Debug::getNamea64(TR::Snippet * snippet)
       case TR::Snippet::IsMonitorExit:
          return "MonitorExit Dec Counter";
          break;
+      case TR::Snippet::IsHeapAlloc:
+         return "Heap Alloc Snippet";
+         break;
       default:
          return "<unknown snippet>";
       }
@@ -1479,6 +1482,7 @@ TR_Debug::printa64(TR::FILE *pOutFile, TR::Snippet * snippet)
 
       case TR::Snippet::IsMonitorExit:
       case TR::Snippet::IsMonitorEnter:
+      case TR::Snippet::IsHeapAlloc:
          snippet->print(pOutFile, this);
          break;
       default:

--- a/compiler/aarch64/codegen/OMRSnippet.hpp
+++ b/compiler/aarch64/codegen/OMRSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,6 +77,7 @@ class OMR_EXTENSIBLE Snippet : public OMR::Snippet
       IsHelperCall,
          IsMonitorEnter,
          IsMonitorExit,
+      IsHeapAlloc,
       IsRecompilation,
       IsForceRecompilation,
       IsStackCheckFailure,


### PR DESCRIPTION
Add `IsHeapAlloc` to enum for Snippet kind.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>