### PR TITLE
Improve RISC-V recursive method invocations

### DIFF
--- a/compiler/riscv/codegen/OMRCodeGenerator.hpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.hpp
@@ -78,7 +78,7 @@ public:
 
    CodeGenerator();
 
-   initialize();
+   void initialize();
 
    /**
     * @brief AArch64 hook to begin instruction selection

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -521,7 +521,7 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
       TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
       TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
 
-      if (resolvedMethod != NULL && resolvedMethod->isSameMethod(cg()->comp()->getCurrentMethod()))
+      if (comp()->isRecursiveMethodTarget(resolvedMethod))
          {
          offset = cg()->getCodeStart() - cursor;
          }

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -27,6 +27,7 @@
 #include "codegen/CodeGenerator.hpp"              // for CodeGenerator, etc
 #include "codegen/InstOpCode.hpp"                 // for InstOpCode, etc
 #include "codegen/Instruction.hpp"                // for Instruction
+#include "codegen/Linkage.hpp"
 #include "codegen/Machine.hpp"                    // for Machine, etc
 #include "codegen/MemoryReference.hpp"            // for MemoryReference
 #include "codegen/RealRegister.hpp"               // for RealRegister, etc
@@ -523,7 +524,8 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
 
       if (comp()->isRecursiveMethodTarget(resolvedMethod))
          {
-         offset = cg()->getCodeStart() - cursor;
+         intptr_t jitToJitStart = cg()->getLinkage()->entryPointFromCompiledMethod();
+         offset = jitToJitStart - reinterpret_cast<intptr_t>(cursor);
          }
       else
          {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -879,3 +879,13 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
    return retReg;
    }
 
+intptr_t TR::RVSystemLinkage::entryPointFromCompiledMethod()
+   {
+   return reinterpret_cast<intptr_t>(cg()->getCodeStart());
+   }
+
+intptr_t TR::RVSystemLinkage::entryPointFromInterpretedMethod()
+   {
+   return reinterpret_cast<intptr_t>(cg()->getCodeStart());
+   }
+

--- a/compiler/riscv/codegen/RVSystemLinkage.hpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.hpp
@@ -130,6 +130,34 @@ class RVSystemLinkage : public TR::Linkage
       return buildDispatch(callNode);
       }
 
+   /**
+    * @brief Provides the entry point in a method to use when that method is invoked
+    *        from a method compiled with the same linkage.
+    *
+    * @details
+    *    When asked on the method currently being compiled, this API will return 0 if
+    *    asked before code memory has been allocated.
+    *
+    *    The compiled method entry point may be the same as the interpreter entry point.
+    *
+    * @return The entry point for compiled methods to use; 0 if the entry point is unknown
+    */
+   virtual intptr_t entryPointFromCompiledMethod();
+
+   /**
+    * @brief Provides the entry point in a method to use when that method is invoked
+    *        from an interpreter using the same linkage.
+    *
+    * @details
+    *    When asked on the method currently being compiled, this API will return 0 if
+    *    asked before code memory has been allocated.
+    *
+    *    The compiled method entry point may be the same as the interpreter entry point.
+    *
+    * @return The entry point for interpreted methods to use; 0 if the entry point is unknown
+    */
+   virtual intptr_t entryPointFromInterpretedMethod();
+
    };
 
 }


### PR DESCRIPTION
* Replace recursive method checks with `isRecursiveMethodTarget` Compilation query.
* Provide System linkage implementations of entry point APIs
* Use entryPointFromCompiledMethod linkage API for RISC-V recursive calls

Signed-off-by: Daryl Maier <maier@ca.ibm.com>