### PR TITLE
Provide Factory Methods for Power MemoryReference objects

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3908,24 +3908,24 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
             {
             TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, addrRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
-            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(offset), 8, cg));
+            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, LO_VALUE(offset), 8));
             }
          else
             {
-            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(cg->getTOCBaseRegister(), offset, 8, cg));
+            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, TR::MemoryReference::createWithDisplacement(cg, cg->getTOCBaseRegister(), offset, 8));
             }
 
          if(isInt64)
-            generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 8, cg));
+            generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, 0, 8));
          else
-            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 4, cg));
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, 0, 4));
          }
       else
          {
          if (cg->needRelocationsForLookupEvaluationData())
             {
             loadAddressConstant(cg, true, node, address, addrRegister);
-            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 4, cg));
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, 0, 4));
             }
          else
             {
@@ -3935,12 +3935,12 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
                {
                if (nextAddress >= 32760)
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::ldu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 8, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::ldu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 8));
                   nextAddress = 8;
                   }
                else
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 8, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 8));
                   nextAddress += 8;
                   }
                }
@@ -3948,12 +3948,12 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
                {
                if (nextAddress >= 32764)
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress = 4;
                   }
                else
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress += 4;
                   }
                } // is64BitInt ?
@@ -3969,16 +3969,16 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          nextAddress = LO_VALUE(address);
          if (nextAddress == 32760)
             {
-            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
             nextAddress += 4;
-            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister->getLowOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister->getLowOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
             nextAddress = 4;
             }
          else
             {
-            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
             nextAddress += 4;
-            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getLowOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getLowOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
             nextAddress += 4;
             }
          }
@@ -3986,19 +3986,19 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          {
          if (cg->comp()->compileRelocatableCode())
             {
-            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, LO_VALUE(address), 4, cg));
+            rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, LO_VALUE(address), 4));
             }
          else
             {
             nextAddress = LO_VALUE(address);
             if (nextAddress >= 32764)
                {
-               rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+               rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                nextAddress = 4;
                }
             else
                {
-               rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+               rel2 = generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                nextAddress += 4;
                }
             }
@@ -4059,12 +4059,12 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
                {
                if (nextAddress >= 32760)
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::ldu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 8, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::ldu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 8));
                   nextAddress = 8;
                   }
                else
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 8, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 8));
                   nextAddress += 8;
                   }
                }
@@ -4072,16 +4072,16 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
                {
                if (nextAddress == 32760)
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress += 4;
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister->getLowOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister->getLowOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress = 4;
                   }
                else
                   {
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getHighOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress += 4;
-                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getLowOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+                  generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister->getLowOrder(), TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                   nextAddress += 4;
                   }
                } // 64BitTarget ?
@@ -4090,12 +4090,12 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
             {
             if (nextAddress >= 32764)
                {
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+               generateTrg1MemInstruction(cg, TR::InstOpCode::lwzu, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                nextAddress = 4;
                }
             else
                {
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, nextAddress, 4, cg));
+               generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, TR::MemoryReference::createWithDisplacement(cg, addrRegister, nextAddress, 4));
                nextAddress += 4;
                }
             }
@@ -4211,11 +4211,11 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
             {
             TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != cg->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, pivotRegister, cg->getTOCBaseRegister(), cg->hiValue(offset));
-            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(pivotRegister, LO_VALUE(offset), 8, cg));
+            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, TR::MemoryReference::createWithDisplacement(cg, pivotRegister, LO_VALUE(offset), 8));
             }
          else
             {
-            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, new (cg->trHeapMemory()) TR::MemoryReference(cg->getTOCBaseRegister(), offset, 8, cg));
+            generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, addrRegister, TR::MemoryReference::createWithDisplacement(cg, cg->getTOCBaseRegister(), offset, 8));
             }
          }
       else
@@ -4252,19 +4252,19 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
       {
       if (two_reg)
          {
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister->getHighOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, pivotRegister, 4, cg));
+         generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister->getHighOrder(), TR::MemoryReference::createWithIndexReg(cg, addrRegister, pivotRegister, 4));
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, pivotRegister, pivotRegister, 4);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister->getLowOrder(), new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, pivotRegister, 4, cg));
+         generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister->getLowOrder(), TR::MemoryReference::createWithIndexReg(cg, addrRegister, pivotRegister, 4));
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, pivotRegister, pivotRegister, -4);
          }
       else
          {
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ldx, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, pivotRegister, 8, cg));
+         generateTrg1MemInstruction(cg, TR::InstOpCode::ldx, node, dataRegister, TR::MemoryReference::createWithIndexReg(cg, addrRegister, pivotRegister, 8));
          }
       }
    else
       {
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, pivotRegister, 4, cg));
+      generateTrg1MemInstruction(cg, TR::InstOpCode::lwzx, node, dataRegister, TR::MemoryReference::createWithIndexReg(cg, addrRegister, pivotRegister, 4));
       }
 
    if (isInt64)

--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -119,33 +119,33 @@ TR::Instruction *generateMvFprGprInstructions(TR::CodeGenerator *cg, TR::Node *n
       location = cg->allocateSpill(8, false, NULL);
       if ((mode == gprSp2fpr) || (mode == fpr2gprSp) || (mode == gprLow2fpr))
          {
-         tempMRStore1 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 4, cg);
-         tempMRLoad1 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, 0, 4, cg);
+         tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 4);
+         tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 0, 4);
          }
       else if (mode == gpr2fprHost32)
          {
          if (isLittleEndian)
             {
-            tempMRStore2 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 4, cg);
-            tempMRStore1 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore2, 4, 4, cg);
+            tempMRStore2 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 4);
+            tempMRStore1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore2, 4, 4);
             }
          else
             {
-            tempMRStore1 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 4, cg);
-            tempMRStore2 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, 4, 4, cg);
+            tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 4);
+            tempMRStore2 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 4, 4);
             }
-         tempMRLoad1 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 8, cg);
+         tempMRLoad1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8);
          }
       else
          {
-         tempMRStore1 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 8, cg);
+         tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8);
 
          if (mode == fpr2gprHost32)
-            tempMRLoad1 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, isLittleEndian ? 4 : 0, 4, cg);
+            tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, isLittleEndian ? 4 : 0, 4);
          if ((mode == fpr2gprHost64) || (mode == gpr2fprHost64))
-            tempMRLoad1 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, 0, 8, cg);
+            tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 0, 8);
          else
-            tempMRLoad2 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, isLittleEndian ? 0 : 4, 4, cg);
+            tempMRLoad2 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, isLittleEndian ? 0 : 4, 4);
          }
 
       if ((mode == fpr2gprHost64) || (mode == fpr2gprLow))

--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -38,6 +38,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    {
    private:
 
+   //TODO: get rid of extra int paramenter once legacy constructor is removed and replaced
    MemoryReference(TR::Register *br,
       int64_t disp,
       uint8_t len,
@@ -59,6 +60,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, len, cg) {}
 
+   //TODO: legacy constructor - should be replaced by int64_t version (called by withDisplacement)
    MemoryReference(TR::Register *br,
       int32_t disp,
       uint8_t len,
@@ -74,7 +76,15 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    MemoryReference(TR::Node *node, MemoryReference& mr, int32_t n, uint32_t len, TR::CodeGenerator *cg):
       OMR::MemoryReferenceConnector(node, mr, n, len, cg) {}
 
-   static TR::MemoryReference *withDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length);
+   static TR::MemoryReference *create(TR::CodeGenerator *cg);
+   static TR::MemoryReference *createWithLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length);
+   static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t length);
+   static TR::MemoryReference *createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length);
+   static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore, uint32_t length);
+   static TR::MemoryReference *createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, uint32_t length);
+   static TR::MemoryReference *createWithMemRef(TR::CodeGenerator *cg, TR::Node *node, TR::MemoryReference& memRef, int32_t displacement, uint32_t length);
+
+   //Keeping the old version of the createWithLabel helper here to make sure OpenJ9 doesn't break 
    static TR::MemoryReference *withLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length);
    };
 }

--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -38,7 +38,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    {
    private:
 
-   //TODO: get rid of extra int paramenter once legacy constructor is removed and replaced
    MemoryReference(TR::Register *br,
       int64_t disp,
       uint8_t len,
@@ -60,7 +59,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, len, cg) {}
 
-   //TODO: legacy constructor - should be replaced by int64_t version (called by withDisplacement)
    MemoryReference(TR::Register *br,
       int32_t disp,
       uint8_t len,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1721,11 +1721,9 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = self()->allocateRegister();
 
    cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), counterReg, cursor);
    if (cond)
       {
       uint32_t preCondCursor = cond->getAddCursorForPre();
@@ -1751,11 +1749,9 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = self()->allocateRegister();
 
    cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), counterReg, cursor);
    if (cond)
       {
       uint32_t preCondCursor = cond->getAddCursorForPre();
@@ -1791,11 +1787,9 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
    cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), counterReg, cursor);
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
    return cursor;
@@ -1812,11 +1806,9 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
    cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0, 4), counterReg, cursor);
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
    return cursor;
@@ -2266,7 +2258,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
 
       if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
          {
-         generateTrg1MemInstruction(self(), TR::InstOpCode::paddi, node, trgReg, TR::MemoryReference::withLabel(self(), label, 0, 0));
+         generateTrg1MemInstruction(self(), TR::InstOpCode::paddi, node, trgReg, TR::MemoryReference::createWithLabel(self(), label, 0, 0));
          }
       else
          {
@@ -2280,11 +2272,11 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
                {
                TR_ASSERT_FATAL_WITH_NODE(node, 0x00008000 != self()->hiValue(offset), "TOC offset (0x%x) is unexpectedly high. Can not encode upper 16 bits into an addis instruction.", offset);
                generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
-               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
+               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, TR::MemoryReference::createWithDisplacement(self(), trgReg, LO_VALUE(offset), 8));
                }
             else
                {
-               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(self()->getTOCBaseRegister(), offset, 8, self()));
+               generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, TR::MemoryReference::createWithDisplacement(self(), self()->getTOCBaseRegister(), offset, 8));
                }
             }
          else

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -82,8 +82,7 @@ TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argS
    TR::Machine *machine = self()->machine();
    const TR::PPCLinkageProperties& properties = self()->getProperties();
 
-   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
-                                                                              argSize+self()->getOffsetToFirstParm(), length, self()->cg());
+   TR::MemoryReference *result = TR::MemoryReference::createWithDisplacement(self()->cg(), machine->getRealRegister(properties.getNormalStackPointerRegister()), argSize+self()->getOffsetToFirstParm(), length);
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode;
@@ -220,14 +219,14 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                }
 
             cursor = generateMemSrc1Instruction(self()->cg(), op, firstNode,
-                        new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, length, self()->cg()),
+                        TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, length),
                         REAL_REGISTER(regNum),
                         cursor);
 
             if (twoRegs)
                {
                cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()),
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset+4, 4),
                            REAL_REGISTER(REGNUM(regNum+1)),
                            cursor);
                if (ai<0)
@@ -273,7 +272,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   if (freeScratchable.isSet(aiLow))
                      {
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, REAL_REGISTER(REGNUM(aiLow)),
-                                 new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                                 TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                      freeScratchable.reset(aiLow);
                      }
                   else
@@ -317,7 +316,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                if (freeScratchable.isSet(ai))
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, REAL_REGISTER(REGNUM(ai)),
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                   freeScratchable.reset(ai);
                   }
                else
@@ -332,7 +331,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                if (freeScratchable.isSet(ai))
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(),TR::InstOpCode::Op_load, firstNode, REAL_REGISTER(REGNUM(ai)),
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress(), self()->cg()), cursor);
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress()), cursor);
                   freeScratchable.reset(ai);
                   }
                else
@@ -352,7 +351,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   if (freeScratchable.isSet(ai))
                      {
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::ld, firstNode, REAL_REGISTER(REGNUM(ai)),
-                              new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
+                              TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 8), cursor);
                      freeScratchable.reset(ai);
                      }
                   else
@@ -368,7 +367,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   if (freeScratchable.isSet(ai))
                      {
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, REAL_REGISTER(REGNUM(ai)),
-                              new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                              TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                      freeScratchable.reset(ai);
                      }
                   else
@@ -383,7 +382,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   if (freeScratchable.isSet(ai))
                      {
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, REAL_REGISTER(REGNUM(ai)),
-                              new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()), cursor);
+                              TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset+4, 4), cursor);
                      freeScratchable.reset(ai);
                      }
                   else
@@ -399,7 +398,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                if (freeScratchable.isSet(ai))
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lfs, firstNode, REAL_REGISTER(REGNUM(ai)),
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                   freeScratchable.reset(ai);
                   }
                else
@@ -414,7 +413,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                if (freeScratchable.isSet(ai))
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lfd, firstNode, REAL_REGISTER(REGNUM(ai)),
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 8), cursor);
                   freeScratchable.reset(ai);
                   }
                else
@@ -477,7 +476,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(), op, firstNode,
                               REAL_REGISTER(REGNUM(target)),
-                              new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, source, length, self()->cg()),
+                              TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, source, length),
                               cursor);
                   }
 
@@ -529,7 +528,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, argRegister,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                }
             numIntArgs++;
             break;
@@ -538,7 +537,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(self()->cg(),TR::InstOpCode::Op_load, firstNode, argRegister,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress(), self()->cg()), cursor);
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress()), cursor);
                }
             numIntArgs++;
             break;
@@ -549,16 +548,16 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                if (self()->comp()->target().is64Bit())
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::ld, firstNode, argRegister,
-                        new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
+                        TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 8), cursor);
                else
                   {
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, argRegister,
-                        new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
+                        TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4), cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
                      argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, argRegister,
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()), cursor);
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset+4, 4), cursor);
                      }
                   }
                }
@@ -588,7 +587,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                   }
 
                cursor = generateTrg1MemInstruction(self()->cg(), op, firstNode, argRegister,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, length, self()->cg()), cursor);
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, length), cursor);
                }
             numFloatArgs++;
             break;
@@ -629,7 +628,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()),
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4),
                      argRegister, cursor);
                }
             numIntArgs++;
@@ -639,7 +638,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(self()->cg(),TR::InstOpCode::Op_st, firstNode,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress(), self()->cg()),
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress()),
                      argRegister, cursor);
                }
             numIntArgs++;
@@ -651,18 +650,18 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                if (self()->comp()->target().is64Bit())
                   cursor = generateMemSrc1Instruction(self()->cg(),TR::InstOpCode::Op_st, firstNode,
-                        new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()),
+                        TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 8),
                         argRegister, cursor);
                else
                   {
                   cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
-                        new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()),
+                        TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, 4),
                         argRegister, cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
                      argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                      cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
-                           new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()),
+                           TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset+4, 4),
                            argRegister, cursor);
                      }
                   }
@@ -693,7 +692,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                   }
 
                cursor = generateMemSrc1Instruction(self()->cg(), op, firstNode,
-                     new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, length, self()->cg()),
+                     TR::MemoryReference::createWithDisplacement(self()->cg(), stackPtr, offset, length),
                      argRegister, cursor);
                }
             numFloatArgs++;

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -734,7 +734,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
          best->getRegisterNumber() - TR::RealRegister::FirstCCR);
    candidates[0]->setBackingStorage(location);
 
-   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), TR::Compiler->om.sizeofReferenceAddress(), self()->cg());
+   tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference(), TR::Compiler->om.sizeofReferenceAddress());
 
    if (rk == TR_CCR)
       {
@@ -934,7 +934,7 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction      *c
          crtemp->setHasBeenAssignedInMethod(true);
       }
 
-   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), TR::Compiler->om.sizeofReferenceAddress(), self()->cg());
+   tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference(), TR::Compiler->om.sizeofReferenceAddress());
    TR::Instruction *spillInstr = NULL;
 
    int32_t dataSize = spillSizeForRegister(spilledRegister);

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -69,11 +69,42 @@ class TR_OpaqueClassBlock;
 
 static TR::RealRegister::RegNum choose_rX(TR::Instruction *, TR::RealRegister *);
 
-TR::MemoryReference *TR::MemoryReference::withDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length)
+TR::MemoryReference *TR::MemoryReference::create(TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(label, offset, length, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t length)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, length, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length)
    {
    return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, displacement, length, cg, 0);
    }
 
+TR::MemoryReference *TR::MemoryReference::createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore, uint32_t length)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(rootLoadOrStore, length, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, uint32_t length)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(node, symRef, length, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithMemRef(TR::CodeGenerator *cg, TR::Node *node, TR::MemoryReference& memRef, int32_t displacement, uint32_t length)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(node, memRef, displacement, length, cg);
+   }
+
+//Keeping the old version of the createWithLabel helper here to make sure OpenJ9 doesn't break
 TR::MemoryReference *TR::MemoryReference::withLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length)
    {
    return new (cg->trHeapMemory()) TR::MemoryReference(label, offset, length, cg);

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1227,25 +1227,25 @@ TR::Instruction *OMR::Power::MemoryReference::expandForUnresolvedSnippet(TR::Ins
          }
       else if (displacement < LOWER_IMMED || displacement > UPPER_IMMED)
          {
-         newMR = new (cg->trHeapMemory()) TR::MemoryReference(self()->getModBase(), LO_VALUE(displacement), self()->getLength(), cg);
+         newMR = TR::MemoryReference::createWithDisplacement(cg, self()->getModBase(), LO_VALUE(displacement), self()->getLength());
          }
       }
    else if (index != NULL || isUsingDelayedIndexedForm())
       {
       if (index == NULL)
          {
-         newMR = new (cg->trHeapMemory()) TR::MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::gr0), base, self()->getLength(), cg);
+         newMR = TR::MemoryReference::createWithIndexReg(cg, cg->machine()->getRealRegister(TR::RealRegister::gr0), base, self()->getLength());
          }
       else
          {
-         newMR = new (cg->trHeapMemory()) TR::MemoryReference(base, index, self()->getLength(), cg);
+         newMR = TR::MemoryReference::createWithIndexReg(cg, base, index, self()->getLength());
          }
 
       prevInstruction = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, base, base, 0, prevInstruction);
       }
    else
       {
-      newMR = new (cg->trHeapMemory()) TR::MemoryReference(self()->getModBase(), 0, self()->getLength(), cg);
+      newMR = TR::MemoryReference::createWithDisplacement(cg, self()->getModBase(), 0, self()->getLength());
       }
 
    // Since J9UnresolvedDataSnippet will look at this memory reference's registers, modifying them in place to be
@@ -1501,7 +1501,7 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
             cg,
             TR::InstOpCode::Op_st,
             node,
-            new (comp->trHeapMemory()) TR::MemoryReference(stackPtr, -saveLen, saveLen, cg),
+            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen), 
             rX,
             prevInstruction
          );
@@ -1515,7 +1515,7 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
             TR::InstOpCode::Op_load,
             node,
             rX,
-            new (comp->trHeapMemory()) TR::MemoryReference(stackPtr, -saveLen, saveLen, cg),
+            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen), 
             currentInstruction
          );
          }
@@ -1667,7 +1667,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
                cg->addSnippet(snippet);
                }
 
-            TR::MemoryReference *fakeTocRef = new (cg->trHeapMemory()) TR::MemoryReference(NULL, 0, sizeof(uintptr_t), cg);
+            TR::MemoryReference *fakeTocRef = TR::MemoryReference::createWithDisplacement(cg, NULL, 0, sizeof(uintptr_t));
             fakeTocRef->setSymbol(symbol, cg);
             fakeTocRef->getSymbolReference()->copyFlags(ref);
             fakeTocRef->setUsingStaticTOC();
@@ -1713,7 +1713,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
             }
 
          // TODO: Improve the code sequence for cases when we know pTOC is full.
-         TR::MemoryReference *tocRef = new (cg->trHeapMemory()) TR::MemoryReference(cg->getTOCBaseRegister(), 0, sizeof(uintptr_t), cg);
+         TR::MemoryReference *tocRef = TR::MemoryReference::createWithDisplacement(cg, cg->getTOCBaseRegister(), 0, sizeof(uintptr_t));
          tocRef->setSymbol(symbol, cg);
          tocRef->getSymbolReference()->copyFlags(ref);
          tocRef->setUsingStaticTOC();

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -119,7 +119,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          uint8_t len,
          TR::CodeGenerator *cg);
 
-   //TODO: legacy constructor - should be replaced by int64_t version (called by createWithDisplacement)
    MemoryReference(
          TR::Register *br,
          int32_t disp,

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -82,7 +82,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    // The extra int parameter at the end is needed to ensure that this constructor is never
    // ambiguous with the legacy constructor taking an int32_t for its displacement. This detail
    // is hidden from other code, since this constructor can only be used by calling the
-   // MemoryReference::withDisplacement helper. Once the legacy constructor is removed, the extra
+   // MemoryReference::createWithDisplacement helper. Once the legacy constructor is removed, the extra
    // parameter here can also be removed.
    MemoryReference(
          TR::Register *br,
@@ -119,6 +119,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          uint8_t len,
          TR::CodeGenerator *cg);
 
+   //TODO: legacy constructor - should be replaced by int64_t version (called by createWithDisplacement)
    MemoryReference(
          TR::Register *br,
          int32_t disp,

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -785,7 +785,7 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
                   traceMsg(comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
                TR::Node            *currentNode = currentInstruction->getNode();
                TR::RealRegister    *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-               TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t), cg);
+               TR::MemoryReference *tempMR = TR::MemoryReference::createWithSymRef(cg, currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t));
                TR_RegisterKinds     rk = virtReg->getKind();
 
                TR::InstOpCode::Mnemonic opCode;

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1424,7 +1424,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
 
          if (!cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8))
             {
-            tempMR = new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getStackPointerRegister(), -8, 8, cg());
+            tempMR = TR::MemoryReference::createWithDisplacement(cg(), cg()->getStackPointerRegister(), -8, 8);
             cg()->traceRAInstruction(cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, currentNode, tempMR, getTargetRegister(1), cursor));
             }
 
@@ -1437,7 +1437,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          if (cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8))
             cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::mfvsrwz, currentNode, getTargetRegister(2), getTargetRegister(1), cursor));
          else
-            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(2), new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, *tempMR, 4, 4, cg()), cursor));
+            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(2), TR::MemoryReference::createWithMemRef(cg(), currentNode, *tempMR, 4, 4), cursor));
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
 
          break;
@@ -1454,7 +1454,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
             }
          if (!cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8)|| cg()->comp()->target().is32Bit())
             {
-            tempMR = new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getStackPointerRegister(), -8, 8, cg());
+            tempMR = TR::MemoryReference::createWithDisplacement(cg(), cg()->getStackPointerRegister(), -8, 8);
             cg()->traceRAInstruction(cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, currentNode, tempMR, getTargetRegister(1), cursor));
             }
 
@@ -1473,8 +1473,8 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
             }
          else
             {
-            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(2), new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, *tempMR, 0, 4, cg()), cursor));
-            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(3), new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, *tempMR, 4, 4, cg()), cursor));
+            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(2), TR::MemoryReference::createWithMemRef(cg(), currentNode, *tempMR, 0, 4), cursor));
+            cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(3), TR::MemoryReference::createWithMemRef(cg(), currentNode, *tempMR, 4, 4), cursor));
             }
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
 

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -651,7 +651,7 @@ TR::PPCSystemLinkage::createPrologue(
       }
 
    if (machine->getLinkRegisterKilled())
-      cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, 2*TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), gr0, cursor);
+      cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, 2*TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()), gr0, cursor);
 
    // Save in-register arguments to the caller frame: this will not be
    // necessary if this linkage can be accounted for in the code-gen.
@@ -668,7 +668,7 @@ TR::PPCSystemLinkage::createPrologue(
    for (regIndex=TR::RealRegister::LastFPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
       {
       argSize = argSize - 8;
-      cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 8, cg()), machine->getRealRegister(regIndex), cursor);
+      cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, argSize, 8), machine->getRealRegister(regIndex), cursor);
       }
 
    savedFirst = TR::RealRegister::gr13;
@@ -686,12 +686,12 @@ TR::PPCSystemLinkage::createPrologue(
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
             {
             argSize = argSize - TR::Compiler->om.sizeofReferenceAddress();
-            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), machine->getRealRegister(regIndex), cursor);
+            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, argSize, TR::Compiler->om.sizeofReferenceAddress()), machine->getRealRegister(regIndex), cursor);
             }
       else
          {
          argSize = argSize - (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
-         cursor = generateMemSrc1Instruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), machine->getRealRegister(savedFirst), cursor);
+         cursor = generateMemSrc1Instruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, argSize, 4*(TR::RealRegister::LastGPR-savedFirst+1)), machine->getRealRegister(savedFirst), cursor);
          }
       }
 
@@ -701,7 +701,7 @@ TR::PPCSystemLinkage::createPrologue(
         machine->getRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
       {
       cursor = generateTrg1Instruction(cg(), TR::InstOpCode::mfcr, firstNode, gr0, cursor);
-      cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), gr0, cursor);
+      cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()), gr0, cursor);
       }
 
    // If only the link area is needed, a stack frame is unnecessary.
@@ -714,11 +714,11 @@ TR::PPCSystemLinkage::createPrologue(
       if (size > (-LOWER_IMMED))
          {
          cursor = loadConstant(cg(), firstNode, -size, gr11, cursor);
-         cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_stux, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, gr11, TR::Compiler->om.sizeofReferenceAddress(), cg()), sp, cursor);
+         cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_stux, firstNode, TR::MemoryReference::createWithIndexReg(cg(), sp, gr11, TR::Compiler->om.sizeofReferenceAddress()), sp, cursor);
          }
       else
          {
-         cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_stu, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, -size, TR::Compiler->om.sizeofReferenceAddress(), cg()), sp, cursor);
+         cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_stu, firstNode, TR::MemoryReference::createWithDisplacement(cg(), sp, -size, TR::Compiler->om.sizeofReferenceAddress()), sp, cursor);
          }
       }
    else   // leaf routine
@@ -771,7 +771,7 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
    for (regIndex=TR::RealRegister::LastFPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
       {
       saveSize = saveSize - 8;
-      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lfd, currentNode, machine->getRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 8, cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lfd, currentNode, machine->getRealRegister(regIndex), TR::MemoryReference::createWithDisplacement(cg(), sp, saveSize, 8), cursor);
       }
 
    savedFirst = TR::RealRegister::gr13;
@@ -789,12 +789,12 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
             {
             saveSize = saveSize - TR::Compiler->om.sizeofReferenceAddress();
-            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
+            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getRealRegister(regIndex), TR::MemoryReference::createWithDisplacement(cg(), sp, saveSize, TR::Compiler->om.sizeofReferenceAddress()), cursor);
             }
       else
          {
          saveSize = saveSize - (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
-         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
+         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getRealRegister(savedFirst), TR::MemoryReference::createWithDisplacement(cg(), sp, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1)), cursor);
          }
       }
 
@@ -819,7 +819,7 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    if (machine->getLinkRegisterKilled())
       {
-      cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, gr0, new (trHeapMemory()) TR::MemoryReference(sp, 2*TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, gr0, TR::MemoryReference::createWithDisplacement(cg(), sp, 2*TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()), cursor);
       cursor = generateSrc1Instruction(cg(), TR::InstOpCode::mtlr, currentNode, gr0, 0, cursor);
       }
 
@@ -828,7 +828,7 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
         machine->getRealRegister(TR::RealRegister::cr3)->getHasBeenAssignedInMethod() ||
         machine->getRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
       {
-      cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, gr0, new (trHeapMemory()) TR::MemoryReference(sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, gr0, TR::MemoryReference::createWithDisplacement(cg(), sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()), cursor);
       cursor = generateSrc1Instruction(cg(), TR::InstOpCode::mtcr, currentNode, gr0, 0, cursor);
       }
 
@@ -1441,9 +1441,9 @@ void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
             TR::Register *geReg = dependencies->searchPreConditionRegister(TR::RealRegister::gr12);
             if (!cg()->comp()->getOption(TR_DisableTOC))
                generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, geReg,
-                  new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getTOCBaseRegister(),
+                  TR::MemoryReference::createWithDisplacement(cg(), cg()->getTOCBaseRegister(),
                        (refNum-1)*TR::Compiler->om.sizeofReferenceAddress(),
-                       TR::Compiler->om.sizeofReferenceAddress(), cg()));
+                       TR::Compiler->om.sizeofReferenceAddress()));
             else
                loadAddressConstant(cg(), callNode, (int64_t)runtimeHelperValue((TR_RuntimeHelper)refNum), geReg);
             }
@@ -1571,7 +1571,7 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
    if (cg()->comp()->target().cpu.isBigEndian())
       {
       // load target from FD
-      generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, gr0, new (trHeapMemory()) TR::MemoryReference(callNode->getChild(0)->getRegister(), 0, TR::Compiler->om.sizeofReferenceAddress(), cg()));
+      generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, gr0, TR::MemoryReference::createWithDisplacement(cg(), callNode->getChild(0)->getRegister(), 0, TR::Compiler->om.sizeofReferenceAddress()));
 
       targetRegister = gr0;
       }
@@ -1585,12 +1585,12 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
    generateSrc1Instruction(cg(), TR::InstOpCode::mtctr, callNode, targetRegister, 0);
 
    if (cg()->comp()->target().cpu.isBigEndian())
-      generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, grTOCReg, new (trHeapMemory()) TR::MemoryReference(callNode->getChild(0)->getRegister(), TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()));
+      generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, grTOCReg, TR::MemoryReference::createWithDisplacement(cg(), callNode->getChild(0)->getRegister(), TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress()));
 
    generateDepInstruction(cg(), TR::InstOpCode::bctrl, callNode, dependencies);
 
    // load JIT TOC back
-   generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, grTOCReg, new (trHeapMemory()) TR::MemoryReference(grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress(), cg()));
+   generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, grTOCReg, TR::MemoryReference::createWithDisplacement(cg(), grSysStackReg, callerSaveTOCOffset, TR::Compiler->om.sizeofReferenceAddress()));
    }
 
 

--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -202,12 +202,12 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                fp1Reg = cg->allocateRegister(TR_FPR);
                TR_BackingStore * location;
                location = cg->allocateSpill(8, false, NULL);
-               TR::MemoryReference *tempMRStore1 = new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 4, cg);
-               TR::MemoryReference *tempMRStore2 =  new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMRStore1, 4, 4, cg);
+               TR::MemoryReference *tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 4);
+               TR::MemoryReference *tempMRStore2 =  TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 4, 4);
                generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMRStore1, valueReg->getHighOrder());
                generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMRStore2, valueReg->getLowOrder());
                generateInstruction(cg, TR::InstOpCode::lwsync, node);
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, fp1Reg, new (cg->trHeapMemory()) TR::MemoryReference(node, location->getSymbolReference(), 8, cg));
+               generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, fp1Reg, TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8));
                cg->freeSpill(location, 8, 0);
                }
             if (!fillReg)
@@ -253,7 +253,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, addrReg, 1); // 2 aligned??
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label0, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 1, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 1), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 1);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lenReg, lenReg, -1);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label0); // L0
@@ -265,7 +265,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, label1, condReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, addrReg, 2); // 4 aligned??
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label1, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 2, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 2), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 2);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lenReg, lenReg, -2);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label1); // L1
@@ -277,7 +277,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, label6, condReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, addrReg, 4); // 8 aligned??
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label6, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node,TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 4), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 4);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lenReg, lenReg, -4);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label6); // L6
@@ -296,14 +296,14 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label2, condReg);
       generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, tempReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label3); // L3
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 8, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 16, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 24, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 32, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 40, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 48, 8, cg), dblFillReg);
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 56, 8, cg), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 8, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 16, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 24, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 32, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 40, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 48, 8), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 56, 8), dblFillReg);
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 64);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::bdnz, node, label3, condReg);
       generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, lenReg, lenReg, 0, 63); // Mask
@@ -314,7 +314,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label5, condReg);
       generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, tempReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label7); // L7
-      generateMemSrc1Instruction(cg, dblStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 8, cg), dblFillReg);
+      generateMemSrc1Instruction(cg, dblStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 8), dblFillReg);
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 8);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::bdnz, node, label7, condReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label5); //L5
@@ -324,7 +324,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, lenReg, 4);
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label4, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 4), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 4);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label4); // L4
          }
@@ -334,7 +334,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, lenReg, 2);
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label9, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 2, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 2), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 2);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label9); // L9
          }
@@ -344,7 +344,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, lenReg, 1);
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, donelabel, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 1, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 1), fillReg);
          }
 
       generateDepLabelInstruction(cg, TR::InstOpCode::label, node, donelabel, deps); // LdoneLabel
@@ -380,7 +380,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, addrReg, 1); // 2 aligned??
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label6, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 1, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node,TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 1), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 1);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lenReg, lenReg, -1);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label6); // L6
@@ -392,7 +392,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, label5, condReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, addrReg, 2); // 4 aligned??
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label5, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 2, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 2), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 2);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, lenReg, lenReg, -2);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label5); // L5
@@ -409,14 +409,14 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label2, condReg);
       generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, tempReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label3); // L3
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 4, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 8, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 12, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 16, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 20, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 24, 4, cg), fillReg);
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 28, 4, cg), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 4, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 8, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 12, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 16, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 20, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 24, 4), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 28, 4), fillReg);
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 32);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::bdnz, node, label3, condReg);
       generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, lenReg, lenReg, 0, 31); // Mask
@@ -426,7 +426,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label4, condReg);
       generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, tempReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label10); // L10
-      generateMemSrc1Instruction(cg, wdStoreOp, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, cg), fillReg);
+      generateMemSrc1Instruction(cg, wdStoreOp, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 4), fillReg);
       generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 4);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::bdnz, node, label10, condReg);
       generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, lenReg, lenReg, 0, 3); // Mask
@@ -436,7 +436,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, lenReg, 2);
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, label9, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 2, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 2), fillReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, addrReg, addrReg, 2);
          generateLabelInstruction(cg, TR::InstOpCode::label, node, label9); // L9
          }
@@ -445,7 +445,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
          {
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andi_r, node, tempReg, lenReg, 1);
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, donelabel, condReg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node,new (cg->trHeapMemory()) TR::MemoryReference(addrReg, 0, 1, cg), fillReg);
+         generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node, TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, 1), fillReg);
          }
 
       generateDepLabelInstruction(cg, TR::InstOpCode::label, node, donelabel, deps); // LdoneLabel

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -285,7 +285,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
       if (!trgReg && child->getOpCode().isMemoryReference() && child->getReferenceCount() == 1)
          {
          trgReg = cg->allocateRegister();
-         TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
 #ifdef J9_PROJECT_SPECIFIC
          if (node->getFirstChild()->getOpCodeValue() == TR::irsload)
             {
@@ -459,7 +459,7 @@ TR::Register *OMR::Power::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
    if (child->getReferenceCount()==1 &&
        child->getOpCode().isMemoryReference() && (temp == NULL))
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
@@ -499,7 +499,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2cEvaluator(TR::Node *node, TR::CodeGe
        child->getOpCode().isMemoryReference() &&
        child->getRegister() == NULL)
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?2:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
@@ -522,7 +522,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2sEvaluator(TR::Node *node, TR::CodeGe
        child->getOpCode().isMemoryReference() &&
        child->getRegister() == NULL)
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?2:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, trgReg);
@@ -561,7 +561,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2bEvaluator(TR::Node *node, TR::CodeGe
    if (child->getReferenceCount()==1 &&
        child->getOpCode().isMemoryReference() && (child->getRegister() == NULL))
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 1, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 1);
       trgReg = cg->allocateRegister();
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?7:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
@@ -601,7 +601,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2buEvaluator(TR::Node *node, TR::CodeG
    if (child->getReferenceCount()==1 &&
        child->getOpCode().isMemoryReference() && (child->getRegister() == NULL))
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 1, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 1);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?7:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
@@ -632,7 +632,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2cEvaluator(TR::Node *node, TR::CodeGe
    if (child->getReferenceCount()==1 &&
        child->getOpCode().isMemoryReference() && (temp == NULL))
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?6:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
@@ -658,7 +658,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2sEvaluator(TR::Node *node, TR::CodeGe
        child->getOpCode().isMemoryReference() &&
        child->getRegister() == NULL)
       {
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?6:0, cg);
       if (cg->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P6))  // avoid algebraic loads on P6
          {
@@ -691,7 +691,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
        child->getOpCode().isMemoryReference() && (temp == NULL))
       {
       trgReg = cg->allocateRegister();
-      TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
+      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);
       tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?4:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
@@ -789,7 +789,7 @@ TR::Register *OMR::Power::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeG
       if (child->getReferenceCount()==1 &&
           child->getOpCode().isMemoryReference() && (temp == NULL))
          {
-         TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
          generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
          tempMR->decNodeReferenceCounts(cg);
          }
@@ -811,7 +811,7 @@ TR::Register *OMR::Power::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeG
       if (child->getReferenceCount()==1 &&
           child->getOpCode().isMemoryReference() && (temp == NULL))
          {
-         TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
          generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg->getLowOrder(), tempMR);
          tempMR->decNodeReferenceCounts(cg);
          }
@@ -847,7 +847,7 @@ TR::Register *OMR::Power::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeG
       if (!trgReg && child->getOpCode().isMemoryReference() && trgReg == NULL)
          {
          trgReg = cg->allocateRegister();
-         TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
+         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
          generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
          child->setRegister(trgReg);
          tempMR->decNodeReferenceCounts(cg);

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -822,7 +822,7 @@ TEST_P(PPCTrg1MemPCRelativeEncodingTest, encode) {
         std::get<0>(GetParam()),
         fakeNode,
         cg()->machine()->getRealRegister(std::get<1>(GetParam())),
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0)
     );
 
     label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + std::get<2>(GetParam()));
@@ -840,7 +840,7 @@ TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodePrefixCrossingBoundary) {
         std::get<0>(GetParam()),
         fakeNode,
         cg()->machine()->getRealRegister(std::get<1>(GetParam())),
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0)
     );
 
     label->setCodeLocation(reinterpret_cast<uint8_t*>(getAlignedBuf()) + 64 + std::get<2>(GetParam()));
@@ -858,7 +858,7 @@ TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodeWithRelocation) {
         std::get<0>(GetParam()),
         fakeNode,
         cg()->machine()->getRealRegister(std::get<1>(GetParam())),
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0)
     );
 
     auto size = encodeInstruction(instr)._words.size() * 4;
@@ -878,7 +878,7 @@ TEST_P(PPCTrg1MemPCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocat
         std::get<0>(GetParam()),
         fakeNode,
         cg()->machine()->getRealRegister(std::get<1>(GetParam())),
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0)
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0)
     );
 
     auto size = encodeInstruction(instr, 60)._words.size() * 4;
@@ -996,7 +996,7 @@ TEST_P(PPCMemSrc1PCRelativeEncodingTest, encode) {
         cg(),
         std::get<0>(GetParam()),
         fakeNode,
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0),
         cg()->machine()->getRealRegister(std::get<1>(GetParam()))
     );
 
@@ -1014,7 +1014,7 @@ TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodePrefixCrossingBoundary) {
         cg(),
         std::get<0>(GetParam()),
         fakeNode,
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0),
         cg()->machine()->getRealRegister(std::get<1>(GetParam()))
     );
 
@@ -1032,7 +1032,7 @@ TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodeWithRelocation) {
         cg(),
         std::get<0>(GetParam()),
         fakeNode,
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0),
         cg()->machine()->getRealRegister(std::get<1>(GetParam()))
     );
 
@@ -1052,7 +1052,7 @@ TEST_P(PPCMemSrc1PCRelativeEncodingTest, encodePrefixCrossingBoundaryWithRelocat
         cg(),
         std::get<0>(GetParam()),
         fakeNode,
-        TR::MemoryReference::withLabel(cg(), label, std::get<3>(GetParam()), 0),
+        TR::MemoryReference::createWithLabel(cg(), label, std::get<3>(GetParam()), 0),
         cg()->machine()->getRealRegister(std::get<1>(GetParam()))
     );
 

--- a/fvtest/compilerunittest/p/MemoryReferenceExpansion.cpp
+++ b/fvtest/compilerunittest/p/MemoryReferenceExpansion.cpp
@@ -30,7 +30,7 @@ class PPCMemInstructionExpansionTest : public TRTest::CodeGenTest {};
 TEST_F(PPCMemInstructionExpansionTest, zeroDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -59,7 +59,7 @@ TEST_F(PPCMemInstructionExpansionTest, zeroDisp) {
 TEST_F(PPCMemInstructionExpansionTest, smallPositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x7fff, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x7fff, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -88,7 +88,7 @@ TEST_F(PPCMemInstructionExpansionTest, smallPositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, smallNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8000, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -117,7 +117,7 @@ TEST_F(PPCMemInstructionExpansionTest, smallNegativeDisp) {
 TEST_F(PPCMemInstructionExpansionTest, largePositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x8000, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -191,7 +191,7 @@ TEST_F(PPCMemInstructionExpansionTest, largePositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, largeNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8001, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8001, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -265,7 +265,7 @@ TEST_F(PPCMemInstructionExpansionTest, largeNegativeDisp) {
 TEST_F(PPCMemInstructionExpansionTest, modBaseLargePositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x8000, 4);
 
     mr->setBaseModifiable();
 
@@ -306,7 +306,7 @@ TEST_F(PPCMemInstructionExpansionTest, modBaseLargePositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, modBaseLargeNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8001, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8001, 4);
 
     mr->setBaseModifiable();
 
@@ -378,7 +378,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexZeroDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setIndexRegister(indexReg);
@@ -411,7 +411,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexSmallPositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x7fff, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x7fff, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setIndexRegister(indexReg);
@@ -453,7 +453,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexSmallNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8000, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setIndexRegister(indexReg);
@@ -495,7 +495,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexLargePositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x8000, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setIndexRegister(indexReg);
@@ -546,7 +546,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexLargeNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8001, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8001, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setIndexRegister(indexReg);
@@ -596,7 +596,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexLargeNegativeDisp) {
 TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseZeroDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setBaseModifiable();
@@ -628,7 +628,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseZeroDisp) {
 TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseSmallPositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x7fff, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x7fff, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setBaseModifiable();
@@ -670,7 +670,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseSmallPositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseSmallNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8000, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setBaseModifiable();
@@ -712,7 +712,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseSmallNegativeDisp) {
 TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseLargePositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x8000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x8000, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setBaseModifiable();
@@ -763,7 +763,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseLargePositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseLargeNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x8001, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x8001, 4);
 
     mr->setUsingDelayedIndexedForm();
     mr->setBaseModifiable();
@@ -814,7 +814,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedIndexModBaseLargeNegativeDisp) {
 TEST_F(PPCMemInstructionExpansionTest, prefixNoExpandPositiveDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, 0x1ffffffff, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, 0x1ffffffff, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -843,7 +843,7 @@ TEST_F(PPCMemInstructionExpansionTest, prefixNoExpandPositiveDisp) {
 TEST_F(PPCMemInstructionExpansionTest, prefixNoExpandNegativeDisp) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
-    TR::MemoryReference* mr = TR::MemoryReference::withDisplacement(cg(), baseReg, -0x200000000, 4);
+    TR::MemoryReference* mr = TR::MemoryReference::createWithDisplacement(cg(), baseReg, -0x200000000, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));

--- a/fvtest/compilerunittest/p/MemoryReferenceExpansion.cpp
+++ b/fvtest/compilerunittest/p/MemoryReferenceExpansion.cpp
@@ -348,7 +348,7 @@ TEST_F(PPCMemInstructionExpansionTest, simpleIndex) {
     TR::Register* dataReg = cg()->machine()->getRealRegister(TR::RealRegister::gr0);
     TR::Register* baseReg = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::Register* indexReg = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
-    TR::MemoryReference* mr = new (cg()->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, 4, cg());
+    TR::MemoryReference* mr = TR::MemoryReference::createWithIndexReg(cg(), baseReg, indexReg, 4);
 
     TR::Node* fakeNode = TR::Node::create(TR::treetop);
     TR::Instruction* startInstr = generateLabelInstruction(cg(), TR::InstOpCode::label, fakeNode, generateLabelSymbol(cg()));
@@ -883,7 +883,7 @@ TEST_F(PPCMemInstructionExpansionTest, tocSmallPositiveDisp) {
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
     symRef->setUnresolved();
 
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
     mr->setUsingStaticTOC();
@@ -930,7 +930,7 @@ TEST_F(PPCMemInstructionExpansionTest, tocSmallNegativeDisp) {
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
     symRef->setUnresolved();
 
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
     mr->setUsingStaticTOC();
@@ -977,7 +977,7 @@ TEST_F(PPCMemInstructionExpansionTest, tocLargePositiveDisp) {
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
     symRef->setUnresolved();
 
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
     mr->setUsingStaticTOC();
@@ -1034,7 +1034,7 @@ TEST_F(PPCMemInstructionExpansionTest, tocLargeNegativeDisp) {
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
     symRef->setUnresolved();
 
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
     mr->setUsingStaticTOC();
@@ -1091,7 +1091,7 @@ TEST_F(PPCMemInstructionExpansionTest, tocFull) {
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
     symRef->setUnresolved();
 
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
     mr->setUsingStaticTOC();
@@ -1169,7 +1169,7 @@ TEST_F(PPCMemInstructionExpansionTest, delayedOffset) {
 
     TR::AutomaticSymbol* sym = TR::AutomaticSymbol::create(cg()->trHeapMemory());
     TR::SymbolReference* symRef = new (cg()->trHeapMemory()) TR::SymbolReference(cg()->comp()->getSymRefTab(), sym);
-    TR::MemoryReference *mr = new (cg()->trHeapMemory()) TR::MemoryReference(cg());
+    TR::MemoryReference *mr = TR::MemoryReference::create(cg());
 
     mr->setSymbolReference(symRef);
 

--- a/fvtest/compilerunittest/p/Peephole.cpp
+++ b/fvtest/compilerunittest/p/Peephole.cpp
@@ -31,7 +31,7 @@ TEST_F(PeepholeTest, testRegressIssue5418FlatLoad) {
     TR::RealRegister *gr1 = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::RealRegister *gr2 = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
 
-    TR::Instruction *instr1 = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::withDisplacement(cg(), gr1, 0, 4), gr2);
+    TR::Instruction *instr1 = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::createWithDisplacement(cg(), gr1, 0, 4), gr2);
     TR::Instruction *instr2 = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::lwz, fakeNode, gr2, gr1, 0);
 
     TR::Peephole peephole(cg()->comp());
@@ -46,7 +46,7 @@ TEST_F(PeepholeTest, testRegressIssue5418End) {
     TR::RealRegister *gr1 = cg()->machine()->getRealRegister(TR::RealRegister::gr1);
     TR::RealRegister *gr2 = cg()->machine()->getRealRegister(TR::RealRegister::gr2);
 
-    TR::Instruction *instr = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::withDisplacement(cg(), gr1, 0, 4), gr2);
+    TR::Instruction *instr = generateMemSrc1Instruction(cg(), TR::InstOpCode::stw, fakeNode, TR::MemoryReference::createWithDisplacement(cg(), gr1, 0, 4), gr2);
 
     TR::Peephole peephole(cg()->comp());
     peephole.perform();

--- a/fvtest/compilerunittest/p/Util.hpp
+++ b/fvtest/compilerunittest/p/Util.hpp
@@ -93,7 +93,7 @@ public:
                 cg
             );
         } else {
-            return TR::MemoryReference::withDisplacement(
+            return TR::MemoryReference::createWithDisplacement(
                 cg,
                 cg->machine()->getRealRegister(_baseReg),
                 _displacement,

--- a/fvtest/compilerunittest/p/Util.hpp
+++ b/fvtest/compilerunittest/p/Util.hpp
@@ -86,11 +86,11 @@ public:
             if (_displacement != 0)
                 throw std::invalid_argument("A MemoryReference cannot have a displacement and an index register");
 
-            return new (cg->trHeapMemory()) TR::MemoryReference(
+            return TR::MemoryReference::createWithIndexReg(
+                cg, 
                 cg->machine()->getRealRegister(_baseReg),
                 cg->machine()->getRealRegister(_indexReg),
-                0,
-                cg
+                0
             );
         } else {
             return TR::MemoryReference::createWithDisplacement(


### PR DESCRIPTION
This PR does the following:

-Add static helper methods for each MemoryReference constructor
-Replace all direct calls to MemoryReference constructors with corresponding static helpers