### PR TITLE
CMake: Ensure that ddrgen is run as part of CI builds

### DIFF
--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -63,6 +63,8 @@ function(make_ddr_set set_name)
 	set_property(TARGET "${DDR_TARGET_NAME}" PROPERTY DDR_BIN_DIR "${DDR_BIN_DIR}")
 	set_property(TARGET "${DDR_TARGET_NAME}" PROPERTY DDR_SET TRUE)
 
+	add_dependencies(${DDR_TARGET_NAME} omr_ddrgen)
+
 	file(READ ${OMR_MODULES_DIR}/ddr/DDRSetStub.cmake.in cmakelist_template)
 	string(CONFIGURE "${cmakelist_template}" cmakelist_template @ONLY)
 	file(GENERATE OUTPUT ${DDR_BIN_DIR}/CMakeLists.txt CONTENT "${cmakelist_template}")

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -23,6 +23,9 @@ set(OMR_WARNING_AS_ERROR_FLAG -Werror)
 
 set(OMR_ENHANCED_WARNING_FLAG -Wall)
 
+set(OMR_DEBUG_COMPILE_FLAG "-g")
+set(OMR_DEBUG_LINK_FLAG)
+
 # disable builtin strncpy buffer length check for components that use variable length
 # array fields at the end of structs
 set(OMR_STRNCPY_FORTIFY_OPTIONS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1)

--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,8 @@ include(OmrUtility)
 set(OMR_WARNING_AS_ERROR_FLAG /WX)
 
 set(OMR_ENHANCED_WARNING_FLAG /W3)
+set(OMR_DEBUG_COMPILE_FLAG "/Zi")
+set(OMR_DEBUG_LINK_FLAG "/debug")
 
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
 	/GR-    # Disable RTTI

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -19,6 +19,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+set(OMR_DEBUG_COMPILE_FLAG "-g")
+set(OMR_DEBUG_LINK_FLAG)
+
 if(OMR_HOST_ARCH STREQUAL "ppc")
 	set(OMR_WARNING_AS_ERROR_FLAG -qhalt=w)
 

--- a/ddr/CMakeLists.txt
+++ b/ddr/CMakeLists.txt
@@ -37,4 +37,7 @@ target_include_directories(omr_ddr_base
 
 add_subdirectory(lib)
 add_subdirectory(tools)
-add_subdirectory(test)
+
+if(OMR_FVTEST)
+	add_subdirectory(test)
+endif()

--- a/ddr/test/CMakeLists.txt
+++ b/ddr/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,12 @@
 
 include(OmrDDRSupport)
 
+# We need to make sure that ddrgentest is built with debug info
+# regardless of our global compile flags
+omr_append_flags(CMAKE_C_FLAGS ${OMR_DEBUG_COMPILE_FLAG})
+omr_append_flags(CMAKE_CXX_FLAGS ${OMR_DEBUG_COMPILE_FLAG})
+omr_append_flags(CMAKE_EXE_LINKER_FLAGS ${OMR_DEBUG_LINK_FLAG})
+
 add_executable(ddrgentest
     test_subdir/testFileInSubDir.cpp
     sample1.cpp
@@ -31,5 +37,11 @@ add_executable(ddrgentest
 )
 
 make_ddr_set(ddr_testset)
+set_target_properties(ddr_testset PROPERTIES
+    BLOB ${CMAKE_CURRENT_BINARY_DIR}/blob.dat
+    SUPERSET ${CMAKE_CURRENT_BINARY_DIR}/superset.dat
+    BLACKLIST ${CMAKE_CURRENT_SOURCE_DIR}/blacklist
+    EXCLUDE_FROM_ALL FALSE
+)
 target_enable_ddr(ddrgentest GLOB_HEADERS_RECURSIVE)
 ddr_set_add_targets(ddr_testset ddrgentest)


### PR DESCRIPTION
While we don't have automated tests to ensure that the output is correct,
we can at least make sure that ddrgen is capable of running without error.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>