### PR TITLE
AArch64: Add a method to kill temporary registers added to register dependency

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -920,6 +920,8 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
       }
 
    callNode->setRegister(retReg);
+
+   dependencies->stopUsingDepRegs(cg(), retReg);
    return retReg;
    }
 

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -277,6 +277,14 @@ OMR::ARM64::RegisterDependencyConditions::clone(
    return result;
    }
 
+void OMR::ARM64::RegisterDependencyConditions::stopUsingDepRegs(TR::CodeGenerator *cg, TR::Register *returnRegister)
+   {
+   if (_preConditions != NULL)
+      _preConditions->stopUsingDepRegs(getAddCursorForPre(), returnRegister, cg);
+   if (_postConditions != NULL)
+      _postConditions->stopUsingDepRegs(getAddCursorForPost(), returnRegister, cg);
+   }
+
 void TR_ARM64RegisterDependencyGroup::assignRegisters(
                         TR::Instruction *currentInstruction,
                         TR_RegisterKinds kindToBeAssigned,

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -172,6 +172,22 @@ class TR_ARM64RegisterDependencyGroup
          _dependencies[i].getRegister()->unblock();
          }
       }
+
+   /**
+    * @brief Kills registers held by this dependency group
+    * @param[in] numberOfRegisters : # of registers
+    * @param[in] returnRegister    : register which is not killed
+    * @param[in] cg                : CodeGenerator
+    */
+   void stopUsingDepRegs(uint32_t numberOfRegisters, TR::Register *returnRegister, TR::CodeGenerator *cg)
+      {
+      for (uint32_t i = 0; i < numberOfRegisters; i++)
+         {
+         TR::Register *depReg = _dependencies[i].getRegister();
+         if (depReg && (depReg != returnRegister))
+            cg->stopUsingRegister(depReg);
+         }
+      }
    };
 
 namespace OMR
@@ -457,6 +473,13 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
     * @param[in] cg : CodeGenerator
     */
    void bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg);
+
+   /**
+    * @brief Kills placeholder registers held by the RegisterDependencyConditions
+    * @param[in] cg : CodeGenerator
+    * @param[in] returnRegister : return register
+    */
+   void stopUsingDepRegs(TR::CodeGenerator *cg, TR::Register *returnRegister = NULL);
    };
 
 } // ARM64


### PR DESCRIPTION
Add `stopUsingDepRegs` to the register dependency class for properly killing
temporary registers added to the dependency.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>