### PR TITLE
Unify LinkageInfo word initialization

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1205,6 +1205,18 @@ public:
 
    public:
 
+   /**
+    * @brief initializeLinkageInfo
+    *
+    * The linkage info word is emitted to be right before the startPC. In OMR, there is no
+    * interpreter entry point. Therefore, after the Linkage Info word is emitted, the next
+    * instruction is the compiled method start PC. This means that when the code in
+    * doBinaryEncoding tries to determine the offset of the interpreter entry point from the
+    * start PC, it will always compute 0. Since the Linkage Info word is emitted as 32-bit
+    * word of 0s, there is nothing to initialize.
+    */
+   uint32_t initializeLinkageInfo(void *linkageInfo) { return 0; }
+
    int32_t internalControlFlowNestingDepth() {return _internalControlFlowNestingDepth;}
    int32_t internalControlFlowSafeNestingDepth() { return _internalControlFlowSafeNestingDepth; }
    void incInternalControlFlowNestingDepth() {_internalControlFlowNestingDepth++;}

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1049,22 +1049,8 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
 
       if (isPrivateLinkage && data.cursorInstruction==data.jitTojitStart)
          {
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(self()->comp()->getReturnInfo());
-
-         *(uint32_t *)(data.preProcInstruction->getBinaryEncoding()) = magicWord;
-
-#ifdef J9_PROJECT_SPECIFIC
-         if (data.recomp!=NULL && data.recomp->couldBeCompiledAgain())
-            {
-            J9::PrivateLinkage::LinkageInfo *lkInfo = J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart());
-            if (data.recomp->useSampling())
-               lkInfo->setSamplingMethodBody();
-            else
-               lkInfo->setCountingMethodBody();
-            }
-#endif
-
-         toPPCImmInstruction(data.preProcInstruction)->setSourceImmediate(*(uint32_t *)(data.preProcInstruction->getBinaryEncoding()));
+         uint32_t linkageInfoWord = self()->initializeLinkageInfo(data.preProcInstruction->getBinaryEncoding());
+         toPPCImmInstruction(data.preProcInstruction)->setSourceImmediate(linkageInfoWord);
          }
 
       self()->getLinkage()->performPostBinaryEncoding();

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1959,19 +1959,8 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          // A hack to set the linkage info word
          //
          TR_ASSERT(_returnTypeInfoInstruction->getOpCodeValue() == DDImm4, "assertion failure");
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(self()->comp()->getReturnInfo());
-         uint32_t recompFlag = 0;
-         TR::Recompilation * recomp = self()->comp()->getRecompilationInfo();
-
-#ifdef J9_PROJECT_SPECIFIC
-         if (recomp !=NULL && recomp->couldBeCompiledAgain())
-            {
-            recompFlag = (recomp->useSampling())?METHOD_SAMPLING_RECOMPILATION:METHOD_COUNTING_RECOMPILATION;
-            }
-#endif
-         magicWord |= recompFlag;
-         _returnTypeInfoInstruction->setSourceImmediate(magicWord);
-         *(uint32_t*)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
+         uint32_t linkageInfoWord = self()->initializeLinkageInfo(_returnTypeInfoInstruction->getBinaryEncoding());
+         _returnTypeInfoInstruction->setSourceImmediate(linkageInfoWord);
          }
 
       self()->addToAtlas(cursorInstruction);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2560,31 +2560,8 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       // generate magic word
       if (isPrivateLinkage && data.cursorInstruction == data.jitTojitStart)
          {
-         uint32_t argSize = self()->getBinaryBufferCursor() - self()->getCodeStart();
-         uint32_t magicWord = (argSize << 16) | static_cast<uint32_t>(self()->comp()->getReturnInfo());
-         uint32_t recompFlag = 0;
-
-#ifdef J9_PROJECT_SPECIFIC
-         if (recomp != NULL && recomp->couldBeCompiledAgain())
-            {
-            J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(self()->getCodeStart());
-            if (recomp->useSampling())
-               {
-               recompFlag = METHOD_SAMPLING_RECOMPILATION;
-               linkageInfo->setSamplingMethodBody();
-               }
-            else
-               {
-               recompFlag = METHOD_COUNTING_RECOMPILATION;
-               linkageInfo->setCountingMethodBody();
-               }
-            }
-#endif
-         magicWord |= recompFlag;
-
-         // first word is the code size of intrepeter-to-jit glue in bytes and the second word is the return info
-         toS390ImmInstruction(data.preProcInstruction)->setSourceImmediate(magicWord);
-         *(uint32_t *) (data.preProcInstruction->getBinaryEncoding()) = magicWord;
+         uint32_t linkageInfoWord = self()->initializeLinkageInfo(data.preProcInstruction->getBinaryEncoding());
+         toS390ImmInstruction(data.preProcInstruction)->setSourceImmediate(linkageInfoWord);
          }
       }
 


### PR DESCRIPTION
The Linkage Info word is a 32-bit piece of memory right before the start PC of a compiled body. It is not used in OMR, but **is** used by at least one downstream project (OpenJ9). This PR abstracts away the initialization of this word so that downstream projects can initialize it appropriately.