### PR TITLE
Include <netinet/in.h> in omrsock.h

### DIFF
--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -38,7 +38,6 @@
 #define _OPEN_SYS_SOCK_IPV6
 #endif
 
-
 #include <sys/types.h> /* Some historical implementations need this file, POSIX.1-2001 does not. */
 #include <sys/socket.h>
 #include <netinet/in.h> /* Must come before <netinet/tcp.h> */

--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -38,9 +38,10 @@
 #define _OPEN_SYS_SOCK_IPV6
 #endif
 
+
 #include <sys/types.h> /* Some historical implementations need this file, POSIX.1-2001 does not. */
 #include <sys/socket.h>
-#include <netinet/in.h>
+#include <netinet/in.h> /* Must come before <netinet/tcp.h> */
 #include <netinet/tcp.h>
 
 typedef struct sockaddr omr_os_sockaddr;

--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -40,6 +40,7 @@
 
 #include <sys/types.h> /* Some historical implementations need this file, POSIX.1-2001 does not. */
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 
 typedef struct sockaddr omr_os_sockaddr;


### PR DESCRIPTION
This header is responsible for defining the in6_addr struct. This type
is used in the header <netinet/tcp.h>. On some versions of AIX, tcp.h
does not include in.h (despite using types defined there), so we have to
manually include it before tcp.h. This isn't a problem on other posix
platforms.

Fixes: #5360
Signed-off-by: Robert Young <rwy0717@gmail.com>