### PR TITLE
Switch to using a label for StartPC in the Power codegen

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1667,16 +1667,12 @@ OMR::Power::CodeGenerator::expandInstructions()
    _binaryEncodingData.estimate = 0;
    self()->generateBinaryEncodingPrologue(&_binaryEncodingData);
 
-   // This instruction needs to be generated here for the time being, since OpenJ9 directly
-   // overrides the generateBinaryEncodingPrologue method. Additionally, this instruction *must*
-   // be created using the constructor, since this may be the first instruction and the helpers
-   // don't handle that case properly.
-   new (self()->trHeapMemory()) TR::PPCLabelInstruction(
+   generateLabelInstruction(
+      self(),
       TR::InstOpCode::label,
       self()->comp()->getStartTree()->getNode(),
       self()->getStartPCLabel(),
-      _binaryEncodingData.preProcInstruction->getPrev(),
-      self()
+      _binaryEncodingData.preProcInstruction
    );
 
    for (TR::Instruction *instr = self()->getFirstInstruction(); instr; instr = instr->getNext())

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -539,6 +539,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    uint32_t getHotLoopAlignment();
 
+   TR::LabelSymbol *getStartPCLabel();
+
    private:
 
    enum // flags
@@ -589,6 +591,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    uint32_t *                       _tbTableEnd;
    uint32_t                         _numVRF;
 
+   TR::LabelSymbol *_startPCLabel;
    };
 
 } // PPC

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -431,11 +431,6 @@ OMR::ConstantDataSnippet::emitAddressConstant(
       iloc1 = requestors[i]->getBinaryEncoding();
       iloc2 = requestors[i+1]->getBinaryEncoding();
       addr = (intptr_t)codeCursor;
-      // if it's the start PC, don't use the constant, but grab it from the symbol:
-      TR::Symbol *sym = requestors[i]->getNode()->getSymbol();
-      TR::StaticSymbol *staticSym = sym ? sym->getStaticSymbol() : NULL;
-      if (staticSym && staticSym->isStartPC())
-         addr = (intptr_t) staticSym->getStaticAddress();
       if (count==4)
          {
          iloc3 = requestors[i+2]->getBinaryEncoding();


### PR DESCRIPTION
Currently, the Power codegen has a decent amount of special handling to deal with trying to load the StartPC of the current method, including a particularly egregious hack in `ConstantDataSnippet` that would cause the address of StartPC itself to be patched on the instructions rather than the address of a slot in the snippet from which to load. In addition to being generally very confusing and inconsistent, this hack makes modifications to this snippet (such as those required for #5367) quite difficult without inadvertently breaking things.

Since this functionality was introduced, the Power codegen has become capable of generating and relocating a sequence to load the address of an arbitrary label into a register in a much more reasonable manner. By instead generating a label at StartPC and then using this more general method of loading its address, not only can the `ConstantDataSnippet` hack be eliminated but we also gain the ability to load this address from the pTOC where applicable.