### PR TITLE
Initialize RX Compilation setting before CodeGenerator construction

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -407,6 +407,11 @@ OMR::Compilation::Compilation(
       self()->getNodePool().enableNodeGC();
       }
 
+   if (self()->getOption(TR_ForceGenerateReadOnlyCode))
+      {
+      self()->setGenerateReadOnlyCode();
+      }
+
    //codegen also needs _methodSymbol
    _codeGenerator = allocateCodeGenerator(self());
 
@@ -468,12 +473,6 @@ OMR::Compilation::Compilation(
       }
    else
       _osrCompilationData = NULL;
-
-  if (self()->getOption(TR_ForceGenerateReadOnlyCode))
-      {
-      self()->setGenerateReadOnlyCode();
-      }
-
    }
 
 OMR::Compilation::~Compilation() throw()


### PR DESCRIPTION
The readOnlyCode setting may be needed during CodeGenerator initialization.

Issue: #5542

Signed-off-by: Daryl Maier <maier@ca.ibm.com>