### PR TITLE
AArch64: Make getRegisterName() support NoReg

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1323,6 +1323,7 @@ getRegisterName(TR::RealRegister::RegNum num, bool is64bit)
    {
    switch (num)
       {
+      case TR::RealRegister::NoReg: return "NoReg";
       case TR::RealRegister::x0: return (is64bit ? "x0" : "w0");
       case TR::RealRegister::x1: return (is64bit ? "x1" : "w1");
       case TR::RealRegister::x2: return (is64bit ? "x2" : "w2");


### PR DESCRIPTION
This commit changes `getRegisterName()` in `ARM64Debug.cpp`
to support `NoReg`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>