### PR TITLE
AArch64: Code generation for loading unsigned short/byte

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -212,12 +212,38 @@ TR::Register *OMR::ARM64::TreeEvaluator::i2lEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 7, cg);
+   TR::Node *child = node->getFirstChild();
+
+   if ((child->getOpCodeValue() == TR::bload || child->getOpCodeValue() == TR::bloadi)
+       && child->getRegister() == NULL)
+      {
+      // Use unsigned load
+      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrbimm, cg);
+      node->setRegister(trgReg);
+      return trgReg;
+      }
+   else
+      {
+      return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 7, cg);
+      }
    }
 
 TR::Register *OMR::ARM64::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 15, cg);
+   TR::Node *child = node->getFirstChild();
+
+   if ((child->getOpCodeValue() == TR::sload || child->getOpCodeValue() == TR::sloadi)
+       && child->getRegister() == NULL)
+      {
+      // Use unsigned load
+      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrhimm, cg);
+      node->setRegister(trgReg);
+      return trgReg;
+      }
+   else
+      {
+      return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 15, cg);
+      }
    }
 
 TR::Register *OMR::ARM64::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
This commit improves code generation for loading unsigned short/byte
for AArch64.

The AArch64 compiler used to generate `ldrshimmx` (signed halfword)
instruction followed by `uxthx` instruction for zero extension, for
an IL sequence `sloadi - su2i`.
This commit uses `ldrhimmx` (unsigned halfword) instruction instead,
and there is no need for zero extension.
It also does the similar for loading unsigned byte.

Closes: #5343

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>