### PR TITLE
Fix warning in port linux/omrosdump_helpers.c

### DIFF
--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -973,14 +973,14 @@ getSharedAndPrivateDataSegments(struct OMRPortLibrary *portLibrary, intptr_t fd,
 
 						/* get the offset */
 						next++;
-						strtoull(next, &next, 16);
+						J9_IGNORE_RETURNVAL(strtoull(next, &next, 16));
 
 						/* skip over the device */
 						next += 5;
 
 						/* get the inode */
 						next++;
-						strtoull(next, &next, 10);
+						J9_IGNORE_RETURNVAL(strtoull(next, &next, 10));
 
 						/* get the path */
 						while (isspace(*next)) {


### PR DESCRIPTION
Some versions of glibc generate warnings about ignoring the return
value of strtoull. Its not important here as we are just strtoull
to advance the string pointer.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>