### PR TITLE
AArch64: Implement insertZeroRegister() in some Instruction classes

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -460,11 +460,10 @@ uint8_t *TR::ARM64Trg1ZeroSrc1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
    insertTargetRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
-   zeroReg->setRegisterFieldRN(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);
@@ -490,10 +489,8 @@ uint8_t *TR::ARM64ZeroSrc1ImmInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
-
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertImmediateField(toARM64Cursor(cursor));
    insertNbit(toARM64Cursor(cursor));
@@ -702,10 +699,8 @@ uint8_t *TR::ARM64ZeroSrc2Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
-
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertSource2Register(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1200,23 +1200,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
    {
    printPrefix(pOutFile, instr);
    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-   bool isCmp = false;
-   if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw)
-      {
-      TR::Register *r = instr->getTargetRegister();
-      if (r && r->getRealRegister()
-          && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
-         {
-         // cmp alias
-         isCmp = true;
-         trfprintf(pOutFile, "cmp%c \t", (op == TR::InstOpCode::subsx) ? 'x' : 'w');
-         }
-      }
-   if (!isCmp)
-      {
-      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
-      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
-      }
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
 

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1578,7 +1578,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
 
 /*
  * This class is designated to be used for alias instruction such as movw, movx, negw, negx
- */ 
+ */
 class ARM64Trg1ZeroSrc1Instruction : public ARM64Trg1Src1Instruction
    {
    public:
@@ -1627,6 +1627,16 @@ class ARM64Trg1ZeroSrc1Instruction : public ARM64Trg1Src1Instruction
       {
       TR::RealRegister *source1 = toRealRegister(getSource1Register());
       source1->setRegisterFieldRM(instruction);
+      }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRN(instruction);
       }
 
    /**
@@ -3171,7 +3181,7 @@ class ARM64Src1Instruction : public TR::Instruction
 
 /*
  * This class is designated to be used for alias instruction such as cmpimmw, cmpimmx, tstimmw, tstimmx
- */ 
+ */
 class ARM64ZeroSrc1ImmInstruction : public ARM64Src1Instruction
    {
    uint32_t _source1Immediate;
@@ -3268,8 +3278,18 @@ class ARM64ZeroSrc1ImmInstruction : public ARM64Src1Instruction
     * @brief Sets the N bit (bit 22)
     * @param[in] n : N bit value
     * @return N bit value
-    */ 
+    */
    bool setNbit(bool n) { return (_Nbit = n);}
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRD(instruction);
+      }
 
    /**
     * @brief Sets immediate field in binary encoding
@@ -3461,6 +3481,16 @@ class ARM64ZeroSrc2Instruction : public ARM64Src2Instruction
     * @return instruction kind
     */
    virtual Kind getKind() { return IsZeroSrc2; }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRD(instruction);
+      }
 
    /**
     * @brief Generates binary encoding of the instruction


### PR DESCRIPTION
This commit contains the following changes:

- Implement and use insertZeroRegister() functions in classes introduced
by #5280
- Remove the code for printing "cmp" from ARM64Trg1Src2Instruction
(It was moved to ARM64ZeroSrc2Instruction)
- Remove some trailing spaces

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>