### PR TITLE
PortTest: Enable verbose output on windows

### DIFF
--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -137,9 +137,16 @@ if(OMR_HOST_OS STREQUAL "aix")
 endif()
 
 if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos")
+	# add verbose output to debug #5100
+	if(OMR_OS_WINDOWS)
+		set(extra_opts "-verbose")
+	else()
+		set(extra_opts)
+	endif()
+
 	add_test(
 		NAME porttest
-		COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
+		COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml ${extra_opts}
 	)
 endif()
 

--- a/fvtest/porttest/main.cpp
+++ b/fvtest/porttest/main.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ extern "C" int
 omr_main_entry(int argc, char **argv, char **envp)
 {
 	bool isChild = false;
+	bool isVerbose = false;
 	bool earlyExit = false;
 	int i = 0;
 	char testName[99] = "";
@@ -45,6 +46,8 @@ omr_main_entry(int argc, char **argv, char **envp)
 			strcpy(testName, &argv[i][7]);
 		} else if (0 == strcmp(argv[i], "-earlyExit")) {
 			earlyExit = true;
+		} else if (0 == strcmp(argv[i], "-verbose")) {
+			isVerbose = true;
 		}
 	}
 
@@ -52,7 +55,9 @@ omr_main_entry(int argc, char **argv, char **envp)
 		::testing::InitGoogleTest(&argc, argv);
 	}
 
-	OMREventListener::setDefaultTestListener();
+	if (!isVerbose) {
+		OMREventListener::setDefaultTestListener();
+	}
 
 	INITIALIZE_THREADLIBRARY_AND_ATTACH();
 


### PR DESCRIPTION
Add verbose output on tests run to diagnose #5100

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>