### PR TITLE
Remove some statics from z/codegen

### DIFF
--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -387,7 +387,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
    )
    {
    TR::RealRegister * stackPtr = self()->getNormalStackPointerRealRegister();
-   static const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
+   const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
 
    // for XPLink or FASTLINK, there are cases where the "normal" stack pointer is
    // not appropriate for where to save arguments in registers.
@@ -1952,7 +1952,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
    TR::DataType resType = callNode->getType();
    TR::DataType resDataType = resType.getDataType();
 
-   static const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
+   const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
 
 
    //Not kill special registers

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1611,7 +1611,6 @@ bool OMR::Z::MemoryReference::tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node*
    bool debug = false;
    TR::Register* breg = NULL;
    TR::Register* ireg= NULL;
-   static int folded = 0;
 
    // From here, down, stack memory allocations will expire / die when the function returns
    TR::StackMemoryRegion stackMemoryRegion(*cg->trMemory());
@@ -1698,7 +1697,6 @@ bool OMR::Z::MemoryReference::tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node*
       if (sub)
          traceMsg(comp, "&&& TBID sub rc %d\n", sub->getReferenceCount());
       traceMsg(comp, "&&& TBID index rc %d\n", index->getReferenceCount());
-      traceMsg(comp, "&&& TBID folded %d\n", ++folded);
       }
 
    self()->setBaseRegister(breg, cg);

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1232,23 +1232,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RILInstruction * instr)
    trfflush(pOutFile);
    }
 
-static char *
-bitString(int8_t val)
-   {
-   static char bits[16][5] =
-      {
-      "0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111", "1000", "1001", "1010", "1011", "1100", "1101", "1110", "1111"
-      };
-   if (val > 15 || val < 0)
-      {
-      return "????";
-      }
-   else
-      {
-      return bits[val];
-      }
-   }
-
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RSLInstruction * instr)
    {


### PR DESCRIPTION
Downstream projects such an OpenJ9's JITServer
cannot operate correctly if certain fields are static.
This is because the JITServer can talk to multiple
JVM clients such that the static field's value on the JITServer
side is no longer valid for all client JVMs. This commit
removes those problematic statics.

An unused function is also removed.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>