### PR TITLE
AArch64: Fix generateTestInstruction to use andsx/andsw

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1161,7 +1161,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc1ImmInstruction *instr)
       auto immr = imm12 >> 6;
       auto imms = imm12 & 0x3f;
       auto n = instr->getNbit();
-      if (op == TR::InstOpCode::andimmx)
+      if (op == TR::InstOpCode::andsimmx)
          {
          uint64_t immediate;
          if (decodeBitMasks(n, immr, imms, immediate))

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -409,7 +409,7 @@ TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node,
    {
    /* Alias of ANDS instruction */
 
-   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andx : TR::InstOpCode::andw;
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsx : TR::InstOpCode::andsw;
 
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64ZeroSrc2Instruction(op, node, s1reg, s2reg, preced, cg);


### PR DESCRIPTION
Fix `generateTestInstruction` to use `andsx`/`andsw`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>