### PR TITLE
Adding `stalltimems` in `gc-end` stanza

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1667,7 +1667,7 @@ MM_ParallelGlobalGC::reportGCIncrementEnd(MM_EnvironmentBase *env)
 	}
 
 	stats->_endTime = omrtime_hires_clock();
-
+	stats->_stallTime = _extensions->globalGCStats.getStallTime();
 	TRIGGER_J9HOOK_MM_PRIVATE_GC_INCREMENT_END(
 		_extensions->privateHookInterface,
 		env->getOmrVMThread(),

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4757,6 +4757,7 @@ MM_Scavenger::reportGCIncrementEnd(MM_EnvironmentStandard *env)
 	}
 
 	stats->_endTime = omrtime_hires_clock();
+	stats->_stallTime = _extensions->scavengerStats.getStallTime();
 
 	TRIGGER_J9HOOK_MM_PRIVATE_GC_INCREMENT_END(
 		_extensions->privateHookInterface,

--- a/gc/stats/CollectionStatistics.hpp
+++ b/gc/stats/CollectionStatistics.hpp
@@ -42,6 +42,7 @@ public:
 
 	uint64_t  _startTime;		/**< Collection start time */
 	uint64_t  _endTime;			/**< Collection end time */
+	uint64_t  _stallTime;		/**< Collection stall time */
 
 	omrthread_process_time_t _startProcessTimes; /**< Process (Kernel and User) start time(s) */
 	omrthread_process_time_t _endProcessTimes;   /**< Process (Kernel and User) end time(s) */
@@ -58,6 +59,7 @@ public:
 		,_totalFreeHeapSize(0)
 		,_startTime(0)
 		,_endTime(0)
+		,_stallTime(0)
 		,_startProcessTimes()
 		,_endProcessTimes()
 	{};

--- a/gc/stats/GlobalGCStats.hpp
+++ b/gc/stats/GlobalGCStats.hpp
@@ -77,6 +77,16 @@ public:
 		finalizableCount = 0;
 	};
 
+	/**
+	 * Get the total stall time
+	 * @return the time in hi-res ticks
+	 */
+	MMINLINE uint64_t 
+	getStallTime()
+	{
+		return markStats.getStallTime() + workPacketStats.getStallTime() + sweepStats.idleTime;
+	}
+
 	MM_GlobalGCStats()
 		: gcCount(0)
 		, workPacketStats()

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -346,7 +346,7 @@ public:
 	 *
 	 * @note should be moved to protected once all standard usage is converted.
 	 */
-	uintptr_t getTagTemplateWithDuration(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t durationus, uint64_t usertimeus, uint64_t cputimeus, uint64_t wallTimeMs);
+	uintptr_t getTagTemplateWithDuration(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t durationus, uint64_t usertimeus, uint64_t cputimeus, uint64_t wallTimeMs, uint64_t stalltimeus);
 
 	/**
 	 * Handle any output or data tracking for the initialized phase of verbose GC.

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -380,6 +380,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="durationms" type="float" use="required" />
 		<attribute name="usertimems" type="float" use="required" />
 		<attribute name="systemtimems" type="float" use="required" />
+		<attribute name="stalltimems" type="float" use="required" />
 		<attribute name="timestamp" type="dateTime" use="required" />
 		<attribute name="activeThreads" type="integer" use="required" />
 	</complexType>


### PR DESCRIPTION
- Attribute `stalltimems` is added to `gc-end` to report time spent in stalling (in ms).
- New API `getStallTime()` introduced for `MM_GlobalGCStats`
- Expanded `MM_CollectionStatistics` to `_stallTime`
- New attribute is added in `gc-end` in schema.
- Update `MM_VerboseHandlerOutput::getTagTemplateWithDuration()` to reflect the addition of `stalltimems`

Signed-off-by: Enson Guo <enson.guo@ibm.com>