### PR TITLE
Add shouldForceLowMemoryHeapCeilingShiftIfPossible flag to gc extensions

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -305,6 +305,12 @@ MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase*
 		}
 #endif /* defined(S390) */
 
+		if (extensions->shouldForceLowMemoryHeapCeilingShiftIfPossible) {
+			if (canChangeShift && (shift < DEFAULT_LOW_MEMORY_HEAP_CEILING_SHIFT)) {
+				shift = DEFAULT_LOW_MEMORY_HEAP_CEILING_SHIFT;
+			}
+		}
+
 		omrVM->_compressedPointersShift = shift;
 	}
 

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -814,6 +814,7 @@ public:
 	MUTEX memcheckHashTableMutex;
 #endif /* defined(OMR_VALGRIND_MEMCHECK) */
 
+	bool shouldForceLowMemoryHeapCeilingShiftIfPossible; /**< Whether we should force compressed reference shift to 3 **/
 	/* Function Members */
 private:
 
@@ -1800,6 +1801,7 @@ public:
 #if defined(OMR_VALGRIND_MEMCHECK)
 		, valgrindMempoolAddr(0)
 		, memcheckHashTable(NULL)
+		, shouldForceLowMemoryHeapCeilingShiftIfPossible(false)
 #endif /* defined(OMR_VALGRIND_MEMCHECK) */
 	{
 		_typeId = __FUNCTION__;


### PR DESCRIPTION
When this flag is on, compressed reference shift is set to 3 if possible.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>