### PR TITLE
Use Snippet to load methodPointer in remote compile

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -288,8 +288,16 @@ genLoadAddressConstant(TR::CodeGenerator * cg, TR::Node * node, uintptr_t value,
    if (node->isClassUnloadingConst())
       {
       uintptr_t value = node->getAddress();
-      TR::Instruction *unloadableConstInstr = generateRILInstruction(cg, TR::InstOpCode::LARL, node, targetRegister, reinterpret_cast<void*>(value));
-      TR_OpaqueClassBlock* unloadableClass = NULL;
+      TR::Instruction *unloadableConstInstr = NULL;
+      if (cg->canUseRelativeLongInstructions(value))
+         {
+         unloadableConstInstr = generateRILInstruction(cg, TR::InstOpCode::LARL, node, targetRegister, reinterpret_cast<void*>(value));
+         }
+      else
+         {
+         unloadableConstInstr = genLoadAddressConstantInSnippet(cg, node, value, targetRegister, NULL, NULL, NULL, true);
+         }
+
       if (node->isMethodPointerConstant())
          {
          comp->getStaticMethodPICSites()->push_front(unloadableConstInstr);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -4931,7 +4931,15 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
             && constNode->isClassUnloadingConst())
       {
       uintptr_t value = constNode->getAddress();
-      TR::Instruction *unloadableConstInstr = generateRILInstruction(cg, TR::InstOpCode::LARL, node, tempReg, reinterpret_cast<void*>(value));
+      TR::Instruction *unloadableConstInstr = NULL;
+      if (cg->canUseRelativeLongInstructions(value))
+         {
+         unloadableConstInstr = generateRILInstruction(cg, TR::InstOpCode::LARL, node, tempReg, reinterpret_cast<void*>(value));
+         }
+      else
+         {
+         unloadableConstInstr = genLoadAddressConstantInSnippet(cg, node, value, tempReg, NULL, NULL, NULL, true);
+         }
       TR_OpaqueClassBlock* unloadableClass = NULL;
       if (constNode->isMethodPointerConstant())
          {


### PR DESCRIPTION
Relocatable compiles such as remote compilations in openj9 don't allow the use of PC relative instructions like LARL. This commit prevents the use of such an instruction when
tring to load a methodPointerConstant.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>