### PR TITLE
FMOV (imm) instruction implementation

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1345,6 +1345,10 @@ class ARM64Trg1ImmInstruction : public ARM64Trg1Instruction
          {
          *instruction |= ((_sourceImmediate & 0x3ffff) << 5);
          }
+      else if (op == TR::InstOpCode::fmovimms || op == TR::InstOpCode::fmovimmd)
+         {
+         *instruction |= ((_sourceImmediate & 0xFF) << 13);
+         }
       else if (op == TR::InstOpCode::adr || op == TR::InstOpCode::adrp)
          {
          *instruction |= ((_sourceImmediate & 0x1ffffc) << 3) | ((_sourceImmediate & 0x3) << 29);


### PR DESCRIPTION
This commit verifies floating point values by the respective IEEE 754
representation, generates the relevant 8-bit immediate values,
implements FMOV (imm) instruction, and does the binary encoding
associated to the instruction.

Partially Fixes: #3377

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>