### PR TITLE
Add comp:utilities label to util and comp:core to include_core

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,6 +51,9 @@ cmake:
 comp:compiler:
   - compiler/**/*
 
+comp:core:
+  - include_core/**/*
+
 comp:diagnostic:
   - ddr/**/*
 
@@ -72,6 +75,9 @@ comp:thread:
 comp:tril:
   - fvtest/compilertriltest/**/*
   - fvtest/tril/**/*
+
+comp:utilities:
+  - util/**/*
 
 documentation:
   - doc/**/*


### PR DESCRIPTION
Modify the labeler GitHub Action to add the `comp:utilities` label to
PRs which modify files in `util` directory and `comp:core` to PRs which
modify files in `include_core` directory.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>