### PR TITLE
Temporarily disable SI(16) range assert on Power

### DIFF
--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -667,7 +667,9 @@ static void fillFieldDS(TR::Instruction *instr, uint32_t *cursor, uint32_t val)
  */
 static void fillFieldSI16(TR::Instruction *instr, uint32_t *cursor, uint32_t val)
    {
-   TR_ASSERT_FATAL_WITH_INSTRUCTION(instr, isValidInSignExtendedField(val, 0xffffu), "0x%x is out-of-range for SI(16) field", val);
+   // TODO: This assert is temporarily disabled due to a number of issues with invalid immediate
+   //       being passed to li/lis/addi/addis instructions in OpenJ9
+   //TR_ASSERT_FATAL_WITH_INSTRUCTION(instr, isValidInSignExtendedField(val, 0xffffu), "0x%x is out-of-range for SI(16) field", val);
    *cursor |= val & 0xffff;
    }
 


### PR DESCRIPTION
Previously, instructions filling in a 16-bit signed SI field in the
Power codegen would check that the immediate was within the expected
range of -0x8000 to 0x7fff. Recently, several new issues were found with
out-of-range immediates being used in OpenJ9 and there's a worry that
there may be more lurking in the code. Since the OpenJ9 0.21 release is
quite close, this assert is being temporarily disabled to avoid
triggering in this release.

Signed-off-by: gita-omr <koblents@ca.ibm.com>