### PR TITLE
Replace and disable the pTOC on POWER10

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1970,6 +1970,11 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
    if (_sampleInterval == 0) // sampleInterval==0 does make much sense
       _sampleInterval = 1;
 
+   // POWER10 introduced prefixed loads with PC-relative addressing, so the pTOC is now obsolete
+   // and should no longer be used when such instructions are available.
+   if (TR::Compiler->target.cpu.isPower() && TR::Compiler->target.cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+      self()->setOption(TR_DisableTOC);
+
 #if defined(TR_HOST_ARM)
    // OSR is not available for ARM yet
    self()->setOption(TR_DisableOSR);

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3484,34 +3484,13 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
       {
       if (cg->comp()->target().is64Bit())
          {
-         int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, cg);
-
          if (tReg == NULL)
             {
             tReg = cg->allocateRegister();
             TR::addDependency(conditions, tReg, TR::RealRegister::NoReg, TR_GPR, cg);
             }
 
-         if (offset != PTOC_FULL_INDEX)
-            {
-            offset *= 8;
-            cg->itemTracking(offset, table);
-            if (offset<LOWER_IMMED||offset>UPPER_IMMED)
-               {
-               TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
-               generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, reg1, cg->getTOCBaseRegister(), cg->hiValue(offset));
-               generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(reg1, LO_VALUE(offset), 8, cg));
-               }
-            else
-               {
-               generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, reg1, new (cg->trHeapMemory()) TR::MemoryReference(cg->getTOCBaseRegister(), offset, 8, cg));
-               }
-            }
-         else
-            {
-            cg->fixedLoadLabelAddressIntoReg(node, reg1, table, NULL, tReg);
-            }
-
+         cg->fixedLoadLabelAddressIntoReg(node, reg1, table, NULL, tReg);
          generateShiftLeftImmediate(cg, node, tReg, sReg, 2);
          generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, reg1, reg1, tReg);
          }

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -360,9 +360,6 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
    double value = node->getDouble();
    TR::Compilation *comp = cg->comp();
 
-   if (value == ((double) ((float) value)))
-      return fconstHandler(node, cg, (float) value);
-
    TR::Register *trgRegister = cg->allocateRegister(TR_FPR);
 
    loadFloatConstant(cg, TR::InstOpCode::lfd, node, TR::DataTypes::Double, &value, trgRegister);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -375,7 +375,8 @@ OMR::Power::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
 void
 OMR::Power::CodeGenerator::ppcCGOnClassUnloading(void *loaderPtr)
    {
-   TR_PPCTableOfConstants::onClassUnloading(loaderPtr);
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableTOC))
+      TR_PPCTableOfConstants::onClassUnloading(loaderPtr);
    }
 
 TR_RuntimeHelper

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2260,33 +2260,41 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
       TR::Register *tempReg,
       bool useADDISFor32Bit)
    {
-   TR::Compilation *comp = self()->comp();
    if (self()->comp()->target().is64Bit())
       {
-      int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, self());
+      TR_ASSERT_FATAL(!useADDISFor32Bit, "Cannot set useADDISFor32Bit on 64-bit systems");
 
-      if (offset != PTOC_FULL_INDEX)
+      if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
          {
-         offset *= 8;
-         self()->itemTracking(offset, label);
-         if (offset<LOWER_IMMED||offset>UPPER_IMMED)
-            {
-            TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
-            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
-            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
-            }
-         else
-            {
-            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(self()->getTOCBaseRegister(), offset, 8, self()));
-            }
+         generateTrg1MemInstruction(self(), TR::InstOpCode::paddi, node, trgReg, TR::MemoryReference::withLabel(self(), label, 0, 0));
          }
       else
          {
-         TR::Instruction *q[4];
+         int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, self());
 
-         fixedSeqMemAccess(self(), node, 0, q, trgReg, trgReg, TR::InstOpCode::addi2, 4, NULL, tempReg);
+         if (offset != PTOC_FULL_INDEX)
+            {
+            offset *= 8;
+            self()->itemTracking(offset, label);
+            if (offset<LOWER_IMMED||offset>UPPER_IMMED)
+               {
+               TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
+               generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
+               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
+               }
+            else
+               {
+               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(self()->getTOCBaseRegister(), offset, 8, self()));
+               }
+            }
+         else
+            {
+            TR::Instruction *q[4];
 
-         self()->addMetaDataFor64BitFixedLoadLabelAddressIntoReg(node, label, tempReg, q);
+            fixedSeqMemAccess(self(), node, 0, q, trgReg, trgReg, TR::InstOpCode::addi2, 4, NULL, tempReg);
+
+            self()->addMetaDataFor64BitFixedLoadLabelAddressIntoReg(node, label, tempReg, q);
+            }
          }
       }
    else

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -942,23 +942,23 @@ void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
    }
 
 
-int32_t OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataType t,
+void OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataType t,
                              TR::Instruction *n0, TR::Instruction *n1,
                              TR::Instruction *n2, TR::Instruction *n3)
    {
    if (_constantData == NULL)
       _constantData = new (self()->trHeapMemory()) TR::ConstantDataSnippet(self());
-   return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, NULL, false));
+   _constantData->addConstantRequest(v, t, n0, n1, n2, n3, NULL, false);
    }
 
-int32_t OMR::Power::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataType t,
+void OMR::Power::CodeGenerator::findOrCreateAddressConstant(void *v, TR::DataType t,
                              TR::Instruction *n0, TR::Instruction *n1,
                              TR::Instruction *n2, TR::Instruction *n3,
                              TR::Node *node, bool isUnloadablePicSite)
    {
    if (_constantData == NULL)
       _constantData = new (self()->trHeapMemory()) TR::ConstantDataSnippet(self());
-   return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, node, isUnloadablePicSite));
+   _constantData->addConstantRequest(v, t, n0, n1, n2, n3, node, isUnloadablePicSite);
    }
 
 bool OMR::Power::CodeGenerator::isSnippetMatched(TR::Snippet *snippet, int32_t snippetKind, TR::SymbolReference *symRef)

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -62,6 +62,13 @@ namespace TR { class PPCImmInstruction; }
 namespace TR { class Snippet; }
 namespace TR { struct PPCLinkageProperties; }
 
+extern void loadFloatConstant(TR::CodeGenerator *cg,
+                              TR::InstOpCode::Mnemonic loadOp,
+                              TR::Node *node,
+                              TR::DataType type,
+                              void* value,
+                              TR::Register *trgReg);
+
 extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg,
                                     TR::Node        *node,
                                     intptr_t      address,
@@ -223,10 +230,10 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void dumpDataSnippets(TR::FILE *outFile);
 #endif
 
-   int32_t findOrCreateFloatConstant(void *v, TR::DataType t,
+   void findOrCreateFloatConstant(void *v, TR::DataType t,
                   TR::Instruction *n0, TR::Instruction *n1,
                   TR::Instruction *n2, TR::Instruction *n3);
-   int32_t findOrCreateAddressConstant(void *v, TR::DataType t,
+   void findOrCreateAddressConstant(void *v, TR::DataType t,
                   TR::Instruction *n0, TR::Instruction *n1,
                   TR::Instruction *n2, TR::Instruction *n3,
                   TR::Node *node, bool isUnloadablePicSite);

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -38,7 +38,7 @@
 #include "p/codegen/PPCTableOfConstants.hpp"
 #include "runtime/Runtime.hpp"
 
-int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
+void OMR::ConstantDataSnippet::addConstantRequest(void              *v,
                                                   TR::DataType       type,
                                                   TR::Instruction *nibble0,
                                                   TR::Instruction *nibble1,
@@ -60,8 +60,6 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
 
    intptr_t   ain, aex;
 
-   int32_t ret = PTOC_FULL_INDEX;
-
    switch(type)
       {
       case TR::Float:
@@ -81,15 +79,8 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             fcursor = new (_cg->trHeapMemory()) PPCConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
-            if (comp->target().is64Bit())
-               {
-               ret = TR_PPCTableOfConstants::lookUp(fin.fvalue, _cg);
-               }
-            fcursor->setTOCOffset(ret);
             }
-         ret = fcursor->getTOCOffset();
-         if (comp->target().is32Bit() || ret==PTOC_FULL_INDEX)
-            fcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
+         fcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
          }
          break;
 
@@ -110,15 +101,8 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             dcursor = new (_cg->trHeapMemory()) PPCConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
-            if (comp->target().is64Bit())
-               {
-               ret = TR_PPCTableOfConstants::lookUp(din.dvalue, _cg);
-               }
-            dcursor->setTOCOffset(ret);
             }
-         ret = dcursor->getTOCOffset();
-         if (comp->target().is32Bit() || ret==PTOC_FULL_INDEX)
-            dcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
+         dcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
          }
          break;
 
@@ -155,8 +139,6 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
       default:
          TR_ASSERT(0, "Only float and address constants are supported. Data type is %s.\n", type.toString());
       }
-
-   return(ret);
    }
 
 

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -148,7 +148,9 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    PPCConstant<double>                 *dcursor=diterator.getFirst();
    int32_t count;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+      count = 1;
+   else if (cg()->comp()->target().is64Bit())
       count = 4;
    else
       count = 2;

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -164,45 +164,37 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    {
    ListIterator< PPCConstant<double> >  diterator(&_doubleConstants);
    PPCConstant<double>                 *dcursor=diterator.getFirst();
-   int32_t count = cg()->comp()->target().is64Bit()?4:2;
+   int32_t count;
+
+   if (TR::Compiler->target.is64Bit())
+      count = 4;
+   else
+      count = 2;
+
+   q[0] = NULL;
+   q[1] = NULL;
+   q[2] = NULL;
+   q[3] = NULL;
 
    while (dcursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = dcursor->getRequestors();
-      if (requestors.size() > 0)
+      for (int32_t i = 0; i < requestors.size(); i+=count)
          {
-         for (int32_t i = 0; i < requestors.size(); i+=count)
+         for (int32_t j = 0; j < count; j++)
             {
-            if (count == 2)
+            if (requestors[i + j] == nibble)
                {
-               if (requestors[i] == nibble || requestors[i+1] == nibble)
+               for (int32_t k = 0; k < count; k++)
+                  q[k] = requestors[i + k];
+
+               if (remove)
                   {
-                  q[0] = requestors[i];
-                  q[1] = requestors[i+1];
-                  q[2] = NULL;
-                  q[3] = NULL;
-                  if (remove)
-                     {
-                     requestors.remove(i+1);
+                  for (int32_t k = 0; k < count; k++)
                      requestors.remove(i);
-                     }
-                  return true;
                   }
-               }
-            else // count == 4
-               {
-               int32_t j;
-               if (requestors[i] == nibble || requestors[i+1] == nibble || requestors[i+2] == nibble || requestors[i+3] == nibble)
-                  {
-                  for (j = 0; j < count; j++)
-                      q[j] = requestors[i+j];
-                  if (remove)
-                     {
-                     for (j = count-1; j >= 0 ; j--)
-                         requestors.remove(i+j);
-                     }
-                  return true;
-                  }
+
+               return true;
                }
             }
          }
@@ -213,40 +205,22 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    while (fcursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = fcursor->getRequestors();
-      if (requestors.size() > 0)
+      for (int32_t i = 0; i < requestors.size(); i+=count)
          {
-         for (int32_t i = 0; i < requestors.size(); i+=count)
+         for (int32_t j = 0; j < count; j++)
             {
-            if (count == 2)
+            if (requestors[i + j] == nibble)
                {
-               if (requestors[i] == nibble || requestors[i+1] == nibble)
+               for (int32_t k = 0; k < count; k++)
+                  q[k] = requestors[i + k];
+
+               if (remove)
                   {
-                  q[0] = requestors[i];
-                  q[1] = requestors[i+1];
-                  q[2] = NULL;
-                  q[3] = NULL;
-                  if (remove)
-                     {
-                     requestors.remove(i+1);
+                  for (int32_t k = 0; k < count; k++)
                      requestors.remove(i);
-                     }
-                  return true;
                   }
-               }
-            else // count == 4
-               {
-               int32_t j = 0;
-               if (requestors[i] == nibble || requestors[i+1] == nibble || requestors[i+2] == nibble || requestors[i+3] == nibble)
-                  {
-                  for (j = 0; j < count; j++)
-                      q[j] = requestors[i+j];
-                  if (remove)
-                     {
-                     for (j = count-1; j >= 0 ; j--)
-                         requestors.remove(i+j);
-                     }
-                  return true;
-                  }
+
+               return true;
                }
             }
          }
@@ -257,40 +231,22 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    while (acursor != NULL)
       {
       TR_Array<TR::Instruction *> &requestors = acursor->getRequestors();
-      if (requestors.size() > 0)
+      for (int32_t i = 0; i < requestors.size(); i+=count)
          {
-         for (int32_t i = 0; i < requestors.size(); i+=count)
+         for (int32_t j = 0; j < count; j++)
             {
-            if (count == 2)
+            if (requestors[i + j] == nibble)
                {
-               if (requestors[i] == nibble || requestors[i+1] == nibble)
+               for (int32_t k = 0; k < count; k++)
+                  q[k] = requestors[i + k];
+
+               if (remove)
                   {
-                  q[0] = requestors[i];
-                  q[1] = requestors[i+1];
-                  q[2] = NULL;
-                  q[3] = NULL;
-                  if (remove)
-                     {
-                     requestors.remove(i+1);
+                  for (int32_t k = 0; k < count; k++)
                      requestors.remove(i);
-                     }
-                  return true;
                   }
-               }
-            else // count == 4
-               {
-               int32_t j = 0;
-               if (requestors[i] == nibble || requestors[i+1] == nibble || requestors[i+2] == nibble || requestors[i+3] == nibble)
-                  {
-                  for (j = 0; j < count; j++)
-                      q[j] = requestors[i+j];
-                  if (remove)
-                     {
-                     for (j = count-1; j >= 0 ; j--)
-                         requestors.remove(i+j);
-                     }
-                  return true;
-                  }
+
+               return true;
                }
             }
          }
@@ -299,90 +255,15 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    return false;
    }
 
-
 void
-OMR::ConstantDataSnippet::emitFloatingPointConstant(
-      TR_Array<TR::Instruction *> &requestors,
-      uint8_t *codeCursor,
-      int32_t count)
+OMR::ConstantDataSnippet::emitAddressConstant(PPCConstant<intptr_t> *acursor, uint8_t *codeCursor)
    {
-   uint8_t *iloc1, *iloc2, *iloc3, *iloc4;
-   intptr_t addr;
-   int32_t i;
-   int32_t size = requestors.size();
-   TR::Compilation *comp = cg()->comp();
-
-   TR_ASSERT(size%count == 0, "Requestors are paired.\n");
-   for (i=0; i<size; i+=count)
-      {
-      iloc1 = requestors[i]->getBinaryEncoding();
-      iloc2 = requestors[i+1]->getBinaryEncoding();
-      addr = (intptr_t)codeCursor;
-      if (count==4)
-         {
-         iloc3 = requestors[i+2]->getBinaryEncoding();
-         iloc4 = requestors[i+3]->getBinaryEncoding();
-
-         if (cg()->canEmitDataForExternallyRelocatableInstructions())
-            {
-            *(int32_t *)iloc4 |= LO_VALUE(addr) & 0x0000ffff;
-            addr = cg()->hiValue(addr);
-            *(int32_t *)iloc3 |= addr & 0x0000ffff;
-            *(int32_t *)iloc2 |= (addr>>16) & 0x0000ffff;
-            *(int32_t *)iloc1 |= (addr>>32) & 0x0000ffff;
-            }
-         else
-            {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
-                                                                                         (uint8_t *)(addr),
-                                                                                         (uint8_t *)fixedSequence4,
-                                                                                         TR_FixedSequenceAddress2,
-                                                                                         cg()),
-                                   __FILE__,
-                                   __LINE__,
-                                   requestors[i]->getNode());
-            }
-         }
-      else
-         {
-         *(int32_t *)iloc1 |= cg()->hiValue(addr) & 0x0000ffff;
-         *(int32_t *)iloc2 |= LO_VALUE(addr) & 0x0000ffff;
-
-         TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
-         recordInfo->data3 = orderedPairSequence1;
-         cg()->addExternalRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1,
-                                                                                                iloc2,
-                                                                                                (uint8_t *)recordInfo,
-                                                                                                TR_AbsoluteMethodAddressOrderedPair,
-                                                                                                cg()),
-                                __FILE__,
-                                __LINE__,
-                                requestors[i]->getNode());
-         }
-      }
-
-   }
-
-
-void
-OMR::ConstantDataSnippet::emitAddressConstant(
-      PPCConstant<intptr_t> *acursor,
-      TR_Array<TR::Instruction *> &requestors,
-      uint8_t *codeCursor,
-      int32_t count)
-   {
-   uint8_t *iloc1, *iloc2, *iloc3, *iloc4;
-   intptr_t addr;
-   int32_t i;
-   int32_t size = requestors.size();
-   TR::Compilation *comp = cg()->comp();
-
    if (cg()->profiledPointersRequireRelocation())
       {
       TR::Node *node = acursor->getNode();
       if (node != NULL && node->getOpCodeValue() == TR::aconst)
          {
-         if (comp->getOption(TR_UseSymbolValidationManager))
+         if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             TR::SymbolType type;
 
@@ -425,105 +306,57 @@ OMR::ConstantDataSnippet::emitAddressConstant(
          }
       }
 
-   TR_ASSERT(size%count == 0, "Requestors are paired.\n");
-   for (i=0; i<size; i+=count)
-      {
-      iloc1 = requestors[i]->getBinaryEncoding();
-      iloc2 = requestors[i+1]->getBinaryEncoding();
-      addr = (intptr_t)codeCursor;
-      if (count==4)
-         {
-         iloc3 = requestors[i+2]->getBinaryEncoding();
-         iloc4 = requestors[i+3]->getBinaryEncoding();
-         if (cg()->canEmitDataForExternallyRelocatableInstructions())
-            {
-            *(int32_t *)iloc4 |= LO_VALUE(addr) & 0x0000ffff;
-            addr = cg()->hiValue(addr);
-            *(int32_t *)iloc3 |= addr & 0x0000ffff;
-            *(int32_t *)iloc2 |= (addr>>16) & 0x0000ffff;
-            *(int32_t *)iloc1 |= (addr>>32) & 0x0000ffff;
-            }
-         else
-            {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(requestors[i],
-                                                                                         (uint8_t *)(addr),
-                                                                                         (uint8_t *)fixedSequence4,
-                                                                                         TR_FixedSequenceAddress2,
-                                                                                         cg()),
-                                   __FILE__,
-                                   __LINE__,
-                                   requestors[i]->getNode());
-            }
-         }
-      else
-         {
-         *(int32_t *)iloc1 |= _cg->hiValue(addr) & 0x0000ffff;
-         *(int32_t *)iloc2 |= LO_VALUE(addr) & 0x0000ffff;
-
-         TR_RelocationRecordInformation *recordInfo = (TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
-         recordInfo->data3 = orderedPairSequence1;
-         cg()->addExternalRelocation(new (_cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(iloc1, iloc2, (uint8_t *)recordInfo, TR_AbsoluteMethodAddressOrderedPair, cg()),
-                                __FILE__, __LINE__, requestors[i]->getNode());
-         }
-      }
-
+   acursor->patchRequestors(cg(), reinterpret_cast<intptr_t>(codeCursor));
    }
 
 
 uint8_t *OMR::ConstantDataSnippet::emitSnippetBody()
    {
    uint8_t *codeCursor = cg()->getBinaryBufferCursor();
-   int32_t size, count;
 
    setSnippetBinaryStart(codeCursor);
-   count = cg()->comp()->target().is64Bit()?4:2;
 
    // Align cursor to 8 bytes alignment
    codeCursor = (uint8_t *)((intptr_t)(codeCursor+7) & ~7);
 
    // Emit order is double, address, float. In this order we can ensure the 8 bytes alignment of double and address.
 
-   ListIterator< PPCConstant<double> > diterator(&_doubleConstants);
+   ListIterator<PPCConstant<double>> diterator(&_doubleConstants);
    PPCConstant<double> *dcursor=diterator.getFirst();
    while (dcursor != NULL)
       {
-      TR_Array<TR::Instruction *> &requestors = dcursor->getRequestors();
-      size = requestors.size();
-      if (size > 0)
+      if (dcursor->getRequestors().size() > 0)
          {
          *(double *)codeCursor = dcursor->getConstantValue();
-         emitFloatingPointConstant(requestors, codeCursor, count);
+         dcursor->patchRequestors(cg(), reinterpret_cast<intptr_t>(codeCursor));
          codeCursor += 8;
          }
 
       dcursor = diterator.getNext();
       }
 
-   ListIterator< PPCConstant<intptr_t> > aiterator(&_addressConstants);
+   ListIterator<PPCConstant<intptr_t>> aiterator(&_addressConstants);
    PPCConstant<intptr_t> *acursor=aiterator.getFirst();
    while (acursor != NULL)
       {
-      TR_Array<TR::Instruction *> &requestors = acursor->getRequestors();
-      size = requestors.size();
-      if (size > 0)
+      if (acursor->getRequestors().size() > 0)
          {
          *(intptr_t *)codeCursor = acursor->getConstantValue();
-         emitAddressConstant(acursor, requestors, codeCursor, count);
+         emitAddressConstant(acursor, codeCursor);
          codeCursor += sizeof(intptr_t);
          }
+
       acursor = aiterator.getNext();
       }
 
-   ListIterator< PPCConstant<float> > fiterator(&_floatConstants);
+   ListIterator<PPCConstant<float>> fiterator(&_floatConstants);
    PPCConstant<float> *fcursor=fiterator.getFirst();
    while (fcursor != NULL)
       {
-      TR_Array<TR::Instruction *> &requestors = fcursor->getRequestors();
-      size = requestors.size();
-      if (size > 0)
+      if (fcursor->getRequestors().size() > 0)
          {
          *(float *)codeCursor = fcursor->getConstantValue();
-         emitFloatingPointConstant(requestors, codeCursor, count);
+         fcursor->patchRequestors(cg(), reinterpret_cast<intptr_t>(codeCursor));
          codeCursor += 4;
          }
 

--- a/compiler/p/codegen/OMRConstantDataSnippet.hpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.hpp
@@ -50,7 +50,6 @@ namespace OMR
 template <class T> class PPCConstant
    {
    TR_Array<TR::Instruction *>   _instructionPairs;
-   int32_t                         _tocOffset;
    T                               _value;
    TR::Node                        *_node;
    bool                            _isUnloadablePicSite;
@@ -162,8 +161,6 @@ template <class T> class PPCConstant
          }
       }
 
-   int32_t getTOCOffset() {return _tocOffset;}
-   void setTOCOffset(int32_t o) {_tocOffset = o;}
    TR::Node *getNode() { return _node; }
    };
 
@@ -188,7 +185,7 @@ class ConstantDataSnippet
    uint8_t *getSnippetBinaryStart() {return _snippetBinaryStart;}
    uint8_t *setSnippetBinaryStart(uint8_t *p) {return _snippetBinaryStart=p;}
 
-   int32_t addConstantRequest(void              *v,
+   void addConstantRequest(void              *v,
                            TR::DataType       type,
                            TR::Instruction *nibble0,
                            TR::Instruction *nibble1,

--- a/compiler/p/codegen/OMRConstantDataSnippet.hpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.hpp
@@ -106,7 +106,7 @@ template <class T> class PPCConstant
             uint32_t *cursor = reinterpret_cast<uint32_t*>(instr->getBinaryEncoding() + instr->getBinaryLength() - 8);
             intptr_t offset = reinterpret_cast<uint8_t*>(addr) - reinterpret_cast<uint8_t*>(cursor);
 
-            TR_ASSERT_FATAL_WITH_INSTRUCTION(instr, offset >= -0x200000000 && offset <= 0x1ffffffff, "Offset to ConstantDataSnippet is out of range");
+            TR_ASSERT_FATAL_WITH_INSTRUCTION(instr, offset >= LOWER_IMMED_34 && offset <= UPPER_IMMED_34, "Offset to ConstantDataSnippet is out of range");
 
             cursor[0] |= (offset >> 16) & 0x3ffff;
             cursor[1] |= offset & 0xffff;

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -53,6 +53,8 @@ template <typename ListKind> class List;
 #define NUM_PPC_MAXR 32
 #define UPPER_IMMED ((1 << 15) - 1)
 #define LOWER_IMMED (-(1 << 15))
+#define UPPER_IMMED_34 ((1LL << 33) - 1)
+#define LOWER_IMMED_34 (-(1LL << 33))
 
 namespace OMR
 {

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1022,91 +1022,141 @@ void OMR::Power::MemoryReference::assignRegisters(TR::Instruction *currentInstru
 
 void OMR::Power::MemoryReference::mapOpCode(TR::Instruction *currentInstruction)
    {
-   TR::InstOpCode::Mnemonic op = currentInstruction->getOpCodeValue();
-   TR::Register  *index = self()->getIndexRegister();
-
-   if (index == NULL && !self()->isUsingDelayedIndexedForm())
-      return;
-
-   switch (op)
+   if (self()->getIndexRegister() != NULL || self()->isUsingDelayedIndexedForm())
       {
-      case TR::InstOpCode::lbz:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lbzx);
-         break;
-      case TR::InstOpCode::ld:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::ldx);
-         break;
-      case TR::InstOpCode::lfd:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lfdx);
-         break;
-      case TR::InstOpCode::lfdu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lfdux);
-         break;
-      case TR::InstOpCode::lfs:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lfsx);
-         break;
-      case TR::InstOpCode::lfsu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lfsux);
-         break;
-      case TR::InstOpCode::lha:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lhax);
-         break;
-      case TR::InstOpCode::lhau:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lhaux);
-         break;
-      case TR::InstOpCode::lhz:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lhzx);
-         break;
-      case TR::InstOpCode::lhzu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lhzux);
-         break;
-      case TR::InstOpCode::lwa:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lwax);
-         break;
-      case TR::InstOpCode::lwz:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lwzx);
-         break;
-      case TR::InstOpCode::lwzu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::lwzux);
-         break;
-      case TR::InstOpCode::stb:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stbx);
-         break;
-      case TR::InstOpCode::stbu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stbux);
-         break;
-      case TR::InstOpCode::std:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stdx);
-         break;
-      case TR::InstOpCode::stdu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stdux);
-         break;
-      case TR::InstOpCode::stfd:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stfdx);
-         break;
-      case TR::InstOpCode::stfdu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stfdux);
-         break;
-      case TR::InstOpCode::stfs:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stfsx);
-         break;
-      case TR::InstOpCode::stfsu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stfsux);
-         break;
-      case TR::InstOpCode::sth:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::sthx);
-         break;
-      case TR::InstOpCode::sthu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::sthux);
-         break;
-      case TR::InstOpCode::stw:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stwx);
-         break;
-      case TR::InstOpCode::stwu:
-         currentInstruction->setOpCodeValue(TR::InstOpCode::stwux);
-         break;
-      default:
-         break;
+      switch (currentInstruction->getOpCodeValue())
+         {
+         case TR::InstOpCode::lbz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lbzx);
+            break;
+         case TR::InstOpCode::ld:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::ldx);
+            break;
+         case TR::InstOpCode::lfd:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lfdx);
+            break;
+         case TR::InstOpCode::lfdu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lfdux);
+            break;
+         case TR::InstOpCode::lfs:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lfsx);
+            break;
+         case TR::InstOpCode::lfsu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lfsux);
+            break;
+         case TR::InstOpCode::lha:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lhax);
+            break;
+         case TR::InstOpCode::lhau:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lhaux);
+            break;
+         case TR::InstOpCode::lhz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lhzx);
+            break;
+         case TR::InstOpCode::lhzu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lhzux);
+            break;
+         case TR::InstOpCode::lwa:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lwax);
+            break;
+         case TR::InstOpCode::lwz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lwzx);
+            break;
+         case TR::InstOpCode::lwzu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::lwzux);
+            break;
+         case TR::InstOpCode::stb:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stbx);
+            break;
+         case TR::InstOpCode::stbu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stbux);
+            break;
+         case TR::InstOpCode::std:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stdx);
+            break;
+         case TR::InstOpCode::stdu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stdux);
+            break;
+         case TR::InstOpCode::stfd:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stfdx);
+            break;
+         case TR::InstOpCode::stfdu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stfdux);
+            break;
+         case TR::InstOpCode::stfs:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stfsx);
+            break;
+         case TR::InstOpCode::stfsu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stfsux);
+            break;
+         case TR::InstOpCode::sth:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::sthx);
+            break;
+         case TR::InstOpCode::sthu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::sthux);
+            break;
+         case TR::InstOpCode::stw:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stwx);
+            break;
+         case TR::InstOpCode::stwu:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::stwux);
+            break;
+         default:
+            break;
+         }
+      }
+   else if ((self()->getOffset() < LOWER_IMMED || self()->getOffset() > UPPER_IMMED || self()->getLabel()) && currentInstruction->cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+      {
+      switch (currentInstruction->getOpCodeValue())
+         {
+         case TR::InstOpCode::addi:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::paddi);
+            break;
+         case TR::InstOpCode::lbz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plbz);
+            break;
+         case TR::InstOpCode::ld:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pld);
+            break;
+         case TR::InstOpCode::lfd:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plfd);
+            break;
+         case TR::InstOpCode::lfs:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plfs);
+            break;
+         case TR::InstOpCode::lha:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plha);
+            break;
+         case TR::InstOpCode::lhz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plhz);
+            break;
+         case TR::InstOpCode::lwa:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plwa);
+            break;
+         case TR::InstOpCode::lwz:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::plwz);
+            break;
+         case TR::InstOpCode::stb:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pstb);
+            break;
+         case TR::InstOpCode::std:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pstd);
+            break;
+         case TR::InstOpCode::stfd:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pstfd);
+            break;
+         case TR::InstOpCode::stfs:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pstfs);
+            break;
+         case TR::InstOpCode::sth:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::psth);
+            break;
+         case TR::InstOpCode::stw:
+            currentInstruction->setOpCodeValue(TR::InstOpCode::pstw);
+            break;
+         default:
+            break;
+         }
       }
    }
 
@@ -1227,15 +1277,14 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
    // a memory instruction.
    TR_ASSERT_FATAL(currentInstruction->getPrev(), "The first instruction cannot be a memory instruction");
 
-   if (self()->getLabel())
-      return currentInstruction;
-
+   self()->setOffset(self()->getOffset(*cg->comp()));
+   self()->setDelayedOffsetDone();
    self()->mapOpCode(currentInstruction);
 
    if (self()->getUnresolvedSnippet() != NULL)
       return self()->expandForUnresolvedSnippet(currentInstruction, cg);
 
-   if (!self()->getBaseRegister())
+   if (!self()->getBaseRegister() && !self()->getLabel())
       {
       if (self()->getModBase())
          self()->setBaseRegister(self()->getModBase());
@@ -1259,10 +1308,7 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
    TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
    TR::RealRegister *index = toRealRegister(self()->getIndexRegister());
    TR::RealRegister *data = toRealRegister(currentInstruction->getMemoryDataRegister());
-   int32_t displacement = self()->getOffset(*comp);
-
-   self()->setOffset(displacement);
-   self()->setDelayedOffsetDone();
+   int32_t displacement = self()->getOffset();
 
    TR_ASSERT_FATAL_WITH_INSTRUCTION(
       currentInstruction,

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -356,7 +356,7 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, int64_t amount, T
       }
    int64_t displacement = self()->getOffset() + amount;
    if (((displacement<LOWER_IMMED || displacement>UPPER_IMMED) && !cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10)) ||
-         (displacement < -0x200000000 || displacement > 0x1ffffffff))
+         (displacement < LOWER_IMMED_34 || displacement > UPPER_IMMED_34))
       {
       TR::Register  *newBase;
       intptr_t     upper, lower;

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -354,8 +354,9 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, int64_t amount, T
       {
       self()->consolidateRegisters(NULL, NULL, false, cg);
       }
-   intptr_t displacement = self()->getOffset() + amount;
-   if (displacement<LOWER_IMMED || displacement>UPPER_IMMED)
+   int64_t displacement = self()->getOffset() + amount;
+   if (((displacement<LOWER_IMMED || displacement>UPPER_IMMED) && !cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10)) ||
+         (displacement < -0x200000000 || displacement > 0x1ffffffff))
       {
       TR::Register  *newBase;
       intptr_t     upper, lower;
@@ -415,7 +416,9 @@ void OMR::Power::MemoryReference::addToOffset(TR::Node * node, int64_t amount, T
       self()->setBaseModifiable();
       }
    else
+      {
       self()->setOffset(displacement);
+      }
    }
 
 void OMR::Power::MemoryReference::forceIndexedForm(TR::Node * node, TR::CodeGenerator *cg, TR::Instruction *cursor)
@@ -1110,6 +1113,7 @@ void OMR::Power::MemoryReference::mapOpCode(TR::Instruction *currentInstruction)
       switch (currentInstruction->getOpCodeValue())
          {
          case TR::InstOpCode::addi:
+         case TR::InstOpCode::addi2:
             currentInstruction->setOpCodeValue(TR::InstOpCode::paddi);
             break;
          case TR::InstOpCode::lbz:

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -136,6 +136,7 @@ void loadFloatConstant(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic loadOp, T
          }
 
       cg->findOrCreateFloatConstant(value, type, loadInstr, NULL, NULL, NULL);
+      return;
       }
    else if (cg->comp()->target().is64Bit())
       {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5266,37 +5266,10 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
       else
          {
          int64_t  offset = mref->getOffset(*comp);
-         if (mref->hasDelayedOffset() || offset!=0 || comp->getOption(TR_AOT))
+         if (mref->hasDelayedOffset() || !mref->getBaseRegister() || mref->getLabel() || offset!=0 || comp->getOption(TR_AOT))
             {
             resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
-            if (mref->hasDelayedOffset())
-               {
-               generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, resultReg, mref);
-               }
-            else
-               {
-               if (offset>=LOWER_IMMED && offset<=UPPER_IMMED)
-                  {
-                  TR::Instruction *src2ForStatic;
-
-                  src2ForStatic = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, resultReg, mref->getBaseRegister(), offset);
-                  if (mref->getStaticRelocation() != NULL)
-                     mref->getStaticRelocation()->setSource2Instruction(src2ForStatic);
-                  }
-               else
-                  {
-                  if (0x00008000 == HI_VALUE(offset))
-                     {
-                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), 0x7FFF);
-                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, resultReg, 0x1);
-                     }
-                  else
-                     {
-                     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, resultReg, mref->getBaseRegister(), HI_VALUE(offset));
-                     }
-                  generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, resultReg, resultReg, LO_VALUE(offset));
-                  }
-               }
+            generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, resultReg, mref);
            }
            else
               {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -323,6 +323,9 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
       return loadConstant(cg, node, (int32_t)value, trgReg, cursor, isPicSite);
       }
 
+   if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+      return loadAddressConstantInSnippet(cg, node, value, trgReg, NULL, TR::InstOpCode::ld, isPicSite, cursor);
+
    TR::Compilation *comp = cg->comp();
    TR::Instruction *temp = cursor;
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -319,6 +319,11 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int32_t va
 
 TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t value, TR::Register *trgReg, TR::Instruction *cursor, bool isPicSite, bool useTOC)
    {
+   // When loading 64-bit constants in 32-bit builds, we should not be using this function. This
+   // function assumes that 64-bit instructions are available and that intptr_t and int64_t are
+   // interchangeable.
+   TR_ASSERT_FATAL_WITH_NODE(node, cg->comp()->target().is64Bit(), "Should not use 64-bit loadConstant on 32-bit builds");
+
    if ((TR::getMinSigned<TR::Int32>() <= value) && (value <= TR::getMaxSigned<TR::Int32>()))
       {
       return loadConstant(cg, node, (int32_t)value, trgReg, cursor, isPicSite);

--- a/compiler/p/codegen/PPCOpsDefines.hpp
+++ b/compiler/p/codegen/PPCOpsDefines.hpp
@@ -958,10 +958,12 @@ FORMAT_XS5_D34_RA_R
 #define Op_stu       stdu
 #define Op_stx       stdx
 #define Op_stux      stdux
+#define Op_pst       pstd
 #define Op_load      ld
 #define Op_loadu     ldu
 #define Op_loadx     ldx
 #define Op_loadux    ldux
+#define Op_pload     pld
 #define Op_cmp       cmp8
 #define Op_cmpi      cmpi8
 #define Op_cmpl      cmpl8
@@ -973,10 +975,12 @@ FORMAT_XS5_D34_RA_R
 #define Op_stu       stwu
 #define Op_stx       stwx
 #define Op_stux      stwux
+#define Op_pst       pstw
 #define Op_load      lwz
 #define Op_loadu     lwzu
 #define Op_loadx     lwzx
 #define Op_loadux    lwzux
+#define Op_pload     plwz
 #define Op_cmp       cmp4
 #define Op_cmpi      cmpi4
 #define Op_cmpl      cmpl4

--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -160,11 +160,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       if (fillNode->getDataType() != TR::Double && dofastPath)
          {
          fp1Reg = cg->allocateRegister(TR_FPR);
-         if (cg->comp()->target().is32Bit())
-            {
-            fixedSeqMemAccess(cg, node, 0, q, fp1Reg, tempReg, TR::InstOpCode::lfd, 8, NULL, tempReg);
-            cg->findOrCreateFloatConstant(&doubleword, TR::Double, q[0], q[1], q[2], q[3]);
-            }
+         loadFloatConstant(cg, TR::InstOpCode::lfd, node, TR::Double, &doubleword, fp1Reg);
          }
       }
    else //variable fill value


### PR DESCRIPTION
This PR implements the majority of the changes proposed in #5367 to replace and disable the pTOC when POWER10 support is enabled. Generally, this PR switches to using `ConstantDataSnippet` with PC-relative loads for most 64-bit and FP constants, applies the `disableToc` option by default, switches to using PC-relative `paddi` when loading label addresses, and adds some smaller exploitations of these new instructions when run with POWER10 support enabled.

This PR is currently marked as WIP since it causes issues with the LHS peephole (#5418) due to creation of load instructions with a `Trg1Imm` instruction class. This issue must be corrected before this PR can be merged.