### PR TITLE
Reintroduce Dispatcher Rework with fix

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -439,6 +439,7 @@ public:
 	uintptr_t gcThreadCount; /**< Initial number of GC threads - chosen default or specified in java options*/
 	bool gcThreadCountForced; /**< true if number of GC threads is specified in java options. Currently we have a few ways to do this:
 										-Xgcthreads		-Xthreads= (RT only)	-XthreadCount= */
+	uintptr_t dispatcherHybridNotifyThreadBound; /** Bound for determining hybrid notification type (Individual notifies for count < MIN(bound, maxThreads/2), otherwise notify_all) */
 
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	enum ScavengerScanOrdering {
@@ -1516,6 +1517,7 @@ public:
 #endif /* OMR_GC_BATCH_CLEAR_TLH */
 		, gcThreadCount(0)
 		, gcThreadCountForced(false)
+		, dispatcherHybridNotifyThreadBound(16)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -47,6 +47,7 @@ class MM_ParallelDispatcher : public MM_BaseVirtual
 	 */
 private:
 protected:
+	MM_Task *_task;
 	MM_GCExtensionsBase *_extensions;
 
 	enum {
@@ -76,6 +77,7 @@ protected:
 	uintptr_t _threadCountMaximum; /**< maximum threadcount - this is the size of the thread tables etc */
 	uintptr_t _threadCount; /**< number of threads currently forked */
 	uintptr_t _activeThreadCount; /**< number of threads actively running a task */
+	uintptr_t _threadsToReserve; /**< Indicates number of threads remaining to dispatch tasks upon notify. Must be exactly 0 after tasks are dispatched. */
 
 	omrsig_handler_fn _handler;
 	void* _handler_arg;
@@ -138,6 +140,7 @@ public:
 
 	MM_ParallelDispatcher(MM_EnvironmentBase *env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize) :
 		MM_BaseVirtual()
+		,_task(NULL)
 		,_extensions(MM_GCExtensionsBase::getExtensions(env->getOmrVM()))
 		,_threadShutdownCount(0)
 		,_threadTable(NULL)
@@ -151,6 +154,7 @@ public:
 		,_threadCountMaximum(1)
 		,_threadCount(1)
 		,_activeThreadCount(1)
+		,_threadsToReserve(0)		
 		,_handler(handler)
 		,_handler_arg(handler_arg)
 		,_defaultOSStackSize(defaultOSStackSize)


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9/issues/10171

For details regarding the reverted changes being reintroduced here, please refer back to the original PR (https://github.com/eclipse/omr/pull/5336). This PR details the issue with the original change and the patch to fix it.

Initial changes caused intermittent test failures/hangs. This was caused by a race (introduced by rework) between task dispatch and thread startup routine. This occurred when a task was dispatched before a thread finished its startup routine - before the thread got a chance to enter its main loop (in worker entryPoint) and "wait for the task". This caused the thread to miss wakeUp notification and wait indefinitely.

Before the rework, thread status was updated prior to task being dispatched. Hence, a task dispatched prior to  thread entering the loop would already have the thread's status as reserved, the thread would continue on with task rather than wait upon entering the loop. However, with this new approach, thread status is updated as threads wakes up. The initial implementation of this approach assumed that a thread must be "waiting" for a task, which is not the case as a dispatch can occur before a thread "waits" during thread startup. In this case, if a task is dispatched prior to thread completing startup/entering its loop and waiting, the thread would simply see its status as "waiting" and suspend even though it must reserve. The thread would reach the wait point after notification and miss it, this would cause it to wait indefinitely.

The fix is to simply reorder the waiting loop to check wether the thread should reserve or sleep.

Signed-off-by: Salman Rana <salman.rana@ibm.com>