### PR TITLE
AArch64: Change register dependency to set up live register information

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -32,6 +32,7 @@
 #include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/LiveRegister.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterIterator.hpp"
 #include "codegen/TreeEvaluator.hpp"
@@ -624,4 +625,15 @@ TR_ARM64ScratchRegisterManager *
 OMR::ARM64::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
    return new (self()->trHeapMemory()) TR_ARM64ScratchRegisterManager(capacity, self());
+   }
+
+void OMR::ARM64::CodeGenerator::setRealRegisterAssociation(TR::Register *virtualRegister, TR::RealRegister::RegNum realNum)
+   {
+   if (!virtualRegister->isLive() || realNum == TR::RealRegister::NoReg || realNum == TR::RealRegister::xzr)
+      {
+      return;
+      }
+
+   TR::RealRegister *realReg = self()->machine()->getRealRegister(realNum);
+   self()->getLiveRegisters(virtualRegister->getKind())->setAssociation(virtualRegister, realReg);
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -465,6 +465,13 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool enableRegisterAssociations() { return true; }
 
    /**
+    * @brief Set live register association
+    * @param[in] virtualRegister : virtual register
+    * @param[rn] realNum : real register number
+    */
+   void setRealRegisterAssociation(TR::Register *virtualRegister, TR::RealRegister::RegNum realNum);
+
+   /**
     * @brief Returns bit mask for real register
     * @param[in] reg: real register number
     * 

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -226,8 +226,8 @@ void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instr
       return;
 
    // We create a register association directive for each dependency
-
-   if (cg->enableRegisterAssociations() && !cg->isOutOfLineColdPath())
+   bool isOOL = cg->isOutOfLineColdPath();
+   if (cg->enableRegisterAssociations() && !isOOL)
       {
       TR::Machine *machine = cg->machine();
 
@@ -258,11 +258,21 @@ void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instr
 
    for (int i = 0; i < _addCursorForPre; i++)
       {
-      instr->useRegister(_preConditions->getRegisterDependency(i)->getRegister());
+      auto dependency = _preConditions->getRegisterDependency(i);
+      TR::Register *virtReg = dependency->getRegister();
+      TR::RealRegister::RegNum regNum = dependency->getRealRegister();
+      instr->useRegister(virtReg);
+      if (!isOOL)
+         cg->setRealRegisterAssociation(virtReg, regNum);
       }
    for (int j = 0; j < _addCursorForPost; j++)
       {
-      instr->useRegister(_postConditions->getRegisterDependency(j)->getRegister());
+      auto dependency = _postConditions->getRegisterDependency(j);
+      TR::Register *virtReg = dependency->getRegister();
+      TR::RealRegister::RegNum regNum = dependency->getRealRegister();
+      instr->useRegister(virtReg);
+      if (!isOOL)
+         cg->setRealRegisterAssociation(virtReg, regNum);
       }
    }
 


### PR DESCRIPTION
This commit changes register dependency class to set up
live register information.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>