### PR TITLE
Implement binary encoding for POWER10 PC-relative loads and stores

### DIFF
--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -45,6 +45,9 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       int) :
          OMR::MemoryReferenceConnector(br, disp, len, cg, 0) {}
 
+   MemoryReference(TR::LabelSymbol *label, int64_t disp, int8_t len, TR::CodeGenerator *cg) :
+      OMR::MemoryReferenceConnector(label, disp, len, cg) {}
+
    public:
 
    MemoryReference(TR::CodeGenerator *cg) :
@@ -72,6 +75,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       OMR::MemoryReferenceConnector(node, mr, n, len, cg) {}
 
    static TR::MemoryReference *withDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length);
+   static TR::MemoryReference *withLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length);
    };
 }
 

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -66,6 +66,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    TR::Register *_indexRegister;
    TR::Node *_indexNode;
    TR::Register *_modBase;
+   TR::LabelSymbol *_label;
    int64_t _offset;
 
    TR::UnresolvedDataSnippet *_unresolvedSnippet;
@@ -89,6 +90,12 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          uint8_t len,
          TR::CodeGenerator *cg,
          int);
+
+   MemoryReference(
+         TR::LabelSymbol *label,
+         int64_t disp,
+         uint8_t len,
+         TR::CodeGenerator *cg);
 
    public:
 
@@ -140,6 +147,9 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    uint32_t getLength() {return _length;}
    uint32_t setLength(uint32_t len) {return (_length = len);}
+
+   TR::LabelSymbol *getLabel() {return _label;}
+   TR::LabelSymbol *setLabel(TR::LabelSymbol *label) {return (_label = label);}
 
    bool useIndexedForm();
 

--- a/compiler/p/codegen/PPCAOTRelocation.hpp
+++ b/compiler/p/codegen/PPCAOTRelocation.hpp
@@ -83,9 +83,9 @@ class PPCPairedRelocation: public TR::PPCRelocation
    TR::Node                         *_node;
    };
 
-// This class has nothing to do with AOT, but for the lack of more appropriate locations
-// this class is defined here.
-//
+// TODO(#5404): The classes defined below here are specific to Power, but are not actually AOT
+//              relocations. They are only here for lack of a better place to put them.
+
 // PPC Specific Relocation: update the immediate fields of a pair of ppc instructions
 // with the absolute address of a label (extended to 64bit as well).  For example:
 //   lis  gr3, addr_hi
@@ -107,6 +107,41 @@ class PPCPairedLabelAbsoluteRelocation : public TR::LabelRelocation
    TR::Instruction *_instr2;
    TR::Instruction *_instr3;
    TR::Instruction *_instr4;
+   };
+
+/**
+ * \brief Represents a relocation on the D34 field of a PC-relative prefixed load/store instruction
+ *        that should use an offset from a TR::LabelSymbol.
+ */
+class PPCD34LabelRelocation : public TR::LabelRelocation
+   {
+   public:
+
+   /**
+    * \brief
+    *   Creates a new PPCD34LabelRelocation.
+    *
+    * \param instr
+    *   The TR::Instruction for which this relocation was created, or \c NULL if this relocation is
+    *   not associated with an instruction object.
+    *
+    * \param cursor
+    *   The start of the prefixed load/store instruction to relocate.
+    *
+    * \param label
+    *   The label relative to which the load/store should occur.
+    *
+    * \param offset
+    *   The byte offset from the label at which the load/store should occur.
+    */
+   PPCD34LabelRelocation(TR::Instruction *instr, uint32_t *cursor, TR::LabelSymbol *label, int64_t offset)
+      : TR::LabelRelocation(reinterpret_cast<uint8_t*>(cursor), label), _instr(instr), _offset(offset) {}
+
+   virtual void apply(TR::CodeGenerator *cg);
+
+   private:
+   TR::Instruction *_instr;
+   int64_t _offset;
    };
 
 }

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1403,6 +1403,36 @@ void TR::PPCSrc1Instruction::fillBinaryEncodingFields(uint32_t *cursor)
          fillFieldFXM1(self(), cursor, imm);
          break;
 
+      case FORMAT_RS_D34_RA_R:
+         fillFieldRS(self(), cursor + 1, src);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_RSP_D34_RA_R:
+         fillFieldRSP(self(), cursor + 1, src);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_FRS_D34_RA_R:
+         fillFieldFRS(self(), cursor + 1, src);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_VRS_D34_RA_R:
+         fillFieldVRS(self(), cursor + 1, src);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_XS5_D34_RA_R:
+         fillFieldXS5(self(), cursor + 1, src);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
       default:
          TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), false, "Format %d cannot be binary encoded by PPCSrc1Instruction", getOpCode().getFormat());
       }
@@ -1531,6 +1561,36 @@ TR::PPCTrg1ImmInstruction::fillBinaryEncodingFields(uint32_t *cursor)
       case FORMAT_VRT_SIM:
          fillFieldVRT(self(), cursor, trg);
          fillFieldSIM(self(), cursor, imm);
+         break;
+
+      case FORMAT_RT_D34_RA_R:
+         fillFieldRT(self(), cursor + 1, trg);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_RTP_D34_RA_R:
+         fillFieldRTP(self(), cursor + 1, trg);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_FRT_D34_RA_R:
+         fillFieldFRT(self(), cursor + 1, trg);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_VRT_D34_RA_R:
+         fillFieldVRT(self(), cursor + 1, trg);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_XT5_D34_RA_R:
+         fillFieldXT5(self(), cursor + 1, trg);
+         fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
+         fillFieldR(self(), cursor, 1);
          break;
 
       default:

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -755,6 +755,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, bool d_form)
       print(pOutFile, mr->getBaseRegister());
       trfprintf(pOutFile, ", ");
       }
+   else if (mr->getLabel() != NULL)
+      {
+      print(pOutFile, mr->getLabel());
+      trfprintf(pOutFile, ", ");
+      }
 
    if (mr->getIndexRegister() != NULL)
       print(pOutFile, mr->getIndexRegister());

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -820,6 +820,84 @@ TEST_P(PPCTrg1MemEncodingTest, encodePrefixCrossingBoundary) {
     );
 }
 
+class PPCTrg1MemPCRelativeEncodingTest : public PowerBinaryEncoderTest, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int64_t, int64_t, BinaryInstruction>> {};
+
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encode) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateTrg1MemInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+    );
+
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + std::get<2>(GetParam()));
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        encodeInstruction(instr, 0)
+    );
+}
+
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodePrefixCrossingBoundary) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateTrg1MemInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+    );
+
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + 64 + std::get<2>(GetParam()));
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        encodeInstruction(instr, 60)
+    );
+}
+
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodeWithRelocation) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateTrg1MemInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+    );
+
+    auto size = encodeInstruction(instr)._words.size() * 4;
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + std::get<2>(GetParam()));
+    cg()->processRelocations();
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        getEncodedInstruction(size, 0)
+    );
+}
+
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocation) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateTrg1MemInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+    );
+
+    auto size = encodeInstruction(instr, 60)._words.size() * 4;
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + 64 + std::get<2>(GetParam()));
+    cg()->processRelocations();
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        getEncodedInstruction(size, 60)
+    );
+}
+
 class PPCMemSrc1EncodingTest : public PowerBinaryEncoderTest, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, MemoryReference, TR::RealRegister::RegNum, BinaryInstruction, bool>> {};
 
 TEST_P(PPCMemSrc1EncodingTest, encode) {
@@ -872,6 +950,84 @@ TEST_P(PPCMemSrc1EncodingTest, encodePrefixCrossingBoundary) {
             ? std::get<3>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode)
             : std::get<3>(GetParam()),
         encodeInstruction(instr, 60)
+    );
+}
+
+class PPCMemSrc1PCRelativeEncodingTest : public PowerBinaryEncoderTest, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int64_t, int64_t, BinaryInstruction>> {};
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encode) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateMemSrc1Instruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        cg()->machine()->getRealRegister(std::get<1>(GetParam()))
+    );
+
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + std::get<2>(GetParam()));
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        encodeInstruction(instr, 0)
+    );
+}
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodePrefixCrossingBoundary) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateMemSrc1Instruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        cg()->machine()->getRealRegister(std::get<1>(GetParam()))
+    );
+
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + 64 + std::get<2>(GetParam()));
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        encodeInstruction(instr, 60)
+    );
+}
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodeWithRelocation) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateMemSrc1Instruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        cg()->machine()->getRealRegister(std::get<1>(GetParam()))
+    );
+
+    auto size = encodeInstruction(instr)._words.size() * 4;
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + std::get<2>(GetParam()));
+    cg()->processRelocations();
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        getEncodedInstruction(size, 0)
+    );
+}
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocation) {
+    auto label = generateLabelSymbol(cg());
+    auto instr = generateMemSrc1Instruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        cg()->machine()->getRealRegister(std::get<1>(GetParam()))
+    );
+
+    auto size = encodeInstruction(instr, 60)._words.size() * 4;
+    label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + 64 + std::get<2>(GetParam()));
+    cg()->processRelocations();
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        getEncodedInstruction(size, 60)
     );
 }
 
@@ -3175,6 +3331,166 @@ INSTANTIATE_TEST_CASE_P(LoadPrefix, PPCTrg1MemEncodingTest, ::testing::ValuesIn(
     std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,  MemoryReference(TR::RealRegister::gr0, -0x000008000), BinaryInstruction(0x0403ffffu, 0xc8008000u), true)
 )));
 
+INSTANTIATE_TEST_CASE_P(LoadPrefix, PPCTrg1MemPCRelativeEncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int64_t, int64_t, BinaryInstruction>>(
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x88000000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x8be00000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0x88000000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0x8800ffffu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0x8800ffffu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0x88000000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0x8800ffffu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0x88007fffu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0x88008000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0x88008000u)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0x88007ffeu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0x8800ffffu)),
+    std::make_tuple(TR::InstOpCode::plbz,   TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0x8800ffffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xe4000000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xe7e00000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xe4000000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xe400ffffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xe400ffffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xe4000000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xe400ffffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xe4007fffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xe4008000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xe4008000u)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xe4007ffeu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xe400ffffu)),
+    std::make_tuple(TR::InstOpCode::pld,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xe400ffffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xcbe00000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xc8007fffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xc8008000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xc8008000u)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xc8007ffeu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plfd,   TR::RealRegister::fp0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xc0000000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xc3e00000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xc0000000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xc000ffffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xc000ffffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xc0000000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xc000ffffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xc0007fffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xc0008000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xc0008000u)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xc0007ffeu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xc000ffffu)),
+    std::make_tuple(TR::InstOpCode::plfs,   TR::RealRegister::fp0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xc000ffffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xabe00000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xa8007fffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xa8008000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xa8008000u)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xa8007ffeu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plha,   TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xa0000000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xa3e00000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xa0000000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xa000ffffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xa000ffffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xa0000000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xa000ffffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xa0007fffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xa0008000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xa0008000u)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xa0007ffeu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xa000ffffu)),
+    std::make_tuple(TR::InstOpCode::plhz,   TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xa000ffffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xe0000000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr30,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xe3c00000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xe0000000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xe000ffffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xe000ffffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xe0000000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xe000ffffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xe0007fffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xe0008000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xe0008000u)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xe0007ffeu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xe000ffffu)),
+    std::make_tuple(TR::InstOpCode::plq,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xe000ffffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xa4000000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xa7e00000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xa4000000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xa400ffffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xa400ffffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xa4000000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xa400ffffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xa4007fffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xa4008000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xa4008000u)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xa4007ffeu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xa400ffffu)),
+    std::make_tuple(TR::InstOpCode::plwa,   TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xa400ffffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x80000000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x83e00000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0x80000000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0x8000ffffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0x8000ffffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0x80000000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0x8000ffffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0x80007fffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0x80008000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0x80008000u)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0x80007ffeu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0x8000ffffu)),
+    std::make_tuple(TR::InstOpCode::plwz,   TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0x8000ffffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xabe00000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xa8000000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xa8007fffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xa8008000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xa8008000u)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xa8007ffeu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxsd,  TR::RealRegister::vr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xa800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xac000000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xafe00000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xac000000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xac00ffffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xac00ffffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xac000000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xac00ffffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xac007fffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xac008000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xac008000u)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xac007ffeu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xac00ffffu)),
+    std::make_tuple(TR::InstOpCode::plxssp, TR::RealRegister::vr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xac00ffffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr31,  0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xcbe00000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr63,  0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xcfe00000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,  -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,  -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xc8000000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xc8007fffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,  -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xc8008000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xc8008000u)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xc8007ffeu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xc800ffffu)),
+    std::make_tuple(TR::InstOpCode::plxv,   TR::RealRegister::vsr0,   0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xc800ffffu))
+)));
+
 INSTANTIATE_TEST_CASE_P(LoadPrefix, PPCRecordFormSanityTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::plbz,   TR::InstOpCode::bad, BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::pld,    TR::InstOpCode::bad, BinaryInstruction()),
@@ -3606,6 +3922,140 @@ INSTANTIATE_TEST_CASE_P(StorePrefix, PPCMemSrc1EncodingTest, ::testing::ValuesIn
     std::make_tuple(TR::InstOpCode::pstxv,   MemoryReference(TR::RealRegister::gr0,  0x00000ffff), TR::RealRegister::vsr0,  BinaryInstruction(0x04000000u, 0xd800ffffu), true),
     std::make_tuple(TR::InstOpCode::pstxv,   MemoryReference(TR::RealRegister::gr0,  0x000007fff), TR::RealRegister::vsr0,  BinaryInstruction(0x04000000u, 0xd8007fffu), true),
     std::make_tuple(TR::InstOpCode::pstxv,   MemoryReference(TR::RealRegister::gr0, -0x000008000), TR::RealRegister::vsr0,  BinaryInstruction(0x0403ffffu, 0xd8008000u), true)
+)));
+
+INSTANTIATE_TEST_CASE_P(StorePrefix, PPCMemSrc1PCRelativeEncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int64_t, int64_t, BinaryInstruction>>(
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x98000000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x9be00000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0x98000000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0x9800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0x9800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0x98000000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0x9800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0x98007fffu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0x98008000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0x98008000u)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0x98007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0x9800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstb,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0x9800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xf4000000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xf7e00000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xf4000000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xf400ffffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xf400ffffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xf4000000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xf400ffffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xf4007fffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xf4008000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xf4008000u)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xf4007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xf400ffffu)),
+    std::make_tuple(TR::InstOpCode::pstd,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xf400ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xdbe00000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xd8007fffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xd8008000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xd8008000u)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xd8007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfd,   TR::RealRegister::fp0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xd0000000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xd3e00000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xd0000000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xd000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xd000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xd0000000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xd000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xd0007fffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xd0008000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xd0008000u)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xd0007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xd000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstfs,   TR::RealRegister::fp0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xd000ffffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xb0000000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0xb3e00000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0xb0000000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0xb000ffffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0xb000ffffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0xb0000000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0xb000ffffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0xb0007fffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0xb0008000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0xb0008000u)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0xb0007ffeu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0xb000ffffu)),
+    std::make_tuple(TR::InstOpCode::psth,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0xb000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xf0000000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr30,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xf3c00000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xf0000000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xf000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xf000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xf0000000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xf000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xf0007fffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xf0008000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xf0008000u)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xf0007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xf000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstq,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xf000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x90000000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr31,   0x000000000,  0x000000000, BinaryInstruction(0x06100000u, 0x93e00000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,   -0x200000000,  0x000000000, BinaryInstruction(0x06120000u, 0x90000000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0611ffffu, 0x9000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0613ffffu, 0x9000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0611ffffu, 0x90000000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x06100000u, 0x9000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x000007fff,  0x000000000, BinaryInstruction(0x06100000u, 0x90007fffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0613ffffu, 0x90008000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x000007fff,  0x000000001, BinaryInstruction(0x06100000u, 0x90008000u)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x000007fff, -0x000000001, BinaryInstruction(0x06100000u, 0x90007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x000007fff,  0x000008000, BinaryInstruction(0x06100000u, 0x9000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstw,    TR::RealRegister::gr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0611ffffu, 0x9000ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xb8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xbbe00000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xb8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xb800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xb800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xb8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xb800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xb8007fffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xb8008000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xb8008000u)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xb8007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xb800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxsd,  TR::RealRegister::vr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xb800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xbc000000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr31,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xbfe00000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,   -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xbc000000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xbc00ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,   -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xbc00ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xbc000000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xbc00ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xbc007fffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,   -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xbc008000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xbc008000u)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xbc007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xbc00ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxssp, TR::RealRegister::vr0,    0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xbc00ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr31,  0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xdbe00000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr63,  0x000000000,  0x000000000, BinaryInstruction(0x04100000u, 0xdfe00000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,  -0x200000000,  0x000000000, BinaryInstruction(0x04120000u, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x1ffffffff,  0x000000000, BinaryInstruction(0x0411ffffu, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,  -0x000000001,  0x000000000, BinaryInstruction(0x0413ffffu, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x1ffff0000,  0x000000000, BinaryInstruction(0x0411ffffu, 0xd8000000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x00000ffff,  0x000000000, BinaryInstruction(0x04100000u, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000000000, BinaryInstruction(0x04100000u, 0xd8007fffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,  -0x000008000,  0x000000000, BinaryInstruction(0x0413ffffu, 0xd8008000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000000001, BinaryInstruction(0x04100000u, 0xd8008000u)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x000007fff, -0x000000001, BinaryInstruction(0x04100000u, 0xd8007ffeu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x000007fff,  0x000008000, BinaryInstruction(0x04100000u, 0xd800ffffu)),
+    std::make_tuple(TR::InstOpCode::pstxv,   TR::RealRegister::vsr0,   0x0ffffffff,  0x100000000, BinaryInstruction(0x0411ffffu, 0xd800ffffu))
 )));
 
 INSTANTIATE_TEST_CASE_P(StorePrefix, PPCRecordFormSanityTest, ::testing::Values(

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -898,6 +898,48 @@ TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocat
     );
 }
 
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodeFlat) {
+    int64_t displacement = std::get<2>(GetParam()) + std::get<3>(GetParam());
+
+    // PPCTrg1ImmInstruction currently only supports 32-bit immediates
+    if (displacement < -0x80000000 || displacement > 0x7fffffff)
+        return;
+
+    auto instr = generateTrg1ImmInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        displacement
+    );
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        encodeInstruction(instr, 0)
+    );
+}
+
+TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodeFlatPrefixCrossingBoundary) {
+    int64_t displacement = std::get<2>(GetParam()) + std::get<3>(GetParam());
+
+    // PPCTrg1ImmInstruction currently only supports 32-bit immediates
+    if (displacement < -0x80000000 || displacement > 0x7fffffff)
+        return;
+
+    auto instr = generateTrg1ImmInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        displacement
+    );
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        encodeInstruction(instr, 60)
+    );
+}
+
 class PPCMemSrc1EncodingTest : public PowerBinaryEncoderTest, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, MemoryReference, TR::RealRegister::RegNum, BinaryInstruction, bool>> {};
 
 TEST_P(PPCMemSrc1EncodingTest, encode) {
@@ -1028,6 +1070,48 @@ TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocat
     ASSERT_EQ(
         std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
         getEncodedInstruction(size, 60)
+    );
+}
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodeFlat) {
+    int64_t displacement = std::get<2>(GetParam()) + std::get<3>(GetParam());
+
+    // PPCSrc1Instruction currently only supports 32-bit immediates
+    if (displacement < -0x80000000 || displacement > 0x7fffffff)
+        return;
+
+    auto instr = generateSrc1Instruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        displacement
+    );
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()),
+        encodeInstruction(instr, 0)
+    );
+}
+
+TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodeFlatPrefixCrossingBoundary) {
+    int64_t displacement = std::get<2>(GetParam()) + std::get<3>(GetParam());
+
+    // PPCSrc1Instruction currently only supports 32-bit immediates
+    if (displacement < -0x80000000 || displacement > 0x7fffffff)
+        return;
+
+    auto instr = generateTrg1ImmInstruction(
+        cg(),
+        std::get<0>(GetParam()),
+        fakeNode,
+        cg()->machine()->getRealRegister(std::get<1>(GetParam())),
+        displacement
+    );
+
+    ASSERT_EQ(
+        std::get<4>(GetParam()).prepend(TR::InstOpCode::metadata[TR::InstOpCode::nop].opcode),
+        encodeInstruction(instr, 60)
     );
 }
 


### PR DESCRIPTION
This PR adds binary encoder support for encoding PC-relative offsets on the new POWER10 prefixed loads and stores. There are currently two different ways of specifying the displacement:

1. Using an offset relative to a `TR::LabelSymbol`
2. Using a constant displacement

The first method is meant to be the standard way of doing this, with the second method existing only to allow the displacement field to be forced to be 0 when a PC-relative load/store's displacement will be patched.