### PR TITLE
Refactor the Power select evaluators

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -237,7 +237,7 @@ bool is16BitSignedImmediate(int64_t value)
  * \return
  *    true if the value provided can be encoded in a 16-bit UI field; false otherwise.
  */
-bool is16BitUnsigedImmediate(uint64_t value)
+bool is16BitUnsignedImmediate(uint64_t value)
    {
    return value < 0x10000;
    }
@@ -455,7 +455,7 @@ CompareCondition evaluateDualIntCompareToConditionRegister(
       int32_t secondHi = secondChild->getLongIntHigh();
       int32_t secondLo = secondChild->getLongIntLow();
 
-      if (compareInfo.isUnsigned && is16BitUnsigedImmediate(secondHi))
+      if (compareInfo.isUnsigned && is16BitUnsignedImmediate(secondHi))
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, condReg, firstReg->getHighOrder(), secondHi);
          }
@@ -473,7 +473,7 @@ CompareCondition evaluateDualIntCompareToConditionRegister(
          cg->stopUsingRegister(secondHiReg);
          }
 
-      if (is16BitUnsigedImmediate(secondLo))
+      if (is16BitUnsignedImmediate(secondLo))
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, condReg2, firstReg->getLowOrder(), secondLo);
          }
@@ -635,7 +635,7 @@ void evaluateThreeWayIntCompareToConditionRegister(
    TR::Register *firstReg = evaluateAndExtend(firstChild, compareInfo.isUnsigned, false, cg);
    bool canUseCmpi = secondChild->getOpCode().isLoadConst() &&
       (compareInfo.isUnsigned
-         ? is16BitUnsigedImmediate(secondChild->get64bitIntegralValueAsUnsigned())
+         ? is16BitUnsignedImmediate(secondChild->get64bitIntegralValueAsUnsigned())
          : is16BitSignedImmediate(secondChild->get64bitIntegralValue()));
 
    if (canUseCmpi)

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1770,6 +1770,11 @@ TR::Register *OMR::Power::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::Co
             generateTrg1Src3Instruction(cg, iselOp, node, trgReg, trueReg, falseReg, condReg);
          }
 
+      TR_ASSERT_FATAL_WITH_NODE(
+         node,
+         !trueReg->containsInternalPointer() && !falseReg->containsInternalPointer(),
+         "Select nodes cannot have children that are internal pointers"
+      );
       if (trueReg->containsCollectedReference() || falseReg->containsCollectedReference())
          trgReg->setContainsCollectedReference();
       }
@@ -1780,6 +1785,11 @@ TR::Register *OMR::Power::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::Co
       trgReg = cg->gprClobberEvaluate(trueNode);
       TR::Register *falseReg = cg->evaluate(falseNode);
 
+      TR_ASSERT_FATAL_WITH_NODE(
+         node,
+         !trgReg->containsInternalPointer() && !falseReg->containsInternalPointer(),
+         "Select nodes cannot have children that are internal pointers"
+      );
       if (falseReg->containsCollectedReference())
          trgReg->setContainsCollectedReference();
 

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -133,6 +133,8 @@ CRCompareCondition compareConditionInCR(CompareCondition cond)
          return CRCompareCondition(TR::RealRegister::CRCC_GT, false);
       case CompareCondition::le:
          return CRCompareCondition(TR::RealRegister::CRCC_GT, true);
+      default:
+         TR_ASSERT_FATAL(false, "Invalid CompareCondition %d", static_cast<int>(cond));
       }
    }
 
@@ -162,6 +164,8 @@ CompareCondition reverseCondition(CompareCondition cond)
          return CompareCondition::le;
       case CompareCondition::le:
          return CompareCondition::gt;
+      default:
+         TR_ASSERT_FATAL(false, "Invalid CompareCondition %d", static_cast<int>(cond));
       }
    }
 
@@ -192,6 +196,8 @@ CompareCondition flipConditionOrder(CompareCondition cond)
          return CompareCondition::lt;
       case CompareCondition::le:
          return CompareCondition::ge;
+      default:
+         TR_ASSERT_FATAL(false, "Invalid CompareCondition %d", static_cast<int>(cond));
       }
    }
 
@@ -222,6 +228,8 @@ TR::InstOpCode::Mnemonic compareConditionToBranch(CompareCondition cond)
          return TR::InstOpCode::bgt;
       case CompareCondition::le:
          return TR::InstOpCode::ble;
+      default:
+         TR_ASSERT_FATAL(false, "Invalid CompareCondition %d", static_cast<int>(cond));
       }
    }
 
@@ -598,6 +606,9 @@ CompareCondition evaluateDualIntCompareToConditionRegister(
          generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::cror, node, condReg, condReg2, condReg,
             (TR::RealRegister::CRCC_EQ << TR::RealRegister::pos_RT) | (TR::RealRegister::CRCC_EQ << TR::RealRegister::pos_RA) | (TR::RealRegister::CRCC_LT << TR::RealRegister::pos_RB));
          break;
+
+      default:
+         TR_ASSERT_FATAL(false, "Invalid CompareCondition %d", static_cast<int>(compareInfo.cond));
       }
 
    cg->stopUsingRegister(condReg2);

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -555,7 +555,6 @@
    lrem,             // long remainder for 64 bit target
    d2i,              // converts from double to integer
    d2l,              // converts from double to long
-   iselect,          // select evaluator
 // bcdcpsgn_r,       // Decimal copySign & record
 // bcdcfn_r,         // Decimal convert from national & record
 // bcdcfsq_r,        // Decimal convert from signed qword & record

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -6367,17 +6367,6 @@
    /* .properties  = */ PPCOpProp_None,
    },
 
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::iselect,
-   /* .name        = */ "iselect",
-   /* .description =    "select evaluator", */
-   /* .prefix      = */ 0x00000000,
-   /* .opcode      = */ 0x00000000,
-   /* .format      = */ FORMAT_UNKNOWN,
-   /* .minimumALS  = */ OMR_PROCESSOR_PPC_UNKNOWN,
-   /* .properties  = */ PPCOpProp_None,
-   },
-
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::bcdcpsgn_r, */
    /* .name        =    "bcdcpsgn.", */

--- a/compiler/p/codegen/OMRRegister.hpp
+++ b/compiler/p/codegen/OMRRegister.hpp
@@ -62,21 +62,7 @@ class OMR_EXTENSIBLE Register: public OMR::Register
    uint64_t getInterference()           {return _liveRegisterInfo._interference;}
    uint64_t setInterference(uint64_t i) {return (_liveRegisterInfo._interference = i);}
 
-
-   /*
-    * Method for manipulating flags
-    */
-   bool isFlippedCCR()  {return _flags.testAny(FlipBranchOffThisCCR);}
-   void setFlippedCCR() {_flags.set(FlipBranchOffThisCCR);}
-   void resetFlippedCCR() {_flags.reset(FlipBranchOffThisCCR);}
-
-
    private:
-
-   enum
-      {
-      FlipBranchOffThisCCR          = 0x4000, // PPC may have swapped register positions in compare
-      };
 
    // Both x and z also have this union but ppc uses uint64_t instead of uint32_t
    union

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -96,6 +96,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *returnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *indirectCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -396,8 +396,8 @@
    TR::TreeEvaluator::iselectEvaluator,                 // TR::bselect
    TR::TreeEvaluator::iselectEvaluator,                 // TR::sselect
    TR::TreeEvaluator::iselectEvaluator,                 // TR::aselect
-   TR::TreeEvaluator::iselectEvaluator,                 // TR::fselect
-   TR::TreeEvaluator::iselectEvaluator,                 // TR::dselect
+   TR::TreeEvaluator::fselectEvaluator,                 // TR::fselect
+   TR::TreeEvaluator::fselectEvaluator,                 // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,                 // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodEnterHook (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodExitHook (J9)

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -2474,7 +2474,6 @@ int32_t TR::PPCControlFlowInstruction::estimateBinaryLength(int32_t currentEstim
       case TR::InstOpCode::iflong:
       case TR::InstOpCode::idiv:
       case TR::InstOpCode::ldiv:
-      case TR::InstOpCode::iselect:
          if (useRegPairForResult())
             {
             if (!useRegPairForCond())

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1479,50 +1479,6 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
 
          break;
-      case TR::InstOpCode::iselect:
-         {
-         cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(0), 0, cursor));
-
-         if (useRegPairForResult())
-            {
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(1), cursor));
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(2), getSourceRegister(2), cursor));
-            }
-         else
-            {
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(1), cursor));
-            }
-         cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
-
-         if (useRegPairForResult())
-            {
-            if (useRegPairForCond())
-               {
-               cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(5), 0, cursor));
-               cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
-               }
-            }
-         else
-            {
-            if (useRegPairForCond())
-               {
-               cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(3), 0, cursor));
-               cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
-               }
-            }
-
-         if (useRegPairForResult())
-            {
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(3), cursor));
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(2), getSourceRegister(4), cursor));
-            }
-         else
-            {
-            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(2), cursor));
-            }
-         cg()->traceRAInstruction(cursor = generateLabelInstruction      (cg(), TR::InstOpCode::label,currentNode, label2, cursor));
-         }
-         break;
       default:
          TR_ASSERT(false,"unknown control flow instruction ");
       }

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -1352,6 +1352,8 @@ class Int32SelectInt8CompareTest : public SelectCompareTest<int8_t, int32_t> {};
 
 TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 
@@ -1382,6 +1384,8 @@ TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 
@@ -1413,6 +1417,8 @@ TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 
@@ -1453,6 +1459,8 @@ class Int32SelectInt16CompareTest : public SelectCompareTest<int16_t, int32_t> {
 
 TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 
@@ -1483,6 +1491,8 @@ TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 
@@ -1514,6 +1524,8 @@ TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
 
     auto param = to_struct(GetParam());
 

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -1354,6 +1354,8 @@ TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 
@@ -1386,6 +1388,8 @@ TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 
@@ -1419,6 +1423,8 @@ TEST_P(Int32SelectInt8CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 
@@ -1461,6 +1467,8 @@ TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 
@@ -1493,6 +1501,8 @@ TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 
@@ -1526,6 +1536,8 @@ TEST_P(Int32SelectInt16CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
+    SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
+    SKIP_ON_HAMMER(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
 
     auto param = to_struct(GetParam());
 

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -23,95 +23,920 @@
 #include "default_compiler.hpp"
 #include "omrformatconsts.h"
 
-// C++11 upgrade (Issue #1916).
+enum class Comparison {
+   eq, ne, lt, ge, gt, le
+};
+
+template <typename ValType>
+class SelectTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<int32_t, std::tuple<ValType, ValType>>> {};
+
+template <typename ValType>
+struct SelectTestParamStruct {
+    int32_t selector;
+    ValType v1;
+    ValType v2;
+};
+
+template <typename ValType>
+SelectTestParamStruct<ValType> to_struct(std::tuple<int32_t, std::tuple<ValType, ValType>> param) {
+    SelectTestParamStruct<ValType> s;
+
+    s.selector = std::get<0>(param);
+    s.v1 = std::get<0>(std::get<1>(param));
+    s.v2 = std::get<1>(std::get<1>(param));
+
+    return s;
+}
+
 template <typename CompareType, typename ValType>
-class SelectTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)>> {};
+class SelectCompareTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<Comparison, std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>>> {};
 
-/** \brief
- *     Struct equivalent of the SelectTestParamStruct tuple.
- *
- *  \tparam CompareType
- *     The type of the compare child of the select opcode.
- *
- *  \tparam ValType
- *     The type that the select opcode returns.
- */
 template <typename CompareType, typename ValType>
-struct SelectTestParamStruct
-   {
-   CompareType c1;
-   CompareType c2;
-   ValType v1;
-   ValType v2;
-   ValType (*oracle)(CompareType, CompareType, ValType, ValType);
-   };
+struct SelectCompareTestParamStruct {
+    Comparison cmp;
+    CompareType c1;
+    CompareType c2;
+    ValType v1;
+    ValType v2;
+};
 
-/** \brief
- *     Given an instance of SelectTestParamStruct, returns an equivalent instance of SelectTestParamStruct.
- */
 template <typename CompareType, typename ValType>
-SelectTestParamStruct<CompareType, ValType> to_struct(std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)> param)
-   {
-   SelectTestParamStruct<CompareType, ValType> s;
+SelectCompareTestParamStruct<CompareType, ValType> to_struct(std::tuple<Comparison, std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>> param) {
+    SelectCompareTestParamStruct<CompareType, ValType> s;
 
-   s.c1 = std::get<0>(std::get<0>(param));
-   s.c2 = std::get<1>(std::get<0>(param));
-   s.v1 = std::get<0>(std::get<1>(param));
-   s.v2 = std::get<1>(std::get<1>(param));
-   s.oracle = std::get<2>(param);
-   return s;
-   }
+    s.cmp = std::get<0>(param);
+    s.c1 = std::get<0>(std::get<1>(param));
+    s.c2 = std::get<1>(std::get<1>(param));
+    s.v1 = std::get<0>(std::get<2>(param));
+    s.v2 = std::get<1>(std::get<2>(param));
 
-/** \brief
- *     The oracle function which computes the expected result of the select test.
- *
- *  \tparam CompareType
- *     The type of the values compared by oracle function.
- *  \tparam ValType
- *     The return type of the oracle function.
- */
-template <typename CompareType, typename ValType>
-static ValType xselectOracle(CompareType c1, CompareType c2, ValType v1, ValType v2)
-   {
-   return ((c1 < c2) ? v1 : v2);
-   }
+    return s;
+}
 
-/** \brief
- *     The function computes the input vector of pairs for the compare node.
- */
+template <typename CompareType>
+static const char* xcmpSuffix(Comparison cmp) {
+    switch (cmp) {
+        case Comparison::eq:
+            return "eq";
+        case Comparison::ne:
+            return OMR::IsFloatingPoint<CompareType>::VALUE ? "neu" : "ne";
+        case Comparison::lt:
+            return "lt";
+        case Comparison::ge:
+            return "ge";
+        case Comparison::gt:
+            return "gt";
+        case Comparison::le:
+            return "le";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, Comparison cmp) {
+    return os << "Comparison::" << xcmpSuffix<int32_t>(cmp);
+}
+
+template <typename CompareType>
+static int32_t xcmpOracle(Comparison cmp, CompareType c1, CompareType c2) {
+    switch (cmp) {
+        case Comparison::eq:
+            return c1 == c2;
+        case Comparison::ne:
+            return c1 != c2;
+        case Comparison::lt:
+            return c1 < c2;
+        case Comparison::ge:
+            return c1 >= c2;
+        case Comparison::gt:
+            return c1 > c2;
+        case Comparison::le:
+            return c1 <= c2;
+    }
+}
+
+template <typename ValType>
+static ValType xselectOracle(int32_t sel, ValType v1, ValType v2) {
+   return sel ? v1 : v2;
+}
+
 template <typename T>
-static std::vector<std::tuple<T, T>> compareInputs()
-   {
-   std::tuple<T, T> inputArray[] =
-      {
-      std::make_pair(std::numeric_limits<T>::min(), std::numeric_limits<T>::max()),
-      std::make_pair(std::numeric_limits<T>::max(), std::numeric_limits<T>::min()),
-      std::make_pair(std::numeric_limits<T>::min(), std::numeric_limits<T>::min()),
-      std::make_pair(0, std::numeric_limits<T>::max()),
-      std::make_pair(0, std::numeric_limits<T>::min()),
-      std::make_pair(std::numeric_limits<T>::min(), 0),
-      std::make_pair(std::numeric_limits<T>::max(), 0),
-      };
-   return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray)/sizeof(std::tuple<T, T>));
-   }
+static typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE, std::vector<std::tuple<T, T>>>::Type compareInputs() {
+    std::tuple<T, T> inputArray[] = {
+        std::make_pair(std::numeric_limits<T>::min(), std::numeric_limits<T>::max()),
+        std::make_pair(std::numeric_limits<T>::max(), std::numeric_limits<T>::min()),
+        std::make_pair(0, std::numeric_limits<T>::max()),
+        std::make_pair(0, std::numeric_limits<T>::min()),
+        std::make_pair(0, 0),
+    };
+    return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray) / sizeof(*inputArray));
+}
 
-/** \brief
- *     The function computes the true/false result vector of pairs for the select node.
- */
 template <typename T>
-static std::vector<std::tuple<T, T>> resultInputs()
-   {
-   std::tuple<T, T> inputArray[] =
-      {
-      std::make_pair(1, 0),
-      std::make_pair(0, 1),
-      };
-   return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray)/sizeof(std::tuple<T, T>));
-   }
+static typename OMR::EnableIf<OMR::IsFloatingPoint<T>::VALUE, std::vector<std::tuple<T, T>>>::Type compareInputs() {
+    std::tuple<T, T> inputArray[] = {
+        std::make_pair(-std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity()),
+        std::make_pair(std::numeric_limits<T>::infinity(), -std::numeric_limits<T>::infinity()),
+        std::make_pair(0.0, std::numeric_limits<T>::infinity()),
+        std::make_pair(0.0, -std::numeric_limits<T>::infinity()),
+        std::make_pair(0.0, std::numeric_limits<T>::quiet_NaN()),
+        std::make_pair(0.0, 0.0),
+    };
+    return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray) / sizeof(*inputArray));
+}
 
-class Int32SelectInt32CompareTest : public SelectTest<int32_t, int32_t> {};
+template <typename T>
+static std::vector<std::tuple<T, T>> resultInputs() {
+    std::tuple<T, T> inputArray[] = {
+        std::make_pair(1, 0),
+        std::make_pair(0, 1),
+        std::make_pair(-1, 0),
+        std::make_pair(0, -1),
+        std::make_pair(5, 7),
+    };
+    return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray) / sizeof(*inputArray));
+}
+
+static std::vector<int32_t> selectors() {
+    int32_t inputArray[] = { 0, 1, 2, -1 };
+    return std::vector<int32_t>(inputArray, inputArray + sizeof(inputArray) / sizeof(*inputArray));
+}
+
+static std::vector<Comparison> allComparisons() {
+    Comparison comparisons[] = {
+        Comparison::eq,
+        Comparison::ne,
+        Comparison::lt,
+        Comparison::ge,
+        Comparison::gt,
+        Comparison::le,
+    };
+    return std::vector<Comparison>(comparisons, comparisons + sizeof(comparisons) / sizeof(*comparisons));
+}
+
+class Int8SelectTest : public SelectTest<int8_t> {};
+
+TEST_P(Int8SelectTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int32, Int8, Int8]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (iload parm=0)"
+        "          (bload parm=1)"
+        "          (bload parm=2))))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int32_t, int8_t, int8_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(Int8SelectTest, UsingConstSelector) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int8, Int8]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (iconst %d)"
+        "          (bload parm=0)"
+        "          (bload parm=1))))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int8_t, int8_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(Int8SelectTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (iload parm=0)"
+        "          (bconst %" OMR_PRId8 ")"
+        "          (bconst %" OMR_PRId8 "))))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int8_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, Int8SelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<int8_t>())));
+
+class Int16SelectTest : public SelectTest<int16_t> {};
+
+TEST_P(Int16SelectTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int32, Int16, Int16]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (iload parm=0)"
+        "          (sload parm=1)"
+        "          (sload parm=2))))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int32_t, int16_t, int16_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(Int16SelectTest, UsingConstSelector) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int16, Int16]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (iconst %d)"
+        "          (sload parm=0)"
+        "          (sload parm=1))))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int16_t, int16_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(Int16SelectTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (iload parm=0)"
+        "          (sconst %" OMR_PRId16 ")"
+        "          (sconst %" OMR_PRId16 "))))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, Int16SelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<int16_t>())));
+
+class Int32SelectTest : public SelectTest<int32_t> {};
+
+TEST_P(Int32SelectTest, UsingLoadParam) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int32, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (iload parm=0)"
+        "        (iload parm=1)"
+        "        (iload parm=2)))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectTest, UsingConstSelector) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (iconst %d)"
+        "        (iload parm=0)"
+        "        (iload parm=1)))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(Int32SelectTest, UsingConstValues) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (iload parm=0)"
+        "        (iconst %d)"
+        "        (iconst %d)))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
+
+class Int64SelectTest : public SelectTest<int64_t> {};
+
+TEST_P(Int64SelectTest, UsingLoadParam) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int32, Int64, Int64]"
+        "  (block"
+        "    (lreturn"
+        "      (lselect"
+        "        (iload parm=0)"
+        "        (lload parm=1)"
+        "        (lload parm=2)))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t, int64_t, int64_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(Int64SelectTest, UsingConstSelector) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int64, Int64]"
+        "  (block"
+        "    (lreturn"
+        "      (lselect"
+        "        (iconst %d)"
+        "        (lload parm=0)"
+        "        (lload parm=1)))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int64_t, int64_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(Int64SelectTest, UsingConstValues) {
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int32]"
+        "  (block"
+        "    (lreturn"
+        "      (lselect"
+        "        (iload parm=0)"
+        "        (lconst %" OMR_PRId64 ")"
+        "        (lconst %" OMR_PRId64 ")))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<int64_t>())));
+
+class FloatSelectTest : public SelectTest<float> {};
+
+TEST_P(FloatSelectTest, UsingLoadParam) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float args=[Int32, Float, Float]"
+        "  (block"
+        "    (freturn"
+        "      (fselect"
+        "        (iload parm=0)"
+        "        (fload parm=1)"
+        "        (fload parm=2)))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(int32_t, float, float)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(FloatSelectTest, UsingConstSelector) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float args=[Float, Float]"
+        "  (block"
+        "    (freturn"
+        "      (fselect"
+        "        (iconst %d)"
+        "        (fload parm=0)"
+        "        (fload parm=1)))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(float, float)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(FloatSelectTest, UsingConstValues) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float args=[Int32]"
+        "  (block"
+        "    (freturn"
+        "      (fselect"
+        "        (iload parm=0)"
+        "        (fconst %f)"
+        "        (fconst %f)))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, FloatSelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<float>())));
+
+class DoubleSelectTest : public SelectTest<double> {};
+
+TEST_P(DoubleSelectTest, UsingLoadParam) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double args=[Int32, Double, Double]"
+        "  (block"
+        "    (dreturn"
+        "      (dselect"
+        "        (iload parm=0)"
+        "        (dload parm=1)"
+        "        (dload parm=2)))))");
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(int32_t, double, double)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector, param.v1, param.v2));
+}
+
+TEST_P(DoubleSelectTest, UsingConstSelector) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double args=[Double, Double]"
+        "  (block"
+        "    (dreturn"
+        "      (dselect"
+        "        (iconst %d)"
+        "        (dload parm=0)"
+        "        (dload parm=1)))))",
+        param.selector);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(double, double)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.v1, param.v2));
+}
+
+TEST_P(DoubleSelectTest, UsingConstValues) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double args=[Int32]"
+        "  (block"
+        "    (dreturn"
+        "      (dselect"
+        "        (iload parm=0)"
+        "        (dconst %f)"
+        "        (dconst %f)))))",
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(int32_t)>();
+    ASSERT_EQ(xselectOracle(param.selector, param.v1, param.v2), entry_point(param.selector));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectTest, DoubleSelectTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(selectors()),
+        ::testing::ValuesIn(resultInputs<double>())));
+
+class Int8SelectInt32CompareTest : public SelectCompareTest<int32_t, int8_t> {};
+
+TEST_P(Int8SelectInt32CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int32, Int32, Int8, Int8]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iload parm=1))"
+        "          (bload parm=2)"
+        "          (bload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int32_t, int32_t, int8_t, int8_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int8SelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int32, Int8, Int8]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iconst %d))"
+        "          (bload parm=1)"
+        "          (bload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int32_t, int8_t, int8_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int8SelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int8 args=[Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (b2i"
+        "        (bselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iload parm=1))"
+        "          (bconst %" OMR_PRId8 ")"
+        "          (bconst %" OMR_PRId8 "))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int8_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int8SelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<int8_t>())));
+
+class Int16SelectInt32CompareTest : public SelectCompareTest<int32_t, int16_t> {};
+
+TEST_P(Int16SelectInt32CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int32, Int32, Int16, Int16]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iload parm=1))"
+        "          (sload parm=2)"
+        "          (sload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int32_t, int32_t, int16_t, int16_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int16SelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int32, Int16, Int16]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iconst %d))"
+        "          (sload parm=1)"
+        "          (sload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int32_t, int16_t, int16_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int16SelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int16 args=[Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (s2i"
+        "        (sselect"
+        "          (icmp%s"
+        "            (iload parm=0)"
+        "            (iload parm=1))"
+        "          (sconst %" OMR_PRId16 ")"
+        "          (sconst %" OMR_PRId16 "))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int16_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int16SelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<int16_t>())));
+
+class Int32SelectInt32CompareTest : public SelectCompareTest<int32_t, int32_t> {};
 
 TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -120,12 +945,12 @@ TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
         "  (block"
         "    (ireturn"
         "      (iselect"
-        "        (icmplt"
+        "        (icmp%s"
         "          (iload parm=0)"
         "          (iload parm=1))"
         "        (iload parm=2)"
-        "        (iload parm=3))"
-        ")))");
+        "        (iload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -136,28 +961,27 @@ TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t, int32_t, int32_t)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(Int32SelectInt32CompareTest, UsingConst) {
+TEST_P(Int32SelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int32"
+        "(method return=Int32 args=[Int32, Int32, Int32]"
         "  (block"
         "    (ireturn"
         "      (iselect"
-        "        (icmplt"
-        "          (iconst %d)"
+        "        (icmp%s"
+        "          (iload parm=0)"
         "          (iconst %d))"
-        "        (iconst %d)"
-        "        (iconst %d))"
-        ")))",
-        param.c1,
-        param.c2,
-        param.v1,
-        param.v2);
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -167,199 +991,27 @@ TEST_P(Int32SelectInt32CompareTest, UsingConst) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(void)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
 }
 
-INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectInt32CompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<int32_t>()),
-            ::testing::ValuesIn(resultInputs<int32_t>()),
-            ::testing::Values(xselectOracle<int32_t, int32_t>)));
-
-class Int64SelectInt64CompareTest : public SelectTest<int64_t, int64_t> {};
-
-TEST_P(Int64SelectInt64CompareTest, UsingLoadParam) {
-    auto param = to_struct(GetParam());
-
-    char inputTrees[512] = {0};
-    std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int64 args=[Int64, Int64, Int64, Int64]"
-        "  (block"
-        "    (lreturn"
-        "      (lselect"
-        "        (lcmplt"
-        "          (lload parm=0)"
-        "          (lload parm=1))"
-        "        (lload parm=2)"
-        "        (lload parm=3))"
-        ")))");
-    auto trees = parseString(inputTrees);
-
-    ASSERT_NOTNULL(trees);
-
-    Tril::DefaultCompiler compiler(trees);
-
-    int32_t compileResult = compiler.compile();
-    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<int64_t (*)(int64_t, int64_t, int64_t, int64_t)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
-}
-
-TEST_P(Int64SelectInt64CompareTest, UsingConst) {
-    auto param = to_struct(GetParam());
-
-    char inputTrees[512] = {0};
-    std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int64"
-        "  (block"
-        "    (lreturn"
-        "      (lselect"
-        "        (lcmplt"
-        "          (lconst %" OMR_PRId64 ")"
-        "          (lconst %" OMR_PRId64 "))"
-        "        (lconst %" OMR_PRId64 ")"
-        "        (lconst %" OMR_PRId64 "))"
-        ")))",
-        param.c1,
-        param.c2,
-        param.v1,
-        param.v2);
-    auto trees = parseString(inputTrees);
-
-    ASSERT_NOTNULL(trees);
-
-    Tril::DefaultCompiler compiler(trees);
-
-    int32_t compileResult = compiler.compile();
-    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<int64_t (*)(void)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
-}
-
-INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectInt64CompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<int64_t>()),
-            ::testing::ValuesIn(resultInputs<int64_t>()),
-            ::testing::Values(xselectOracle<int64_t, int64_t>)));
-
-class Int64SelectDoubleCompareTest : public SelectTest<double, int64_t> {};
-
-TEST_P(Int64SelectDoubleCompareTest, UsingLoadParam) {
-    auto param = to_struct(GetParam());
-
-    char inputTrees[512] = {0};
-    std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int64 args=[Double, Double, Int64, Int64]"
-        "  (block"
-        "    (lreturn"
-        "      (lselect"
-        "        (dcmplt"
-        "          (dload parm=0)"
-        "          (dload parm=1))"
-        "        (lload parm=2)"
-        "        (lload parm=3))"
-        ")))");
-    auto trees = parseString(inputTrees);
-
-    ASSERT_NOTNULL(trees);
-
-    Tril::DefaultCompiler compiler(trees);
-
-    int32_t compileResult = compiler.compile();
-    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<int64_t (*)(double, double, int64_t, int64_t)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
-}
-
-TEST_P(Int64SelectDoubleCompareTest, UsingConst) {
-    auto param = to_struct(GetParam());
-
-    char inputTrees[512] = {0};
-    std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int64 args=[Double, Double]"
-        "  (block"
-        "    (lreturn"
-        "      (lselect"
-        "        (dcmplt"
-        "          (dload parm=0)"
-        "          (dload parm=1))"
-        "        (lconst %" OMR_PRId64 ")"
-        "        (lconst %" OMR_PRId64 "))"
-        ")))",
-        param.v1,
-        param.v2);
-    auto trees = parseString(inputTrees);
-
-    ASSERT_NOTNULL(trees);
-
-    Tril::DefaultCompiler compiler(trees);
-
-    int32_t compileResult = compiler.compile();
-    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<int64_t (*)(double, double)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
-}
-
-INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectDoubleCompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<double>()),
-            ::testing::ValuesIn(resultInputs<int64_t>()),
-            ::testing::Values(xselectOracle<double, int64_t>)));
-
-class Int32SelectDoubleCompareTest : public SelectTest<double, int32_t> {};
-
-TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
-    SKIP_ON_AARCH64(MissingImplementation);
+TEST_P(Int32SelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
 
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int32 args=[Double, Double, Int32, Int32]"
+        "(method return=Int32 args=[Int32, Int32]"
         "  (block"
         "    (ireturn"
         "      (iselect"
-        "        (dcmplt"
-        "          (dload parm=0)"
-        "          (dload parm=1))"
-        "        (iload parm=2)"
-        "        (iload parm=3))"
-        ")))");
-    auto trees = parseString(inputTrees);
-
-    ASSERT_NOTNULL(trees);
-
-    Tril::DefaultCompiler compiler(trees);
-
-    int32_t compileResult = compiler.compile();
-    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
-
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(double, double, int32_t, int32_t)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
-}
-
-TEST_P(Int32SelectDoubleCompareTest, UsingConst) {
-    SKIP_ON_AARCH64(MissingImplementation);
-
-    auto param = to_struct(GetParam());
-
-    char inputTrees[512] = {0};
-    std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int32 args=[Double, Double]"
-        "  (block"
-        "    (ireturn"
-        "      (iselect"
-        "        (dcmplt"
-        "          (dload parm=0)"
-        "          (dload parm=1))"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iload parm=1))"
         "        (iconst %d)"
-        "        (iconst %d))"
-        ")))",
+        "        (iconst %d))))))",
+        xcmpSuffix<int32_t>(param.cmp),
         param.v1,
         param.v2);
     auto trees = parseString(inputTrees);
@@ -371,35 +1023,35 @@ TEST_P(Int32SelectDoubleCompareTest, UsingConst) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(double, double)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectDoubleCompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<double>()),
-            ::testing::ValuesIn(resultInputs<int32_t>()),
-            ::testing::Values(xselectOracle<double, int32_t>)));
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
 
+class Int64SelectInt32CompareTest : public SelectCompareTest<int32_t, int64_t> {};
 
-class ShortSelectDoubleCompareTest : public SelectTest<double, int16_t> {};
+TEST_P(Int64SelectInt32CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
 
-TEST_P(ShortSelectDoubleCompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int16 args=[Double, Double, Int16, Int16]"
+        "(method return=Int64 args=[Int32, Int32, Int64, Int64]"
         "  (block"
-        "    (ireturn"
-        "      (s2i"
-        "        (sselect"
-        "          (dcmplt"
-        "            (dload parm=0)"
-        "            (dload parm=1))"
-        "          (sload parm=2)"
-        "          (sload parm=3))"
-        "))))");
+        "    (lreturn"
+        "      (lselect"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iload parm=1))"
+        "        (lload parm=2)"
+        "        (lload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -409,26 +1061,58 @@ TEST_P(ShortSelectDoubleCompareTest, UsingLoadParam) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<int16_t (*)(double, double, int16_t, int16_t)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t, int32_t, int64_t, int64_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(ShortSelectDoubleCompareTest, UsingConst) {
+TEST_P(Int64SelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Int16 args=[Double, Double]"
+        "(method return=Int64 args=[Int32, Int64, Int64]"
         "  (block"
-        "    (ireturn"
-        "      (s2i"
-        "        (sselect"
-        "          (dcmplt"
-        "            (dload parm=0)"
-        "            (dload parm=1))"
-        "          (sconst %d)"
-        "          (sconst %d))"
-        "))))",
+        "    (lreturn"
+        "      (lselect"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iconst %d))"
+        "        (lload parm=1)"
+        "        (lload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t, int64_t, int64_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int64SelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int32, Int32]"
+        "  (block"
+        "    (lreturn"
+        "      (lselect"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iload parm=1))"
+        "        (lconst %" OMR_PRId64 ")"
+        "        (lconst %" OMR_PRId64 "))))))",
+        xcmpSuffix<int32_t>(param.cmp),
         param.v1,
         param.v2);
     auto trees = parseString(inputTrees);
@@ -440,17 +1124,17 @@ TEST_P(ShortSelectDoubleCompareTest, UsingConst) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<int16_t (*)(double, double)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(SelectTest, ShortSelectDoubleCompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<double>()),
-            ::testing::ValuesIn(resultInputs<int16_t>()),
-            ::testing::Values((xselectOracle<double, int16_t>))));
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int64SelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<int64_t>())));
 
-class FloatSelectInt32CompareTest : public SelectTest<int32_t, float> {};
+class FloatSelectInt32CompareTest : public SelectCompareTest<int32_t, float> {};
 
 TEST_P(FloatSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
@@ -465,12 +1149,12 @@ TEST_P(FloatSelectInt32CompareTest, UsingLoadParam) {
         "  (block"
         "    (freturn"
         "      (fselect"
-        "        (icmplt"
+        "        (icmp%s"
         "          (iload parm=0)"
         "          (iload parm=1))"
         "        (fload parm=2)"
-        "        (fload parm=3))"
-        ")))");
+        "        (fload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -481,26 +1165,61 @@ TEST_P(FloatSelectInt32CompareTest, UsingLoadParam) {
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<float (*)(int32_t, int32_t, float, float)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(FloatSelectInt32CompareTest, UsingConst) {
+TEST_P(FloatSelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Float"
+        "(method return=Float args=[Int32, Float, Float]"
         "  (block"
         "    (freturn"
         "      (fselect"
-        "        (icmplt"
-        "          (iconst %d)"
+        "        (icmp%s"
+        "          (iload parm=0)"
         "          (iconst %d))"
+        "        (fload parm=1)"
+        "        (fload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(int32_t, float, float)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(FloatSelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float args=[Int32, Int32]"
+        "  (block"
+        "    (freturn"
+        "      (fselect"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iload parm=1))"
         "        (fconst %f)"
-        "        (fconst %f))"
-        ")))",
-        param.c1,
-        param.c2,
+        "        (fconst %f))))))",
+        xcmpSuffix<int32_t>(param.cmp),
         param.v1,
         param.v2);
     auto trees = parseString(inputTrees);
@@ -512,17 +1231,17 @@ TEST_P(FloatSelectInt32CompareTest, UsingConst) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<float (*)(void)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
+    auto entry_point = compiler.getEntryPoint<float (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(SelectTest, FloatSelectInt32CompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<int32_t>()),
-            ::testing::ValuesIn(resultInputs<float>()),
-            ::testing::Values(xselectOracle<int32_t, float>)));
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, FloatSelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<float>())));
 
-class DoubleSelectInt32CompareTest : public SelectTest<int32_t, double> {};
+class DoubleSelectInt32CompareTest : public SelectCompareTest<int32_t, double> {};
 
 TEST_P(DoubleSelectInt32CompareTest, UsingLoadParam) {
     SKIP_ON_X86(MissingImplementation);
@@ -537,12 +1256,12 @@ TEST_P(DoubleSelectInt32CompareTest, UsingLoadParam) {
         "  (block"
         "    (dreturn"
         "      (dselect"
-        "        (icmplt"
+        "        (icmp%s"
         "          (iload parm=0)"
         "          (iload parm=1))"
         "        (dload parm=2)"
-        "        (dload parm=3))"
-        ")))");
+        "        (dload parm=3))))))",
+        xcmpSuffix<int32_t>(param.cmp));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -553,26 +1272,61 @@ TEST_P(DoubleSelectInt32CompareTest, UsingLoadParam) {
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<double (*)(int32_t, int32_t, double, double)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(DoubleSelectInt32CompareTest, UsingConst) {
+TEST_P(DoubleSelectInt32CompareTest, UsingConstCompare) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-        "(method return=Double"
+        "(method return=Double args=[Int32, Double, Double]"
         "  (block"
         "    (dreturn"
         "      (dselect"
-        "        (icmplt"
-        "          (iconst %d)"
+        "        (icmp%s"
+        "          (iload parm=0)"
         "          (iconst %d))"
+        "        (dload parm=1)"
+        "        (dload parm=2))))))",
+        xcmpSuffix<int32_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(int32_t, double, double)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(DoubleSelectInt32CompareTest, UsingConstValues) {
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double args=[Int32, Int32]"
+        "  (block"
+        "    (dreturn"
+        "      (dselect"
+        "        (icmp%s"
+        "          (iload parm=0)"
+        "          (iload parm=1))"
         "        (dconst %f)"
-        "        (dconst %f))"
-        ")))",
-        param.c1,
-        param.c2,
+        "        (dconst %f))))))",
+        xcmpSuffix<int32_t>(param.cmp),
         param.v1,
         param.v2);
     auto trees = parseString(inputTrees);
@@ -584,12 +1338,527 @@ TEST_P(DoubleSelectInt32CompareTest, UsingConst) {
     int32_t compileResult = compiler.compile();
     ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
-    auto entry_point = compiler.getEntryPoint<double (*)(void)>();
-    ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
+    auto entry_point = compiler.getEntryPoint<double (*)(int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(SelectTest, DoubleSelectInt32CompareTest,
-        ::testing::Combine(
-            ::testing::ValuesIn(compareInputs<int32_t>()),
-            ::testing::ValuesIn(resultInputs<double>()),
-            ::testing::Values(xselectOracle<int32_t, double>)));
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, DoubleSelectInt32CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int32_t>()),
+        ::testing::ValuesIn(resultInputs<double>())));
+
+class Int32SelectInt8CompareTest : public SelectCompareTest<int8_t, int32_t> {};
+
+TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int8, Int8, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (bcmp%s"
+        "          (bload parm=0)"
+        "          (bload parm=1))"
+        "        (iload parm=2)"
+        "        (iload parm=3))))))",
+        xcmpSuffix<int8_t>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int8_t, int8_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int8, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (bcmp%s"
+        "          (bload parm=0)"
+        "          (bconst %" OMR_PRId8 "))"
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<int8_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int8_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt8CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int8, Int8]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (bcmp%s"
+        "          (bload parm=0)"
+        "          (bload parm=1))"
+        "        (iconst %d)"
+        "        (iconst %d))))))",
+        xcmpSuffix<int8_t>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int8_t, int8_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectInt8CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int8_t>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
+
+class Int32SelectInt16CompareTest : public SelectCompareTest<int16_t, int32_t> {};
+
+TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int16, Int16, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (scmp%s"
+        "          (sload parm=0)"
+        "          (sload parm=1))"
+        "        (iload parm=2)"
+        "        (iload parm=3))))))",
+        xcmpSuffix<int16_t>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int16_t, int16_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int16, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (scmp%s"
+        "          (sload parm=0)"
+        "          (sconst %" OMR_PRId16 "))"
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<int16_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int16_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt16CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int16, Int16]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (scmp%s"
+        "          (sload parm=0)"
+        "          (sload parm=1))"
+        "        (iconst %d)"
+        "        (iconst %d))))))",
+        xcmpSuffix<int16_t>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int16_t, int16_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectInt16CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int16_t>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
+
+class Int32SelectInt64CompareTest : public SelectCompareTest<int64_t, int32_t> {};
+
+TEST_P(Int32SelectInt64CompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int64, Int64, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (lcmp%s"
+        "          (lload parm=0)"
+        "          (lload parm=1))"
+        "        (iload parm=2)"
+        "        (iload parm=3))))))",
+        xcmpSuffix<int64_t>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int64_t, int64_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt64CompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int64, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (lcmp%s"
+        "          (lload parm=0)"
+        "          (lconst %" OMR_PRId64 "))"
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<int64_t>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int64_t, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectInt64CompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int64, Int64]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (lcmp%s"
+        "          (lload parm=0)"
+        "          (lload parm=1))"
+        "        (iconst %d)"
+        "        (iconst %d))))))",
+        xcmpSuffix<int64_t>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int64_t, int64_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectInt64CompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<int64_t>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
+
+class Int32SelectFloatCompareTest : public SelectCompareTest<float, int32_t> {};
+
+TEST_P(Int32SelectFloatCompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Float, Float, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (fcmp%s"
+        "          (fload parm=0)"
+        "          (fload parm=1))"
+        "        (iload parm=2)"
+        "        (iload parm=3))))))",
+        xcmpSuffix<float>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(float, float, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectFloatCompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    if (std::isnan(param.c2)) {
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
+    }
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Float, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (fcmp%s"
+        "          (fload parm=0)"
+        "          (fconst %f))"
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<float>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(float, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectFloatCompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Float, Float]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (fcmp%s"
+        "          (fload parm=0)"
+        "          (fload parm=1))"
+        "        (iconst %d)"
+        "        (iconst %d))))))",
+        xcmpSuffix<float>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(float, float)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectFloatCompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<float>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));
+
+class Int32SelectDoubleCompareTest : public SelectCompareTest<double, int32_t> {};
+
+TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Double, Double, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (dcmp%s"
+        "          (dload parm=0)"
+        "          (dload parm=1))"
+        "        (iload parm=2)"
+        "        (iload parm=3))))))",
+        xcmpSuffix<double>(param.cmp));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(double, double, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectDoubleCompareTest, UsingConstCompare) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    if (std::isnan(param.c2)) {
+        SKIP_ON_ZOS(KnownBug) << "TRIL parser cannot handle NaN values on zOS (see issue #5183)";
+        SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
+    }
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Double, Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (dcmp%s"
+        "          (dload parm=0)"
+        "          (dconst %f))"
+        "        (iload parm=1)"
+        "        (iload parm=2))))))",
+        xcmpSuffix<double>(param.cmp),
+        param.c2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(double, int32_t, int32_t)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.v1, param.v2));
+}
+
+TEST_P(Int32SelectDoubleCompareTest, UsingConstValues) {
+    SKIP_ON_ARM(MissingImplementation);
+
+    auto param = to_struct(GetParam());
+
+    char inputTrees[512] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Double, Double]"
+        "  (block"
+        "    (ireturn"
+        "      (iselect"
+        "        (dcmp%s"
+        "          (dload parm=0)"
+        "          (dload parm=1))"
+        "        (iconst %d)"
+        "        (iconst %d))))))",
+        xcmpSuffix<double>(param.cmp),
+        param.v1,
+        param.v2);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    int32_t compileResult = compiler.compile();
+    ASSERT_EQ(0, compileResult) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(double, double)>();
+    ASSERT_EQ(xselectOracle(xcmpOracle(param.cmp, param.c1, param.c2), param.v1, param.v2), entry_point(param.c1, param.c2));
+}
+
+INSTANTIATE_TEST_CASE_P(SelectCompareTest, Int32SelectDoubleCompareTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(allComparisons()),
+        ::testing::ValuesIn(compareInputs<double>()),
+        ::testing::ValuesIn(resultInputs<int32_t>())));


### PR DESCRIPTION
This PR performs major refactors primarily focusing on the `*select` evaluators in the Power codegen:

- Split floating-point and integer select evaluation into two separate evaluators
- Switch from a control flow pseudoinstruction to internal control flow for the branching sequence
- Add an optimization to switch the order of the operands to avoid register shuffles due to `gprClobberEvaluate`
- Exploit `isel` to perform branchless integer selects on POWER10
- Add a general API for evaluating a node to a condition register bit, reusing infrastructure from the newly refactored compare evaluators
- Move compare operand flipping into `evaluateThreeWayIntCompareToConditionRegister`
- Improve Tril test coverage for these evaluators