### PR TITLE
Add calls to setNeedsAOTRelocation() in ARM64RelocatableImmInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -203,6 +203,7 @@ public:
       : TR::Instruction(op, node, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -219,6 +220,7 @@ public:
       : TR::Instruction(op, node, precedingInstruction, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -235,6 +237,7 @@ public:
       : TR::Instruction(op, node, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -252,6 +255,7 @@ public:
       : TR::Instruction(op, node, precedingInstruction, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
+      setNeedsAOTRelocation();
       }
 
    /**


### PR DESCRIPTION
This commit adds calls to setNeedsAOTRelocation() in the constructors
of ARM64RelocatableImmInstruction.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>