### PR TITLE
Explicit conversion to char* from void*

### DIFF
--- a/util/omrutil/j9memclr.cpp
+++ b/util/omrutil/j9memclr.cpp
@@ -57,7 +57,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 #endif /* defined(J9ZOS390) || (defined(LINUX) && defined(S390)) */
 
 #if defined(AIXPPC) || defined(LINUXPPC)
-	char *addr = ptr;
+	char *addr = static_cast<char*>(ptr);
 	char *limit;
 	uintptr_t localCacheLineSize;
 


### PR DESCRIPTION
This fixes ppc build failures due to https://github.com/eclipse/omr/pull/5430

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>