### PR TITLE
WIP: Disable OMR::CFGSimplifier::simplifyNullToException

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -644,6 +644,12 @@ bool OMR::CFGSimplifier::simplifySimpleStore(bool needToDuplicateTree)
 
 bool OMR::CFGSimplifier::simplifyNullToException(bool needToDuplicateTree)
    {
+   // This simplification is temporarily disabled while issues are investigated.
+   // See https://github.com/eclipse/openj9/issues/9754
+   static char *enableSimplifyNullToException = feGetEnv("TR_enableSimplifyNullToException");
+   if (enableSimplifyNullToException == NULL)
+      return false;
+
    static char *disableSimplifyExplicitNULLTest = feGetEnv("TR_disableSimplifyExplicitNULLTest");
    static char *disableSimplifyNullToException = feGetEnv("TR_disableSimplifyNullToException");
    if (disableSimplifyExplicitNULLTest != NULL || disableSimplifyNullToException != NULL)


### PR DESCRIPTION
I am opening this PR to temporarily disable this method while I continue to investigate the root cause of the issue.

The simplification performed by this method seems to be causing an issue in
openj9. This commit disables this method unless the environment variable
TR_enableSimplifyNullToException is set.

See: https://github.com/eclipse/openj9/issues/9754

Signed-off-by: Ryan Shukla <ryans@ibm.com>