### PR TITLE
Windows: Fix copyright strings in shared libraries

### DIFF
--- a/configure
+++ b/configure
@@ -749,8 +749,9 @@ OMR_ZOS_LINK_COMPAT
 OMR_ZOS_COMPILE_TUNE
 OMR_ZOS_COMPILE_TARGET
 OMR_ZOS_COMPILE_ARCHITECTURE
-OMR_PRODUCT_VERSION
 OMR_PRODUCT_DESCRIPTION
+OMR_PRODUCT_VERSION
+OMR_PRODUCT_NAME
 OMR_COMPANY_COPYRIGHT
 OMR_COMPANY_NAME
 OMR_CROSS_CONFIGURE
@@ -918,8 +919,9 @@ OMR_TOOLS_CXX
 OMR_CROSS_CONFIGURE
 OMR_COMPANY_NAME
 OMR_COMPANY_COPYRIGHT
-OMR_PRODUCT_DESCRIPTION
+OMR_PRODUCT_NAME
 OMR_PRODUCT_VERSION
+OMR_PRODUCT_DESCRIPTION
 OMR_ZOS_COMPILE_ARCHITECTURE
 OMR_ZOS_COMPILE_TARGET
 OMR_ZOS_COMPILE_TUNE
@@ -1739,10 +1741,13 @@ Some influential environment variables:
               The company name of product integrating OMR. (Default: )
   OMR_COMPANY_COPYRIGHT
               The copyright of product integrating OMR. (Default: )
-  OMR_PRODUCT_DESCRIPTION
-              The description of product integrating OMR. (Default: OMR 0.1)
+  OMR_PRODUCT_NAME
+              The name of the product integrating OMR. (Default: OMR)
   OMR_PRODUCT_VERSION
-              The version of product integrating OMR. (Default: 0.1)
+              The version of the product integrating OMR. (Default: 0.1)
+  OMR_PRODUCT_DESCRIPTION
+              A description of the product which is integrating OMR. (Default:
+              OMR 0.1 )
   OMR_ZOS_COMPILE_ARCHITECTURE
               The z/OS compile machine architecture. (Default: 7)
   OMR_ZOS_COMPILE_TARGET
@@ -2874,8 +2879,8 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 OMR_COMPANY_NAME=${OMR_COMPANY_NAME:-""}
 OMR_COMPANY_COPYRIGHT=${OMR_COMPANY_COPYRIGHT:-""}
-OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"OMR 0.1 "}
 OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
+OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"OMR 0.1 "}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"0.1"}
 
 OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}

--- a/configure.ac
+++ b/configure.ac
@@ -59,12 +59,12 @@ AC_ARG_VAR([OMR_COMPANY_NAME],
   [The company name of product integrating OMR.] (Default: ))
 AC_ARG_VAR([OMR_COMPANY_COPYRIGHT],
   [The copyright of product integrating OMR.] (Default: ))
-AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION],
-  [The description of product integrating OMR.] (Default: AC_PACKAGE_STRING))
+AC_ARG_VAR([OMR_PRODUCT_NAME],
+  [The name of the product integrating OMR.] (Default: AC_PACKAGE_NAME))
 AC_ARG_VAR([OMR_PRODUCT_VERSION],
-  [The version of product integrating OMR.] (Default: AC_PACKAGE_VERSION))
+  [The version of the product integrating OMR.] (Default: AC_PACKAGE_VERSION))
 AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION],
-  [The description of product integrating OMR.] (Default: AC_PACKAGE_STRING AC_PACKAGE_URL))
+  [A description of the product which is integrating OMR.] (Default: AC_PACKAGE_STRING AC_PACKAGE_URL))
 
 AC_ARG_VAR([OMR_ZOS_COMPILE_ARCHITECTURE],
   [The z/OS compile machine architecture. (Default: 7)])


### PR DESCRIPTION
OMR_PRODUCT_NAME was not properly substituted due to a typo

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>