### PR TITLE
AArch64: Enable Live Registers

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -32,6 +32,7 @@
 #include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/LiveRegister.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterIterator.hpp"
 #include "codegen/TreeEvaluator.hpp"
@@ -70,6 +71,11 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
    self()->getLinkage()->initARM64RealRegisterLinkage();
    self()->setSupportsGlRegDeps();
    self()->setSupportsGlRegDepOnFirstBlock();
+
+   self()->addSupportedLiveRegisterKind(TR_GPR);
+   self()->addSupportedLiveRegisterKind(TR_FPR);
+   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_GPR);
+   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_FPR);
 
    self()->setSupportsVirtualGuardNOPing();
 


### PR DESCRIPTION
This commit enables Live Registers for aarch64 code generator.

Depends on:
https://github.com/eclipse/omr/pull/5516
https://github.com/eclipse/omr/pull/5526
https://github.com/eclipse/omr/pull/5527
https://github.com/eclipse/omr/pull/5528
https://github.com/eclipse/omr/pull/5529
https://github.com/eclipse/omr/pull/5530

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>