### PR TITLE
Deprecate label target NOPs on Z

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -78,7 +78,6 @@ using namespace OMR;
 #define TR_VSS_ALIGNMENT 8
 #define TR_AGGR_CONST_DISPLAY_SIZE 16
 #define TR_STORAGE_ALIGNMENT_DISPLAY_SIZE 128
-#define TR_LABEL_TARGET_NOP_LIMIT 232
 
 #define TR_MAX_BUCKET_INDEX_COUNT 20
 #define TR_MAX_LIMITED_GRA_REGS 5
@@ -696,7 +695,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableJProfiling",                   "O\tenable JProfiling", SET_OPTION_BIT(TR_EnableJProfiling), "F"},
    {"enableJProfilingInProfilingCompilations", "O\tEnable the use of jprofiling instrumentation in profiling compilations", RESET_OPTION_BIT(TR_DisableJProfilingInProfilingCompilations), "F"},
    {"enableJVMPILineNumbers",            "M\tenable output of line numbers via JVMPI",       SET_OPTION_BIT(TR_EnableJVMPILineNumbers), "F"},
-   {"enableLabelTargetNOPs",             "O\tenable inserting NOPs before label targets", SET_OPTION_BIT(TR_EnableLabelTargetNOPs),  "F"},
    {"enableLastRetrialLogging",          "O\tenable fullTrace logging for last compilation attempt. Needs to have a log defined on the command line", SET_OPTION_BIT(TR_EnableLastCompilationRetrialLogging), "F"},
    {"enableLocalVPSkipLowFreqBlock",     "O\tSkip processing of low frequency blocks in localVP", SET_OPTION_BIT(TR_EnableLocalVPSkipLowFreqBlock), "F" },
    {"enableLoopEntryAlignment",            "O\tenable loop Entry alignment",                          SET_OPTION_BIT(TR_EnableLoopEntryAlignment), "F"},
@@ -877,9 +875,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"jProfilingMethodRecompThreshold=",      "C<nnn>\tMethod invocations for jProfiling body",
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jProfilingMethodRecompThreshold), 0, "F%d"},
    {"keepBCDWidening",       "O\tstress testing option -- do not remove widening BCD operations", SET_OPTION_BIT(TR_KeepBCDWidening), "F" },
-
-   {"labelTargetNOPLimit=", "C<nnn>\t(labelTargetAddress&0xff) > _labelTargetNOPLimit are padded out with NOPs until the next 256 byte boundary",
-      TR::Options::set32BitNumeric, offsetof(OMR::Options,_labelTargetNOPLimit), TR_LABEL_TARGET_NOP_LIMIT , "F%d"},
    {"largeCompiledMethodExemptionFreqCutoff=", "O<nnn>\tInliner threshold",
       TR::Options::set32BitNumeric, offsetof(OMR::Options, _largeCompiledMethodExemptionFreqCutoff), 0, "F%d" },
    {"largeNumberOfLoops=", "O<nnn>\tnumber of loops to consider 'a large number'", TR::Options::set32BitNumeric, offsetof(OMR::Options,_largeNumberOfLoops), 0, "F%d"},
@@ -891,8 +886,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_lastOptSubIndex), 0, "F%d"},
    {"lastOptTransformationIndex=", "O<nnn>\tindex of the last optimization transformation to perform",
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_lastOptTransformationIndex), 0, "F%d"},
-   {"lnl=", "C<nnn>\t(labelTargetAddress&0xff) > _labelTargetNOPLimit are padded out with NOPs until the next 256 byte boundary",
-      TR::Options::set32BitNumeric, offsetof(OMR::Options,_labelTargetNOPLimit), TR_LABEL_TARGET_NOP_LIMIT , "F%d"},
    {"lockReserveClass=",  "O{regex}\tenable reserving locks for specified classes", TR::Options::setRegex, offsetof(OMR::Options, _lockReserveClass), 0, "P"},
    {"lockVecRegs=",    "M<nn>\tThe number of vector register to lock (from end) Range: 0-32", TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_numVecRegsToLock, 0, "F%d", NOT_IN_SUBSET},
    {"log=",               "L<filename>\twrite log output to filename",
@@ -1151,7 +1144,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceJProfilingValue",             "L\ttrace insertion of jProfiling trees for value profiling",    TR::Options::traceOptimization, jProfilingValue, 0, "P"},
 #endif
    {"traceKnownObjectGraph",            "L\ttrace the relationships between objects in the known-object table", SET_OPTION_BIT(TR_TraceKnownObjectGraph), "P" },
-   {"traceLabelTargetNOPs",             "L\ttrace inserting of NOPs before label targets", SET_OPTION_BIT(TR_TraceLabelTargetNOPs), "F"},
    {"traceLastOpt",                     "L\textra tracing for the opt corresponding to lastOptIndex; usually used with traceFull", SET_OPTION_BIT(TR_TraceLastOpt), "F"},
    {"traceLiveMonitorMetadata",         "L\ttrace live monitor metadata",                  SET_OPTION_BIT(TR_TraceLiveMonitorMetadata), "F" },
    {"traceLiveness",                     "L\ttrace liveness analysis",                     SET_OPTION_BIT(TR_TraceLiveness), "P" },
@@ -2563,7 +2555,6 @@ OMR::Options::jitPreProcess()
    _maxLimitedGRARegs = TR_MAX_LIMITED_GRA_REGS;
    _counterBucketGranularity = 2;
    _minCounterFidelity = INT_MIN;
-   _labelTargetNOPLimit = TR_LABEL_TARGET_NOP_LIMIT;
    _lastIpaOptTransformationIndex = INT_MAX;
    _jProfilingMethodRecompThreshold = 4000;
    _jProfilingLoopRecompThreshold = 2000;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -796,9 +796,9 @@ enum TR_CompilationOptions
    // Available                                       = 0x00001000 + 24,
    TR_EnableCopyingTROTInduction1Idioms               = 0x00002000 + 24,
    // Available                                       = 0x00004000 + 24,
-   TR_EnableLabelTargetNOPs                           = 0x00008000 + 24,
+   // Available                                       = 0x00008000 + 24,
    // Available                                       = 0x00010000 + 24,
-   TR_TraceLabelTargetNOPs                            = 0x00020000 + 24,
+   // Available                                       = 0x00020000 + 24,
    TR_CrashDuringCompilation                          = 0x00040000 + 24,
    TR_DisableShareableMethodHandleThunks              = 0x00080000 + 24,
    TR_DisableCustomMethodHandleThunks                 = 0x00100000 + 24,
@@ -1666,9 +1666,6 @@ public:
    int32_t getInlinerCGVeryColdBorderFrequency() { return _inlinerCGVeryColdBorderFrequency; }
    void    setInlinerCGVeryColdBorderFrequency(int32_t n) { _inlinerCGVeryColdBorderFrequency = n; }
    int32_t getAlwaysWorthInliningThreshold() const { return _alwaysWorthInliningThreshold; }
-
-   int32_t getLabelTargetNOPLimit() { return _labelTargetNOPLimit; }
-
    int32_t getMaxLimitedGRACandidates()   { return _maxLimitedGRACandidates; }
    int32_t getMaxLimitedGRARegs()         { return _maxLimitedGRARegs; }
    int32_t getNumLimitedGRARegsWithheld();
@@ -2296,10 +2293,7 @@ protected:
    int32_t                     _initialSCount;
    int32_t                     _enableSCHintFlags;
    bool                        _insertGCRTrees; // more like a flag than an option; cannot be set by user
-
-
-   int32_t                     _labelTargetNOPLimit;
-
+   
    int32_t                     _maxLimitedGRACandidates;
    int32_t                     _maxLimitedGRARegs;
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2294,26 +2294,8 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
 
          if (skipOneReturn == false)
             {
-            TR::Instruction * temp = data.cursorInstruction->getPrev();
-            TR::Instruction *originalNextInstruction = temp->getNext();
-
+            TR::Instruction* temp = data.cursorInstruction->getPrev();
             self()->getLinkage()->createEpilogue(temp);
-
-            if (self()->comp()->getOption(TR_EnableLabelTargetNOPs))
-               {
-               for (TR::Instruction *inst = temp->getNext(); inst != originalNextInstruction; inst = inst->getNext())
-                  {
-                  TR::Instruction *s390Inst = inst;
-                  if (s390Inst->getKind() == TR::Instruction::IsLabel)
-                     {
-                     if (self()->comp()->getOption(TR_TraceLabelTargetNOPs))
-                        traceMsg(self()->comp(),"\t\tepilogue inst %p (%s) setSkipForLabelTargetNOPs\n",s390Inst,s390Inst->getOpCode().getMnemonicName());
-                     TR::S390LabelInstruction *labelInst = (TR::S390LabelInstruction*)s390Inst;
-                     labelInst->setSkipForLabelTargetNOPs();
-                     }
-                  }
-               }
-
             data.cursorInstruction = temp->getNext();
 
             /* skipOneReturn only if epilog is generated which is indicated by instructions being */

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -457,23 +457,13 @@ class S390BranchOnIndexInstruction : public TR::S390LabeledInstruction
 ////////////////////////////////////////////////////////////////////////////////
 class S390LabelInstruction : public TR::S390LabeledInstruction
    {
-   flags8_t _flags;
-
-   enum
-      {
-      // AVAILABLE                    = 0x01,
-      skipForLabelTargetNOPs          = 0x02,
-      estimateDoneForLabelTargetNOPs  = 0x04,
-      // AVAILABLE                    = 0x08
-      };
-
    public:
 
    S390LabelInstruction(TR::InstOpCode::Mnemonic    op,
                            TR::Node          *n,
                            TR::LabelSymbol    *sym,
                            TR::CodeGenerator *cg)
-      : S390LabeledInstruction(op, n, sym, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cg), _alignment(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
@@ -485,7 +475,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::LabelSymbol    *sym,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator *cg)
-      : S390LabeledInstruction(op, n, sym, cond, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cond, cg), _alignment(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
@@ -497,7 +487,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::LabelSymbol    *sym,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, precedingInstruction, cg), _alignment(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
@@ -510,7 +500,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction   *precedingInstruction,
                            TR::CodeGenerator *cg)
-      : S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, sym, cond, precedingInstruction, cg), _alignment(0)
       {
       if (op==TR::InstOpCode::LABEL)
          sym->setInstruction(this);
@@ -521,7 +511,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::Node           *n,
                            TR::Snippet        *s,
                            TR::CodeGenerator  *cg)
-      : S390LabeledInstruction(op, n, s, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cg), _alignment(0)
       {}
 
    S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
@@ -529,7 +519,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::Snippet        *s,
                            TR::RegisterDependencyConditions * cond,
                            TR::CodeGenerator  *cg)
-      : S390LabeledInstruction(op, n, s, cond, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cond, cg), _alignment(0)
       {}
 
    S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
@@ -537,7 +527,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::Snippet        *s,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : S390LabeledInstruction(op, n, s, precedingInstruction, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, precedingInstruction, cg), _alignment(0)
       {}
 
    S390LabelInstruction(TR::InstOpCode::Mnemonic     op,
@@ -546,7 +536,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
                            TR::RegisterDependencyConditions * cond,
                            TR::Instruction    *precedingInstruction,
                            TR::CodeGenerator  *cg)
-      : S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg), _alignment(0), _flags(0)
+      : S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg), _alignment(0)
       {}
 
    virtual char *description() { return "S390LabelInstruction"; }
@@ -555,14 +545,6 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
    virtual uint8_t *generateBinaryEncoding();
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    void assignRegistersAndDependencies(TR_RegisterKinds kindToBeAssigned);
-
-   void setSkipForLabelTargetNOPs()    { _flags.set(skipForLabelTargetNOPs);}
-   bool isSkipForLabelTargetNOPs()     {return _flags.testAny(skipForLabelTargetNOPs); }
-
-   void setEstimateDoneForLabelTargetNOPs()     { _flags.set(estimateDoneForLabelTargetNOPs);}
-   bool wasEstimateDoneForLabelTargetNOPs()     {return _flags.testAny(estimateDoneForLabelTargetNOPs); }
-
-   bool considerForLabelTargetNOPs(bool inEncodingPhase);
 
    uint16_t getAlignment()          {return _alignment;}
    uint16_t setAlignment(uint16_t alignment) {return _alignment = alignment;}


### PR DESCRIPTION
Label target NOPs was a feature on the Z codegen which inserted padding
NOP bytes before labels to align them to cache boundaries. This was an
experimental feature for performance which did not pan out and is
currently unused (disabled by default). We do not envision padding
labels for cache alignment in the future, especially in the way things
are currently implemented as we do now support an ALIGN
pseudo-instruction for this purpose.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>