### PR TITLE
Guard OSR defining map first child access

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -870,7 +870,8 @@ TR_OSRMethodData::buildDefiningMap(TR::Block *block, DefiningMap *blockMap, Defi
                }
             }
          }
-      else if (node->getFirstChild() &&
+      else if (node->getNumChildren() > 0 &&
+               node->getFirstChild() &&
                node->getFirstChild()->getOpCode().isCall() &&
                node->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
          {


### PR DESCRIPTION
Currently buildDefiningMap calls to read the first child of a node without
checking if the node has a first child. This change adds the simple check
to ensure the child exists.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>