### PR TITLE
Upgrade stale GitHub Action to v3.0.0

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,13 +1,13 @@
 name: "Mark/Close Stale Issues/PRs"
 on:
   schedule:
-  - cron: "* */1 * * *"
+  - cron: "0 13 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1.1.0
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: |-


### PR DESCRIPTION
Apparently v1.1.0 does not support `exempt-issue-labels` option, even
though the release page [1] says it does. Upgrade to v3.0.0 and set the
cron job to run only once per day so we can evaluate whether the issue
is fixed.

[1] https://github.com/actions/stale/releases/tag/v1.1.0

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>