### PR TITLE
Privatize all MemoryReference constructors and Remove/Replace legacy constructor

### DIFF
--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -41,8 +41,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    MemoryReference(TR::Register *br,
       int64_t disp,
       uint8_t len,
-      TR::CodeGenerator *cg,
-      int) :
+      TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, disp, len, cg, 0) {}
 
    MemoryReference(TR::LabelSymbol *label, int64_t disp, int8_t len, TR::CodeGenerator *cg) :
@@ -58,12 +57,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       uint8_t len,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, len, cg) {}
-
-   MemoryReference(TR::Register *br,
-      int32_t disp,
-      uint8_t len,
-      TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(br, disp, len, cg) {}
 
    MemoryReference(TR::Node *rootLoadOrStore, uint32_t len, TR::CodeGenerator *cg):
       OMR::MemoryReferenceConnector(rootLoadOrStore, len, cg) {}

--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -42,12 +42,10 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       int64_t disp,
       uint8_t len,
       TR::CodeGenerator *cg) :
-         OMR::MemoryReferenceConnector(br, disp, len, cg, 0) {}
+         OMR::MemoryReferenceConnector(br, disp, len, cg) {}
 
    MemoryReference(TR::LabelSymbol *label, int64_t disp, int8_t len, TR::CodeGenerator *cg) :
       OMR::MemoryReferenceConnector(label, disp, len, cg) {}
-
-   public:
 
    MemoryReference(TR::CodeGenerator *cg) :
       OMR::MemoryReferenceConnector(cg) {}
@@ -67,6 +65,8 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    MemoryReference(TR::Node *node, MemoryReference& mr, int32_t n, uint32_t len, TR::CodeGenerator *cg):
       OMR::MemoryReferenceConnector(node, mr, n, len, cg) {}
 
+   public:
+
    static TR::MemoryReference *create(TR::CodeGenerator *cg);
    static TR::MemoryReference *createWithLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length);
    static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t length);
@@ -74,9 +74,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore, uint32_t length);
    static TR::MemoryReference *createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef, uint32_t length);
    static TR::MemoryReference *createWithMemRef(TR::CodeGenerator *cg, TR::Node *node, TR::MemoryReference& memRef, int32_t displacement, uint32_t length);
-
-   //Keeping the old version of the createWithLabel helper here to make sure OpenJ9 doesn't break 
-   static TR::MemoryReference *withLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length);
    };
 }
 

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -104,12 +104,6 @@ TR::MemoryReference *TR::MemoryReference::createWithMemRef(TR::CodeGenerator *cg
    return new (cg->trHeapMemory()) TR::MemoryReference(node, memRef, displacement, length, cg);
    }
 
-//Keeping the old version of the createWithLabel helper here to make sure OpenJ9 doesn't break
-TR::MemoryReference *TR::MemoryReference::withLabel(TR::CodeGenerator *cg, TR::LabelSymbol *label, int64_t offset, int8_t length)
-   {
-   return new (cg->trHeapMemory()) TR::MemoryReference(label, offset, length, cg);
-   }
-
 OMR::Power::MemoryReference::MemoryReference(
       TR::CodeGenerator *cg) :
    _baseRegister(NULL),

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -86,7 +86,7 @@ TR::MemoryReference *TR::MemoryReference::createWithIndexReg(TR::CodeGenerator *
 
 TR::MemoryReference *TR::MemoryReference::createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement, int8_t length)
    {
-   return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, displacement, length, cg, 0);
+   return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, displacement, length, cg);
    }
 
 TR::MemoryReference *TR::MemoryReference::createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore, uint32_t length)
@@ -171,17 +171,9 @@ OMR::Power::MemoryReference::MemoryReference(
 
 OMR::Power::MemoryReference::MemoryReference(
       TR::Register *br,
-      int32_t disp,
-      uint8_t len,
-      TR::CodeGenerator *cg) :
-   OMR::Power::MemoryReference(br, static_cast<int64_t>(disp), len, cg, 0) {}
-
-OMR::Power::MemoryReference::MemoryReference(
-      TR::Register *br,
       int64_t disp,
       uint8_t len,
-      TR::CodeGenerator *cg,
-      int) :
+      TR::CodeGenerator *cg) :
    _baseRegister(br),
    _baseNode(NULL),
    _indexRegister(NULL),

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -79,11 +79,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    protected:
 
-   // The extra int parameter at the end is needed to ensure that this constructor is never
-   // ambiguous with the legacy constructor taking an int32_t for its displacement. This detail
-   // is hidden from other code, since this constructor can only be used by calling the
-   // MemoryReference::createWithDisplacement helper. Once the legacy constructor is removed, the extra
-   // parameter here can also be removed.
    MemoryReference(
          TR::Register *br,
          int64_t disp,
@@ -95,6 +90,20 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          int64_t disp,
          uint8_t len,
          TR::CodeGenerator *cg);
+
+   MemoryReference(TR::CodeGenerator *cg);
+
+   MemoryReference(
+         TR::Register *br,
+         TR::Register *ir,
+         uint8_t len,
+         TR::CodeGenerator *cg);
+
+   MemoryReference(TR::Node *rootLoadOrStore, uint32_t len, TR::CodeGenerator *cg);
+
+   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg);
+
+   MemoryReference(TR::Node *node, TR::MemoryReference& mr, int32_t n, uint32_t len, TR::CodeGenerator *cg);
 
    public:
 
@@ -109,14 +118,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       TR_PPCMemoryReferenceControl_OffsetRequiresWordAlignment = 0x10,
       TR_PPCMemoryReferenceControl_DelayedOffsetDone           = 0x20
       } TR_PPCMemoryReferenceControl;
-
-   MemoryReference(TR::CodeGenerator *cg);
-
-   MemoryReference(
-         TR::Register *br,
-         TR::Register *ir,
-         uint8_t len,
-         TR::CodeGenerator *cg);
 
    virtual TR::RegisterDependencyConditions *getConditions() { return _conditions; }
 
@@ -298,12 +299,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    void setSymbol(TR::Symbol *symbol, TR::CodeGenerator *cg);
 
    void checkRegisters(TR::CodeGenerator *cg);
-
-   MemoryReference(TR::Node *rootLoadOrStore, uint32_t len, TR::CodeGenerator *cg);
-
-   MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg);
-
-   MemoryReference(TR::Node *node, TR::MemoryReference& mr, int32_t n, uint32_t len, TR::CodeGenerator *cg);
 
    void accessStaticItem(TR::Node *node, TR::SymbolReference *ref, bool isStore, TR::CodeGenerator *cg);
 

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -88,8 +88,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          TR::Register *br,
          int64_t disp,
          uint8_t len,
-         TR::CodeGenerator *cg,
-         int);
+         TR::CodeGenerator *cg);
 
    MemoryReference(
          TR::LabelSymbol *label,
@@ -116,12 +115,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    MemoryReference(
          TR::Register *br,
          TR::Register *ir,
-         uint8_t len,
-         TR::CodeGenerator *cg);
-
-   MemoryReference(
-         TR::Register *br,
-         int32_t disp,
          uint8_t len,
          TR::CodeGenerator *cg);
 


### PR DESCRIPTION
This PR does the following:

-Remove and replace legacy MemoryReference constructor
-Change all MemoryReference constructors from public to private/protected

Depends on https://github.com/eclipse/openj9/pull/10553