### PR TITLE
AArch64: Enhance irol evalutor to cancel out double negation

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1293,12 +1293,26 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ShiftedInstruction *instr)
    {
    printPrefix(pOutFile, instr);
-   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   if ((op == TR::InstOpCode::extrw || op == TR::InstOpCode::extrx) &&
+         (instr->getSource1Register() == instr->getSource2Register()))
+      {
+      // ror alias
+      trfprintf(pOutFile, "ror%c \t", (op == TR::InstOpCode::extrx) ? 'x' : 'w');
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", #%d", instr->getShiftAmount());
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
-   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
-   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
-   print(pOutFile, instr->getSource2Register(), TR_WordReg);
-   trfprintf(pOutFile, " %s %d", ARM64ShiftCodeNames[instr->getShiftType()], instr->getShiftAmount());
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource2Register(), TR_WordReg);
+      trfprintf(pOutFile, " %s %d", ARM64ShiftCodeNames[instr->getShiftType()], instr->getShiftAmount());
+      }
+
    trfflush(_comp->getOutFile());
    }
 


### PR DESCRIPTION
When the OpenJ9 optimizer inlines Integer.rotateRight, it creates
`irol` node with `ineg` child node to adjust shift amount.
AArch64 has instruction for rotate to right only, so we need to negate
the shift amount again. This commit changes `irolEvaluator` to
use child node of `ineg` node as shift amount if the `ineg` node is not commoned.

Also, this commit enhances trace output to print `rorx`/`rorw` instruction
instead of `extrx`/`extrw` instruction.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>