### PR TITLE
Move code out of ~TR_OutlinedInstructionsGenerator(), preventing it from throwing

### DIFF
--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -428,6 +428,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
          TR_OutlinedInstructionsGenerator og(slowPathLabel, node, cg);
          generateRegImm64Instruction(MOV8RegImm64, node, treg, DOUBLE_NAN, cg);
          generateLabelInstruction(JMP4, node, endLabel, cg);
+         og.endOutlinedInstructionSequence();
          }
 
          // Merge point

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1466,6 +1466,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
                                 cg);
 
       generateLabelInstruction(JMP4, node, endLabel, cg);
+      og.endOutlinedInstructionSequence();
       }
 
       generateLabelInstruction(LABEL, node, endLabel, deps, cg);
@@ -1793,6 +1794,7 @@ TR::Register *OMR::X86::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Code
          TR_OutlinedInstructionsGenerator og(slowPathLabel, node, cg);
          generateRegImmInstruction( MOV4RegImm4, node, treg, FLOAT_NAN, cg);
          generateLabelInstruction(  JMP4,        node, endLabel,        cg);
+         og.endOutlinedInstructionSequence();
          }
 
          // Merge point

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1796,6 +1796,7 @@ static void arrayCopy16BitPrimitive(TR::Node* node, TR::Register* dstReg, TR::Re
       generateRepMovsInstruction(REPMOVSW, node, sizeReg, NULL, cg);
       generateInstruction(CLD, node, cg);
       generateLabelInstruction(JMP4, node, mainEndLabel, cg);
+      og.endOutlinedInstructionSequence();
       }
       }
    generateLabelInstruction(LABEL, node, mainEndLabel, dependencies, cg);
@@ -1876,6 +1877,7 @@ static void arrayCopyDefault(TR::Node* node, uint8_t elementSize, TR::Register* 
       generateRepMovsInstruction(repmovs, node, sizeReg, NULL, cg);
       generateInstruction(CLD, node, cg);
       generateLabelInstruction(JMP4, node, mainEndLabel, cg);
+      og.endOutlinedInstructionSequence();
       }
 
       generateLabelInstruction(LABEL, node, mainEndLabel, dependencies, cg);

--- a/compiler/x/codegen/OutlinedInstructions.cpp
+++ b/compiler/x/codegen/OutlinedInstructions.cpp
@@ -371,6 +371,7 @@ TR::Node *TR_OutlinedInstructions::createOutlinedCallNode(TR::Node *callNode, TR
    }
 
 TR_OutlinedInstructionsGenerator::TR_OutlinedInstructionsGenerator(TR::LabelSymbol* entryLabel, TR::Node* node, TR::CodeGenerator* cg)
+   : _hasEnded(false)
    {
    _oi = new (cg->trHeapMemory()) TR_OutlinedInstructions(entryLabel, cg);
    _oi->setCallNode(node);
@@ -382,14 +383,15 @@ TR_OutlinedInstructionsGenerator::TR_OutlinedInstructionsGenerator(TR::LabelSymb
 void
 TR_OutlinedInstructionsGenerator::endOutlinedInstructionSequence()
    {
-   /// TODO: Move cleanup code from destrdductor here
+   generateLabelInstruction(LABEL, _oi->_callNode, generateLabelSymbol(_oi->_cg), _oi->_cg);
+   _oi->swapInstructionListsWithCompilation();
+   _hasEnded = true;
    }
 
 TR_OutlinedInstructionsGenerator::~TR_OutlinedInstructionsGenerator()
    {
    if (!std::uncaught_exception())
       {
-      generateLabelInstruction(LABEL, _oi->_callNode, generateLabelSymbol(_oi->_cg), _oi->_cg);
-      _oi->swapInstructionListsWithCompilation();
+      TR_ASSERT_FATAL(_hasEnded, "TR_OutlinedInstructionsGenerator object has gone out of scope before call to endOutlinedInstructionSequence().");
       }
    }

--- a/compiler/x/codegen/OutlinedInstructions.hpp
+++ b/compiler/x/codegen/OutlinedInstructions.hpp
@@ -177,12 +177,6 @@ class TR_OutlinedInstructionsGenerator
     */
    void endOutlinedInstructionSequence();
 
-   /**
-      @brief Obtain the underlying TR_OutlinedInstructions.
-   */
-   inline TR_OutlinedInstructions* obtain()     { return _oi; }
-   inline TR_OutlinedInstructions* operator->() { return obtain(); }
-
    private:
    TR_OutlinedInstructions* _oi;
    bool _hasEnded;

--- a/compiler/x/codegen/OutlinedInstructions.hpp
+++ b/compiler/x/codegen/OutlinedInstructions.hpp
@@ -185,6 +185,7 @@ class TR_OutlinedInstructionsGenerator
 
    private:
    TR_OutlinedInstructions* _oi;
+   bool _hasEnded;
    };
 
 #endif


### PR DESCRIPTION
`TR_OutlinedInstructionsGenerator::endOutlinedInstructionSequence()` can now be safely implemented by taking the code from the class destructor. The destructor will now also assert that `endOutlinedInstructionSequence()` is called when needed.

Closes #4846