### PR TITLE
Add heap free ratio heuristics for heap expansion

### DIFF
--- a/gc/base/MemorySubSpaceUniSpace.cpp
+++ b/gc/base/MemorySubSpaceUniSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -285,8 +285,9 @@ MM_MemorySubSpaceUniSpace::timeForHeapContract(MM_EnvironmentBase *env, MM_Alloc
 		}
 	}
 	
-	/* Don't shrink if -Xmaxf1.0 specfied , i.e max free is 100% */
-	if ( _extensions->heapFreeMaximumRatioMultiplier == 100 ) {
+	/* Don't shrink if -Xmaxf1.0 specfied, i.e max free is 100% */
+	uintptr_t heapFreeMaximumHeuristicMultiplier = getHeapFreeMaximumHeuristicMultiplier(env);
+	if (100 == _extensions->heapFreeMaximumRatioMultiplier || heapFreeMaximumHeuristicMultiplier >= 100) {
 		Trc_MM_MemorySubSpaceUniSpace_timeForHeapContract_Exit2(env->getLanguageVMThread());
 		return false;
 	}
@@ -326,8 +327,9 @@ MM_MemorySubSpaceUniSpace::timeForHeapContract(MM_EnvironmentBase *env, MM_Alloc
 	 * the start of the garbage collection 
 	 */ 
 	 if (systemGC) {
+		uintptr_t heapFreeMinimumHeuristicMultiplier = getHeapFreeMinimumHeuristicMultiplier(env);
 	 	uintptr_t minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor) 
-								* _extensions->heapFreeMinimumRatioMultiplier;
+								* heapFreeMinimumHeuristicMultiplier;
 		uintptr_t freeBytesAtSystemGCStart = _extensions->heap->getResizeStats()->getFreeBytesAtSystemGCStart();
 		
 		if (freeBytesAtSystemGCStart < minimumFree) {
@@ -374,8 +376,10 @@ MM_MemorySubSpaceUniSpace::calculateTargetContractSize(MM_EnvironmentBase *env, 
 	} else {
 		uintptr_t currentFree = getApproximateActiveFreeMemorySize() - allocSize;
 		uintptr_t currentHeapSize = getActiveMemorySize();
-		uintptr_t maximumFreePercent =  ratioContract ? OMR_MIN(_extensions->heapFreeMinimumRatioMultiplier + 5, _extensions->heapFreeMaximumRatioMultiplier + 1) :
-													_extensions->heapFreeMaximumRatioMultiplier + 1;
+		uintptr_t heapFreeMaximumHeuristicMultiplier = getHeapFreeMaximumHeuristicMultiplier(env);
+		uintptr_t heapFreeMinimumHeuristicMultiplier = getHeapFreeMinimumHeuristicMultiplier(env);
+		uintptr_t maximumFreePercent =  ratioContract ? OMR_MIN(heapFreeMinimumHeuristicMultiplier + 5, heapFreeMaximumHeuristicMultiplier + 1) :
+													heapFreeMaximumHeuristicMultiplier + 1;
 		uintptr_t maximumFree = (currentHeapSize / _extensions->heapFreeMaximumRatioDivisor) * maximumFreePercent;
 
 		/* Do we have more free than is desirable ? */
@@ -441,19 +445,19 @@ MM_MemorySubSpaceUniSpace::calculateTargetContractSize(MM_EnvironmentBase *env, 
 uintptr_t
 MM_MemorySubSpaceUniSpace::calculateExpandSize(MM_EnvironmentBase *env, uintptr_t bytesRequired, bool expandToSatisfy)
 {
-	uintptr_t currentFree, minimumFree, desiredFree;
 	uintptr_t expandSize = 0;
 	
 	Trc_MM_MemorySubSpaceUniSpace_calculateExpandSize_Entry(env->getLanguageVMThread(), bytesRequired);
 	
 	/* How much heap space currently free ? */
-	currentFree = getApproximateActiveFreeMemorySize();
+	uintptr_t currentFree = getApproximateActiveFreeMemorySize();
 	
 	/* and how much do we need free after this GC to meet -Xminf ? */
-	minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor) * _extensions->heapFreeMinimumRatioMultiplier;
+	uintptr_t heapFreeMinimumHeuristicMultiplier = getHeapFreeMinimumHeuristicMultiplier(env);
+	uintptr_t minimumFree = (getActiveMemorySize() / _extensions->heapFreeMinimumRatioDivisor) * heapFreeMinimumHeuristicMultiplier;
 	
-	/* The derired free is the sum of these 2 rounded to heapAlignment */
-	desiredFree= MM_Math::roundToCeiling(_extensions->heapAlignment, minimumFree + bytesRequired);
+	/* The desired free is the sum of these 2 rounded to heapAlignment */
+	uintptr_t desiredFree = MM_Math::roundToCeiling(_extensions->heapAlignment, minimumFree + bytesRequired);
 
 	if(desiredFree <= currentFree) {
 		/* Only expand if we didn't expand in last _extensions->heapExpansionStabilizationCount global collections */
@@ -479,7 +483,7 @@ MM_MemorySubSpaceUniSpace::calculateExpandSize(MM_EnvironmentBase *env, uintptr_
 		/* Calculate how much we need to expand the heap by in order to meet the 
 		 * allocation request and the desired -Xminf amount AFTER expansion 
 		 */
-		expandSize= ((desiredFree - currentFree) / (100 - _extensions->heapFreeMinimumRatioMultiplier)) * _extensions->heapFreeMinimumRatioDivisor;
+		expandSize = ((desiredFree - currentFree) / (100 - heapFreeMinimumHeuristicMultiplier)) * _extensions->heapFreeMinimumRatioDivisor;
 
 		if (expandSize > 0 ) {
 			/* Remember reason for contraction for later */
@@ -573,35 +577,34 @@ uintptr_t
 MM_MemorySubSpaceUniSpace::checkForRatioExpand(MM_EnvironmentBase *env, uintptr_t bytesRequired)
 {
 	Trc_MM_MemorySubSpaceUniSpace_checkForRatioExpand_Entry(env->getLanguageVMThread(), bytesRequired);
-	
-	uint32_t gcPercentage;
-	uintptr_t currentFree, maxFree;
 
-	/* How many bytes currently free ? */	 
-	currentFree = getApproximateActiveFreeMemorySize();
-						 
-	/* How many bytes free would constitute -Xmaxf at current heap size ? */				 
-	maxFree = (uintptr_t)(((uint64_t)getActiveMemorySize()  * _extensions->heapFreeMaximumRatioMultiplier)
-														 / ((uint64_t)_extensions->heapFreeMaximumRatioDivisor));
-														 
-	/* If we have hit -Xmaxf limit already ...return immiediatley */													 
-	if (currentFree >= maxFree) { 
+	uint32_t gcPercentage = 0;
+
+	/* How many bytes currently free ? */
+	uintptr_t currentFree = getApproximateActiveFreeMemorySize();
+
+	/* How many bytes free would constitute -Xmaxf at current heap size ? */
+	uintptr_t heapFreeMaximumHeuristicMultiplier = getHeapFreeMaximumHeuristicMultiplier(env);
+	uintptr_t maxFree = (uintptr_t)(getActiveMemorySize() * heapFreeMaximumHeuristicMultiplier / _extensions->heapFreeMaximumRatioDivisor);
+
+	/* If we have hit -Xmaxf limit already ...return immiediatley */
+	if (currentFree >= maxFree) {
 		Trc_MM_MemorySubSpaceUniSpace_checkForRatioExpand_Exit1(env->getLanguageVMThread());
 		return 0;
-	}														 
-						 
+	}
+
 	/* Ask the collector for percentage of time being spent in GC */
-	if(NULL != _collector) {
+	if (NULL != _collector) {
 		gcPercentage = _collector->getGCTimePercentage(env);
 	} else {
-		gcPercentage= _extensions->getGlobalCollector()->getGCTimePercentage(env);
+		gcPercentage = _extensions->getGlobalCollector()->getGCTimePercentage(env);
 	}
-	
+
 	/* Is too much time is being spent in GC? */
 	if (gcPercentage < _extensions->heapExpansionGCTimeThreshold) {
 		Trc_MM_MemorySubSpaceUniSpace_checkForRatioExpand_Exit2(env->getLanguageVMThread(), gcPercentage);
 		return 0;
-	} else { 
+	} else {
 		/* 
 		 * We are spending too much time in gc and are below -Xmaxf free space so expand to 
 		 * attempt to reduce gc time.
@@ -610,31 +613,29 @@ MM_MemorySubSpaceUniSpace::checkForRatioExpand(MM_EnvironmentBase *env, uintptr_
 		 * 
 		 * We expand by HEAP_FREE_RATIO_EXPAND_MULTIPLIER percentage provided this does not take us above
 		 * -Xmaxf. If it does we expand up to the -Xmaxf limit.
-		 */ 
-		uintptr_t ratioExpandAmount, maxExpandSize;
-			
+		 */
+
 		/* How many bytes (maximum) do we want to expand by ?*/
-		ratioExpandAmount =(uintptr_t)(((uint64_t)getActiveMemorySize()  * HEAP_FREE_RATIO_EXPAND_MULTIPLIER)
-						 / ((uint64_t)HEAP_FREE_RATIO_EXPAND_DIVISOR));		
-						 
+		uintptr_t ratioExpandAmount = (uintptr_t)(((uint64_t)getActiveMemorySize() * HEAP_FREE_RATIO_EXPAND_MULTIPLIER)
+						 / ((uint64_t)HEAP_FREE_RATIO_EXPAND_DIVISOR));
+
 		/* If user has set -Xmaxf1.0 then they do not care how much free space we have
 		 * so no need to limit expand size here. Expand size will later be checked  
 		 * against -Xmaxe value.
 		 */
-		if (_extensions->heapFreeMaximumRatioMultiplier < 100 ) {					 
-			
-			/* By how much could we expand current heap without taking us above -Xmaxf bytes in 
+		if (heapFreeMaximumHeuristicMultiplier < 100) {
+			/* By how much could we expand current heap without taking us above -Xmaxf bytes in
 			 * resulting new (larger) heap
-			 */ 
-			maxExpandSize = ((maxFree - currentFree) / (100 - _extensions->heapFreeMaximumRatioMultiplier)) *
+			 */
+			uintptr_t maxExpandSize = ((maxFree - currentFree) / (100 - heapFreeMaximumHeuristicMultiplier)) *
 								_extensions->heapFreeMaximumRatioDivisor;
-				
+
 			ratioExpandAmount = OMR_MIN(maxExpandSize,ratioExpandAmount);
-		}	
+		}
 
 		/* Round expansion amount UP to heap alignment */
-		ratioExpandAmount = MM_Math::roundToCeiling(_extensions->heapAlignment, ratioExpandAmount);	
-				
+		ratioExpandAmount = MM_Math::roundToCeiling(_extensions->heapAlignment, ratioExpandAmount);
+
 		Trc_MM_MemorySubSpaceUniSpace_checkForRatioExpand_Exit3(env->getLanguageVMThread(), gcPercentage, ratioExpandAmount);
 		return ratioExpandAmount;
 	}
@@ -724,4 +725,45 @@ MM_MemorySubSpaceUniSpace::adjustExpansionWithinSoftMax(MM_EnvironmentBase *env,
 		}
 	}
 	return expandSize;
-}	
+}
+
+uintptr_t
+MM_MemorySubSpaceUniSpace::getHeapFreeMaximumHeuristicMultiplier(MM_EnvironmentBase *env)
+{
+	uint32_t gcPercentage = 0;
+
+	if (NULL != _collector) {
+		gcPercentage = _collector->getGCTimePercentage(env);
+	} else {
+		gcPercentage = _extensions->getGlobalCollector()->getGCTimePercentage(env);
+	}
+
+	uintptr_t expectedGcPercentage = (_extensions->heapContractionGCTimeThreshold + _extensions->heapExpansionGCTimeThreshold) / 2;
+	uintptr_t gcRatio = gcPercentage / expectedGcPercentage;
+	uintptr_t freeMaxMultiplier = _extensions->heapFreeMaximumRatioMultiplier + 6 * gcRatio * gcRatio;
+	
+	Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier(env->getLanguageVMThread(), freeMaxMultiplier);
+
+	return freeMaxMultiplier;
+}
+
+uintptr_t
+MM_MemorySubSpaceUniSpace::getHeapFreeMinimumHeuristicMultiplier(MM_EnvironmentBase *env)
+{
+	uint32_t gcPercentage = 0;
+
+	if (NULL != _collector) {
+		gcPercentage = _collector->getGCTimePercentage(env);
+	} else {
+		gcPercentage = _extensions->getGlobalCollector()->getGCTimePercentage(env);
+	}
+
+	uintptr_t expectedGcPercentage = (_extensions->heapContractionGCTimeThreshold + _extensions->heapExpansionGCTimeThreshold) / 2;
+	uintptr_t gcRatio = gcPercentage / expectedGcPercentage;
+	uintptr_t freeMinMultiplier = _extensions->heapFreeMinimumRatioMultiplier + 1 * gcRatio * gcRatio;
+	
+	Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier(env->getLanguageVMThread(), freeMinMultiplier);
+
+	return freeMinMultiplier;
+}
+

--- a/gc/base/MemorySubSpaceUniSpace.hpp
+++ b/gc/base/MemorySubSpaceUniSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,6 +53,8 @@ protected:
 	bool timeForHeapExpand(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);	
 	uintptr_t performExpand(MM_EnvironmentBase *env);
 	uintptr_t performContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
+	uintptr_t getHeapFreeMaximumHeuristicMultiplier(MM_EnvironmentBase *env);
+	uintptr_t getHeapFreeMinimumHeuristicMultiplier(MM_EnvironmentBase *env);
 
 public:
 	virtual void checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription = NULL, bool _systemGC = false);

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -925,3 +925,6 @@ TraceException=Trc_MM_double_map_Failed Overhead=1 Level=1 Group=arraylet Templa
 TraceExit=Trc_MM_double_map_Exit Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::doubleMapArraylets. result=%p"
 
 TraceEvent=Trc_MM_Scavenger_percolate_delegate Overhead=1 Level=1 Group=percolate Template="Percolating due to language specific reason"
+
+TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Maximum free multiplier = %zu"
+TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Minimum free multiplier = %zu"


### PR DESCRIPTION
The expansion and contraction of flat memory for tenured space, used by the optthuput/opavgpause
heap and gencon old gen, is governed by several criteria. Prior to this change, it evaluated a
simple minimum and maximum heap free percentage then checked the GC STW time overhead. If the
current heap free percentage was greater than the configured max free, the heap would not be
expanded even with very high GC time overhead. This change employs a heuristic to offset the
allowable maximum heap free percentage by a factor of the GC time overhead to allow the GC to
expand even with high free memory percentage when the GC time overhead is very high.

For example, with max free memory of 60% and a max CPU overhead of 13%, the heap would not be
expanded when the heap is 70% free even if the GC time overhead is 80%, well beyond the max.
By increasing the maximum allowed free percentage by a factor of the CPU overhead, the heap
would be expanded and the GC time overhead subsequently reduced in such a case.

Minimum free is checked to consider heap contraction. The default Xminf is 30 and the default
Xmaxf is 60. The new offset is as follows:

CPU Overhead	Min Free	Max Free
13%		Xminf+1.69	No heap expansion
20%		Xminf+4		Xmaxf+24
30%		Xminf+9		Xmaxf+54
40%		Xminf+16	Xmaxf+96
50%		Xminf+25	100
60%		Xminf+36	100
70%		Xminf+49	100
80%		Xminf+64	100
90%		Xminf+81	100
100%		100		100

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>