### PR TITLE
Explicitly specify target in Compilation constructor

### DIFF
--- a/compiler/compile/Compilation.hpp
+++ b/compiler/compile/Compilation.hpp
@@ -49,7 +49,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
          TR::Options &options,
          TR::Region &heapMemoryRegion,
          TR_Memory *memory,
-         TR_OptimizationPlan *optimizationPlan) :
+         TR_OptimizationPlan *optimizationPlan,
+         TR::Environment *target = NULL) :
       OMR::CompilationConnector(
          compThreadId,
          omrVMThread,
@@ -59,7 +60,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
          options,
          heapMemoryRegion,
          memory,
-         optimizationPlan)
+         optimizationPlan,
+         target)
       {}
 
    ~Compilation() {}

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -204,7 +204,8 @@ OMR::Compilation::Compilation(
       TR::Options &options,
       TR::Region &heapMemoryRegion,
       TR_Memory *m,
-      TR_OptimizationPlan *optimizationPlan) :
+      TR_OptimizationPlan *optimizationPlan,
+      TR::Environment *target) :
    _signature(compilee->signature(m)),
    _options(&options),
    _heapMemoryRegion(heapMemoryRegion),
@@ -294,9 +295,17 @@ OMR::Compilation::Compilation(
    _gpuPtxCount(0),
    _bitVectorPool(self()),
    _typeLayoutMap((LayoutComparator()), LayoutAllocator(self()->region())),
-   _target(TR::Compiler->target),
    _tlsManager(*self())
    {
+   if (target != NULL)
+      {
+      _target = *target;
+      }
+   else
+      {
+      _target = TR::Compiler->target;
+      }
+
    //Avoid expensive initialization and uneeded option checking if we are doing AOT Loads
    if (_optimizationPlan && _optimizationPlan->getIsAotLoad())
       {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -300,7 +300,8 @@ public:
          TR::Options &,
          TR::Region &heapMemoryRegion,
          TR_Memory *,
-         TR_OptimizationPlan *optimizationPlan
+         TR_OptimizationPlan *optimizationPlan,
+         TR::Environment *target = NULL
          );
 
    TR::SymbolReference * getSymbolReferenceByReferenceNumber(int32_t referenceNumber);


### PR DESCRIPTION
This is needed so that the codegen is able to set the correct
flags when initializing.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>