### PR TITLE
Change how lxvl/stxvl instructions are represented

### DIFF
--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -426,6 +426,14 @@ TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::
    return new (cg->trHeapMemory()) TR::PPCSrc2Instruction(op, n, s1reg, s2reg, cg);
    }
 
+TR::Instruction *generateSrc3Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
+   TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::PPCSrc3Instruction(op, n, s1reg, s2reg, s3reg, preced, cg);
+   return new (cg->trHeapMemory()) TR::PPCSrc3Instruction(op, n, s1reg, s2reg, s3reg, cg);
+   }
+
 TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::Register *treg, TR::Register *s1reg, TR::Instruction *preced)
    {

--- a/compiler/p/codegen/GenerateOMRInstructions.hpp
+++ b/compiler/p/codegen/GenerateOMRInstructions.hpp
@@ -305,6 +305,15 @@ TR::Instruction *generateSrc2Instruction(
                    TR::Register    *s2reg,
                    TR::Instruction *preced = 0);
 
+TR::Instruction *generateSrc3Instruction(
+                   TR::CodeGenerator      *cg,
+                   TR::InstOpCode::Mnemonic   op,
+                   TR::Node        *n,
+                   TR::Register    *s1reg,
+                   TR::Register    *s2reg,
+                   TR::Register    *s3reg,
+                   TR::Instruction *preced = 0);
+
 TR::Instruction *generateShiftLeftImmediate(
                    TR::CodeGenerator      *cg,
                    TR::Node        *n,

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -12175,7 +12175,9 @@
    /* .name        = */ "lxvl",
    /* .description =    "Load VSX Vector with Length", */
    /* .opcode      = */ 0x7C00021A,
-   /* .format      = */ FORMAT_XT_RA_RB_MEM,
+   // Even though lxvl is a memory instruction, its RB register is *not* an index register, so it
+   // should not be used with a TR::MemoryReference.
+   /* .format      = */ FORMAT_XT_RA_RB,
    // NOTE: This instruction was technically added in Power 9, but the Power 9 chips have
    //       functional and performance problems with this instruction. As a result, it should not
    //       be used until Power 10.
@@ -12589,7 +12591,9 @@
    /* .name        = */ "stxvl",
    /* .description =    "Store VSX Vector with Length", */
    /* .opcode      = */ 0x7C00031A,
-   /* .format      = */ FORMAT_XS_RA_RB_MEM,
+   // Even though stxvl is a memory instruction, its RB register is *not* an index register, so it
+   // should not be used with a TR::MemoryReference.
+   /* .format      = */ FORMAT_XS_RA_RB,
    // NOTE: This instruction was technically added in Power 9, but the Power 9 chips have
    //       functional and performance problems with this instruction. As a result, it should not
    //       be used until Power 10.

--- a/compiler/p/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/p/codegen/OMRInstructionKindEnum.hpp
@@ -47,6 +47,7 @@
             IsTrg1Src3,
       IsTrg1Mem,
    IsSrc2,
+      IsSrc3,
    IsMem,
       IsMemSrc1,
    IsControlFlow,

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1690,6 +1690,7 @@ void TR::PPCTrg1Src2Instruction::fillBinaryEncodingFields(uint32_t *cursor)
          fillFieldVRB(self(), cursor, src2);
          break;
 
+      case FORMAT_XT_RA_RB:
       case FORMAT_XT_RA_RB_MEM:
          fillFieldXT(self(), cursor, trg);
          fillFieldRA(self(), cursor, src1);
@@ -1867,6 +1868,45 @@ void TR::PPCSrc2Instruction::fillBinaryEncodingFields(uint32_t *cursor)
 
       default:
          TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), false, "Format %d cannot be binary encoded by PPCSrc2Instruction", getOpCode().getFormat());
+      }
+   }
+
+void TR::PPCSrc3Instruction::fillBinaryEncodingFields(uint32_t *cursor)
+   {
+   TR::RealRegister *src1 = toRealRegister(getSource1Register());
+   TR::RealRegister *src2 = toRealRegister(getSource2Register());
+   TR::RealRegister *src3 = toRealRegister(getSource3Register());
+
+   switch (getOpCode().getFormat())
+      {
+      case FORMAT_RS_RA_RB:
+      case FORMAT_RS_RA_RB_MEM:
+         fillFieldRS(self(), cursor, src1);
+         fillFieldRA(self(), cursor, src2);
+         fillFieldRB(self(), cursor, src3);
+         break;
+
+      case FORMAT_FRS_RA_RB_MEM:
+         fillFieldFRS(self(), cursor, src1);
+         fillFieldRA(self(), cursor, src2);
+         fillFieldRB(self(), cursor, src3);
+         break;
+
+      case FORMAT_VRS_RA_RB_MEM:
+         fillFieldVRS(self(), cursor, src1);
+         fillFieldRA(self(), cursor, src2);
+         fillFieldRB(self(), cursor, src3);
+         break;
+
+      case FORMAT_XS_RA_RB:
+      case FORMAT_XS_RA_RB_MEM:
+         fillFieldXS(self(), cursor, src1);
+         fillFieldRA(self(), cursor, src2);
+         fillFieldRB(self(), cursor, src3);
+         break;
+
+      default:
+         TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), false, "Format %d cannot be binary encoded by PPCSrc3Instruction", getOpCode().getFormat());
       }
    }
 

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -177,6 +177,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * instr)
       case OMR::Instruction::IsSrc2:
          print(pOutFile, (TR::PPCSrc2Instruction *)instr);
          break;
+      case OMR::Instruction::IsSrc3:
+         print(pOutFile, (TR::PPCSrc3Instruction *)instr);
+         break;
       case OMR::Instruction::IsMem:
          print(pOutFile, (TR::PPCMemInstruction *)instr);
          break;
@@ -531,6 +534,17 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc2Instruction * instr)
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::PPCSrc3Instruction * instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource3Register(), TR_WordReg);
    trfflush(_comp->getOutFile());
    }
 

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -831,21 +831,11 @@ class PPCSrc2Instruction : public TR::Instruction
    public:
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register   *s1reg,
-                         TR::Register   *s2reg, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _source1Register(s1reg), _source2Register(s2reg)
-      {
-      useRegister(s1reg);
-      useRegister(s2reg);
-      }
+                         TR::Register   *s2reg, TR::CodeGenerator *codeGen);
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register   *s1reg,
                          TR::Register    *s2reg,
-                         TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _source1Register(s1reg), _source2Register(s2reg)
-      {
-      useRegister(s1reg);
-      useRegister(s2reg);
-      }
+                         TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
 
    virtual Kind getKind() { return IsSrc2; }
 
@@ -877,6 +867,64 @@ class PPCSrc2Instruction : public TR::Instruction
       {
       state->removeVirtualRegister(getSource1Register());
       state->removeVirtualRegister(getSource2Register());
+      }
+   };
+
+class PPCSrc3Instruction : public PPCSrc2Instruction
+   {
+   TR::Register *_source3Register;
+
+   public:
+
+   PPCSrc3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg,
+                      TR::Register *s2reg, TR::Register *s3reg, TR::CodeGenerator *cg)
+      : TR::PPCSrc2Instruction(op, n, s1reg, s2reg, cg), _source3Register(s3reg)
+      {
+      useRegister(s3reg);
+      }
+
+   PPCSrc3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg,
+                      TR::Register *s2reg, TR::Register *s3reg,
+                      TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::PPCSrc2Instruction(op, n, s1reg, s2reg, precedingInstruction, cg), _source3Register(s3reg)
+      {
+      useRegister(s3reg);
+      }
+
+   virtual Kind getKind() { return IsSrc3; }
+
+   TR::Register *getSource3Register() { return _source3Register; }
+   TR::Register *setSource3Register(TR::Register *sr) { return (_source3Register = sr); }
+
+   virtual TR::Register *getSourceRegister(uint32_t i)
+      {
+      return i == 2 ? _source3Register : PPCSrc2Instruction::getSourceRegister(i);
+      }
+
+   virtual void fillBinaryEncodingFields(uint32_t *cursor);
+
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   virtual bool refsRegister(TR::Register *reg)
+      {
+      return reg == _source3Register || TR::PPCSrc2Instruction::refsRegister(reg);
+      }
+   virtual bool usesRegister(TR::Register *reg)
+      {
+      return reg == _source3Register || TR::PPCSrc2Instruction::usesRegister(reg);
+      }
+
+   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
+      {
+      state->addVirtualRegister(getSource1Register());
+      state->addVirtualRegister(getSource2Register());
+      state->addVirtualRegister(getSource3Register());
+      }
+   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
+      {
+      state->removeVirtualRegister(getSource1Register());
+      state->removeVirtualRegister(getSource2Register());
+      state->removeVirtualRegister(getSource3Register());
       }
    };
 

--- a/compiler/p/codegen/PPCOpsDefines.hpp
+++ b/compiler/p/codegen/PPCOpsDefines.hpp
@@ -304,6 +304,7 @@ FORMAT_VRT_VRA_VRB,
 // |      | XT       | RA       | RB       |                 | XT |
 // | 0    | 6        | 11       | 16       | 21              | 31 |
 // +------+----------+----------+----------+-----------------+----+
+FORMAT_XT_RA_RB,
 FORMAT_XT_RA_RB_MEM,
 
 // Format for instructions with an XT field encoding the target VSX register and XA and XB fields
@@ -699,6 +700,7 @@ FORMAT_RS_DS_RA,
 // |      | RS       | RA       | RB       |                      |
 // | 0    | 6        | 11       | 16       | 21                   |
 // +------+----------+----------+----------+----------------------+
+FORMAT_RS_RA_RB,
 FORMAT_RS_RA_RB_MEM,
 
 // Format for instructions with an FRS field encoding the source FP register, and RA and RB fields
@@ -726,6 +728,7 @@ FORMAT_VRS_RA_RB_MEM,
 // |      | XS       | RA       | RB       |                 | XS |
 // | 0    | 6        | 11       | 16       | 21              | 31 |
 // +------+----------+----------+----------+-----------------+----+
+FORMAT_XS_RA_RB,
 FORMAT_XS_RA_RB_MEM,
 
 // Format for instructions with an RT field encoding the target register, RA and RB fields encoding

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -185,6 +185,7 @@ namespace TR { class PPCTrg1ImmInstruction;              }
 namespace TR { class PPCTrg1Src1ImmInstruction;          }
 namespace TR { class PPCTrg1Src1Imm2Instruction;         }
 namespace TR { class PPCSrc2Instruction;                 }
+namespace TR { class PPCSrc3Instruction;                 }
 namespace TR { class PPCTrg1Src2Instruction;             }
 namespace TR { class PPCTrg1Src2ImmInstruction;          }
 namespace TR { class PPCTrg1Src3Instruction;             }
@@ -900,6 +901,7 @@ public:
    void print(TR::FILE *, TR::PPCTrg1Src1ImmInstruction *);
    void print(TR::FILE *, TR::PPCTrg1Src1Imm2Instruction *);
    void print(TR::FILE *, TR::PPCSrc2Instruction *);
+   void print(TR::FILE *, TR::PPCSrc3Instruction *);
    void print(TR::FILE *, TR::PPCTrg1Src2Instruction *);
    void print(TR::FILE *, TR::PPCTrg1Src2ImmInstruction *);
    void print(TR::FILE *, TR::PPCTrg1Src3Instruction *);


### PR DESCRIPTION
Previously, lxvl and stxvl instructions were represented using Trg1Mem
and MemSrc1 instructions respectively. However, their RB registers did
not actually represent an index register but rather determined the
length of the load, so using TR::MemoryReference might cause issues due
to assumptions made about the index register. Instead, lxvl and stxvl
will now use Trg1Src2 and a new Src3 instruction class respectively.

Signed-off-by: Ben Thomas <ben@benthomas.ca>