### PR TITLE
Deprecate getJitMethodEntryAlignmentThreshold

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2213,17 +2213,9 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
          "alignedBinaryBufferCursor [%p] is not aligned to the specified boundary (%d)", alignedBinaryBufferCursor, boundary);
 
       alignedBinaryBufferCursor -= offset;
-
-      uint32_t threshold = self()->getJitMethodEntryAlignmentThreshold();
-
-      TR_ASSERT_FATAL(threshold <= boundary, "JIT method entry alignment threshold (%d) definition is violated as it is larger than the boundary (%d)", threshold, boundary);
-
-      if (alignedBinaryBufferCursor - _binaryBufferCursor <= threshold)
-         {
-         _binaryBufferCursor = alignedBinaryBufferCursor;
-         self()->setJitMethodEntryPaddingSize(_binaryBufferCursor - _binaryBufferStart);
-         memset(_binaryBufferStart, 0, self()->getJitMethodEntryPaddingSize());
-         }
+      _binaryBufferCursor = alignedBinaryBufferCursor;
+      self()->setJitMethodEntryPaddingSize(_binaryBufferCursor - _binaryBufferStart);
+      memset(_binaryBufferStart, 0, self()->getJitMethodEntryPaddingSize());
       }
 
    return _binaryBufferCursor;
@@ -2239,12 +2231,6 @@ uint32_t
 OMR::CodeGenerator::getJitMethodEntryAlignmentBoundary()
    {
    return 1;
-   }
-
-uint32_t
-OMR::CodeGenerator::getJitMethodEntryAlignmentThreshold()
-   {
-   return self()->getJitMethodEntryAlignmentBoundary();
    }
 
 int32_t

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -773,17 +773,6 @@ class OMR_EXTENSIBLE CodeGenerator
     */
    uint32_t getJitMethodEntryAlignmentBoundary();
 
-   /** \brief
-    *     Determines the byte threshold at which the JIT-to-JIT method entry point boundary alignment will not be
-    *     performed. If the JIT-to-JIT method entry point is already close to the boundary then it may not make sense
-    *     to perform the boundary alignment as much code cache can be wasted. This threshold can be used to avoid such
-    *     situations.
-    *
-    *  \note
-    *     This value must be less than or equal to the boundary returned via \see getJitMethodEntryAlignmentBoundary.
-    */
-   uint32_t getJitMethodEntryAlignmentThreshold();
-
    uint32_t getJitMethodEntryPaddingSize() {return _jitMethodEntryPaddingSize;}
    uint32_t setJitMethodEntryPaddingSize(uint32_t s) {return (_jitMethodEntryPaddingSize = s);}
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4617,12 +4617,6 @@ OMR::Z::CodeGenerator::getJitMethodEntryAlignmentBoundary()
    return 256;
    }
 
-uint32_t
-OMR::Z::CodeGenerator::getJitMethodEntryAlignmentThreshold()
-   {
-   return 192;
-   }
-
 /**
  * This function sign extended the specified number of high order bits in the register.
  */

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -781,8 +781,6 @@ public:
 
    uint32_t getJitMethodEntryAlignmentBoundary();
 
-   uint32_t getJitMethodEntryAlignmentThreshold();
-
    // LL: move to .cpp
    bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child);
 


### PR DESCRIPTION
Aligning the entry point of a method on a particular boundary is a
performance optimization. However, the use of a threshold introduces
non-determinancy (and arguably randomness run-to-run) into any
performance benefit. Whether or not a particular method is aligned
depends on the methods that have been compiled before it. It also
doesn't take into account the "importance" of any particular method.
For instance, a method invoked millions of times is better suited to be
aligned than one only invoked a few times, but it could be rejected for
alignment because it exceeds the threshold. Unless we align every
method boundary we cannot achieve consistent performance.

As such the benefit of having a threshold is overweighed by the
complexity and non-determinism it introduces and is hence being
deprecated here.

Fixes: #4373
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>