### PR TITLE
Print `initialized` stanza to each file

### DIFF
--- a/gc/verbose/VerboseBuffer.cpp
+++ b/gc/verbose/VerboseBuffer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,6 +28,8 @@
 
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
+
+#define INDENT_SPACER "  "
 
 /**
  * Instantiate a new buffer object
@@ -206,4 +208,27 @@ MM_VerboseBuffer::reset()
 {
 	_bufferAlloc = _buffer;
 	_buffer[0] = '\0';
+}
+
+void
+MM_VerboseBuffer::formatAndOutputV(MM_EnvironmentBase *env, uintptr_t indent, const char *format, va_list args)
+{
+	/* Ensure we have a  buffer. */
+	Assert_VGC_true(NULL != _buffer);
+
+	for (uintptr_t i = 0; i < indent; ++i) {
+		add(env, INDENT_SPACER);
+	}
+	
+	vprintf(env, format, args);
+	add(env, "\n");
+}
+
+void
+MM_VerboseBuffer::formatAndOutput(MM_EnvironmentBase *env, uintptr_t indent, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	formatAndOutputV(env, indent, format, args);
+	va_end(args);
 }

--- a/gc/verbose/VerboseBuffer.hpp
+++ b/gc/verbose/VerboseBuffer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,8 @@ protected:
 public:
 	static MM_VerboseBuffer *newInstance(MM_EnvironmentBase *env, uintptr_t size);
 	virtual void kill(MM_EnvironmentBase *env);
+	void formatAndOutputV(MM_EnvironmentBase *env, uintptr_t indent, const char *format, va_list args);
+	void formatAndOutput(MM_EnvironmentBase *env, uintptr_t indent, const char *format, ...);
 
 	void reset();
 	

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,7 @@ class MM_CollectionStatistics;
 class MM_EnvironmentBase;
 class MM_GCExtensionsBase;
 class MM_VerboseManager;
+class MM_VerboseBuffer;
 
 class MM_VerboseHandlerOutput : public MM_Base
 {
@@ -58,7 +59,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
 	virtual bool getThreadName(char *buf, uintptr_t bufLen, OMR_VMThread *vmThread);
-	virtual void writeVmArgs(MM_EnvironmentBase* env);
+	virtual void writeVmArgs(MM_EnvironmentBase* env, MM_VerboseBuffer* buffer);
 
 	bool getTimeDeltaInMicroSeconds(uint64_t *timeInMicroSeconds, uint64_t startTime, uint64_t endTime)
 	{
@@ -106,22 +107,19 @@ protected:
 
 
 	/**
-	 * Handle any output or data tracking for the initialized phase of verbose GC.
-	 * This routine is meant to be overridden by subclasses to implement collector specific output or functionality.
-	 * @param hook Hook interface used by the JVM.
-	 * @param eventNum The hook event number.
-	 * @param eventData hook specific event data.
-	 */
-	virtual void handleInitializedInnerStanzas(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
-
+     * Output a stanza on data tracking for the initialized phase of verbose GC into a verbose buffer.
+     * This method is meant to be overridden by subclasses to implement collector specific output or functionality.
+     * @param env GC thread used for output.
+     * @param buffer The verbose buffer used to store formatted string
+     */
+	virtual void outputInitializedInnerStanza(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer) {};
+	
 	/**
-	 * Handle any output or data tracking for the initialized phase of verbose GC.
-	 * This routing handles region specific information.
-	 * @param hook Hook interface used by the JVM.
-	 * @param eventNum The hook event number.
-	 * @param eventData hook specific event data.
-	 */
-	void handleInitializedRegion(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+ 	 * Output region specific information of the initialized phase of verbose GC into a verbose buffer.
+ 	 * @param env GC thread used for output.
+ 	 * @param buffer The verbose buffer used to store formatted string
+ 	 */
+	virtual void outputInitializedRegion(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer);
 
 	/**
 	 * Determine if the receive has inner stanza details for cycle start events.
@@ -359,11 +357,19 @@ public:
 
 	/**
 	 * Handle any output or data tracking for the initialized phase of verbose GC.
+	 * Called during initialization of GC, stanza printed to all writers via writer chain.
 	 * @param hook Hook interface used by the JVM.
 	 * @param eventNum The hook event number.
 	 * @param eventData hook specific event data.
 	 */
 	virtual void handleInitialized(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+
+	/**
+	 * Write verbose stanza for Initialization of GC in to a verbose buffer
+	 * @param env GC thread used for output.
+	 * @param buffer verbose buffer used to store formatted string
+	 */
+	void outputInitializedStanza(MM_EnvironmentBase *env, MM_VerboseBuffer *buffer);
 
 	/**
 	 * Write verbose stanza for a cycle start event.

--- a/gc/verbose/VerboseManager.hpp
+++ b/gc/verbose/VerboseManager.hpp
@@ -117,7 +117,8 @@ public:
 	virtual void closeStreams(MM_EnvironmentBase *env);
 
 	MMINLINE MM_VerboseWriterChain* getWriterChain() { return _writerChain; }
-	
+	MM_VerboseHandlerOutput* getVerboseHandlerOutput() { return _verboseHandlerOutput; }
+
 	virtual void handleFileOpenError(MM_EnvironmentBase *env, char *fileName) {}
 
 	MM_VerboseManager(OMR_VM *omrVM)

--- a/gc/verbose/VerboseWriterChain.cpp
+++ b/gc/verbose/VerboseWriterChain.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,8 +32,6 @@
 #undef UT_MODULE_UNLOADED
 #include "ut_j9vgc.h"
 
-#define INDENT_SPACER "  "
-
 MM_VerboseWriterChain::MM_VerboseWriterChain()
 	: MM_Base()
 	,_buffer(NULL)
@@ -57,26 +55,12 @@ MM_VerboseWriterChain::newInstance(MM_EnvironmentBase *env)
 }
 
 void
-MM_VerboseWriterChain::formatAndOutputV(MM_EnvironmentBase *env, uintptr_t indent, const char *format, va_list args)
-{
-	/* Ensure we have a  buffer. */
-	Assert_VGC_true(NULL != _buffer);
-
-	for (uintptr_t i = 0; i < indent; ++i) {
-		_buffer->add(env, INDENT_SPACER);
-	}
-	
-	_buffer->vprintf(env, format, args);
-	_buffer->add(env, "\n");
-}
-
-void
 MM_VerboseWriterChain::formatAndOutput(MM_EnvironmentBase *env, uintptr_t indent, const char *format, ...)
 {
 	va_list args;
 
 	va_start(args, format);
-	formatAndOutputV(env, indent, format, args);
+	_buffer->formatAndOutputV(env, indent, format, args);
 	va_end(args);
 }
 

--- a/gc/verbose/VerboseWriterChain.hpp
+++ b/gc/verbose/VerboseWriterChain.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,6 @@ public:
 	void kill(MM_EnvironmentBase *env);
 
 	void formatAndOutput(MM_EnvironmentBase *env, uintptr_t indent, const char *format, ...);
-	void formatAndOutputV(MM_EnvironmentBase *env, uintptr_t indent, const char *format, va_list args);
 	void flush(MM_EnvironmentBase *env);
 
 	/**
@@ -66,6 +65,8 @@ public:
 	 * @return the first writer
 	 */
 	MM_VerboseWriter *getFirstWriter() { return _writers; }
+	
+	MM_VerboseBuffer *getBuffer() { return _buffer; }
 
 	/**
 	 * Notify each of the writers in the chain that a GC cycle has ended

--- a/gc/verbose/VerboseWriterFileLogging.cpp
+++ b/gc/verbose/VerboseWriterFileLogging.cpp
@@ -306,6 +306,7 @@ MM_VerboseWriterFileLogging::endOfCycle(MM_EnvironmentBase *env)
 		if(0 == _currentCycle) {
 			closeFile(env);
 			_currentFile = (_currentFile + 1) % _numFiles;
+			openFile(env, true);
 		}
 	}
 }

--- a/gc/verbose/VerboseWriterFileLogging.hpp
+++ b/gc/verbose/VerboseWriterFileLogging.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +70,7 @@ protected:
 	virtual bool initialize(MM_EnvironmentBase *env, const char *filename, uintptr_t numFiles, uintptr_t numCycles);
 	virtual void tearDown(MM_EnvironmentBase *env);
 
-	virtual bool openFile(MM_EnvironmentBase *env) = 0;
+	virtual bool openFile(MM_EnvironmentBase *env, bool printInitializedHeader = false) = 0;
 	virtual void closeFile(MM_EnvironmentBase *env) = 0;
 
 	intptr_t findInitialFile(MM_EnvironmentBase *env);

--- a/gc/verbose/VerboseWriterFileLoggingBuffered.hpp
+++ b/gc/verbose/VerboseWriterFileLoggingBuffered.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ protected:
 private:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
-	bool openFile(MM_EnvironmentBase *env);
+	bool openFile(MM_EnvironmentBase *env, bool printInitializedHeader = false);
 	void closeFile(MM_EnvironmentBase *env);
 };
 

--- a/gc/verbose/VerboseWriterFileLoggingSynchronous.hpp
+++ b/gc/verbose/VerboseWriterFileLoggingSynchronous.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ protected:
 private:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
-	bool openFile(MM_EnvironmentBase *env);
+	bool openFile(MM_EnvironmentBase *env, bool printInitializedHeader = false);
 	void closeFile(MM_EnvironmentBase *env);
 
 };


### PR DESCRIPTION
When using `-Xverbosegclog`, prints `Initialized` stanza at the beginning of each file.
In order to achieve this, following changes have been made:
- Relocate `formatAndOutput(),formatAndOutputV()` to `MM_VerboseBuffer` from `MM_VerboseWriterChain`
- In `MM_VerboseHandlerOutput`:
   - Modified `writeVmArgs` to take a `MM_VerboseBuffer`
   - Factored out lines for printing `Initialized` stanza in `handleInitialized`
   - Created `outputInitializedStanza` dedicated to output `Initialized` stanza, which also takes a `MM_VerboseBuffer`
   - In `outputInitializedStanza`, replaced `handleInitializedInnerStanzas` with `outputInitializedInnerStanza` 
- In `VerboseHandlerOutput`:
   - Modified `writeVmArgs` to takes a `MM_VerboseBuffer`
   - Implement virtual method `outputInitializedInnerStanza()`
- Implement `MM_VerboseManager::getVerboseHandlerOutput()`
- In `VerboseWriterChain`:
   - Delete `formatAndOutputV()`
   - Redirect `formatAndOutput()` to `MM_VerboseBuffer`
   - Implement `getBuffer()`
- In `MM_VerboseWriterFileLoggingBuffered` and `VerboseWriterFileLoggingSynchronous`:
   - Print `Initialized` stanza on the second file opens (First file is handled by `TRIGGER_J9HOOK_MM_OMR_INITIALIZED`)
- In `MM_VerboseWriterFileLogging::endOfCycle`, opens a file right after last file closes to make sure a new `Initialized` stanza is printed in `openFile(...)`.
- Changes to generalize handleIniaitzed to work on any provided buffer rather than writer chain specific buffer. This is done to bypass the writer chain with a new buffer during openFile to print stanza specifically for the file being opened.