### PR TITLE
AArch64: Remove incTotalUseCount method from OMRRegisterDependencyConditions

### DIFF
--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -220,18 +220,6 @@ bool OMR::ARM64::RegisterDependencyConditions::usesRegister(TR::Register *r)
    return false;
    }
 
-void OMR::ARM64::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::CodeGenerator *cg)
-    {
-    for (int i = 0; i < _addCursorForPre; i++)
-       {
-      _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
-       }
-    for (int j = 0; j < _addCursorForPost; j++)
-       {
-      _postConditions->getRegisterDependency(j)->getRegister()->incTotalUseCount();
-       }
-    }
-
 void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
    {
    for (int i = 0; i < _addCursorForPre; i++)

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -452,12 +452,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    bool usesRegister(TR::Register *r);
 
    /**
-    * @brief Increment totalUseCounts of registers in the RegisterDependencyConditions
-    * @param[in] cg : CodeGenerator
-    */
-   void incRegisterTotalUseCounts(TR::CodeGenerator *cg);
-
-   /**
     * @brief Do bookkeeping of use counts of registers in the RegisterDependencyConditions
     * @param[in] instr : instruction
     * @param[in] cg : CodeGenerator


### PR DESCRIPTION
This commit removes `incTotalUseCount` method from OMRRegisterDependencyConditions.

Depends on:
https://github.com/eclipse/omr/pull/5385
https://github.com/eclipse/openj9/pull/10140

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>