### PR TITLE
Add OMR::CFG::addExceptionEdgeUnchecked method

### DIFF
--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -168,10 +168,9 @@ OMR::CFG::addExceptionEdge(
    {
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
       {
-      traceMsg(comp(),"\nAdding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      traceMsg(comp(),"\nAttempting to add exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
       }
 
-   TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
    TR::Block * newCatchBlock = toBlock(t);
    for (auto e = f->getExceptionSuccessors().begin(); e != f->getExceptionSuccessors().end(); ++e)
       {
@@ -210,11 +209,26 @@ OMR::CFG::addExceptionEdge(
          return;
          }
       }
+
+   addExceptionEdgeUnchecked(f, t);
+   }
+
+void
+OMR::CFG::addExceptionEdgeUnchecked(
+      TR::CFGNode *f,
+      TR::CFGNode *t)
+   {
+   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+      {
+      traceMsg(comp(),"\nAdding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      }
+
+   TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
+
    TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, _internalRegion);
    _numEdges++;
 
    // Tell the control tree to modify the structures containing this edge
-   //
    if (getStructure() != NULL)
       {
       getStructure()->addEdge(e, true);

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -185,11 +185,26 @@ class CFG
 
    /**
     * Create and store exception edge from CFGNode f to CFGNode t 
+    *
+    * The new edge will not be added if there is an existing exception edge
+    * from the "from" node to an existing block which catches the same
+    * exceptions as the new "to" block.
+    *
     * @param f   CFGNode from
     * @param t   CFGNode to
-    * @return    Pointer to newly created exception edge
     */
    void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
+
+   /**
+    * Create and store exception edge from CFGNode f to CFGNode t
+    *
+    * The new edge will be added even if there is an existing exception edge
+    * exiting the "from" node.
+    *
+    * @param f   CFGNode from
+    * @param t   CFGNode to
+    */
+   void addExceptionEdgeUnchecked(TR::CFGNode *f, TR::CFGNode *t);
    void addSuccessorEdges(TR::Block * block);
 
    void copyExceptionSuccessors(TR::CFGNode *from, TR::CFGNode *to, bool (*predicate)(TR::CFGEdge *) = OMR::alwaysTrue);


### PR DESCRIPTION
The motivation behind adding this new method is that monitor elimination in openj9 needs to be able to add a new exception edge before removing an existing one. See this issue: https://github.com/eclipse/openj9/issues/9754.

The method `OMR::CFG::addExceptionEdge` checks for existing exception edges
before adding a new one. In cases where an exception edge already exists, it
silently fails to add a new edge.

Some optimizations which rearrange exception edges may want to add a new
exception edge before removing an existing one. This is not possible to do with
`OMR::CFG::addExceptionEdge`. This commit adds a new method which will add an
exception edge even when one already exists.

Signed-off-by: Ryan Shukla <ryans@ibm.com>