### PR TITLE
Allow memory region to be supplied for building DefiningMaps

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -518,7 +518,7 @@ uint32_t TR_OSRCompilationData::getOSRStackFrameSize(uint32_t methodIndex)
       return 0;
    }
 
-static void printMap(DefiningMap *map, TR::Compilation *comp)
+void TR_OSRCompilationData::printMap(DefiningMap *map)
    {
    for (auto it = map->begin(); it != map->end(); ++it)
       {
@@ -600,7 +600,7 @@ void TR_OSRCompilationData::buildDefiningMap()
          if (osrMethodData->getOSRCatchBlock())
             {
             traceMsg(comp, "final map for OSRCatchBlock(block_%d): \n", osrMethodData->getOSRCatchBlock()->getNumber());
-            printMap(definingMap, comp);
+            printMap(definingMap);
             }
          }
       }
@@ -661,9 +661,9 @@ static void mergeDefiningMaps(DefiningMap *firstMap, DefiningMap *secondMap, TR:
    if (comp->getOption(TR_TraceOSR))
       {
       traceMsg(comp, "mergeDefiningMaps: firstMap before\n");
-      printMap(firstMap, comp);
+      comp->getOSRCompilationData()->printMap(firstMap);
       traceMsg(comp, "mergeDefiningMaps: secondMap before\n");
-      printMap(secondMap, comp);
+      comp->getOSRCompilationData()->printMap(secondMap);
       }
 
    for (auto it = secondMap->begin(); it != secondMap->end(); ++it)
@@ -684,7 +684,7 @@ static void mergeDefiningMaps(DefiningMap *firstMap, DefiningMap *secondMap, TR:
    if (comp->getOption(TR_TraceOSR))
       {
       traceMsg(comp, "mergeDefiningMaps: firstMap after\n");
-      printMap(firstMap, comp);
+      comp->getOSRCompilationData()->printMap(firstMap);
       }
    }
 

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -230,6 +230,12 @@ class TR_OSRCompilationData
                       DefiningMaps &symRefNumberMapForPrepareForOSRCalls
                       );
 
+   /**
+    * \brief Debug dump of \ref DefiningMap
+    * \param map The \c DefiningMap to print out
+    */
+   void printMap(DefiningMap *map);
+
    class TR_ScratchBufferInfo
       {
       public:

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -222,13 +222,36 @@ class TR_OSRCompilationData
    int32_t getSymRefOrder(int32_t symRefNumber);
    TR_OSRSlotSharingInfo* getSlotsInfo(const TR_ByteCodeInfo &bcInfo);
 
-   void buildDefiningMap();
+   /**
+    * \brief This is the top level function to start building \ref DefiningMaps
+    * for the symbol references under \c prepareForOSR call for each method
+    *
+    * \c DefiningMap maps each symRef to the set of symRefs that define it in
+    * one block or several contiguous blocks.
+    *
+    * After the \c DefiningMaps are no longer needed, the client must call
+    * \ref clearDefiningMap in order to drop all references to the
+    * \ref TR::Region that was supplied.
+    *
+    * \param region A \ref TR::Region memory region in which the final
+    *               \c DefiningMaps will be allocated.  The caller is
+    *               responsible for releasing the memory in which the
+    *               \c DefiningMaps are allocated
+    * \see clearDefiningMap
+    */
+   void buildDefiningMap(TR::Region &region);
    void buildFinalMap(int32_t callerIndex,
                       DefiningMap *finalMap,
                       DefiningMap *workingCatchBlockMap,
                       DefiningMaps &definingSymRefsMapAtOSRCodeBlocks, 
                       DefiningMaps &symRefNumberMapForPrepareForOSRCalls
                       );
+   /**
+    * \brief Clears the \ref DefiningMap associated with each
+    * \c prepareForOSR call.
+    * \see buildDefiningMap
+    */
+   void clearDefiningMap();
 
    /**
     * \brief Debug dump of \ref DefiningMap
@@ -364,9 +387,12 @@ class TR_OSRMethodData
    TR_OSRSlotSharingInfo* getSlotsInfo(int32_t byteCodeIndex);
 
    friend TR::Compilation& operator<< (TR::Compilation& out, const TR_OSRMethodData& osrMethodData);
+   friend void TR_OSRCompilationData::buildDefiningMap(TR::Region& region);
+   friend void TR_OSRCompilationData::clearDefiningMap();
 
    private:
    void createOSRBlocks(TR::Node* n);
+   void setDefiningMap(DefiningMap *definingMap);
 
    typedef CS2::HashTable<int32_t, TR_BitVector *, TR::Allocator> TR_BCLiveRangeInfoHashTable;
    typedef CS2::HashTable<int32_t, TR_OSRSlotSharingInfo*, TR::Allocator> TR_BCInfoHashTable;


### PR DESCRIPTION
Updated `OSRCompilationData::buildDefiningMap` to accept a `TR_Region` argument to be supplied.  As the validity of `DefiningMap`s is tied to the current state of the trees, it's likely that an optimization will want to build and then discard the `DefiningMap`s.  Also added an
`OSRCompilationData::clearDefiningMap` method to allow the client to discard the `DefiningMap`s once they are no longer needed.

To simplify this, the `OSRMethodData::getDefiningMap` method is no longer responsible for allocating its own `DefiningMap` - the processing in `OSRCompilationData::buildDefiningMap` is now responsible, and once built, the `DefiningMap` is added to `OSRMethodData` via a `setDefiningMap` method.

Also made `printMap` into a public method of `TR_OSRCompilationData`.
