### PR TITLE
Disable stale issue marker until upstream issue is resolved

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,3 +19,4 @@ jobs:
         exempt-issue-labels: 'backlog'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        debug-only: true


### PR DESCRIPTION
There was a bug in the official implementation caught when the stale
issue action ran on the OMR repo. I have investigated the issue and
submitted a fix in [1], however I'm unsure of when that change will
land into the official repo. Until then we disable the stale issue
marker and run it under debug mode only which will print out all the
actions it is about to do without actually doing them.

Following this change and the upstream fix I'll be able to monitor the
debug output to ensure the action is correctly functioning, at which
point we can enable it again.

[1] https://github.com/actions/stale/pull/85

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>