### PR TITLE
Do not unset control bits while unregistering async handlers

### DIFF
--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -595,7 +595,7 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 				}
 			} else {
 				/* Unset the portlibSignalFlag for other handlers. One signal must be associated to only one handler. */
-				cursor->flags &= ~portlibSignalFlag;
+				cursor->flags &= ~(portlibSignalFlag & ~OMRPORT_SIG_FLAG_CONTROL_BITS_MASK);
 			}
 		}
 		previousLink = &cursor->next;


### PR DESCRIPTION
**Control bits:** In the `unix` version of `omrsignal.c`, the control bits are
the four least significant bits (0xF). They are common/shared between
the port library signal flags. 

**`omrsig_set_async_signal_handler`:** allows multiple async handlers to be
registered against a port library signal flag.

**`omrsig_set_single_async_signal_handler`:** allows only one async handler to
be registered against a port library signal flag. It unregisters other
async handlers previously registered using
`omrsig_set_async_signal_handler`.

**`runHandlers`:** invokes all registered async handlers for a port library
signal flag if the corresponding operating system signal is raised.

**Issue:** Currently, `omrsig_set_single_async_signal_handler` unsets the
control bits while unregistering async handlers for a port library
signal flag. The control bits are common/shared between the port library
signal flags. `runHandlers` fails to invoke correctly registered async
handlers for certain port library signal flags since the common/shared
control bits are unset by `omrsig_set_single_async_signal_handler`.

**Solution:** `omrsig_set_single_async_signal_handler` should not unset the
control bits while unregistering async handlers. This restores the
correct behavior for `runHandlers`.

**Note:** `win32`, `win64amd` and `ztpf` versions of `omrsignal.c` do not use the
control bits. So, this fix does not extend to them.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>