### PR TITLE
Remove bogus tests from JITCrossPlatformsOpCodesTest.UnsupportedOpCodesTest

### DIFF
--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -511,22 +511,6 @@ OpCodesTest::compileTestMethods()
    {
    }
 
-void
-OpCodesTest::addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
-      TR::ILOpCodes opCode,
-      char * resolvedMethodName,
-      TR::DataType * argTypes,
-      TR::DataType returnType)
-   {
-   typedef void (*functype)();
-   functype never_succeeds;
-
-   int32_t returnCode = 0;
-   compileOpCodeMethod(never_succeeds, opCodeArgsNum, opCode, resolvedMethodName, argTypes, returnType, returnCode);
-   EXPECT_TRUE(COMPILATION_IL_GEN_FAILURE == returnCode || COMPILATION_REQUESTED == returnCode)
-      << resolvedMethodName << " is " << returnCode << ", expected is 0 or " << COMPILATION_IL_GEN_FAILURE;
-   }
-
 TR::ResolvedMethod *
 OpCodesTest::resolvedMethod(TR::DataType dataType)
    {
@@ -1293,24 +1277,6 @@ OpCodesTest::invokeDisabledOpCodesTests()
    OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_ZERO, DOUBLE_MAXIMUM), _dRem(DOUBLE_ZERO, DOUBLE_MAXIMUM));
    OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_POS, DOUBLE_NEG), _dRem(DOUBLE_POS, DOUBLE_NEG));
    OMR_CT_EXPECT_DOUBLE_EQ(_dRem, remainder(DOUBLE_MAXIMUM, DOUBLE_POS), _dRem(DOUBLE_MAXIMUM, DOUBLE_POS));
-   }
-
-void
-OpCodesTest::UnsupportedOpCodesTests()
-   {
-   //bdiv, brem
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);
-
-   //sdiv, srem
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);
-
-   //bucmplt, bucmple, bucmpgt, bucmpge
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmplt, "buCmplt", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmpge, "buCmpge", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmpgt, "buCmpgt", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmple, "buCmple", _argTypesBinaryByte, TR::Int32);
    }
 
 void
@@ -2423,12 +2389,6 @@ TEST(JITCrossPlatformsOpCodesTest, AddressTest)
    ::TestCompiler::OpCodesTest addressTest;
    addressTest.compileAddressTestMethods();
    addressTest.invokeAddressTests();
-   }
-
-TEST(JITCrossPlatformsOpCodesTest, UnsupportedOpCodesTest)
-   {
-   ::TestCompiler::OpCodesTest unsupportedOpcodesTest;
-   unsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, DISABLED_OpCodesTests)

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -192,9 +192,6 @@ class OpCodesTest : public TestDriver
    //another function for no helper issue tracking and testing.
    virtual void invokeNoHelperUnaryTests();
 
-   //Unsupported OpCodes are tested in this function
-   virtual void UnsupportedOpCodesTests();
-
    template <typename functiontype>
    int32_t
    compileOpCodeMethod(functiontype& resultpointer,
@@ -407,13 +404,6 @@ class OpCodesTest : public TestDriver
       resultpointer = reinterpret_cast<functiontype>(startPC);
       return returnCode;;
       }
-
-   void
-   addUnsupportedOpCodeTest(int32_t opCodeArgsNum,
-         TR::ILOpCodes opCode,
-         char * resolvedMethodName,
-         TR::DataType * argTypes,
-         TR::DataType returnType);
 
    static TR::ResolvedMethod * resolvedMethod(TR::DataType dataType);
 

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -560,24 +560,6 @@ PPCOpCodesTest::invokeMemoryOperationTests()
    }
 
 void
-PPCOpCodesTest::UnsupportedOpCodesTests()
-   {
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double);
-
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);
-
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);
-
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmplt, "bucmplt", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmpge, "bucmpge", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmpgt, "bucmpgt", _argTypesBinaryByte, TR::Int32);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmple, "bucmple", _argTypesBinaryByte, TR::Int32);
-   }
-
-void
 PPCOpCodesTest::invokeCompareTests()
    {
    int16_t sCmpeqDataArr[][2] =
@@ -4736,12 +4718,6 @@ TEST(JITPPCOpCodesTest, PPCAddressTest)
    ::TestCompiler::PPCOpCodesTest PPCAddressTest;
    PPCAddressTest.compileAddressTestMethods();
    PPCAddressTest.invokeAddressTests();
-   }
-
-TEST(JITPPCOpCodesTest, UnsupportedOpCodesTest)
-   {
-   ::TestCompiler::PPCOpCodesTest PPCUnsupportedOpcodesTest;
-   PPCUnsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEConvertTests)

--- a/fvtest/compilertest/tests/PPCOpCodesTest.hpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.hpp
@@ -39,7 +39,6 @@ class PPCOpCodesTest : public OpCodesTest
    virtual void invokeCompareTests();
    virtual void invokeBitwiseTests();
    virtual void invokeAddressTests();
-   virtual void UnsupportedOpCodesTests();
 
    virtual void compileDisabledConvertTestMethods();
    virtual void compileDisabledCompareTestMethods();

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -4419,53 +4419,6 @@ X86OpCodesTest::invokeSelectTests()
    }
 
 void
-X86OpCodesTest::UnsupportedOpCodesTests()
-   {
-
-   //lu2f, lu2d
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double);
-
-   //bselect, sselect, fselect, dselect
-   addUnsupportedOpCodeTest(_numberOfSelectArgs, TR::fselect, "fSelect", _argTypesSelectFloat, TR::Float);
-   addUnsupportedOpCodeTest(_numberOfSelectArgs, TR::dselect, "dSelect", _argTypesSelectDouble, TR::Double);
-
-   //iu2f, iu2d
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::iu2f, "iu2f", _argTypesUnaryInt, TR::Float);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::iu2d, "iu2d", _argTypesUnaryInt, TR::Double);
-
-   //f2b,f2s,d2b,d2s
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::d2b, "d2b", _argTypesUnaryDouble, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::d2s, "d2s", _argTypesUnaryDouble, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::f2b, "f2b", _argTypesUnaryFloat, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::f2s, "f2s", _argTypesUnaryFloat, TR::Int16);
-
-   //address opcodes
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::b2a, "b2a", _argTypesUnaryByte, TR::Address);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::s2a, "s2a", _argTypesUnaryShort, TR::Address);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::bu2a, "bu2a", _argTypesUnaryByte, TR::Address);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::su2a, "su2a", _argTypesUnaryShort, TR::Address);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2a, "lu2a", _argTypesUnaryLong, TR::Address);
-
-
-#if defined(TR_TARGET_32BIT)
-   //ldiv, lrem
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::ldiv, "lDiv", _argTypesBinaryLong, TR::Int64);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::lrem, "lRem", _argTypesBinaryLong, TR::Int64);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address);
-
-#endif
-
-#if defined(TR_TARGET_64BIT)
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::a2b, "a2b", _argTypesUnaryAddress, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::a2s, "a2s", _argTypesUnaryAddress, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::i2a, "i2a", _argTypesUnaryInt, TR::Address);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::iu2a, "iu2a", _argTypesUnaryInt, TR::Address);
-#endif
-
-}
-
-void
 X86OpCodesTest::invokeDirectCallTests()
    {
    int64_t longDataArray[] = {LONG_NEG, LONG_POS, LONG_MAXIMUM, LONG_MINIMUM, LONG_ZERO};
@@ -4648,12 +4601,6 @@ TEST(JITX86OpCodesTest, DISABLED_X86IntegerArithmeticTest)
    ::TestCompiler::X86OpCodesTest X86IntegerArithmeticTest;
    X86IntegerArithmeticTest.compileDisabledIntegerArithmeticTestMethods();
    X86IntegerArithmeticTest.invokeDisabledIntegerArithmeticTests();
-   }
-
-TEST(JITX86OpCodesTest, UnsupportedOpCodesTest)
-   {
-   ::TestCompiler::X86OpCodesTest X86UnsupportedOpcodesTest;
-   X86UnsupportedOpcodesTest.UnsupportedOpCodesTests();
    }
 
 TEST(JITX86OpCodesTest, DISABLED_X86UnaryTest)

--- a/fvtest/compilertest/tests/X86OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.hpp
@@ -45,7 +45,6 @@ class X86OpCodesTest : public OpCodesTest
    virtual void invokeCompareTests();
    virtual void invokeSelectTests();
    virtual void invokeAddressTests();
-   virtual void UnsupportedOpCodesTests();
 
    virtual void compileDisabledIntegerArithmeticTestMethods();
    virtual void invokeDisabledIntegerArithmeticTests();


### PR DESCRIPTION
This test checked that `bdiv`, `brem`, `sdiv` and `srem` are unsupported. This
is bogus - these should be supported.
