### PR TITLE
Remove reverse load/store opcodes

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -766,18 +766,6 @@ TR::Register *OMR::ARM::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, 
 TR::Register *OMR::ARM::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
 TR::Register *OMR::ARM::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
 
-TR::Register *OMR::ARM::TreeEvaluator::reverseLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR_UNIMPLEMENTED();
-   return NULL;
-   }
-
-TR::Register *OMR::ARM::TreeEvaluator::reverseStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR_UNIMPLEMENTED();
-   return NULL;
-   }
-
 TR::Register *OMR::ARM::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_UNIMPLEMENTED();

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -386,8 +386,6 @@ public:
    static TR::Register *arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraysetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *reverseLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *reverseStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraytranslateEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraycmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *BBStartEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1500,9 +1500,6 @@ public:
    bool getSupportsArrayTranslateAndTest() {return _flags2.testAny(SupportsArrayTranslateAndTest);}
    void setSupportsArrayTranslateAndTest() {_flags2.set(SupportsArrayTranslateAndTest);}
 
-   bool getSupportsReverseLoadAndStore() {return _flags2.testAny(SupportsReverseLoadAndStore);}
-   void setSupportsReverseLoadAndStore() {_flags2.set(SupportsReverseLoadAndStore);}
-
    bool getSupportsArrayTranslateTRxx() {return _flags2.testAny(SupportsArrayTranslate);}
    void setSupportsArrayTranslateTRxx() {_flags2.set(SupportsArrayTranslate);}
    void resetSupportsArrayTranslateTRxx() {_flags2.reset(SupportsArrayTranslate);}
@@ -1769,7 +1766,7 @@ public:
       HasCCZero                                           = 0x00080000,
       HasCCOverflow                                       = 0x00100000,
       HasCCInfo                                           = 0x00200000,
-      SupportsReverseLoadAndStore                         = 0x00400000,
+      // AVAILABLE                                        = 0x00400000,
       SupportsLoweringConstLDivPower2                     = 0x00800000,
       DisableFpGRA                                        = 0x01000000,
       // AVAILABLE                                        = 0x02000000,

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -272,7 +272,6 @@ public:
    bool isAbs()                      const { return properties3().testAny(ILProp3::Abs); }
    bool isVectorReduction()          const { return properties3().testAny(ILProp3::VectorReduction); }
    bool isSignum()                   const { return properties3().testAny(ILProp3::Signum); }
-   bool isReverseLoadOrStore()       const { return properties3().testAny(ILProp3::ReverseLoadOrStore); }
 
 
 

--- a/compiler/il/OMRILProps.hpp
+++ b/compiler/il/OMRILProps.hpp
@@ -259,7 +259,7 @@ namespace ILProp3
       Abs                         = 0x00008000,
       VectorReduction             = 0x00010000, ///< Indicates if opcode performs vector reduction that produces scalar result
       Signum                      = 0x00020000, ///< For Xcmp opcodes
-      ReverseLoadOrStore          = 0x00040000,
+      // Available                = 0x00040000,
       // Available                = 0x00080000,
       // Available                = 0x00100000,
       // Available                = 0x00200000,

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3670,18 +3670,6 @@ OMR::Node::exceptionsRaised()
          if (node->isArrayTRT())
             possibleExceptions |= TR::Block:: CanCatchBoundCheck;
          break;
-#ifdef J9_PROJECT_SPECIFIC
-      case TR::ircload:  // reverse load/store does not throw any exceptions
-      case TR::irsload:
-      case TR::iruiload:
-      case TR::iriload:
-      case TR::irulload:
-      case TR::irlload:
-      case TR::irsstore:
-      case TR::iristore:
-      case TR::irlstore:
-         break;
-#endif
       case TR::arraycmp: // does not throw any exceptions
          break;
       case TR::checkcast:

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -93,9 +93,6 @@ bool OMR::LocalCSE::shouldCopyPropagateNode(TR::Node *parent, TR::Node *node, in
    if (node->getNumChildren() < maxChild)
       return false;
 
-   if (node->getOpCode().isReverseLoadOrStore() || storeNode->getOpCode().isReverseLoadOrStore())
-      return false;
-
    for (int32_t k = 0; k < maxChild; k++)
       {
       if (storeNode->getChild(k) != node->getChild(k))

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1375,15 +1375,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::de2pdSetSign
    constrainChildren,           // TR::de2pdClean
    constrainBCDCHK,          // TR::BCDCHK
-   constrainIiload,             // TR::ircload
-   constrainIiload,             // TR::irsload
-   constrainIiload,             // TR::iruiload
-   constrainIiload,             // TR::iriload
-   constrainLload,              // TR::irulload
-   constrainLload,              // TR::irlload
-   constrainStore,              // TR::irsstore
-   constrainStore,              // TR::iristore
-   constrainStore,              // TR::irlstore
 #endif
 
    };

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -74,15 +74,7 @@ TR::Register *OMR::Power::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Co
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);
-#ifdef J9_PROJECT_SPECIFIC
-      if (node->getFirstChild()->getOpCodeValue() == TR::iriload)
-         {
-         tempMR->forceIndexedForm(child, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, target, tempMR);
-         }
-      else
-#endif
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, target, tempMR);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, target, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
    else
@@ -163,37 +155,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 8);
-#ifdef J9_PROJECT_SPECIFIC
-      if (child->getOpCodeValue() == TR::irlload && cg->comp()->target().is64Bit())        // 64-bit only
-         {
-         TR::Register     *tmpReg = cg->allocateRegister();
-         tempMR->forceIndexedForm(child, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ldbrx, node, tmpReg, tempMR);
-         generateMvFprGprInstructions(cg, node, gpr2fprHost64, true, target, tmpReg);
-         cg->stopUsingRegister(tmpReg);
-         }
-      else if (child->getOpCodeValue() == TR::irlload && cg->comp()->target().is32Bit())   // 32-bit
-         {
-         TR::Register     *highReg = cg->allocateRegister();
-         TR::Register     *lowReg = cg->allocateRegister();
-         TR::MemoryReference *tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, child, *tempMR, 0, 4);
-         TR::MemoryReference *tempMRLoad2 = TR::MemoryReference::createWithMemRef(cg, child, *tempMR, 4, 4);
-
-         tempMRLoad1->forceIndexedForm(child, cg);
-         tempMRLoad2->forceIndexedForm(child, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, lowReg, tempMRLoad1);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, highReg, tempMRLoad2);
-         generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, target, highReg, lowReg);
-
-         tempMRLoad1->decNodeReferenceCounts(cg);
-         tempMRLoad2->decNodeReferenceCounts(cg);
-         cg->stopUsingRegister(highReg);
-         cg->stopUsingRegister(lowReg);
-         cg->decReferenceCount(child);
-         }
-      else
-#endif
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, target, tempMR);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, target, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
    else

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -492,11 +492,6 @@ TR::Instruction *fixedSeqMemAccess(TR::CodeGenerator *cg, TR::Node *node, intptr
 // also handles iiload, iiuload
 TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseLoad = node->getOpCodeValue() == TR::iriload;
-#else
-   bool reverseLoad = false;
-#endif
    TR::Register *tempReg;
    TR::MemoryReference *tempMR = NULL;
    TR::Compilation *comp = cg->comp();
@@ -515,15 +510,7 @@ TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::Code
    // layout in order to patch if it turns out that the reference isn't really volatile.
 
    tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
-   if (reverseLoad)
-      {
-      tempMR->forceIndexedForm(node, cg);
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, tempReg, tempMR);
-      }
-   else
-      {
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-      }
+   generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
 
    cg->insertPrefetchIfNecessary(node, tempReg);
 
@@ -694,11 +681,6 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
 TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseLoad = node->getOpCodeValue() == TR::irlload;
-#else
-   bool reverseLoad = false;
-#endif
    bool needSync;
 
    if (cg->comp()->target().is64Bit())
@@ -715,13 +697,7 @@ TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::Code
       //
       tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
 
-      if (reverseLoad)  // 64-bit only
-         {
-         tempMR->forceIndexedForm(node, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ldbrx, node, trgReg, tempMR);
-         }
-      else
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, trgReg, tempMR);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, trgReg, tempMR);
       if (needSync)
          {
          TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
@@ -740,38 +716,6 @@ TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::Code
       // guarantee atomicity either.
       //
       needSync = node->getSymbolReference()->getSymbol()->isSyncVolatile();
-
-
-      if (reverseLoad)  // 32-bit reverse load. Handles sync
-         {
-         TR::Register *doubleReg = cg->allocateRegister(TR_FPR);
-         TR_BackingStore * location = cg->allocateSpill(8, false, NULL);
-         TR::MemoryReference *tempMR      = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-         TR::MemoryReference *tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 0, 4);
-         TR::MemoryReference *tempMRLoad2 = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 4, 4);
-         // ^ ordering of these temp memory references important?
-
-         // assume SMP since only on POWER 7 and newer
-         if (needSync)
-            {
-            TR::MemoryReference *tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8);
-            generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, tempMRStore1, doubleReg);
-            generateInstruction(cg, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync, node);
-            tempMRStore1->decNodeReferenceCounts(cg);
-            }
-         tempMRLoad1->forceIndexedForm(node, cg);
-         tempMRLoad2->forceIndexedForm(node, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, lowReg, tempMRLoad1);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, highReg, tempMRLoad2);
-
-         cg->freeSpill(location, 8, 0);
-         cg->stopUsingRegister(doubleReg);
-         tempMRLoad1->decNodeReferenceCounts(cg);
-         tempMRLoad2->decNodeReferenceCounts(cg);
-         tempMR->decNodeReferenceCounts(cg);
-         node->setRegister(trgReg);
-         return trgReg;
-         }
 
       if (needSync)
          {
@@ -915,11 +859,6 @@ TR::Register *OMR::Power::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::Code
 // also handles isload
 TR::Register *OMR::Power::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseLoad = node->getOpCodeValue() == TR::irsload;
-#else
-   bool reverseLoad = false;
-#endif
    TR::Register *tempReg = node->setRegister(cg->allocateRegister());
    TR::MemoryReference *tempMR;
 
@@ -929,14 +868,7 @@ TR::Register *OMR::Power::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::Code
    // layout in order to patch if it turns out that the reference isn't really volatile.
 
    tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 2);
-
-   if (reverseLoad)
-      {
-      tempMR->forceIndexedForm(node, cg);
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lhbrx, node, tempReg, tempMR);
-      }
-   else
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lha, node, tempReg, tempMR);
+   generateTrg1MemInstruction(cg, TR::InstOpCode::lha, node, tempReg, tempMR);
 
    if (needSync)
       {
@@ -986,11 +918,6 @@ TR::Register *OMR::Power::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::Code
 TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseStore = node->getOpCodeValue() == TR::iristore;
-#else
-   bool reverseStore = false;
-#endif
    TR::MemoryReference *tempMR = NULL;
    TR::Node *valueChild;
 
@@ -1036,6 +963,13 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
    else
       {
       valueChild = node->getFirstChild();
+      }
+
+   bool reverseStore = false;
+   if (valueChild->getOpCodeValue() == TR::ibyteswap)
+      {
+      reverseStore = true;
+      valueChild = valueChild->getFirstChild();
       }
 
    // Handle special cases
@@ -1204,11 +1138,6 @@ TR::Register *OMR::Power::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::Cod
 TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseStore = node->getOpCodeValue() == TR::irlstore;
-#else
-   bool reverseStore = false;
-#endif
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
       {
@@ -1217,6 +1146,13 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
    else
       {
       valueChild = node->getFirstChild();
+      }
+
+   bool reverseStore = false;
+   if (valueChild->getOpCodeValue() == TR::lbyteswap)
+      {
+      reverseStore = true;
+      valueChild = valueChild->getFirstChild();
       }
 
    // Handle special cases
@@ -1509,11 +1445,6 @@ TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
 // also handles isstore
 TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-#ifdef J9_PROJECT_SPECIFIC
-   bool reverseStore = node->getOpCodeValue() == TR::irsstore;
-#else
-   bool reverseStore = false;
-#endif
    TR::MemoryReference *tempMR;
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
@@ -1524,6 +1455,14 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
       {
       valueChild = node->getFirstChild();
       }
+
+   bool reverseStore = false;
+   if (valueChild->getOpCodeValue() == TR::sbyteswap)
+      {
+      reverseStore = true;
+      valueChild = valueChild->getFirstChild();
+      }
+
    if ((valueChild->getOpCodeValue()==TR::i2s) &&
        valueChild->getReferenceCount()==1 && valueChild->getRegister()==NULL)
        {
@@ -3459,55 +3398,6 @@ static void inlineArrayCopy(TR::Node *node, int64_t byteLen, TR::Register *src, 
 
    conditions->stopUsingDepRegs(cg);
    return;
-   }
-
-
-TR::Register *OMR::Power::TreeEvaluator::reverseStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-#ifdef J9_PROJECT_SPECIFIC
-   if (node->getOpCodeValue() == TR::irsstore)
-      {
-     return sstoreEvaluator(node, cg);
-      }
-   else if (node->getOpCodeValue() == TR::iristore)
-      {
-     return istoreEvaluator(node, cg);
-      }
-   else if (node->getOpCodeValue() == TR::irlstore)
-      {
-     return lstoreEvaluator(node, cg);
-      }
-   else
-#endif
-      {
-      // somehow break here because we have an unimplemented
-      TR_UNIMPLEMENTED();
-      return NULL;
-      }
-   }
-
-TR::Register *OMR::Power::TreeEvaluator::reverseLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-#ifdef J9_PROJECT_SPECIFIC
-   if (node->getOpCodeValue() == TR::irsload)
-      {
-     return sloadEvaluator(node, cg);
-      }
-   else if (node->getOpCodeValue() == TR::iriload)
-      {
-     return iloadEvaluator(node, cg);
-      }
-   else if (node->getOpCodeValue() == TR::irlload)
-      {
-     return lloadEvaluator(node, cg);
-      }
-   else
-#endif
-     {
-     // somehow break here because we have an unimplemented
-     TR_UNIMPLEMENTED();
-     return NULL;
-     }
    }
 
 TR::Register *OMR::Power::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -360,8 +360,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *arraysetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraytranslateEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *reverseLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *reverseStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraycmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compareIntsForEquality(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *compareIntsForEquality(TR::InstOpCode::Mnemonic branchOp, TR::LabelSymbol *dstLabel, TR::Node *node,

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -286,16 +286,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
          {
          trgReg = cg->allocateRegister();
          TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 2);
-#ifdef J9_PROJECT_SPECIFIC
-         if (node->getFirstChild()->getOpCodeValue() == TR::irsload)
-            {
-            tempMR->forceIndexedForm(node->getFirstChild(), cg);
-            generateTrg1MemInstruction(cg, TR::InstOpCode::lhbrx, node, trgReg, tempMR);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, trgReg);
-            }
-         else
-#endif
-            generateTrg1MemInstruction(cg, TR::InstOpCode::lha, node, trgReg, tempMR);
+         generateTrg1MemInstruction(cg, TR::InstOpCode::lha, node, trgReg, tempMR);
          tempMR->decNodeReferenceCounts(cg);
          }
       else

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -3472,15 +3472,6 @@ int32_t childTypes[] =
    TR::DecimalLongDouble,                                    // TR::de2pdSetSign
    TR::DecimalLongDouble,                                    // TR::de2pdClean
    TR::NoType,                                               // TR::BCDCHK
-   TR::Int16 | (TR::Address<<8),                             // TR::ircload
-   TR::Int16 | (TR::Address<<8),                             // TR::irsload
-   TR::Int32 | (TR::Address<<8),                             // TR::iruiload
-   TR::Int32 | (TR::Address<<8),                             // TR::iriload
-   TR::Int64 | (TR::Address<<8),                             // TR::irulload
-   TR::Int64 | (TR::Address<<8),                             // TR::irlload
-   TR::Int16 | (TR::Address<<8),                             // TR::irsstore
-   TR::Int32 | (TR::Address<<8),                             // TR::iristore
-   TR::Int64 | (TR::Address<<8),                             // TR::irlstore
 #endif
 
    };

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -501,7 +501,6 @@ OMR::Z::CodeGenerator::initialize()
       }
 
    cg->setSupportsTestCharComparisonControl();  // TRXX instructions on Danu have mask to disable test char comparison.
-   cg->setSupportsReverseLoadAndStore();
    cg->setSupportsSearchCharString(); // CISC Transformation into SRSTU loop - only on z9.
    cg->setSupportsTranslateAndTestCharString(); // CISC Transformation into TRTE loop - only on z6.
 
@@ -716,7 +715,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
       }
 
    self()->setSupportsTestCharComparisonControl();  // TRXX instructions on Danu have mask to disable test char comparison.
-   self()->setSupportsReverseLoadAndStore();
    self()->setSupportsSearchCharString(); // CISC Transformation into SRSTU loop - only on z9.
    self()->setSupportsTranslateAndTestCharString(); // CISC Transformation into TRTE loop - only on z6.
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5223,13 +5223,12 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
    {
    if (!cg->getConditionalMovesEvaluationMode())
       {
-      if (!storeNode->getOpCode().isReverseLoadOrStore()
-              && storeNode->getType().isIntegral()
+      if (storeNode->getType().isIntegral()
               && !(storeNode->getOpCode().isIndirect() && storeNode->hasUnresolvedSymbolReference()))
          {
          TR::Node* valueNode = storeNode->getOpCode().isIndirect() ? storeNode->getChild(1) : storeNode->getChild(0);
 
-         if (valueNode->getOpCode().isLoadVar() && !valueNode->getOpCode().isReverseLoadOrStore () && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
+         if (valueNode->getOpCode().isLoadVar() && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
             {
             // Pattern match the following trees:
             //
@@ -5271,7 +5270,6 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
 
             // Make sure this is an integral truncation conversion
             if (valueNode->getOpCode().isIntegralLoadVar()
-                    && !valueNode->getOpCode().isReverseLoadOrStore()
                     && valueNode->isSingleRefUnevaluated()
                     && !valueNode->hasUnresolvedSymbolReference())
                {
@@ -5825,36 +5823,6 @@ OMR::Z::TreeEvaluator::axaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
  *   isloadEvaluator handled by sloadEvaluator
  *   icloadEvaluator handled by sloadEvaluator
  *
- * riload Evaluator: load integer reversed
- * handles ruiload too
- */
-TR::Register *
-OMR::Z::TreeEvaluator::riloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return iloadHelper(node, cg, NULL, true);
-   }
-
-/**
- * rlload Evaluator: load long integer reversed
- * handles rulload too
- */
-TR::Register *
-OMR::Z::TreeEvaluator::rlloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return lloadHelper64(node, cg, NULL, true);
-   }
-
-/**
- * rsload Evaluator: load short integer reversed
- * handles rcload too
- */
-TR::Register *
-OMR::Z::TreeEvaluator::rsloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   return sloadHelper(node, cg, NULL, true);
-   }
-
-/**
  * iload Evaluator: load integer
  *   - also handles iiload
  */
@@ -5916,36 +5884,6 @@ OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
  *  isstoreEvaluator handled by sstoreEvaluator
  *  icstoreEvaluator handled by cstoreEvaluator
  */
-/**
- * ristoreEvaluator - store integer reversed
- */
-TR::Register *
-OMR::Z::TreeEvaluator::ristoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   istoreHelper(node, cg, true);
-   return NULL;
-   }
-
-/**
- * rlstoreEvaluator - store long integer reversed
- */
-TR::Register *
-OMR::Z::TreeEvaluator::rlstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   lstoreHelper64(node, cg, true);
-   return NULL;
-   }
-
-/**
- * rsstoreEvaluator - store short integer reversed
- */
-TR::Register *
-OMR::Z::TreeEvaluator::rsstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   sstoreHelper(node, cg, true);
-   return NULL;
-   }
-
 /**
  * istoreEvaluator - store integer
  *  - also used for istorei

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -706,12 +706,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *long2StringEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bitOpMemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *rsloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *riloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *rlloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *rsstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ristoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *rlstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraycmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *arraycmpEvaluatorWithPad(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *BBStartEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Previously, OpenJ9 had a number of opcodes for performing byteswapped
loads and stores implementation details of which have leaked into OMR.
Since OMR now supports byteswap opcodes for all of the types for which
these reverse loads/stores were implemented, these opcodes are being
removed.

Closes: #5149
Signed-off-by: Ben Thomas <ben@benthomas.ca>

This PR needs to be merged concurrently with eclipse/openj9#10938.