### PR TITLE
Remove TR::S390JNICallDataSnippet references

### DIFF
--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -2570,7 +2570,7 @@ void
 OMR::Z::Linkage::performCallNativeFunctionForLinkage(TR::Node * callNode, TR_DispatchType dispatchType, TR::Register * &javaReturnRegister, TR::SystemLinkage * systemLinkage,
       TR::RegisterDependencyConditions * &deps, TR::Register * javaLitOffsetReg, TR::Register * methodAddressReg, bool isJNIGCPoint)
    {
-   TR::S390JNICallDataSnippet * jniCallDataSnippet = NULL;
+   TR::Snippet * callDataSnippet = NULL;
    TR::LabelSymbol * returnFromJNICallLabel = generateLabelSymbol(self()->cg());
    intptr_t targetAddress = (intptr_t) 0;
 
@@ -2583,7 +2583,7 @@ OMR::Z::Linkage::performCallNativeFunctionForLinkage(TR::Node * callNode, TR_Dis
 
    javaReturnRegister = systemLinkage->callNativeFunction(
         callNode, deps, targetAddress, methodAddressReg, javaLitOffsetReg, returnFromJNICallLabel,
-        jniCallDataSnippet, isJNIGCPoint);
+        callDataSnippet, isJNIGCPoint);
    }
 
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -43,7 +43,6 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 
-namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -193,7 +193,7 @@ TR::SystemLinkage::flipBitsRegisterSaveMask(uint16_t mask)
 void
 TR::SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
    TR_ASSERT(0,"Different system types should have their own implementation.");
    }
@@ -205,7 +205,7 @@ TR::SystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::Register
 TR::Register *
 TR::SystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
    return 0;
    }

--- a/compiler/z/codegen/SystemLinkage.hpp
+++ b/compiler/z/codegen/SystemLinkage.hpp
@@ -38,7 +38,6 @@
 #include "infra/Array.hpp"
 #include "infra/Assert.hpp"
 
-namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class Block; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -117,10 +116,10 @@ class SystemLinkage : public TR::Linkage
 
    virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
          intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-         TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+         TR::Snippet * callDataSnippet, bool isJNIGCPoint = true);
 
    virtual TR::Register * callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies,
-      intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet,
+      intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::Snippet * callDataSnippet,
       bool isJNIGCPoint = true);
 
    virtual TR::Register *

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -401,7 +401,7 @@ TR::S390zLinuxSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethod
    }
 
 void
-TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR::RegisterDependencyConditions* deps, intptr_t targetAddress, TR::Register* methodAddressReg, TR::Register* javaLitOffsetReg, TR::LabelSymbol* returnFromJNICallLabel, TR::S390JNICallDataSnippet* jniCallDataSnippet, bool isJNIGCPoint)
+TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR::RegisterDependencyConditions* deps, intptr_t targetAddress, TR::Register* methodAddressReg, TR::Register* javaLitOffsetReg, TR::LabelSymbol* returnFromJNICallLabel, TR::Snippet* callDataSnippet, bool isJNIGCPoint)
    {
    TR::CodeGenerator * codeGen = cg();
 
@@ -444,13 +444,13 @@ TR::Register *
 TR::S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
    TR::RegisterDependencyConditions * deps, intptr_t targetAddress,
    TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-   TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+   TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
    /********************************/
    /***Generate call instructions***/
    /********************************/
    generateInstructionsForCall(callNode, deps, targetAddress, methodAddressReg,
-         javaLitOffsetReg, returnFromJNICallLabel, jniCallDataSnippet,isJNIGCPoint);
+         javaLitOffsetReg, returnFromJNICallLabel, callDataSnippet,isJNIGCPoint);
 
    TR::Register * returnRegister = NULL;
    // set dependency on return register

--- a/compiler/z/codegen/SystemLinkageLinux.hpp
+++ b/compiler/z/codegen/SystemLinkageLinux.hpp
@@ -38,7 +38,6 @@
 class TR_EntryPoint;
 class TR_zOSGlobalCompilationInfo;
 namespace TR { class S390ConstantDataSnippet; }
-namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -63,8 +62,8 @@ class S390zLinuxSystemLinkage : public TR::SystemLinkage
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method);
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol>&parmList);
 
-   virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint);
-   virtual TR::Register* callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+   virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::Snippet * callDataSnippet, bool isJNIGCPoint);
+   virtual TR::Register* callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::Snippet * callDataSnippet, bool isJNIGCPoint = true);
 
    virtual int32_t getRegisterSaveOffset(TR::RealRegister::RegNum);
    virtual void initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList=0);

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -394,14 +394,14 @@ TR::S390zOSSystemLinkage::getOutgoingParameterBlockSize()
 TR::Register *
 TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
 
    /*****************************/
    /***Front-end customization***/
    /*****************************/
    generateInstructionsForCall(callNode, deps, targetAddress, methodAddressReg,
-         javaLitOffsetReg, returnFromJNICallLabel, jniCallDataSnippet, isJNIGCPoint);
+         javaLitOffsetReg, returnFromJNICallLabel, callDataSnippet, isJNIGCPoint);
 
    TR::CodeGenerator * codeGen = cg();
 
@@ -526,7 +526,7 @@ TR::S390zOSSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
 void
 TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * deps, intptr_t targetAddress,
       TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel,
-      TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint)
+      TR::Snippet * callDataSnippet, bool isJNIGCPoint)
    {
     // WCode specific
     //

--- a/compiler/z/codegen/SystemLinkagezOS.hpp
+++ b/compiler/z/codegen/SystemLinkagezOS.hpp
@@ -40,7 +40,6 @@
 class TR_EntryPoint;
 class TR_zOSGlobalCompilationInfo;
 namespace TR { class S390ConstantDataSnippet; }
-namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
@@ -139,9 +138,9 @@ class S390zOSSystemLinkage : public TR::SystemLinkage
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * method);
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol>&parmList);
 
-   virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+   virtual void generateInstructionsForCall(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::Snippet * callDataSnippet, bool isJNIGCPoint = true);
 
-   virtual TR::Register* callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::S390JNICallDataSnippet * jniCallDataSnippet, bool isJNIGCPoint = true);
+   virtual TR::Register* callNativeFunction(TR::Node * callNode, TR::RegisterDependencyConditions * dependencies, intptr_t targetAddress, TR::Register * methodAddressReg, TR::Register * javaLitOffsetReg, TR::LabelSymbol * returnFromJNICallLabel, TR::Snippet * callDataSnippet, bool isJNIGCPoint = true);
 
    virtual TR::RealRegister::RegNum getENVPointerRegister();
    virtual TR::RealRegister::RegNum getCAAPointerRegister();


### PR DESCRIPTION
This commit removes references to the S390JNICallDataSnippet
class in OMR. This is in preparation to move the class down
to OpenJ9 as it doesn't belong in OMR.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>