### PR TITLE
WIP: Fix bug in CFG Simplifier where exception types not passed to setHandlerInfo

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -285,7 +285,8 @@ bool OMR::CFGSimplifier::simplifyInstanceOfTestToCheckcast(bool needToDuplicateT
    TR::Node *classNode = compareNode->getFirstChild()->getSecondChild();
 
    TR::Block *catchBlock = TR::Block::createEmptyBlock(compareNode, comp(), throwBlock->getFrequency());
-   catchBlock->setHandlerInfo(0, comp()->getInlineDepth(), 0, comp()->getCurrentMethod(), comp());
+   uint32_t possibleExceptions = TR::Block::CanCatchCheckCast | TR::Block::CanCatchNullCheck;
+   catchBlock->setHandlerInfo(possibleExceptions, comp()->getInlineDepth(), 0, comp()->getCurrentMethod(), comp());
    TR::Node *gotoNode = TR::Node::create(compareNode, TR::Goto, 0);
    gotoNode->setBranchDestination(throwBlock->getEntry());
    catchBlock->append(TR::TreeTop::create(comp(), gotoNode));
@@ -704,7 +705,7 @@ bool OMR::CFGSimplifier::simplifyNullToException(bool needToDuplicateTree)
    compareTreeTop->insertBefore(TR::TreeTop::create(comp(), nullchkNode));
 
    TR::Block *catchBlock = TR::Block::createEmptyBlock(compareNode, comp(), nullBlock->getFrequency());
-   catchBlock->setHandlerInfo(0, comp()->getInlineDepth(), 0, comp()->getCurrentMethod(), comp());
+   catchBlock->setHandlerInfo(TR::Block::CanCatchNullCheck, comp()->getInlineDepth(), 0, comp()->getCurrentMethod(), comp());
    TR::Node *gotoNode = TR::Node::create(compareNode, TR::Goto, 0);
    gotoNode->setBranchDestination(nullBlock->getEntry());
    catchBlock->append(TR::TreeTop::create(comp(), gotoNode));


### PR DESCRIPTION
The methods `OMR::CFGSimplifier::simplifyInstanceOfTestToCheckcast` and
`OMR::CFGSimplifier::simplifyNullToException` both create catch blocks for
exceptions and call `setHandlerInfo` on these new catch blocks.

Previously, the calls to `setHandlerInfo` were passed 0 as the first argument.
This commit replaces the zeros with the correct exception types.

Signed-off-by: Ryan Shukla <ryans@ibm.com>