### PR TITLE
Use flexible array members, disable MSVC W4200

### DIFF
--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -30,6 +30,7 @@ list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
 	/Zm400  # Precompiled header memory allocation limit
 	/wd4577 # Disable warning: Specifying noexcept when exceptions are disabled
 	/wd4091 # Disable warning: Caused by broken windows SDK, see also https://connect.microsoft.com/VisualStudio/feedback/details/1302025/warning-c4091-in-sdk-7-1a-shlobj-h-1051-dbghelp-h-1054-3056
+	/wd4200 # Disable warning: FAM in struct/union is valid in C and widely supported in C++
 )
 
 if(OMR_ENV_DATA64)

--- a/ddr/tools/blob_reader/blob_reader.cpp
+++ b/ddr/tools/blob_reader/blob_reader.cpp
@@ -85,7 +85,7 @@ struct BlobHeaderV1 {
 
 struct BlobString {
 	uint16_t length;
-	char data[1]; /* flexible array member */
+	char data[];
 
 	void endian_swap()
 	{

--- a/include_core/omragent.h
+++ b/include_core/omragent.h
@@ -337,9 +337,6 @@ struct OMR_TI_MemoryCategory {
  * Description of a method that was sampled by the profiler, which is retrieved using GetMethodDescriptions() in OMR_TI.
  * The size of this structure is language-specific. Call GetMethodProperties() to determine its required size.
  */
-#if defined(_MSC_VER)
-#pragma warning(disable : 4200)
-#endif /* defined(_MSC_VER) */
 struct OMR_SampledMethodDescription {
 	/** See comments for GetMethodDescriptions(). */
 	omr_error_t reasonCode;

--- a/include_core/omrprofiler.h
+++ b/include_core/omrprofiler.h
@@ -31,9 +31,6 @@ extern "C" {
 
 /* This file defines the interface used by omrglue/ code to access OMR profiling-related functions */
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 4200)
-#endif /* defined(_MSC_VER) */
 typedef struct OMR_MethodDictionaryEntry {
 	const void *key;
 	const char *propertyValues[];

--- a/include_core/ute_core.h
+++ b/include_core/ute_core.h
@@ -125,7 +125,7 @@ typedef struct UtTraceRecord {
 	uint64_t threadSyn2;	/* Thread synonym 2               */
 	int32_t firstEntry;		/* Offset to first trace entry    */
 	int32_t nextEntry;		/* Offset to next entry           */
-	char threadName[1];		/* Thread name                    */
+	char threadName[];		/* Thread name                    */
 } UtTraceRecord;
 
 /*

--- a/include_core/ute_core.h
+++ b/include_core/ute_core.h
@@ -125,7 +125,7 @@ typedef struct UtTraceRecord {
 	uint64_t threadSyn2;	/* Thread synonym 2               */
 	int32_t firstEntry;		/* Offset to first trace entry    */
 	int32_t nextEntry;		/* Offset to next entry           */
-	char threadName[];		/* Thread name                    */
+	char threadName[0];		/* Thread name                    */
 } UtTraceRecord;
 
 /*

--- a/include_core/ute_dataformat.h
+++ b/include_core/ute_dataformat.h
@@ -180,7 +180,7 @@ typedef struct UtProcSection {
 #define UT_TRACE_ACTIVE_SECTION_NAME "UTTA"
 typedef struct UtActiveSection {
 	UtDataHeader header; /* Eyecatcher, version etc        */
-	char active[1]; /* Trace activation commands      */
+	char active[]; /* Trace activation commands      */
 } UtActiveSection;
 
 /*
@@ -191,7 +191,7 @@ typedef struct UtActiveSection {
 #define UT_TRACE_SERVICE_SECTION_NAME "UTSS"
 typedef struct UtServiceSection {
 	UtDataHeader header; /* Eyecatcher, version etc        */
-	char level[1]; /* Service level info             */
+	char level[]; /* Service level info             */
 } UtServiceSection;
 
 /*
@@ -202,7 +202,7 @@ typedef struct UtServiceSection {
 #define UT_TRACE_STARTUP_SECTION_NAME "UTSO"
 typedef struct UtStartupSection {
 	UtDataHeader header; /* Eyecatcher, version etc        */
-	char options[1]; /* Startup options                */
+	char options[]; /* Startup options                */
 } UtStartupSection;
 
 /*

--- a/omrmakefiles/rules.win.mk
+++ b/omrmakefiles/rules.win.mk
@@ -81,9 +81,10 @@ endif
 
 # Enable more warnings
 ifeq ($(OMR_ENHANCED_WARNINGS),1)
-    GLOBAL_CFLAGS+=-W3
-    GLOBAL_CXXFLAGS+=-W3
-    GLOBAL_ASFLAGS+=-W3
+    # -wd4200: Disable warnings regarding flexible array members.
+    GLOBAL_CFLAGS+=-W3 -wd4200
+    GLOBAL_CXXFLAGS+=-W3 -wd4200
+    GLOBAL_ASFLAGS+=-W3 -wd4200
 endif
 
 # Enable Debugging Symbols

--- a/omrtrace/omrtrace_internal.h
+++ b/omrtrace/omrtrace_internal.h
@@ -157,7 +157,7 @@ typedef struct OMR_TraceGlobal OMR_TraceGlobal;
 typedef struct  UtTraceCfg {
 	UtDataHeader       header;
 	struct UtTraceCfg  *next;             /* Next trace config command        */
-	char               command[1];       /* Start of variable length section */
+	char               command[];         /* Start of variable length section */
 } UtTraceCfg;
 
 typedef struct UtDeferredConfigInfo {


### PR DESCRIPTION
Fixes several gcc 10 warnings, standardize FAMs across codebase. Fixes https://github.com/eclipse/openj9/pull/10293.

This should not conflict with https://github.com/eclipse/openj9/issues/10244#issuecomment-665732046, since FAMs are already used elsewhere, this merely standardizes across the OMR project.