### PR TITLE
Create default parameters for findOrCreateRuntimeHelper

### DIFF
--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -447,9 +447,9 @@ TR::Register *OMR::ARM::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeGen
       }
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongMultiply, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongMultiply)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongMultiply, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongMultiply));
 
    cg->machine()->setLinkRegisterKilled(true);
    node->setRegister(trgReg);
@@ -667,7 +667,7 @@ static TR::Register *idivAndIRemHelper(TR::Node *node, bool isDivide, TR::CodeGe
    TR::addDependency(dependencies, dd_reg, TR::RealRegister::gr0, TR_GPR, cg);
    TR::addDependency(dependencies, dr_reg, TR::RealRegister::gr1, TR_GPR, cg);
 
-   TR::SymbolReference *helper = cg->symRefTab()->findOrCreateRuntimeHelper(isDivide ? TR_ARMintDivide : TR_ARMintRemainder, false, false, false);
+   TR::SymbolReference *helper = cg->symRefTab()->findOrCreateRuntimeHelper(isDivide ? TR_ARMintDivide : TR_ARMintRemainder);
 
    generateImmSymInstruction(cg, ARMOp_bl,
                               node, (uintptr_t)helper->getMethodAddress(),
@@ -771,9 +771,9 @@ static TR::Register *ldivAndLRemHelper(TR::Node *node, bool isDivide, TR::CodeGe
       }
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongDivide, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongDivide)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongDivide, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlongDivide));
 
    cg->machine()->setLinkRegisterKilled(true);
    node->setRegister(trgReg);
@@ -1005,7 +1005,7 @@ static TR::Register *longRightShiftEvaluator(TR::Node *node, bool isLogical, TR:
          TR::addDependency(dependencies, trgReg->getLowOrder(), TR::RealRegister::gr0, TR_GPR, cg);
          TR::addDependency(dependencies, trgReg->getHighOrder(), TR::RealRegister::gr1, TR_GPR, cg);
          TR::addDependency(dependencies, shiftAmountReg, TR::RealRegister::gr2, TR_GPR, cg);
-         TR::SymbolReference *longShiftHelper = cg->symRefTab()->findOrCreateRuntimeHelper(isLogical ? TR_ARMlongShiftRightLogical : TR_ARMlongShiftRightArithmetic, false, false, false);
+         TR::SymbolReference *longShiftHelper = cg->symRefTab()->findOrCreateRuntimeHelper(isLogical ? TR_ARMlongShiftRightLogical : TR_ARMlongShiftRightArithmetic);
 
          generateImmSymInstruction(cg, ARMOp_bl,
                                    node, (uintptr_t)longShiftHelper->getMethodAddress(),

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -269,9 +269,9 @@ static TR::Register *callLong2DoubleHelper(TR::Node *node, TR::CodeGenerator *cg
    dependencies->stopAddingConditions();
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Double, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Double)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Double, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Double));
 
    if (noFPRA)
       {
@@ -356,9 +356,9 @@ static TR::Register *callLong2FloatHelper(TR::Node *node, TR::CodeGenerator *cg)
    dependencies->stopAddingConditions();
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Float, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Float)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Float, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMlong2Float));
 
    if (noFPRA)
       {
@@ -467,9 +467,9 @@ static TR::Register *callDouble2LongHelper(TR::Node *node, TR::CodeGenerator *cg
    dependencies->stopAddingConditions();
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdouble2Long, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdouble2Long)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdouble2Long, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdouble2Long));
 
    //dependencies->stopUsingDepRegs(cg, trgReg);
 
@@ -554,9 +554,9 @@ static TR::Register *callFloat2LongHelper(TR::Node *node, TR::CodeGenerator *cg)
    dependencies->stopAddingConditions();
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloat2Long, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloat2Long)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloat2Long, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloat2Long));
 
    //dependencies->stopUsingDepRegs(cg, trgReg);
    //cg->stopUsingRegister(dummyReg);
@@ -676,9 +676,9 @@ static TR::Register *callDoubleRemainderHelper(TR::Node *node, TR::CodeGenerator
       }
    dependencies->stopAddingConditions();
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdoubleRemainder, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdoubleRemainder)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdoubleRemainder, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMdoubleRemainder));
 
    if (noFPRA)
       {
@@ -779,9 +779,9 @@ static TR::Register *callFloatRemainderHelper(TR::Node *node, TR::CodeGenerator 
    dependencies->stopAddingConditions();
 
    generateImmSymInstruction(cg, ARMOp_bl,
-                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloatRemainder, false, false, false)->getMethodAddress(),
+                             node, (uintptr_t)cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloatRemainder)->getMethodAddress(),
                              dependencies,
-                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloatRemainder, false, false, false));
+                             cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMfloatRemainder));
 
    if (noFPRA)
       {

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -457,9 +457,9 @@ TR::Instruction *OMR::ARM::CodeGenerator::generateSwitchToInterpreterPrePrologue
    TR::Register   *gr4 = self()->machine()->getRealRegister(TR::RealRegister::gr4);
    TR::Register   *lr = self()->machine()->getRealRegister(TR::RealRegister::gr14); // link register
    TR::ResolvedMethodSymbol *methodSymbol = comp->getJittedMethodSymbol();
-   TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMrevertToInterpreterGlue, false, false, false);
+   TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMrevertToInterpreterGlue);
    uintptr_t             ramMethod = (uintptr_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
-   TR::SymbolReference    *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()), false, false, false);
+   TR::SymbolReference    *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()));
    uintptr_t             helperAddr = (uintptr_t)helperSymRef->getMethodAddress();
 
    // gr4 must contain the saved LR; see Recompilation.s

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -971,7 +971,7 @@ TR::Register *OMR::ARM::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
    TR::addDependency(deps, srcAddrReg, TR::RealRegister::gr1, TR_GPR, cg);
    TR::addDependency(deps, dstAddrReg, TR::RealRegister::gr2, TR_GPR, cg);
 
-   arrayCopyHelper = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMarrayCopy, false, false, false);
+   arrayCopyHelper = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARMarrayCopy);
 
    generateImmSymInstruction(cg, ARMOp_bl,
                                    node, (uintptr_t)arrayCopyHelper->getMethodAddress(),

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -176,7 +176,7 @@ class SymbolReferenceTable
        */
       osrFearPointHelperSymbol,
       /** \brief
-       * 
+       *
        * A call with this symbol marks a place where we want/need escape analysis to add heapifications for any stack allocated
        * objects. The primary use case is to force escape of all live local objects ahead of a throw to an OSR catch block
        * but they may also be inserted to facilitate peeking of methods under HCR or other uses. Calls to this helper should
@@ -357,16 +357,16 @@ class SymbolReferenceTable
       atomicCompareAndSwapReturnValueSymbol,
 
       /** \brief
-       *  
+       *
        * These symbols represent placeholder calls for profiling value which will be lowered into trees later.
-       * 
+       *
        * \code
        *    call <jProfileValue/jProfileValueWithNullCHK>
        *       <value to be profiled>
        *       <table address>
        * \endcode
        */
-      jProfileValueSymbol, 
+      jProfileValueSymbol,
       jProfileValueWithNullCHKSymbol,
 
       /** \brief
@@ -495,7 +495,7 @@ class SymbolReferenceTable
    TR::SymbolReference * getSymRef(int32_t i) { return baseArray.element(i); }
 
    TR::SymbolReference * createRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
-   TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
+   TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn = false, bool canGCandExcept = false, bool preservesAllRegisters = false);
 
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
    TR::SymbolReference * findOrCreateJProfileValuePlaceHolderSymbolRef();

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -832,7 +832,7 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->decReferenceCount(secondChild);
    return trgReg;
    }
- 
+
 TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (cg->comp()->target().is64Bit())
@@ -2104,7 +2104,7 @@ strengthReducingLongDivideOrRemainder32BitMode(TR::Node *node,      TR::CodeGene
    else
       helper = isSignedOp ? TR_PPClongDivide : TR_PPCunsignedLongDivide;
 
-   TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+   TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper);
    uintptr_t addr = (uintptr_t)helperSym->getMethodAddress();
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg->trMemory());
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -652,9 +652,9 @@ OMR::Power::CodeGenerator::generateSwitchToInterpreterPrePrologue(
    {
    TR::Register   *gr0 = self()->machine()->getRealRegister(TR::RealRegister::gr0);
    TR::ResolvedMethodSymbol *methodSymbol = self()->comp()->getJittedMethodSymbol();
-   TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue, false, false, false);
+   TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue);
    uintptr_t             ramMethod = (uintptr_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
-   TR::SymbolReference    *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()), false, false, false);
+   TR::SymbolReference    *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()));
    uintptr_t             helperAddr = (uintptr_t)helperSymRef->getMethodAddress();
 
    // gr0 must contain the saved LR; see Recompilation.s
@@ -2580,49 +2580,49 @@ void TR_PPCScratchRegisterManager::addScratchRegistersToDependencyList(
 TR::SymbolReference & OMR::Power::CodeGenerator::getArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCopy);
    }
 
 TR::SymbolReference & OMR::Power::CodeGenerator::getWordArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCwordArrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCwordArrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCwordArrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCwordArrayCopy);
    }
 
 TR::SymbolReference & OMR::Power::CodeGenerator::getHalfWordArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPChalfWordArrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPChalfWordArrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPChalfWordArrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPChalfWordArrayCopy);
    }
 
 TR::SymbolReference & OMR::Power::CodeGenerator::getForwardArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardArrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardArrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardArrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardArrayCopy);
    }
 
 TR::SymbolReference &OMR::Power::CodeGenerator::getForwardWordArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardWordArrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardWordArrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardWordArrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardWordArrayCopy);
    }
 
 TR::SymbolReference &OMR::Power::CodeGenerator::getForwardHalfWordArrayCopySymbolReference()
    {
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6))
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardHalfWordArrayCopy_dp, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardHalfWordArrayCopy_dp);
    else
-      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardHalfWordArrayCopy, false, false, false);
+      return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCforwardHalfWordArrayCopy);
    }
 
 bool OMR::Power::CodeGenerator::supportsTransientPrefetch()

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -305,62 +305,62 @@ public:
    int32_t getCurrentBlockIndex() { return _currentBlockIndex; }
    int32_t arrayInitMinimumNumberOfBytes() {return 32;}
 
-   TR::SymbolReference &getDouble2LongSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCdouble2Long, false, false, false); }
-   TR::SymbolReference &getDoubleRemainderSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCdoubleRemainder, false, false, false); }
-   TR::SymbolReference &getInteger2DoubleSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinteger2Double, false, false, false); }
-   TR::SymbolReference &getLong2DoubleSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Double, false, false, false); }
-   TR::SymbolReference &getLong2FloatSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Float, false, false, false); }
-   TR::SymbolReference &getLong2Float_mvSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Float_mv, false, false, false); }
-   TR::SymbolReference &getLongMultiplySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClongMultiply, false, false, false); }
-   TR::SymbolReference &getLongDivideSymbolReference()   { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClongDivide, false, false, false); }
-   TR::SymbolReference &getUnresolvedStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedSpecialGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedSpecialGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedDirectVirtualGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedDirectVirtualGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedClassGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedClassGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedClassGlue2SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedClassGlue2, false, false, false); }
-   TR::SymbolReference &getUnresolvedStringGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStringGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedStaticDataGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticDataGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedStaticDataStoreGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticDataStoreGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedInstanceDataGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedInstanceDataGlue, false, false, false); }
-   TR::SymbolReference &getUnresolvedInstanceDataStoreGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedInstanceDataStoreGlue, false, false, false); }
-   TR::SymbolReference &getVirtualUnresolvedHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCvirtualUnresolvedHelper, false, false, false); }
-   TR::SymbolReference &getInterfaceCallHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterfaceCallHelper, false, false, false); }
-   TR::SymbolReference &getItrgSendVirtual0SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual0, false, false, false); }
-   TR::SymbolReference &getItrgSendVirtual1SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1, false, false, false); }
-   TR::SymbolReference &getItrgSendVirtualJSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ, false, false, false); }
-   TR::SymbolReference &getItrgSendVirtualFSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualF, false, false, false); }
-   TR::SymbolReference &getItrgSendVirtualDSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualD, false, false, false); }
-   TR::SymbolReference &getVoidStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterVoidStaticGlue, false, false, false); }
-   TR::SymbolReference &getSyncVoidStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncVoidStaticGlue, false, false, false); }
-   TR::SymbolReference &getGPR3StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterGPR3StaticGlue, false, false, false); }
-   TR::SymbolReference &getSyncGPR3StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncGPR3StaticGlue, false, false, false); }
-   TR::SymbolReference &getGPR3GPR4StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterGPR3GPR4StaticGlue, false, false, false); }
-   TR::SymbolReference &getSyncGPR3GPR4StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncGPR3GPR4StaticGlue, false, false, false); }
-   TR::SymbolReference &getFPR0FStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterFPR0FStaticGlue, false, false, false); }
-   TR::SymbolReference &getSyncFPR0FStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncFPR0FStaticGlue, false, false, false); }
-   TR::SymbolReference &getFPR0DStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterFPR0DStaticGlue, false, false, false); }
-   TR::SymbolReference &getSyncFPR0DStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncFPR0DStaticGlue, false, false, false); }
-   TR::SymbolReference &getNativeStaticHelperForUnresolvedGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCnativeStaticHelperForUnresolvedGlue, false, false, false); }
-   TR::SymbolReference &getNativeStaticHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCnativeStaticHelper, false, false, false); }
-   TR::SymbolReference &getCollapseJNIReferenceFrameSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcollapseJNIReferenceFrame, false, false, false); }
+   TR::SymbolReference &getDouble2LongSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCdouble2Long); }
+   TR::SymbolReference &getDoubleRemainderSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCdoubleRemainder); }
+   TR::SymbolReference &getInteger2DoubleSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinteger2Double); }
+   TR::SymbolReference &getLong2DoubleSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Double); }
+   TR::SymbolReference &getLong2FloatSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Float); }
+   TR::SymbolReference &getLong2Float_mvSymbolReference()  { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClong2Float_mv); }
+   TR::SymbolReference &getLongMultiplySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClongMultiply); }
+   TR::SymbolReference &getLongDivideSymbolReference()   { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPClongDivide); }
+   TR::SymbolReference &getUnresolvedStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticGlue); }
+   TR::SymbolReference &getUnresolvedSpecialGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedSpecialGlue); }
+   TR::SymbolReference &getUnresolvedDirectVirtualGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedDirectVirtualGlue); }
+   TR::SymbolReference &getUnresolvedClassGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedClassGlue); }
+   TR::SymbolReference &getUnresolvedClassGlue2SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedClassGlue2); }
+   TR::SymbolReference &getUnresolvedStringGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStringGlue); }
+   TR::SymbolReference &getUnresolvedStaticDataGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticDataGlue); }
+   TR::SymbolReference &getUnresolvedStaticDataStoreGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedStaticDataStoreGlue); }
+   TR::SymbolReference &getUnresolvedInstanceDataGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedInstanceDataGlue); }
+   TR::SymbolReference &getUnresolvedInstanceDataStoreGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterUnresolvedInstanceDataStoreGlue); }
+   TR::SymbolReference &getVirtualUnresolvedHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCvirtualUnresolvedHelper); }
+   TR::SymbolReference &getInterfaceCallHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterfaceCallHelper); }
+   TR::SymbolReference &getItrgSendVirtual0SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual0); }
+   TR::SymbolReference &getItrgSendVirtual1SymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtual1); }
+   TR::SymbolReference &getItrgSendVirtualJSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualJ); }
+   TR::SymbolReference &getItrgSendVirtualFSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualF); }
+   TR::SymbolReference &getItrgSendVirtualDSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCicallVMprJavaSendVirtualD); }
+   TR::SymbolReference &getVoidStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterVoidStaticGlue); }
+   TR::SymbolReference &getSyncVoidStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncVoidStaticGlue); }
+   TR::SymbolReference &getGPR3StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterGPR3StaticGlue); }
+   TR::SymbolReference &getSyncGPR3StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncGPR3StaticGlue); }
+   TR::SymbolReference &getGPR3GPR4StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterGPR3GPR4StaticGlue); }
+   TR::SymbolReference &getSyncGPR3GPR4StaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncGPR3GPR4StaticGlue); }
+   TR::SymbolReference &getFPR0FStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterFPR0FStaticGlue); }
+   TR::SymbolReference &getSyncFPR0FStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncFPR0FStaticGlue); }
+   TR::SymbolReference &getFPR0DStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterFPR0DStaticGlue); }
+   TR::SymbolReference &getSyncFPR0DStaticGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinterpreterSyncFPR0DStaticGlue); }
+   TR::SymbolReference &getNativeStaticHelperForUnresolvedGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCnativeStaticHelperForUnresolvedGlue); }
+   TR::SymbolReference &getNativeStaticHelperSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCnativeStaticHelper); }
+   TR::SymbolReference &getCollapseJNIReferenceFrameSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcollapseJNIReferenceFrame); }
    TR::SymbolReference &getArrayCopySymbolReference();
    TR::SymbolReference &getWordArrayCopySymbolReference();
    TR::SymbolReference &getHalfWordArrayCopySymbolReference();
    TR::SymbolReference &getForwardArrayCopySymbolReference();
    TR::SymbolReference &getForwardWordArrayCopySymbolReference();
    TR::SymbolReference &getForwardHalfWordArrayCopySymbolReference();
-   TR::SymbolReference &getReferenceArrayCopySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCreferenceArrayCopy, false, false, false); }
-   TR::SymbolReference &getGeneralArrayCopySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCgeneralArrayCopy, false, false, false); }
-   TR::SymbolReference &getArrayCmpVMXSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpVMX, false, false, false); }
-   TR::SymbolReference &getArrayCmpLenVMXSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpLenVMX, false, false, false); }
-   TR::SymbolReference &getArrayCmpScalarSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpScalar, false, false, false); }
-   TR::SymbolReference &getArrayCmpLenScalarSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpLenScalar, false, false, false); }
-   TR::SymbolReference &getSamplingPatchCallSiteSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCsamplingPatchCallSite, false, false, false); }
-   TR::SymbolReference &getSamplingRecompileMethodSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCsamplingRecompileMethod, false, false, false); }
-   TR::SymbolReference &getCountingPatchCallSiteSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcountingPatchCallSite, false, false, false); }
-   TR::SymbolReference &getCountingRecompileMethodSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcountingRecompileMethod, false, false, false); }
-   TR::SymbolReference &getInduceRecompilationSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinduceRecompilation, false, false, false); }
-   TR::SymbolReference &getRevertToInterpreterGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue, false, false, false); }
+   TR::SymbolReference &getReferenceArrayCopySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCreferenceArrayCopy); }
+   TR::SymbolReference &getGeneralArrayCopySymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCgeneralArrayCopy); }
+   TR::SymbolReference &getArrayCmpVMXSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpVMX); }
+   TR::SymbolReference &getArrayCmpLenVMXSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpLenVMX); }
+   TR::SymbolReference &getArrayCmpScalarSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpScalar); }
+   TR::SymbolReference &getArrayCmpLenScalarSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCarrayCmpLenScalar); }
+   TR::SymbolReference &getSamplingPatchCallSiteSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCsamplingPatchCallSite); }
+   TR::SymbolReference &getSamplingRecompileMethodSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCsamplingRecompileMethod); }
+   TR::SymbolReference &getCountingPatchCallSiteSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcountingPatchCallSite); }
+   TR::SymbolReference &getCountingRecompileMethodSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCcountingRecompileMethod); }
+   TR::SymbolReference &getInduceRecompilationSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCinduceRecompilation); }
+   TR::SymbolReference &getRevertToInterpreterGlueSymbolReference() { return *_symRefTab->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue); }
 
    bool hasCall()                 {return _flags.testAny(HasCall);}
    bool noStackFrame()            {return _flags.testAny(NoStackFrame);}

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1713,7 +1713,7 @@ TR::Register *OMR::Power::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::C
    cg->evaluate(sideEffectNode);
    cg->decReferenceCount(sideEffectNode);
    // Delegate the evaluation of the remaining children and the store operation to the storeEvaluator.
-   return TR::TreeEvaluator::astoreEvaluator(node, cg);  
+   return TR::TreeEvaluator::astoreEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::dwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3302,7 +3302,7 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
       {
       TR::Register *cndReg = cg->allocateRegister(TR_CCR);
       TR::addDependency(conditions, cndReg, cndDep, TR_CCR, cg);
-   
+
       if (cg->comp()->target().is64Bit())
          {
          groups = byteLen >> 5;
@@ -3313,10 +3313,10 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
          groups = byteLen >> 4;
          residual = byteLen & 0x0000000F;
          }
-   
+
       regs[0] = cg->allocateRegister(TR_GPR);
       TR::addDependency(conditions, regs[0], tempDep, TR_GPR, cg);
-   
+
       if (groups != 0)
          {
          regs[1] = cg->allocateRegister(TR_GPR);
@@ -3326,24 +3326,24 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
          TR::addDependency(conditions, regs[2], TR::RealRegister::NoReg, TR_GPR, cg);
          TR::addDependency(conditions, regs[3], TR::RealRegister::NoReg, TR_GPR, cg);
          }
-   
+
       if (supportsLEArrayCopyInline)
          {
          fpRegs[0] = cg->allocateRegister(TR_FPR);
          fpRegs[1] = cg->allocateRegister(TR_FPR);
          fpRegs[2] = cg->allocateRegister(TR_FPR);
          fpRegs[3] = cg->allocateRegister(TR_FPR);
-   
+
          TR::addDependency(conditions, fpRegs[0], TR::RealRegister::NoReg, TR_FPR, cg);
          TR::addDependency(conditions, fpRegs[1], TR::RealRegister::NoReg, TR_FPR, cg);
          TR::addDependency(conditions, fpRegs[2], TR::RealRegister::NoReg, TR_FPR, cg);
          TR::addDependency(conditions, fpRegs[3], TR::RealRegister::NoReg, TR_FPR, cg);
          }
-   
+
       if (groups != 0)
          {
          TR::LabelSymbol *loopStart;
-   
+
          if (groups != 1)
             {
             if (groups <= UPPER_IMMED)
@@ -3351,7 +3351,7 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
             else
                loadConstant(cg, node, groups, regs[0]);
             generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, regs[0]);
-   
+
             loopStart = generateLabelSymbol(cg);
             generateLabelInstruction(cg, TR::InstOpCode::label, node, loopStart);
             }
@@ -3395,7 +3395,7 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
             ix = 4*memRefSize;
             }
          }
-   
+
       for (; residual>=memRefSize; residual-=memRefSize, ix+=memRefSize)
          {
          if (supportsLEArrayCopyInline)
@@ -3415,7 +3415,7 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
             generateMemSrc1Instruction(cg, store, node, TR::MemoryReference::createWithDisplacement(cg, dst, ix, memRefSize), oneReg);
             }
          }
-   
+
       if (residual != 0)
          {
          if (residual & 4)
@@ -3688,7 +3688,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraytranslateEvaluator(TR::Node *node,
             TR_ASSERT(node->isTargetByteArrayTranslate(), "Both source and target are word for array translate");
             helper = arraytranslateTRTO255 ? TR_PPCarrayTranslateTRTO255 : TR_PPCarrayTranslateTRTO;
             }
-         TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
+         TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper);
          uintptr_t          addr = (uintptr_t)helperSym->getMethodAddress();
          generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node, addr, deps, helperSym);
       }
@@ -4148,7 +4148,7 @@ OMR::Power::TreeEvaluator::generateHelperBranchAndLinkInstruction(
       TR::CodeGenerator* cg)
    {
    TR::SymbolReference *helperSym =
-      cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex, false, false, false);
+      cg->symRefTab()->findOrCreateRuntimeHelper(helperIndex);
 
    return generateDepImmSymInstruction(
       cg, TR::InstOpCode::bl, node,
@@ -4467,11 +4467,11 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
       {
       tmp3Reg = cg->allocateRegister(TR_GPR);
       TR::addDependency(conditions, tmp3Reg, TR::RealRegister::gr0, TR_GPR, cg);
-   
+
       // Call the right version of arrayCopy code to do the job
       TR::addDependency(conditions, tmp1Reg, TR::RealRegister::gr5, TR_GPR, cg);
       TR::addDependency(conditions, tmp2Reg, TR::RealRegister::gr6, TR_GPR, cg);
-   
+
       if (copyUsingVSX)
          {
          vec0Reg = cg->allocateRegister(TR_VRF);
@@ -4588,7 +4588,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
          }
       }
    TR::TreeEvaluator::generateHelperBranchAndLinkInstruction(helper, node, conditions, cg);
-         
+
    conditions->stopUsingDepRegs(cg);
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -790,12 +790,12 @@ TR::Register *OMR::X86::TreeEvaluator::fpRemEvaluator(TR::Node *node, TR::CodeGe
       if (cg->comp()->target().is64Bit())
          {
          // TODO: We should do this for IA32 eventually
-         TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_AMD64doubleRemainder : TR_AMD64floatRemainder, false, false, false);
+         TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_AMD64doubleRemainder : TR_AMD64floatRemainder);
          targetRegister = TR::TreeEvaluator::performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
          }
       else
          {
-         TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_IA32doubleRemainderSSE : TR_IA32floatRemainderSSE, false, false, false);
+         TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_IA32doubleRemainderSSE : TR_IA32floatRemainderSSE);
          targetRegister = TR::TreeEvaluator::performHelperCall(node, helperSymRef, nodeIsDouble ? TR::dcall : TR::fcall, false, cg);
          }
       }
@@ -1229,7 +1229,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       generateLabelInstruction(LABEL, node, reStartLabel, deps, cg);
 
       TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
-      TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE,false,false,false);
+      TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE);
       d2l->getSymbol()->getMethodSymbol()->setLinkage(TR_Helper);
       TR::Node::recreate(node, TR::lcall);
       node->setSymbolReference(d2l);
@@ -1492,7 +1492,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
    else
       {
       TR_ASSERT(cg->comp()->target().is32Bit(), "assertion failure");
-      return TR::TreeEvaluator::fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(node->getOpCodeValue() == TR::f2i ? TR_IA32floatToInt : TR_IA32doubleToInt, false, false, false), cg);
+      return TR::TreeEvaluator::fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(node->getOpCodeValue() == TR::f2i ? TR_IA32floatToInt : TR_IA32doubleToInt), cg);
       }
    }
 
@@ -1500,7 +1500,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
 TR::Register *OMR::X86::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
-   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong, false, false, false), cg);
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong), cg);
    }
 
 
@@ -1568,7 +1568,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGene
    {
    TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
 
-   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong, false, false, false), cg);
+   return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong), cg);
    }
 
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -4554,7 +4554,7 @@ generateCallMemInstruction(TR::Instruction *prevInstr,
 TR::X86ImmSymInstruction  *
 generateHelperCallInstruction(TR::Instruction * cursor, TR_RuntimeHelper index, TR::CodeGenerator *cg)
    {
-   TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index, false, false, false);
+   TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index);
    cg->resetIsLeafMethod();
    return new (cg->trHeapMemory()) TR::X86ImmSymInstruction(cursor, CALLImm4, (uintptr_t)helperSymRef->getMethodAddress(), helperSymRef, cg);
    }
@@ -4562,7 +4562,7 @@ generateHelperCallInstruction(TR::Instruction * cursor, TR_RuntimeHelper index, 
 TR::X86ImmSymInstruction  *
 generateHelperCallInstruction(TR::Node * node, TR_RuntimeHelper index, TR::RegisterDependencyConditions  *dependencies, TR::CodeGenerator *cg)
    {
-   TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index, false, false, false);
+   TR::SymbolReference * helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(index);
    cg->resetIsLeafMethod();
    return generateImmSymInstruction(
          CALLImm4,

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -874,7 +874,7 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, labelOK);        // it is not < +0
       generateRRInstruction(cg, TR::InstOpCode::LCEBR, node, targetRegister, targetRegister); // negate answer to be -0
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelOK);        // it is not < +0
-      TR::SymbolReference *helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitMathHelperFREM, false, false, false);
+      TR::SymbolReference *helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitMathHelperFREM);
       callNode = TR::Node::createWithSymRef(node, TR::fcall, 2, helperCallSymRef);
       }
    else
@@ -890,7 +890,7 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, labelOK);        // it is not < +0
       generateRRInstruction(cg, TR::InstOpCode::LCDBR, node, targetRegister, targetRegister); // negate answer to be -0
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelOK);        // it is not < +0
-      TR::SymbolReference *helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitMathHelperDREM, false, false, false);
+      TR::SymbolReference *helperCallSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390jitMathHelperDREM);
       callNode = TR::Node::createWithSymRef(node, TR::dcall, 2, helperCallSymRef);
       }
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3051,7 +3051,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
       TR_S390BinaryCommutativeAnalyser temp(cg);
       TR_ASSERT_FATAL(firstChild->getDataType() == secondChild->getDataType(), "Data type of firstChild (%s) and secondChild (%s) should match for generating compare and branch", firstChild->getDataType().toString(), secondChild->getDataType().toString());
 
-      // On 64-Bit platforms with compressed references it is possible that one (or both) of the children of the 
+      // On 64-Bit platforms with compressed references it is possible that one (or both) of the children of the
       // compare is loading a class from the object (VFT symbol). This symbol is specially treated within the JIT at
       // the moment because it is an `aloadi` which loads a 32-bit value (64-bit compressed references) and zero
       // extends it to a 64-bit address. Unfortunately the generic analyzers used below are unaware of this fact
@@ -6122,7 +6122,7 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    // If the only consumer is the bstore, then don't bother extending
    //
    else if (valueChild->getReferenceCount() == 1 && valueChild->getRegister() == NULL &&
-               (valueChild->getOpCodeValue() == TR::bload || 
+               (valueChild->getOpCodeValue() == TR::bload ||
                 valueChild->getOpCodeValue() == TR::bloadi     ))
       {
       sourceRegister = cg->allocateRegister();
@@ -10138,7 +10138,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          // At first, load up the branch address into raReg, because
          // to ensure that no weird spilling happens if the code decides it needs
          // to allocate a register at this point for the literal pool base address.
-         intptr_t helper = (intptr_t) cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayTranslateAndTestHelper, false, false, false)->getMethodAddress();
+         intptr_t helper = (intptr_t) cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayTranslateAndTestHelper)->getMethodAddress();
 
          TR::LabelSymbol * labelEntryElementChar = generateLabelSymbol(cg);
          TR::Instruction * cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelEntryElementChar);
@@ -11961,7 +11961,7 @@ OMR::Z::TreeEvaluator::long2StringEvaluator(TR::Node * node, TR::CodeGenerator *
    // At first, load up the branch address into raReg, because
    // to ensure that no weird spilling happens if the code decides it needs
    // to allocate a register at this point for the literal pool base address.
-   intptr_t helper = (intptr_t) cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390long2StringHelper,false,false,false)->getMethodAddress();
+   intptr_t helper = (intptr_t) cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390long2StringHelper)->getMethodAddress();
    genLoadAddressConstant(cg, node, helper, raReg);
 
    TR::MemoryReference * workTopMR = generateS390MemoryReference(workReg, 0, cg);

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -572,25 +572,25 @@ MemInitConstLenMacroOp::generateRemainder()
 intptr_t
 MemInitVarLenMacroOp::getHelper()
    {
-   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arraySetGeneralHelper, false, false, false)->getMethodAddress();
+   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arraySetGeneralHelper)->getMethodAddress();
    }
 
 intptr_t
 MemClearVarLenMacroOp::getHelper()
    {
-   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arraySetZeroHelper, false, false, false)->getMethodAddress();
+   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arraySetZeroHelper)->getMethodAddress();
    }
 
 intptr_t
 MemCpyVarLenMacroOp::getHelper()
    {
-   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayCopyHelper, false, false, false)->getMethodAddress();
+   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayCopyHelper)->getMethodAddress();
    }
 
 intptr_t
 MemCmpVarLenMacroOp::getHelper()
    {
-   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayCmpHelper, false, false, false)->getMethodAddress();
+   return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayCmpHelper)->getMethodAddress();
    }
 
 intptr_t
@@ -599,11 +599,11 @@ BitOpMemVarLenMacroOp::getHelper()
    switch(_opcode)
       {
       case TR::InstOpCode::XC:
-         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayXORHelper, false, false, false)->getMethodAddress();
+         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayXORHelper)->getMethodAddress();
       case TR::InstOpCode::NC:
-         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayANDHelper, false, false, false)->getMethodAddress();
+         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayANDHelper)->getMethodAddress();
       case TR::InstOpCode::OC:
-         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayORHelper, false, false, false)->getMethodAddress();
+         return (intptr_t) _cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayORHelper)->getMethodAddress();
       default:
          TR_ASSERT( 0, "not support");
       }


### PR DESCRIPTION
* Make findOrCreateRuntimeHelper boolean parms default to false
* Replace references to findOrCreateRuntimeHelper on Power
* Replace references to findOrCreateRuntimeHelper on Z
* Replace references to findOrCreateRuntimeHelper on X86
* Replace references to findOrCreateRuntimeHelper on ARM

Closes: #5601