### PR TITLE
Add APIs answering if cpu supports integer rotation

### DIFF
--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -84,6 +84,27 @@ public:
     */
    bool isTargetWithinUnconditionalBranchImmediateRange(intptr_t targetAddress, intptr_t sourceAddress);
 
+   /**
+    * @brief Determines whether 32bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
+   /**
+    * @brief Determines whether 64bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
+
    };
 
 }

--- a/compiler/arm/env/OMRCPU.hpp
+++ b/compiler/arm/env/OMRCPU.hpp
@@ -84,6 +84,26 @@ public:
     */
    bool isTargetWithinBranchImmediateRange(intptr_t targetAddress, intptr_t sourceAddress);
 
+   /**
+    * @brief Determines whether 32bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
+   /**
+    * @brief Determines whether 64bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
    };
 
 }

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -127,6 +127,27 @@ public:
    bool supportsDecimalFloatingPoint() { return false; }
    bool hasFPU() { return true; }
 
+   /**
+    * @brief Determines whether 32bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return false; }
+   /**
+    * @brief Determines whether 64bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return false; }
+
    TR::Endianness endianness() { return _endianness; }
    void setEndianness(TR::Endianness e) { _endianness = e; }
    bool isBigEndian() { return _endianness == TR::endian_big; }

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -93,6 +93,12 @@ OMR::Power::CPU::supportsFeature(uint32_t feature)
    }
 
 bool
+OMR::Power::CPU::getSupportsHardware64bitRotate(bool requireRotateToLeft)
+   {
+   return TR::Compiler->target.is64Bit();
+   }
+
+bool
 OMR::Power::CPU::is(OMRProcessorArchitecture p)
    {
    if (TR::Compiler->omrPortLib == NULL)

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -67,6 +67,27 @@ public:
    bool hasPopulationCountInstruction();
    bool supportsDecimalFloatingPoint();
 
+   /**
+    * @brief Determines whether 32bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return true; }
+   /**
+    * @brief Determines whether 64bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false);
+
    /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
     *         Alias of supportsFeature(OMR_FEATURE_PPC_HTM) as a platform agnostic query.
     *

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -101,6 +101,27 @@ public:
    bool supportsAVX();
    bool testOSForSSESupport() { return false; }
    
+   /**
+    * @brief Determines whether 32bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return true; }
+   /**
+    * @brief Determines whether 64bit integer rotate is available
+    *
+    * @details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return true; }
+
    // Will be removed once we no longer need the old processor detection apis
    bool is(OMRProcessorArchitecture p);
    bool is_old_api(OMRProcessorArchitecture p);

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -274,6 +274,27 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
    bool setSupportsGuardedStorageFacility(bool value);
    
    /**
+    * \brief Determines whether 32bit integer rotate is available
+    *
+    * \details
+    *    Returns true if 32bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 32bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * \param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware32bitRotate(bool requireRotateToLeft=false) { return true; }
+   /**
+    * \brief Determines whether 64bit integer rotate is available
+    *
+    * \details
+    *    Returns true if 64bit integer rotate to left is available when requireRotateToLeft is true.
+    *    Returns true if 64bit integer rotate (right or left) is available when requireRotateToLeft is false.
+    *
+    * \param requireRotateToLeft if true, returns true if rotate to left operation is available.
+    */
+   bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return true; }
+
+   /**
     * @brief Answers whether the distance between a target and source address
     *        is within the reachable displacement range for a branch relative
     *        RIL-format instruction.


### PR DESCRIPTION
This commit adds `getSupportsHardware32bitRotate` and `getSupportsHardware64bitRotate`
to CPU class.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>