### PR TITLE
Fix bugs in codegen for aselect nodes where register not flagged as collected reference

### DIFF
--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -510,6 +510,23 @@ OMR::RV::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *falseReg = cg->evaluate(falseNode);
    TR::RealRegister *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
+   // Internal pointers cannot be handled since we cannot set the pinning array
+   // on the result register without knowing which side of the select will be
+   // taken.
+   TR_ASSERT_FATAL_WITH_NODE(
+      node,
+      !trueReg->containsInternalPointer() && !falseReg->containsInternalPointer(),
+      "Select nodes cannot have children that are internal pointers"
+   );
+   if (falseReg->containsCollectedReference())
+      {
+      if (cg->comp()->getOption(TR_TraceCG))
+         traceMsg(
+            cg->comp(),
+            "Setting containsCollectedReference on result of select node in register %s\n",
+            cg->getDebug()->getName(trueReg));
+      trueReg->setContainsCollectedReference();
+      }
 
    TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *joinLabel = generateLabelSymbol(cg);

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -351,8 +351,32 @@ TR::Register *OMR::RV::CodeGenerator::gprClobberEvaluate(TR::Node *node)
    {
    if (node->getReferenceCount() > 1)
       {
+      TR::Register *sourceReg = self()->evaluate(node);
       TR::Register *targetReg = self()->allocateRegister();
-      generateITYPE(TR::InstOpCode::_addi, node, targetReg, self()->evaluate(node), 0, self());
+      generateITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, self());
+
+      if (sourceReg->containsCollectedReference())
+         {
+         if (self()->comp()->getOption(TR_TraceCG))
+            traceMsg(
+               self()->comp(),
+               "Setting containsCollectedReference on register %s\n",
+               self()->getDebug()->getName(targetRegister));
+         targetReg->setContainsCollectedReference();
+         }
+      if (sourceReg->containsInternalPointer())
+         {
+         TR::AutomaticSymbol *pinningArrayPointer = sourceRegister->getPinningArrayPointer();
+         if (self()->comp()->getOption(TR_TraceCG))
+            traceMsg(
+               self()->comp(),
+               "Setting containsInternalPointer on register %s and setting pinningArrayPointer to " POINTER_PRINTF_FORMAT "\n",
+               self()->getDebug()->getName(targetRegister),
+               pinningArrayPointer);
+         targetReg->setContainsInternalPointer();
+         targetReg->setPinningArrayPointer(pinningArrayPointer);
+         }
+
       return targetReg;
       }
    else

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2032,10 +2032,28 @@ TR::Register *OMR::X86::CodeGenerator::gprClobberEvaluate(TR::Node * node, TR_X8
 
       TR::Register *targetRegister = self()->allocateRegister();
       generateRegRegInstruction(movRegRegOpCode, node, targetRegister, sourceRegister, self());
-      //
-      // TODO: Should we do this?
-      // if (sourceRegister->containsCollectedReference())
-      //    targetRegister->setContainsCollectedReference();
+
+      if (sourceRegister->containsCollectedReference())
+         {
+         if (self()->comp()->getOption(TR_TraceCG))
+            traceMsg(
+               self()->comp(),
+               "Setting containsCollectedReference on register %s\n",
+               self()->getDebug()->getName(targetRegister));
+         targetRegister->setContainsCollectedReference();
+         }
+      if (sourceRegister->containsInternalPointer())
+         {
+         TR::AutomaticSymbol *pinningArrayPointer = sourceRegister->getPinningArrayPointer();
+         if (self()->comp()->getOption(TR_TraceCG))
+            traceMsg(
+               self()->comp(),
+               "Setting containsInternalPointer on register %s and setting pinningArrayPointer to " POINTER_PRINTF_FORMAT "\n",
+               self()->getDebug()->getName(targetRegister),
+               pinningArrayPointer);
+         targetRegister->setContainsInternalPointer();
+         targetRegister->setPinningArrayPointer(pinningArrayPointer);
+         }
 
       return targetRegister;
       }


### PR DESCRIPTION
In the codegen for `aselect` nodes, if at least one of the possible values of the `aselect` is the address of a collected reference, then the result register for the `aselect` node should be flagged as a collected reference.

This PR addresses 2 existing issues related to collected references in `aselect` nodes:

  1. On some platforms, the evaluator for `aselect` nodes did not check for collected references or checked incorrectly. This PR ensures that the correct check is done and that `setContainsCollectedReference()` is called on the result register if necessary.

  2. On some platforms, `gprClobberEvaluate` was used to generate a register for the result of the `aselect` node. In some cases, `gprClobberEvaluate` will allocate a new register to hold the given value. In these cases, it should check to see if the value is a collected reference before moving it to the new register. If it is a collected reference, the new register should be flagged as containing a collected reference. This PR ensures this check is done on platforms that use `gprClobberEvaluate` while evaluating `aselect` nodes.

This also adds fatal asserts in evaluators for `aselect` nodes which will fail if the nodes have children that are internal pointers.

Issue: https://github.com/eclipse/openj9/issues/8397

Signed-off-by: Ryan Shukla <ryans@ibm.com>