### PR TITLE
Remove CodeGenerator::deleteInst from the Power codegen

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1641,16 +1641,6 @@ OMR::Power::CodeGenerator::calculateRegisterPressure()
    return NULL;
    }
 
-
-//FIXME: should this be common code in CodeGen?
-void OMR::Power::CodeGenerator::deleteInst(TR::Instruction* old)
-   {
-   TR::Instruction* prv = old->getPrev();
-   TR::Instruction* nxt = old->getNext();
-   prv->setNext(nxt);
-   nxt->setPrev(prv);
-   }
-
 TR::Linkage *
 OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -190,7 +190,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void doPeephole();
    void expandInstructions();
    virtual TR_RegisterPressureSummary *calculateRegisterPressure();
-   void deleteInst(TR::Instruction* old);
    TR::Instruction *generateNop(TR::Node *n, TR::Instruction *preced = 0, TR_NOPKind nopKind=TR_NOPStandard);
    TR::Instruction *generateGroupEndingNop(TR::Node *node , TR::Instruction *preced = 0);
    TR::Instruction *generateProbeNop(TR::Node *node , TR::Instruction *preced = 0);


### PR DESCRIPTION
The Power code generator previously had a method on TR::CodeGenerator to
delete an instruction from the list of instructions. However, this
method is no longer used, as Instruction::remove is the preferred way of
doing this now. To reflect this, the old method has now been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>