### PR TITLE
Add and use CodeGenerator factory function

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -149,6 +149,15 @@ OMR::CodeGenerator::generateNop(TR::Node * node, TR::Instruction *instruction, T
     { TR_ASSERT(0, "shouldn't get here"); return NULL;}
 
 
+TR::CodeGenerator *
+OMR::CodeGenerator::create(TR::Compilation *comp)
+   {
+   TR::CodeGenerator *cg = new (comp->trHeapMemory()) TR::CodeGenerator(comp);
+   cg->initialize();
+   return cg;
+   }
+
+
 OMR::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
       _compilation(comp),
       _trMemory(comp->trMemory()),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -281,6 +281,15 @@ public:
    TR_ALLOC(TR_Memory::CodeGenerator)
 
    /**
+    * @brief Factory function to create and initialize a new \c TR::CodeGenerator object.
+    *
+    * @param[in] comp \c TR::Compilation object
+    *
+    * @return An allocated and initialized \c TR::CodeGenerator object
+    */
+   static TR::CodeGenerator *create(TR::Compilation *comp);
+
+   /**
     * @brief Initialize a \c TR::CodeGenerator object
     */
    void initialize();

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -186,15 +186,6 @@ OMR::Compilation::getHotnessName(TR_Hotness h)
    }
 
 
-static TR::CodeGenerator * allocateCodeGenerator(TR::Compilation * comp)
-   {
-   return new (comp->trHeapMemory()) TR::CodeGenerator();
-   }
-
-
-
-
-
 OMR::Compilation::Compilation(
       int32_t id,
       OMR_VMThread *omrVMThread,
@@ -380,7 +371,7 @@ OMR::Compilation::Compilation(
          );
    _isServerInlining = !options.getOption(TR_NoOptServer);
 
-   // TR_DisableInternalPointers must be set before allocateCodeGenerator(self()) is called because
+   // TR_DisableInternalPointers must be set before the TR::CodeGenerator object is created because
    // CodeGenerator's _disableInternalPointers member is set in its constructor and this is one of
    // options that is checked for
    if (_isOptServer)
@@ -413,7 +404,7 @@ OMR::Compilation::Compilation(
       }
 
    //codegen also needs _methodSymbol
-   _codeGenerator = allocateCodeGenerator(self());
+   _codeGenerator = TR::CodeGenerator::create(self());
 
    _recompilationInfo = _codeGenerator->getSupportsRecompilation() ? _codeGenerator->allocateRecompilationInfo() : NULL;
 


### PR DESCRIPTION
* Add factory create() function to CodeGenerator class

* Call factory create() function to instantiate a CodeGenerator

Issue: #3235

Signed-off-by: Daryl Maier <maier@ca.ibm.com>