### PR TITLE
Remove unneeded content from FrontEnd.hpp

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -58,6 +58,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "env/TypeLayout.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/defines.h"
 #include "env/jittypes.h"
 #include "il/Block.hpp"

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -36,6 +36,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
+#include "env/VerboseLog.hpp"
 #include "il/Block.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -47,6 +47,7 @@
 #include "env/PersistentInfo.hpp"
 #include "env/Processors.hpp"
 #include "env/TRMemory.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/defines.h"
 #include "env/jittypes.h"
 #include "il/ResolvedMethodSymbol.hpp"

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -39,6 +39,7 @@
 #include "env/IO.hpp"
 #include "env/ObjectModel.hpp"
 #include "env/Processors.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/defines.h"
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"

--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,8 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
+#include "env/VerboseLog.hpp"
+
 namespace TR {
 
 /**
@@ -57,7 +59,7 @@ namespace TR {
  * These defaults can be overridden using the TR_CompileTimeProfiler env var.
  *
  * The current implementation only supports perf, but other profiling
- * utilities could be introduced. 
+ * utilities could be introduced.
  *
  * In testing, the initial portion of the compile was lost, due to perf's
  * start up. A delay has been added to manage this.
@@ -77,7 +79,7 @@ public:
          char timestr[_timeLength];
          time_t timer = time(NULL);
          snprintf(timestr, sizeof(timestr), "%i", (int32_t)timer % 100000);
-         
+
          char tidstr[_threadIDLength];
          snprintf(tidstr, sizeof(tidstr), "%ld", syscall(SYS_gettid));
 
@@ -86,8 +88,8 @@ public:
          snprintf(filename, sizeof(filename), "%s.%s.%s.data", identifier ? identifier : "perf", tidstr, timestr);
 
          // Build up the constant options, with env var override
-         if (filenamePos == 0) 
-            parseOptions(cacheOptions, filenamePos, threadIDPos); 
+         if (filenamePos == 0)
+            parseOptions(cacheOptions, filenamePos, threadIDPos);
 
          // Copy and specialize options
          char *options[_optionsLength];
@@ -120,7 +122,7 @@ public:
          // Give perf some time to start
          usleep(_initMicroSecDelay);
          }
-      } 
+      }
 
    ~CompileTimeProfiler()
       {
@@ -162,7 +164,7 @@ private:
             if (*iter == ' ')
                {
                *iter = '\0';
-               newArg = true; 
+               newArg = true;
                }
             else if (newArg)
                {

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@
 #include "env/FEBase.hpp"
 #include "env/IO.hpp"
 #include "env/JitConfig.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/jittypes.h"
 #include "compile/CompilationException.hpp"
 #include "il/ILOps.hpp"

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -35,50 +35,29 @@
 // Add your query to the appropriate category, or create a new category if
 // it is warranted.
 
-#include "infra/List.hpp"
-#include "infra/Random.hpp"
-
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "codegen/CodeGenPhase.hpp"
-#include "env/KnownObjectTable.hpp"
-#include "codegen/Snippet.hpp"
-#include "compile/CompilationTypes.hpp"
-#include "env/Processors.hpp"
 #include "env/ProcessorInfo.hpp"
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
 #include "il/ILOps.hpp"
-#include "infra/Array.hpp"
-#include "infra/Assert.hpp"
-#include "infra/Flags.hpp"
-#include "optimizer/OptimizationStrategies.hpp"
-#include "optimizer/Optimizations.hpp"
 #include "runtime/Runtime.hpp"
-#include "env/VerboseLog.hpp"
 
 class TR_Debug;
 class TR_FrontEnd;
 class TR_Memory;
 class TR_ResolvedMethod;
 namespace OMR { struct MethodMetaDataPOD; }
-namespace TR { class CodeCache; }
-namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
-namespace TR { class MethodSymbol; }
-namespace TR { class Node; }
 namespace TR { class Options; }
 namespace TR { class PersistentInfo; }
 namespace TR { class ResolvedMethodSymbol; }
-namespace TR { class Symbol; }
 namespace TR { class SymbolReference; }
-namespace TR { class TreeTop; }
 struct TR_InlinedCallSite;
-template <typename ListKind> class List;
 
 char * feGetEnv(const char *);
 

--- a/compiler/env/TRPersistentMemory.cpp
+++ b/compiler/env/TRPersistentMemory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@
 #include "control/Options_inlines.hpp"
 #include "env/PersistentAllocator.hpp"
 #include "env/TRMemory.hpp"
+#include "env/VerboseLog.hpp"
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 #include "infra/Monitor.hpp"

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -38,6 +38,7 @@
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
+#include "env/VerboseLog.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/Block.hpp"
 #include "il/DataTypes.hpp"

--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ namespace OMR { typedef OMR::ResolvedMethodSymbol ResolvedMethodSymbolConnector;
 #include <stddef.h>
 #include <stdint.h>
 #include "env/FrontEnd.hpp"
+#include "env/KnownObjectTable.hpp"
 #include "compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "il/MethodSymbol.hpp"

--- a/compiler/infra/SimpleRegex.cpp
+++ b/compiler/infra/SimpleRegex.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,7 @@
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "env/StackMemoryRegion.hpp"
+#include "env/VerboseLog.hpp"
 #include "il/DataTypes.hpp"
 #include "ras/Debug.hpp"
 #include "ras/IgnoreLocale.hpp"

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -36,6 +36,7 @@
 #include "env/CompilerEnv.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/TRMemory.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
 #include "optimizer/OptimizationManager.hpp"

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -31,6 +31,7 @@
 #include "env/ObjectModel.hpp"
 #include "env/jittypes.h"
 #include "env/CompilerEnv.hpp"
+#include "env/VerboseLog.hpp"
 #include "infra/Assert.hpp"
 #include "infra/SimpleRegex.hpp"
 #include "optimizer/Optimizations.hpp"

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -33,6 +33,7 @@
 #include "env/IO.hpp"
 #include "env/defines.h"
 #include "env/jittypes.h"
+#include "env/VerboseLog.hpp"
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 #include "infra/CriticalSection.hpp"

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -33,6 +33,7 @@
 #include "env/defines.h"
 #include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
+#include "env/VerboseLog.hpp"
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 #include "infra/CriticalSection.hpp"


### PR DESCRIPTION
* eliminate unnecessary includes and forward declarations
* fix up other files to accommodate removed includes and declarations

Signed-off-by: Daryl Maier <maier@ca.ibm.com>