### PR TITLE
Replace some uses of TR::comp() with cheaper alternatives

### DIFF
--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -135,7 +135,7 @@ OMR::ARM::Instruction::Instruction(TR::Instruction                     *precedin
 
 void OMR::ARM::Instruction::ARMNeedsGCMap(uint32_t mask)
    {
-   if (TR::comp()->useRegisterMaps())
+   if (self()->cg()->comp()->useRegisterMaps())
       self()->setNeedsGCMap(mask);
    }
 
@@ -303,7 +303,7 @@ TR::ARMImmSymInstruction::ARMImmSymInstruction(TR::Instruction                  
 
 void TR::ARMLabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
    TR::Machine  *machine        = cg()->machine();
    TR::Register    *target1Virtual = getTarget1Register();
    TR::Register    *source1Virtual = getSource1Register();

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -3992,8 +3992,9 @@ static void orderSensitiveDescendants(TR::Node *node, TR::NodeChecklist &out)
  */
 static bool substPreservesEvalOrder(TR::Node *orig, TR::Node *replacement)
    {
-   TR::NodeChecklist origEvaluated(TR::comp());
-   TR::NodeChecklist replacementEvaluated(TR::comp());
+   TR::Compilation *comp = TR::comp();
+   TR::NodeChecklist origEvaluated(comp);
+   TR::NodeChecklist replacementEvaluated(comp);
    orderSensitiveDescendants(orig, origEvaluated);
    orderSensitiveDescendants(replacement, replacementEvaluated);
    return origEvaluated == replacementEvaluated;

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2288,7 +2288,7 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
       if (isEquivalent)
          {
          bool canBeRemoved = true; //comp()->cg()->canNullChkBeImplicit(cursorNode);
-         if (TR::comp()->getOption(TR_DisableTraps) ||
+         if (comp()->getOption(TR_DisableTraps) ||
              TR::Compiler->om.offsetOfObjectVftField() >= comp()->cg()->getNumberBytesReadInaccessible())
            canBeRemoved = false;
 

--- a/compiler/optimizer/LoopReplicator.cpp
+++ b/compiler/optimizer/LoopReplicator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,11 +67,13 @@ TR_LoopReplicator::TR_LoopReplicator(TR::OptimizationManager *manager)
 //Add static debug counter for a given replication failure
 static void countReplicationFailure(char *failureReason, int32_t regionNum)
    {
+   TR::Compilation *comp = TR::comp();
+
    //Assemble format string: "LoopReplicator/<failureReason>/%s/(%s)/region_%d"
-   TR::DebugCounter::incStaticDebugCounter(TR::comp(), TR::DebugCounter::debugCounterName(TR::comp(),
+   TR::DebugCounter::incStaticDebugCounter(comp, TR::DebugCounter::debugCounterName(comp,
       "LoopReplicator/%s/%s/(%s)/region_%d", failureReason,
-      TR::comp()->getHotnessName(TR::comp()->getMethodHotness()),
-      TR::comp()->signature(), regionNum));
+      comp->getHotnessName(comp->getMethodHotness()),
+      comp->signature(), regionNum));
    }
 
 int32_t TR_LoopReplicator::perform()

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -78,7 +78,7 @@ OMR::Power::Instruction::isCall()
 void
 OMR::Power::Instruction::PPCNeedsGCMap(uint32_t mask)
    {
-   if (TR::comp()->useRegisterMaps())
+   if (self()->cg()->comp()->useRegisterMaps())
       self()->setNeedsGCMap(mask);
    }
 

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -1236,7 +1236,7 @@ class PPCMemInstruction : public TR::Instruction
 
    virtual TR::Register *getMemoryBase()    {return getMemoryReference()->getBaseRegister();}
    virtual TR::Register *getMemoryIndex()   {return getMemoryReference()->getIndexRegister();}
-   virtual int64_t      getOffset()        {return getMemoryReference()->getOffset(*TR::comp());}
+   virtual int64_t      getOffset()        {return getMemoryReference()->getOffset(*(cg()->comp()));}
 
    virtual void fillBinaryEncodingFields(uint32_t *cursor);
    virtual TR::Instruction *expandInstruction();
@@ -1384,7 +1384,7 @@ class PPCTrg1MemInstruction : public PPCTrg1Instruction
 
    virtual TR::Register *getMemoryBase()    {return getMemoryReference()->getBaseRegister();}
    virtual TR::Register *getMemoryIndex()   {return getMemoryReference()->getIndexRegister();}
-   virtual int64_t      getOffset()        {return getMemoryReference()->getOffset(*TR::comp());}
+   virtual int64_t      getOffset()        {return getMemoryReference()->getOffset(*(cg()->comp()));}
 
    bool encodeMutexHint();
    bool haveHint() {return getHint() != PPCOpProp_NoHint;};

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,14 +74,14 @@ zeroExtendTo32BitRegister(TR::Node          *node,
    }
 
 /*
- * \brief 
- * this API is for check nodes(like OverflowCHK) with certain operation where the operands 
+ * \brief
+ * this API is for check nodes(like OverflowCHK) with certain operation where the operands
  * are given explicitly by the caller and are not the first and second child of the given root node
  *
  * \param root
  *     the check node
- * \param firstChild, secondChild 
- *     the operands for the operation 
+ * \param firstChild, secondChild
+ *     the operands for the operation
  */
 void TR_X86BinaryCommutativeAnalyser::genericAnalyserWithExplicitOperands(TR::Node      *root,
                                                                           TR::Node      *firstChild,
@@ -99,7 +99,7 @@ void TR_X86BinaryCommutativeAnalyser::genericAnalyserWithExplicitOperands(TR::No
    }
 
 /*
- * \brief 
+ * \brief
  * this API is for regular operation nodes where the first child and second child are the operands by default
  */
 void TR_X86BinaryCommutativeAnalyser::genericAnalyser(TR::Node      *root,
@@ -130,7 +130,7 @@ void TR_X86BinaryCommutativeAnalyser::genericAnalyser(TR::Node      *root,
    }
 
 /*
- * users should call the genericAnalyser or genericAnalyserWithExplicitOperands APIs instead of calling this one directly 
+ * users should call the genericAnalyser or genericAnalyserWithExplicitOperands APIs instead of calling this one directly
  */
 TR::Register* TR_X86BinaryCommutativeAnalyser::genericAnalyserImpl(TR::Node      *root,
                                                                    TR::Node      *firstChild,
@@ -700,7 +700,7 @@ void TR_X86BinaryCommutativeAnalyser::genericLongAnalyser(TR::Node       *root,
    }
 
 /*
- * \brief 
+ * \brief
  * this API is intended for regular add operation nodes where the first child and second child are the operands by default
  */
 void TR_X86BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node      *root,
@@ -731,18 +731,18 @@ void TR_X86BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node      *root,
    }
 
 /*
- * \brief 
- * this API is for check nodes(like OverflowCHK) with an add operation where the operands 
+ * \brief
+ * this API is for check nodes(like OverflowCHK) with an add operation where the operands
  * are given explicitly by the caller and are not the first and second child of the given root node
  *
  * \param root
  *     the check node
- * \param firstChild, secondChild 
- *     the operands for the add operation 
+ * \param firstChild, secondChild
+ *     the operands for the add operation
  */
 void TR_X86BinaryCommutativeAnalyser::integerAddAnalyserWithExplicitOperands(TR::Node      *root,
-                                                                             TR::Node      *firstChild, 
-                                                                             TR::Node      *secondChild, 
+                                                                             TR::Node      *firstChild,
+                                                                             TR::Node      *secondChild,
                                                                              TR_X86OpCodes regRegOpCode,
                                                                              TR_X86OpCodes regMemOpCode,
                                                                              bool          needsEflags, // false by default
@@ -754,16 +754,16 @@ void TR_X86BinaryCommutativeAnalyser::integerAddAnalyserWithExplicitOperands(TR:
    _cg->decReferenceCount(secondChild);
    _cg->stopUsingRegister(tempReg);
    }
- 
+
 /*
- * users should call the integerAddAnalyser or integerAddAnalyserWithGivenOperands APIs instead of calling this one directly 
+ * users should call the integerAddAnalyser or integerAddAnalyserWithGivenOperands APIs instead of calling this one directly
  */
 TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node      *root,
-                                                                      TR::Node      *firstChild, 
-                                                                      TR::Node      *secondChild, 
+                                                                      TR::Node      *firstChild,
+                                                                      TR::Node      *secondChild,
                                                                       TR_X86OpCodes regRegOpCode,
                                                                       TR_X86OpCodes regMemOpCode,
-                                                                      bool          needsEflags,     
+                                                                      bool          needsEflags,
                                                                       TR::Node      *carry)
    {
    TR::Register *targetRegister;
@@ -927,9 +927,9 @@ TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node  
 // get clobbered by the memory barrier immediately preceding the
 // ADC4RegMem instruction.
 //
-static bool isVolatileMemoryOperand(TR::Node *node)
+bool TR_X86BinaryCommutativeAnalyser::isVolatileMemoryOperand(TR::Node *node)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    TR_ASSERT_FATAL(comp, "isVolatileMemoryOperand should only be called during a compilation!");
    if (comp->target().isSMP() && node->getOpCode().isMemoryReference())
       {
@@ -941,14 +941,14 @@ static bool isVolatileMemoryOperand(TR::Node *node)
    }
 
 /*
- * \brief 
- * this API is for check nodes(like OverflowCHK) an ladd operation where the operands 
+ * \brief
+ * this API is for check nodes(like OverflowCHK) an ladd operation where the operands
  * are given explicitly by the caller and are not the first and second child of the given root node
  *
  * \param root
  *     the check node
- * \param firstChild, secondChild 
- *     the operands for the add operation 
+ * \param firstChild, secondChild
+ *     the operands for the add operation
  */
 void TR_X86BinaryCommutativeAnalyser::longAddAnalyserWithExplicitOperands(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild)
    {
@@ -960,12 +960,12 @@ void TR_X86BinaryCommutativeAnalyser::longAddAnalyserWithExplicitOperands(TR::No
    }
 
 /*
- * \brief 
+ * \brief
  * this API is intended for regular ladd operation nodes where the first child and second child are the operands by default
  */
 void TR_X86BinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
    {
-   TR::Node *firstChild = NULL; 
+   TR::Node *firstChild = NULL;
    TR::Node *secondChild = NULL;
    if (_cg->whichChildToEvaluate(root) == 0)
       {
@@ -986,7 +986,7 @@ void TR_X86BinaryCommutativeAnalyser::longAddAnalyser(TR::Node *root)
    }
 
 /*
- * users should call the longAddAnalyser or longAddAnalyserWithExplicitOperands APIs instead of calling this one directly 
+ * users should call the longAddAnalyser or longAddAnalyserWithExplicitOperands APIs instead of calling this one directly
  */
 TR::Register* TR_X86BinaryCommutativeAnalyser::longAddAnalyserImpl(TR::Node *root, TR::Node *&firstChild, TR::Node *&secondChild)
    {

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.hpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ class TR_X86BinaryCommutativeAnalyser  : public TR_Analyser
                                                TR::Node *secondChild,
                                                TR_X86OpCodes regRegOpCode,
                                                TR_X86OpCodes regMemOpCode,
-                                               bool needsEflags = false, 
+                                               bool needsEflags = false,
                                                TR::Node *carry = 0);
 
    TR::Register* integerAddAnalyserImpl(TR::Node       *root,
@@ -104,7 +104,7 @@ class TR_X86BinaryCommutativeAnalyser  : public TR_Analyser
                            TR::Node *secondChild,
                            TR_X86OpCodes regRegOpCode,
                            TR_X86OpCodes regMemOpCode,
-                           bool needsEflags, 
+                           bool needsEflags,
                            TR::Node *carry);
 
    void longAddAnalyserWithExplicitOperands(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild);
@@ -128,6 +128,7 @@ class TR_X86BinaryCommutativeAnalyser  : public TR_Analyser
    bool getOpReg2Mem1() {return (_actionMap[getInputs()] & OpReg2Mem1) ? true : false;}
    bool getCopyRegs()   {return (_actionMap[getInputs()] & (CopyReg1 | CopyReg2)) ? true : false;}
 
+   bool isVolatileMemoryOperand(TR::Node *node);
    };
 
 #endif

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -232,7 +232,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
 
 #if defined(TR_TARGET_X86) && !defined(J9HAMMER)
    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) == _targetProcessorInfo.supportsSSE2(), "supportsSSE2() failed\n");
-   
+
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) && comp->target().cpu.testOSForSSESupport())
       supportsSSE2 = true;
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
@@ -2927,7 +2927,7 @@ TR_X86ScratchRegisterManager *OMR::X86::CodeGenerator::generateScratchRegisterMa
 bool
 TR_X86ScratchRegisterManager::reclaimAddressRegister(TR::MemoryReference *mr)
    {
-   if (TR::comp()->target().is32Bit())
+   if (_cg->comp()->target().is32Bit())
       return false;
 
    return reclaimScratchRegister(mr->getAddressRegister());

--- a/compiler/x/codegen/OutlinedInstructions.hpp
+++ b/compiler/x/codegen/OutlinedInstructions.hpp
@@ -66,7 +66,6 @@ class TR_OutlinedInstructions
 
    bool                 _hasBeenRegisterAssigned;
 
-   TR::Compilation *comp() { return TR::comp(); }
    TR::CodeGenerator *cg() { return _cg; }
 
    public:

--- a/compiler/x/codegen/SubtractAnalyser.cpp
+++ b/compiler/x/codegen/SubtractAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,14 +42,14 @@
 #include "x/codegen/X86Ops.hpp"
 
 /*
- * \brief 
- * this API is for check nodes(like OverflowCHK) with sub operation where the operands 
+ * \brief
+ * this API is for check nodes(like OverflowCHK) with sub operation where the operands
  * are given explicitly by the caller and are not the first and second child of the given root node
  *
  * \param root
  *     the check node
- * \param firstChild, secondChild 
- *     the operands for the sub operation 
+ * \param firstChild, secondChild
+ *     the operands for the sub operation
  */
 void TR_X86SubtractAnalyser::integerSubtractAnalyserWithExplicitOperands(TR::Node      *root,
                                                                          TR::Node      *firstChild,
@@ -68,7 +68,7 @@ void TR_X86SubtractAnalyser::integerSubtractAnalyserWithExplicitOperands(TR::Nod
    }
 
 /*
- * \brief 
+ * \brief
  * this API is for regular sub operation nodes where the first child and second child are the operands by default
  */
 void TR_X86SubtractAnalyser::integerSubtractAnalyser(TR::Node      *root,
@@ -88,7 +88,7 @@ void TR_X86SubtractAnalyser::integerSubtractAnalyser(TR::Node      *root,
    }
 
 /*
- * users should call the integerSubtractAnalyser or integerSubtractAnalyserWithExplicitOperands APIs instead of calling this one directly 
+ * users should call the integerSubtractAnalyser or integerSubtractAnalyserWithExplicitOperands APIs instead of calling this one directly
  */
 TR::Register* TR_X86SubtractAnalyser::integerSubtractAnalyserImpl(TR::Node     *root,
                                                                   TR::Node     *firstChild,
@@ -96,8 +96,8 @@ TR::Register* TR_X86SubtractAnalyser::integerSubtractAnalyserImpl(TR::Node     *
                                                                   TR_X86OpCodes regRegOpCode,
                                                                   TR_X86OpCodes regMemOpCode,
                                                                   TR_X86OpCodes copyOpCode,
-                                                                  bool needsEflags, 
-                                                                  TR::Node *borrow)  
+                                                                  bool needsEflags,
+                                                                  TR::Node *borrow)
    {
    TR::Register *targetRegister = NULL;
    TR::Register *firstRegister = firstChild->getRegister();
@@ -234,9 +234,9 @@ TR::Register* TR_X86SubtractAnalyser::integerSubtractAnalyserImpl(TR::Node     *
 // get clobbered by the memory barrier immediately preceding the
 // SBB4RegMem instruction.
 //
-static bool isVolatileMemoryOperand(TR::Node *node)
+bool TR_X86SubtractAnalyser::isVolatileMemoryOperand(TR::Node *node)
    {
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = _cg->comp();
    if (comp->target().isSMP() && node->getOpCode().isMemoryReference())
       {
       TR_ASSERT(node->getSymbolReference(), "expecting a symbol reference\n");
@@ -247,14 +247,14 @@ static bool isVolatileMemoryOperand(TR::Node *node)
    }
 
 /*
- * \brief 
- * this API is for check nodes(like OverflowCHK) with an lsub operation where the operands 
+ * \brief
+ * this API is for check nodes(like OverflowCHK) with an lsub operation where the operands
  * are given explicitly by the caller and are not the first and second child of the given root node
  *
  * \param root
  *     the check node
- * \param firstChild, secondChild 
- *     the operands for the lsub operation 
+ * \param firstChild, secondChild
+ *     the operands for the lsub operation
  */
 void TR_X86SubtractAnalyser::longSubtractAnalyserWithExplicitOperands(TR::Node *root, TR::Node *firstChild, TR::Node *secondChild)
    {
@@ -266,7 +266,7 @@ void TR_X86SubtractAnalyser::longSubtractAnalyserWithExplicitOperands(TR::Node *
    }
 
 /*
- * \brief 
+ * \brief
  * this API is intended for regular lsub operation nodes where the first child and second child are the operands by default
  */
 void TR_X86SubtractAnalyser::longSubtractAnalyser(TR::Node *root)
@@ -281,7 +281,7 @@ void TR_X86SubtractAnalyser::longSubtractAnalyser(TR::Node *root)
    }
 
 /*
- * users should call the longSubtractAnalyser or longSubtractAnalyserWithExplicitOperands APIs instead of calling this one directly 
+ * users should call the longSubtractAnalyser or longSubtractAnalyserWithExplicitOperands APIs instead of calling this one directly
  */
 TR::Register* TR_X86SubtractAnalyser::longSubtractAnalyserImpl(TR::Node *root, TR::Node *&firstChild, TR::Node *&secondChild)
    {

--- a/compiler/x/codegen/SubtractAnalyser.hpp
+++ b/compiler/x/codegen/SubtractAnalyser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,6 +86,7 @@ class TR_X86SubtractAnalyser  : public TR_Analyser
    bool getSubReg1Mem2() {return (_actionMap[getInputs()] & SubReg1Mem2) ? true : false;}
    bool getSubReg3Mem2() {return (_actionMap[getInputs()] & SubReg3Mem2) ? true : false;}
 
+   bool isVolatileMemoryOperand(TR::Node *node);
    };
 
 #endif

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,9 +38,10 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    rex.W = rex_w;
    // Use AVX if possible
 
-   TR_ASSERT_FATAL(TR::comp()->compileRelocatableCode() || TR::comp()->isOutOfProcessCompilation() || TR::comp()->target().cpu.supportsAVX() == TR::CodeGenerator::getX86ProcessorInfo().supportsAVX(), "supportsAVX() failed\n");
+   TR::Compilation *comp = TR::comp();
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.supportsAVX() == TR::CodeGenerator::getX86ProcessorInfo().supportsAVX(), "supportsAVX() failed\n");
 
-   if (supportsAVX() && TR::comp()->target().cpu.supportsAVX())
+   if (supportsAVX() && comp->target().cpu.supportsAVX())
       {
       TR::Instruction::VEX<3> vex(rex, modrm_opcode);
       vex.m = escape;

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,7 +101,7 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
    secondChild = root->getSecondChild();
    TR::Register * firstRegister = firstChild->getRegister();
    TR::Register * secondRegister = secondChild->getRegister();
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
 
    setInputs(firstChild, firstRegister, secondChild, secondRegister, false, false, comp, false, false);
 
@@ -287,7 +287,7 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    bool setsOrReadsCC = NEED_CC(root) || (root->getOpCodeValue() == TR::lusubb);
    TR::InstOpCode::Mnemonic regToRegOpCode;
    TR::InstOpCode::Mnemonic memToRegOpCode;
-   TR::Compilation *comp = TR::comp();
+   TR::Compilation *comp = cg()->comp();
 
    if (!setsOrReadsCC)
       {

--- a/compiler/z/codegen/ConstantDataSnippet.hpp
+++ b/compiler/z/codegen/ConstantDataSnippet.hpp
@@ -29,7 +29,7 @@
 #include "compile/Compilation.hpp"
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
-#include "OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 class TR_Debug;
 namespace TR { class CodeGenerator; }
@@ -95,7 +95,7 @@ class S390ConstantDataSnippet : public TR::Snippet
       {
       return _reloType = rt;
       }
-   TR::Compilation* comp() { return TR::comp(); }
+   TR::Compilation* comp() { return cg()->comp(); }
 
    };
 

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -196,10 +196,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    /** \brief
     *     This is a helper function that will try to use a rotate instruction
     *     to perform an 'land' (Long AND) operation. It will handle cases
-    *     where the second child of the Long AND is a lconst node, and the 
+    *     where the second child of the Long AND is a lconst node, and the
     *     lconst value is a sequence of contiguous 1's surrounded by 0's or vice versa.
     *     For example, the lconst value can be:
-    *     00011111111000, 1111000000011111, 0100000  
+    *     00011111111000, 1111000000011111, 0100000
     *
     *     For example, consider the following tree:
     *
@@ -208,26 +208,26 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *           iload parm=0
     *        lconst 0x0000FFFFFFFF0000
     *
-    *     We can either materialize the constant in a register or use the NIHF+NILF instructions 
-    *     to AND the most and least significant 32 bit portions in the first operand. These 
+    *     We can either materialize the constant in a register or use the NIHF+NILF instructions
+    *     to AND the most and least significant 32 bit portions in the first operand. These
     *     are both more expensive than generating a RISBG instruction.
     *
-    *     This is because in the above case we can perform the AND operation with the 
+    *     This is because in the above case we can perform the AND operation with the
     *     following single RISBG instruction:
     *
     *     RISBG R2,R1,33,175,0 //R1 holds parm 0
     *
     *     In the above instruction the value of 175 comes from
     *     the sum of 128 and 47. 47 represents the ending position
-    *     of the bit range to preserve, and 128 is there to set the 
+    *     of the bit range to preserve, and 128 is there to set the
     *     zero bit. The instruction is saying to take the value in R1 and
     *     do the following:
     *        -preserve the bits from 33 - 47 (inclusive)
     *        -zero the remaining bits
     *        -rotate the preserved bits by a factor of 0(hence no rotation)
     *        -store the result in R2
-    * 
-    *     Note: RISBG is non-destructive (unlike the AND immediate instructions). 
+    *
+    *     Note: RISBG is non-destructive (unlike the AND immediate instructions).
     *     So the original value in R1 is preserved.
     *
     *   \param node
@@ -235,19 +235,19 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *   \param cg
     *      The code generator used to generate the instructions
-    * 
+    *
     *    \param shiftAmount
     *      The number of bits we should shift the result of the logical AND. A positive value represents a left shift,
     *      a negative value represents a right shift, and a value of zero represents no shift.
     *      Note that if the absolute value of number is greater than 6 bits, then this optimization will not work
     *      since the RISBG instruction will only hold 6 bits for the shift operand.
-    * 
+    *
     *   \param isSignedShift
     *      If replacing a signed shift+and combination, this variable evaluates to true. Else it will evaluate to false.
     *      Note: If we are using this function to replace a standalone 'and', then this variable should be false.
     *
     *   \return
-    *      The target register for the instruction, or NULL if generating a 
+    *      The target register for the instruction, or NULL if generating a
     *      RISBG instruction is not suitable
     *
     */
@@ -413,8 +413,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::InstOpCode::Mnemonic getCompareOpFromNode(TR::CodeGenerator *cg, TR::Node *node);
    static TR::Register *selectEvaluator(TR::Node * node, TR::CodeGenerator * cg);
    static TR::Register *dselectEvaluator(TR::Node * node, TR::CodeGenerator * cg);
-   static bool treeContainsAllOtherUsesForNode(TR::Node *condition, TR::Node *trueVal);
-   static int32_t countReferencesInTree(TR::Node *treeNode, TR::Node *node);
+   static bool treeContainsAllOtherUsesForNode(TR::Node *condition, TR::Node *trueVal, TR::CodeGenerator *cg);
+   static int32_t countReferencesInTree(TR::Node *treeNode, TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *NOPEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *barrierFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lookupEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -463,7 +463,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *inlineVectorBitSelectOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
 
    static TR::Register *bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   
+
    static TR::Register *tryToReuseInputVectorRegs(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *checkAndAllocateReferenceRegister(TR::Node * node,
@@ -538,7 +538,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
 
 /** \brief
     *  Generates Load/Store sequence for array copy as per type of array copy element
-    *  
+    *
     * \param node
     *     The arraycopy node.
     *
@@ -553,13 +553,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *  \param srm
     *     Scratch Register Manager providing pool of scratch registers to use
-    * 
+    *
     *  \param elementType
     *     Array Copy element type
-    * 
+    *
     *  \param needsGuardedLoad
     *     Boolean stating if we need to use Guarded Load instruction
-    * 
+    *
     *  \param deps
     *     Register dependency conditions of the external ICF. Load-and-store for array copy
     *     itself is usually a load-store instruction pair without internal control flows.
@@ -586,13 +586,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *  \param byteLenReg
     *     Register holding number of bytes to copy
-    * 
+    *
     *  \param byteLenNode
     *     Node for number of bytes to copy
-    * 
+    *
     *  \param srm
     *     Scratch Register Manager providing pool of scratch registers to use
-    * 
+    *
     *  \param mergeLabel
     *     Label Symbol where we merge from Out Of line code section
     */
@@ -617,19 +617,19 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *  \param byteLenReg
     *     Register holding number of bytes to copy
-    * 
+    *
     *  \param srm
     *     Scratch Register Manager providing pool of scratch registers to use
     *
     *  \param isForward
     *     Boolean specifying if we need to copy elements in forward direction
-    * 
+    *
     *  \param needsGuardedLoad
     *     Boolean stating if we need to use Guarded Load instruction
     *
     *  \param genStartICFLabel
     *     Boolean stating if we need to set the start ICF flag
-    * 
+    *
     *  \param deps
     *     Register dependency conditions of the external ICF this mem-to-mem copy resides. Mem-to-Mem element copy
     *     itself is a loop of load-store instructions that has its own ICF. If this ICF resides in another ICF,
@@ -637,19 +637,19 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *  \return
     *     Register depdendecy conditions containg registers allocated within Internal Control Flow
-    * 
+    *
     */
    static TR::RegisterDependencyConditions* generateMemToMemElementCopy(TR::Node *node, TR::CodeGenerator *cg, TR::Register *byteSrcReg, TR::Register *byteDstReg, TR::Register *byteLenReg, TR_S390ScratchRegisterManager *srm, bool isForward, bool needsGuardedLoad, bool genStartICFLabel=false, TR::RegisterDependencyConditions* deps = NULL);
 
 /** \brief
     *  Generates sequence for backward array copy
-    *  
+    *
     * \param node
     *     The arraycopy node.
     *
     *  \param cg
     *     The code generator used to generate the instructions.
-    * 
+    *
     *  \param byteSrcReg
     *     Register holding starting address of source
     *
@@ -661,13 +661,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *  \param byteLenNode
     *     Node for number of bytes to copy
-    * 
+    *
     *  \param srm
     *     Scratch Register Manager providing pool of scratch registers to use
-    * 
+    *
     *  \param mergeLabel
     *     Label Symbol where we merge from Out Of line code section
-    * 
+    *
     *  \return
     *     Register depdendecy conditions containg registers allocated within Internal Control Flow
     */
@@ -732,7 +732,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *GlRegDepsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   
+
    static TR::Register *iminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fminEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -797,7 +797,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    /** \brief
     *     Inlines an intrinsic for calls to atomicAddSymbol which are represented by a call node of the form for
     *     32-bit (64-bit similar):
-    * 
+    *
     *     \code
     *       icall <atomicAddSymbol>
     *         <address>
@@ -821,11 +821,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *     A register holding the <value> node.
     */
    static TR::Register* intrinsicAtomicAdd(TR::Node* node, TR::CodeGenerator* cg);
-   
+
    /** \brief
     *     Inlines an intrinsic for calls to atomicFetchAndAddSymbol which are represented by a call node of the form for
     *     32-bit (64-bit similar):
-    * 
+    *
     *     \code
     *       icall <atomicFetchAndAddSymbol>
     *         <address>
@@ -850,11 +850,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *     A register holding the original value in memory (before the addition) at the <address> location.
     */
    static TR::Register* intrinsicAtomicFetchAndAdd(TR::Node* node, TR::CodeGenerator* cg);
-   
+
    /** \brief
     *     Inlines an intrinsic for calls to atomicSwapSymbol which are represented by a call node of the form for
     *     32-bit (64-bit similar):
-    * 
+    *
     *     \code
     *       icall <atomicSwapSymbol>
     *         <address>
@@ -879,7 +879,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *     A register holding the original value in memory (before the swap) at the <address> location.
     */
    static TR::Register* intrinsicAtomicSwap(TR::Node* node, TR::CodeGenerator* cg);
-   
+
    static void         commonButestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* ifFoldingHelper(TR::Node *node, TR::CodeGenerator *cg, bool &handledBIF);
    };

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -68,7 +68,7 @@ class MemToMemMacroOp
          _srcRegTemp = NULL;
          _dstRegTemp = NULL;
          _litReg = NULL;
-         TR::Compilation *comp = TR::comp();
+         TR::Compilation *comp = _cg->comp();
 
          if(cursorBefore == NULL) cursorBefore = comp->cg()->getAppendInstruction();
          _cursor = generateLoop();

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -111,7 +111,7 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
          else
             {
             if (instr->getNode() && instr->getNode()->getOpCodeValue() != TR::BBStart && instr->getRegisterOperand(1))
-               trfprintf(pOutFile, "#%d (%s)", instr->getMemoryReference()->getSymbolReference()->getReferenceNumber(),instr->getRegisterOperand(1)->getRegisterName(TR::comp()));
+               trfprintf(pOutFile, "#%d (%s)", instr->getMemoryReference()->getSymbolReference()->getReferenceNumber(),instr->getRegisterOperand(1)->getRegisterName(_comp));
             else
                trfprintf(pOutFile, "#%d           ", instr->getMemoryReference()->getSymbolReference()->getReferenceNumber());
 
@@ -121,7 +121,7 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
                                                    ((TR::S390SS1Instruction *)(instr))->getMemoryReference2() :
                                                    ((TR::S390SS2Instruction *)(instr))->getMemoryReference2();
                if (memRef && memRef->getSymbolReference() && instr->getNode()->getOpCodeValue() != TR::BBStart && instr->getRegisterOperand(0))
-                  trfprintf(pOutFile, ", #%d (%s)", memRef->getSymbolReference()->getReferenceNumber(), instr->getRegisterOperand(0)->getRegisterName(TR::comp()));
+                  trfprintf(pOutFile, ", #%d (%s)", memRef->getSymbolReference()->getReferenceNumber(), instr->getRegisterOperand(0)->getRegisterName(_comp));
                else if (memRef && memRef->getSymbolReference())
                   trfprintf(pOutFile, ", #%d  ", memRef->getSymbolReference()->getReferenceNumber());
                else


### PR DESCRIPTION
The `TR::Compilation` object is sometimes fetched from TLS (via `TR::comp()`)
when there are cheaper alternative means available (e.g., fetching it from
a `TR::CodeGenerator` object).  Replace some obvious candidates.  Also,
when the TLS version must be used, optimize its use to avoid repeated calls
in the same function.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>