### PR TITLE
Enable tril tests on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
  
       - script: |
           set PATH=C:\Program Files (x86)\Windows Kits\10\bin\10.0.16299.0\x64;%PATH%
-          cmake .. -G "Visual Studio 15 2017 Win64" -C../cmake/caches/Windows.cmake .. -DOMR_DDR=0
+          cmake .. -G "Visual Studio 15 2017 Win64" -C../cmake/caches/Windows.cmake .. -DOMR_DDR=0 -DOMR_TEST_COMPILER=ON -DOMR_JITBUILDER_TEST=ON
         displayName: 'Configure'
         workingDirectory: 'build'
  

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -1702,8 +1702,12 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_b2s, convert(byteDataArray[i], SHORT_POS), _b2s(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(_b2i, convert(byteDataArray[i], INT_POS), _b2i(byteDataArray[i]));
       OMR_CT_EXPECT_EQ(_b2l, convert(byteDataArray[i], LONG_POS), _b2l(byteDataArray[i]));
-      OMR_CT_EXPECT_FLOAT_EQ(_b2f, convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
-      OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
+      if (byteDataArray[i] >= 0)
+            // Skip char to fp conversion on X86: Known bug, see Issue #5378
+            {
+            OMR_CT_EXPECT_FLOAT_EQ(_b2f, convert(byteDataArray[i], FLOAT_POS), _b2f(byteDataArray[i]));
+            OMR_CT_EXPECT_DOUBLE_EQ(_b2d, convert(byteDataArray[i], DOUBLE_POS), _b2d(byteDataArray[i]));
+            }
 
       sprintf(resolvedMethodName, "b2sConst%d", i + 1);
       compileOpCodeMethod(b2sConst, _numberOfUnaryArgs, TR::b2s,
@@ -1774,8 +1778,12 @@ X86OpCodesTest::invokeUnaryTests()
       OMR_CT_EXPECT_EQ(_s2b, convert(shortDataArray[i], BYTE_POS), _s2b(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(_s2i, convert(shortDataArray[i], INT_POS), _s2i(shortDataArray[i]));
       OMR_CT_EXPECT_EQ(_s2l, convert(shortDataArray[i], LONG_POS), _s2l(shortDataArray[i]));
-      OMR_CT_EXPECT_FLOAT_EQ(_s2f, convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
-      OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
+      if (byteDataArray[i] >= 0)
+            // Skip short to fp conversion on X86: Known bug, see Issue #5378
+            {
+            OMR_CT_EXPECT_FLOAT_EQ(_s2f, convert(shortDataArray[i], FLOAT_POS), _s2f(shortDataArray[i]));
+            OMR_CT_EXPECT_DOUBLE_EQ(_s2d, convert(shortDataArray[i], DOUBLE_POS), _s2d(shortDataArray[i]));
+            }
 
       sprintf(resolvedMethodName, "s2bConst%d", i + 1);
       compileOpCodeMethod(s2bConst, _numberOfUnaryArgs, TR::s2b,

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -591,31 +591,31 @@ TEST_P(Int8Arithmetic, UsingLoadParamAndLoadConst) {
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("iadd", add),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("isub", sub),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("imul", mul),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("imulh", imulh))));
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("iadd", add),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("isub", sub),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("imul", mul),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("imulh", imulh))));
 
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int64Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int64_t, int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("ladd", add),
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lsub", sub),
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmul", mul))));
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("ladd", add),
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lsub", sub),
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmul", mul))));
 
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int16Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int16_t, int16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("sadd", add<int16_t>),
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", sub<int16_t>),
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("smul", mul<int16_t>))));
+        std::tuple<const char*, int16_t(*)(int16_t, int16_t)>("sadd", add<int16_t>),
+        std::tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", sub<int16_t>),
+        std::tuple<const char*, int16_t(*)(int16_t, int16_t)>("smul", mul<int16_t>))));
 
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int8Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int8_t, int8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("badd", add<int8_t>),
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", sub<int8_t>),
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bmul", mul<int8_t>))));
+        std::tuple<const char*, int8_t(*)(int8_t, int8_t)>("badd", add<int8_t>),
+        std::tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", sub<int8_t>),
+        std::tuple<const char*, int8_t(*)(int8_t, int8_t)>("bmul", mul<int8_t>))));
 
 /**
  * @brief Filter function for *div opcodes
@@ -643,15 +643,15 @@ INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<int32_t, int32_t>(), div_filter<int32_t> )),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("idiv", div),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("irem", rem))));
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("idiv", div),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("irem", rem))));
 
 INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int64Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<int64_t, int64_t>(), div_filter<int64_t> )),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("ldiv", div),
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lrem", rem))));
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("ldiv", div),
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lrem", rem))));
 
 /**
  * @brief Filter function for *udiv opcodes
@@ -671,14 +671,14 @@ INSTANTIATE_TEST_CASE_P(DivArithmeticTest, UInt32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<uint32_t, uint32_t>(), udiv_filter<uint32_t> )),
     ::testing::Values(
-        std::make_tuple<const char*, uint32_t(*)(uint32_t, uint32_t)>("iudiv", udiv),
-        std::make_tuple<const char*, uint32_t(*)(uint32_t, uint32_t)>("iurem", urem))));
+        std::tuple<const char*, uint32_t(*)(uint32_t, uint32_t)>("iudiv", udiv),
+        std::tuple<const char*, uint32_t(*)(uint32_t, uint32_t)>("iurem", urem))));
 
 INSTANTIATE_TEST_CASE_P(DivArithmeticTest, UInt64Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<uint64_t, uint64_t>(), udiv_filter<uint64_t> )),
     ::testing::Values(
-        std::make_tuple<const char*, uint64_t(*)(uint64_t, uint64_t)>("ludiv", udiv))));
+        std::tuple<const char*, uint64_t(*)(uint64_t, uint64_t)>("ludiv", udiv))));
 
 template <typename T>
 bool smallFp_filter(std::tuple<T, T> a)
@@ -788,10 +788,10 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, FloatArithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, float (*)(float, float)>("fadd", static_cast<float (*)(float, float)>(add)),
-        std::make_tuple<const char*, float (*)(float, float)>("fsub", static_cast<float (*)(float, float)>(sub)),
-        std::make_tuple<const char*, float (*)(float, float)>("fmul", static_cast<float (*)(float, float)>(mul)),
-        std::make_tuple<const char*, float (*)(float, float)>("fdiv", static_cast<float (*)(float, float)>(div))
+        std::tuple<const char*, float (*)(float, float)>("fadd", static_cast<float (*)(float, float)>(add)),
+        std::tuple<const char*, float (*)(float, float)>("fsub", static_cast<float (*)(float, float)>(sub)),
+        std::tuple<const char*, float (*)(float, float)>("fmul", static_cast<float (*)(float, float)>(mul)),
+        std::tuple<const char*, float (*)(float, float)>("fdiv", static_cast<float (*)(float, float)>(div))
     )));
 
 #ifdef OMR_ENV_DATA64
@@ -906,7 +906,7 @@ TEST_P(AddressInt64Arithmetic, UsingLoadConstAndLoadParam) {
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, AddressInt64Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint64_t, int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, uint64_t(*)(uint64_t, int64_t)>("aladd", aladd))));
+        std::tuple<const char*, uint64_t(*)(uint64_t, int64_t)>("aladd", aladd))));
 #endif
 
 #ifdef OMR_ENV_DATA32
@@ -1021,7 +1021,7 @@ TEST_P(AddressInt32Arithmetic, UsingLoadConstAndLoadParam) {
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, AddressInt32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, uint32_t(*)(uint32_t, int32_t)>("aiadd", aiadd))));
+        std::tuple<const char*, uint32_t(*)(uint32_t, int32_t)>("aiadd", aiadd))));
 #endif
 
 class DoubleArithmetic : public TRTest::BinaryOpTest<double> {};
@@ -1122,10 +1122,10 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, DoubleArithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, double (*)(double, double)>("dadd", add),
-        std::make_tuple<const char*, double (*)(double, double)>("dsub", sub),
-        std::make_tuple<const char*, double (*)(double, double)>("dmul", mul),
-        std::make_tuple<const char*, double (*)(double, double)>("ddiv", div)
+        std::tuple<const char*, double (*)(double, double)>("dadd", add),
+        std::tuple<const char*, double (*)(double, double)>("dsub", sub),
+        std::tuple<const char*, double (*)(double, double)>("dmul", mul),
+        std::tuple<const char*, double (*)(double, double)>("ddiv", div)
     )));
 
 template <typename T>
@@ -1202,8 +1202,8 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, FloatUnaryArithmetic, ::testing::Combine
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<float>(), smallFp_unary_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, float (*)(float)>("fabs", static_cast<float (*)(float)>(std::abs)),
-        std::make_tuple<const char*, float (*)(float)>("fneg", fneg)
+        std::tuple<const char*, float (*)(float)>("fabs", static_cast<float (*)(float)>(std::abs)),
+        std::tuple<const char*, float (*)(float)>("fneg", fneg)
     )));
 
 double dneg(double x) {
@@ -1273,6 +1273,6 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, DoubleUnaryArithmetic, ::testing::Combin
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<double>(), smallFp_unary_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, double (*)(double)>("dabs", static_cast<double (*)(double)>(std::abs)),
-        std::make_tuple<const char*, double (*)(double)>("dneg", dneg)
+        std::tuple<const char*, double (*)(double)>("dabs", static_cast<double (*)(double)>(std::abs)),
+        std::tuple<const char*, double (*)(double)>("dneg", dneg)
     )));

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -696,7 +696,8 @@ TEST_P(FloatArithmetic, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -756,7 +757,8 @@ TEST_P(FloatArithmetic, UsingLoadParamAndLoadConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -1030,7 +1032,8 @@ TEST_P(DoubleArithmetic, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -1091,6 +1094,7 @@ TEST_P(DoubleArithmetic, UsingLoadParamAndLoadConst) {
 
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -1146,6 +1150,7 @@ TEST_P(FloatUnaryArithmetic, UsingConst) {
 
     if ( std::isnan(param.value) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -1217,6 +1222,7 @@ TEST_P(DoubleUnaryArithmetic, UsingConst) {
 
     if ( std::isnan(param.value) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -29,6 +29,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Add bigobj compiler options for TypeConversionTest.cpp under Windows
+if(OMR_HOST_OS STREQUAL "win")
+	add_compile_options(-bigobj)
+endif()
 
 omr_add_executable(comptest
 	main.cpp

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -105,12 +105,12 @@ TEST_P(Int32Compare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, Int32Compare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpeq", icmpeq),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpne", icmpne),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpgt", icmpgt),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpge", icmpge),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmplt", icmplt),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmple", icmple)
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpeq", icmpeq),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpne", icmpne),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpgt", icmpgt),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmpge", icmpge),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmplt", icmplt),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("icmple", icmple)
     )));
 
 int32_t iucmpgt(uint32_t l, uint32_t r) {
@@ -186,10 +186,10 @@ TEST_P(UInt32Compare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, UInt32Compare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint32_t, uint32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmpgt", iucmpgt),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmpge", iucmpge),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmplt", iucmplt),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmple", iucmple)
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmpgt", iucmpgt),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmpge", iucmpge),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmplt", iucmplt),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("iucmple", iucmple)
     )));
 
 int32_t lcmpeq(int64_t l, int64_t r) {
@@ -277,13 +277,13 @@ TEST_P(Int64Compare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, Int64Compare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int64_t, int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpeq", lcmpeq),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpne", lcmpne),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpgt", lcmpgt),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpge", lcmpge),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmplt", lcmplt),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmple", lcmple),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmp", lcmp)
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpeq", lcmpeq),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpne", lcmpne),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpgt", lcmpgt),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmpge", lcmpge),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmplt", lcmplt),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmple", lcmple),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("lcmp", lcmp)
     )));
 
 
@@ -360,10 +360,10 @@ TEST_P(UInt64Compare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, UInt64Compare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint64_t, uint64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmpgt", lucmpgt),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmpge", lucmpge),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmplt", lucmplt),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmple", lucmple)
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmpgt", lucmpgt),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmpge", lucmpge),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmplt", lucmplt),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("lucmple", lucmple)
     )));
 
 static const int32_t IFCMP_TRUE_NUM = 123;
@@ -454,12 +454,12 @@ TEST_P(Int32IfCompare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, Int32IfCompare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpeq", ificmpeq),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpne", ificmpne),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmplt", ificmplt),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmple", ificmple),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpge", ificmpge),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpgt", ificmpgt)
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpeq", ificmpeq),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpne", ificmpne),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmplt", ificmplt),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmple", ificmple),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpge", ificmpge),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ificmpgt", ificmpgt)
     )));
 
 int32_t ifiucmplt(uint32_t l, uint32_t r) {
@@ -539,10 +539,10 @@ TEST_P(UInt32IfCompare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, UInt32IfCompare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint32_t, uint32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmplt", ifiucmplt),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmple", ifiucmple),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmpge", ifiucmpge),
-        std::make_tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmpgt", ifiucmpgt)
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmplt", ifiucmplt),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmple", ifiucmple),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmpge", ifiucmpge),
+        std::tuple<const char*, int32_t(*)(uint32_t, uint32_t)>("ifiucmpgt", ifiucmpgt)
     )));
 
 int32_t iflcmpeq(int64_t l, int64_t r) {
@@ -630,12 +630,12 @@ TEST_P(Int64IfCompare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, Int64IfCompare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int64_t, int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpeq", iflcmpeq),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpne", iflcmpne),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmplt", iflcmplt),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmple", iflcmple),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpge", iflcmpge),
-        std::make_tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpgt", iflcmpgt)
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpeq", iflcmpeq),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpne", iflcmpne),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmplt", iflcmplt),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmple", iflcmple),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpge", iflcmpge),
+        std::tuple<const char*, int32_t(*)(int64_t, int64_t)>("iflcmpgt", iflcmpgt)
     )));
 
 int32_t iflucmplt(uint64_t l, uint64_t r) {
@@ -715,10 +715,10 @@ TEST_P(UInt64IfCompare, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(CompareTest, UInt64IfCompare, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<uint64_t, uint64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmplt", iflucmplt),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmple", iflucmple),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmpge", iflucmpge),
-        std::make_tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmpgt", iflucmpgt)
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmplt", iflucmplt),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmple", iflucmple),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmpge", iflucmpge),
+        std::tuple<const char*, int32_t(*)(uint64_t, uint64_t)>("iflucmpgt", iflucmpgt)
     )));
 
 template <typename T>
@@ -835,12 +835,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, FloatCompare, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpeq", fcmpeq),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpne", fcmpne),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpgt", fcmpgt),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpge", fcmpge),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmplt", fcmplt),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmple", fcmple)
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpeq", fcmpeq),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpne", fcmpne),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpgt", fcmpgt),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpge", fcmpge),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmplt", fcmplt),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmple", fcmple)
     )));
 
 int32_t dcmpeq(double l, double r) {
@@ -948,12 +948,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, DoubleCompare, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpeq", dcmpeq),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpne", dcmpne),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpgt", dcmpgt),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpge", dcmpge),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmplt", dcmplt),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmple", dcmple)
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpeq", dcmpeq),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpne", dcmpne),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpgt", dcmpgt),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpge", dcmpge),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmplt", dcmplt),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmple", dcmple)
     )));
 
 int32_t iffcmpeq(float l, float r) {
@@ -1069,12 +1069,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, FloatIfCompare, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpeq", iffcmpeq),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpne", iffcmpne),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmplt", iffcmplt),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmple", iffcmple),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpge", iffcmpge),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpgt", iffcmpgt)
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpeq", iffcmpeq),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpne", iffcmpne),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmplt", iffcmplt),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmple", iffcmple),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpge", iffcmpge),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpgt", iffcmpgt)
     )));
 
 int32_t ifdcmpeq(double l, double r) {
@@ -1190,12 +1190,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, DoubleIfCompare, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpeq", ifdcmpeq),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpne", ifdcmpne),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmplt", ifdcmplt),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmple", ifdcmple),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpge", ifdcmpge),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpgt", ifdcmpgt)
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpeq", ifdcmpeq),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpne", ifdcmpne),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmplt", ifdcmplt),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmple", ifdcmple),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpge", ifdcmpge),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpgt", ifdcmpgt)
     )));
 
 int32_t fcmpequ(float l, float r) {
@@ -1302,12 +1302,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, FloatCompareOrUnordered, ::testing::Combine
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpequ", fcmpequ),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpneu", fcmpneu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpgtu", fcmpgtu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpgeu", fcmpgeu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpltu", fcmpltu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("fcmpleu", fcmpleu)
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpequ", fcmpequ),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpneu", fcmpneu),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpgtu", fcmpgtu),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpgeu", fcmpgeu),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpltu", fcmpltu),
+        std::tuple<const char*, int32_t (*)(float, float)>("fcmpleu", fcmpleu)
     )));
 
 int32_t dcmpequ(double l, double r) {
@@ -1414,12 +1414,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, DoubleCompareOrUnordered, ::testing::Combin
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpequ", dcmpequ),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpneu", dcmpneu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpgtu", dcmpgtu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpgeu", dcmpgeu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpltu", dcmpltu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("dcmpleu", dcmpleu)
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpequ", dcmpequ),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpneu", dcmpneu),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpgtu", dcmpgtu),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpgeu", dcmpgeu),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpltu", dcmpltu),
+        std::tuple<const char*, int32_t (*)(double, double)>("dcmpleu", dcmpleu)
 
     )));
 
@@ -1531,12 +1531,12 @@ INSTANTIATE_TEST_CASE_P(CompareTest, FloatIfCompareOrUnordered, ::testing::Combi
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpequ", iffcmpequ),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpneu", iffcmpneu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpltu", iffcmpltu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpleu", iffcmpleu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpgeu", iffcmpgeu),
-        std::make_tuple<const char*, int32_t (*)(float, float)>("iffcmpgtu", iffcmpgtu)
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpequ", iffcmpequ),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpneu", iffcmpneu),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpltu", iffcmpltu),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpleu", iffcmpleu),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpgeu", iffcmpgeu),
+        std::tuple<const char*, int32_t (*)(float, float)>("iffcmpgtu", iffcmpgtu)
     )));
 
 int32_t ifdcmpequ(double l, double r) {
@@ -1647,10 +1647,10 @@ INSTANTIATE_TEST_CASE_P(CompareTest, DoubleIfCompareOrUnordered, ::testing::Comb
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpequ", ifdcmpequ),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpneu", ifdcmpneu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpltu", ifdcmpltu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpleu", ifdcmpleu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpgeu", ifdcmpgeu),
-        std::make_tuple<const char*, int32_t (*)(double, double)>("ifdcmpgtu", ifdcmpgtu)
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpequ", ifdcmpequ),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpneu", ifdcmpneu),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpltu", ifdcmpltu),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpleu", ifdcmpleu),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpgeu", ifdcmpgeu),
+        std::tuple<const char*, int32_t (*)(double, double)>("ifdcmpgtu", ifdcmpgtu)
     )));

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -775,7 +775,8 @@ TEST_P(FloatCompare, UsingConst) {
         SKIP_ON_POWER(KnownBug) << "fcmpne returns wrong value on POWER (see #5152)";
     }
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -888,7 +889,8 @@ TEST_P(DoubleCompare, UsingConst) {
         SKIP_ON_POWER(KnownBug) << "dcmpne returns wrong value on POWER (see #5152)";
     }
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};
@@ -1004,6 +1006,7 @@ TEST_P(FloatIfCompare, UsingConst) {
     }
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[256] = {0};
@@ -1125,6 +1128,7 @@ TEST_P(DoubleIfCompare, UsingConst) {
     }
     if ( std::isnan(param.lhs) || std::isnan(param.rhs) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -704,6 +704,20 @@ AssertionResult CmpHelperEQ<volatile double, volatile double>(const char* lhs_ex
    SKIP_ON(OMRPORT_ARCH_X86, reason)
 
 /*
+ * @brief A macro to allow a test to be conditionally skipped on X86 running under the Windows operating system.
+ *
+ * The basic syntax for using this macro is:
+ *
+ *    SKIP_ON_X86_WINDOWS(<reason>) << <message>;
+ *
+ */
+#define SKIP_ON_X86_WINDOWS(reason) \
+   switch (0) case 0: default: /* guard against ambiguous else */ \
+   if (strcmp("Windows", omrsysinfo_get_OS_type()) != 0) { /* allow test to proceed normally */ } \
+   else \
+      SKIP_ON(OMRPORT_ARCH_X86, reason)
+
+/*
  * @brief A macro to allow a test to be conditionally skipped on POWER
  *
  * The basic syntax for using this macro is:

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -704,18 +704,20 @@ AssertionResult CmpHelperEQ<volatile double, volatile double>(const char* lhs_ex
    SKIP_ON(OMRPORT_ARCH_X86, reason)
 
 /*
- * @brief A macro to allow a test to be conditionally skipped on X86 running under the Windows operating system.
+ * @brief A macro to allow a test to be conditionally skipped under the Windows operating system.
  *
  * The basic syntax for using this macro is:
  *
- *    SKIP_ON_X86_WINDOWS(<reason>) << <message>;
+ *    SKIP_ON_WINDOWS(<reason>) << <message>;
  *
  */
-#define SKIP_ON_X86_WINDOWS(reason) \
-   switch (0) case 0: default: /* guard against ambiguous else */ \
-   if (strcmp("Windows", omrsysinfo_get_OS_type()) != 0) { /* allow test to proceed normally */ } \
-   else \
-      SKIP_ON(OMRPORT_ARCH_X86, reason)
+#if defined (OMR_OS_WINDOWS)
+   #define SKIP_ON_WINDOWS(reason) \
+      SKIP_IF(true, reason)
+#else
+   #define SKIP_ON_WINDOWS(reason) \
+      SKIP_IF(false, reason)
+#endif /* defined(OMR_OS_WINDOWS) */
 
 /*
  * @brief A macro to allow a test to be conditionally skipped on POWER

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -165,7 +165,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -215,7 +215,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -269,7 +269,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -327,7 +327,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -389,7 +389,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -455,7 +455,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -525,7 +525,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -599,7 +599,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -707,7 +707,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -754,7 +754,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -802,7 +802,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -851,7 +851,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -901,7 +901,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -952,7 +952,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1004,7 +1004,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1057,7 +1057,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1447,7 +1447,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1500,7 +1500,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1557,7 +1557,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1618,7 +1618,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1683,7 +1683,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1752,7 +1752,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1825,7 +1825,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1902,7 +1902,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2207,7 +2207,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2257,7 +2257,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2308,7 +2308,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2360,7 +2360,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2413,7 +2413,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2467,7 +2467,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2522,7 +2522,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2578,7 +2578,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
-    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
+    SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -165,6 +165,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -214,6 +215,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -267,6 +269,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -324,6 +327,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -385,6 +389,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -450,6 +455,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -519,6 +525,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -592,6 +599,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -699,6 +707,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -745,6 +754,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -792,6 +802,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -840,6 +851,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -889,6 +901,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -939,6 +952,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -990,6 +1004,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1042,6 +1057,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9A
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1431,6 +1447,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1483,6 +1500,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1539,6 +1557,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1599,6 +1618,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1663,6 +1683,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1731,6 +1752,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1803,6 +1825,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1879,6 +1902,7 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2183,6 +2207,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2232,6 +2257,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2282,6 +2308,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2333,6 +2360,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2385,6 +2413,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2438,6 +2467,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2492,6 +2522,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -2547,6 +2578,7 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
+    SKIP_ON_X86_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgumentFromMixedTypes<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";

--- a/fvtest/compilertriltest/LogicalTest.cpp
+++ b/fvtest/compilertriltest/LogicalTest.cpp
@@ -105,8 +105,8 @@ TEST_P(Int32LogicalUnary, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(LogicalTest, Int32LogicalUnary, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t)>("ineg", ineg),
-        std::make_tuple<const char*, int32_t(*)(int32_t)>("iabs", iabs)
+        std::tuple<const char*, int32_t(*)(int32_t)>("ineg", ineg),
+        std::tuple<const char*, int32_t(*)(int32_t)>("iabs", iabs)
     )));
 
 class Int32LogicalBinary : public TRTest::BinaryOpTest<int32_t> {};
@@ -151,9 +151,9 @@ TEST_P(Int32LogicalBinary, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(LogicalTest, Int32LogicalBinary, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t,int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ior", ior),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("iand", iand),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ixor", ixor)
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ior", ior),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("iand", iand),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ixor", ixor)
     )));
 
 class Int64LogicalBinary : public TRTest::BinaryOpTest<int64_t> {};
@@ -212,9 +212,9 @@ TEST_P(Int64LogicalBinary, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(LogicalTest, Int64LogicalBinary, ::testing::Combine(
 	::testing::ValuesIn(TRTest::const_value_pairs<int64_t,int64_t>()),
 	::testing::Values(
-		std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lor", lor),
-		std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("land", land),
-		std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lxor", lxor)
+		std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lor", lor),
+		std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("land", land),
+		std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lxor", lxor)
    )));
 
                 
@@ -276,5 +276,5 @@ TEST_P(Int64LogicalUnary, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(LogicalTest, Int64LogicalUnary, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int64_t)>("lneg", lneg)
+        std::tuple<const char*, int64_t(*)(int64_t)>("lneg", lneg)
         )));

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -130,8 +130,8 @@ TEST_P(Int32MaxMin, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(MaxMin, Int32MaxMin, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("imax", imax),
-        std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("imin", imin))));
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("imax", imax),
+        std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("imin", imin))));
 
 class Int64MaxMin : public TRTest::BinaryOpTest<int64_t> {};
 
@@ -191,8 +191,8 @@ TEST_P(Int64MaxMin, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(MaxMin, Int64MaxMin, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int64_t, int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmax", lmax),
-        std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmin", lmin))));
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmax", lmax),
+        std::tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmin", lmin))));
 
 class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
 
@@ -269,8 +269,8 @@ INSTANTIATE_TEST_CASE_P(MaxMin, FloatMaxMin, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, float(*)(float, float)>("fmax", f_max),
-        std::make_tuple<const char*, float(*)(float, float)>("fmin", f_min))));
+        std::tuple<const char*, float(*)(float, float)>("fmax", f_max),
+        std::tuple<const char*, float(*)(float, float)>("fmin", f_min))));
 
 class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
 
@@ -348,5 +348,5 @@ INSTANTIATE_TEST_CASE_P(MaxMin, DoubleMaxMin, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, double(*)(double, double)>("dmax", dmax),
-        std::make_tuple<const char*, double(*)(double, double)>("dmin", dmin))));
+        std::tuple<const char*, double(*)(double, double)>("dmax", dmax),
+        std::tuple<const char*, double(*)(double, double)>("dmin", dmin))));

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -180,9 +180,9 @@ TEST_P(Int32ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int32ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<int32_t, int32_t>> (*) (void) > (test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ishl", static_cast<int32_t(*)(int32_t, int32_t)>(shift_left)),
-                      std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("ishr", static_cast<int32_t(*)(int32_t, int32_t)>(shift_right)),
-                      std::make_tuple<const char*, int32_t(*)(int32_t, int32_t)>("irol", static_cast<int32_t(*)(int32_t, int32_t)>(rotate))
+    ::testing::Values(std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ishl", static_cast<int32_t(*)(int32_t, int32_t)>(shift_left)),
+                      std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("ishr", static_cast<int32_t(*)(int32_t, int32_t)>(shift_right)),
+                      std::tuple<const char*, int32_t(*)(int32_t, int32_t)>("irol", static_cast<int32_t(*)(int32_t, int32_t)>(rotate))
     )));
 
 class Int64ShiftAndRotate : public ShiftAndRotateArithmetic<int64_t> {};
@@ -289,9 +289,9 @@ TEST_P(Int64ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int64ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<int64_t, int32_t>> (*) (void) > (test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, int64_t(*)(int64_t, int32_t)>("lshl", static_cast<int64_t(*)(int64_t, int32_t)>(shift_left)),
-                      std::make_tuple<const char*, int64_t(*)(int64_t, int32_t)>("lshr", static_cast<int64_t(*)(int64_t, int32_t)>(shift_right)),
-                      std::make_tuple<const char*, int64_t(*)(int64_t, int32_t)>("lrol", static_cast<int64_t(*)(int64_t,int32_t)>(rotate))
+    ::testing::Values(std::tuple<const char*, int64_t(*)(int64_t, int32_t)>("lshl", static_cast<int64_t(*)(int64_t, int32_t)>(shift_left)),
+                      std::tuple<const char*, int64_t(*)(int64_t, int32_t)>("lshr", static_cast<int64_t(*)(int64_t, int32_t)>(shift_right)),
+                      std::tuple<const char*, int64_t(*)(int64_t, int32_t)>("lrol", static_cast<int64_t(*)(int64_t,int32_t)>(rotate))
     )));
 
 class Int8ShiftAndRotate : public ShiftAndRotateArithmetic<int8_t> {};
@@ -402,8 +402,8 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int8ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<int8_t, int32_t>> (*) (void) > (test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, int8_t(*)(int8_t, int32_t)>("bshl", static_cast<int8_t(*)(int8_t, int32_t)>(shift_left)),
-                      std::make_tuple<const char*, int8_t(*)(int8_t, int32_t)>("bshr", static_cast<int8_t(*)(int8_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, int8_t(*)(int8_t, int32_t)>("bshl", static_cast<int8_t(*)(int8_t, int32_t)>(shift_left)),
+                      std::tuple<const char*, int8_t(*)(int8_t, int32_t)>("bshr", static_cast<int8_t(*)(int8_t, int32_t)>(shift_right))
     )));
 
 class Int16ShiftAndRotate : public ShiftAndRotateArithmetic<int16_t> {};
@@ -514,8 +514,8 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int16ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<int16_t, int32_t>> (*) (void) > (test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, int16_t(*)(int16_t, int32_t)>("sshl", static_cast<int16_t(*)(int16_t, int32_t)>(shift_left)),
-                      std::make_tuple<const char*, int16_t(*)(int16_t, int32_t)>("sshr", static_cast<int16_t(*)(int16_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, int16_t(*)(int16_t, int32_t)>("sshl", static_cast<int16_t(*)(int16_t, int32_t)>(shift_left)),
+                      std::tuple<const char*, int16_t(*)(int16_t, int32_t)>("sshr", static_cast<int16_t(*)(int16_t, int32_t)>(shift_right))
     )));
 
 class UInt32ShiftAndRotate : public ShiftAndRotateArithmetic<uint32_t> {};
@@ -622,7 +622,7 @@ TEST_P(UInt32ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt32ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint32_t, int32_t>> (*) (void)>(test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint32_t (*) (uint32_t, int32_t)>("iushr", static_cast<uint32_t (*) (uint32_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, uint32_t (*) (uint32_t, int32_t)>("iushr", static_cast<uint32_t (*) (uint32_t, int32_t)>(shift_right))
     )));
 
 class UInt64ShiftAndRotate : public ShiftAndRotateArithmetic<uint64_t> {};
@@ -729,7 +729,7 @@ TEST_P(UInt64ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt64ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint64_t, int32_t>> (*) (void)>(test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint64_t (*) (uint64_t, int32_t)>("lushr", static_cast<uint64_t (*) (uint64_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, uint64_t (*) (uint64_t, int32_t)>("lushr", static_cast<uint64_t (*) (uint64_t, int32_t)>(shift_right))
     )));
 
 class UInt8ShiftAndRotate : public ShiftAndRotateArithmetic<uint8_t> {};
@@ -840,7 +840,7 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt8ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint8_t, int32_t>> (*) (void) > (test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint8_t (*) (uint8_t, int32_t)>("bushr", static_cast<uint8_t (*) (uint8_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, uint8_t (*) (uint8_t, int32_t)>("bushr", static_cast<uint8_t (*) (uint8_t, int32_t)>(shift_right))
     )));
 
 class UInt16ShiftAndRotate : public ShiftAndRotateArithmetic<uint16_t> {};
@@ -951,7 +951,7 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt16ShiftAndRotate, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint16_t, int32_t>> (*) (void) >(test_input_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint16_t (*) (uint16_t, int32_t)>("sushr", static_cast<uint16_t (*) (uint16_t, int32_t)>(shift_right))
+    ::testing::Values(std::tuple<const char*, uint16_t (*) (uint16_t, int32_t)>("sushr", static_cast<uint16_t (*) (uint16_t, int32_t)>(shift_right))
     )));
 
 template <typename T> static
@@ -1157,7 +1157,7 @@ TEST_P(UInt64MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt64MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<uint64_t, uint64_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint64_t (*) (uint64_t, uint64_t, int32_t)>("lushr", static_cast<uint64_t (*) (uint64_t, uint64_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, uint64_t (*) (uint64_t, uint64_t, int32_t)>("lushr", static_cast<uint64_t (*) (uint64_t, uint64_t, int32_t)>(mask_then_shift_right))
     )));
 
 class Int64MaskThenShift : public MaskThenShiftArithmetic<int64_t> {};
@@ -1193,8 +1193,8 @@ TEST_P(Int64MaskThenShift, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int64MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<int64_t, int64_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshr", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_right)),
-        std::make_tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshl", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_left))
+        std::tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshr", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_right)),
+        std::tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshl", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_left))
     )));
 
 class UInt32MaskThenShift : public MaskThenShiftArithmetic<uint32_t> {};
@@ -1229,7 +1229,7 @@ TEST_P(UInt32MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt32MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<uint32_t, uint32_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint32_t (*) (uint32_t, uint32_t, int32_t)>("iushr", static_cast<uint32_t (*) (uint32_t, uint32_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, uint32_t (*) (uint32_t, uint32_t, int32_t)>("iushr", static_cast<uint32_t (*) (uint32_t, uint32_t, int32_t)>(mask_then_shift_right))
     )));
 
 class Int32MaskThenShift : public MaskThenShiftArithmetic<int32_t> {};
@@ -1264,7 +1264,7 @@ TEST_P(Int32MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int32MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<int32_t, int32_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, int32_t (*) (int32_t, int32_t, int32_t)>("ishr", static_cast<int32_t (*) (int32_t, int32_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, int32_t (*) (int32_t, int32_t, int32_t)>("ishr", static_cast<int32_t (*) (int32_t, int32_t, int32_t)>(mask_then_shift_right))
     )));
 
 class UInt16MaskThenShift : public MaskThenShiftArithmetic<uint16_t> {};
@@ -1300,7 +1300,7 @@ TEST_P(UInt16MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt16MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<uint16_t, uint16_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint16_t (*) (uint16_t, uint16_t, int32_t)>("sushr", static_cast<uint16_t (*) (uint16_t, uint16_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, uint16_t (*) (uint16_t, uint16_t, int32_t)>("sushr", static_cast<uint16_t (*) (uint16_t, uint16_t, int32_t)>(mask_then_shift_right))
     )));
 
 class Int16MaskThenShift : public MaskThenShiftArithmetic<int16_t> {};
@@ -1336,7 +1336,7 @@ TEST_P(Int16MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int16MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<int16_t, int16_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, int16_t (*) (int16_t, int16_t, int32_t)>("sshr", static_cast<int16_t (*) (int16_t, int16_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, int16_t (*) (int16_t, int16_t, int32_t)>("sshr", static_cast<int16_t (*) (int16_t, int16_t, int32_t)>(mask_then_shift_right))
     )));
 
 class UInt8MaskThenShift : public MaskThenShiftArithmetic<uint8_t> {};
@@ -1372,7 +1372,7 @@ TEST_P(UInt8MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt8MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<uint8_t, uint8_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, uint8_t (*) (uint8_t, uint8_t, int32_t)>("bushr", static_cast<uint8_t (*) (uint8_t, uint8_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, uint8_t (*) (uint8_t, uint8_t, int32_t)>("bushr", static_cast<uint8_t (*) (uint8_t, uint8_t, int32_t)>(mask_then_shift_right))
     )));
 
 class Int8MaskThenShift : public MaskThenShiftArithmetic<int8_t> {};
@@ -1408,5 +1408,5 @@ TEST_P(Int8MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int8MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<int8_t, int8_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, int8_t (*) (int8_t, int8_t, int32_t)>("bshr", static_cast<int8_t (*) (int8_t, int8_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(std::tuple<const char*, int8_t (*) (int8_t, int8_t, int32_t)>("bshr", static_cast<int8_t (*) (int8_t, int8_t, int32_t)>(mask_then_shift_right))
     )));

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -126,7 +126,7 @@ TEST_P(Int8ToInt32, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int8ToInt32, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int8_t)>("b2i", b2i)
+        std::tuple<const char*, int32_t(*)(int8_t)>("b2i", b2i)
     )));
 
 class UInt8ToInt32 : public TRTest::UnaryOpTest<int32_t,uint8_t> {};
@@ -183,7 +183,7 @@ TEST_P(UInt8ToInt32, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, UInt8ToInt32, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<uint8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint8_t)>("bu2i", bu2i)
+        std::tuple<const char*, int32_t(*)(uint8_t)>("bu2i", bu2i)
     )));
 
 class Int8ToInt64 : public TRTest::UnaryOpTest<int64_t,int8_t> {};
@@ -240,7 +240,7 @@ TEST_P(Int8ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int8ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int8_t)>("b2l", b2l)
+        std::tuple<const char*, int64_t(*)(int8_t)>("b2l", b2l)
     )));
 
 class UInt8ToInt64 : public TRTest::UnaryOpTest<int64_t,uint8_t> {};
@@ -297,7 +297,7 @@ TEST_P(UInt8ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, UInt8ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<uint8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(uint8_t)>("bu2l", bu2l)
+        std::tuple<const char*, int64_t(*)(uint8_t)>("bu2l", bu2l)
     )));
 
 class Int16ToInt32 : public TRTest::UnaryOpTest<int32_t,int16_t> {};
@@ -354,7 +354,7 @@ TEST_P(Int16ToInt32, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int16ToInt32, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int16_t)>("s2i", s2i)
+        std::tuple<const char*, int32_t(*)(int16_t)>("s2i", s2i)
     )));
 
 class UInt16ToInt32 : public TRTest::UnaryOpTest<int32_t,uint16_t> {};
@@ -411,7 +411,7 @@ TEST_P(UInt16ToInt32, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, UInt16ToInt32, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<uint16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(uint16_t)>("su2i", su2i)
+        std::tuple<const char*, int32_t(*)(uint16_t)>("su2i", su2i)
     )));
 
 class Int16ToInt64 : public TRTest::UnaryOpTest<int64_t,int16_t> {};
@@ -468,7 +468,7 @@ TEST_P(Int16ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int16ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int16_t)>("s2l", s2l)
+        std::tuple<const char*, int64_t(*)(int16_t)>("s2l", s2l)
     )));
 
 class UInt16ToInt64 : public TRTest::UnaryOpTest<int64_t,uint16_t> {};
@@ -525,7 +525,7 @@ TEST_P(UInt16ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, UInt16ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<uint16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(uint16_t)>("su2l", su2l)
+        std::tuple<const char*, int64_t(*)(uint16_t)>("su2l", su2l)
     )));
 
 class Int32ToInt64 : public TRTest::UnaryOpTest<int64_t,int32_t> {};
@@ -581,7 +581,7 @@ TEST_P(Int32ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int32ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(int32_t)>("i2l", i2l)
+        std::tuple<const char*, int64_t(*)(int32_t)>("i2l", i2l)
     )));
 
 class UInt32ToInt64 : public TRTest::UnaryOpTest<int64_t,uint32_t> {};
@@ -639,7 +639,7 @@ TEST_P(UInt32ToInt64, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, UInt32ToInt64, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<uint32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(uint32_t)>("iu2l", iu2l)
+        std::tuple<const char*, int64_t(*)(uint32_t)>("iu2l", iu2l)
     )));
 
 int32_t l2i(int64_t x) {
@@ -699,7 +699,7 @@ TEST_P(Int64ToInt32, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int64ToInt32, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(int64_t)>("l2i", l2i)
+        std::tuple<const char*, int32_t(*)(int64_t)>("l2i", l2i)
     )));
 
 #ifndef TR_TARGET_POWER
@@ -772,7 +772,7 @@ TEST_P(Int32ToFloat, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int32ToFloat, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, float(*)(int32_t)>("i2f", i2f)
+        std::tuple<const char*, float(*)(int32_t)>("i2f", i2f)
     )));
 
 class Int64ToFloat : public TRTest::UnaryOpTest<float,int64_t> {};
@@ -828,7 +828,7 @@ TEST_P(Int64ToFloat, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int64ToFloat, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, float(*)(int64_t)>("l2f", l2f)
+        std::tuple<const char*, float(*)(int64_t)>("l2f", l2f)
     )));
 
 class Int32ToDouble : public TRTest::UnaryOpTest<double,int32_t> {};
@@ -884,7 +884,7 @@ TEST_P(Int32ToDouble, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int32ToDouble, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int32_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, double(*)(int32_t)>("i2d", i2d)
+        std::tuple<const char*, double(*)(int32_t)>("i2d", i2d)
     )));
 
 class Int64ToDouble : public TRTest::UnaryOpTest<double,int64_t> {};
@@ -940,7 +940,7 @@ TEST_P(Int64ToDouble, UsingLoadParam) {
 INSTANTIATE_TEST_CASE_P(TypeConversionTest, Int64ToDouble, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int64_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, double(*)(int64_t)>("l2d", l2d)
+        std::tuple<const char*, double(*)(int64_t)>("l2d", l2d)
     )));
 #endif
 
@@ -1041,7 +1041,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatToInt32, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<float>(), fp_filter<float, int32_t>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(float)>("f2i", f2i)
+        std::tuple<const char*, int32_t(*)(float)>("f2i", f2i)
     )));
 
 class FloatToInt64 : public TRTest::UnaryOpTest<int64_t,float> {};
@@ -1102,7 +1102,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatToInt64, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<float>(), fp_filter<float, int64_t>)),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(float)>("f2l", f2l)
+        std::tuple<const char*, int64_t(*)(float)>("f2l", f2l)
     )));
 
 class DoubleToInt32 : public TRTest::UnaryOpTest<int32_t,double> {};
@@ -1163,7 +1163,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, DoubleToInt32, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<double>(), fp_filter<double, int32_t>)),
     ::testing::Values(
-        std::make_tuple<const char*, int32_t(*)(double)>("d2i", d2i)
+        std::tuple<const char*, int32_t(*)(double)>("d2i", d2i)
     )));
 
 class DoubleToInt64 : public TRTest::UnaryOpTest<int64_t,double> {};
@@ -1224,7 +1224,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, DoubleToInt64, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<double>(), fp_filter<double, int64_t>)),
     ::testing::Values(
-        std::make_tuple<const char*, int64_t(*)(double)>("d2l", d2l)
+        std::tuple<const char*, int64_t(*)(double)>("d2l", d2l)
     )));
 
 template <typename T>
@@ -1308,7 +1308,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatToDouble, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<float>(), smallFp_filter<float>)),
     ::testing::Values(
-        std::make_tuple<const char*, double(*)(float)>("f2d", f2d)
+        std::tuple<const char*, double(*)(float)>("f2d", f2d)
     )));
 
 class DoubleToFloat : public TRTest::UnaryOpTest<float,double> {};
@@ -1377,7 +1377,7 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, DoubleToFloat, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_values<double>(), smallFp_filter<double>)),
     ::testing::Values(
-        std::make_tuple<const char*, float(*)(double)>("d2f", d2f)
+        std::tuple<const char*, float(*)(double)>("d2f", d2f)
     )));
 
 static std::vector<uint32_t> normalize_fnan_values()

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -985,6 +985,7 @@ TEST_P(FloatToInt32, UsingConst) {
 
     if ( std::isnan(param.value) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[160] = {0};
@@ -1051,6 +1052,7 @@ TEST_P(FloatToInt64, UsingConst) {
 
     if ( std::isnan(param.value) ) {
        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+       SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[160] = {0};
@@ -1111,7 +1113,8 @@ TEST_P(DoubleToInt32, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.value) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[512] = {0};
@@ -1172,7 +1175,8 @@ TEST_P(DoubleToInt64, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.value) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[512] = {0};
@@ -1248,7 +1252,8 @@ TEST_P(FloatToDouble, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.value) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[160] = {0};
@@ -1317,7 +1322,8 @@ TEST_P(DoubleToFloat, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if ( std::isnan(param.value) ) {
-       SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
     char inputTrees[512] = {0};

--- a/fvtest/jitbuildertest/JBTestUtil.hpp
+++ b/fvtest/jitbuildertest/JBTestUtil.hpp
@@ -177,7 +177,7 @@
          DefineReturnType(returnType); \
          std::pair<const char *, OMR::JitBuilder::IlType *> argsArray[] = {std::pair<const char *, OMR::JitBuilder::IlType *>("", NULL), __VA_ARGS__}; \
          std::vector<std::pair<const char *, OMR::JitBuilder::IlType *> > args(argsArray, argsArray + sizeof(argsArray)/sizeof(std::pair<const char *, OMR::JitBuilder::IlType *>)); \
-         for (int i = 1, s = args.size(); i < s; ++i) \
+         for (std::vector<std::pair<const char *, OMR::JitBuilder::IlType *> >::size_type i = 1, s = args.size(); i < s; ++i) \
             { \
             DefineParameter(args[i].first, args[i].second); \
             } \

--- a/fvtest/tril/tril/parser.cpp
+++ b/fvtest/tril/tril/parser.cpp
@@ -32,6 +32,11 @@
 #include <limits>
 #include <stdlib.h>
 
+// A workaround for strtoull when building with visual studio 2012 (AppVeyor build)
+#ifdef _WIN32
+#define strtoull _strtoui64
+#endif
+
 class Token {
     public:
         enum Type {

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -65,7 +65,7 @@ int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     // to compile the method
     TR::ResolvedMethod resolvedMethod("file", "line", "name",
                                       argIlTypes.size(),
-                                      &argIlTypes[0],
+                                      argIlTypes.size() != 0 ? &argIlTypes[0] : NULL,
                                       types.PrimitiveType(methodInfo.getReturnType()),
                                       0,
                                       &ilgenerator);


### PR DESCRIPTION
Tril Tests are currently not running on Windows. Fix Tril Tests errors that occurs under Windows and enable it for Windows Azure builds. Note that `Tril Test` refers to the two ctest units in `fvtest`: `comptest` and `triltest`.

Details about the fix is stated in issue #5324 

- [x] Enable tril tests (`comptest` and `triltest`) on Windows build in `Azure build`
- [x] Fix/skip failing test cases in `comptest` on Windows
- [x] Fix/skip failing test cases in `triltest` on Windows
- [x] Skip failing test cases in `compilertest` see details in #5378

Issue: #5324
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>