### PR TITLE
AArch64: Add is64bit parameter to functions to generate shift instructions

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -539,13 +539,13 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
       switch (shiftType)
          {
          case TR::SH_LSL:
-            generateLogicalShiftLeftImmInstruction(cg, node, trgReg, srcReg, shift);
+            generateLogicalShiftLeftImmInstruction(cg, node, trgReg, srcReg, shift, is64bit);
             break;
          case TR::SH_LSR:
-            generateLogicalShiftRightImmInstruction(cg, node, trgReg, srcReg, shift);
+            generateLogicalShiftRightImmInstruction(cg, node, trgReg, srcReg, shift, is64bit);
             break;
          case TR::SH_ASR:
-            generateArithmeticShiftRightImmInstruction(cg, node, trgReg, srcReg, shift);
+            generateArithmeticShiftRightImmInstruction(cg, node, trgReg, srcReg, shift, is64bit);
             break;
          default:
             TR_ASSERT(false, "Unsupported shift type.");

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -273,11 +273,10 @@ TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::
    }
 
 TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of SBFM instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::sbfmx : TR::InstOpCode::sbfmw;
@@ -291,11 +290,10 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *c
    }
 
 TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of UBFM instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw;
@@ -309,11 +307,10 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, 
    }
 
 TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of UBFM instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::Mnemonic::ubfmx : TR::InstOpCode::Mnemonic::ubfmw;

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -605,6 +605,7 @@ TR::Instruction *generateSrc2Instruction(
  * @param[in] treg : target register
  * @param[in] sreg : source register
  * @param[in] shiftAmount : shift amount
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -614,6 +615,7 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(
                    TR::Register *treg,
                    TR::Register *sreg,
                    uint32_t shiftAmount,
+                   bool is64bit = true,
                    TR::Instruction *preced = NULL);
 
 /*
@@ -623,6 +625,7 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(
  * @param[in] treg : target register
  * @param[in] sreg : source register
  * @param[in] shiftAmount : shift amount
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -632,6 +635,7 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(
                    TR::Register *treg,
                    TR::Register *sreg,
                    uint32_t shiftAmount,
+                   bool is64bit = true,
                    TR::Instruction *preced = NULL);
 
 /*
@@ -641,6 +645,7 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(
  * @param[in] treg : target register
  * @param[in] sreg : source register
  * @param[in] shiftAmount : shift amount
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -650,6 +655,7 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(
                    TR::Register *treg,
                    TR::Register *sreg,
                    uint32_t shiftAmount,
+                   bool is64bit = true,
                    TR::Instruction *preced = NULL);
 
 /*

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -116,7 +116,7 @@ static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator
    TR::InstOpCode::Mnemonic eorOp = is64bit ? TR::InstOpCode::eorx : TR::InstOpCode::eorw;
    TR::InstOpCode::Mnemonic subOp = is64bit ? TR::InstOpCode::subx : TR::InstOpCode::subw;
 
-   generateArithmeticShiftRightImmInstruction(cg, node, tempReg, reg, is64bit ? 63 : 31);
+   generateArithmeticShiftRightImmInstruction(cg, node, tempReg, reg, is64bit ? 63 : 31, is64bit);
    generateTrg1Src2Instruction(cg, eorOp, node, reg, reg, tempReg);
    generateTrg1Src2Instruction(cg, subOp, node, reg, reg, tempReg);
 


### PR DESCRIPTION
This commit adds `is64bit` parameter to following functions:
- generateArithmeticShiftRightImmInstruction
- generateLogicalShiftRightImmInstruction
- generateLogicalShiftLeftImmInstruction

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>