### PR TITLE
Replace strncpy with memcpy to avoid AdoptOpenJDK11 build error

### DIFF
--- a/port/unix/omrsharedhelper.c
+++ b/port/unix/omrsharedhelper.c
@@ -434,8 +434,7 @@ omr_unlinkControlFile(struct OMRPortLibrary* portLibrary, const char *controlFil
 				controlFileStatus->errorMsg = omrmem_allocate_memory(portLibrary, msgLen+1, OMR_GET_CALLSITE(), 
 OMRMEM_CATEGORY_PORT_LIBRARY);
 				if (NULL != controlFileStatus->errorMsg) {
-					strncpy(controlFileStatus->errorMsg, unlinkErrMsg, msgLen);
-					controlFileStatus->errorMsg[msgLen] = '\0';
+					memcpy(controlFileStatus->errorMsg, unlinkErrMsg, msgLen+1);
 				}
 			}
 			rc = FALSE;


### PR DESCRIPTION
strncpy() is replaced with strcpy() in order to avoid warnings/errors
which lead to failure of AdoptOpenJDK11 build (riscv) with GCC version 9.

Issue: #5484

Co-authored-by: Damian Diago D'monte <damian.dmonte@unb.ca>
Co-authored-by: Mark Thom <markjordanthom@gmail.com>

Signed-off-by: Damian Diago D'monte <damian.dmonte@unb.ca>