### PR TITLE
AArch64: Fix memory reference for indirect load of const node

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -203,6 +203,16 @@ OMR::ARM64::MemoryReference::MemoryReference(
             self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, rootLoadOrStore->getSymbolReference(), isStore, false));
             cg->addSnippet(self()->getUnresolvedSnippet());
             }
+         // if an aconst feeds an aloadi, we need to load the constant
+         if (base->getOpCode().isLoadConst())
+            {
+            cg->evaluate(base);
+            }
+         if (symbol->isMethodMetaData())
+            {
+            _baseRegister = cg->getMethodMetaDataRegister();
+            }
+
          self()->populateMemoryReference(rootLoadOrStore->getFirstChild(), cg);
          }
       }


### PR DESCRIPTION
This commit fixes a problem of memory reference when
root node is indirect load and the child of that node
is const. The problem was introduced by OMR #5520.

When the problem is exposed, `_baseRegister` is NULL.
This change evaluates the `base` node so that the valid value
is set to `_baseRegister` in `populateMemoryReference`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>