### PR TITLE
Fix 0 getContractionSize() in MemorySubSpaceGenerational

### DIFF
--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -180,7 +180,7 @@ public:
 	MMINLINE void isAllocatable(bool isAllocatable) {_isAllocatable = isAllocatable; }
 	MMINLINE bool isAllocatable() { return _isAllocatable; }
 	
-	MMINLINE uintptr_t getContractionSize() const { return _contractionSize; }
+	virtual MMINLINE uintptr_t getContractionSize() const { return _contractionSize; }
 	MMINLINE uintptr_t getExpansionSize() const { return _expansionSize; }
 	MMINLINE void setContractionSize(uintptr_t size) { _contractionSize = size; }
 	MMINLINE void setExpansionSize(uintptr_t size) { _expansionSize = size; }

--- a/gc/base/MemorySubSpaceGenerational.hpp
+++ b/gc/base/MemorySubSpaceGenerational.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,6 +108,8 @@ public:
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env);
 #endif
+
+	virtual MMINLINE uintptr_t getContractionSize() const { return _memorySubSpaceOld->getContractionSize(); }
 
 	/**
 	 * Create a MemorySubSpaceGenerational object.


### PR DESCRIPTION
Fixes a bug in Gencon where an incorrectly returned 0 contraction size
prevents additional compaction to aid contraction from occuring. The
generational memory subspace was returining its own unused field rather
than the correct contraction size of the actual sub space.

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>