### PR TITLE
AArch64: Implement fsqrt/dsqrtEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -481,6 +481,8 @@ static const char *opCodeToNameMap[] =
    "fabsd",
    "fnegs",
    "fnegd",
+   "fsqrts",
+   "fsqrtd",
    "fadds",
    "faddd",
    "fsubs",

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -445,6 +445,18 @@ OMR::ARM64::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::fnegd, cg);
    }
 
+TR::Register *
+OMR::ARM64::TreeEvaluator::fsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::fsqrts, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::fsqrtd, cg);
+   }
+
 static TR::Register *
 intFpTypeConversionHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -432,6 +432,12 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    static uint32_t registerBitMask(int32_t reg);
 
+   /**
+    * @brief Answers whether single-precision SQRT is supported or not
+    * @return true if supported, false otherwise
+    */
+   bool supportsSinglePrecisionSQRT() { return true; }
+
    private:
 
    enum // flags

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -459,6 +459,8 @@
 		fabsd,                                                  	/* 0x1E60C000	FABS      	 */
 		fnegs,                                                  	/* 0x1E214000	FNEG      	 */
 		fnegd,                                                  	/* 0x1E614000	FNEG      	 */
+		fsqrts,                                                 	/* 0x1E21C000	FSQRT     	 */
+		fsqrtd,                                                 	/* 0x1E61C000	FSQRT     	 */
 	/* Floating-Point Data-processing (2 source) */
 		fadds,                                                  	/* 0x1E202800	FADD      	 */
 		faddd,                                                  	/* 0x1E602800	FADD      	 */

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -688,8 +688,8 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dintEvaluator ,	// TR::dint		// truncate double to int
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fnintEvaluator ,	// TR::fnint		// round float to nearest int
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dnintEvaluator ,	// TR::dnint		// round double to nearest int
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fsqrtEvaluator ,	// TR::fsqrt		// square root of float
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dsqrtEvaluator ,	// TR::dsqrt		// square root of double
+    TR::TreeEvaluator::fsqrtEvaluator, // TR::fsqrt		// square root of float
+    TR::TreeEvaluator::dsqrtEvaluator, // TR::dsqrt		// square root of double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::getstackEvaluator ,	// TR::getstack		// returns current value of SP
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::deallocaEvaluator ,	// TR::dealloca		// resets value of SP
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::idozEvaluator ,	// TR::idoz		// difference or zero

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -458,6 +458,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x1E60C000,	/* FABS      	fabsd	 */
 		0x1E214000,	/* FNEG      	fnegs	 */
 		0x1E614000,	/* FNEG      	fnegd	 */
+		0x1E21C000,	/* FSQRT     	fsqrts	 */
+		0x1E61C000,	/* FSQRT     	fsqrtd	 */
 	/* Floating-Point Data-processing (2 source) */
 		0x1E202800,	/* FADD      	fadds	 */
 		0x1E602800,	/* FADD      	faddd	 */

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -54,6 +54,12 @@ protected:
 public:
 
    /**
+    * @brief Answers whether the CPU has hardware support for SQRT or not
+    * @return true if supported, false otherwise
+    */
+   bool getSupportsHardwareSQRT() { return true; }
+
+   /**
     * @brief Provides the maximum forward branch displacement in bytes reachable
     *        with a relative unconditional branch with immediate (B or BL) instruction.
     *


### PR DESCRIPTION
This commit implements fsqrt/dsqrtEvaluator() for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>