### PR TITLE
Swapped `PFD` with `memset` to 0 object heap mem

### DIFF
--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -137,7 +137,7 @@ list(APPEND OBJECTS
 	argscan.c
 	detectVMDirectory.c
 	gettimebase.c
-	j9memclr.c
+	j9memclr.cpp
 	omrcrc32.c
 	poolForPort.c
 	primeNumberHelper.c


### PR DESCRIPTION
This commit replaces `PFD` with `memset` as the default way to zero
object heap memory. `PFD` can be toggled back on by setting environment 
variable `PFD_TO_ZERO_OBJECT_HEAP_MEMORY_ENABLED`

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>