### PR TITLE
Remove X86VFPCallCleanupInstruction assignRegister assert

### DIFF
--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -4576,11 +4576,6 @@ generateHelperCallInstruction(TR::Node * node, TR_RuntimeHelper index, TR::Regis
 void
 TR::X86VFPCallCleanupInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   if (kindsToBeAssigned & TR_GPR_Mask)
-      {
-      TR_ASSERT(cg()->internalControlFlowNestingDepth() >= 1, "TR::X86VFPCallCleanupInstruction %s must only be used inside internal control flow", cg()->getDebug()->getName(this));
-      }
-
    OMR::X86::Instruction::assignRegisters(kindsToBeAssigned);
    }
 


### PR DESCRIPTION
The assert is too restrictive.  It has been in place for a very long time
and I believe the situation it is trying to prevent is one where a register
spill is inserted in between the call instruction and the VFP cleanup
instruction (because the spill instruction uses the stack pointer and may
get an incorrect offset).  Restricting this special instruction's use to
ICF regions would ensure that because (in theory) no spilling should be
happening within an ICF.  Hence the assert.

However, there are circumstances in carefully constructed call sequences
where this instruction could be used outside of an internal control flow
region where register assignment and spilling won't be a problem between
the call instruction and the VFP cleanup instruction.

Like any instruction, when used properly in the right context this
instruction will behave correctly.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>