### PR TITLE
AArch64: Utility functions addConstant32/64()

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -64,7 +64,7 @@ extern TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, in
 
 extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node *node, intptr_t value, TR::Register *trgReg, TR::Instruction *cursor=NULL, bool isPicSite=false, int16_t typeAddress=-1);
 
- /* @brief Generates instruction for loading address constant to register using constant data snippet
+/* @brief Generates instruction for loading address constant to register using constant data snippet
  * @param[in] cg : CodeGenerator
  * @param[in] node: node
  * @param[in] address : address
@@ -74,6 +74,26 @@ extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node *nod
  * @return generated instruction
  */
 extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, intptr_t address, TR::Register *trgReg, TR_ExternalRelocationTargetKind reloKind, TR::Instruction *cursor=NULL);
+
+/**
+ * @brief Generates instructions for adding 64-bit integer value to a register
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] trgReg : target register
+ * @param[in] srcReg : source register
+ * @param[in] value : value to be added
+ */
+TR::Instruction *addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value);
+
+/**
+ * @brief Generates instructions for adding 32-bit integer value to a register
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] trgReg : target register
+ * @param[in] srcReg : source register
+ * @param[in] value : value to be added
+ */
+TR::Instruction *addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value);
 
 /**
  * @brief Helper function for encoding immediate value of logic instructions.

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -183,6 +183,44 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
    return cursor;
    }
 
+TR::Instruction *addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value)
+   {
+   TR::Instruction *cursor;
+
+   if (constantIsUnsignedImm12(value))
+      {
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, trgReg, srcReg, value);
+      }
+   else
+      {
+      TR::Register *tempReg = cg->allocateRegister();
+      loadConstant64(cg, node, value, tempReg);
+      cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, trgReg, srcReg, tempReg);
+      cg->stopUsingRegister(tempReg);
+      }
+
+   return cursor;
+   }
+
+TR::Instruction *addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value)
+   {
+   TR::Instruction *cursor;
+
+   if (constantIsUnsignedImm12(value))
+      {
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, trgReg, srcReg, value);
+      }
+   else
+      {
+      TR::Register *tempReg = cg->allocateRegister();
+      loadConstant32(cg, node, value, tempReg);
+      cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::addw, node, trgReg, srcReg, tempReg);
+      cg->stopUsingRegister(tempReg);
+      }
+
+   return cursor;
+   }
+
 /**
  * Add meta data to instruction loading address constant
  * @param[in] cg : CodeGenerator


### PR DESCRIPTION
This commit adds two JIT utilify functions for AArch64, addConstant32/64().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>