### PR TITLE
Add -Wno-stringop-overflow when compiling with GCC 10

### DIFF
--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -37,6 +37,12 @@ ifeq (gcc,$(OMR_TOOLCHAIN))
     GLOBAL_CFLAGS+=-MMD -MP
     GLOBAL_CXXFLAGS+=-MMD -MP
   endif
+
+  ifeq ($(shell expr `($(CC) -dumpversion 2>/dev/null || echo 1) | cut -d. -f1` \>= 10),1)
+    # Suppress stringop-overflow warning on GCC >=10
+    GLOBAL_CFLAGS+=-Wno-stringop-overflow
+    GLOBAL_CXXFLAGS+=-Wno-stringop-overflow
+  endif
 endif
 
 ###


### PR DESCRIPTION
Starting with GCC 10, some code fails to compile with -Wall -Werror,
While GCC 10 is not "officially" supported, it is the GCC available on Debian
for RISC-V. 
This commit fixes compilation of OpenJ9 on Debian for RISC-V, both
cross-compile and native-compile. 