### PR TITLE
AArch64: Fix order of calls to maintain the proper live state of registers

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -124,9 +124,9 @@ genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstO
       generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -324,9 +324,9 @@ OMR::ARM64::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -368,9 +368,9 @@ OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       cg->stopUsingRegister(tmpReg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -417,9 +417,9 @@ OMR::ARM64::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -435,9 +435,9 @@ static TR::Register *idivHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
 
    generateTrg1Src2Instruction(cg, is64bit ? TR::InstOpCode::sdivx : TR::InstOpCode::sdivw, node, trgReg, src1Reg, src2Reg);
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -456,9 +456,9 @@ static TR::Register *iremHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
    generateTrg1Src3Instruction(cg, is64bit ? TR::InstOpCode::msubx : TR::InstOpCode::msubw, node, trgReg, tmpReg, src2Reg, src1Reg);
 
    cg->stopUsingRegister(tmpReg);
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -492,9 +492,9 @@ OMR::ARM64::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       cg->stopUsingRegister(tmpReg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 
@@ -922,9 +922,9 @@ logicBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstOpC
       generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
       }
 
+   node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
-   node->setRegister(trgReg);
    return trgReg;
    }
 

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -404,8 +404,8 @@ commonFpUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, bool isDoubl
       trgReg = srcReg;
       }
    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
-   cg->decReferenceCount(firstChild);
    node->setRegister(trgReg);
+   cg->decReferenceCount(firstChild);
    return trgReg;
    }
 

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -918,8 +918,8 @@ OMR::ARM64::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR::CodeGenerato
    {
    TR::Node *child = node->getFirstChild();
    TR::Register *trgReg = cg->evaluate(child);
-   cg->decReferenceCount(child);
    node->setRegister(trgReg);
+   cg->decReferenceCount(child);
    return trgReg;
    }
 

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -88,8 +88,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeG
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *reg = cg->gprClobberEvaluate(firstChild);
    generateNegInstruction(cg, node, reg, reg);
+   node->setRegister(reg);
    cg->decReferenceCount(firstChild);
-   return node->setRegister(reg);
+   return reg;
    }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -97,8 +98,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *tempReg = cg->gprClobberEvaluate(firstChild);
    generateNegInstruction(cg, node, tempReg, tempReg, true);
+   node->setRegister(tempReg);
    cg->decReferenceCount(firstChild);
-   return node->setRegister(tempReg);
+   return tempReg;
    }
 
 static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
This commit fixes evaluators where `TR::CodeGenerator::decReferenceCount()`
is issued before a `TR::Node::setRegister()`, which kills the register too early.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>