### PR TITLE
Runtime compressed refs work

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -261,7 +261,11 @@ public:
 	MMINLINE bool compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -861,7 +861,11 @@ public:
 	MMINLINE bool compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -147,7 +147,11 @@ public:
 	MMINLINE bool const compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -109,13 +109,17 @@ public:
 	{
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
-#else /* OMR_GC_FULL_POINTERS */
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
+#else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
-#endif /* OMR_GC_FULL_POINTERS */
-#else /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		return false;
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	}
 
 	/**

--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -143,7 +143,11 @@ public:
 	MMINLINE bool compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -135,7 +135,11 @@ public:
 	MMINLINE bool compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */

--- a/gc/structs/ForwardedHeader.hpp
+++ b/gc/structs/ForwardedHeader.hpp
@@ -255,7 +255,11 @@ public:
 	MMINLINE bool compressObjectReferences() {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
+		return (bool)OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES;
+#else /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		return _compressObjectReferences;
+#endif /* defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
 #endif /* defined(OMR_GC_FULL_POINTERS) */


### PR DESCRIPTION
Support compiling the GC twice (once for compressed, once for full) in
mixed reference mode.

Rather than attempting to alter the OMR build flags, the multiple
compilation will be controlled by defining
OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES to 0 or 1.

This PR does not create multiple compilations, it simply allows for it.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>