### PR TITLE
Compile twice for DDR on z/OS so optimization is not hindered

### DIFF
--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -42,12 +42,22 @@ endif
 ifeq ($(OMR_ENHANCED_WARNINGS),1)
 endif
 
-# Enable Debugging Symbols
+# Enable debugging symbols?
 ifeq ($(ENABLE_DDR),yes)
-  GLOBAL_CFLAGS   += -Wc,debug
-  GLOBAL_CXXFLAGS += -Wc,debug
-else ifeq ($(OMR_DEBUG),1)
-endif
+  # Optimization is limited when using '-Wc,debug', but *.dbg files are required for DDR.
+  # Override compile commands to compile twice: once with '-Wc,debug', and a second time
+  # without that option.
+
+  define COMPILE_C_COMMAND
+    $(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -c $(GLOBAL_CFLAGS) $(MODULE_CFLAGS) $(CFLAGS) -Wc,debug -o $@ $<
+    $(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -c $(GLOBAL_CFLAGS) $(MODULE_CFLAGS) $(CFLAGS) -o $@ $<
+  endef
+
+  define COMPILE_CXX_COMMAND
+    $(CXX) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -c $(GLOBAL_CXXFLAGS) $(MODULE_CXXFLAGS) $(CXXFLAGS) -Wc,debug -o $@ $<
+    $(CXX) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -c $(GLOBAL_CXXFLAGS) $(MODULE_CXXFLAGS) $(CXXFLAGS) -o $@ $<
+  endef
+endif # ENABLE_DDR
 
 # Enable Optimizations
 ifeq ($(OMR_OPTIMIZE),1)


### PR DESCRIPTION
Performance is seriously degraded on z/OS when files are compiled with `-Wc,debug` (for example, GC times are increased by a factor of over 2.5). On the other hand, `-Wc,debug` is required to produce the debug information required by DDR.

The solution is to compile files twice on z/OS when DDR is enabled. The first compile uses `-Wc,debug` to produce the `*.dbg` file required for DDR, a second compile omits `-Wc,debug` to avoid limiting the optimizer.