### PR TITLE
AArch64: Implement OutOfLineCodeSection

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -27,6 +27,7 @@
 #include "codegen/ARM64ConditionCode.hpp"
 #include "codegen/ARM64HelperCallSnippet.hpp"
 #include "codegen/ARM64Instruction.hpp"
+#include "codegen/ARM64OutOfLineCodeSection.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/GCRegisterMap.hpp"
@@ -1518,6 +1519,7 @@ getRegisterName(TR::RealRegister::RegNum num, bool is64bit)
    switch (num)
       {
       case TR::RealRegister::NoReg: return "NoReg";
+      case TR::RealRegister::SpilledReg: return "SpilledReg";
       case TR::RealRegister::x0: return (is64bit ? "x0" : "w0");
       case TR::RealRegister::x1: return (is64bit ? "x1" : "w1");
       case TR::RealRegister::x2: return (is64bit ? "x2" : "w2");
@@ -1603,7 +1605,26 @@ TR_Debug::getARM64RegisterName(uint32_t regNum, bool is64bit)
 
 void TR_Debug::printARM64OOLSequences(TR::FILE *pOutFile)
    {
-   TR_UNIMPLEMENTED();
+   auto oiIterator = _cg->getARM64OutOfLineCodeSectionList().begin();
+
+   while (oiIterator != _cg->getARM64OutOfLineCodeSectionList().end())
+      {
+      trfprintf(pOutFile, "\n------------ start out-of-line instructions\n");
+      TR::Instruction *instr = (*oiIterator)->getFirstInstruction();
+
+      do {
+         print(pOutFile, instr);
+         instr = instr->getNext();
+      } while (instr != (*oiIterator)->getAppendInstruction());
+
+      if ((*oiIterator)->getAppendInstruction())
+         {
+         print(pOutFile, (*oiIterator)->getAppendInstruction());
+         }
+      trfprintf(pOutFile, "\n------------ end out-of-line instructions\n");
+
+      ++oiIterator;
+      }
    }
 
 const char *

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -523,6 +523,12 @@ class ARM64LabelInstruction : public TR::Instruction
       }
 
    /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */
@@ -534,6 +540,15 @@ class ARM64LabelInstruction : public TR::Instruction
     * @return estimated binary length
     */
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
+
+   protected:
+
+   /**
+    * @brief Assigns registers for OutOfLineCodeSection
+    *
+    * @param[in] kindToBeAssigned : register kind
+    */
+   void assignRegistersForOutOfLineCodeSection(TR_RegisterKinds kindToBeAssigned);
    };
 
 class ARM64ConditionalBranchInstruction : public ARM64LabelInstruction

--- a/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
+++ b/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,11 @@
  *******************************************************************************/
 
 #include "codegen/ARM64OutOfLineCodeSection.hpp"
+#include "codegen/BackingStore.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "codegen/Machine.hpp"
+#include "codegen/Register.hpp"
 
 TR_ARM64OutOfLineCodeSection::TR_ARM64OutOfLineCodeSection(TR::Node *callNode,
                             TR::ILOpCodes callOp,
@@ -36,7 +39,62 @@ TR_ARM64OutOfLineCodeSection::TR_ARM64OutOfLineCodeSection(TR::Node *callNode,
 
 void TR_ARM64OutOfLineCodeSection::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   TR_UNIMPLEMENTED();
+   TR::Compilation *comp = _cg->comp();
+   if (hasBeenRegisterAssigned())
+      return;
+   // nested internal control flow assert:
+   _cg->setInternalControlFlowSafeNestingDepth(_cg->internalControlFlowNestingDepth());
+
+   // Create a dependency list on the first instruction in this stream that captures all current real register associations.
+   // This is necessary to get the register assigner back into its original state before the helper stream was processed.
+   //
+   _cg->incOutOfLineColdPathNestedDepth();
+
+   // this is to prevent the OOL entry label from resetting all register's startOfrange during RA
+   _cg->toggleIsInOOLSection();
+   TR::RegisterDependencyConditions *liveRealRegDeps = _cg->machine()->createDepCondForLiveGPRs(_cg->getSpilledRegisterList());
+
+   if (liveRealRegDeps)
+      {
+      _firstInstruction->setDependencyConditions(liveRealRegDeps);
+      liveRealRegDeps->bookKeepingRegisterUses(_firstInstruction, _cg);
+      }
+   _cg->toggleIsInOOLSection(); // toggle it back because there is another toggle inside swapInstructionListsWithCompilation()
+
+
+   // Register assign the helper dispatch instructions.
+   swapInstructionListsWithCompilation();
+   _cg->doRegisterAssignment(kindsToBeAssigned);
+
+   TR::list<TR::Register*> *firstTimeLiveOOLRegisterList = _cg->getFirstTimeLiveOOLRegisterList();
+   TR::list<TR::Register*> *spilledRegisterList = _cg->getSpilledRegisterList();
+
+   for (auto li = firstTimeLiveOOLRegisterList->begin(); li != firstTimeLiveOOLRegisterList->end(); ++li)
+      {
+      if ((*li)->getBackingStorage())
+         {
+         (*li)->getBackingStorage()->setMaxSpillDepth(1);
+         traceMsg(comp,"Adding virtReg:%s from _firstTimeLiveOOLRegisterList to _spilledRegisterList \n", _cg->getDebug()->getName((*li)));
+         spilledRegisterList->push_front((*li));
+         }
+      }
+   _cg->getFirstTimeLiveOOLRegisterList()->clear();
+
+   swapInstructionListsWithCompilation();
+
+   _cg->decOutOfLineColdPathNestedDepth();
+
+   // Returning to mainline, reset this counter
+   _cg->setInternalControlFlowSafeNestingDepth(0);
+
+   // Link in the helper stream into the mainline code.
+   // We will end up with the OOL items attached at the bottom of the instruction stream
+   TR::Instruction *appendInstruction = _cg->getAppendInstruction();
+   appendInstruction->setNext(_firstInstruction);
+   _firstInstruction->setPrev(appendInstruction);
+   _cg->setAppendInstruction(_appendInstruction);
+
+   setHasBeenRegisterAssigned(true);
    }
 
 void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
@@ -45,7 +103,14 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
    //
    swapInstructionListsWithCompilation();
 
-   generateLabelInstruction(_cg, TR::InstOpCode::label, _callNode, _entryLabel);
+   TR::Instruction *entryLabelInstruction = generateLabelInstruction(_cg, TR::InstOpCode::label, _callNode, _entryLabel);
+
+   _cg->incOutOfLineColdPathNestedDepth();
+   TR_Debug *debugObj = _cg->getDebug();
+   if (debugObj)
+     {
+     debugObj->addInstructionComment(entryLabelInstruction, "Denotes start of OOL sequence");
+     }
 
    TR::Register *resultReg = TR::TreeEvaluator::performCall(_callNode, _callNode->getOpCode().isCallIndirect(), _cg);
 
@@ -56,10 +121,15 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
       }
    _cg->decReferenceCount(_callNode);
 
-   if (_restartLabel)
-      generateLabelInstruction(_cg, TR::InstOpCode::b, _callNode, _restartLabel);
+   TR::Instruction *returnBranchInstruction = generateLabelInstruction(_cg, TR::InstOpCode::b, _callNode, _restartLabel);
+
+   if (debugObj)
+     {
+     debugObj->addInstructionComment(returnBranchInstruction, "Denotes end of OOL: return to mainline");
+     }
+
+   _cg->decOutOfLineColdPathNestedDepth();
 
    // Switch from cold helper instruction stream.
-   //
    swapInstructionListsWithCompilation();
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -271,6 +271,20 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void setIsOutOfLineHotPath(bool v) { _flags.set(IsOutOfLineHotPath, v);}
 
    /**
+    * @brief Returns the list of registers which is assigned first time in OOL cold path
+    *
+    * @return the list of registers which is assigned first time in OOL cold path
+    */
+   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
+   /**
+    * @brief Sets the list of registers which is assigned first time in OOL cold path
+    *
+    * @param r : the list of registers which is assigned first time in OOL cold path
+    * @return the list of registers
+    */
+   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
+
+   /**
     * @brief Picks register
     * @param[in] regCan : register candidate
     * @param[in] barr : array of blocks
@@ -396,6 +410,14 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void generateBinaryEncodingPrePrologue(TR_ARM64BinaryEncodingData &data);
 
    /**
+    * @brief Finds OutOfLineCodeSection associated with the specified label
+    *
+    * @param[in] label : label
+    * @return OutOfLineCodeSection associated with the specified label
+    */
+   TR_ARM64OutOfLineCodeSection *findARM64OutOfLineCodeSectionFromLabel(TR::LabelSymbol *label);
+
+   /**
     * @brief Generates nop
     * @param[in] node: node
     * @param[in] preced : preceding instruction
@@ -429,6 +451,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    const TR::ARM64LinkageProperties *_linkageProperties;
    TR::list<TR_ARM64OutOfLineCodeSection*> _outOfLineCodeSectionList;
    TR::vector<TR::ARM64ConstantDataSnippet*> _dataSnippetList;
+   TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
 
    };
 

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -41,6 +41,7 @@ namespace OMR { typedef OMR::ARM64::Machine MachineConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
 
 #define NUM_ARM64_MAXR 32
 
@@ -139,6 +140,22 @@ public:
     * @brief Restore the register file from snapshot
     */
    void restoreRegisterStateFromSnapShot();
+
+   /**
+    * @brief Creates register dependency conditions for the entry label of cold path of OutOfLineCodeSection
+    *
+    * @param spilledRegisterList : the list of spilled registers in main line and hot path
+    * @return register dependency conditions
+    */
+   TR::RegisterDependencyConditions *createDepCondForLiveGPRs(TR::list<TR::Register*> *spilledRegisterList);
+
+   /**
+    * @brief Decrease future use count of the register and unlatch it if necessary
+    *
+    * @param currentInstruction     : instruction
+    * @param virtualRegister        : virtual register
+    */
+   void decFutureUseCountAndUnlatch(TR::Instruction *currentInstruction, TR::Register *virtualRegister);
 
 private:
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -26,6 +26,7 @@
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "codegen/Machine.hpp"
 #include "codegen/Relocation.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"
 #include "il/Node.hpp"
@@ -699,21 +700,13 @@ void OMR::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstru
 
    if (_baseRegister != NULL)
       {
-      if (_baseRegister->decFutureUseCount() == 0)
-         {
-         _baseRegister->setAssignedRegister(NULL);
-         assignedBaseRegister->setState(TR::RealRegister::Unlatched);
-         }
+      machine->decFutureUseCountAndUnlatch(currentInstruction, _baseRegister);
       _baseRegister = assignedBaseRegister;
       }
 
    if (_indexRegister != NULL)
       {
-      if (_indexRegister->decFutureUseCount() == 0)
-         {
-         _indexRegister->setAssignedRegister(NULL);
-         assignedIndexRegister->setState(TR::RealRegister::Unlatched);
-         }
+      machine->decFutureUseCountAndUnlatch(currentInstruction, _indexRegister);
       _indexRegister = assignedIndexRegister;
       }
    if (self()->getUnresolvedSnippet() != NULL)

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -462,6 +462,7 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
    for (i = 0; i < numberOfRegisters; i++)
       {
       TR::Register *dependentRegister = getRegisterDependency(i)->getRegister();
+      dependentRegNum = getRegisterDependency(i)->getRealRegister();
       if (dependentRegister->getAssignedRegister())
          {
          TR::RealRegister *assignedRegister = dependentRegister->getAssignedRegister()->getRealRegister();
@@ -469,12 +470,11 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
          if (getRegisterDependency(i)->getRealRegister() == TR::RealRegister::NoReg)
             getRegisterDependency(i)->setRealRegister(toRealRegister(assignedRegister)->getRegisterNumber());
 
-         if (dependentRegister->decFutureUseCount() == 0)
-            {
-            dependentRegister->setAssignedRegister(NULL);
-            assignedRegister->setAssignedRegister(NULL);
-            assignedRegister->setState(TR::RealRegister::Unlatched); // Was setting to Free
-            }
+         machine->decFutureUseCountAndUnlatch(currentInstruction, dependentRegister);
+         }
+      else if (dependentRegNum == TR::RealRegister::SpilledReg)
+         {
+         machine->decFutureUseCountAndUnlatch(currentInstruction, dependentRegister);
          }
       }
    }

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -276,7 +276,7 @@ OMR::CodeGenerator::buildGCMapForInstruction(TR::Instruction *instr)
          {
          TR::AutomaticSymbol * s = (*location)->getSymbolReference()->getSymbol()->getAutoSymbol();
 
-         // For PPC/390 OOL codegen; If a spill is in the collected list and it
+         // For PPC/390/aarch64 OOL codegen; If a spill is in the collected list and it
          // has maxSpillDepth==0 then the following is true:
          //
          // 1) This GC point is in the hot path of an OOL section
@@ -288,7 +288,7 @@ OMR::CodeGenerator::buildGCMapForInstruction(TR::Instruction *instr)
          // skip it.  The occupied flag is not accurate in this case because we
          // did not free the spill and therefore did not clear the flag.
          //
-         if ((self()->comp()->target().cpu.isPower() || self()->comp()->target().cpu.isZ()) && (*location)->getMaxSpillDepth() == 0  && comp->cg()->isOutOfLineHotPath())
+         if ((self()->comp()->target().cpu.isPower() || self()->comp()->target().cpu.isZ() || self()->comp()->target().cpu.isARM64()) && (*location)->getMaxSpillDepth() == 0  && comp->cg()->isOutOfLineHotPath())
             {
             if (self()->getDebug())
                traceMsg(comp, "\nSkipping GC map [%p] index %d (%s) for instruction [%p] in OOL hot path because it has already been reverse spilled.\n",

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2595,11 +2595,13 @@ TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees
 
       // Dump OOL instruction sequences.
       //
-#if defined(TR_TARGET_POWER) || defined(TR_TARGET_S390)
+#if defined(TR_TARGET_POWER) || defined(TR_TARGET_S390) || defined(TR_TARGET_ARM64)
       // After RA outlined code is linked to the regular instruction stream and will automatically be printed
       if (_comp->cg()->getCodeGeneratorPhase() < TR::CodeGenPhase::RegisterAssigningPhase)
 #if defined(TR_TARGET_POWER)
          printPPCOOLSequences(pOutFile);
+#elif defined(TR_TARGET_ARM64)
+         printARM64OOLSequences(pOutFile);
 #else
          printS390OOLSequences(pOutFile);
 #endif


### PR DESCRIPTION
This commit implements OutOfLineCodeSection for aarch64.
Some parts of OutOfLineCodeSection were already implemented.
This commit adds missing parts.

The major parts of OOL section are following:
1. Take a snapshot of all register states at the merge point and restore
 the states at the end of the cold path.
2. Take a snapshot of all virtual - real register assignments at the branch
 instruction (*) to the entry label of the cold path and attach it as register
 dependencies at the entry label.
3. Create a list of all spilled registers in main line and the hot path until
 the branch instruction (*) and attach it as register dependencies (SpilledReg)
 at the entry label.
4. Protect any spilled register's backing storage if the register is spilled
 in a lower "depth" path and reuse the same backing storage when generating reverse spills.

                   |
                   | main line
                   |
       branch (*)  +-----, entry label
                   |     |
       hot path    |     | cold path
                   |     |
       merge label +-----'
                   |
                   | main line
                   |

There are 2 more things to consider:
1. Unlatching registers in the hot path whose all remaining uses are out of line.
  We use register's out of line use count to handle this.
  This is the same approach as P codegen.
2. Adding registers first assigned in the cold path to spilled register list.
  We add those registers to `firstTimeLiveOOLRegisterList` and
  move them to spilled register list after register assignment for
  the cold path is finished.
  This is the same approach as Z codegen.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>