### PR TITLE
AArch64: Implement byteswap evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -83,6 +83,8 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    self()->setSupportsSelect();
 
+   self()->setSupportsByteswap();
+
    _numberBytesReadInaccessible = 0;
    _numberBytesWriteInaccessible = 0;
 

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -749,7 +749,9 @@ public:
 	static TR::Register *lnolzEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lnotzEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lpopcntEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *lbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bbitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *sbitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ibitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -727,9 +727,9 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lnolzEvaluator ,	// TR::lnolz
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lnotzEvaluator ,	// TR::lnotz
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lpopcntEvaluator ,	// TR::lpopcnt
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sbyteswapEvaluator ,	// TR::sbyteswap // swap bytes in a short
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ibyteswapEvaluator ,	// TR::ibyteswap // swap bytes in an integer
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lbyteswapEvaluator ,	// TR::lbyteswap // swap bytes in a long
+    TR::TreeEvaluator::sbyteswapEvaluator, // TR::sbyteswap		// swap bytes in a short
+    TR::TreeEvaluator::ibyteswapEvaluator, // TR::ibyteswap		// swap bytes in an integer
+    TR::TreeEvaluator::lbyteswapEvaluator, // TR::lbyteswap		// swap bytes in a long
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bbitpermuteEvaluator ,	// TR::bbitpermute
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sbitpermuteEvaluator ,	// TR::sbitpermute
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ibitpermuteEvaluator ,	// TR::ibitpermute

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -133,6 +133,35 @@ TR::Register *OMR::ARM64::TreeEvaluator::labsEvaluator(TR::Node *node, TR::CodeG
    return commonIntegerAbsEvaluator(node, cg);
    }
 
+static TR::Register *commonUnaryHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+   {
+   TR::Node *child = node->getFirstChild();
+   TR::Register *srcReg = cg->evaluate(child);
+   TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+
+   generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+   node->setRegister(trgReg);
+   cg->decReferenceCount(child);
+   return trgReg;
+   }
+
+TR::Register *OMR::ARM64::TreeEvaluator::sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::Register *trgReg = commonUnaryHelper(node, TR::InstOpCode::rev16w, cg);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, trgReg, 15); // sign extension
+   return trgReg;
+   }
+
+TR::Register *OMR::ARM64::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return commonUnaryHelper(node, TR::InstOpCode::revw, cg);
+   }
+
+TR::Register *OMR::ARM64::TreeEvaluator::lbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return commonUnaryHelper(node, TR::InstOpCode::revx, cg);
+   }
+
 // also handles i2b, i2s, l2b, l2s, s2b
 TR::Register *OMR::ARM64::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/fvtest/compilertriltest/LogicalTest.cpp
+++ b/fvtest/compilertriltest/LogicalTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,6 @@ TEST_P(Int16LogicalUnary, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "sbyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }
@@ -127,7 +126,6 @@ TEST_P(Int16LogicalUnary, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "sbyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }
@@ -167,7 +165,6 @@ TEST_P(Int32LogicalUnary, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "ibyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }
@@ -192,7 +189,6 @@ TEST_P(Int32LogicalUnary, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "ibyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }
@@ -335,7 +331,6 @@ TEST_P(Int64LogicalUnary, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "lbyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }
@@ -369,7 +364,6 @@ TEST_P(Int64LogicalUnary, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     if (param.opcode == "lbyteswap") {
-        SKIP_ON_AARCH64(MissingImplementation);
         SKIP_ON_ARM(MissingImplementation);
         SKIP_ON_RISCV(MissingImplementation);
     }


### PR DESCRIPTION
This commit implements byteswap evaluators for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>