### PR TITLE
AArch64: Enable Recompilation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2629,6 +2629,10 @@ OMR::Options::jitPreProcess()
 #if defined(TR_HOST_ARM64)
       // Prefetch is not supported on ARM64 yet
       _disabledOptimizations[prefetchInsertion] = true;
+
+      // Profiling is not supported on ARM64 yet
+      // Eclipse OpenJ9 Issue #9881
+      self()->setOption(TR_DisableProfiling);
 #endif
 
       self()->setOption(TR_DisableThunkTupleJ2I); // JSR292:TODO: Figure out how to do this without confusing startPCIfAlreadyCompiled


### PR DESCRIPTION
This commit enables recompilation for AArch64.
Profiling is not supported yet.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>