### PR TITLE
Clear array split stats

### DIFF
--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -161,6 +161,8 @@ MM_ScavengerStats::clear(bool firstIncrement)
 	_acquireScanListCount = 0;
 	_acquireListLockCount = 0;
 	_aliasToCopyCacheCount = 0;
+	_arraySplitCount = 0;
+	_arraySplitAmount = 0;
 	_workStallCount = 0;
 	_completeStallCount = 0;
 	_syncStallCount = 0;


### PR DESCRIPTION
In Scavenger, when we clear stats for each GC cycle, we miss to clear 2
fields relevant for array splitting, causing the stats being cumulative
since the beginning of the run.

Marking array splitting is ok.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>