### PR TITLE
WIP: Recognize Unsafe.copyMemory0 in JDK11

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -452,7 +452,7 @@ class ValuePropagation : public TR::Optimization
    int32_t getPrimitiveArrayType(char primitiveArrayChar);
 
    bool canRunTransformToArrayCopy();
-   bool transformUnsafeCopyMemoryCall(TR::Node *arraycopyNode);
+   virtual bool transformUnsafeCopyMemoryCall(TR::Node *arraycopyNode);
 
    static TR::CFGEdge *findOutEdge(TR::CFGEdgeList &edges, TR::CFGNode *target);
    bool isUnreachablePath(ValueConstraints &valueConstraints);


### PR DESCRIPTION
Identify jdk/internal/misc/Unsafe.copyMemory0 calls to transform them into System.arrayCopy calls.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>