### PR TITLE
AArch64: Enable Register Association

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1067,6 +1067,12 @@ class ARM64AdminInstruction : public TR::Instruction
    TR::Node *getFenceNode() { return _fenceNode; }
 
    /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -459,6 +459,12 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *preced = 0);
 
    /**
+    * @brief Determines whether register association is enabled
+    * @return true if register association is enabled
+    */
+   bool enableRegisterAssociations() { return true; }
+
+   /**
     * @brief Returns bit mask for real register
     * @param[in] reg: real register number
     * 

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -481,5 +481,6 @@
 		dd,    // Define word
 		label, // Destination of a jump
 		vgdnop, // Virtual Guard NOP instruction
-		ARM64LastOp = vgdnop,
+		assocreg, // Associate real registers with Virtual registers.
+		ARM64LastOp = assocreg,
 		ARM64NumOpCodes = ARM64LastOp+1,

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -157,12 +157,60 @@ public:
     */
    void decFutureUseCountAndUnlatch(TR::Instruction *currentInstruction, TR::Register *virtualRegister);
 
+   // Register Association Stuff ///////////////
+
+   /**
+    * @brief Sets register weights from register associations
+    *
+    */
+   void setRegisterWeightsFromAssociations();
+
+   /**
+    * @brief Creates a regassoc pseudo instruction
+    *
+    */
+   void createRegisterAssociationDirective(TR::Instruction *cursor);
+
+   /**
+    * @brief Returns a virtual register associted to the passed real register.
+    *
+    * @param regNum                 : real register number
+    */
+   TR::Register *getVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum)
+      {
+      return _registerAssociations[regNum];
+      }
+
+   /**
+    * @brief Associates the virtual register to the real register.
+    *
+    * @param regNum                 : real register number
+    * @param virtReg                : virtual register
+    * @returns virtual register
+    */
+   TR::Register *setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register *virtReg);
+
+
+   /**
+    * @brief Clears register association
+    *
+    */
+   void clearRegisterAssociations()
+      {
+      memset(_registerAssociations, 0, sizeof(TR::Register *) * (TR::RealRegister::NumRegisters));
+      }
+
 private:
 
    // For register snap shot
    uint16_t                   _registerFlagsSnapShot[TR::RealRegister::NumRegisters];
    TR::RealRegister::RegState _registerStatesSnapShot[TR::RealRegister::NumRegisters];
    TR::Register               *_assignedRegisterSnapShot[TR::RealRegister::NumRegisters];
+   TR::Register               *_registerAssociationsSnapShot[TR::RealRegister::NumRegisters];
+   uint16_t                   _registerWeightSnapShot[TR::RealRegister::NumRegisters];
+
+   // register association
+   TR::Register               *_registerAssociations[TR::RealRegister::NumRegisters];
 
    void initializeRegisterFile();
    };

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -64,12 +64,28 @@ public:
 
    /**
     * @brief Finds the best free register
+    * @param[in] currentInstruction : current instruction
+    * @param[in] rk : register kind
+    * @param[in] considerUnlatched : consider unlatched state or not
+    * @param[in] virtualReg : virtual register
+    * @return Free RealRegister
+    */
+   TR::RealRegister *findBestFreeRegister(TR::Instruction *currentInstruction,
+                                            TR_RegisterKinds rk,
+                                            bool considerUnlatched = false,
+                                            TR::Register *virtualReg = NULL);
+
+   /**
+    * @brief Finds the best free register
     * @param[in] rk : register kind
     * @param[in] considerUnlatched : consider unlatched state or not
     * @return Free RealRegister
     */
    TR::RealRegister *findBestFreeRegister(TR_RegisterKinds rk,
-                                            bool considerUnlatched = false);
+                                            bool considerUnlatched = false)
+      {
+      return findBestFreeRegister(NULL, rk, considerUnlatched);
+      }
 
    /**
     * @brief Frees the best register

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -669,7 +669,7 @@ void OMR::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstru
          {
          if (_baseRegister->getTotalUseCount() == _baseRegister->getFutureUseCount())
             {
-            if ((assignedBaseRegister = machine->findBestFreeRegister(TR_GPR, true)) == NULL)
+            if ((assignedBaseRegister = machine->findBestFreeRegister(currentInstruction, TR_GPR, true, _baseRegister)) == NULL)
                {
                assignedBaseRegister = machine->freeBestRegister(currentInstruction, _baseRegister);
                }
@@ -701,7 +701,7 @@ void OMR::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstru
          {
          if (_indexRegister->getTotalUseCount() == _indexRegister->getFutureUseCount())
             {
-            if ((assignedIndexRegister = machine->findBestFreeRegister(TR_GPR, false)) == NULL)
+            if ((assignedIndexRegister = machine->findBestFreeRegister(currentInstruction, TR_GPR, false, _indexRegister)) == NULL)
                {
                assignedIndexRegister = machine->freeBestRegister(currentInstruction, _indexRegister);
                }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -475,7 +475,7 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
             {
             if (virtReg->getTotalUseCount() == virtReg->getFutureUseCount())
                {
-               if ((assignedRegister = machine->findBestFreeRegister(virtReg->getKind(), true)) == NULL)
+               if ((assignedRegister = machine->findBestFreeRegister(currentInstruction, virtReg->getKind(), true, virtReg)) == NULL)
                   {
                   assignedRegister = machine->freeBestRegister(currentInstruction, virtReg, NULL);
                   }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -157,7 +157,8 @@ class TR_ARM64RegisterDependencyGroup
       {
       for (uint32_t i = 0; i < numberOfRegisters; i++)
          {
-         _dependencies[i].getRegister()->block();
+         if (_dependencies[i].getRegister())
+            _dependencies[i].getRegister()->block();
          }
       }
 
@@ -169,7 +170,8 @@ class TR_ARM64RegisterDependencyGroup
       {
       for (uint32_t i = 0; i < numberOfRegisters; i++)
          {
-         _dependencies[i].getRegister()->unblock();
+         if (_dependencies[i].getRegister())
+            _dependencies[i].getRegister()->unblock();
          }
       }
    };

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1152,6 +1152,7 @@ public:
    void printARM64GCRegisterMap(TR::FILE *, TR::GCRegisterMap *);
    void printInstructionComment(TR::FILE *, int32_t, TR::Instruction *);
    void printMemoryReferenceComment(TR::FILE *, TR::MemoryReference *);
+   void printAssocRegDirective(TR::FILE *, TR::Instruction *);
 
    const char *getARM64RegisterName(uint32_t, bool = true);
 


### PR DESCRIPTION
Implement Register Association for aarch64.

- Introduce `assocreg` pseudo instruction.
- Keep track of the real register to virtual register mappings
  which are set up by register dependencies.
- Emit `assocreg` instructions at the end of every extended basic block.
- Emit `assocreg` instructions when setting up register dependencies.
- In register assignment phase, update virtual register to real register mappings
  when we encounter an `assocreg` instruction.

- Enhance `findBestFreeRegister` and `freeBestRegister` to use register assocations.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>