### PR TITLE
Dispatcher Rework: Thread Selection & Hybrid Notification

### DIFF
--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -50,9 +50,9 @@ class MM_Task;
 class MM_Dispatcher : public MM_BaseVirtual
 {
 private:
+protected:
 	MM_Task *_task;
 	
-protected:
 	bool initialize(MM_EnvironmentBase *env);
 	
 	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -439,6 +439,7 @@ public:
 	uintptr_t gcThreadCount; /**< Initial number of GC threads - chosen default or specified in java options*/
 	bool gcThreadCountForced; /**< true if number of GC threads is specified in java options. Currently we have a few ways to do this:
 										-Xgcthreads		-Xthreads= (RT only)	-XthreadCount= */
+	uintptr_t dispatcherHybridNotifyThreadBound; /** Bound for determining hybrid notification type (Individual notifies for count < MIN(bound, maxThreads/2), otherwise notify_all) */
 
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	enum ScavengerScanOrdering {
@@ -1510,6 +1511,7 @@ public:
 #endif /* OMR_GC_BATCH_CLEAR_TLH */
 		, gcThreadCount(0)
 		, gcThreadCountForced(false)
+		, dispatcherHybridNotifyThreadBound(16)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -160,6 +160,12 @@ MM_ParallelDispatcher::slaveEntryPoint(MM_EnvironmentBase *env)
 		/* Wait for a task to be dispatched to the slave thread */
 		while(slave_status_waiting == _statusTable[slaveID]) {
 			omrthread_monitor_wait(_slaveThreadMutex);
+			if (_slaveThreadsReservedForGC && (_threadsToReserve > 0)) {
+				Assert_MM_true(slave_status_dying != _statusTable[slaveID]);
+				_threadsToReserve -= 1;
+				_statusTable[slaveID] = slave_status_reserved;
+				_taskTable[slaveID] = _task;
+			}
 		}
 
 		if(slave_status_reserved == _statusTable[slaveID]) {
@@ -387,7 +393,20 @@ MM_ParallelDispatcher::shutDownThreads()
 void
 MM_ParallelDispatcher::wakeUpThreads(uintptr_t count)
 {
-	omrthread_monitor_notify_all(_slaveThreadMutex);	
+	/* This thread should notify and release _slaveThreadMutex asap. Threads waking up will need to
+	 * reacquire the mutex before proceeding with the task.
+	 *
+	 * Hybrid approach to notifying threads:
+	 * 	- Cheaper to do to individual notifies for small set of threads from a large pool
+	 * 	- More expensive to do with individual notifies with large set of threads
+	 */
+	if (count < OMR_MIN((_threadCountMaximum / 2), _extensions->dispatcherHybridNotifyThreadBound)) {
+		for (uintptr_t threads = 0; threads < count; threads++) {
+			omrthread_monitor_notify(_slaveThreadMutex);
+		}
+	} else {
+		omrthread_monitor_notify_all(_slaveThreadMutex);
+	}
 }
 
 /**
@@ -473,13 +492,20 @@ MM_ParallelDispatcher::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *t
 	 */
 	_slaveThreadsReservedForGC = true; 
 
+	Assert_MM_true(_task == NULL);
+	_task = task;
+
 	task->setSynchronizeMutex(_synchronizeMutex);
-	
-	for(uintptr_t index=0; index < threadCount; index++) {
-		_statusTable[index] = slave_status_reserved;
-		_taskTable[index] = task;
-	}
-	wakeUpThreads(threadCount);
+
+	/* This thread will be used - update thread's status */
+	_statusTable[env->getSlaveID()] = slave_status_reserved;
+	_taskTable[env->getSlaveID()] = task;
+
+	/* This thread doesn't need to be woken up */
+	Assert_MM_true(_threadsToReserve == 0);
+	_threadsToReserve = threadCount - 1;
+	wakeUpThreads(_threadsToReserve);
+
 	omrthread_monitor_exit(_slaveThreadMutex);
 }
 
@@ -514,6 +540,8 @@ MM_ParallelDispatcher::cleanupAfterTask(MM_EnvironmentBase *env)
 	omrthread_monitor_enter(_slaveThreadMutex);
 	
 	_slaveThreadsReservedForGC = false;
+	Assert_MM_true(_threadsToReserve == 0);
+	_task = NULL;
 	
 	if (_inShutdown) {
 		omrthread_monitor_notify_all(_slaveThreadMutex);

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -46,6 +46,7 @@ class MM_ParallelDispatcher : public MM_Dispatcher
 	 * Data members
 	 */
 private:
+	uintptr_t _threadsToReserve; /**< Indicates number of threads remaining to dispatch tasks upon notify. Must be exactly 0 after tasks are dispatched. */
 protected:
 	MM_GCExtensionsBase *_extensions;
 
@@ -134,6 +135,7 @@ public:
 
 	MM_ParallelDispatcher(MM_EnvironmentBase *env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize) :
 		MM_Dispatcher(env)
+		,_threadsToReserve(0)
 		,_extensions(MM_GCExtensionsBase::getExtensions(env->getOmrVM()))
 		,_threadShutdownCount(0)
 		,_threadTable(NULL)


### PR DESCRIPTION
**Assign task to threads at hand (earliest available) to start task independently of which threads are available:**

- Forgo selecting specific threads and updating thread tables prior to notification.
- Use threads in the order they wake up/reacquire slave thread mutex after notification.

**Hybrid approach to notifying threads:**
When using a small set of threads from a large pool, it can be significantly cheaper to do to individual notifies (`omrthread_monitor_notify`) as compared to `omrthread_monitor_notify_all`. However, for large set of threads, it will be more expensive to wake up threads with individual notifies.

- Introduced `dispatcherHybridNotifyThreadBound` (Individual notifies for count < MIN(bound, maxThreads/2), otherwise notify_all))

Background & Results: https://github.com/eclipse/omr/issues/5318

Signed-off-by: Salman Rana <salman.rana@ibm.com>