### PR TITLE
Add field to adjust compact to contract minimum contraction ratio

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -355,6 +355,7 @@ public:
 	int loaFreeHistorySize; /**< max size of _loaFreeRatioHistory array */
 	uintptr_t lastGlobalGCFreeBytesLOA; /**< records the LOA free memory size from after Global GC cycle */
 	ConcurrentMetering concurrentMetering;
+	uintptr_t minimumContractionRatio;
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 
 	bool disableExplicitGC;
@@ -1466,6 +1467,7 @@ public:
 		, loaFreeHistorySize(15)
 		, lastGlobalGCFreeBytesLOA(0)
 		, concurrentMetering(METER_BY_SOA)
+		, minimumContractionRatio(DEFAULT_MINIMUM_CONTRACTION_RATIO)
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 		, disableExplicitGC(false)
 		, heapAlignment(HEAP_ALIGNMENT)

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -827,16 +827,16 @@ MM_ParallelGlobalGC::compactRequiredBeforeHeapContraction(MM_EnvironmentBase *en
 	/* Note: We know based on the collector that this is a single contiguous area */
 	lengthLastFree = env->_cycleState->_activeSubSpace->getAvailableContractionSize(env, allocDescription);
 	
-	/* If chunk at end of heap is free then check its at least 10% of 
+	/* If chunk at end of heap is free then check its at least minimumContractionRatio percent of the
 	 * requested contraction amount
 	 */
-	if (lengthLastFree > 0 ) {
+	if (lengthLastFree > 0) {
 		uintptr_t minContractSize = (contractionSize / MINIMUM_CONTRACTION_RATIO_DIVISOR)
-								 * MINIMUM_CONTRACTION_RATIO_MULTIPLIER;
-								 
-		if (lengthLastFree > minContractSize ) {						 
+								 * _extensions->minimumContractionRatio;
+
+		if (lengthLastFree > minContractSize) {
 			return false;
-		}	
+		}
 	}
 
 compactionReqd:

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -271,7 +271,7 @@ struct ModronLnrlOptions {
 #define OLDFREE_INSUFFICIENT					((uintptr_t)(1024 * 128))
 #define MINIMUM_TLHSIZE_MULTIPLIER				2
 #define MINIMUM_CONTRACTION_RATIO_DIVISOR		100
-#define MINIMUM_CONTRACTION_RATIO_MULTIPLIER	10
+#define DEFAULT_MINIMUM_CONTRACTION_RATIO	10
 
 #define DESIRED_SUBAREA_SIZE		((uintptr_t)(4*1024*1024))
 


### PR DESCRIPTION
This is intended to allow a new command-line option to adjust the
ratio of high address free tenure space to requested contraction size
which causes an extra compaction. A higher ratio results in more
performance-heavy compactions and allows tenure to contract more.

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>