### PR TITLE
Remove code related to invokeWithArgumentsHelper

### DIFF
--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -555,10 +555,6 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
       case TR::java_lang_invoke_ComputedCalls_dispatchVirtual:
          specialArgReg = self()->getProperties().getVTableIndexArgumentRegister();
          break;
-      case TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper:
-         numIntArgRegs   = 0;
-         numFloatArgRegs = 0;
-         break;
 #endif
       }
 

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -1466,7 +1466,6 @@ OMR::Z::Linkage::pushLongArg32(TR::Node * callNode, TR::Node * child, int32_t nu
       {
 #ifdef J9_PROJECT_SPECIFIC
       case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method:
-      case TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper:
          isStorePair = true;
          break;
 #endif
@@ -1590,7 +1589,6 @@ OMR::Z::Linkage::pushArg(TR::Node * callNode, TR::Node * child, int32_t numInteg
       {
 #ifdef J9_PROJECT_SPECIFIC
       case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method:
-      case TR::java_lang_invoke_MethodHandle_invokeWithArgumentsHelper:
          isStoreArg = true;
          break;
 #endif


### PR DESCRIPTION
MethodHandle.invokeWithArgumentsHelper was removed in
eclipse/openj9#10859.

This PR removes all dead-code related to invokeWithArgumentsHelper.

Related: https://github.com/eclipse/openj9/issues/7352, https://github.com/eclipse/openj9/pull/10856.

Co-authored-by: Jack Lu <Jack.S.Lu@ibm.com>
Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>