### PR TITLE
AArch64: Allow negative constant for generateCompareImmInstruction()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -899,15 +899,31 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
    printPrefix(pOutFile, instr);
    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
    bool done = false;
-   if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw)
+   if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw ||
+       op == TR::InstOpCode::addsimmx || op == TR::InstOpCode::addsimmw)
       {
       TR::Register *r = instr->getTargetRegister();
       if (r && r->getRealRegister()
           && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
          {
-         // cmp alias
+         // cmp/cmn alias
+         char *mnemonic = NULL;
          done = true;
-         trfprintf(pOutFile, "cmpimm%c \t", (op == TR::InstOpCode::subsimmx) ? 'x' : 'w');
+         switch (op)
+            {
+            case TR::InstOpCode::subsimmx:
+               mnemonic = "cmpimmx";
+               break;
+            case TR::InstOpCode::subsimmw:
+               mnemonic = "cmpimmw";
+               break;
+            case TR::InstOpCode::addsimmx:
+               mnemonic = "cmnimmx";
+               break;
+            case TR::InstOpCode::addsimmw:
+               mnemonic = "cmnimmw";
+            }
+         trfprintf(pOutFile, "%s \t", mnemonic);
          print(pOutFile, instr->getSource1Register(), TR_WordReg);
          trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
          }

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -136,6 +136,11 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
          generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
          useRegCompare = false;
          }
+      else if (constantIsUnsignedImm12(-value))
+         {
+         generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
+         useRegCompare = false;
+         }
       }
 
    if (useRegCompare)
@@ -328,6 +333,11 @@ static TR::Register *icmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
       {
       int64_t value = is64bit ? secondChild->getLongInt() : secondChild->getInt();
       if (constantIsUnsignedImm12(value))
+         {
+         generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
+         useRegCompare = false;
+         }
+      else if (constantIsUnsignedImm12(-value))
          {
          generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
          useRegCompare = false;

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -356,10 +356,21 @@ static TR::Instruction *generateZeroSrc1ImmInstruction(TR::CodeGenerator *cg, TR
 TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
    TR::Register *sreg, int32_t imm, bool is64bit, TR::Instruction *preced)
    {
-   /* Alias of SUBS instruction */
+   TR::InstOpCode::Mnemonic op;
 
-   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
-   TR_ASSERT_FATAL(constantIsUnsignedImm12(imm), "Immediate value is out of range for subsimm");
+   if (constantIsUnsignedImm12(imm))
+      {
+      /* Alias of SUBS instruction */
+      op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
+      }
+   else
+      {
+      TR_ASSERT_FATAL(constantIsUnsignedImm12(-imm), "Immediate value is out of range for cmp/cmn");
+
+      /* Alias of ADDS instruction */
+      op = is64bit ? TR::InstOpCode::addsimmx : TR::InstOpCode::addsimmw;
+      imm = -imm;
+      }
 
    return generateZeroSrc1ImmInstruction(cg, op, node, sreg, imm, preced);
    }


### PR DESCRIPTION
This commit changes generateCompareImmInstruction() to allow negative
constant.  Comparison with zero or positive constant (< 4096) uses
subsimm (cmpimm) instruction, and comparison with negative constant
(> -4096) uses addsimm (cmnimm) instruction.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>