### PR TITLE
Changes in RegDepCopyRemoval for splitPostGRA block splitter

### DIFF
--- a/compiler/optimizer/RegDepCopyRemoval.hpp
+++ b/compiler/optimizer/RegDepCopyRemoval.hpp
@@ -97,6 +97,7 @@ class RegDepCopyRemoval : public TR::Optimization
       {
       TR::Node *original;
       TR::Node *selected;
+      TR::Node *regStoreNode;
       };
 
    const char *registerName(TR_GlobalRegisterNumber reg);
@@ -106,6 +107,7 @@ class RegDepCopyRemoval : public TR::Optimization
 
    void discardAllNodeChoices();
    void discardNodeChoice(TR_GlobalRegisterNumber reg);
+   void clearNodeChoice(TR_GlobalRegisterNumber reg);
    void rememberNodeChoice(TR_GlobalRegisterNumber reg, TR::Node *selected);
 
    void processRegDeps(TR::Node *deps, TR::TreeTop *depTT);

--- a/compiler/ras/ILValidationRules.cpp
+++ b/compiler/ras/ILValidationRules.cpp
@@ -446,6 +446,19 @@ void TR::ValidateChildTypes::validate(TR::Node *node)
          auto childOpcode = node->getChild(i)->getOpCode();
          if (childOpcode.getOpCodeValue() != TR::GlRegDeps)
             {
+            /**
+             * It is possible that a PassThrough is set as child of a node, which
+             * is not real child. We need to traverse through child of PassThrough
+             * till we get the real child to validate.
+             */
+            if (opcode.isStoreReg() && childOpcode.getOpCodeValue() == TR::PassThrough)
+               {
+               TR::Node *childNode = node->getChild(i);
+               while (childNode->getOpCodeValue() == TR::PassThrough)
+                  childNode = childNode->getFirstChild();
+               childOpcode = childNode->getOpCode();
+               }
+
             const auto expChildType = opcode.expectedChildType(i);
             const auto actChildType = childOpcode.getDataType().getDataType();
             const auto expChildTypeName = (expChildType >= TR::NumTypes) ?


### PR DESCRIPTION
RegDepCopyRemoval is the last ran optimization which intends to reduce register shuffling due to global register dependencies. It was generating tree where we have a PassThrough Child under PassThrough to copy node to new virtual register. This tree was not working well with the post GRA block splitter. Issue was that PassThrough child encountered in GlRegDeps was anchored to tree top. In postGRA block splitter, it records the regStores encountered before the GlRegDeps in extended basic block to guide decision on which register to chose for the node after split point.In this commit, adding changes to both splitPostGRA block splitter and RegDepCopyRemoval optimization so that we can split the blocks after later has run.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>