### PR TITLE
Avoid null dereference in inliner due to BCD

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5498,14 +5498,7 @@ TR_InlinerBase::forceInline(TR_CallTarget *calltarget)
 
 void TR_CallSite::tagcalltarget(int32_t index, TR_InlinerTracer *tracer, TR_InlinerFailureReason reason)
    {
-  heuristicTrace(tracer,"Tag Call Target %p from callsite %p for Reason: %s",getTarget(index),this,tracer->getFailureReasonString(reason));
-   if (_comp->cg()->traceBCDCodeGen())
-      {
-      char callerName[1024];
-      traceMsg(_comp, "q^q : tag to inline %s into %s (callNode %p on line_no=%d)\n",
-         signature(_comp->trMemory()),_comp->fe()->sampleSignature(_callerResolvedMethod->getPersistentIdentifier(), callerName, 1024, _comp->trMemory()),
-         _callNode,_comp->getLineNumber(_callNode));
-      }
+   heuristicTrace(tracer,"Tag Call Target %p from callsite %p for Reason: %s",getTarget(index),this,tracer->getFailureReasonString(reason));
 
    getTarget(index)->_failureReason = reason;
 
@@ -5531,13 +5524,6 @@ void TR_CallSite::tagcalltarget(TR_CallTarget *calltarget, TR_InlinerTracer *tra
 void TR_CallSite::removecalltarget(int32_t index, TR_InlinerTracer *tracer, TR_InlinerFailureReason reason)
    {
    heuristicTrace(tracer,"Removing Call Target %p from callsite %p for Reason: %s",getTarget(index),this,tracer->getFailureReasonString(reason));
-   if (_comp->cg()->traceBCDCodeGen() && _callNode != NULL)
-      {
-      char callerName[1024];
-      traceMsg(_comp, "q^q : failing to inline %s into %s (callNode %p on line_no=%d)\n",
-         signature(_comp->trMemory()),_comp->fe()->sampleSignature(_callerResolvedMethod->getPersistentIdentifier(), callerName, 1024, _comp->trMemory()),
-         _callNode,_comp->getLineNumber(_callNode));
-      }
 
    getTarget(index)->_failureReason = reason;
 


### PR DESCRIPTION
The `_callNode` field in the call site may be `NULL` which was not being
checked in code paths guarded by BCD tracing. There was a bug exposed
due to recent changes to enable BCD tracing when `traceCG` is enabled in
#5165. This change activated the BCD tracing code path which exposed the
`NULL` dereference.

The BCD tracing here is actually not very useful because there are
`heuristicTrace` statements immedaitely above which trace pretty much
the same information. Thus the safest and easiest thing to do is to just
remove these extra BCD traces.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>