### PR TITLE
Add tempSlot symbol in Symbol Reference Table

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -369,6 +369,25 @@ class SymbolReferenceTable
       jProfileValueSymbol, 
       jProfileValueWithNullCHKSymbol,
 
+      /** \brief
+       * This symbol represents the tempSlot field in j9vmthread. It will provide a mechanism for the compiler
+       * to insert temporary information that the VM can use - such as the number of args when calling
+       * signature-polymorphic methods that are implemented in the VM as internal natives. The VM can use that
+       * information in a number of ways, such as locating items on the stack.
+       *
+       * \code
+       *    istore  <j9VMThreadTempSlotField>
+       *       iconst <number of args for the call to the signature-polymorphic VM internal native method>
+       *    icall <VM internal native method>
+       *       <object the VM needs to locate>
+       *       <parm1>
+       *       <parm2>
+       *       .
+       *       .
+       * \endcode
+       */
+      j9VMThreadTempSlotFieldSymbol,
+
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,
 

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2118,6 +2118,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<atomicCompareAndSwapReturnValue>",
    "<jProfileValueSymbol>",
    "<jProfileValueWithNullCHKSymbol>",
+   "<j9VMThreadTempSlotField>"
    };
 
 const char *


### PR DESCRIPTION
tempSlotSymbol is a non-helper symbol that will provide a
mechanism for the compiler to insert temporary information
that the VM can use - such as the number of args when calling
signature-polymorphic methods that are implemented in the VM as
internal natives. The VM can use that information to locate
items on the stack.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>