### PR TITLE
Run GitHub Actions only on eclipse/omr repository

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'eclipse/omr'
     runs-on: ubuntu-latest
     steps:
     - uses: fjeremic/cron-first-interaction@0.2.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'eclipse/omr'
     runs-on: ubuntu-latest
     steps:
     - uses: fjeremic/cron-labeler@0.3.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'eclipse/omr'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3


### PR DESCRIPTION
This prevents GitHub Actions from running on people's forks and every
so often the infrastructure will fail on the GitHub side and an Action
job will report as failed which results in an unnecessary notification
to the forked repo owner. We would like to avoid this, in addition to
wasted resources since these Actions are not meant to be ran on forks.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>