### PR TITLE
Bump ALS on Z to z10

### DIFF
--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -189,14 +189,9 @@ genLogicalConversionForInt(TR::Node * node, TR::CodeGenerator * cg, TR::Register
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBGN, node, targetRegister, targetRegister, shift_amount, (int8_t)(63|0x80), 0);
       }
-   else if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-      {
-      generateRIEInstruction(cg, TR::InstOpCode::RISBG, node, targetRegister, targetRegister, shift_amount, (int8_t)(63|0x80), 0);
-      }
    else
       {
-      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, targetRegister, targetRegister, shift_amount);
-      generateRSInstruction(cg, TR::InstOpCode::SRLG, node, targetRegister, targetRegister, shift_amount);
+      generateRIEInstruction(cg, TR::InstOpCode::RISBG, node, targetRegister, targetRegister, shift_amount, (int8_t)(63|0x80), 0);
       }
    }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -391,7 +391,7 @@ bool OMR::Z::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
 
 bool OMR::Z::CodeGenerator::supportsDirectIntegralLoadStoresFromLiteralPool()
    {
-   return self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10);
+   return true;
    }
 
 OMR::Z::CodeGenerator::CodeGenerator()
@@ -494,23 +494,9 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setSupportsSearchCharString(); // CISC Transformation into SRSTU loop - only on z9.
    self()->setSupportsTranslateAndTestCharString(); // CISC Transformation into TRTE loop - only on z6.
 
-   if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
+   if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
       {
-      self()->setSupportsTranslateAndTestCharString();
-
-      if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
-         {
-         self()->setHasResumableTrapHandler();
-         }
-      }
-   else
-      {
-      comp->setOption(TR_DisableCompareAndBranchInstruction);
-
-      // No trap instructions available for z10 and below.
-      // Set disable traps so that the optimizations and codegen can avoid generating
-      // trap-specific nodes or instructions.
-      comp->setOption(TR_DisableTraps);
+      self()->setHasResumableTrapHandler();
       }
 
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z196))
@@ -845,7 +831,7 @@ OMR::Z::CodeGenerator::mulDecompositionCostIsJustified(int32_t numOfOperations, 
             traceMsg(self()->comp(), "MulDecomp cost is too high. numCycle=%i(max:3)\n", numCycles);
       return numCycles <= 3;
       }
-   else if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
+   else
       {
       int32_t numCycles = 0;
       numCycles = numOfOperations+1;
@@ -859,16 +845,6 @@ OMR::Z::CodeGenerator::mulDecompositionCostIsJustified(int32_t numOfOperations, 
          else
             traceMsg(self()->comp(), "MulDecomp cost is too high. numCycle=%i(max:10)\n", numCycles);
       return numCycles <= 9;
-      }
-   else
-      {
-      if (value > MAX_IMMEDIATE_VAL || value < MIN_IMMEDIATE_VAL)
-         {
-         // If more than 16 bits, then justify the shift / subtract
-         return OMR::CodeGenerator::mulDecompositionCostIsJustified(numOfOperations, bitPosition, operationType, value);
-         }
-
-      return false;
       }
    }
 
@@ -967,27 +943,24 @@ OMR::Z::CodeGenerator::isAddMemoryUpdate(TR::Node * node, TR::Node * valueChild)
    {
    static char * disableASI = feGetEnv("TR_DISABLEASI");
 
-   if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
+   if (!disableASI && self()->isMemoryUpdate(node) && valueChild->getSecondChild()->getOpCode().isLoadConst())
       {
-      if (!disableASI && self()->isMemoryUpdate(node) && valueChild->getSecondChild()->getOpCode().isLoadConst())
+      if (valueChild->getOpCodeValue() == TR::iadd || valueChild->getOpCodeValue() == TR::isub)
          {
-         if (valueChild->getOpCodeValue() == TR::iadd || valueChild->getOpCodeValue() == TR::isub)
-            {
-            int32_t value = valueChild->getSecondChild()->getInt();
+         int32_t value = valueChild->getSecondChild()->getInt();
 
-            if (value < (int32_t) 0x7F && value > (int32_t) 0xFFFFFF80)
-               {
-               return true;
-               }
+         if (value < (int32_t) 0x7F && value > (int32_t) 0xFFFFFF80)
+            {
+            return true;
             }
-         else if (self()->comp()->target().is64Bit() && (valueChild->getOpCodeValue() == TR::ladd || valueChild->getOpCodeValue() == TR::lsub))
-            {
-            int64_t value = valueChild->getSecondChild()->getLongInt();
+         }
+      else if (self()->comp()->target().is64Bit() && (valueChild->getOpCodeValue() == TR::ladd || valueChild->getOpCodeValue() == TR::lsub))
+         {
+         int64_t value = valueChild->getSecondChild()->getLongInt();
 
-            if (value < (int64_t) CONSTANT64(0x7F) && value > (int64_t) CONSTANT64(0xFFFFFFFFFFFFFF80))
-               {
-               return true;
-               }
+         if (value < (int64_t) CONSTANT64(0x7F) && value > (int64_t) CONSTANT64(0xFFFFFFFFFFFFFF80))
+            {
+            return true;
             }
          }
       }
@@ -1531,7 +1504,7 @@ OMR::Z::CodeGenerator::isLitPoolFreeForAssignment()
       {
       litPoolRegIsFree = true;
       }
-   else if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && !self()->anyLitPoolSnippets())
+   else if (!self()->anyLitPoolSnippets())
       {
       litPoolRegIsFree = true;
       }
@@ -2337,7 +2310,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    data.estimate = self()->setEstimatedLocationsForSnippetLabels(data.estimate);
    // need to reset constant data snippets offset for inlineEXTarget peephole optimization
    static char * disableEXRLDispatch = feGetEnv("TR_DisableEXRLDispatch");
-   if (!(bool)disableEXRLDispatch && self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
+   if (!(bool)disableEXRLDispatch)
       {
       _extentOfLitPool = self()->setEstimatedOffsetForConstantDataSnippets();
       }
@@ -4467,8 +4440,7 @@ bool OMR::Z::CodeGenerator::isActiveCompareCC(TR::InstOpCode::Mnemonic opcd, TR:
       TR::Register* ccSrcReg = ccInst->srcRegArrElem(0);
 
       // On z10 trueCompElimination may swap the previous compare operands, so give up early
-      if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) &&
-          !self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z196))
+      if (!self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z196))
          {
          if (tReg->getKind() != TR_FPR)
             {

--- a/compiler/z/codegen/OMRPeephole.cpp
+++ b/compiler/z/codegen/OMRPeephole.cpp
@@ -958,9 +958,6 @@ OMR::Z::Peephole::tryToReduceAGI()
 bool
 OMR::Z::Peephole::tryToReduceCLRToCLRJ()
    {
-   if (!self()->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
-      return false;
-
    bool branchTakenPerformReduction = false;
    bool fallThroughPerformReduction = false;
 

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -168,7 +168,7 @@ MemToMemVarLenMacroOp::generateLoop()
 
    generateS390BranchInstruction(_cg, TR::InstOpCode::BRCT, _rootNode, _itersReg, topOfLoop);
 
-   if (_cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && !comp->getOption(TR_DisableInlineEXTarget))
+   if (!comp->getOption(TR_DisableInlineEXTarget))
       {
       if (useEXForRemainder())
          {
@@ -971,7 +971,7 @@ MemToMemVarLenMacroOp::generateRemainder()
 
       TR::Instruction* cursor = NULL;
 
-      if (!_cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) || comp->getOption(TR_DisableInlineEXTarget))
+      if (comp->getOption(TR_DisableInlineEXTarget))
          {
          cursor = generateInstruction(0, 1);
          }
@@ -991,7 +991,7 @@ MemToMemVarLenMacroOp::generateRemainder()
         }
 
 
-      if (_cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && !comp->getOption(TR_DisableInlineEXTarget))
+      if (!comp->getOption(TR_DisableInlineEXTarget))
          {
          TR_ASSERT(_EXTargetLabel != NULL, "Assert: EXTarget label must not be NULL");
 
@@ -1243,7 +1243,7 @@ MemClearConstLenMacroOp::generateInstruction(int32_t offset, int64_t length, TR:
       // For lengths of 1, 2, 4 and 8, the XC sequence is suboptimal, as they require
       // 2 cycles to execute.  If MVI / MVHHI / MVHI / MVGHI are supported, we should
       // generate those instead.
-      if (_cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10) && length <= 8 && TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(length))
+      if (length <= 8 && TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(length))
          {
          switch(length)
             {

--- a/compiler/z/codegen/TranslateEvaluator.cpp
+++ b/compiler/z/codegen/TranslateEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,11 +130,6 @@ TR::Register *inlineTrtEvaluator(
    TR::Register *r1Reg = cg->allocateRegister();
    TR::Register *r2Reg = cg->allocateRegister();
 
-   if (packR2 && !cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-      {
-      generateRRInstruction(cg, TR::InstOpCode::XR, node, r2Reg, r2Reg);
-      }
-
    TR::RegisterDependencyConditions *regDeps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
    regDeps->addPostCondition(r1Reg, TR::RealRegister::GPR1,DefinesDependentRegister);
    regDeps->addPostCondition(r2Reg, TR::RealRegister::GPR2,DefinesDependentRegister);
@@ -173,14 +168,9 @@ TR::Register *inlineTrtEvaluator(
          {
          generateRIEInstruction(cg, TR::InstOpCode::RISBGN, node,  conditionCodeReg, r2Reg, 48, 55, 8);
          }
-      else if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z10))
-         {
-         generateRIEInstruction(cg, TR::InstOpCode::RISBG, node,  conditionCodeReg, r2Reg, 48, 55, 8);
-         }
       else
          {
-         generateRSInstruction(cg, TR::InstOpCode::SLL, node, r2Reg, 8);
-         generateRRInstruction(cg, TR::InstOpCode::OR, node, conditionCodeReg, r2Reg);
+         generateRIEInstruction(cg, TR::InstOpCode::RISBG, node,  conditionCodeReg, r2Reg, 48, 55, 8);
          }
 
       node->setRegister(conditionCodeReg);

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -296,14 +296,14 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
 
    protected:
 
-   CPU() : OMR::CPU(), _supportedArch(z9)
+   CPU() : OMR::CPU(), _supportedArch(z10)
       {
       _processorDescription.processor = OMR_PROCESSOR_S390_UNKNOWN;
       _processorDescription.physicalProcessor = OMR_PROCESSOR_S390_UNKNOWN;
       memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
       }
 
-   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription), _supportedArch(z9) {}
+   CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription), _supportedArch(z10) {}
 
    enum
       {


### PR DESCRIPTION
There are numerous reasons why this change is warranted which are
described below:

- We do not have access to z9 machines to test the project on so the
current unofficial support is untested
- z/OS 2.2 is the minimum supported OMR OS version which has an ALS of
z10, so it is not an issue to drop z9 support from the perspective of
z/OS
- SLES 12, RHEL 7.4, and Ubuntu 16.04 are the minimum supported OS
versions for Linux, and according to [3] z9 is not supported on any of
the OS version specified
- In addition to Centos 7.4 which is based off of RHEL 7.4, meaning
there is no support for z9 systems either
- z9 has been out of service since January 2019 [2]
- Updating the `-march` build flags will allow the compiler to build
the project using z10 instructions which can allow for better C/C++
code to be generated which improves performance (the big one being that
we can use PC relative instructions by default)
- Allows for better code maintenance and reduces complexity of the JIT
compiler, particularly in the area of supporting non-relative based
instruction sequences for z9
- Field research from z/OS OMs and Linux on Z OMs suggest that there is
a very small footprint of users who still have z9 systems, and of those
the % using the latest version of this project will be even smaller, if
not zero
- Officially, no documentation needs to be updated, since we do not
claim support for z9 publicly so the transition can be transparent

[1] https://www.ibm.com/it-infrastructure/z/os/linux-tested-platforms
[2] https://www-03.ibm.com/support/techdocs/atsmastr.nsf/WebIndex/TD105503

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>