### PR TITLE
Remove unnecessary uses of getOptimizationPhaseIsComplete()

### DIFF
--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -58,8 +58,7 @@ OMR::TransformUtil::scalarizeArrayCopy(
        node->getOpCodeValue() != TR::arraycopy ||
        node->getNumChildren() != 3 ||
        comp->requiresSpineChecks() ||
-       !node->getChild(2)->getOpCode().isLoadConst() ||
-       cg->getOptimizationPhaseIsComplete())
+       !node->getChild(2)->getOpCode().isLoadConst())
       return node;
 
    int64_t byteLen = node->getChild(2)->get64bitIntegralValue();

--- a/compiler/z/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/z/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 void
 OMR::Z::CodeGenPhase::performMarkLoadAsZeroOrSignExtensionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
-   if (cg->comp()->target().cpu.isZ() && cg->getOptimizationPhaseIsComplete())
+   if (cg->comp()->target().cpu.isZ())
       {
       TR::Compilation* comp = cg->comp();
       TR::OptimizationManager *manager = comp->getOptimizer()->getOptimization(OMR::loadExtensions);


### PR DESCRIPTION
fold the two calls with the value as in #5402

Signed-off-by: James Guan <jamesgua@ca.ibm.com>