### PR TITLE
AArch64: Enable profiling recompilation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2623,10 +2623,6 @@ OMR::Options::jitPreProcess()
 #if defined(TR_HOST_ARM64)
       // Prefetch is not supported on ARM64 yet
       _disabledOptimizations[prefetchInsertion] = true;
-
-      // Profiling is not supported on ARM64 yet
-      // Eclipse OpenJ9 Issue #9881
-      self()->setOption(TR_DisableProfiling);
 #endif
 
       self()->setOption(TR_DisableThunkTupleJ2I); // JSR292:TODO: Figure out how to do this without confusing startPCIfAlreadyCompiled


### PR DESCRIPTION
This commit enables profiling recompilation on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>