### PR TITLE
Check whether type for VP constraint is definitely an array

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12205,7 +12205,8 @@ static TR_YesNoMaybe isArrayCompTypeValueType(OMR::ValuePropagation *vp, TR::VPC
       {
       isValueType = TR_no;
       }
-   else if (!arrayConstraint || !arrayConstraint->getClass())
+   else if (!(arrayConstraint && arrayConstraint->getClass()
+              && arrayConstraint->getClassType()->isArray() == TR_yes))
       {
       isValueType = TR_maybe;
       }


### PR DESCRIPTION
Code in `isArrayCompTypeValueType` was checking the array component type for the type associated with a constraint, assuming that it must represent an array type, without first checking that the constraint definitely held an array type.  That could lead to segmentation faults for the garbage component type.

Added the missing check to confirm that the constraint is definitely for an array type.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>