### PR TITLE
Upgrade first-interaction to 0.2.0 and decrease cron to every 30 minutes

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,13 +1,13 @@
 name: "First Time Contributor"
 on:
   schedule:
-  - cron: "*/5 * * * *"
+  - cron: "*/30 * * * *"
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: fjeremic/cron-first-interaction@0.1.0
+    - uses: fjeremic/cron-first-interaction@0.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         pr-message: |-


### PR DESCRIPTION
Upgrade the cron-first-interaction GitHub Action to version 0.2.0 [1].
This release improves the query for whether a PRs is a particular users
first PR. The problem with version 0.1.0 is that the action only
fetched the default number of issues per query, which ends up being 25
issues.

The problem we ran into at OMR is that due to the limitation of the
octokit API in that there is no way to filter only PRs by author [2],
we have to resort to fetching both issues and PRs, as that allows for
filtering. Now we only filtered by author, and according to [3] that
defaults to fetching issues and PRs sorted by date created in
descending order, meaning most recent first.

Now the issue arises for contributors in OMR that have very old PRs
open. One example can be seen in [4] by @wbh123456 where the bot marked
several of his PRs as first contributions incorrectly, even though he
has contributed to the repository many times previously.

The reason this happened is precisely because of the problem explained
above. The bot fetched all of his issues and PRs filtered by his
username as the creator [5], and then it compared the current PR number
it is examining against the list returned. If we check [4] vs. [5] we
will note that all PR numbers 4113, 4012, 3935 are all less than any
other issue or PR number seen in the list in [5]. So the bot determined
that the PR it was examining was a first contribution.

There are two fixes in version 0.2.0 to handle this case. The first is
to change how the list of issues and PRs is fetched. We now sort by
date created in ascending order and we increase the number of issues we
fetch to the maximum of 100 possible. The second change introduces a
conservative bailout that if a user has created at least 10 issues or
PRs within the repo it assumes the user is NOT a first contributor.
This is conservative, even though it may not be true as it is better to
miss a user (for example someone who creates 12 issues before opening
up their first PR) than to incorrectly start flagging PRs.

[1] https://github.com/fjeremic/cron-first-interaction/releases/tag/0.2.0
[2] https://octokit.github.io/rest.js/v17#issues-list-for-repo
[3] https://developer.github.com/v3/issues/#list-repository-issues
[4] https://github.com/eclipse/omr/pulls?q=author%3Awbh123456+sort%3Aupdated-desc+label%3A%22first+contribution%22+
[5] https://github.com/eclipse/omr/pulls?q=author%3Awbh123456

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>