### PR TITLE
Remove deprecated Power register liveness code

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2094,40 +2094,6 @@ OMR::CodeGenerator::setSpilledRegsForAllPresentLinkages(TR_BitVector *spilledReg
 
 TR::SymbolReference *OMR::CodeGenerator::TR_RegisterPressureState::getCandidateSymRef(){ return _candidate? _candidate->getSymbolReference() : NULL; }
 
-void OMR::CodeGenerator::TR_RegisterPressureState::addVirtualRegister(TR::Register *reg)
-  {
-  if (reg == NULL) return;
-  if (reg->getRealRegister()) return;
-
-  if (reg->getTotalUseCount() == reg->getFutureUseCount())
-     {
-     // first time we see this register
-     if (reg->getKind() == TR_GPR)
-        _gprPressure++;
-     else if (reg->getKind() == TR_FPR)
-        _fprPressure++;
-     else if (reg->getKind() == TR_VRF)
-        _vrfPressure++;
-     }
-  }
-
-void OMR::CodeGenerator::TR_RegisterPressureState::removeVirtualRegister(TR::Register *reg)
-  {
-  if (reg == NULL) return;
-  if (reg->getRealRegister()) return;
-
-  reg->decFutureUseCount();
-  if (reg->getFutureUseCount() == 0)
-     {
-     // register goes dead
-     if (reg->getKind() == TR_GPR)
-        _gprPressure--;
-     else if (reg->getKind() == TR_FPR)
-        _fprPressure--;
-     else if (reg->getKind() == TR_VRF)
-        _vrfPressure--;
-    }
-  }
 
 bool OMR::CodeGenerator::TR_RegisterPressureState::isInitialized(TR::Node *node){ return node->getVisitCount() == _visitCountForInit; }
 

--- a/compiler/codegen/RegisterPressureSimulatorInner.hpp
+++ b/compiler/codegen/RegisterPressureSimulatorInner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,11 +117,6 @@
        TR::SymbolReference *getCandidateSymRef();
 
        bool candidateIsLiveOnEntry(){ return _candidateIsLiveOnEntry; }
-
-       // this method is used during calculation of actual register
-       // pressure, based on instructions
-       void addVirtualRegister(TR::Register *reg);
-       void removeVirtualRegister(TR::Register *reg);
 
       // This indicates that we have already prepared this node for the simulation process.
       // It's an internal bookkeeping thing.

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -165,9 +165,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual TR::PPCImmInstruction *getPPCImmInstruction();
 #endif
 
-   virtual void registersGoLive(TR_RegisterPressureState *) {}
-   virtual void registersGoDead(TR_RegisterPressureState *) {}
-
    /*
     * Maps to TIndex in Instruction. Here we set values specific to PPC CodeGen.
     *

--- a/compiler/p/codegen/OMRRegisterDependency.hpp
+++ b/compiler/p/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,22 +120,6 @@ class TR_PPCRegisterDependencyGroup
                         TR_RegisterKinds  kindToBeAssigned,
                         uint32_t          numberOfRegisters,
                         TR::CodeGenerator *cg);
-
-   void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state, uint32_t numberOfRegisters)
-      {
-      for (uint32_t i = 0; i < numberOfRegisters; i++)
-         {
-         state->addVirtualRegister(_dependencies[i].getRegister());
-         }
-      }
-
-   void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state, uint32_t numberOfRegisters)
-      {
-      for (uint32_t i = 0; i < numberOfRegisters; i++)
-         {
-         state->removeVirtualRegister(_dependencies[i].getRegister());
-         }
-      }
 
    void blockRegisters(uint32_t numberOfRegisters)
       {
@@ -296,18 +280,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          cg->setRegisterAssignmentFlag(TR_PostDependencyCoercion);
          _postConditions->assignRegisters(currentInstruction, kindToBeAssigned, _addCursorForPost, cg);
          }
-      }
-
-   void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      _preConditions->registersGoLive(state, _addCursorForPre);
-      _preConditions->registersGoDead(state, _addCursorForPre);
-      _postConditions->registersGoLive(state, _addCursorForPost);
-      }
-
-   void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      _postConditions->registersGoDead(state, _addCursorForPost);
       }
 
    TR::Register *searchPreConditionRegister(TR::RealRegister::RegNum rr)

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -233,15 +233,6 @@ class PPCSrc1Instruction : public PPCImmInstruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getSource1Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getSource1Register());
-      }
-
    };
 
 class PPCDepInstruction : public TR::Instruction
@@ -405,15 +396,6 @@ class PPCDepLabelInstruction : public PPCLabelInstruction
    virtual bool defsRealRegister(TR::Register *reg);
 
    virtual bool usesRegister(TR::Register *reg);
-
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      getDependencyConditions()->registersGoLive(state);
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      getDependencyConditions()->registersGoDead(state);
-      }
 
    };
 
@@ -706,15 +688,6 @@ class PPCTrg1Instruction : public TR::Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      }
-
    };
 
 class PPCTrg1ImmInstruction : public PPCTrg1Instruction
@@ -740,15 +713,6 @@ class PPCTrg1ImmInstruction : public PPCTrg1Instruction
    virtual void fillBinaryEncodingFields(uint32_t *cursor);
 
    void addMetaDataForCodeAddress(uint8_t *cursor);
-
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      }
 
    };
 
@@ -787,16 +751,6 @@ class PPCSrc2Instruction : public TR::Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getSource1Register());
-      state->addVirtualRegister(getSource2Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getSource1Register());
-      state->removeVirtualRegister(getSource2Register());
-      }
    };
 
 class PPCSrc3Instruction : public PPCSrc2Instruction
@@ -843,18 +797,6 @@ class PPCSrc3Instruction : public PPCSrc2Instruction
       return reg == _source3Register || TR::PPCSrc2Instruction::usesRegister(reg);
       }
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getSource1Register());
-      state->addVirtualRegister(getSource2Register());
-      state->addVirtualRegister(getSource3Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getSource1Register());
-      state->removeVirtualRegister(getSource2Register());
-      state->removeVirtualRegister(getSource3Register());
-      }
    };
 
 class PPCTrg1Src1Instruction : public PPCTrg1Instruction
@@ -889,16 +831,6 @@ class PPCTrg1Src1Instruction : public PPCTrg1Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getSource1Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getSource1Register());
-      }
    };
 
 class PPCTrg1Src1ImmInstruction : public PPCTrg1Src1Instruction
@@ -953,16 +885,6 @@ class PPCTrg1Src1ImmInstruction : public PPCTrg1Src1Instruction
 
    virtual void fillBinaryEncodingFields(uint32_t *cursor);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getSource1Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getSource1Register());
-      }
    };
 
 class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
@@ -1021,16 +943,6 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
 
    virtual void fillBinaryEncodingFields(uint32_t *cursor);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getSource1Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getSource1Register());
-      }
    };
 
 class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
@@ -1098,18 +1010,6 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getSource1Register());
-      state->addVirtualRegister(getSource2Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getSource1Register());
-      state->removeVirtualRegister(getSource2Register());
-      }
    };
 
 class PPCTrg1Src2ImmInstruction : public PPCTrg1Src2Instruction
@@ -1194,20 +1094,6 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getSource1Register());
-      state->addVirtualRegister(getSource2Register());
-      state->addVirtualRegister(getSource3Register());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getSource1Register());
-      state->removeVirtualRegister(getSource2Register());
-      state->removeVirtualRegister(getSource3Register());
-      }
    };
 
 class PPCMemInstruction : public TR::Instruction
@@ -1255,16 +1141,6 @@ class PPCMemInstruction : public TR::Instruction
 	   }
    }
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->addVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->removeVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
    };
 
 class PPCMemSrc1Instruction : public PPCMemInstruction
@@ -1340,18 +1216,6 @@ class PPCMemSrc1Instruction : public PPCMemInstruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getSourceRegister());
-      state->addVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->addVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getSourceRegister());
-      state->removeVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->removeVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
    };
 
 class PPCTrg1MemInstruction : public PPCTrg1Instruction
@@ -1462,18 +1326,6 @@ class PPCTrg1MemInstruction : public PPCTrg1Instruction
 
    virtual bool usesRegister(TR::Register *reg);
 
-   virtual void registersGoLive(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->addVirtualRegister(getTargetRegister());
-      state->addVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->addVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
-   virtual void registersGoDead(TR::CodeGenerator::TR_RegisterPressureState *state)
-      {
-      state->removeVirtualRegister(getTargetRegister());
-      state->removeVirtualRegister(getMemoryReference()->getBaseRegister());
-      state->removeVirtualRegister(getMemoryReference()->getIndexRegister());
-      }
    };
 
 // If we are using a register allocator that cannot handle registers being alive across basic block


### PR DESCRIPTION
Code became obsolete when instruction scheduler was removed prior to open sourcing.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>