### PR TITLE
CMake: Move a number of functions to OmrTargetSupport.cmake

### DIFF
--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -28,9 +28,6 @@ include(OmrAssert)
 include(OmrDetectSystemInformation)
 include(OmrUtility)
 
-###
-### Platform flags
-### TODO: arch flags. Defaulting to x86-64
 
 omr_detect_system_information()
 
@@ -111,76 +108,3 @@ macro(omr_platform_global_setup)
 		omr_toolconfig_global_setup()
 	endif()
 endmacro()
-
-# omr_process_exports(<target> [symbol]...)
-# Performs appropriate processing to export symbols from a target.
-# Note: function is internaly guarded, so its safe to call multiple times.
-function(omr_process_exports target)
-	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_process_exports called on invalid target '${target}'")
-
-	# Check if we have already processed the exports.
-	get_target_property(has_processed ${target} OMR_EXPORTS_PROCESSED)
-
-	if((NOT has_processed) AND (COMMAND _omr_toolchain_process_exports))
-		_omr_toolchain_process_exports(${target})
-	endif()
-
-	set_target_properties(${target} PROPERTIES OMR_EXPORTS_PROCESSED TRUE)
-endfunction()
-
-# omr_add_exports(<target>)
-# Exports given symbols from a given target, and calls omr_process_exports.
-function(omr_add_exports target)
-	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_add_exports called on invalid target '${target}'")
-	set_property(TARGET ${target} APPEND PROPERTY EXPORTED_SYMBOLS ${ARGN})
-	omr_process_exports(${target})
-endfunction()
-
-# omr_process_split_debug(<target>)
-#   Process a target to generate split debug info if requested/required
-function(omr_process_split_debug target)
-	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_split_debug called on invalid target '${target}'")
-
-	# if we have already processed this target, skip it
-	get_target_property(is_split ${target} OMR_SPLIT_DEBUG_PROCESSED)
-	if(is_split)
-		return()
-	endif()
-
-	set_target_properties(${target} PROPERTIES OMR_SPLIT_DEBUG_PROCESSED TRUE)
-
-	get_target_property(target_type "${target}" TYPE)
-
-	# Only try making split debug info for exes/shared libs, and only if we have support from the toolchain
-	if((target_type MATCHES "EXECUTABLE|SHARED_LIBRARY") AND (COMMAND _omr_toolchain_separate_debug_symbols))
-		# Default to using config option.
-		set(use_split_debug ${OMR_SEPARATE_DEBUG_INFO})
-
-		# OMR_SEPARATE_DEBUG_INFO has no impact on Windows since it already
-		# uses separate .pdb files.
-		if(OMR_OS_WINDOWS)
-			set(use_split_debug FALSE)
-		endif()
-
-		# DDR requires separate debug info on OSX.
-		if(OMR_OS_OSX)
-			set(use_split_debug TRUE)
-		endif()
-
-		if(use_split_debug)
-			_omr_toolchain_separate_debug_symbols("${target}")
-		endif()
-	endif()
-endfunction()
-
-###
-### Flags we aren't using
-###
-
-# TODO: SPEC
-
-# TODO: OMR_HOST_ARCH
-# TODO: OMR_TARGET_DATASIZE
-# TODO: OMR_TOOLCHAIN
-# TODO: OMR_CROSS_CONFIGURE
-# TODO: OMR_RTTI

--- a/cmake/modules/OmrTargetSupport.cmake
+++ b/cmake/modules/OmrTargetSupport.cmake
@@ -98,3 +98,64 @@ function(omr_add_executable name)
 	endif()
 	omr_process_split_debug(${name})
 endfunction()
+
+# omr_process_exports(<target> [symbol]...)
+# Performs appropriate processing to export symbols from a target.
+# Note: function is internaly guarded, so its safe to call multiple times.
+function(omr_process_exports target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_process_exports called on invalid target '${target}'")
+
+	# Check if we have already processed the exports.
+	get_target_property(has_processed ${target} OMR_EXPORTS_PROCESSED)
+
+	if((NOT has_processed) AND (COMMAND _omr_toolchain_process_exports))
+		_omr_toolchain_process_exports(${target})
+	endif()
+
+	set_target_properties(${target} PROPERTIES OMR_EXPORTS_PROCESSED TRUE)
+endfunction()
+
+# omr_add_exports(<target>)
+# Exports given symbols from a given target, and calls omr_process_exports.
+function(omr_add_exports target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_add_exports called on invalid target '${target}'")
+	set_property(TARGET ${target} APPEND PROPERTY EXPORTED_SYMBOLS ${ARGN})
+	omr_process_exports(${target})
+endfunction()
+
+# omr_process_split_debug(<target>)
+#   Process a target to generate split debug info if requested/required
+function(omr_process_split_debug target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_split_debug called on invalid target '${target}'")
+
+	# if we have already processed this target, skip it
+	get_target_property(is_split ${target} OMR_SPLIT_DEBUG_PROCESSED)
+	if(is_split)
+		return()
+	endif()
+
+	set_target_properties(${target} PROPERTIES OMR_SPLIT_DEBUG_PROCESSED TRUE)
+
+	get_target_property(target_type "${target}" TYPE)
+
+	# Only try making split debug info for exes/shared libs, and only if we have support from the toolchain
+	if((target_type MATCHES "EXECUTABLE|SHARED_LIBRARY") AND (COMMAND _omr_toolchain_separate_debug_symbols))
+		# Default to using config option.
+		set(use_split_debug ${OMR_SEPARATE_DEBUG_INFO})
+
+		# OMR_SEPARATE_DEBUG_INFO has no impact on Windows since it already
+		# uses separate .pdb files.
+		if(OMR_OS_WINDOWS)
+			set(use_split_debug FALSE)
+		endif()
+
+		# DDR requires separate debug info on OSX.
+		if(OMR_OS_OSX)
+			set(use_split_debug TRUE)
+		endif()
+
+		if(use_split_debug)
+			_omr_toolchain_separate_debug_symbols("${target}")
+		endif()
+	endif()
+endfunction()


### PR DESCRIPTION
Move omr_process_exports(), omr_add_exports() and,
omr_process_split_debug() to OmrTargetSupport.cmake as they don't really
belong with the platform config code.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>