### PR TITLE
Update comment when excluded methods are compiled

### DIFF
--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -1326,7 +1326,12 @@ TR_Debug::methodSigCanBeCompiledOrRelocated(const char *methodSig, TR_FilterBST 
       {
       if (compOrReloFilter->excludedMethodFilter)
          {
-         // Excluded methods SHOULD be compiled in this case.
+         // The -Xjit:ifExcluded(...) option set is used to set alternate compile options for methods
+         // that are excluded from compilation.  This can be useful for debugging timing-sensitive
+         // optimization bugs where dropping optimization levels can make problems go away.
+         //
+         // If there is an excludedMethodFilter set then excluded methods should be compiled
+         // using that option set.
          //
          found = true;
          filter = compOrReloFilter->excludedMethodFilter;


### PR DESCRIPTION
Update comment to add more context that excluded methods are compiled when -Xjit:ifExcluded() option is specified

Issue #5243
Signed-off-by: Kishor Patil <patil@ca.ibm.com>