### PR TITLE
AArch64: Fix debug print for tst instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1220,7 +1220,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc1ImmInstruction *instr)
          if (decodeBitMasks(n, immr, imms, immediate))
             {
             done = true;
-            trfprintf(pOutFile, "%tstimmw \t");
+            trfprintf(pOutFile, "tstimmw \t");
             print(pOutFile, instr->getSource1Register(), TR_WordReg);
             trfprintf(pOutFile, ", 0x%lx", immediate);
             }


### PR DESCRIPTION
This commit corrects debug printf format string for `tst` instruction.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>