### PR TITLE
Detect variant method parameters and prevent inliner from using their symbol type to get call targets

### DIFF
--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -303,6 +303,23 @@ public:
    void clearProfilingOffsetInfo();
    void dumpProfilingOffsetInfo(TR::Compilation *comp);
 
+   /**
+    * @brief Detects whether a parameter is variant.
+    *
+    * A variant parameter is a reference parameter that is written to,
+    * potentially with a reference to a different class than the reference
+    * originally held by the parameter. In such cases,the type signature
+    * of the parameter symbol cannot be trusted.
+    *
+    * The behavior when invoking this function with a ParameterSymbol that
+    * does not belong to the current ResolvedMethodSymbol is unspecified.
+    *
+    * @param parmSymbol is the parameter symbol to be checked
+    * @return true if the parameter is variant
+    * @return false if the parameter is invariant
+    */
+   bool isParmVariant(TR::ParameterSymbol * parmSymbol);
+
 protected:
    enum Properties
       {
@@ -327,6 +344,18 @@ protected:
       };
 
    flags32_t _properties;
+
+   // Containes a bit for each method parameter.
+   // If a bit is set, the corresponding paramter is variant.
+   TR_BitVector * _variantParms;
+
+   /**
+    * @brief Detects any vairant method parameters
+    *
+    * If _variantParms is null, a new bitvector instance is
+    * allocated and populated.
+    */
+   void detectVariantParms();
 
 private:
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3974,11 +3974,16 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
          if (callsite->_initialCalleeMethod)
             callsite->_receiverClass = callsite->_initialCalleeMethod->classOfMethod();
 
-         int32_t len;
-         const char * s = callNode->getChild(callNode->getFirstArgumentIndex())->getTypeSignature(len);
-         TR_OpaqueClassBlock * type = s ? fe()->getClassFromSignature(s, len, callsite->_callerResolvedMethod, true) : 0;
-         if (type && (!callsite->_receiverClass || (type != callsite->_receiverClass && fe()->isInstanceOf(type, callsite->_receiverClass, true, true) == TR_yes)))
-            callsite->_receiverClass = type;
+         TR::Node* receiverNode = callNode->getChild(callNode->getFirstArgumentIndex());
+         TR::Symbol* receiverSymbol = receiverNode->getOpCode().hasSymbolReference() ? receiverNode->getSymbol() : NULL;
+         if (!receiverSymbol || !receiverSymbol->isParm() || !receiverNode->getSymbolReference()->getOwningMethodSymbol(comp())->isParmVariant(receiverSymbol->getParmSymbol()))
+            {
+            int32_t len;
+            const char * s = receiverNode->getTypeSignature(len);
+            TR_OpaqueClassBlock * type = s ? fe()->getClassFromSignature(s, len, callsite->_callerResolvedMethod, true) : 0;
+            if (type && (!callsite->_receiverClass || (type != callsite->_receiverClass && fe()->isInstanceOf(type, callsite->_receiverClass, true, true) == TR_yes)))
+               callsite->_receiverClass = type;
+            }
          }
       }
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3978,7 +3978,7 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
          TR::Symbol* receiverSymbol = receiverNode->getOpCode().hasSymbolReference() ? receiverNode->getSymbol() : NULL;
          if (!receiverSymbol || !receiverSymbol->isParm() || !receiverNode->getSymbolReference()->getOwningMethodSymbol(comp())->isParmVariant(receiverSymbol->getParmSymbol()))
             {
-            int32_t len;
+            int32_t len = 0;
             const char * s = receiverNode->getTypeSignature(len);
             TR_OpaqueClassBlock * type = s ? fe()->getClassFromSignature(s, len, callsite->_callerResolvedMethod, true) : 0;
             if (type && (!callsite->_receiverClass || (type != callsite->_receiverClass && fe()->isInstanceOf(type, callsite->_receiverClass, true, true) == TR_yes)))


### PR DESCRIPTION
These commits add the `OMR::ResolvedMethodSymbol::isParmVariant()` function that detects variant parameters (parameter slots who's value has been overwritten with something else).

In addition, this new function is used to prevent the inliner from using variant parameter symbols to derive call targets.

Fixes eclipse/openj9#8823