### PR TITLE
Reduce hot loop alignment to 16 bytes on POWER9

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3408,6 +3408,15 @@ OMR::Power::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddress, 
       self()->comp()->getOption(TR_StressTrampolines);
    }
 
+uint32_t
+OMR::Power::CodeGenerator::getHotLoopAlignment()
+   {
+   if (self()->comp()->target().cpu.id() >= TR_PPCp9)
+      return 16;
+   else
+      return 32;
+   }
+
 // Multiply a register by a constant
 void mulConstant(TR::Node * node, TR::Register *trgReg, TR::Register *sourceReg, int32_t value, TR::CodeGenerator *cg)
    {

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -530,6 +530,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    bool directCallRequiresTrampoline(intptr_t targetAddress, intptr_t sourceAddress);
 
+   /**
+    * @brief Gets the preferred alignment of hot loops in bytes.
+    *
+    * In order to reduce the number of unnecessary instructions fetched when jumping back to the
+    * start of a loop, hot loops should be aligned to match the boundary on which the CPU will
+    * begin fetching instructions. This function determines what alignment should be used when
+    * doing this.
+    */
+   uint32_t getHotLoopAlignment();
+
    private:
 
    enum // flags

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5657,7 +5657,7 @@ TR::Register *OMR::Power::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
                                TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC));
 
    if (block->firstBlockInLoop() && !block->isCold())
-      generateAlignmentNopInstruction(cg, node, 32);
+      generateAlignmentNopInstruction(cg, node, cg->getHotLoopAlignment());
 
    TR::Instruction *labelInst = NULL;
 


### PR DESCRIPTION
Previously, the Power codegen would always align hot loops to 32 bytes
for performance reasons. However, it turns out that this alignment can
be reduced to 16 bytes on POWER9 and later chips without sacrificing
performance. To accommodate this, a new function has been added to get
the preferred hot loop alignment and this alignment will now be used
where necessary.

Signed-off-by: Ben Thomas <ben@benthomas.ca>