### PR TITLE
AArch64: Change calls to decReferenceCount()

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -124,8 +124,8 @@ genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstO
       generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -324,8 +324,8 @@ OMR::ARM64::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -368,8 +368,8 @@ OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       cg->stopUsingRegister(tmpReg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -417,8 +417,8 @@ OMR::ARM64::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -435,8 +435,8 @@ static TR::Register *idivHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
 
    generateTrg1Src2Instruction(cg, is64bit ? TR::InstOpCode::sdivx : TR::InstOpCode::sdivw, node, trgReg, src1Reg, src2Reg);
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -456,8 +456,8 @@ static TR::Register *iremHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
    generateTrg1Src3Instruction(cg, is64bit ? TR::InstOpCode::msubx : TR::InstOpCode::msubw, node, trgReg, tmpReg, src2Reg, src1Reg);
 
    cg->stopUsingRegister(tmpReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -492,8 +492,8 @@ OMR::ARM64::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       cg->stopUsingRegister(tmpReg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -572,8 +572,8 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
       }
 
    node->setRegister(trgReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    return trgReg;
    }
 
@@ -635,8 +635,8 @@ OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       }
 
    node->setRegister(trgReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    return trgReg;
    }
 
@@ -889,8 +889,8 @@ logicBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstOpC
       generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    node->setRegister(trgReg);
    return trgReg;
    }

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -166,11 +166,11 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
       result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    if (thirdChild)
       {
-      thirdChild->decReferenceCount();
+      cg->decReferenceCount(thirdChild);
       }
    return result;
    }
@@ -353,8 +353,8 @@ static TR::Register *icmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
    generateCSetInstruction(cg, node, trgReg, cc);
 
    node->setRegister(trgReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    return trgReg;
    }
 
@@ -512,8 +512,8 @@ OMR::ARM64::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->stopUsingRegister(tmpReg);
 
    node->setRegister(trgReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    return trgReg;
    }
 

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -329,7 +329,7 @@ intFpTypeConversionHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeG
 
    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
 
-   child->decReferenceCount();
+   cg->decReferenceCount(child);
    node->setRegister(trgReg);
    return trgReg;
    }
@@ -471,11 +471,11 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
          }
       }
 
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    if (thirdChild)
       {
-      thirdChild->decReferenceCount();
+      cg->decReferenceCount(thirdChild);
       }
    return result;
    }
@@ -594,8 +594,8 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
    generateCSetInstruction(cg, node, trgReg, cc);
 
    node->setRegister(trgReg);
-   firstChild->decReferenceCount();
-   secondChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
    return trgReg;
    }
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -423,7 +423,7 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
             intptr_t amount = (integerChild->getOpCodeValue() == TR::iconst) ?
                                 integerChild->getInt() : integerChild->getLongInt();
             self()->addToOffset(integerChild, amount, cg);
-            integerChild->decReferenceCount();
+            cg->decReferenceCount(integerChild);
             }
          else if (integerChild->getEvaluationPriority(cg) > addressChild->getEvaluationPriority(cg))
             {
@@ -442,8 +442,8 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
          {
          self()->addToOffset(subTree, subTree->getFirstChild()->getInt() <<
                      subTree->getSecondChild()->getInt(), cg);
-         subTree->getFirstChild()->decReferenceCount();
-         subTree->getSecondChild()->decReferenceCount();
+         cg->decReferenceCount(subTree->getFirstChild());
+         cg->decReferenceCount(subTree->getSecondChild());
          }
       else if ((subTree->getOpCodeValue() == TR::loadaddr) && !cg->comp()->compileRelocatableCode())
          {
@@ -495,8 +495,8 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
                }
             }
          self()->addToOffset(subTree, subTree->getSymbolReference()->getOffset(), cg);
-         subTree->decReferenceCount(); // need to decrement ref count because
-                                       // nodes weren't set on memoryreference
+         cg->decReferenceCount(subTree); // need to decrement ref count because
+                                         // nodes weren't set on memoryreference
          }
       else if (subTree->getOpCodeValue() == TR::aconst ||
                subTree->getOpCodeValue() == TR::iconst ||

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -495,7 +495,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xF); // dmb SY
       }
 
-   valueChild->decReferenceCount();
+   cg->decReferenceCount(valueChild);
    tempMR->decNodeReferenceCounts(cg);
 
    return NULL;
@@ -820,7 +820,7 @@ OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *c
                }
             }
          }
-      child->decReferenceCount();
+      cg->decReferenceCount(child);
       }
 
    TR::LabelSymbol *labelSym = node->getLabel();
@@ -870,7 +870,7 @@ OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       TR::Node *child = node->getFirstChild();
       cg->evaluate(child);
       deps = generateRegisterDependencyConditions(cg, child, 0);
-      child->decReferenceCount();
+      cg->decReferenceCount(child);
       }
 
    // put the dependencies (if any) on the fence
@@ -885,7 +885,7 @@ OMR::ARM64::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR::CodeGenerato
    {
    TR::Node *child = node->getFirstChild();
    TR::Register *trgReg = cg->evaluate(child);
-   child->decReferenceCount();
+   cg->decReferenceCount(child);
    node->setRegister(trgReg);
    return trgReg;
    }

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -93,7 +93,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeG
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *reg = cg->gprClobberEvaluate(firstChild);
    generateNegInstruction(cg, node, reg, reg);
-   firstChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
    return node->setRegister(reg);
    }
 
@@ -102,7 +102,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *tempReg = cg->gprClobberEvaluate(firstChild);
    generateNegInstruction(cg, node, tempReg, tempReg, true);
-   firstChild->decReferenceCount();
+   cg->decReferenceCount(firstChild);
    return node->setRegister(tempReg);
    }
 
@@ -157,7 +157,7 @@ static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mne
    generateTrg1Src1ImmInstruction(cg, op, node, trgReg, trgReg, imms);
 
    node->setRegister(trgReg);
-   child->decReferenceCount();
+   cg->decReferenceCount(child);
    return trgReg;
    }
 


### PR DESCRIPTION
This commit changes node->decReferenceCount() in AArch64 code to
cg->decReferenceCount(node).

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>