### PR TITLE
Add Language Specific Changes for Dynamic BF Scan Ordering

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2777,6 +2777,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
    if (base && base->getClass() && !vp->comp()->getOption(TR_DisableMarkingOfHotFields) &&
       node->getFirstChild()->getOpCode().hasSymbolReference() &&
       node->getFirstChild()->getSymbol()->isCollectedReference() &&
+      !vp->comp()->fej9()->isHotReferenceFieldRequired() &&
       vp->_curBlock->getGlobalNormalizedFrequency(vp->comp()->getFlowGraph()) >= TR::Options::_hotFieldThreshold)
       {
       vp->comp()->fej9()->markHotField(vp->comp(), node->getSymbolReference(), base->getClass(), base->isFixedClass());

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -836,8 +836,7 @@ public:
 	MMINLINE uint8_t
 	getHotFieldOffset(MM_ForwardedHeader *forwardedHeader)
 	{
-		//return _delegate.getHotFieldOffset(forwardedHeader); //TODO: will be populated once Language specific implementation is ready
-		return U_8_MAX;
+		return _delegate.getHotFieldOffset(forwardedHeader);
 	}
 
 	/**
@@ -850,8 +849,7 @@ public:
 	MMINLINE uint8_t
 	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
 	{
-		//return _delegate.getHotFieldOffset2(forwardedHeader); //TODO: will be populated once Language specific implementation is ready
-		return U_8_MAX;
+		return _delegate.getHotFieldOffset2(forwardedHeader);
 	}
 
 		/**
@@ -864,8 +862,7 @@ public:
 	MMINLINE uint8_t
 	getHotFieldOffset3(MM_ForwardedHeader *forwardedHeader)
 	{
-		//return _delegate.getHotFieldOffset3(forwardedHeader); //TODO: will be populated once Language specific implementation is ready
-		return U_8_MAX;
+		return _delegate.getHotFieldOffset3(forwardedHeader);
 	}
 
 	/**


### PR DESCRIPTION
Add language specific changes for Dynamic Breadth First Scan Ordering to allow for proper functionality of Dynamic Breadth First Scan Ordering now that https://github.com/eclipse/omr/pull/5377 and https://github.com/eclipse/openj9/pull/10124 are merged.

Issue: eclipse/openj9#7552
Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>