### PR TITLE
Move code that disables RegDepCopyRemoval

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2317,27 +2317,33 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
             fej9->waitOnCompiler(jitConfig);
             }
          }
-
-      // Disable regDepCopyRemoval when value types are enabled
-      //
-      // In OpenJ9, the implementation of value types does not behave well with
-      // regDepCopyRemoval. Specifically,  the ifacmp{eq,ne} operations rely on
-      // lowering that requires basic block splitting after GRA.
-      // RegDepCopyRemoval currently leaves the trees in a state that the post
-      // GRA block splitter cannot handle. So, for now, the optimization is
-      // disabled.
-      //
-      // https://github.com/eclipse/openj9/issues/9712 was opened to track the
-      // work to re-enable the optimization.
-      //
-      // Unfortunately, the design of the option processing framework requires
-      // the disabling code to be in OMR (rather than OpenJ9) and guarded
-      // with J9_PROJECT_SPECIFIC.
-      if (TR::Compiler->om.areValueTypesEnabled())
-         _disabledOptimizations[regDepCopyRemoval] = true;
 #endif
 
       }
+
+#ifdef J9_PROJECT_SPECIFIC
+
+   // Disable regDepCopyRemoval when value types are enabled
+   //
+   // In OpenJ9, the implementation of value types does not behave well with
+   // regDepCopyRemoval. Specifically,  the ifacmp{eq,ne} operations rely on
+   // lowering that requires basic block splitting after GRA.
+   // RegDepCopyRemoval currently leaves the trees in a state that the post
+   // GRA block splitter cannot handle. So, for now, the optimization is
+   // disabled.
+   //
+   // https://github.com/eclipse/openj9/issues/9712 was opened to track the
+   // work to re-enable the optimization.
+   //
+   // Unfortunately, the design of the option processing framework requires
+   // the disabling code to be in OMR (rather than OpenJ9) and guarded
+   // with J9_PROJECT_SPECIFIC.
+   if (TR::Compiler->om.areValueTypesEnabled())
+      {
+      _disabledOptimizations[regDepCopyRemoval] = true;
+      }
+
+#endif
 
    // The adding of the enumeration of register names takes up a lot
    // of heap storage (as much as 100+ MBs) for very large programs. Here


### PR DESCRIPTION
Code that disables the `regDepCopyRemoval` optimization when value types are enabled for OpenJ9 was situated under the `else` branch of an `if` that checks `if (!optionSet)`.  In other words, the optimization was only disabled if there were JIT options to be processed.  Fixed by moving the code out of the `if-else`.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>