### PR TITLE
Add new callUsesHelperImplementation

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -214,6 +214,16 @@ public:
    bool hasWarmCallsBeforeReturn();
 
    /**
+    * @brief Answers whether a method call is implemented using an internal runtime
+    *           helper routine (ex. a j2iTransition)
+    *
+    * @param[in] sym : The symbol holding the call information
+    *
+    * @return : true if the call is represented by a helper; false otherwise.
+    */
+   bool callUsesHelperImplementation(TR::Symbol *sym) { return false; }
+
+   /**
     * @brief Answers whether a trampoline is required for a direct call instruction to
     *           reach a target address.
     *

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2440,7 +2440,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
             TR::Symbol *sym = getSymbolReference() ? getSymbolReference()->getSymbol() : NULL;
             TR::ResolvedMethodSymbol *resolvedMethodSym = sym ? sym->getResolvedMethodSymbol() : NULL;
             TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : NULL;
-            if (sym && sym->castToMethodSymbol()->isHelper())
+            if (sym && (sym->castToMethodSymbol()->isHelper() || cg()->callUsesHelperImplementation(sym)))
                {
                AOTcgDiag1(comp, "add TR_HelperAddress cursor=%x\n", cursor);
                cg()->addProjectSpecializedRelocation(cursor+2, (uint8_t*) getSymbolReference(), NULL, TR_HelperAddress,


### PR DESCRIPTION
This routine will return true if a method call is implemented using an internal runtime helper.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>