### PR TITLE
Initialize TR_X86ProcessorInfo once on x86

### DIFF
--- a/compiler/env/JitConfig.hpp
+++ b/compiler/env/JitConfig.hpp
@@ -47,9 +47,6 @@ class JitConfig
       uint64_t      verboseFlags;
       } options;
 
-   void *getProcessorInfo() { return _processorInfo; }
-   void setProcessorInfo(void *buf) { _processorInfo = buf; }
-
    void setInterpreterTOC(size_t interpreterTOC) { _interpreterTOC = interpreterTOC; }
    size_t getInterpreterTOC()                    { return _interpreterTOC; }
 

--- a/compiler/env/OMRCompilerEnv.cpp
+++ b/compiler/env/OMRCompilerEnv.cpp
@@ -19,11 +19,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/CodeGenerator.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/Environment.hpp"
 #include "env/CPU.hpp"
 #include "env/defines.h"
-
 
 OMR::CompilerEnv::CompilerEnv(
    TR::RawAllocator raw,

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -109,20 +109,20 @@ namespace TR { class RegisterDependencyConditions; }
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
-void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
+void TR_X86ProcessorInfo::initialize()
    {
    if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))
       return;
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
    //
-   _featureFlags.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags());
-   _featureFlags2.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags2());
-   _featureFlags8.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags8());
+   _featureFlags.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags());
+   _featureFlags2.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags2());
+   _featureFlags8.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags8());
 
    // Determine the processor vendor.
    //
-   const char *vendor = cg->comp()->target().cpu.getX86ProcessorVendorId();
+   const char *vendor = TR::Compiler->target.cpu.getX86ProcessorVendorId();
    if (!strncmp(vendor, "GenuineIntel", 12))
       _vendorFlags.set(TR_GenuineIntel);
    else if (!strncmp(vendor, "AuthenticAMD", 12))
@@ -139,7 +139,7 @@ void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
 
    // set up the processor family and cache description
 
-   uint32_t _processorSignature = cg->comp()->target().cpu.getX86ProcessorSignature();
+   uint32_t _processorSignature = TR::Compiler->target.cpu.getX86ProcessorSignature();
 
    if (isGenuineIntel())
       {
@@ -208,7 +208,6 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    {
 
    bool supportsSSE2 = false;
-   _targetProcessorInfo.initialize(self());
 
    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.isGenuineIntel() == _targetProcessorInfo.isGenuineIntel(), "isGenuineIntel() failed\n");
    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.isAuthenticAMD() == _targetProcessorInfo.isAuthenticAMD(), "isAuthenticAMD() failed\n");

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -39,6 +39,7 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/ScratchRegisterManager.hpp"
 #include "compile/Compilation.hpp"
 #include "env/jittypes.h"
+#include "env/CPU.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/LabelSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
@@ -221,9 +222,9 @@ private:
 
    uint32_t _processorDescription;
 
-   friend class OMR::X86::CodeGenerator;
+   friend class OMR::X86::CPU;
 
-   void initialize(TR::CodeGenerator *cg);
+   void initialize();
 
    /**
     * @brief testFlag Ensures that the feature being tested for exists in the mask

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -122,13 +122,15 @@ public:
     */
    bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return true; }
 
-   // Will be removed once we no longer need the old processor detection apis
    bool is(OMRProcessorArchitecture p);
-   bool is_old_api(OMRProcessorArchitecture p);
-   bool is_test(OMRProcessorArchitecture p);
-
    bool supportsFeature(uint32_t feature);
-   bool supports_feature_old_api(uint32_t feature);
+   
+private:
+   // Will be removed once we no longer need the old processor detection apis
+   bool isOldAPI(OMRProcessorArchitecture p);
+   bool supportsFeatureOldAPI(uint32_t feature);
+
+   bool is_test(OMRProcessorArchitecture p);
    bool supports_feature_test(uint32_t feature);
    };
 }


### PR DESCRIPTION
1. Currently we are repeatedly initializing the static struct `TR_X86ProcessorInfo`
in every CodeGenerator object. This may cause a race condition.
Note that this is the old version of processor detection on x86
and we have already switched to using the new version in OpenJ9. The reason this change 
is needed is because currently there are assert tests in place that compares new version
cpu detection APIs against old cpu detection APIs which means we still need
to make sure old APIs are working properly until it gets removed.
2. Another reason why the old version cannot be removed currently is because OMR
is still relying on it. Once OMR compiler has access to OMR port library then we can remove
the old version processor detection on x86.
3. Gives us the option to disable these old vs. new detection assert tests via an environment
variable "TR_DisableOldVersionCPUDetectionTest"

Signed-off-by: Harry Yu <harryyu1994@gmail.com>