### PR TITLE
Revert change to OMR::CPU()

### DIFF
--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -31,36 +31,6 @@
 #include "control/Options_inlines.hpp"
 #include "env/CPU.hpp"
 
-OMR::Z::CPU::CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription)
-      {
-      switch(processorDescription.processor)
-         {
-         case OMR_PROCESSOR_S390_Z10:
-            _supportedArch = z10;
-            break;
-         case OMR_PROCESSOR_S390_Z196:
-            _supportedArch = z196;
-            break;
-         case OMR_PROCESSOR_S390_ZEC12:
-            _supportedArch = zEC12;
-            break;
-         case OMR_PROCESSOR_S390_Z13:
-            _supportedArch = z13;
-            break;
-         case OMR_PROCESSOR_S390_Z14:
-            _supportedArch = z14;
-            break;
-         case OMR_PROCESSOR_S390_Z15:
-            _supportedArch = z15;
-            break;
-         case OMR_PROCESSOR_S390_ZNEXT:
-            _supportedArch = zNext;
-            break;
-         default:
-            TR_ASSERT_FATAL(false, "Unsupported processorDescription.processor type: %s(%d)", TR::CPU::getProcessorName(processorDescription.processor), processorDescription.processor);
-         }
-      }
-
 TR::CPU
 OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
    {

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -303,7 +303,7 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
       memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
       }
 
-   CPU(const OMRProcessorDesc& processorDescription);
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription), _supportedArch(z9) {}
 
    enum
       {


### PR DESCRIPTION
`_supportedArch` shouldn't be initialized in this constructor because it's part of the old implementation.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>