### PR TITLE
Runtime compressed refs work

### DIFF
--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -224,6 +224,26 @@ public:
 		_slot = slot;
 	}
 
+	/**
+	 * Advance the slot address by an integer offset
+	 *
+	 * @param[in] offset the offset to add
+	 */
+	MMINLINE void addToSlotAddress(intptr_t offset)
+	{
+		writeAddressToSlot(addToSlotAddress(readAddressFromSlot(), offset, compressObjectReferences()));
+	}
+
+	/**
+	 * Back up the slot address by an integer offset
+	 *
+	 * @param[in] offset the offset to subtract
+	 */
+	MMINLINE void subtractFromSlotAddress(intptr_t offset)
+	{
+		writeAddressToSlot(subtractFromSlotAddress(readAddressFromSlot(), offset, compressObjectReferences()));
+	}
+
 	GC_SlotObject(OMR_VM *omrVM, volatile fomrobject_t* slot)
 	: _slot(slot)
 #if defined (OMR_GC_COMPRESSED_POINTERS)


### PR DESCRIPTION
Add instance APIs to adjust the slot address in SlotObject.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>