### PR TITLE
Remove InstructionAbsoluteRelocation

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -158,17 +158,6 @@ TR::InstructionLabelRelative32BitRelocation::apply(TR::CodeGenerator* cg)
    *reinterpret_cast<int32_t*>(p) = static_cast<int32_t>(getLabel()->getCodeLocation() - p) / _divisor;
    }
 
-void TR::InstructionAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
-   {
-   intptr_t *cursor = (intptr_t*)getUpdateLocation();
-   intptr_t address = (intptr_t)getInstruction()->getBinaryEncoding();
-   if (useEndAddress())
-      address += getInstruction()->getBinaryLength();
-   AOTcgDiag2(codeGen->comp(), "TR::InstructionAbsoluteRelocation::apply cursor=" POINTER_PRINTF_FORMAT " instruction=" POINTER_PRINTF_FORMAT "\n", cursor, address);
-   *cursor = address;
-   }
-
-
 void TR::LoadLabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    AOTcgDiag3(codeGen->comp(), "TR::LoadLabelRelative16BitRelocation::apply lastInstruction=" POINTER_PRINTF_FORMAT " startLabel=" POINTER_PRINTF_FORMAT " endLabel=" POINTER_PRINTF_FORMAT "\n", getLastInstruction(), getStartLabel(), getEndLabel());

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -268,30 +268,6 @@ class InstructionLabelRelative32BitRelocation : public TR::LabelRelocation
    int32_t _divisor;
    };
 
-class InstructionAbsoluteRelocation : public TR::Relocation
-   {
-   public:
-   InstructionAbsoluteRelocation(uint8_t *updateLocation,
-                                    TR::Instruction *i,
-                                    bool useEndAddr) /* specified if the start or
-                                                        the end address of the instruction
-                                                        is required */
-      : TR::Relocation(updateLocation), _instruction(i), _useEndAddr(useEndAddr) {}
-   virtual void apply(TR::CodeGenerator *cg);
-
-   bool isExternalRelocation() { return false; }
-
-   protected:
-   TR::Instruction *getInstruction() { return _instruction; }
-   bool useEndAddress() { return _useEndAddr; }
-
-   private:
-   TR::Instruction *_instruction;
-   bool            _useEndAddr;
-   };
-
-//FIXME: these label absolute relocations should really be a subclass of instruction
-// absolute.
 class LabelAbsoluteRelocation : public TR::LabelRelocation
    {
    public:
@@ -597,7 +573,6 @@ typedef TR::LabelRelative12BitRelocation TR_12BitLabelRelativeRelocation;
 typedef TR::LabelRelative16BitRelocation TR_16BitLabelRelativeRelocation;
 typedef TR::LabelRelative24BitRelocation TR_24BitLabelRelativeRelocation;
 typedef TR::LabelRelative32BitRelocation TR_32BitLabelRelativeRelocation;
-typedef TR::InstructionAbsoluteRelocation TR_InstructionAbsoluteRelocation;
 typedef TR::LabelAbsoluteRelocation TR_LabelAbsoluteRelocation;
 typedef TR::LoadLabelRelative16BitRelocation TR_16BitLoadLabelRelativeRelocation;
 typedef TR::LoadLabelRelative32BitRelocation TR_32BitLoadLabelRelativeRelocation;


### PR DESCRIPTION
Previously, there was a relocation kind for filling in the absolute
address of an instruction. This was completely unused and is also
completely redundant, as one can simply place a label immediately before
or after the instruction in question and relocate using that instead.
For that reason, this relocation kind has been removed.

Signed-off-by: Ben Thomas <ben@benthomas.ca>