### PR TITLE
AArch64: Use placeholder registers

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGeneratorUtils.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGeneratorUtils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,7 @@ addDependency(
    if (vreg == NULL)
       {
       vreg = cg->allocateRegister(rk);
+      vreg->setPlaceholderReg();
       }
    dep->addPreCondition(vreg, rnum);
    dep->addPostCondition(vreg, rnum);

--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -119,3 +119,16 @@ OMR::ARM64::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       cond->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned, self()->cg());
       }
    }
+
+void
+OMR::ARM64::Instruction::useRegister(TR::Register *reg, bool isDummy)
+   {
+   OMR::Instruction::useRegister(reg);
+   // If an instruction uses a dummy register, that register should no longer be considered dummy.
+   // ARM64RegisterDependencyConditions also calls useRegister, in this case we do not want to reset the dummy status of these regs
+   //
+   if (!isDummy && reg->isPlaceholderReg())
+      {
+      reg->resetPlaceholderReg();
+      }
+   }

--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -218,6 +218,13 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     */
    virtual bool dependencyRefsRegister(TR::Register *reg);
 
+   /**
+    * @brief Calls OMR::Instruction::useRegister and remove placeholder flags if isDummy is false
+    * @param[in] reg : virtual register
+    * @param[in] isDummy : dummy flag
+    */
+   void useRegister(TR::Register *reg, bool isDummy = false);
+
    /*
     * Maps to TIndex in Instruction. Here we set values specific to ARM64 CodeGen.
     *

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -261,7 +261,7 @@ void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instr
       auto dependency = _preConditions->getRegisterDependency(i);
       TR::Register *virtReg = dependency->getRegister();
       TR::RealRegister::RegNum regNum = dependency->getRealRegister();
-      instr->useRegister(virtReg);
+      instr->useRegister(virtReg, true);
       if (!isOOL)
          cg->setRealRegisterAssociation(virtReg, regNum);
       }
@@ -270,7 +270,7 @@ void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instr
       auto dependency = _postConditions->getRegisterDependency(j);
       TR::Register *virtReg = dependency->getRegister();
       TR::RealRegister::RegNum regNum = dependency->getRealRegister();
-      instr->useRegister(virtReg);
+      instr->useRegister(virtReg, true);
       if (!isOOL)
          cg->setRealRegisterAssociation(virtReg, regNum);
       }


### PR DESCRIPTION
This commit makes following changes to register dependencies and instruction class.
- Change `addDependency()` helper method to set place holder flag of virtual register
 if the virtual register is allocated in the method.
- Add `useRegister()` method to `OMR::ARM64::Instruction` class to reset place holder
 flag if the virtual register is actually used by an instruction.

Depends on https://github.com/eclipse/omr/pull/5528

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>