### PR TITLE
AArch64: Enable bcmp*, bucmp*, scmp* and sucmp* evaluators

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -348,60 +348,70 @@ static TR::Register *icmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
    return trgReg;
    }
 
+// also handles bcmpeq, bucmpeq, scmpeq, sucmpeq
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_EQ, false, cg);
    }
 
+// also handles bcmpne, bucmpne, scmpne, sucmpne
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_NE, false, cg);
    }
 
+// also handles bcmplt, scmplt
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_LT, false, cg);
    }
 
+// also handles bcmple, scmple
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_LE, false, cg);
    }
 
+// also handles bcmpge, scmpge
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_GE, false, cg);
    }
 
+// also handles bcmpgt, scmpgt
 TR::Register *
 OMR::ARM64::TreeEvaluator::icmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_GT, false, cg);
    }
 
+// also handles bucmplt, sucmplt
 TR::Register *
 OMR::ARM64::TreeEvaluator::iucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_CC, false, cg);
    }
 
+// also handles bucmple, sucmple
 TR::Register *
 OMR::ARM64::TreeEvaluator::iucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_LS, false, cg);
    }
 
+// also handles bucmpge, sucmpge
 TR::Register *
 OMR::ARM64::TreeEvaluator::iucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return icmpHelper(node, TR::CC_CS, false, cg);
    }
 
+// also handles bucmpgt, sucmpgt
 TR::Register *
 OMR::ARM64::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -283,30 +283,30 @@
     TR::TreeEvaluator::lucmpgeEvaluator , // TR::acmpge		// address compare if greater than or equal
     TR::TreeEvaluator::lucmpgtEvaluator , // TR::acmpgt		// address compare if greater than
     TR::TreeEvaluator::lucmpleEvaluator , // TR::acmple		// address compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpeqEvaluator ,	// TR::bcmpeq		// byte compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpneEvaluator ,	// TR::bcmpne		// byte compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpltEvaluator ,	// TR::bcmplt		// byte compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpgeEvaluator ,	// TR::bcmpge		// byte compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpgtEvaluator ,	// TR::bcmpgt		// byte compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bcmpleEvaluator ,	// TR::bcmple		// byte compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpeqEvaluator ,	// TR::bucmpeq		// unsigned byte compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpneEvaluator ,	// TR::bucmpne		// unsigned byte compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpltEvaluator ,	// TR::bucmplt		// unsigned byte compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpgeEvaluator ,	// TR::bucmpge		// unsigned byte compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpgtEvaluator ,	// TR::bucmpgt		// unsigned byte compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bucmpleEvaluator ,	// TR::bucmple		// unsigned byte compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpeqEvaluator ,	// TR::scmpeq		// short integer compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpneEvaluator ,	// TR::scmpne		// short integer compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpltEvaluator ,	// TR::scmplt		// short integer compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpgeEvaluator ,	// TR::scmpge		// short integer compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpgtEvaluator ,	// TR::scmpgt		// short integer compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::scmpleEvaluator ,	// TR::scmple		// short integer compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpeqEvaluator ,	// TR::sucmpeq		// char compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpneEvaluator ,	// TR::sucmpne		// char compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpltEvaluator ,	// TR::sucmplt		// char compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpgeEvaluator ,	// TR::sucmpge		// char compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpgtEvaluator ,	// TR::sucmpgt		// char compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sucmpleEvaluator ,	// TR::sucmple		// char compare if less than or equal
+    TR::TreeEvaluator::icmpeqEvaluator, // TR::bcmpeq		// byte compare if equal
+    TR::TreeEvaluator::icmpneEvaluator, // TR::bcmpne		// byte compare if not equal
+    TR::TreeEvaluator::icmpltEvaluator, // TR::bcmplt		// byte compare if less than
+    TR::TreeEvaluator::icmpgeEvaluator, // TR::bcmpge		// byte compare if greater than or equal
+    TR::TreeEvaluator::icmpgtEvaluator, // TR::bcmpgt		// byte compare if greater than
+    TR::TreeEvaluator::icmpleEvaluator, // TR::bcmple		// byte compare if less than or equal
+    TR::TreeEvaluator::icmpeqEvaluator, // TR::bucmpeq		// unsigned byte compare if equal
+    TR::TreeEvaluator::icmpneEvaluator, // TR::bucmpne		// unsigned byte compare if not equal
+    TR::TreeEvaluator::iucmpltEvaluator, // TR::bucmplt		// unsigned byte compare if less than
+    TR::TreeEvaluator::iucmpgeEvaluator, // TR::bucmpge		// unsigned byte compare if greater than or equal
+    TR::TreeEvaluator::iucmpgtEvaluator, // TR::bucmpgt		// unsigned byte compare if greater than
+    TR::TreeEvaluator::iucmpleEvaluator, // TR::bucmple		// unsigned byte compare if less than or equal
+    TR::TreeEvaluator::icmpeqEvaluator, // TR::scmpeq		// short integer compare if equal
+    TR::TreeEvaluator::icmpneEvaluator, // TR::scmpne		// short integer compare if not equal
+    TR::TreeEvaluator::icmpltEvaluator, // TR::scmplt		// short integer compare if less than
+    TR::TreeEvaluator::icmpgeEvaluator, // TR::scmpge		// short integer compare if greater than or equal
+    TR::TreeEvaluator::icmpgtEvaluator, // TR::scmpgt		// short integer compare if greater than
+    TR::TreeEvaluator::icmpleEvaluator, // TR::scmple		// short integer compare if less than or equal
+    TR::TreeEvaluator::icmpeqEvaluator, // TR::sucmpeq		// char compare if equal
+    TR::TreeEvaluator::icmpneEvaluator, // TR::sucmpne		// char compare if not equal
+    TR::TreeEvaluator::iucmpltEvaluator, // TR::sucmplt		// char compare if less than
+    TR::TreeEvaluator::iucmpgeEvaluator, // TR::sucmpge		// char compare if greater than or equal
+    TR::TreeEvaluator::iucmpgtEvaluator, // TR::sucmpgt		// char compare if greater than
+    TR::TreeEvaluator::iucmpleEvaluator, // TR::sucmple		// char compare if less than or equal
     TR::TreeEvaluator::lcmpEvaluator, // TR::lcmp		// long compare (1 if child1 > child2; 0 if child1 == child2; -1 if child1 < child2)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmplEvaluator ,	// TR::fcmpl		// float compare l (1 if child1 > child2; 0 if child1 == child2; -1 if child1 < child2 or unordered)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpgEvaluator ,	// TR::fcmpg		// float compare g (1 if child1 > child2 or unordered; 0 if child1 == child2; -1 if child1 < child2)


### PR DESCRIPTION
This commit enables bcmp*, bucmp*, scmp* and sucmp* evaluators for
AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>