### PR TITLE
Fix include path for j9a2e

### DIFF
--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -33,7 +33,7 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 )
 
 list(APPEND OMR_PLATFORM_INCLUDE_DIRECTORIES
-	${CMAKE_SOURCE_DIR}/util/a2e/headers
+	${omr_SOURCE_DIR}/util/a2e/headers
 	/usr/lpp/cbclib/include
 	/usr/include
 )


### PR DESCRIPTION
Use omr_SOURCE_DIR rather than CMAKE_SOURCE_DIR in case omr is not the
top cmake project

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>