### PR TITLE
AArch64: Change ConstantDataSnippet to use targetaddress2 for non-aconst node

### DIFF
--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -78,12 +78,17 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
                }
             else
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    reinterpret_cast<uint8_t *>(node),
-                                                                                    reloType,
-                                                                                    cg()),
-                                                                                    __FILE__, __LINE__,
-                                                                                    node);
+               TR::Relocation *relo;
+               //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
+               //so we need to pass it to relocation in targetaddress2 for now
+               uint8_t * targetAdress2 = NULL;
+               if (getNode()->getOpCodeValue() != TR::aconst)
+                  {
+                  targetAdress2 = reinterpret_cast<uint8_t *>(*(reinterpret_cast<uint64_t*>(cursor)));
+                  }
+               relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, reinterpret_cast<uint8_t *>(node),
+                                                                        targetAdress2, reloType, cg());
+               cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
                }
             break;
 


### PR DESCRIPTION
Change `ConstantDataSnippet` to use targetaddress2 parameter to
constructors of `TR_ExternalRelocation` class if the node is not `aconst`
because some evaluators in downstream projects would use `ConstantDataSnippet` for loading
address constant with non-aconst node.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>