### PR TITLE
MOVI (Imm) instruction implementation for 0.0

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -468,6 +468,8 @@ static const char *opCodeToNameMap[] =
    "scvtf_xtod",
    "fmovimms",
    "fmovimmd",
+   "movi0s",
+   "movi0d",
    "fcmps",
    "fcmps_zero",
    "fcmpd",

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -157,6 +157,14 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
    return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, cond, node, fenceNode, cg);
    }
 
+TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, cg);
+   }
+
 TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Register *treg, uint32_t imm, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -311,6 +311,22 @@ TR::Instruction *generateAdminInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates trg instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTrgInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates imm-to-trg instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -444,6 +444,9 @@
 	/* Floating-Point Immediate */
 		fmovimms,                                               	/* 0x1E201000	FMOV      	 */
 		fmovimmd,                                               	/* 0x1E601000	FMOV      	 */
+	/* Move Immediate */
+		movi0s,                                               		/* 0x0F000400	MOVI      	 */
+		movi0d,                                               		/* 0x2F00E400	MOVI      	 */
 	/* Floating-Point Compare */
 		fcmps,                                                  	/* 0x1E202000	FCMP      	 */
 		fcmps_zero,                                             	/* 0x1E202008	FCMP      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -443,6 +443,9 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 	/* Floating-Point Immediate */
 		0x1E201000,	/* FMOV      	fmovimms	 */
 		0x1E601000,	/* FMOV      	fmovimmd	 */
+	/* Move Immediate */
+		0x0F000400,	/* MOVI      	movi0s	 */
+		0x2F00E400,	/* MOVI      	movi0d	 */
 	/* Floating-Point Compare */
 		0x1E202000,	/* FCMP      	fcmps	 */
 		0x1E202008,	/* FCMP      	fcmps_zero	 */


### PR DESCRIPTION
This commit adds the opcodes for the MOVI (Imm) instruction for
loading the constant 0.0 into an FP register and implements the
generateTrgInstruction() function for this operation.

Closes: #5415

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>