### PR TITLE
Adding Global GC Flag to pretouch Heap Memory

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -798,6 +798,8 @@ public:
 
 	uintptr_t darkMatterSampleRate;/**< the weight of darkMatterSample for standard gc, default:32, if the weight = 0, disable darkMatterSampling */
 
+	bool pretouchHeapOnExpand; /**< True to pretouch memory during initial heap inflation or heap expansion */
+
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 	uintptr_t idleMinimumFree;   /**< percentage of free heap to be retained as committed, default=0 for gencon, complete tenture free memory will be decommitted */
 	bool gcOnIdle; /**< Enables releasing free heap pages if true while systemGarbageCollect invoked with IDLE GC code, default is false */
@@ -1786,6 +1788,7 @@ public:
 		, referenceChainWalkerMarkMap(NULL)
 		, trackMutatorThreadCategory(false)
 		, darkMatterSampleRate(32)
+		, pretouchHeapOnExpand(false)
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 		, idleMinimumFree(0)
 		, gcOnIdle(false)

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -312,7 +312,14 @@ MM_HeapVirtualMemory::commitMemory(void* address, uintptr_t size)
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
 	MM_MemoryManager* memoryManager = extensions->memoryManager;
-	return memoryManager->commitMemory(&_vmemHandle, address, size);
+
+	bool resultCommitMemory = memoryManager->commitMemory(&_vmemHandle, address, size);
+
+	if (resultCommitMemory && extensions->pretouchHeapOnExpand) {
+		memset(address, 0, size);
+	}
+	
+	return resultCommitMemory;
 }
 
 /**


### PR DESCRIPTION
Commits memory during initial Heap Inflation or Heap Expansion by writing 0s.
Default: Disabled

Signed-off-by: Enson Guo <enson.guo@ibm.com>