### PR TITLE
OSX libraries should have a version, set 1.0.0

### DIFF
--- a/omrmakefiles/rules.osx.mk
+++ b/omrmakefiles/rules.osx.mk
@@ -77,7 +77,7 @@ endif
 ###
 
 ifneq (,$(findstring shared,$(ARTIFACT_TYPE)))
-  GLOBAL_LDFLAGS+=-shared
+  GLOBAL_LDFLAGS+=-shared -compatibility_version 1.0.0 -current_version 1.0.0
   GLOBAL_SHARED_LIBS+=c m dl
 
   ## Export File


### PR DESCRIPTION
Previously the version was 0.0.0

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>