### PR TITLE
Add Andrew Craik as IL code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,7 +39,7 @@
 # Compiler
 /compiler/ @0xdaryl @mstoodle
 /compiler/optimizer/ @vijaysun-omr @andrewcraik
-/compiler/il/ @vijaysun-omr @Leonardo2718
+/compiler/il/ @vijaysun-omr @Leonardo2718 @andrewcraik
 /compiler/arm/ @0xdaryl @knn-k
 /compiler/aarch64/ @0xdaryl @knn-k
 /compiler/z/ @fjeremic


### PR DESCRIPTION
Given how tightly coupled the optimizer is to the IL I am adding myself as an
owner of the IL since I want to be involved in the designs/reviews and be aware
of impacts on the optimizer of any such changes.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>