### PR TITLE
Fix compiler warning

### DIFF
--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3127,7 +3127,7 @@ convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 		resultSize = (outBufferSize - wideBufferLimit); /* number of bytes written */
 	}
 #endif /* defined(OMR_OS_WINDOWS) */
-	if ((outBufferSize > 0) && ((outBufferSize - resultSize) >= 2)) {
+	if ((outBufferSize >= 2) && (resultSize <= (outBufferSize - 2))) {
 		uint16_t *terminator = (uint16_t *) &outBuffer[resultSize];
 		*terminator = 0;
 	}


### PR DESCRIPTION
Re-write guard condition involving signed and unsigned types to avoid undefined behavior.
Without this change, gcc 10 complains:
```
In function ‘convertPlatformToWide’,
    inlined from ‘convertPlatformToMutf8’ at ../../../../../../../omr/port/common/omrstr.c:2524:35,
    inlined from ‘omrstr_convert’ at ../../../../../../../omr/port/common/omrstr.c:264:13:
../../../../../../../omr/port/common/omrstr.c:3132:15: error: writing 2 bytes into a region of size 0 [-Werror=stringop-overflow=]
 3132 |   *terminator = 0;
      |   ~~~~~~~~~~~~^~~
../../../../../../../omr/port/common/omrstr.c: In function ‘omrstr_convert’:
../../../../../../../omr/port/common/omrstr.c:2486:10: note: at offset -450 to object ‘onStackBuffer’ with size 256 declared here
 2486 |  uint8_t onStackBuffer[CONVERSION_BUFFER_SIZE];
      |          ^~~~~~~~~~~~~
```