### PR TITLE
Revert "Add heap free ratio heuristics for heap expansion"

### DIFF
--- a/gc/base/MemorySubSpaceUniSpace.hpp
+++ b/gc/base/MemorySubSpaceUniSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2015 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,8 +53,6 @@ protected:
 	bool timeForHeapExpand(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);	
 	uintptr_t performExpand(MM_EnvironmentBase *env);
 	uintptr_t performContract(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
-	uintptr_t getHeapFreeMaximumHeuristicMultiplier(MM_EnvironmentBase *env);
-	uintptr_t getHeapFreeMinimumHeuristicMultiplier(MM_EnvironmentBase *env);
 
 public:
 	virtual void checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription = NULL, bool _systemGC = false);

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -925,6 +925,3 @@ TraceException=Trc_MM_double_map_Failed Overhead=1 Level=1 Group=arraylet Templa
 TraceExit=Trc_MM_double_map_Exit Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::doubleMapArraylets. result=%p"
 
 TraceEvent=Trc_MM_Scavenger_percolate_delegate Overhead=1 Level=1 Group=percolate Template="Percolating due to language specific reason"
-
-TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Maximum free multiplier = %zu"
-TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Minimum free multiplier = %zu"


### PR DESCRIPTION
Reverts eclipse/omr#5327

Change caused intermittent serbuf test failures on all platforms

Signed-off-by: Jason Hall jasonhal@ca.ibm.com