### PR TITLE
Ineffective _causedRememberedSetOverflow Flag Fix

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -2464,7 +2464,7 @@ MM_Scavenger::addToRememberedSetFragment(MM_EnvironmentStandard *env, omrobjectp
 		/* There wasn't enough room in the current fragment - allocate a new one */
 		if(allocateMemoryForSublistFragment(env->getOmrVMThread(), (J9VMGC_SublistFragment*)&env->_scavengerRememberedSet)) {
 			/* Failed to allocate a fragment - set the remembered set overflow state and exit */
-			if(!isRememberedSetInOverflowState()) {
+			if (!_isRememberedSetInOverflowAtTheBeginning) {
 				env->_scavengerStats._causedRememberedSetOverflow = 1;
 			}
 			setRememberedSetOverflowState();


### PR DESCRIPTION
#### Overview
`_causedRememberedSetOverflow` scavenger stat flag is never set. This flag is the only way to tell whether a completed collection caused an overflow. Other than missing details in verbose log, this hasn't been an issue. However, there's planned future work relying on this flag being correct.

#### Details
Guard condition around setting `_causedRememberedSetOverflow` will never pass. Consequently, it's impossible for it to be set:

```
if(!isRememberedSetInOverflowState())
	env->_scavengerStats._causedRememberedSetOverflow = 1;
```

 Upon `allocateMemoryForSublistFragment` failing, `setRememberedSetOverflowState` is called which will makes `isRememberedSetInOverflowState()` true and the condition fail.

#### Fix
We can rely on `_isRememberedSetInOverflowAtTheBeginning` as the condition (Cached RS Overflow flag at the beginning of the scavenge), if it isn't set then we know Scavenger must of caused the overflow.

Signed-off-by: Salman Rana <salman.rana@ibm.com>