### PR TITLE
CMake: Fix typo in FindDiaSDK

### DIFF
--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -59,7 +59,7 @@ if(NOT DiaSDK_ROOT)
 		endif()
 	endif()
 
-	if(DIA_COM_DLL_DIR AND EXISTS DIA_COM_DLL_DIR)
+	if(DIA_COM_DLL_DIR AND EXISTS "${DIA_COM_DLL_DIR}")
 		# The DLL will live in  "X/DIA SDK/lib" or "X/DIA SDK/lib/amd64"
 		if(DIA_COM_DLL_DIR MATCHES "amd64$")
 			set(DiaSDK_ROOT "${DIA_COM_DLL_DIR}/../..")


### PR DESCRIPTION
if(EXISTS ...) does not auto expand variables, like other if() commands

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>