### PR TITLE
AArch64: Create new instruction classes to handle alias instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -456,12 +456,44 @@ uint8_t *TR::ARM64Trg1Src1Instruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64Trg1ZeroSrc1Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   zeroReg->setRegisterFieldRN(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64Trg1Src1ImmInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
    insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   insertNbit(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64ZeroSrc1ImmInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertImmediateField(toARM64Cursor(cursor));
    insertNbit(toARM64Cursor(cursor));
@@ -658,6 +690,22 @@ uint8_t *TR::ARM64Src2Instruction::generateBinaryEncoding()
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64ZeroSrc2Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertSource2Register(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -574,6 +574,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1ImmSym:
          print(pOutFile, (TR::ARM64Trg1ImmSymInstruction *)instr);
          break;
+      case OMR::Instruction::IsTrg1ZeroSrc1:
+         print(pOutFile, (TR::ARM64Trg1ZeroSrc1Instruction *)instr);
+         break;
       case OMR::Instruction::IsTrg1Src1:
          print(pOutFile, (TR::ARM64Trg1Src1Instruction *)instr);
          break;
@@ -613,8 +616,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsSrc1:
          print(pOutFile, (TR::ARM64Src1Instruction *)instr);
          break;
+      case OMR::Instruction::IsZeroSrc1Imm:
+         print(pOutFile, (TR::ARM64ZeroSrc1ImmInstruction *)instr);
+         break;
       case OMR::Instruction::IsSrc2:
          print(pOutFile, (TR::ARM64Src2Instruction *)instr);
+         break;
+      case OMR::Instruction::IsZeroSrc2:
+         print(pOutFile, (TR::ARM64ZeroSrc2Instruction *)instr);
          break;
       default:
          TR_ASSERT(false, "unexpected instruction kind");
@@ -911,6 +920,32 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1Instruction *instr)
    }
 
 void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1ZeroSrc1Instruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+
+   if (op == TR::InstOpCode::orrx || op == TR::InstOpCode::orrw)
+      {
+      // mov alias
+      trfprintf(pOutFile, "mov%c \t", (op == TR::InstOpCode::orrx) ? 'x' : 'w');
+      }
+   else if (op == TR::InstOpCode::subx || op == TR::InstOpCode::subw)
+      {
+      // neg alias
+      trfprintf(pOutFile, "neg%c \t", (op == TR::InstOpCode::subx) ? 'x' : 'w');
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      }
+
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource1Register(), TR_WordReg);
+   trfflush(_comp->getOutFile());
+   }
+
+void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
    {
    printPrefix(pOutFile, instr);
@@ -1098,6 +1133,69 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
    }
 
 void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc1ImmInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   bool done = false;
+   if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw)
+      {
+      // cmp alias
+      done = true;
+      trfprintf(pOutFile, "cmpimm%c \t", (op == TR::InstOpCode::subsimmx) ? 'x' : 'w');
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      }
+   else if (op == TR::InstOpCode::addsimmx || op == TR::InstOpCode::addsimmw)
+      {
+      // cmn alias
+      done = true;
+      trfprintf(pOutFile, "cmnimm%c \t", (op == TR::InstOpCode::addsimmx) ? 'x' : 'w');
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      }
+   else if (op == TR::InstOpCode::andsimmx || op == TR::InstOpCode::andsimmw)
+      {
+      // tst alias
+      uint32_t imm12 = instr->getSourceImmediate();
+      auto immr = imm12 >> 6;
+      auto imms = imm12 & 0x3f;
+      auto n = instr->getNbit();
+      if (op == TR::InstOpCode::andimmx)
+         {
+         uint64_t immediate;
+         if (decodeBitMasks(n, immr, imms, immediate))
+            {
+            done = true;
+            trfprintf(pOutFile, "tstimmx \t");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", 0x%llx", immediate);
+            }
+         }
+      else
+         {
+         uint32_t immediate;
+         if (decodeBitMasks(n, immr, imms, immediate))
+            {
+            done = true;
+            trfprintf(pOutFile, "%tstimmw \t");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", 0x%lx", immediate);
+            }
+         }
+      }
+
+   if (!done)
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      }
+
+   trfflush(_comp->getOutFile());
+   }
+
+void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
    {
    printPrefix(pOutFile, instr);
@@ -1124,6 +1222,36 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
 
    if (instr->getDependencyConditions())
       print(pOutFile, instr->getDependencyConditions());
+
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc2Instruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw)
+      {
+      // cmp alias
+      trfprintf(pOutFile, "cmp%c \t", (op == TR::InstOpCode::subsx) ? 'x' : 'w');
+      }
+   else if (op == TR::InstOpCode::addsx || op == TR::InstOpCode::addsw)
+      {
+      // cmn alias
+      trfprintf(pOutFile, "cmn%c \t", (op == TR::InstOpCode::addsx) ? 'x' : 'w');
+      }
+   else if (op == TR::InstOpCode::andsx || op == TR::InstOpCode::andsw)
+      {
+      // tst alias
+      trfprintf(pOutFile, "tst%c \t", (op == TR::InstOpCode::andsx) ? 'x' : 'w');
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      }
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg);
 
    trfflush(_comp->getOutFile());
    }

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1540,6 +1540,66 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
+/*
+ * This class is designated to be used for alias instruction such as movw, movx, negw, negx
+ */ 
+class ARM64Trg1ZeroSrc1Instruction : public ARM64Trg1Src1Instruction
+   {
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1ZeroSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                             TR::Register *sreg, TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, sreg, cg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1ZeroSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                             TR::Register *sreg,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, sreg, precedingInstruction, cg)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg1ZeroSrc1; }
+
+   /**
+    * @brief Sets source register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertSource1Register(uint32_t *instruction)
+      {
+      TR::RealRegister *source1 = toRealRegister(getSource1Register());
+      source1->setRegisterFieldRM(instruction);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
 class ARM64Trg1Src1ImmInstruction : public ARM64Trg1Src1Instruction
    {
    uint32_t _source1Immediate;
@@ -1871,6 +1931,7 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
     */
    virtual uint8_t *generateBinaryEncoding();
    };
+
 
 class ARM64CondTrg1Src2Instruction : public ARM64Trg1Src2Instruction
    {
@@ -3072,6 +3133,136 @@ class ARM64Src1Instruction : public TR::Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
+/*
+ * This class is designated to be used for alias instruction such as cmpimmw, cmpimmx, tstimmw, tstimmx
+ */ 
+class ARM64ZeroSrc1ImmInstruction : public ARM64Src1Instruction
+   {
+   uint32_t _source1Immediate;
+   bool _Nbit;
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] sreg : source register
+    * @param[in] imm : immediate value
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                TR::Register *sreg, uint32_t imm, TR::CodeGenerator *cg)
+      : ARM64Src1Instruction(op, node, sreg, cg), _source1Immediate(imm), _Nbit(false)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] sreg : source register
+    * @param[in] N   : N bit value
+    * @param[in] imm : immediate value
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                TR::Register *sreg, bool N, uint32_t imm, TR::CodeGenerator *cg)
+      : ARM64Src1Instruction(op, node, sreg, cg), _source1Immediate(imm), _Nbit(N)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] sreg : source register
+    * @param[in] imm : immediate value
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                TR::Register *sreg, uint32_t imm,
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Src1Instruction(op, node, sreg, precedingInstruction, cg), _source1Immediate(imm), _Nbit(false)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] sreg : source register
+    * @param[in] N   : N bit value
+    * @param[in] imm : immediate value
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                TR::Register *sreg, bool N, uint32_t imm,
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Src1Instruction(op, node, sreg, precedingInstruction, cg), _source1Immediate(imm), _Nbit(N)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsZeroSrc1Imm; }
+
+   /**
+    * @brief Gets source immediate
+    * @return source immediate
+    */
+   uint32_t getSourceImmediate() {return _source1Immediate;}
+   /**
+    * @brief Sets source immediate
+    * @param[in] si : immediate value
+    * @return source immediate
+    */
+   uint32_t setSourceImmediate(uint32_t si) {return (_source1Immediate = si);}
+
+   /**
+    * @brief Gets the N bit (bit 22)
+    * @return N bit value
+    */
+   bool getNbit() { return _Nbit;}
+   /**
+    * @brief Sets the N bit (bit 22)
+    * @param[in] n : N bit value
+    * @return N bit value
+    */ 
+   bool setNbit(bool n) { return (_Nbit = n);}
+
+   /**
+    * @brief Sets immediate field in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertImmediateField(uint32_t *instruction)
+      {
+      *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */
+      }
+
+   /**
+    * @brief Sets N bit (bit 22) field in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertNbit(uint32_t *instruction)
+      {
+      if (_Nbit)
+         {
+         *instruction |= (1 << 22);
+         }
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
 class ARM64Src2Instruction : public ARM64Src1Instruction
    {
    TR::Register *_source2Register;
@@ -3180,6 +3371,60 @@ class ARM64Src2Instruction : public ARM64Src1Instruction
     * @param[in] kindToBeAssigned : register kind
     */
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
+/*
+ * This class is designated to be used for alias instruction such as cmpw, cmpx, tstw, tstx
+ */
+class ARM64ZeroSrc2Instruction : public ARM64Src2Instruction
+   {
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc2Instruction( TR::InstOpCode::Mnemonic op,
+                         TR::Node *node,
+                         TR::Register *s1reg,
+                         TR::Register *s2reg, TR::CodeGenerator *cg)
+      : ARM64Src2Instruction(op, node, s1reg, s2reg, cg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64ZeroSrc2Instruction( TR::InstOpCode::Mnemonic op,
+                         TR::Node *node,
+                         TR::Register *s1reg,
+                         TR::Register *s2reg,
+                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Src2Instruction(op, node, s1reg, s2reg, precedingInstruction, cg)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsZeroSrc2; }
 
    /**
     * @brief Generates binary encoding of the instruction

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -40,6 +40,7 @@
       IsTrg1Cond,
       IsTrg1Imm,
          IsTrg1ImmSym,
+      IsTrg1ZeroSrc1,
       IsTrg1Src1,
          IsTrg1Src1Imm,
          IsTrg1Src2,
@@ -53,4 +54,6 @@
       IsMemSrc1,
          IsMemSrc2,
    IsSrc1,
+      IsZeroSrc1Imm,
       IsSrc2,
+         IsZeroSrc2

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -345,6 +345,7 @@ namespace TR { class ARM64Trg1CondInstruction; }
 namespace TR { class ARM64Trg1ImmInstruction; }
 namespace TR { class ARM64Trg1ImmSymInstruction; }
 namespace TR { class ARM64Trg1Src1Instruction; }
+namespace TR { class ARM64Trg1ZeroSrc1Instruction; }
 namespace TR { class ARM64Trg1Src1ImmInstruction; }
 namespace TR { class ARM64Trg1Src2Instruction; }
 namespace TR { class ARM64CondTrg1Src2Instruction; }
@@ -357,7 +358,9 @@ namespace TR { class ARM64MemSrc1Instruction; }
 namespace TR { class ARM64MemSrc2Instruction; }
 namespace TR { class ARM64Trg1MemSrc1Instruction; }
 namespace TR { class ARM64Src1Instruction; }
+namespace TR { class ARM64ZeroSrc1ImmInstruction; }
 namespace TR { class ARM64Src2Instruction; }
+namespace TR { class ARM64ZeroSrc2Instruction; }
 namespace TR { class ARM64HelperCallSnippet; }
 
 namespace TR { class LabelInstruction; }
@@ -1116,6 +1119,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1ImmSymInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1Instruction *);
+   void print(TR::FILE *, TR::ARM64Trg1ZeroSrc1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2Instruction *);
    void print(TR::FILE *, TR::ARM64CondTrg1Src2Instruction *);
@@ -1128,7 +1132,9 @@ public:
    void print(TR::FILE *, TR::ARM64MemSrc2Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1MemSrc1Instruction *);
    void print(TR::FILE *, TR::ARM64Src1Instruction *);
+   void print(TR::FILE *, TR::ARM64ZeroSrc1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Src2Instruction *);
+   void print(TR::FILE *, TR::ARM64ZeroSrc2Instruction *);
 #ifdef J9_PROJECT_SPECIFIC
    void print(TR::FILE *, TR::ARM64VirtualGuardNOPInstruction *);
 #endif


### PR DESCRIPTION
This commit introduces 3 new instruction classes:
- ARM64Trg1ZeroSrc1Instruction
- ARM64ZeroSrc1ImmInstruction
- ARM64ZeroSrc2Instruction

These classes are used to handle alias instructions using the `xzr` register.
For example, `cmp` instruction is an alias of `subs` instruction with `xzr`
as target register.
The current implementation of helper functions for generating alias instructions
such as `generateCompareImmInstruction` allocates a virtual register
and associates it with `xzr` using register dependency.
Ths problem with this approach is:
- That register dependency interferes other register dependencies.
- Those helper functions cannot be used to generate instructions after
 register assignment phase. (generating prologue/epilogue)

The new implementation of those helper functions use newly introduced
instruction classes instead of allocating virtual register for `xzr`.
Those instruction classes does not hold a register for `xzr`.
`generateBinaryEncoding` of those classes encodes register number of `xzr`
to the appropriate position of instructions.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>