### PR TITLE
AArch64: Fix memory reference to kill registers properly

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -521,17 +521,7 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
          {
          intptr_t amount = (subTree->getOpCodeValue() == TR::iconst) ?
                              subTree->getInt() : subTree->getLongInt();
-         if (_baseRegister != NULL)
-            {
-            self()->addToOffset(subTree, amount, cg);
-            }
-         else
-            {
-            _baseRegister = cg->allocateRegister();
-            _baseNode = subTree;
-            self()->setBaseModifiable();
-            loadConstant64(cg, subTree, amount, _baseRegister);
-            }
+         self()->addToOffset(subTree, amount, cg);
          }
       else
          {


### PR DESCRIPTION
When the node of memory reference is `aconst`/`iconst`/`lconst`,
a base register may not be killed in `decNodeReferenceCounts`
because both `_baseRegister` and `_baseNode` are not NULL.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>