### PR TITLE
Add option '-statErrorsAreFatal'

### DIFF
--- a/tools/tracegen/TDFTypes.hpp
+++ b/tools/tracegen/TDFTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,6 @@ typedef struct J9TDFGroupTp {
 	unsigned int id;
 	struct J9TDFGroupTp *next;
 } J9TDFGroupTp;
-
 
 /* Trace group and link-list of TP ids that belong to this group*/
 typedef struct J9TDFGroup {
@@ -135,6 +134,7 @@ typedef struct J9TDFOptions {
 
 	bool force;
 	bool generateCFiles;
+	bool statErrorsAreFatal;
 	bool writeToCurrentDir;
 
 	Path *rootDirectory;
@@ -151,6 +151,7 @@ typedef struct J9TDFOptions {
 		, threshold(1)
 		, force(false)
 		, generateCFiles(false)
+		, statErrorsAreFatal(false)
 		, writeToCurrentDir(false)
 		, rootDirectory(NULL)
 		, files(NULL)

--- a/tools/tracemerge/DATMerge.cpp
+++ b/tools/tracemerge/DATMerge.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corp. and others
+ * Copyright (c) 2014, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -90,20 +90,20 @@ startTraceMerge(int argc, char *argv[])
 
 	dir = options.rootDirectory;
 	while (NULL != dir) {
-		if (0 != FileUtils::visitDirectory(&options, dir->path, TRACE_FILE_FRAGMENT_EXT, &datMerge, DATMerge::mergeCallback))	{
+		if (0 != FileUtils::visitDirectory(&options, dir->path, TRACE_FILE_FRAGMENT_EXT, &datMerge, DATMerge::mergeCallback)) {
 			FileUtils::printError("Failed to merge PDAT files\n");
 			goto failed;
 		}
 		dir = dir->next;
 	}
 
+done:
 	argParser.freeOptions(&options);
 	return rc;
 failed:
-	argParser.freeOptions(&options);
-	return RC_FAILED;
+	rc = RC_FAILED;
+	goto done;
 }
-
 
 RCType
 DATMerge::merge(J9TDFOptions *options, const char *fromFileName)


### PR DESCRIPTION
Tools like `tracemerge` may encounter temporary files or directories created by other processes running in parallel that disappear almost immediately: failing to `stat()` such resources should not be fatal by default.

Fixes eclipse/openj9#9869.