### PR TITLE
Checking the constraints with allocationFence

### DIFF
--- a/compiler/optimizer/LocalLiveRangeReducer.cpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -491,7 +491,8 @@ bool TR_LocalLiveRangeReduction::isAnySymInDefinedOrUsedBy(TR_TreeRefInfo *curre
       return true;
       }
 
-   if (comp()->target().cpu.isPower() && opCode.getOpCodeValue() == TR::allocationFence)
+   if ((comp()->target().cpu.isPower() || comp()->target().cpu.isARM64())
+       && opCode.getOpCodeValue() == TR::allocationFence)
       {
       // Can't move allocations past flushes
       if (movingNode->getOpCodeValue() == TR::treetop &&


### PR DESCRIPTION
This commit changes the condition for checking constraints with allocationFence
in TR_LocalLiveRangeReduction::isAnySymInDefinedOrUsedBy().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>