### PR TITLE
Targeted recognition of trivial array operations

### DIFF
--- a/compiler/optimizer/LoopCanonicalizer.hpp
+++ b/compiler/optimizer/LoopCanonicalizer.hpp
@@ -256,7 +256,7 @@ class TR_LoopCanonicalizer : public TR_LoopTransformer
    void rewritePostToPreIncrementTestInRegion(TR_RegionStructure *region);
    void rewritePostToPreIncrementTestInBlock(TR::Block *block);
 
-   bool trivialArrayOperationCheck(TR::NodeChecklist &visited, TR::Node *node);
+   bool trivialArrayOperationCheck(TR::NodeChecklist &visited, TR::Node *node, int32_t loopEntryBlockNumber);
 
    TR::SymbolReference *_symRefBeingReplaced;
    TR::SymbolReference *_primaryInductionVariable;

--- a/compiler/optimizer/LoopCanonicalizer.hpp
+++ b/compiler/optimizer/LoopCanonicalizer.hpp
@@ -256,6 +256,8 @@ class TR_LoopCanonicalizer : public TR_LoopTransformer
    void rewritePostToPreIncrementTestInRegion(TR_RegionStructure *region);
    void rewritePostToPreIncrementTestInBlock(TR::Block *block);
 
+   bool trivialArrayOperationCheck(TR::NodeChecklist &visited, TR::Node *node);
+
    TR::SymbolReference *_symRefBeingReplaced;
    TR::SymbolReference *_primaryInductionVariable;
    TR::Node *_primaryInductionVarStoreInBlock;


### PR DESCRIPTION
Goal is to disallow induction variable elimination for trivial array operations as having those induction variables visible will probably lead to better optimizations later on.

We disallow the induction variable reduction if:
- taken side of the if is low frequency
- load and store to local variable
- tree top which anchors stuff
- NULLCHK, BNDCHK and array store check
- aladd under loadi or storei which has mathematical expressions based on induction variables and constants
