### PR TITLE
AArch64: Remove length parameter from MemoryReference (step 3)

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -126,28 +126,28 @@ OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg
 TR::Register *
 OMR::ARM64::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vldrimms, 4, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::vldrimms, cg);
    }
 
 // also handles dloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vldrimmd, 8, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::vldrimmd, cg);
    }
 
 // also handles fstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, 4, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, cg);
    }
 
 // also handles dstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, 8, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, cg);
    }
 
 TR::Register *

--- a/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/compiler/aarch64/codegen/MemoryReference.hpp
@@ -82,30 +82,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
          OMR::MemoryReferenceConnector(br, disp, cg) {}
 
    /**
-    * @brief Constructor -- To be obsoleted
-    * @param[in] node : load or store node
-    * @param[in] len : length
-    * @param[in] cg : CodeGenerator object
-    */
-   MemoryReference(TR::Node *node,
-      uint32_t len,
-      TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(node, cg) {}
-
-   /**
-    * @brief Constructor -- To be obsoleted
-    * @param[in] node : node
-    * @param[in] symRef : symbol reference
-    * @param[in] len : length
-    * @param[in] cg : CodeGenerator object
-    */
-   MemoryReference(TR::Node *node,
-      TR::SymbolReference *symRef,
-      uint32_t len,
-      TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(node, symRef, cg) {}
-
-   /**
     * @brief Constructor
     * @param[in] node : load or store node
     * @param[in] cg : CodeGenerator object

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -186,7 +186,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
 
    candidates[0]->setBackingStorage(location);
 
-   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
+   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
 
    if (!comp->getOption(TR_DisableOOL))
       {
@@ -304,7 +304,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
                   targetRegister->getRegisterName(comp));
       }
 
-   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
+   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
 
    if (comp->getOption(TR_DisableOOL))
       {

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -128,25 +128,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          TR::CodeGenerator *cg);
 
    /**
-    * @brief Constructor -- To be obsoleted
-    * @param[in] node : load or store node
-    * @param[in] len : length
-    * @param[in] cg : CodeGenerator object
-    */
-   MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg)
-      : MemoryReference(node, cg) {}
-
-   /**
-    * @brief Constructor -- To be obsoleted
-    * @param[in] node : node
-    * @param[in] symRef : symbol reference
-    * @param[in] len : length
-    * @param[in] cg : CodeGenerator object
-    */
-   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg)
-      : MemoryReference(node, symRef, cg) {}
-
-   /**
     * @brief Constructor
     * @param[in] node : load or store node
     * @param[in] cg : CodeGenerator object

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -308,7 +308,7 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
                traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
                TR::Node *currentNode = currentInstruction->getNode();
                TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-               TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t), cg);
+               TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), cg);
                TR_RegisterKinds rk = virtReg->getKind();
                TR::InstOpCode::Mnemonic opCode;
                switch (rk)

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -340,7 +340,7 @@ OMR::ARM64::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeGenerator *c
 	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 	}
 
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
    bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
@@ -358,7 +358,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
       tempReg = cg->allocateRegister();
       }
    node->setRegister(tempReg);
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
    generateTrg1MemInstruction(cg, op, node, tempReg, tempMR);
 
    if (needSync)
@@ -375,7 +375,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
 TR::Register *
 OMR::ARM64::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::ldrimmw, 4, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::ldrimmw, cg);
    }
 
 // also handles aloadi
@@ -402,21 +402,18 @@ OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    node->setRegister(tempReg);
 
    TR::InstOpCode::Mnemonic op;
-   int32_t sizeOfMR;
 
    if (TR::Compiler->om.generateCompressedObjectHeaders() &&
        (node->getSymbol()->isClassObject() ||
         (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())))
       {
       op = TR::InstOpCode::ldrimmw;
-      sizeOfMR = 4;
       }
    else
       {
       op = TR::InstOpCode::ldrimmx;
-      sizeOfMR = 8;
       }
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, sizeOfMR, cg);
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
    generateTrg1MemInstruction(cg, op, node, tempReg, tempMR);
 
    if (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())
@@ -439,28 +436,28 @@ OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::ldrimmx, 8, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::ldrimmx, cg);
    }
 
 // also handles bloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::ldrsbimmx, 1, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::ldrsbimmx, cg);
    }
 
 // also handles sloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::ldrshimmx, 2, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::ldrshimmx, cg);
    }
 
 // also handles cloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::ldrhimm, 2, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::ldrhimm, cg);
    }
 
 TR::Register *
@@ -470,9 +467,9 @@ OMR::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *c
 	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 	}
 
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
+TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {
-   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
+   TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
    bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    TR::Node *valueChild;
 
@@ -505,21 +502,21 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
 TR::Register *
 OMR::ARM64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::strimmx, 8, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::strimmx, cg);
    }
 
 // also handles bstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::strbimm, 1, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::strbimm, cg);
    }
 
 // also handles sstorei, cstore, cstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::strhimm, 2, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::strhimm, cg);
    }
 
 // also handles istorei
@@ -528,7 +525,7 @@ OMR::ARM64::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg
    {
    TR::Compilation *comp = cg->comp();
 
-   commonStoreEvaluator(node, TR::InstOpCode::strimmw, 4, cg);
+   commonStoreEvaluator(node, TR::InstOpCode::strimmw, cg);
 
    if (comp->useCompressedPointers() && node->getOpCode().isIndirect())
       node->setStoreAlreadyEvaluated(true);
@@ -544,10 +541,9 @@ OMR::ARM64::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg
    bool isCompressedClassPointerOfObjectHeader = TR::Compiler->om.generateCompressedObjectHeaders() &&
          (node->getSymbol()->isClassObject() ||
          (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()));
-   auto sizeOfMR = isCompressedClassPointerOfObjectHeader ? 4 : 8;
    TR::InstOpCode::Mnemonic op = isCompressedClassPointerOfObjectHeader ? TR::InstOpCode::strimmw : TR::InstOpCode::strimmx;
 
-   return commonStoreEvaluator(node, op, sizeOfMR, cg);
+   return commonStoreEvaluator(node, op, cg);
    }
 
 TR::Register *
@@ -670,7 +666,7 @@ OMR::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::CodeGenerator *
    TR::Register *resultReg;
    TR::Symbol *sym = node->getSymbol();
    TR::Compilation *comp = cg->comp();
-   TR::MemoryReference *mref = new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSymbolReference(), 0, cg);
+   TR::MemoryReference *mref = new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSymbolReference(), cg);
 
    if (mref->getUnresolvedSnippet() != NULL)
       {

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -53,19 +53,17 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
  * @brief Helper function for xloadEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for load
- * @param[in] memSize : data size on memory
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg);
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
 /**
  * @brief Helper function for xstoreEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for store
- * @param[in] memSize : data size on memory
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg);
+TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
 namespace OMR
 {


### PR DESCRIPTION
This commit removes the unused length parameter from calls to
MemoryReference constructors.
It also removes the old constructors with the length parameter.
It depends on eclipse/openj9#10023.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>