### PR TITLE
Move pTOC label processing into processRelocations

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1790,16 +1790,6 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
       self()->getLinkage()->performPostBinaryEncoding();
       }
 
-   // We late-processing TOC entries here: obviously cannot deal with snippet labels.
-   // If needed, we should move this step to common code around relocation processing.
-   if (self()->comp()->target().is64Bit())
-      {
-      int32_t idx;
-      for (idx=0; idx<self()->getTrackItems()->size(); idx++)
-         TR_PPCTableOfConstants::setTOCSlot(self()->getTrackItems()->element(idx)->getTOCOffset(),
-            (uintptr_t)self()->getTrackItems()->element(idx)->getLabel()->getCodeLocation());
-      }
-
    // Create exception table entries for outlined instructions.
    //
    if (!self()->comp()->getOption(TR_DisableOOL))
@@ -1821,6 +1811,20 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
          ++oiIterator;
          }
       }
+   }
+
+void OMR::Power::CodeGenerator::processRelocations()
+   {
+   // Fill in pTOC entries that are used to load label addresses. This is done during relocation
+   // processing to ensure that snippet labels can be handled correctly.
+   if (self()->comp()->target().is64Bit())
+      {
+      for (int32_t idx = 0; idx < self()->getTrackItems()->size(); idx++)
+         TR_PPCTableOfConstants::setTOCSlot(self()->getTrackItems()->element(idx)->getTOCOffset(),
+            (uintptr_t)self()->getTrackItems()->element(idx)->getLabel()->getCodeLocation());
+      }
+
+   OMR::CodeGenerator::processRelocations();
    }
 
 // different from evaluate in that it returns a clobberable register

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -187,6 +187,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void endInstructionSelection();
    void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
+   void processRelocations();
    void doPeephole();
    void expandInstructions();
    virtual TR_RegisterPressureSummary *calculateRegisterPressure();


### PR DESCRIPTION
When trying to load the address of a label into a register on 64-bit
machines, it is necessary to allocate a pTOC entry to be filled in
later. Previously, such entries were being filled in immediately after
binary encoding, which was fine as long as the label in question was not
part of a snippet.

However, there are several snippets in OpenJ9 which require that their
addresses be loaded into a register. Previously, this was handled
individually by each snippet by patching the mainline code manually with
the correct address. Not only does loading addresses this way cause
needless code duplication and other such issues, it also makes it very
difficult to take advantage of POWER10 PC-relative paddi instructions
in a uniform manner.

In order to prepare for OpenJ9 to be able to handle this in a more
elegant manner, it's necessary to ensure that loading the address of a
label whose code location is set during snippet emission works
correctly. To accomplish this, filling in pTOC entries with label
addresses now occurs during relocation processing.

Signed-off-by: Ben Thomas <ben@benthomas.ca>