### PR TITLE
Enable CS Exhaustive Termination by default

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1535,7 +1535,7 @@ public:
 		, concurrentScavengerBackgroundThreadsForced(false)
 		, concurrentScavengerSlack(0)
 		, concurrentScavengerAllocDeviationBoost(2.0)
-		, concurrentScavengeExhaustiveTermination(false)
+		, concurrentScavengeExhaustiveTermination(true)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)


### PR DESCRIPTION
Enabling the low pause optimization by default. High level description
and a series of PRs that implements the optimization can be found here:
https://github.com/eclipse/omr/issues/4787

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>