### PR TITLE
AArch64: Remove length parameter from MemoryReference (step 1)

### DIFF
--- a/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
          OMR::MemoryReferenceConnector(br, disp, cg) {}
 
    /**
-    * @brief Constructor
+    * @brief Constructor -- To be obsoleted
     * @param[in] node : load or store node
     * @param[in] len : length
     * @param[in] cg : CodeGenerator object
@@ -90,10 +90,10 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    MemoryReference(TR::Node *node,
       uint32_t len,
       TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(node, len, cg) {}
+         OMR::MemoryReferenceConnector(node, cg) {}
 
    /**
-    * @brief Constructor
+    * @brief Constructor -- To be obsoleted
     * @param[in] node : node
     * @param[in] symRef : symbol reference
     * @param[in] len : length
@@ -103,7 +103,27 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::SymbolReference *symRef,
       uint32_t len,
       TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(node, symRef, len, cg) {}
+         OMR::MemoryReferenceConnector(node, symRef, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] node : load or store node
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node,
+      TR::CodeGenerator *cg) :
+         OMR::MemoryReferenceConnector(node, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] node : node
+    * @param[in] symRef : symbol reference
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node,
+      TR::SymbolReference *symRef,
+      TR::CodeGenerator *cg) :
+         OMR::MemoryReferenceConnector(node, symRef, cg) {}
    };
 } // TR
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -109,7 +109,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
-   _length(0),
    _scale(0)
    {
    _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
@@ -128,7 +127,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
-   _length(0),
    _scale(0)
    {
    _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
@@ -147,7 +145,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
-   _length(0),
    _scale(0),
    _offset(disp)
    {
@@ -157,7 +154,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
 
 OMR::ARM64::MemoryReference::MemoryReference(
       TR::Node *rootLoadOrStore,
-      uint32_t len,
       TR::CodeGenerator *cg) :
    _baseRegister(NULL),
    _baseNode(NULL),
@@ -166,7 +162,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
-   _length(len),
    _scale(0),
    _offset(0),
    _symbolReference(rootLoadOrStore->getSymbolReference())
@@ -222,7 +217,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
 OMR::ARM64::MemoryReference::MemoryReference(
       TR::Node *node,
       TR::SymbolReference *symRef,
-      uint32_t len,
       TR::CodeGenerator *cg) :
    _baseRegister(NULL),
    _baseNode(NULL),
@@ -231,7 +225,6 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
-   _length(len),
    _scale(0),
    _offset(0),
    _symbolReference(symRef)

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -73,7 +73,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    TR::Register *_extraRegister;
 
    uint8_t _flag;
-   uint8_t _length;
    uint8_t _scale;
 
    public:
@@ -129,21 +128,38 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          TR::CodeGenerator *cg);
 
    /**
-    * @brief Constructor
+    * @brief Constructor -- To be obsoleted
     * @param[in] node : load or store node
     * @param[in] len : length
     * @param[in] cg : CodeGenerator object
     */
-   MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg);
+   MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg)
+      : MemoryReference(node, cg) {}
 
    /**
-    * @brief Constructor
+    * @brief Constructor -- To be obsoleted
     * @param[in] node : node
     * @param[in] symRef : symbol reference
     * @param[in] len : length
     * @param[in] cg : CodeGenerator object
     */
-   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg);
+   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg)
+      : MemoryReference(node, symRef, cg) {}
+
+   /**
+    * @brief Constructor
+    * @param[in] node : load or store node
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node, TR::CodeGenerator *cg);
+
+   /**
+    * @brief Constructor
+    * @param[in] node : node
+    * @param[in] symRef : symbol reference
+    * @param[in] cg : CodeGenerator object
+    */
+   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg);
 
    /**
     * @brief Gets base register
@@ -204,18 +220,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
     * @return extra register
     */
    TR::Register *setExtraRegister(TR::Register *er) {return (_extraRegister = er);}
-
-   /**
-    * @brief Gets length
-    * @return length
-    */
-   uint32_t getLength() {return _length;}
-   /**
-    * @brief Sets length
-    * @param[in] len : length
-    * @return length
-    */
-   uint32_t setLength(uint32_t len) {return (_length = len);}
 
    /**
     * @brief Gets scale


### PR DESCRIPTION
This commit removes the unused _length field from OMRMemoryReference.
It also adds constructors without the length parameter.

Issue: #4137

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>