### PR TITLE
AArch64: Implement ARM64Trg1Src2ZeroInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -562,6 +562,21 @@ uint8_t *TR::ARM64Trg1Src2ExtendedInstruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64Trg1Src2ZeroInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64Trg1Src3Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -595,6 +595,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1Src2Extended:
          print(pOutFile, (TR::ARM64Trg1Src2ExtendedInstruction *)instr);
          break;
+      case OMR::Instruction::IsTrg1Src2Zero:
+         print(pOutFile, (TR::ARM64Trg1Src2ZeroInstruction *)instr);
+         break;
       case OMR::Instruction::IsTrg1Src3:
          print(pOutFile, (TR::ARM64Trg1Src3Instruction *)instr);
          break;
@@ -1296,6 +1299,26 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ExtendedInstruction *instr)
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
    trfprintf(pOutFile, " %s %d", ARM64ExtendCodeNames[instr->getExtendType()], instr->getShiftAmount());
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ZeroInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   if (op == TR::InstOpCode::maddx || op == TR::InstOpCode::maddw)
+      {
+      // mul alias
+      trfprintf(pOutFile, "mul%c \t", (op == TR::InstOpCode::maddx) ? 'x' : 'w');
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      }
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg);
    trfflush(_comp->getOutFile());
    }
 

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2305,6 +2305,75 @@ class ARM64Trg1Src2ExtendedInstruction : public ARM64Trg1Src2Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
+/*
+ * This class is designated to be used for alias instruction such as mulw, mulx
+ */
+class ARM64Trg1Src2ZeroInstruction : public ARM64Trg1Src2Instruction
+   {
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ZeroInstruction( TR::InstOpCode::Mnemonic op,
+                                 TR::Node *node,
+                                 TR::Register *treg,
+                                 TR::Register *s1reg,
+                                 TR::Register *s2reg,
+                                 TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ZeroInstruction( TR::InstOpCode::Mnemonic op,
+                                 TR::Node *node,
+                                 TR::Register *treg,
+                                 TR::Register *s1reg,
+                                 TR::Register *s2reg,
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg1Src2Zero; }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRA(instruction);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
 class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
    {
    TR::Register *_source3Register;

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -448,19 +448,9 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node,
    bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::maddx : TR::InstOpCode::maddw;
 
-   /* Use xzr as the third source register */
-   TR::Register *zeroReg = cg->allocateRegister();
-   TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
-   TR::addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
-
-   TR::Instruction *instr =
-      (preced) ?
-      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg) :
-      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
-
-   cg->stopUsingRegister(zeroReg);
-
-   return instr;
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, cg);
    }
 
 TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -47,6 +47,7 @@
             IsCondTrg1Src2,
             IsTrg1Src2Shifted,
             IsTrg1Src2Extended,
+            IsTrg1Src2Zero,
             IsTrg1Src3,
       IsTrg1Mem,
          IsTrg1MemSrc1,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -351,6 +351,7 @@ namespace TR { class ARM64Trg1Src2Instruction; }
 namespace TR { class ARM64CondTrg1Src2Instruction; }
 namespace TR { class ARM64Trg1Src2ShiftedInstruction; }
 namespace TR { class ARM64Trg1Src2ExtendedInstruction; }
+namespace TR { class ARM64Trg1Src2ZeroInstruction; }
 namespace TR { class ARM64Trg1Src3Instruction; }
 namespace TR { class ARM64Trg1MemInstruction; }
 namespace TR { class ARM64MemInstruction; }
@@ -1125,6 +1126,7 @@ public:
    void print(TR::FILE *, TR::ARM64CondTrg1Src2Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ShiftedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ExtendedInstruction *);
+   void print(TR::FILE *, TR::ARM64Trg1Src2ZeroInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src3Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemInstruction *);


### PR DESCRIPTION
This commit implements ARM64Trg1Src2ZeroInstruction class so that we can
get rid of the register dependency on the zero register in generating
instructions for integer multiply.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>