### PR TITLE
Fixed imm value for addis and lis

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3001,15 +3001,8 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            if (0x00008000 == cg->hiValue(offset))
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), 0x7FFF);
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, addrRegister, 0x1);
-               }
-            else
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
-               }
+            TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3311,15 +3304,8 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            if (0x00008000 == cg->hiValue(offset))
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), 0x7FFF);
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, pivotRegister, 0x1);
-               }
-            else
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
-               }
+            TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(pivotRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3512,15 +3498,8 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
             cg->itemTracking(offset, table);
             if (offset<LOWER_IMMED||offset>UPPER_IMMED)
                {
-               if (0x00008000 == cg->hiValue(offset))
-                  {
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), 0x7FFF);
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, reg1, 0x1);
-                  }
-               else
-                  {
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
-                  }
+               TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
                generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(reg1, LO_VALUE(offset), 8, cg));
                }
             else

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3001,7 +3001,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(offset), 8, cg));
             }
@@ -3304,7 +3304,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(pivotRegister, LO_VALUE(offset), 8, cg));
             }
@@ -3498,7 +3498,7 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
             cg->itemTracking(offset, table);
             if (offset<LOWER_IMMED||offset>UPPER_IMMED)
                {
-               TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+               TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
                generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(reg1, LO_VALUE(offset), 8, cg));
                }

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3001,7 +3001,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3056,7 +3056,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
       }  // ...if 64BitTarget
    else  // if 32bit mode
       {
-      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, addrRegister, cg->hiValue(address));
+      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, addrRegister, (int16_t)cg->hiValue(address));
 
       if (isInt64)
          {
@@ -3303,7 +3303,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(pivotRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3318,7 +3318,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
       }
    else
       {
-      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, pivotRegister, cg->hiValue(address));
+      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, pivotRegister, (int16_t)cg->hiValue(address));
       rel2 = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, addrRegister,
                            pivotRegister, LO_VALUE(address));
 
@@ -3496,7 +3496,7 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
             cg->itemTracking(offset, table);
             if (offset<LOWER_IMMED||offset>UPPER_IMMED)
                {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
                generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(reg1, LO_VALUE(offset), 8, cg));
                }
             else

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3001,7 +3001,15 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
+            if (0x00008000 == cg->hiValue(offset))
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), 0x7FFF);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, addrRegister, 0x1);
+               }
+            else
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
+               }
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3303,7 +3311,15 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          TR_PPCTableOfConstants::setTOCSlot(offset, address);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
+            if (0x00008000 == cg->hiValue(offset))
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), 0x7FFF);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, pivotRegister, 0x1);
+               }
+            else
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
+               }
             generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(pivotRegister, LO_VALUE(offset), 8, cg));
             }
          else
@@ -3496,7 +3512,15 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
             cg->itemTracking(offset, table);
             if (offset<LOWER_IMMED||offset>UPPER_IMMED)
                {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset));
+               if (0x00008000 == cg->hiValue(offset))
+                  {
+                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), 0x7FFF);
+                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, reg1, 0x1);
+                  }
+               else
+                  {
+                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
+                  }
                generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(reg1, LO_VALUE(offset), 8, cg));
                }
             else

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -359,15 +359,8 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
             {
             srcRegister = cg->allocateRegister();
 
-            if (0x00008000 == HI_VALUE(offset))
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), 0x7FFF);
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, srcRegister, 0x1);
-               }
-            else
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
-               }
+            TR_ASSERT_FATAL(0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
             generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, trgRegister, new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 4, cg));
             cg->stopUsingRegister(srcRegister);
             }
@@ -443,15 +436,8 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
             {
             srcRegister = cg->allocateRegister();
 
-            if (0x00008000 == HI_VALUE(offset))
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), 0x7FFF);
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, srcRegister, 0x1);
-               }
-            else
-               {
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
-               }
+            TR_ASSERT_FATAL(0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
 
             TR::MemoryReference *memRef = new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 8, cg);
             if (splats)

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -359,7 +359,7 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
             {
             srcRegister = cg->allocateRegister();
 
-            TR_ASSERT_FATAL(0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
             generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, trgRegister, new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 4, cg));
             cg->stopUsingRegister(srcRegister);
@@ -436,7 +436,7 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
             {
             srcRegister = cg->allocateRegister();
 
-            TR_ASSERT_FATAL(0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != HI_VALUE(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
 
             TR::MemoryReference *memRef = new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 8, cg);

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -358,7 +358,16 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
          if (offset<LOWER_IMMED || offset>UPPER_IMMED)
             {
             srcRegister = cg->allocateRegister();
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), (int16_t)HI_VALUE(offset));
+
+            if (0x00008000 == HI_VALUE(offset))
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), 0x7FFF);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, srcRegister, 0x1);
+               }
+            else
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
+               }
             generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, trgRegister, new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 4, cg));
             cg->stopUsingRegister(srcRegister);
             }
@@ -433,7 +442,16 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
          if (offset<LOWER_IMMED || offset>UPPER_IMMED)
             {
             srcRegister = cg->allocateRegister();
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), (int16_t)HI_VALUE(offset));
+
+            if (0x00008000 == HI_VALUE(offset))
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), 0x7FFF);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, srcRegister, 0x1);
+               }
+            else
+               {
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
+               }
 
             TR::MemoryReference *memRef = new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 8, cg);
             if (splats)

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -358,7 +358,7 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
          if (offset<LOWER_IMMED || offset>UPPER_IMMED)
             {
             srcRegister = cg->allocateRegister();
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), (int16_t)HI_VALUE(offset));
             generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, trgRegister, new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 4, cg));
             cg->stopUsingRegister(srcRegister);
             }
@@ -433,7 +433,7 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
          if (offset<LOWER_IMMED || offset>UPPER_IMMED)
             {
             srcRegister = cg->allocateRegister();
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), HI_VALUE(offset));
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, srcRegister, cg->getTOCBaseRegister(), (int16_t)HI_VALUE(offset));
 
             TR::MemoryReference *memRef = new (cg->trHeapMemory()) TR::MemoryReference(srcRegister, LO_VALUE(offset), 8, cg);
             if (splats)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3239,15 +3239,8 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
          self()->itemTracking(offset, label);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            if (0x00008000 == self()->hiValue(offset))
-               {
-               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), 0x7FFF);
-               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, trgReg, 0x1);
-               }
-            else
-               {
-               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
-               }
+            TR_ASSERT_FATAL(0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
             generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
             }
          else
@@ -3608,15 +3601,7 @@ TR::Register *addConstantToInteger(TR::Node * node, TR::Register *trgReg, TR::Re
       }
    else
       {
-      if (0x00008000 == HI_VALUE(value))
-         {
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, 0x7FFF);
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, trgReg, 0x1);
-         }
-      else
-         {
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, HI_VALUE(value));
-         }
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, (int16_t)HI_VALUE(value));
 
       if (value & 0xFFFF)
          {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3542,7 +3542,7 @@ TR::Register *addConstantToLong(TR::Node *node, TR::Register *srcReg,
       {
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, value >> 16);
       if (value & 0x7fff)
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, LO_VALUE(value));
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, value & 0x7fff);
       }
    else
       {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3068,10 +3068,10 @@ OMR::Power::CodeGenerator::loadAddressConstantFixed(
    else
       {
       // lis tempReg, bits[0-15]
-      cursor = firstInstruction = generateTrg1ImmInstruction(self(), TR::InstOpCode::lis, node, tempReg, canEmitData ? value>>48 : 0, cursor);
+      cursor = firstInstruction = generateTrg1ImmInstruction(self(), TR::InstOpCode::lis, node, tempReg, canEmitData ? (value>>48) : 0, cursor);
 
       // lis trgReg, bits[32-47]
-      cursor = generateTrg1ImmInstruction(self(), TR::InstOpCode::lis, node, trgReg, canEmitData ? ((value>>16) & 0x0000ffff) : 0, cursor);
+      cursor = generateTrg1ImmInstruction(self(), TR::InstOpCode::lis, node, trgReg, canEmitData ? ((int16_t)(value>>16)) : 0, cursor);
       // ori tempReg, tempReg, bits[16-31]
       cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::ori, node, tempReg, tempReg, canEmitData ? ((value>>32) & 0x0000ffff) : 0, cursor);
       // ori trgReg, trgReg, bits[48-63]
@@ -3239,7 +3239,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
          self()->itemTracking(offset, label);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
+            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), (int16_t)self()->hiValue(offset));
             generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
             }
          else
@@ -3542,7 +3542,7 @@ TR::Register *addConstantToLong(TR::Node *node, TR::Register *srcReg,
       {
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, value >> 16);
       if (value & 0x7fff)
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, value & 0x7fff);
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, LO_VALUE(value));
       }
    else
       {
@@ -3594,26 +3594,17 @@ TR::Register *addConstantToLong(TR::Node * node, TR::Register *srcHighReg, TR::R
 
 TR::Register *addConstantToInteger(TR::Node * node, TR::Register *trgReg, TR::Register *srcReg, int32_t value, TR::CodeGenerator *cg)
    {
-   intParts localVal(value);
-
-   if (localVal.getValue() >= LOWER_IMMED && localVal.getValue() <= UPPER_IMMED)
+   if (value >= LOWER_IMMED && value <= UPPER_IMMED)
       {
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, srcReg, localVal.getValue());
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, srcReg, value);
       }
    else
       {
-      int32_t upperLit = localVal.getHighBitsSigned();
-      int32_t lowerLit = localVal.getLowBitsSigned();
-      if (lowerLit < 0)
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, (int16_t)HI_VALUE(value));
+
+      if (value & 0xFFFF)
          {
-         upperLit++;
-         if (upperLit == 0x8000)
-            upperLit = -upperLit;
-         }
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, upperLit);
-      if (lowerLit != 0)
-         {
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, lowerLit);
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, trgReg, trgReg, LO_VALUE(value));
          }
       }
    return trgReg;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3239,7 +3239,15 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
          self()->itemTracking(offset, label);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), (int16_t)self()->hiValue(offset));
+            if (0x00008000 == self()->hiValue(offset))
+               {
+               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), 0x7FFF);
+               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, trgReg, 0x1);
+               }
+            else
+               {
+               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
+               }
             generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
             }
          else
@@ -3600,7 +3608,15 @@ TR::Register *addConstantToInteger(TR::Node * node, TR::Register *trgReg, TR::Re
       }
    else
       {
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, (int16_t)HI_VALUE(value));
+      if (0x00008000 == HI_VALUE(value))
+         {
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, 0x7FFF);
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, trgReg, 0x1);
+         }
+      else
+         {
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, srcReg, HI_VALUE(value));
+         }
 
       if (value & 0xFFFF)
          {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3239,7 +3239,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
          self()->itemTracking(offset, label);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            TR_ASSERT_FATAL(0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
             generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
             }

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -319,10 +319,9 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, intptr_t amount, 
       intptr_t     upper, lower;
 
       self()->setOffset(0);
-      lower = (intptr_t)(int16_t)displacement;
-      upper = displacement >> 16;
-      if (lower < 0)
-         upper++;
+      lower = (intptr_t)LO_VALUE(displacement);
+      upper = HI_VALUE(displacement);
+
       if (_baseRegister!=NULL && self()->isBaseModifiable())
          newBase = _baseRegister;
       else
@@ -355,7 +354,8 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, intptr_t amount, 
                cg->stopUsingRegister(tempReg);
                }
             else
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, newBase, _baseRegister, upper);
+               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, newBase, _baseRegister, (int16_t)upper);
+
             if (lower != 0)
                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, newBase, newBase, lower);
             }
@@ -1624,7 +1624,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          }
 
       self()->setBaseModifiable();
-      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, reg, cg->hiValue(addr));
+      rel1 = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, reg, (int16_t)cg->hiValue(addr));
       self()->addToOffset(node, LO_VALUE(addr), cg);
 
       if (cg->needClassAndMethodPointerRelocations())

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5181,8 +5181,8 @@ static TR::Register *inlineSimpleAtomicUpdate(TR::Node *node, bool isAddOp, bool
           && !deltaChild->getRegister()
           && (deltaChild->getDataType() == TR::Int32
                  || (deltaChild->getDataType() == TR::Int64
-                        && deltaChild->getLongInt() <= INT32_MAX
-                        && deltaChild->getLongInt() >= INT32_MIN)))
+                        && deltaChild->getLongInt() <= 0x000000007FFFFFFFL
+                        && deltaChild->getLongInt() >= 0xFFFFFFFF80000000L)))
       {
       const int64_t deltaLong = (deltaChild->getDataType() == TR::Int64)
                                    ? deltaChild->getLongInt()

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5173,8 +5173,8 @@ static TR::Register *inlineSimpleAtomicUpdate(TR::Node *node, bool isAddOp, bool
           && !deltaChild->getRegister()
           && (deltaChild->getDataType() == TR::Int32
                  || (deltaChild->getDataType() == TR::Int64
-                        && deltaChild->getLongInt() <= UPPER_IMMED
-                        && deltaChild->getLongInt() >= LOWER_IMMED)))
+                        && deltaChild->getLongInt() <= INT32_MAX
+                        && deltaChild->getLongInt() >= INT32_MIN)))
       {
       const int64_t deltaLong = (deltaChild->getDataType() == TR::Int64)
                                    ? deltaChild->getLongInt()

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -227,7 +227,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
       TR_PPCTableOfConstants::setTOCSlot(offset, value);
       if (offset < LOWER_IMMED || offset > UPPER_IMMED)
          {
-         cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), cg->hiValue(offset), cursor);
+         cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset), cursor);
          cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, trgReg, new (cg->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, cg), cursor);
          }
       else
@@ -310,22 +310,22 @@ TR::Instruction *fixedSeqMemAccess(TR::CodeGenerator *cg, TR::Node *node, intptr
 
    if (cg->comp()->target().is32Bit())
       {
-      nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, hiAddr, cursor);
+      nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, (int16_t)hiAddr, cursor);
       idx = 1;
       }
    else
       {
       if (tempReg == NULL)
          {
-         nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, hiAddr>>32, cursor);
+         nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, (int16_t)(hiAddr>>32), cursor);
          nibbles[1] = cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ori, node, baseReg, baseReg, (hiAddr>>16)&0x0000FFFF, cursor);
          cursor = generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldicr, node, baseReg, baseReg, 32, CONSTANT64(0xFFFFFFFF00000000), cursor);
          nibbles[2] = cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::oris, node, baseReg, baseReg, hiAddr&0x0000FFFF, cursor);
          }
       else
          {
-         nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, tempReg, hiAddr>>32, cursor);
-         nibbles[2] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, hiAddr&0x0000FFFF, cursor);
+         nibbles[0] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, tempReg, (int16_t)(hiAddr>>32), cursor);
+         nibbles[2] = cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::lis, node, baseReg, (int16_t)hiAddr, cursor);
          nibbles[1] = cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ori, node, tempReg, tempReg, (hiAddr>>16)&0x0000FFFF, cursor);
          cursor = generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldimi, node, baseReg, tempReg, 32, CONSTANT64(0xFFFFFFFF00000000), cursor);
          }
@@ -5188,9 +5188,7 @@ static TR::Register *inlineSimpleAtomicUpdate(TR::Node *node, bool isAddOp, bool
          // avoid evaluating immediates for add operations
          isDeltaImmediate = true;
          }
-      else if (deltaLong & 0xFFFF == 0
-                  && ((deltaLong >> 32) == -1
-                         || (deltaLong >> 32) == 0))
+      else if ((delta == deltaLong) && (0 == (deltaLong & 0xFFFF)))
          {
          // avoid evaluating shifted immediates for add operations
          isDeltaImmediate = true;
@@ -5233,14 +5231,11 @@ static TR::Register *inlineSimpleAtomicUpdate(TR::Node *node, bool isAddOp, bool
       newValueReg = cg->allocateRegister();
 
       if (isDeltaImmediateShifted)
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node,
-               newValueReg, oldValueReg, ((delta & 0xFFFF0000) >> 16));
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, newValueReg, oldValueReg, delta >> 16);
       else if (isDeltaImmediate)
-         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node,
-               newValueReg, oldValueReg, delta);
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, newValueReg, oldValueReg, delta);
       else
-         generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, newValueReg,
-               oldValueReg, deltaReg);
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, newValueReg, oldValueReg, deltaReg);
       }
    else
       {
@@ -5484,8 +5479,8 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
                   }
                else
                   {
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), ((offset>>16) + ((offset & (1<<15))?1:0)) & 0x0000ffff);
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, resultReg, resultReg, offset & 0x0000ffff);
+                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), (int16_t)HI_VALUE(offset));
+                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, resultReg, resultReg, LO_VALUE(offset));
                   }
                }
            }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -227,7 +227,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
       TR_PPCTableOfConstants::setTOCSlot(offset, value);
       if (offset < LOWER_IMMED || offset > UPPER_IMMED)
          {
-         TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+         TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
          cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), cg->hiValue(offset), cursor);
          cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, trgReg, new (cg->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, cg), cursor);
          }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -227,7 +227,15 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
       TR_PPCTableOfConstants::setTOCSlot(offset, value);
       if (offset < LOWER_IMMED || offset > UPPER_IMMED)
          {
-         cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), (int16_t)cg->hiValue(offset), cursor);
+         if (0x00008000 == cg->hiValue(offset))
+            {
+            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), 0x7FFF, cursor);
+            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, trgReg, 0x1, cursor);
+            }
+         else
+            {
+            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), cg->hiValue(offset), cursor);
+            }
          cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, trgReg, new (cg->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, cg), cursor);
          }
       else
@@ -5479,7 +5487,15 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
                   }
                else
                   {
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), (int16_t)HI_VALUE(offset));
+                  if (0x00008000 == HI_VALUE(offset))
+                     {
+                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), 0x7FFF);
+                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, resultReg, 0x1);
+                     }
+                  else
+                     {
+                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), HI_VALUE(offset));
+                     }
                   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, resultReg, resultReg, LO_VALUE(offset));
                   }
                }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -227,15 +227,8 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
       TR_PPCTableOfConstants::setTOCSlot(offset, value);
       if (offset < LOWER_IMMED || offset > UPPER_IMMED)
          {
-         if (0x00008000 == cg->hiValue(offset))
-            {
-            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), 0x7FFF, cursor);
-            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, trgReg, 0x1, cursor);
-            }
-         else
-            {
-            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), cg->hiValue(offset), cursor);
-            }
+         TR_ASSERT_FATAL(0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+         cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, trgReg, cg->getTOCBaseRegister(), cg->hiValue(offset), cursor);
          cursor = generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, trgReg, new (cg->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, cg), cursor);
          }
       else


### PR DESCRIPTION
addis and lis accept a signed 16 bit value as an immediate. They are passed
into generateTrg1Src1ImmInstruction as signed 32 bit values. In some edge
cases, the sign extension was not handled properly. In most cases this was due
to the value being incremented after sign extension. In other cases it was due
to an unnecessary mask clearing the upper 16 bits.

Also fixed an issue in inlineSimpleAtomicUpdate where the check for whether a
value stored as a signed 64 bit could fit in a signed 32 bit was incorrect.

Closes: #5212
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>