### PR TITLE
Introduce RX code address inquiry functions

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -1228,3 +1228,41 @@ OMR::CodeCacheManager::allocateCodeCacheFromNewSegment(
 
    return NULL;
    }
+
+
+bool
+OMR::CodeCacheManager::isStartPCInRXCode(intptr_t startPC, void *jitConfig)
+   {
+   return TR::CodeCacheManager::isAddressInRXCode(startPC, jitConfig);
+   }
+
+
+bool
+OMR::CodeCacheManager::isAddressInRXCode(intptr_t address, void *jitConfig)
+   {
+   /**
+    * The default implementation first simply validates whether the provided
+    * \a address is in fact a method code address by locating its corresponding
+    * \c CodeCache object.  If it is, then the result depends on the setting of
+    * the \c TR_ForceGenerateReadOnlyCode option.  Otherwise, the result is
+    * \c false.
+    *
+    * This is sufficient as the \c CodeCacheManager and \c CodeCache classes are
+    * not presently architected to manage code caches with different permission
+    * properties.
+    *
+    * Language environments should override this function if this is not the best
+    * approach in those environments.
+    */
+   TR::CodeCacheManager *ccm = TR::CodeCacheManager::instance();
+
+   TR_ASSERT_FATAL(ccm, "TR::CodeCacheManager is not initialized");
+
+   TR::CodeCache *codeCache = ccm->findCodeCacheFromPC(reinterpret_cast<void *>(address));
+   if (!codeCache)
+      {
+      return false;
+      }
+
+   return TR::Options::getCmdLineOptions()->getOption(TR_ForceGenerateReadOnlyCode);
+   }

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -203,6 +203,46 @@ public:
    TR::CodeCache * findCodeCacheFromPC(void *inCacheAddress);
 
    /**
+    * @brief Inquires whether the given code address is in RX code.
+    *
+    * @details
+    *    This function is suitable for calling either at runtime (outside of a
+    *    compilation context) or during compilation of a method.  This function
+    *    is static to facilitate calling from diverse contexts.
+    *
+    * @param[in] address The code address inquired about.
+    * @param[in] jitConfig The jitConfig structure for this language environment
+    *
+    * @returns \c true if the code address is in RX code; \c false otherwise.
+    */
+   static bool isAddressInRXCode(intptr_t address, void *jitConfig);
+
+   /**
+    * @brief Inquires whether the given method startPC code address is in RX code.
+    *
+    * @details
+    *    This function allows implementing language runtimes to provide a more
+    *    efficient version of this query if it is known that the provided address
+    *    is the startPC of a method.
+    *
+    *    This function is suitable for calling either at runtime (outside of a
+    *    compilation context) or during compilation of a method.
+    *
+    *    If the address provided via \a startPC is not a method startPC then the
+    *    result of this function is undefined.  Determining whether the given
+    *    address is actually a startPC will defeat any optimization benefit from
+    *    assuming it is.
+    *
+    *    This function is static to facilitate calling from diverse contexts.
+    *
+    * @param[in] startPC The startPC of a method
+    * @param[in] jitConfig The jitConfig structure for this language environment
+    *
+    * @returns \c true if the code address is in RX code; \c false otherwise.
+    */
+   static bool isStartPCInRXCode(intptr_t startPC, void *jitConfig);
+
+   /**
     * @brief Finds a helper trampoline for the given helper reachable from the
     *        given code cache address.
     *


### PR DESCRIPTION
Two functions are provided for asking whether a given code cache address resides
in a read-only (RX) code cache or not.  While their primary motivation is to be
used at runtime they can be used at either compile-time or runtime.

Issue: #5542

Signed-off-by: Daryl Maier <maier@ca.ibm.com>