### PR TITLE
Fix compiler tests causing lots of warnings

### DIFF
--- a/cmake/modules/OmrTargetSupport.cmake
+++ b/cmake/modules/OmrTargetSupport.cmake
@@ -33,7 +33,7 @@ include(OmrUtility)
 # At present, a thin wrapper around add_library, but it ensures that exports
 # and split debug info are handled
 function(omr_add_library name)
-	set(options SHARED STATIC OBJECT INTERFACE)
+	set(options SHARED STATIC OBJECT INTERFACE NOWARNINGS)
 	set(oneValueArgs OUTPUT_NAME)
 	set(multiValueArgs)
 
@@ -73,7 +73,7 @@ function(omr_add_library name)
 		set_target_properties(${name} PROPERTIES OUTPUT_NAME "${opt_OUTPUT_NAME}")
 	endif()
 
-	if(NOT lib_type STREQUAL "INTERFACE")
+	if(NOT opt_NOWARNINGS AND NOT lib_type STREQUAL "INTERFACE")
 		if(OMR_WARNINGS_AS_ERRORS)
 			target_compile_options(${name} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 		endif()
@@ -96,7 +96,7 @@ endfunction()
 # At present, a thin wrapper around add_executable, but it ensures that
 # split debug info is handled
 function(omr_add_executable name)
-	set(options)
+	set(options NOWARNINGS)
 	set(oneValueArgs OUTPUT_NAME)
 	set(multiValueArgs)
 
@@ -107,14 +107,16 @@ function(omr_add_executable name)
 
 	add_executable(${name} ${opt_UNPARSED_ARGUMENTS})
 
-	if(OMR_WARNINGS_AS_ERRORS)
-		target_compile_options(${name} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
-	endif()
+	if(NOT opt_NOWARNINGS)
+		if(OMR_WARNINGS_AS_ERRORS)
+			target_compile_options(${name} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
+		endif()
 
-	if(OMR_ENHANCED_WARNINGS)
-		target_compile_options(${name} PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
-	else()
-		target_compile_options(${name} PRIVATE ${OMR_BASE_WARNING_FLAGS})
+		if(OMR_ENHANCED_WARNINGS)
+			target_compile_options(${name} PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
+		else()
+			target_compile_options(${name} PRIVATE ${OMR_BASE_WARNING_FLAGS})
+		endif()
 	endif()
 
 	if(opt_OUTPUT_NAME)

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -69,7 +69,7 @@ create_omr_compiler_library(
 # Export paths for dependent objects
 make_compiler_target(testcompiler INTERFACE COMPILER testcompiler)
 
-omr_add_executable(compilertest
+omr_add_executable(compilertest NOWARNINGS
 	tests/main.cpp
 	tests/BuilderTest.cpp
 	tests/FooBarTest.cpp

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -34,7 +34,7 @@ if(OMR_HOST_OS STREQUAL "win")
 	add_compile_options(-bigobj)
 endif()
 
-omr_add_executable(comptest
+omr_add_executable(comptest NOWARNINGS
 	main.cpp
 	JitTest.cpp
 	JitTestUtilitiesTest.cpp

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -41,7 +41,7 @@ if(OMR_ARCH_POWER)
 	)
 endif()
 
-omr_add_executable(compunittest ${COMPCGTEST_FILES})
+omr_add_executable(compunittest NOWARNINGS ${COMPCGTEST_FILES})
 
 # For the time being, link against Tril even though we don't really need Tril itself. This is done
 # to avoid needing to duplicate the boilerplate in Tril's CMakeLists.txt.

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-omr_add_executable(jitbuildertest
+omr_add_executable(jitbuildertest NOWARNINGS
 	main.cpp
 	selftest.cpp
 	UnionTest.cpp

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-omr_add_executable(incordec
+omr_add_executable(incordec NOWARNINGS
 	main.cpp
 )
 

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-omr_add_executable(mandelbrot
+omr_add_executable(mandelbrot NOWARNINGS
 	main.cpp
 )
 

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -28,7 +28,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-omr_add_executable(triltest
+omr_add_executable(triltest NOWARNINGS
 	main.cpp
 	ASTTest.cpp
 	ParserTest.cpp

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(TRIL_BACKEND_LIB      testcompiler)
 
-omr_add_library(tril STATIC
+omr_add_library(tril NOWARNINGS STATIC
 	ast.cpp
 	parser.cpp
 	ilgen.cpp
@@ -62,10 +62,10 @@ if(NOT OMR_HOST_OS STREQUAL "win")
 endif()
 
 
-omr_add_executable(tril_dumper compiler.cpp)
+omr_add_executable(tril_dumper NOWARNINGS compiler.cpp)
 target_link_libraries(tril_dumper tril)
 
-omr_add_executable(tril_compiler compiler.cpp)
+omr_add_executable(tril_compiler NOWARNINGS compiler.cpp)
 target_link_libraries(tril_compiler tril)
 
 # The platform specific ${TR_CXX_COMPILE_OPTIONS} and ${TR_C_COMPILE_OPTIONS} compile options

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 macro(create_jitbuilder_test target)
-	omr_add_executable(${target} ${ARGN})
+	omr_add_executable(${target} NOWARNINGS ${ARGN})
 	target_include_directories(${target} PUBLIC cpp/include)
 	target_link_libraries(${target}
 		jitbuilder


### PR DESCRIPTION
During a previous change, adding the warning flags was moved into
omr_add_executable and omr_add_library. Unfortunately, the OMR compiler
is not yet ready to be compiled with warnings and this causes the
compiler tests to spam lots of warnings. To correct this, these
functions now accept an extra "NOWARNINGS" option that disables this
behaviour, which the OMR compiler uses for its tests and examples.

Fixes: #5296
Signed-off-by: Benjamin Thomas <ben@benthomas.ca>