### PR TITLE
Fix ambiguous MemoryReference constructor call on PPC-32

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1636,7 +1636,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
                cg->addSnippet(snippet);
                }
 
-            TR::MemoryReference *fakeTocRef = new (cg->trHeapMemory()) TR::MemoryReference(NULL, 0, sizeof(uintptr_t), cg);
+            TR::MemoryReference *fakeTocRef = new (cg->trHeapMemory()) TR::MemoryReference(static_cast<TR::Register *>(NULL), 0, sizeof(uintptr_t), cg);
             fakeTocRef->setSymbol(symbol, cg);
             fakeTocRef->getSymbolReference()->copyFlags(ref);
             fakeTocRef->setUsingStaticTOC();


### PR DESCRIPTION
The NULL pointer needs to be casted to (TR::Register *) for the original intention,
otherwise it could be equally converted into (TR::Node *) or (TR::Register *).
Thus,  multiple matching for the OMRMemoryReference constructors.

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>