### PR TITLE
Fix a call to strncpy() in omrsharedhelper.c

### DIFF
--- a/port/unix/omrsharedhelper.c
+++ b/port/unix/omrsharedhelper.c
@@ -434,8 +434,7 @@ omr_unlinkControlFile(struct OMRPortLibrary* portLibrary, const char *controlFil
 				controlFileStatus->errorMsg = omrmem_allocate_memory(portLibrary, msgLen+1, OMR_GET_CALLSITE(), 
 OMRMEM_CATEGORY_PORT_LIBRARY);
 				if (NULL != controlFileStatus->errorMsg) {
-					strncpy(controlFileStatus->errorMsg, unlinkErrMsg, msgLen);
-					controlFileStatus->errorMsg[msgLen] = '\0';
+					strncpy(controlFileStatus->errorMsg, unlinkErrMsg, msgLen+1);
 				}
 			}
 			rc = FALSE;


### PR DESCRIPTION
This commit fixes a call to strncpy() in port/unix/omrsharedhelper.c.
Compiler generates a warning without this fix, depending on compiler
version.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>