### PR TITLE
VGC: report Object Monitors

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -1054,12 +1054,21 @@ MM_VerboseHandlerOutput::handleExcessiveGCRaised(J9HookInterface** hook, uintptr
 }
 
 void
-MM_VerboseHandlerOutput::outputStringConstantInfo(MM_EnvironmentBase *env, uintptr_t ident, uintptr_t candidates, uintptr_t cleared)
+MM_VerboseHandlerOutput::outputStringConstantInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t candidates, uintptr_t cleared)
 {
 	MM_VerboseWriterChain* writer = _manager->getWriterChain();
 
 	if (0 != candidates) {
-		writer->formatAndOutput(env, ident, "<stringconstants candidates=\"%zu\" cleared=\"%zu\"  />", candidates, cleared);
+		writer->formatAndOutput(env, indent, "<stringconstants candidates=\"%zu\" cleared=\"%zu\"  />", candidates, cleared);
+	}
+}
+
+void
+MM_VerboseHandlerOutput::outputMonitorReferenceInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t candidates, uintptr_t cleared)
+{
+	MM_VerboseWriterChain* writer = _manager->getWriterChain();
+	if (0 != candidates) {
+		writer->formatAndOutput(env, indent, "<object-monitors candidates=\"%zu\" cleared=\"%zu\"  />", candidates, cleared);
 	}
 }
 

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -242,6 +242,15 @@ protected:
 	 */
 	void outputStringConstantInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t candidates, uintptr_t cleared);
 
+	/**
+	 * Output monitor references table summary.
+	 * @param env GC thread used for output.
+	 * @param indent base level of indentation for the summary.
+	 * @param candidates total count candidate monitor references considered
+	 * @param cleared total count of cleared monitor references
+	 */
+	void outputMonitorReferenceInfo(MM_EnvironmentBase *env, uintptr_t indent, uintptr_t candidates, uintptr_t cleared);
+
 public:
 	static MM_VerboseHandlerOutput *newInstance(MM_EnvironmentBase *env, MM_VerboseManager *manager);
 

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -71,6 +71,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="finalization" type="vgc:finalization" />
 	<element name="ownableSynchronizers" type="vgc:ownableSynchronizers" />
 	<element name="stringconstants" type="vgc:stringconstants" />
+	<element name="object-monitors" type="vgc:object-monitors" />
 	<element name="classunload-info" type="vgc:classunload-info" />
 	<element name="warning" type="vgc:warning" />
 	<element name="remembered-set-cleared" type="vgc:remembered-set-cleared" />
@@ -478,6 +479,11 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="cleared" type="integer" use="required" />
 	</complexType>
 
+	<complexType name="object-monitors">
+		<attribute name="candidates" type="integer" use="required" />
+		<attribute name="cleared" type="integer" use="required" />
+	</complexType>
+
 	<complexType name="classunload-info">
 		<attribute name="classloadercandidates" type="integer" use="optional" />
 		<attribute name="classloadersunloaded" type="integer" use="required" />
@@ -787,6 +793,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:ownableSynchronizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:references" maxOccurs="unbounded" minOccurs="0" />
 			<element ref="vgc:stringconstants" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:object-monitors" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
 		</sequence>
 	</group>
@@ -812,6 +819,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:finalization" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:ownableSynchronizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:references" maxOccurs="unbounded" minOccurs="0" />
+			<element ref="vgc:object-monitors" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:heap-resize" maxOccurs="1" minOccurs="0" />
 		</sequence>
@@ -846,6 +854,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:ownableSynchronizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:references" maxOccurs="unbounded" minOccurs="0" />
 			<element ref="vgc:stringconstants" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:object-monitors" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:heap-resize" maxOccurs="1" minOccurs="0" />
 		</sequence>
 	</group>


### PR DESCRIPTION
Example:
`<object-monitors candidates="17" cleared="0"  />`

Signed-off-by: Enson Guo <enson.guo@ibm.com>