### PR TITLE
WIP: Power instruction fusion support structure

### DIFF
--- a/compiler/p/CMakeLists.txt
+++ b/compiler/p/CMakeLists.txt
@@ -49,5 +49,6 @@ compiler_library(p
 	${CMAKE_CURRENT_LIST_DIR}/codegen/TreeEvaluatorVMX.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRConstantDataSnippet.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/PPCInstructionFusionPairs.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
 )

--- a/compiler/p/codegen/PPCInstructionFusion.hpp
+++ b/compiler/p/codegen/PPCInstructionFusion.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include "p/codegen/PPCInstruction.hpp"
+
+
+
+namespace OMR
+{
+
+namespace Power
+{
+
+class PPCInstructionFusion
+    {
+
+    public:
+
+    enum FusionPairEnum {
+        #include "p/codegen/PPCInstructionFusionEnum.hpp"
+        NumFusionPairs
+    };
+
+    typedef struct {
+        TR::InstOpCode::Mnemonic op;
+        int8_t trgReg;
+        int8_t src1Reg;
+        int8_t src2Reg;
+        // int imm1;
+        // int imm2;
+    } FusionInstFormat;
+
+    typedef struct {
+        FusionPairEnum pair;
+        FusionInstFormat inst1;
+        FusionInstFormat inst2;
+    } FusionPair;
+    
+    static const FusionPair fusionPairs[NumFusionPairs];
+
+    };
+
+}
+
+}

--- a/compiler/p/codegen/PPCInstructionFusionEnum.hpp
+++ b/compiler/p/codegen/PPCInstructionFusionEnum.hpp
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+
+    addadd,
+    addadd_rb,
+

--- a/compiler/p/codegen/PPCInstructionFusionPairs.cpp
+++ b/compiler/p/codegen/PPCInstructionFusionPairs.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "p/codegen/PPCInstructionFusion.hpp"
+
+const OMR::Power::PPCInstructionFusion::FusionPair OMR::Power::PPCInstructionFusion::fusionPairs[NumFusionPairs] =
+   {
+   #include "codegen/PPCInstructionFusionPairs.hpp"
+   };
+

--- a/compiler/p/codegen/PPCInstructionFusionPairs.hpp
+++ b/compiler/p/codegen/PPCInstructionFusionPairs.hpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within a static table.  Only comments and
+ * definitions are permitted.
+ */
+
+/*
+ *  Register values:
+ *      -1  == any register
+ *      0   == must be GPR0
+ *      >=1 == shared register
+*/
+
+
+    {
+        /*
+            add rx, ra, ab
+            add rt, rx, rc
+        */
+        /* pair */      addadd, 
+        { /* Inst1 */ 
+            /* op */        TR::InstOpCode::add, 
+            /* trgReg */    1, 
+            /* src1Reg */   -1, 
+            /* src2Reg */   -1
+        },
+        { /* Inst2 */ 
+            /* op */        TR::InstOpCode::add, 
+            /* trgReg */    -1, 
+            /* src1Reg */   1, 
+            /* src2Reg */   -1
+        },
+    },
+
+    {
+        /*
+            add rx, ra, ab
+            add rt, rc, rx
+        */
+        /* pair */      addadd_rb, 
+        { /* Inst1 */ 
+            /* op */        TR::InstOpCode::add, 
+            /* trgReg */    1, 
+            /* src1Reg */   -1, 
+            /* src2Reg */   -1
+        },
+        { /* Inst2 */ 
+            /* op */        TR::InstOpCode::add, 
+            /* trgReg */    -1, 
+            /* src1Reg */   -1, 
+            /* src2Reg */   1
+        },
+    },
+
+
+
+


### PR DESCRIPTION

### Design Aspects

For the new Power instruction fusion feature, this PR aims to add a structure for supported fusion pairs. 
This structure can be used by different parts of OMR and should be easy to scale supporting future fusion pairs.

Points to start with:
* Supporting multiple instruction formats.
* Registers in a instruction can be one of:
  * Any: unrelated to fusion
  * Shared: must be the same register with one used in the other inst
  * Specific: currently only for `GPR0` in `addi(s) rx,0,si`
* Immediates in instructions can be one of:
  * Any: fusion condition doesn't depend on imm value
  * Specific: for some load-compare and rotate-logical fusion conditions.
* The manyInst1-to-manyInst2 support (Some support specifications shows any of 2 inst1 formats to any of 4 inst2 formats, which specifys 8 possible fusion pairs)
* The interchangable srcReg place. For most (if not all) `PPCTrg1Src2Instruction` with a shared register fusion condition as a srcReg, the architecture fuses the instruction if the register was either srcReg1 or srcReg2
* The assumption of fusing only 2 instructions
* Access to the structure



### Draft Design 
Commit d8e3897

This design simply is two `FusionInstFormat` for inst1 and inst2 inside a `FusionPair` alongside the pair name, all stored in a const array of `FusionPair`s.

* Design is similar to the codegen instruction properties design to start with
* `FusionInstFormat` will include multiple inst forms fields concerently (imm1, etc), the part accessing the structure (or an API) checks appropriate fields depending on the opcode
* Design assumes only specific register condition would be the register `GPR0`
* A value for the immediate that specify no condition on the value, as values `(0, 1, -1, ...)` are used as fusion condition. Or another bool field indicating if imm is specific-value or any 
* The manyInst1-to-manyInst2 in this design will be ineffecient as a 2-to-4 (8 fusion cases) will need 16 `FusionInstFormat` when they are all copies of 6 formats
* For interchangable srcReg, this design will need to add both formats seperatly
* Access to the structure would be through linear iteration over all supported pairs, which is not ideal


This is meant to be a start of a discussion and I appreciate any input.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>