### PR TITLE
Disable TM by default on POWER

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -747,6 +747,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableSymbolValidationManager",      "M\tEnable Symbol Validation Manager for Relocatable Compile Validations", SET_OPTION_BIT(TR_EnableSymbolValidationManager), "F"},
    {"enableTailCallOpt",                  "R\tenable tall call optimization in peephole", SET_OPTION_BIT(TR_EnableTailCallOpt), "F"},
    {"enableThisLiveRangeExtension",       "R\tenable this live range extesion to the end of the method", SET_OPTION_BIT(TR_EnableThisLiveRangeExtension), "F"},
+   {"enableTM",                           "O\tenable transactional memory support", SET_OPTION_BIT(TR_EnableTM), "F"},
    {"enableTraps",                        "C\tenable trap instructions",                     RESET_OPTION_BIT(TR_DisableTraps), "F"},
    {"enableTreePatternMatching",          "O\tEnable opts that use the TR_Pattern framework", RESET_OPTION_BIT(TR_DisableTreePatternMatching), "F"},
    {"enableUpgradesByJitSamplingWhenHWProfilingEnabled", "O\tAllow Jit Sampling to upgrade cold compilations when HW Profiling is on",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -345,7 +345,7 @@ enum TR_CompilationOptions
    TR_DisableSelectiveNoOptServer         = 0x00020000 + 8,
    TR_DisableStripMining                  = 0x00040000 + 8,
    TR_EnableSharedCacheTiming             = 0x00080000 + 8,
-   // Available                           = 0x00100000 + 8,
+   TR_EnableTM                            = 0x00100000 + 8,
    // Available                           = 0x00200000 + 8,
    TR_NoOptServer                         = 0x00400000 + 8,
    TR_DisableDLTrecompilationPrevention   = 0x00800000 + 8,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -279,8 +279,10 @@ OMR::Power::CodeGenerator::CodeGenerator() :
 
    /*
     * TODO: TM is currently not compatible with read barriers. If read barriers are required, TM is disabled until the issue is fixed.
+    *       TM is now disabled by default, due to various reasons (OS, hardware, etc), unless it is explicitly enabled.
     */
-   if (self()->comp()->target().cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM) && TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
+   if (self()->comp()->target().cpu.getPPCSupportsTM() && self()->comp()->getOption(TR_EnableTM) &&
+       !self()->comp()->getOption(TR_DisableTM) && TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
       self()->setSupportsTM();
 
    if (self()->comp()->target().cpu.getPPCSupportsVMX() && self()->comp()->target().cpu.getPPCSupportsVSX())


### PR DESCRIPTION
Due to various reasons:

    It never gave tangible performance benefit anyway. except for construed micro-benchmark scenario;
    RHEL8 is buggy on TM. We don't want to see PMRs pouring in because of it. We already spent quite some resources on investigating weird crashes because of it (two PMRs and one internal performance testing).

    Plus, TM is likely transforming into a totally new architecture on future POWER hardwares. POWER10 implementation is quite less ambitious.

Closes: #4231

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>