### PR TITLE
Fix typo in NodePool::removeDeadNodes

### DIFF
--- a/compiler/il/NodePool.cpp
+++ b/compiler/il/NodePool.cpp
@@ -87,7 +87,7 @@ TR::NodePool::removeDeadNodes()
        return false;
       }
 
-   TR_ASSERT(false, "Node garbage colleciotn is not currently implemented");
+   TR_ASSERT(false, "Node garbage collection is not currently implemented");
 
    return false;
    }


### PR DESCRIPTION
error message mispelt collection as colleciotn

Signed-off-by: Austin Wells <austin.wells@mail.utoronto.ca>