### PR TITLE
Pr/riscv fixes to floating point

### DIFF
--- a/compiler/riscv/codegen/FPTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/FPTreeEvaluator.cpp
@@ -470,6 +470,7 @@ compareHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, bool reverse, TR::Cod
       generateRTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
 
    cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
 }


### PR DESCRIPTION
This PR fixes incorrect behavior or floating point operations on RISC-V w.r.t NaN values
that has been uncovered by PR #5121. 