### PR TITLE
Prevent Recompilation & Side-effect guards for a read only code cache

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4224,7 +4224,11 @@ OMR::Options::setCounts()
       _initialCount = initialCount;
       _initialBCount = initialBCount;
       _initialMILCount = initialMILCount;
-      _allowRecompilation = allowRecompilation;
+
+      if (!self()->getOption(TR_ForceGenerateReadOnlyCode))
+         _allowRecompilation = allowRecompilation;
+      else
+         _allowRecompilation = false;
       }
 
    // The following need to stay after the count string has been processed

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -9193,7 +9193,7 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
                      }
                   }
 
-               if (clazzToBeInitialized &&
+               if (!vp->comp()->getGenerateReadOnlyCode() && clazzToBeInitialized &&
                    (((clazzNameLen == 35) && !strncmp(clazzToBeInitialized, "Lcom/ibm/ejs/ras/TraceEnabledToken;", clazzNameLen)) ||
                     ((clazzNameLen == 41) && !strncmp(clazzToBeInitialized, "Lcom/ibm/websphere/ras/TraceEnabledToken;", clazzNameLen)) ||
                     ((clazzNameLen == 40) && !strncmp(clazzToBeInitialized, "Ljava/lang/String$StringCompressionFlag;", clazzNameLen))) &&


### PR DESCRIPTION
https://github.com/eclipse/omr/issues/5542

Disable features that do not currently make sense to have enabled for a read only code cache, specifically:

1. Recompilation (because the code cache is not writable)
2. Side Effect guards (because the associated runtime assumptions cannot patch a read only code cache)