### PR TITLE
AArch64: Enhance bookkeeping of register use count

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2583,7 +2583,7 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
                             TR::MemoryReference *mr, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, cg), _memoryReference(mr)
       {
-      mr->incRegisterTotalUseCounts(cg);
+      mr->bookKeepingRegisterUses(self(), cg);
       }
 
    /*
@@ -2602,7 +2602,7 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _memoryReference(mr)
       {
-      mr->incRegisterTotalUseCounts(cg);
+      mr->bookKeepingRegisterUses(self(), cg);
       }
 
    /**
@@ -2706,7 +2706,7 @@ class ARM64MemInstruction : public TR::Instruction
                         TR::MemoryReference *mr, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _memoryReference(mr)
       {
-      mr->incRegisterTotalUseCounts(cg);
+      mr->bookKeepingRegisterUses(self(), cg);
       }
 
    /*
@@ -2723,7 +2723,7 @@ class ARM64MemInstruction : public TR::Instruction
                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, precedingInstruction, cg), _memoryReference(mr)
       {
-      mr->incRegisterTotalUseCounts(cg);
+      mr->bookKeepingRegisterUses(self(), cg);
       }
 
    /**

--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
    {
    self()->setBlockIndex(cg->getCurrentBlockIndex());
    if (cond)
-      cond->incRegisterTotalUseCounts(cg);
+      cond->bookKeepingRegisterUses(self(), cg);
    }
 
 
@@ -60,7 +60,7 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *pre
    {
    self()->setBlockIndex(cg->getCurrentBlockIndex());
    if (cond)
-      cond->incRegisterTotalUseCounts(cg);
+      cond->bookKeepingRegisterUses(self(), cg);
    }
 
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -610,19 +610,19 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR:
    }
 
 
-void OMR::ARM64::MemoryReference::incRegisterTotalUseCounts(TR::CodeGenerator * cg)
+void OMR::ARM64::MemoryReference::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
    if (_baseRegister != NULL)
       {
-      _baseRegister->incTotalUseCount();
+      instr->useRegister(_baseRegister);
       }
    if (_indexRegister != NULL)
       {
-      _indexRegister->incTotalUseCount();
+      instr->useRegister(_indexRegister);
       }
    if (_extraRegister != NULL)
       {
-      _extraRegister->incTotalUseCount();
+      instr->useRegister(_extraRegister);
       }
    }
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -393,10 +393,11 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    void consolidateRegisters(TR::Register *srcReg, TR::Node *srcTree, bool srcModifiable, TR::CodeGenerator *cg);
 
    /**
-    * @brief Increment totalUseCounts of registers in MemoryReference
+    * @brief Do bookkeeping of use counts of registers in the MemoryReference
+    * @param[in] instr : instruction
     * @param[in] cg : CodeGenerator
     */
-   void incRegisterTotalUseCounts(TR::CodeGenerator *cg);
+   void bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg);
 
    /**
     * @brief Assigns registers

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -221,14 +221,26 @@ bool OMR::ARM64::RegisterDependencyConditions::usesRegister(TR::Register *r)
    }
 
 void OMR::ARM64::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::CodeGenerator *cg)
+    {
+    for (int i = 0; i < _addCursorForPre; i++)
+       {
+      _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
+       }
+    for (int j = 0; j < _addCursorForPost; j++)
+       {
+      _postConditions->getRegisterDependency(j)->getRegister()->incTotalUseCount();
+       }
+    }
+
+void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
    for (int i = 0; i < _addCursorForPre; i++)
       {
-      _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
+      instr->useRegister(_preConditions->getRegisterDependency(i)->getRegister());
       }
    for (int j = 0; j < _addCursorForPost; j++)
       {
-      _postConditions->getRegisterDependency(j)->getRegister()->incTotalUseCount();
+      instr->useRegister(_postConditions->getRegisterDependency(j)->getRegister());
       }
    }
 

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -456,6 +456,13 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
     * @param[in] cg : CodeGenerator
     */
    void incRegisterTotalUseCounts(TR::CodeGenerator *cg);
+
+   /**
+    * @brief Do bookkeeping of use counts of registers in the RegisterDependencyConditions
+    * @param[in] instr : instruction
+    * @param[in] cg : CodeGenerator
+    */
+   void bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg);
    };
 
 } // ARM64


### PR DESCRIPTION
This commit adds `bookKeepingRegisterUses` method to register dependency
and memory reference and changes instruction classes to call them.
This commit also removes `incTotalUseCount` method from memory reference class.
Because `incTotalUseCount` method of register dependency class is used from
instruction class of OpenJ9 side, it will be removed after the instruction class
is changed to use `bookKeepingRegisterUses`.


Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>