### PR TITLE
AArch64: Improve fselectEvaluator() using fcsel

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -475,6 +475,8 @@ static const char *opCodeToNameMap[] =
    "fcmps_zero",
    "fcmpd",
    "fcmpd_zero",
+   "fcsels",
+   "fcseld",
    "fmovs",
    "fmovd",
    "fabss",

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -1005,18 +1005,15 @@ OMR::ARM64::TreeEvaluator::fselectEvaluator(TR::Node *node, TR::CodeGenerator *c
    TR::Register *resultReg = trueReg;
 
    bool isDouble = trueNode->getDataType().isDouble();
-   TR::InstOpCode::Mnemonic movOp = isDouble ? TR::InstOpCode::fmovd : TR::InstOpCode::fmovs;
 
    if (!cg->canClobberNodesRegister(trueNode))
       {
       resultReg = isDouble ? cg->allocateRegister(TR_FPR) : cg->allocateSinglePrecisionRegister();
-      generateTrg1Src1Instruction(cg, movOp, node, resultReg, trueReg);
       }
 
-   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-   generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, condReg, doneLabel);
-   generateTrg1Src1Instruction(cg, movOp, node, resultReg, falseReg);
-   generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
+   generateCompareImmInstruction(cg, node, condReg, 0, true); // 64-bit compare
+   TR::InstOpCode::Mnemonic fcselOp = isDouble ? TR::InstOpCode::fcseld : TR::InstOpCode::fcsels;
+   generateCondTrg1Src2Instruction(cg, fcselOp, node, resultReg, trueReg, falseReg, TR::CC_NE);
 
    node->setRegister(resultReg);
    cg->decReferenceCount(condNode);

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -452,6 +452,9 @@
 		fcmps_zero,                                             	/* 0x1E202008	FCMP      	 */
 		fcmpd,                                                  	/* 0x1E602000	FCMP      	 */
 		fcmpd_zero,                                             	/* 0x1E602008	FCMP      	 */
+	/* Floating-point conditional select */
+		fcsels,                                                 	/* 0x1E200C00	FCSEL     	 */
+		fcseld,                                                 	/* 0x1E600C00	FCSEL     	 */
 	/* Floating-Point Data-processing (1 source) */
 		fmovs,                                                  	/* 0x1E204000	FMOV      	 */
 		fmovd,                                                  	/* 0x1E604000	FMOV      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -451,6 +451,9 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x1E202008,	/* FCMP      	fcmps_zero	 */
 		0x1E602000,	/* FCMP      	fcmpd	 */
 		0x1E602008,	/* FCMP      	fcmpd_zero	 */
+	/* Floating-point conditional select */
+		0x1E200C00,	/* FCSEL     	fcsels	 */
+		0x1E600C00,	/* FCSEL     	fcseld	 */
 	/* Floating-Point Data-processing (1 source) */
 		0x1E204000,	/* FMOV      	fmovs	 */
 		0x1E604000,	/* FMOV      	fmovd	 */


### PR DESCRIPTION
This commit changes the code generation in fselectEvaluator() for
AArch64, using the fcsel instruction.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>