### PR TITLE
CMake: call $(MAKE) for ddr on makefile generators

### DIFF
--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -60,10 +60,17 @@ function(make_ddr_set set_name)
 		COMMAND "${CMAKE_COMMAND}" -E touch "${DDR_CONFIG_STAMP}"
 		WORKING_DIRECTORY "${DDR_BIN_DIR}"
 	)
-	add_custom_target(${DDR_TARGET_NAME}
-		DEPENDS "${DDR_CONFIG_STAMP}"
-		COMMAND ${CMAKE_COMMAND} --build "${DDR_BIN_DIR}"
-	)
+	if(CMAKE_GENERATOR MATCHES "Makefiles")
+		add_custom_target(${DDR_TARGET_NAME}
+			DEPENDS "${DDR_CONFIG_STAMP}"
+			COMMAND "$(MAKE)" -C "${DDR_BIN_DIR}"
+		)
+	else()
+		add_custom_target(${DDR_TARGET_NAME}
+			DEPENDS "${DDR_CONFIG_STAMP}"
+			COMMAND ${CMAKE_COMMAND} --build "${DDR_BIN_DIR}"
+		)
+	endif()
 	set_property(TARGET "${DDR_TARGET_NAME}" PROPERTY DDR_BIN_DIR "${DDR_BIN_DIR}")
 	set_property(TARGET "${DDR_TARGET_NAME}" PROPERTY DDR_SET TRUE)
 


### PR DESCRIPTION
When we are using a makefile generator, build ddrsets using $(MAKE)
to ensure we get proper parallelism.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>