### PR TITLE
Fix undefined behaviour in the Power LHS peephole

### DIFF
--- a/compiler/p/codegen/OMRPeephole.cpp
+++ b/compiler/p/codegen/OMRPeephole.cpp
@@ -268,6 +268,12 @@ OMR::Power::Peephole::tryToRemoveRedundantLoadAfterStore()
    if (disableLHSPeephole)
       return false;
 
+   // Just because the instruction opcode is a load or store doesn't mean we're necessarily using
+   // a MemoryReference. In some cases, we use other instruction kinds (e.g. Trg1Imm) if we're
+   // going to patch the instruction.
+   if (cursor->getKind() != TR::Instruction::IsMemSrc1 || !cursor->getNext() || cursor->getNext()->getKind() != TR::Instruction::IsTrg1Mem)
+      return false;
+
    TR::Instruction *storeInstruction = cursor;
    TR::Instruction   *loadInstruction = storeInstruction->getNext();
    TR::InstOpCode&      storeOp = storeInstruction->getOpCode();

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -37,6 +37,7 @@ if(OMR_ARCH_POWER)
 	list(APPEND COMPCGTEST_FILES
 		p/BinaryEncoder.cpp
 		p/MemoryReferenceExpansion.cpp
+		p/Peephole.cpp
 	)
 endif()
 

--- a/fvtest/compilerunittest/CodeGenTest.hpp
+++ b/fvtest/compilerunittest/CodeGenTest.hpp
@@ -83,7 +83,10 @@ class CodeGenTest : public ::testing::Test {
     NullIlGenRequest _ilGenRequest;
     TR::ResolvedMethod _method;
     TR::Compilation _comp;
+
 public:
+    TR::Node *fakeNode;
+
     CodeGenTest() :
         _jitInit(),
         _rawAllocator(),
@@ -95,6 +98,7 @@ public:
         _ilGenRequest(),
         _method("compunittest", "0", "test", 0, NULL, _types.NoType, NULL, NULL),
         _comp(0, NULL, &OMR::FrontEnd::singleton(), &_method, _ilGenRequest, _options, _dispatchRegion, &_trMemory, TR_OptimizationPlan::alloc(warm)) {
+        fakeNode = TR::Node::create(TR::treetop);
     }
 
     TR::CodeGenerator* cg() { return _comp.cg(); }

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -84,8 +84,6 @@ std::ostream& operator<<(std::ostream& os, const BinaryInstruction& instr) {
 
 class PowerBinaryEncoderTest : public TRTest::CodeGenTest {
 public:
-    TR::Node* fakeNode;
-
     uint32_t buf[64];
 
     // POWER10 prefixed instructions cannot cross a 64-byte boundary, so we need to ensure the
@@ -94,12 +92,7 @@ public:
         return reinterpret_cast<uint32_t*>(((reinterpret_cast<uintptr_t>(buf) - 1) & ~0x3f) + 0x40);
     }
 
-    TR::RealRegister* createReg(TR_RegisterKinds kind, TR::RealRegister::RegNum reg, TR::RealRegister::RegMask mask) {
-        return new (cg()->trHeapMemory()) TR::RealRegister(kind, 0, TR::RealRegister::Free, reg, mask, cg());
-    }
-
     PowerBinaryEncoderTest() {
-        fakeNode = TR::Node::create(TR::treetop);
         cg()->setBinaryBufferStart(reinterpret_cast<uint8_t*>(&getAlignedBuf()[0]));
     }
 

--- a/fvtest/compilerunittest/p/Peephole.cpp
+++ b/fvtest/compilerunittest/p/Peephole.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "../CodeGenTest.hpp"
+#include "Util.hpp"
+
+#include "codegen/GenerateInstructions.hpp"
+#include "codegen/Peephole.hpp"
+
+class PeepholeTest : public TRTest::CodeGenTest {};
+
+TEST_F(PeepholeTest, testRegressIssue5418FlatLoad) {
+    TR::RealRegister *gr1 = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
+    TR::RealRegister *gr2 = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
+
+    TR::Instruction *instr1 = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::withDisplacement(cg(), gr1, 0, 4), gr2);
+    TR::Instruction *instr2 = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::lwz, fakeNode, gr2, gr1, 0);
+
+    TR::Peephole peephole(cg()->comp());
+    peephole.perform();
+
+    ASSERT_EQ(instr1, cg()->getFirstInstruction());
+    ASSERT_EQ(instr2, instr1->getNext());
+    ASSERT_FALSE(instr2->getNext());
+}
+
+TEST_F(PeepholeTest, testRegressIssue5418End) {
+    TR::RealRegister *gr1 = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
+    TR::RealRegister *gr2 = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
+
+    TR::Instruction *instr = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::withDisplacement(cg(), gr1, 0, 4), gr2);
+
+    TR::Peephole peephole(cg()->comp());
+    peephole.perform();
+
+    ASSERT_EQ(instr, cg()->getFirstInstruction());
+    ASSERT_FALSE(instr->getNext());
+}


### PR DESCRIPTION
The Power code generator's load-hit-store peephole invokes undefined
behaviour by always assuming that the current instruction is a MemSrc1
instruction and that the next instruction is a Trg1Mem instruction. This
could cause a segfault if the current instruction is the last
instruction or if the next instruction has a load opcode, but is not a
Trg1Mem instruction. This has now been fixed.

Fixes: #5418
Signed-off-by: Ben Thomas <ben@benthomas.ca>