### PR TITLE
Use _NSGetEnviron() on OSX to retrieve environ

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -50,6 +50,10 @@
 #include <sys/sysctl.h>
 #endif /* defined(OSX) || defined(OMR_OS_BSD) */
 
+#if defined(OSX)
+#include <crt_externs.h>
+#endif /* defined(OSX) */
+
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -188,9 +192,6 @@ uintptr_t Get_Number_Of_CPUs();
 #define JIFFIES         100
 #define USECS_PER_SEC   1000000
 #define TICKS_TO_USEC   ((uint64_t)(USECS_PER_SEC/JIFFIES))
-
-/* For the omrsysinfo_env_iterator */
-extern char **environ;
 
 static uintptr_t copyEnvToBuffer(struct OMRPortLibrary *portLibrary, void *args);
 static uintptr_t copyEnvToBufferSignalHandler(struct OMRPortLibrary *portLib, uint32_t gpType, void *gpInfo, void *unUsed);
@@ -3963,6 +3964,13 @@ copyEnvToBuffer(struct OMRPortLibrary *portLibrary, void *args)
 	BOOLEAN bufferBigEnough = TRUE;
 	uintptr_t i;
 	uintptr_t rc;
+
+	/* For the omrsysinfo_env_iterator */
+#if defined(OSX)
+	char **environ = *_NSGetEnviron();
+#else /* defined(OSX) */
+	extern char **environ;
+#endif /* defined(OSX) */
 
 #if defined(J9VM_USE_ICONV)
 	iconv_t converter;


### PR DESCRIPTION
As per: https://github.com/eclipse/openj9/issues/7247

Direct access to `environ` on OSX should use `_NSGetEnviron`, as `environ` is only directly accessible via that environment
subroutine from shared libraries and bundles since Mac OS X 10.5 (Leopard).

This change likely does not fix the crash noted in the issue, but makes access to `environ` available from shared libraries and bundles.

---

`environ` is a list of strings that is made available when a process begins. Each string has the convention "name=value" which is set in the user environment.

`environ` can be directly accessed, except from shared libraries and bundles, since it is only available to the loader `ld` when a complete program is being linked. The environment routines `getenv`, `setenv` and `putenv` can be used to access `environ` whether referenced by the loader or in shared libraries and bundles. If direct access to `environ` is needed in shared libraries or bundles for OSX, `_NSGetEnviron` (defined in `crt_externs.h`) can be used to retrieve `environ` at runtime.

Source: https://opensource.apple.com/source/Libc/Libc-1353.41.1/man/FreeBSD/environ.7.auto.html
Some other info: https://www.gnu.org/software/gnulib/manual/gnulib.html#environ
`crt_externs.h`: https://opensource.apple.com/source/Libc/Libc-1353.41.1/sys/crt_externs.c.auto.html