### PR TITLE
CMake: Enable support for ddr on zos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,13 @@ if(OMR_DDR)
 		${CMAKE_CURRENT_SOURCE_DIR}/include_core
 		${CMAKE_CURRENT_BINARY_DIR}
 	)
+	set_property(TARGET omrddr PROPERTY DDR_OBJECT_EXCLUDES
+		ddr/
+		fvtest/
+		jitbuilder/
+		third_party/
+		tools/
+	)
 endif()
 
 ###

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -82,6 +82,10 @@ function(make_ddr_set set_name)
 	# This is so that you can process misc headers which don't logically belong to any other target.
 	target_enable_ddr(${DDR_TARGET_NAME})
 	set_property(TARGET "${DDR_TARGET_NAME}" APPEND PROPERTY DDR_TARGETS "${DDR_TARGET_NAME}")
+
+	# default to search the current binary dir
+	# note: only used on zos
+	set_property(TARGET "${DDR_TARGET_NAME}" PROPERTY DDR_OBJECT_SEARCH_ROOT "${CMAKE_CURRENT_BINARY_DIR}")
 endfunction(make_ddr_set)
 
 function(ddr_set_add_targets ddr_set)

--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -32,6 +32,7 @@ set(DDR_SUPERSET "$<TARGET_PROPERTY:@DDR_TARGET_NAME@,SUPERSET>")
 set(DDR_MACRO_LIST "${DDR_INFO_DIR}/sets/@DDR_TARGET_NAME@.macros")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${OMR_MODULES_DIR})
 set(PATH_TOOL "@PATH_TOOL@")
+set(OBJECT_SEARCH_ROOT "$<TARGET_PROPERTY:@DDR_TARGET_NAME@,DDR_OBJECT_SEARCH_ROOT>")
 
 set(DDR_TARGETS
 	$<JOIN:$<TARGET_PROPERTY:@DDR_TARGET_NAME@,DDR_TARGETS>,
@@ -41,6 +42,7 @@ set(DDR_SUBSETS
 	$<JOIN:$<TARGET_PROPERTY:@DDR_TARGET_NAME@,DDR_SUBSETS>,
 	>
 )
+set(OBJECT_EXCLUDE_REGEX "^$<JOIN:$<TARGET_PROPERTY:@DDR_TARGET_NAME@,DDR_OBJECT_EXCLUDES>,|^>")
 
 project(@DDR_TARGET_NAME@ LANGUAGES NONE)
 
@@ -244,6 +246,23 @@ foreach(subset IN LISTS DDR_SUBSETS)
 	list(APPEND subset_binaries ${binaries})
 endforeach()
 
+if(ZOS)
+	# On zos, we have to glob for the individual .dbg files
+	set(target_files)
+
+	if(OBJECT_EXCLUDE_REGEX STREQUAL "^")
+		# Empty exclude regex, just include everything
+		file(GLOB_RECURSE target_files "${OBJECT_SEARCH_ROOT}/*.dbg")
+	else()
+		file(GLOB_RECURSE dbg_files  RELATIVE "${OBJECT_SEARCH_ROOT}" "${OBJECT_SEARCH_ROOT}/*.dbg")
+		foreach(item IN LISTS dbg_files)
+			if(NOT "${item}" MATCHES "${OBJECT_EXCLUDE_REGEX}")
+				list(APPEND target_files "${OBJECT_SEARCH_ROOT}/${item}")
+			endif()
+		endforeach()
+	endif()
+
+endif()
 # now we generate our own list of binaries, so that they can be parsed if we are a subset
 omr_join("\n" binaries_list
 	${target_files}


### PR DESCRIPTION
zos doesnt store the dwarf debug info in the target executable, but
creates a .dbg file for every compilation unit. In order to collect
these we glob for .dbg files residing under a directory specified by
the DDR_OBJECT_SEARCH_ROOT property on the ddrset target (which defaults
to the ddr set's binary dir). In addition to this paths to exclude from
the globbing are specified in the DDR_OBJECT_EXCLUDES property

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>