### PR TITLE
Fix AIX compile warnings

### DIFF
--- a/compiler/p/codegen/OMRInstOpCode.hpp
+++ b/compiler/p/codegen/OMRInstOpCode.hpp
@@ -206,6 +206,7 @@ class InstOpCode: public OMR::InstOpCode
             return 8;
          default:
             TR_ASSERT_FATAL(false, "Invalid template format for %s", getMnemonicName());
+            return 0;
          }
       }
 
@@ -223,6 +224,7 @@ class InstOpCode: public OMR::InstOpCode
             return 12;
          default:
             TR_ASSERT_FATAL(false, "Invalid template format for %s", getMnemonicName());
+            return 0;
          }
       }
 


### PR DESCRIPTION
Add missing return statements (compiler doesn't know that `TR_ASSERT_FATAL` never returns).

Without this, we have these warnings (many, many times):
```
00:27:19.227  "/home/jenkins/workspace/Build_JDK8_ppc64_aix_Personal/build/aix-ppc64-normal-server-release/vm/compiler/../omr/compiler/p/codegen/OMRInstOpCode.hpp", line 210.7: 1540-1101 (W) A return value of type "signed char" is expected.
00:27:19.227  "/home/jenkins/workspace/Build_JDK8_ppc64_aix_Personal/build/aix-ppc64-normal-server-release/vm/compiler/../omr/compiler/p/codegen/OMRInstOpCode.hpp", line 227.7: 1540-1101 (W) A return value of type "signed char" is expected.
```