### PR TITLE
AArch64: Change register allocation in i2lEvaluator, etc.

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -148,13 +148,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
 
 static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, uint32_t imms, TR::CodeGenerator *cg)
    {
-   TR::Node *child  = node->getFirstChild();
-   TR::Register *trgReg = cg->gprClobberEvaluate(child);
+   TR::Node *child = node->getFirstChild();
+   TR::Register *srcReg = cg->evaluate(child);
+   TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
 
    // signed extension: alias of SBFM
    // unsigned extension: alias of UBFM
    TR_ASSERT(imms < 32, "Extension size too big");
-   generateTrg1Src1ImmInstruction(cg, op, node, trgReg, trgReg, imms);
+   generateTrg1Src1ImmInstruction(cg, op, node, trgReg, srcReg, imms);
 
    node->setRegister(trgReg);
    cg->decReferenceCount(child);


### PR DESCRIPTION
This commit changes register allocation in extendToIntOrLongHelper()
for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>