### PR TITLE
Stop referencing TOCBaseRegister on POWER10

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1636,7 +1636,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
                cg->addSnippet(snippet);
                }
 
-            TR::MemoryReference *fakeTocRef = new (cg->trHeapMemory()) TR::MemoryReference(cg->getTOCBaseRegister(), 0, sizeof(uintptr_t), cg);
+            TR::MemoryReference *fakeTocRef = new (cg->trHeapMemory()) TR::MemoryReference(NULL, 0, sizeof(uintptr_t), cg);
             fakeTocRef->setSymbol(symbol, cg);
             fakeTocRef->getSymbolReference()->copyFlags(ref);
             fakeTocRef->setUsingStaticTOC();

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1439,10 +1439,13 @@ void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
             {
             //For Little Endian, load target's Global Entry Point into r12, TOC will be restored at branch target.
             TR::Register *geReg = dependencies->searchPreConditionRegister(TR::RealRegister::gr12);
-            generateTrg1MemInstruction( cg(),TR::InstOpCode::Op_load, callNode, geReg,
+            if (!cg()->comp()->getOption(TR_DisableTOC))
+               generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, geReg,
                   new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getTOCBaseRegister(),
-                        (refNum-1)*TR::Compiler->om.sizeofReferenceAddress(),
-                        TR::Compiler->om.sizeofReferenceAddress(), cg()));
+                       (refNum-1)*TR::Compiler->om.sizeofReferenceAddress(),
+                       TR::Compiler->om.sizeofReferenceAddress(), cg()));
+            else
+               loadAddressConstant(cg(), callNode, (int64_t)runtimeHelperValue((TR_RuntimeHelper)refNum), geReg);
             }
          }
 


### PR DESCRIPTION
After disableTOC is turned on in POWER10 and TOCBaseRegister is about to
be recovered as a usual preserved register, we should get rid
of any reference to TOCBaseRegister. Otherwise, we will crash
in register assignment phase.

We set the baseRegister in the fake memRef to NULL
instead, given the pTOC is full by definition due to disableTOC.

Set up gr12 for systemLinkage dispatch for LE Linux naturally
through PC-relative constant snippet or direct materialization.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>