### PR TITLE
Add CCData data structure and related functions/tests

### DIFF
--- a/compiler/codegen/CCData.cpp
+++ b/compiler/codegen/CCData.cpp
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "OMR/Bytes.hpp"
+
+#include "codegen/CCData.hpp"
+
+#include "infra/Monitor.hpp"
+#include "infra/CriticalSection.hpp"
+
+using OMR::CCData;
+
+CCData::key_t CCData::key(const uint8_t * const data, const size_t sizeBytes)
+   {
+   return key_t(reinterpret_cast<const key_t::value_type *>(data), sizeBytes);
+   }
+
+CCData::key_t CCData::key(const char * const str)
+   {
+   return key_t(reinterpret_cast<const key_t::value_type *>(str));
+   }
+
+// Converts a size in units of bytes to a size in units of sizeof(data_t).
+#define DATA_SIZE_FROM_BYTES_SIZE(x) (((x) + (sizeof(data_t)) - 1) / (sizeof(data_t)))
+
+// Converts an alignment in units of bytes to an alignment in units of alignof(data_t).
+#define DATA_ALIGNMENT_FROM_BYTES_ALIGNMENT(x) (((x) + (alignof(data_t)) - 1) / (alignof(data_t)))
+
+CCData::CCData(const size_t sizeBytes)
+: _data(new data_t[DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)]), _capacity(DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)), _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(false)
+   {
+   }
+
+CCData::CCData(uint8_t * const storage, const size_t sizeBytes)
+: CCData(alignStorage(storage, sizeBytes))
+   {
+   }
+
+CCData::CCData(const storage_and_size_pair_t storageAndSize)
+: _data(storageAndSize.first), _capacity(storageAndSize.second), _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(true)
+   {
+   }
+
+CCData::~CCData()
+   {
+   // Memory for data can either be allocated by this class or passed in via
+   // the constructor. If allocated, it has to be freed now; if passed in we can't free
+   // it.
+   // The _data member var is a smart pointer that will automatically
+   // free the underlying memory when it goes out of scope. If memory was passed in
+   // via the constructor we have to release it now to prevent the smart pointer from
+   // freeing it.
+   if (_releaseData)
+      _data.release();
+   }
+
+const CCData::storage_and_size_pair_t CCData::alignStorage(uint8_t * const storage, size_t sizeBytes)
+   {
+   // This function takes buffer, aligns it for data_t, and converts the size in bytes to the size in units of data_t.
+   // It returns the aligned pointer and adjusted size in an std::pair so that we can use it when calling a constructor in an initializer list.
+   void *alignedStorage = storage;
+   OMR::align(alignof(data_t), sizeof(data_t), alignedStorage, sizeBytes);
+   return std::make_pair(reinterpret_cast<data_t *>(alignedStorage), DATA_SIZE_FROM_BYTES_SIZE(sizeBytes));
+   }
+
+bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index)
+   {
+   const OMR::CriticalSection cs(_lock);
+
+   /**
+    * Multiple compilation threads may be attempting to update the same value with
+    * the same key.  Once we have the mutex, check if the value already exists and
+    * return successfully.
+    */
+   if (key && find_unsafe(*key, &index))
+      {
+      return true;
+      }
+
+   // The following feels like it could be simplified and calculated more efficiently. If you're reading this, have a go at it.
+   const size_t sizeDataUnits = DATA_SIZE_FROM_BYTES_SIZE(sizeBytes);
+   const size_t alignmentDataUnits = DATA_ALIGNMENT_FROM_BYTES_ALIGNMENT(alignmentBytes);
+   const size_t alignmentMask = alignmentDataUnits - 1;
+   const size_t alignmentPadding = (alignmentDataUnits - ((reinterpret_cast<uintptr_t>(_data.get() + _putIndex) / alignof(data_t)) & alignmentMask)) & alignmentMask;
+   const size_t remainingCapacity = _capacity - _putIndex;
+
+   if (sizeDataUnits + alignmentPadding > remainingCapacity)
+      return false;
+
+   _putIndex += alignmentPadding;
+   index = _putIndex;
+
+   if (key != nullptr)
+      _mappings[*key] = _putIndex;
+
+   if (value != nullptr)
+      {
+      std::copy(value,
+                value + sizeBytes,
+                reinterpret_cast<uint8_t *>(_data.get() + _putIndex));
+      }
+
+   _putIndex += sizeDataUnits;
+
+   return true;
+   }
+
+bool CCData::get(const index_t index, uint8_t * const value, const size_t sizeBytes) const
+   {
+   if (index >= _capacity)
+      return false;
+
+   std::copy(reinterpret_cast<const uint8_t *>(_data.get() + index),
+             reinterpret_cast<const uint8_t *>(_data.get() + index) + sizeBytes,
+             value);
+
+   return true;
+   }
+
+bool CCData::find(const key_t key, index_t * const index) const
+   {
+   const OMR::CriticalSection cs(_lock);
+   return find_unsafe(key, index);
+   }
+
+bool CCData::find_unsafe(const key_t key, index_t * const index) const
+   {
+   auto e = _mappings.find(key);
+   if (e != _mappings.cend())
+      {
+      if (index != nullptr)
+         *index = e->second;
+      return true;
+      }
+
+   return false;
+   }

--- a/compiler/codegen/CCData.cpp
+++ b/compiler/codegen/CCData.cpp
@@ -72,7 +72,7 @@ CCData::~CCData()
 
 bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index)
    {
-   const OMR::CriticalSection cs(_lock);
+   const OMR::CriticalSection critsec(_lock);
 
    /**
     * Multiple compilation threads may be attempting to update the same value with
@@ -126,7 +126,7 @@ bool CCData::get(const index_t index, uint8_t * const value, const size_t sizeBy
 
 bool CCData::find(const key_t key, index_t * const index) const
    {
-   const OMR::CriticalSection cs(_lock);
+   const OMR::CriticalSection critsec(_lock);
    return find_unsafe(key, index);
    }
 

--- a/compiler/codegen/CCData.hpp
+++ b/compiler/codegen/CCData.hpp
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_CCDATA_INCL
+#define OMR_CCDATA_INCL
+
+#include <memory>
+#include <map>
+#include <string>
+#include <cstddef>
+
+namespace TR { class Monitor; }
+
+namespace OMR
+{
+
+/**
+ * @class CCData
+ *
+ * @brief This class represents a table that can be used to implement a GOT or TOC or a PLT or similar.
+ *
+ * <TODO: A more detailed discussion about the design here.>
+ */
+class CCData
+   {
+   private:
+      /** \typedef data_t Implementation detail. This type represents the units of the table. Typically bytes, but can be some other data type, as long as it can be default-constructed. */
+      typedef uint8_t data_t;
+
+      /** \typedef section_t Implementation detail. This type represents the table itself. It must behave like a pointer to an array of type data_t. */
+      typedef std::unique_ptr<data_t[]> section_t;
+
+   public:
+      /** \typedef index_t This type represents the indices defined in the public interface of this class. They must behave like integral types. */
+      typedef size_t index_t;
+
+      /** \typedef key_t This type represents the keys defined in the public interface of this class. The constructor is unspecified, use CCData_t::key() to create keys. */
+      typedef std::string key_t;
+
+#if __cpp_static_assert
+      static_assert(sizeof(key_t::value_type) == 1, "Unimplemented key unit size, remaining bytes need to be zeroed to support key units >1.");
+#endif
+
+   private:
+      /** \typedef map_t Implementation detail. This type represents the associative container that maps keys to indices. It must behave like std::unordered_map. */
+      typedef std::map<key_t, index_t> map_t;
+
+   public:
+      /**
+       * @brief Creates a key_t from the given value. The value's type must have a unique object representation.
+       *
+       * Unique Object Representations
+       *
+       * Structs and classes usually have padding bytes which are going to be included in their memory representations.
+       * Even if the padding is at the end of the instance, sizeof() will include it. Calculating a key based on the memory
+       * representation is going to include the padding, which is incorrect. If the key includes the padding, two otherwise
+       * equal objects will result in different keys if their padding bytes differ.
+       *
+       * This also applies to floats and doubles because of various "don't care" (DC) bits in the binary representation.
+       * Logically equal float values might have different bit patterns and would result in different keys.
+       *
+       * Types that don't have any padding or DC bits have unique object representations in C++ standard parlance.
+       *
+       * @tparam T The type of the value to create the key from. The type must have a unique object representation. A static assertion checks for the std::has_unique_object_representations<T> type trait on capable compilers.
+       * @param[In] value The value to create the key from.
+       * @return The key.
+       */
+      template <typename T>
+      static key_t key(const T value);
+
+      /**
+       * @brief Creates a key_t from the given buffer of data. The entire buffer will be used as input, including any unused bits/bytes that you may not be aware of. See key(const T value) for info on why this is important to note.
+       *
+       * @param[In] data A pointer to the buffer of data.
+       * @param[In] sizeBytes The size (in bytes) of the data.
+       * @return The key.
+       */
+      static key_t key(const uint8_t * const data, const size_t sizeBytes);
+
+      /**
+       * @brief Creates a key_t from the given null-terminated C string.
+
+       * @param[In] data A pointer to the string.
+       * @return The key.
+       * \TODO: Decide if we need this; useful for string literals, but susceptible to bugs/attack because of the unbounded string.
+       */
+      static key_t key(const char * const str);
+
+      /**
+       * @brief Constructs a CCData.
+
+       * @param[In] sizeBytes The amount of data (in bytes) that CCData can hold.
+       */
+      CCData(const size_t sizeBytes);
+
+      /**
+       * @brief Constructs a CCData and accepts a pointer to a memory buffer that will be used to hold the data.
+       *
+       * The lifetime of the memory buffer must exceed the lifetime of the resulting CCData object. The memory buffer will still be valid after the CCData object is destructed (i.e. the memory buffer will not be freed, do it yourself).
+       *
+       * @param[In] storage A pointer to a memory buffer that CCData will use.
+       * @param[In] sizeBytes The amount of data (in bytes) that the buffer contains.
+       */
+      CCData(uint8_t * const storage, const size_t sizeBytes);
+
+      ~CCData();
+
+      /**
+       * @brief Puts the given value in the table, optionally mapped to the given key (if any), aligned to the value's natural type, and returns the index to the value. Synchronized.
+
+       * @tparam T The type of the value to put in the table. The type must be TriviallyCopyable. A static assertion checks for the std::is_trivially_copyable<T> type trait on capable compilers.
+       * @param[In] value The value to put.
+       * @param[In] key Optional. The key to map the resulting index to. Without a key the index is the only reference to the data.
+       * @param[Out] index The index that refers to the value.
+       */
+      template <typename T>
+      bool put(const T value, const key_t * const key, index_t &index);
+
+      /**
+       * @brief Puts the given value in the table, optionally mapped to the given key (if any), aligned to the given boundary (in bytes), and returns the index to the value. Synchronized.
+
+       * @param[In] value Optional. A pointer to the value to put. If null, no data will be copied but the space will be allocated none the less.
+       * @param[In] sizeBytes The size of the value pointed to.
+       * @param[In] alignmentBytes The alignment (in bytes) to align the value to.
+       * @param[In] key Optional. The key to map the resulting index to. Without a key the index is the only reference to the data. If the key is already mapped to an index the operation will return the index and true, but no data will be written.
+       * @param[Out] index The index that refers to the value.
+       * @return True if the value was placed in the table, or the key was already mapped to an index, false otherwise.
+       */
+      bool put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index);
+
+      /**
+       * @brief Gets the value referred to by the index from the table.
+
+       * @param[In] T The type of the value to get from the table. The type must be TriviallyCopyable. A static assertion checks for the std::is_trivially_copyable<T> type trait on capable compilers.
+       * @param[In] index The index that refers to the value.
+       * @param[out] value A reference to the value to write the result to.
+       * @return True if the value was placed in the table, false otherwise.
+       */
+      template <typename T>
+      bool get(const index_t index, T &value) const;
+
+      /**
+       * @brief Gets the value referred to by the index from the table.
+
+       * @param[In] index The index that refers to the value.
+       * @param[in] value A pointer to the value to write the result to. This parameter is ignored unless this function returns true.
+       * @param[In] sizeBytes The size (in bytes) of the value pointed to. This parameter is ignored unless this function returns true.
+       * @return True if the index refers to an existing value, false otherwise.
+       */
+      bool get(const index_t index, uint8_t * const value, const size_t sizeBytes) const;
+
+      /**
+       * @brief Gets a pointer to the value referred to by the index from the table.
+
+       * @param[In] T The type of the value to get from the table. The type need not be TriviallyCopyable, since this function doesn't do any copying, but it probably should be for symmetry with the put() functions.
+       * @param[In] index The index that refers to the value.
+       * @return A pointer to the value if the index refers to an existing value, nullptr otherwise.
+       */
+      template <typename T>
+      T* get(const index_t index) const;
+
+      /**
+       * @brief Checks if the given key maps to an index in this table and returns the index. Synchronized.
+
+       * @param[In] key The key to check.
+       * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
+       * @return True if the given key maps to an index, false otherwise.
+       */
+      bool find(const key_t key, index_t * const index = nullptr) const;
+
+   private:
+      // Helper stuff used by the general (storage, sizeBytes) ctor.
+      typedef std::pair<data_t * const, const size_t> storage_and_size_pair_t;
+      CCData(const storage_and_size_pair_t storageAndSize);
+      static const storage_and_size_pair_t alignStorage(uint8_t * const storage, size_t sizeBytes);
+
+      /**
+       * @brief Checks if the given key maps to an index in this table and returns the index.
+       *        This function is NOT synchronized (hence unsafe).
+       *
+       * @param[In] key The key to check.
+       * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
+       * @return True if the given key maps to an index, false otherwise.
+       */
+      bool find_unsafe(const key_t key, index_t * const index = nullptr) const;
+
+   private:
+      section_t         _data;         // Could be const were it not for the release() call in the dtor.
+      const size_t      _capacity;
+      size_t            _putIndex;
+      map_t             _mappings;
+      TR::Monitor      *_lock;
+      const bool        _releaseData;
+   };
+
+}
+
+#endif // OMR_CCDATA_INCL

--- a/compiler/codegen/CCData.hpp
+++ b/compiler/codegen/CCData.hpp
@@ -22,7 +22,6 @@
 #ifndef OMR_CCDATA_INCL
 #define OMR_CCDATA_INCL
 
-#include <memory>
 #include <map>
 #include <string>
 #include <cstddef>
@@ -44,9 +43,6 @@ class CCData
    private:
       /** \typedef data_t Implementation detail. This type represents the units of the table. Typically bytes, but can be some other data type, as long as it can be default-constructed. */
       typedef uint8_t data_t;
-
-      /** \typedef section_t Implementation detail. This type represents the table itself. It must behave like a pointer to an array of type data_t. */
-      typedef std::unique_ptr<data_t[]> section_t;
 
    public:
       /** \typedef index_t This type represents the indices defined in the public interface of this class. They must behave like integral types. */
@@ -172,7 +168,7 @@ class CCData
 
        * @param[In] T The type of the value to get from the table. The type need not be TriviallyCopyable, since this function doesn't do any copying, but it probably should be for symmetry with the put() functions.
        * @param[In] index The index that refers to the value.
-       * @return A pointer to the value if the index refers to an existing value, nullptr otherwise.
+       * @return A pointer to the value if the index refers to an existing value, NULL otherwise.
        */
       template <typename T>
       T* get(const index_t index) const;
@@ -184,14 +180,9 @@ class CCData
        * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
        * @return True if the given key maps to an index, false otherwise.
        */
-      bool find(const key_t key, index_t * const index = nullptr) const;
+      bool find(const key_t key, index_t * const index = NULL) const;
 
    private:
-      // Helper stuff used by the general (storage, sizeBytes) ctor.
-      typedef std::pair<data_t * const, const size_t> storage_and_size_pair_t;
-      CCData(const storage_and_size_pair_t storageAndSize);
-      static const storage_and_size_pair_t alignStorage(uint8_t * const storage, size_t sizeBytes);
-
       /**
        * @brief Checks if the given key maps to an index in this table and returns the index.
        *        This function is NOT synchronized (hence unsafe).
@@ -200,11 +191,11 @@ class CCData
        * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
        * @return True if the given key maps to an index, false otherwise.
        */
-      bool find_unsafe(const key_t key, index_t * const index = nullptr) const;
+      bool find_unsafe(const key_t key, index_t * const index = NULL) const;
 
    private:
-      section_t         _data;         // Could be const were it not for the release() call in the dtor.
-      const size_t      _capacity;
+      data_t           *_data;
+      size_t            _capacity;
       size_t            _putIndex;
       map_t             _mappings;
       TR::Monitor      *_lock;

--- a/compiler/codegen/CCData_inlines.hpp
+++ b/compiler/codegen/CCData_inlines.hpp
@@ -40,18 +40,22 @@ CCData::key_t CCData::key(const T value)
 template <typename T>
 bool CCData::put(const T value, const key_t * const key, index_t &index)
    {
-#if __cpp_static_assert
-   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-#endif
+   // std::is_trivially_copyable is a C++11 type trait, but unfortunately there's no test macro for it.
+   // static_assert is also a C++11 feature, so testing for that would hopefully be enough, but unfortunately some old compilers have static_assert but not is_trivially_copyable,
+   // hence `#if __cpp_static_assert` is insufficient.
+//#if __cpp_static_assert
+//   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+//#endif
    return put(reinterpret_cast<const uint8_t *>(&value), sizeof(value), alignof(value), key, index);
    }
 
 template <typename T>
 bool CCData::get(const index_t index, T &value) const
    {
-#if __cpp_static_assert
-   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-#endif
+   // See above.
+//#if __cpp_static_assert
+//   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+//#endif
    return get(index, reinterpret_cast<uint8_t *>(&value), sizeof(value));
    }
 
@@ -61,9 +65,9 @@ T* CCData::get(const index_t index) const
    // Don't have to check if T is trivially_copyable here since we're not copying to/from a T.
    // The caller might, but it is then their responsibility to make sure.
    if (index >= _capacity)
-      return nullptr;
+      return NULL;
 
-   return reinterpret_cast<T *>(_data.get() + index);
+   return reinterpret_cast<T *>(_data + index);
    }
 
 }

--- a/compiler/codegen/CCData_inlines.hpp
+++ b/compiler/codegen/CCData_inlines.hpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_CCDATA_INLINES_INCL
+#define OMR_CCDATA_INLINES_INCL
+
+#include <type_traits>
+
+namespace OMR
+{
+
+template <typename T>
+CCData::key_t CCData::key(const T value)
+   {
+#if __cpp_static_assert && __cpp_lib_has_unique_object_representations
+   // std::has_unique_object_representations is only available in C++17.
+   static_assert(std::has_unique_object_representations<T>::value == true, "T must have unique object representations.");
+#endif
+   return key(reinterpret_cast<const uint8_t *>(&value), sizeof(value));
+   }
+
+template <typename T>
+bool CCData::put(const T value, const key_t * const key, index_t &index)
+   {
+#if __cpp_static_assert
+   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+#endif
+   return put(reinterpret_cast<const uint8_t *>(&value), sizeof(value), alignof(value), key, index);
+   }
+
+template <typename T>
+bool CCData::get(const index_t index, T &value) const
+   {
+#if __cpp_static_assert
+   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+#endif
+   return get(index, reinterpret_cast<uint8_t *>(&value), sizeof(value));
+   }
+
+template <typename T>
+T* CCData::get(const index_t index) const
+   {
+   // Don't have to check if T is trivially_copyable here since we're not copying to/from a T.
+   // The caller might, but it is then their responsibility to make sure.
+   if (index >= _capacity)
+      return nullptr;
+
+   return reinterpret_cast<T *>(_data.get() + index);
+   }
+
+}
+
+#endif // OMR_CCDATA_INLINES_INCL

--- a/compiler/codegen/CMakeLists.txt
+++ b/compiler/codegen/CMakeLists.txt
@@ -22,6 +22,7 @@
 compiler_library(codegen
 	${CMAKE_CURRENT_LIST_DIR}/OMRAheadOfTimeCompile.cpp
 	${CMAKE_CURRENT_LIST_DIR}/Analyser.cpp
+	${CMAKE_CURRENT_LIST_DIR}/CCData.cpp
 	${CMAKE_CURRENT_LIST_DIR}/CodeGenPrep.cpp
 	${CMAKE_CURRENT_LIST_DIR}/CodeGenGC.cpp
 	${CMAKE_CURRENT_LIST_DIR}/CodeGenRA.cpp

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -74,6 +74,7 @@ omr_add_executable(compilertest NOWARNINGS
 	tests/FooBarTest.cpp
 	tests/LimitFileTest.cpp
 	tests/LogFileTest.cpp
+	tests/CCDataTest.cpp
 	tests/OMRTestEnv.cpp
 	tests/OptionSetTest.cpp
 	tests/OpCodesTest.cpp

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -74,7 +74,6 @@ omr_add_executable(compilertest NOWARNINGS
 	tests/FooBarTest.cpp
 	tests/LimitFileTest.cpp
 	tests/LogFileTest.cpp
-	tests/CCDataTest.cpp
 	tests/OMRTestEnv.cpp
 	tests/OptionSetTest.cpp
 	tests/OpCodesTest.cpp
@@ -97,6 +96,14 @@ omr_add_executable(compilertest NOWARNINGS
 	tests/injectors/SelectOpIlInjector.cpp
 	tests/injectors/UnaryOpIlInjector.cpp
 )
+
+# MSVC and XL C/C++ have trouble with this file
+if (NOT OMR_TOOLCONFIG STREQUAL "msvc" AND NOT OMR_TOOLCONFIG STREQUAL "xlc")
+	target_sources(compilertest
+		PRIVATE
+			tests/CCDataTest.cpp
+	)
+endif()
 
 if(OMR_ARCH_X86)
 	target_sources(compilertest

--- a/fvtest/compilertest/tests/CCDataTest.cpp
+++ b/fvtest/compilertest/tests/CCDataTest.cpp
@@ -102,7 +102,7 @@ class GeneratedMethodInfo : public MethodInfo
 class TableTest : public OptTestDriver
    {
    public:
-      TableTest() : _caseValues(nullptr), _numCaseValues(0) {}
+      TableTest() : _caseValues(NULL), _numCaseValues(0) {}
       void setCaseValues(const int32_t * const caseValues, const size_t numCaseValues)
          {
          _caseValues = caseValues;
@@ -110,7 +110,7 @@ class TableTest : public OptTestDriver
          }
       virtual void invokeTests() override
          {
-         EXPECT_NE(_caseValues, nullptr);
+         EXPECT_TRUE(_caseValues != NULL);
          EXPECT_GT(_numCaseValues, 0);
          auto compiledMethod = getCompiledMethod<GeneratedMethodInfo::compiled_method_t>();
          for (auto i = 0; i < _numCaseValues; ++i)
@@ -219,9 +219,9 @@ TYPED_TEST(CCDataTest, test_basics_templated)
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it was written to an aligned address.
-   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (OMR_ALIGNOF(data) - 1), 0);
    // Make sure it was written correctly.
    EXPECT_EQ(*dataPtr, data);
    // We should be able to find something with this key now.
@@ -244,7 +244,7 @@ TYPED_TEST(CCDataTest, test_basics_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(data, nullptr, index));
+   while (table.put(data, NULL, index));
    }
 
 TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
@@ -261,16 +261,16 @@ TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
    CCData::index_t index = INVALID_INDEX;
 
    // Put the data in the table, associate it with the key, retrieve the index.
-   EXPECT_TRUE(table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), &key, index));
+   EXPECT_TRUE(table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), OMR_ALIGNOF(data), &key, index));
    // Make sure the index was written.
    EXPECT_NE(index, INVALID_INDEX);
 
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it was written to an aligned address.
-   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (OMR_ALIGNOF(data) - 1), 0);
    // Make sure it was written correctly.
    EXPECT_TRUE(std::equal(data, data + sizeof(data)/sizeof(data[0]), dataPtr));
    // We should be able to find something with this key now.
@@ -294,7 +294,7 @@ TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), nullptr, index));
+   while (table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), OMR_ALIGNOF(data), NULL, index));
    }
 
 TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
@@ -311,18 +311,18 @@ TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
    CCData::index_t index2 = INVALID_INDEX;
 
    // Reserve space in the table, associate it with the key, retrieve the index.
-   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index));
+   EXPECT_TRUE(table.put(NULL, reservationSize, reservationAlignment, &key, index));
    // Make sure the index was written.
    EXPECT_NE(index, INVALID_INDEX);
    // Try to update the value via the key.
-   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index2));
+   EXPECT_TRUE(table.put(NULL, reservationSize, reservationAlignment, &key, index2));
    // Make sure the index was written.
    EXPECT_EQ(index2, index);
 
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the reservation was done.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure we got an aligned address.
    EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (reservationAlignment - 1), 0);
    // We should be able to find something with this key now.
@@ -336,7 +336,7 @@ TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(nullptr, reservationSize, reservationAlignment, nullptr, index));
+   while (table.put(NULL, reservationSize, reservationAlignment, NULL, index));
    }
 
 #define STRINGIFY(x) #x
@@ -377,7 +377,7 @@ TYPED_TEST(CCDataTest, test_error_conditions_templated)
       CCData::index_t   index = INVALID_INDEX;
 
       // Shouldn't be able to put.
-      EXPECT_FALSE(zeroTable.put(data, nullptr, index));
+      EXPECT_FALSE(zeroTable.put(data, NULL, index));
       // Make sure the index didn't change.
       EXPECT_EQ(index, INVALID_INDEX);
       }
@@ -391,7 +391,7 @@ TYPED_TEST(CCDataTest, test_error_conditions_templated)
 
       int count = 0;
 
-      while (smallTable.put(data, nullptr, curIndex))
+      while (smallTable.put(data, NULL, curIndex))
          {
          // Make sure the index changed.
          EXPECT_NE(curIndex, lastIndex);
@@ -428,7 +428,7 @@ TYPED_TEST(CCDataTest, test_updating_templated)
    TypeParam * const dataPtr = table.get<TypeParam>(index1);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it wasn't updated.
    EXPECT_EQ(*dataPtr, data1);
    // Change the value via a pointer.
@@ -543,21 +543,21 @@ TEST(AllTypesCCDataTest, test_basics)
    const double * const ptr_doubleA = table.get<const double>(doubleAIndex);
    const double * const ptr_doubleB = table.get<const double>(doubleBIndex);
 
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classAptr) & (alignof(*ptr_classAptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classBptr) & (alignof(*ptr_classBptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcAptr) & (alignof(*ptr_funcAptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcBptr) & (alignof(*ptr_funcBptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intA) & (alignof(*ptr_intA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intB) & (alignof(*ptr_intB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortA) & (alignof(*ptr_shortA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortB) & (alignof(*ptr_shortB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatA) & (alignof(*ptr_floatA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatB) & (alignof(*ptr_floatB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleA) & (alignof(*ptr_doubleA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleB) & (alignof(*ptr_doubleB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classAptr) & (OMR_ALIGNOF(*ptr_classAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classBptr) & (OMR_ALIGNOF(*ptr_classBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcAptr) & (OMR_ALIGNOF(*ptr_funcAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcBptr) & (OMR_ALIGNOF(*ptr_funcBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intA) & (OMR_ALIGNOF(*ptr_intA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intB) & (OMR_ALIGNOF(*ptr_intB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortA) & (OMR_ALIGNOF(*ptr_shortA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortB) & (OMR_ALIGNOF(*ptr_shortB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatA) & (OMR_ALIGNOF(*ptr_floatA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatB) & (OMR_ALIGNOF(*ptr_floatB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleA) & (OMR_ALIGNOF(*ptr_doubleA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleB) & (OMR_ALIGNOF(*ptr_doubleB) - 1), 0);
 
-   void     *out_classAptr = nullptr, *out_classBptr = nullptr;
-   void     *out_funcAptr = nullptr, *out_funcBptr = nullptr;
+   void     *out_classAptr = NULL, *out_classBptr = NULL;
+   void     *out_funcAptr = NULL, *out_funcBptr = NULL;
    int      out_intA = ~intA, out_intB = ~intB;
    short    out_shortA = ~shortA, out_shortB = ~shortB;
    float    out_floatA = -floatA, out_floatB = -floatB;

--- a/fvtest/compilertest/tests/CCDataTest.cpp
+++ b/fvtest/compilertest/tests/CCDataTest.cpp
@@ -1,0 +1,639 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "tests/CCDataTest.hpp"
+
+/**
+ * Compile testing
+ */
+
+#include "compile/SymbolReferenceTable.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/MethodInfo.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "infra/ILWalk.hpp"
+#include "ras/IlVerifier.hpp"
+#include "OptTestDriver.hpp"
+
+using namespace TR;
+using namespace TestCompiler;
+
+class TableInjector : public TR::IlInjector
+   {
+   public:
+
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   TableInjector(TR::TypeDictionary *types, TestDriver *test, const int32_t * const caseValues, const size_t numCaseValues)
+   : _caseValues(caseValues), _numCaseValues(numCaseValues), TR::IlInjector(types, test)
+      {
+      }
+
+   bool injectIL()
+      {
+      createBlocks(2 + _numCaseValues);
+
+      generateToBlock(0);
+      auto defaultCase = TR::Node::createCase(NULL, block(1)->getEntry());
+      auto table = TR::Node::create(TR::table, 2 + _numCaseValues, parameter(0, Int32), defaultCase);
+      for (auto i = 0; i < _numCaseValues; ++i)
+         table->setAndIncChild(2 + i, TR::Node::createCase(NULL, block(2 + i)->getEntry()));
+      genTreeTop(table);
+      cfg()->addEdge(_currentBlock, block(1));
+      for (auto i = 0; i < _numCaseValues; ++i)
+         cfg()->addEdge(_currentBlock, block(2 + i));
+
+      generateToBlock(1);
+      returnValue(parameter(1, Int32));
+
+      for (auto i = 0; i < _numCaseValues; ++i)
+         {
+         generateToBlock(2 + i);
+         returnValue(iconst(_caseValues[i]));
+         }
+
+      return true;
+      }
+
+   private:
+      const int32_t  *_caseValues;
+      const size_t   _numCaseValues;
+   };
+
+class GeneratedMethodInfo : public MethodInfo
+   {
+   public:
+      typedef int32_t (*compiled_method_t)(int32_t, int32_t);
+
+      GeneratedMethodInfo(TestDriver *test, const int32_t * const caseValues, const size_t numCaseValues) : _ilInjector(&_types, test, caseValues, numCaseValues)
+         {
+         TR::IlType *int32 = _types.PrimitiveType(TR::Int32);
+         _args[0] = {int32};
+         _args[1] = {int32};
+         DefineFunction(__FILE__, LINETOSTR(__LINE__), "TableTest", sizeof(_args) / sizeof(_args[0]), _args, int32);
+         DefineILInjector(&_ilInjector);
+         }
+   private:
+      TR::TypeDictionary   _types;
+      TR::IlType           *_args[2];
+      TableInjector        _ilInjector;
+   };
+
+class TableTest : public OptTestDriver
+   {
+   public:
+      TableTest() : _caseValues(nullptr), _numCaseValues(0) {}
+      void setCaseValues(const int32_t * const caseValues, const size_t numCaseValues)
+         {
+         _caseValues = caseValues;
+         _numCaseValues = numCaseValues;
+         }
+      virtual void invokeTests() override
+         {
+         EXPECT_NE(_caseValues, nullptr);
+         EXPECT_GT(_numCaseValues, 0);
+         auto compiledMethod = getCompiledMethod<GeneratedMethodInfo::compiled_method_t>();
+         for (auto i = 0; i < _numCaseValues; ++i)
+            EXPECT_EQ(compiledMethod(i, -1), _caseValues[i]);
+         EXPECT_EQ(compiledMethod(_numCaseValues, -1), -1);
+         }
+      private:
+         const int32_t  *_caseValues;
+         size_t         _numCaseValues;
+   };
+
+class TableVerifier : public TR::IlVerifier
+   {
+   public:
+   TableVerifier(const size_t numCaseValues) : _numCaseValues(numCaseValues) {}
+   bool verifyNode(TR::Node * const node) const
+      {
+      return node->getOpCodeValue() == TR::table
+             && node->getNumChildren() == 2 + _numCaseValues;
+      }
+   virtual int32_t verify(TR::ResolvedMethodSymbol *sym) override
+      {
+      for (TR::PreorderNodeIterator iter(sym->getFirstTreeTop(), sym->comp()); iter.currentTree(); ++iter)
+         {
+         if (verifyNode(iter.currentNode()))
+            return 0;
+         }
+      return 1;
+      }
+   private:
+      const size_t _numCaseValues;
+   };
+
+TEST_F(TableTest, test_table)
+   {
+   const int32_t caseValues[] = {8, 6, 7, 5, 3, 0, 9};
+   const size_t numCaseValues = sizeof(caseValues) / sizeof(caseValues[0]);
+   this->setCaseValues(caseValues, numCaseValues);
+   GeneratedMethodInfo info(this, caseValues, numCaseValues);
+   setMethodInfo(&info);
+   TableVerifier ilVerifier(numCaseValues);
+   setIlVerifier(&ilVerifier);
+   VerifyAndInvoke();
+   }
+
+/**
+ * Unit testing
+ */
+
+#include "codegen/CCData.hpp"
+#include "codegen/CCData_inlines.hpp"
+
+using OMR::CCData;
+
+const CCData::index_t INVALID_INDEX = std::numeric_limits<CCData::index_t>::max();
+
+template <typename T>
+class CCDataTest : public testing::Test
+   {
+   };
+
+struct odd_sized_t
+   {
+   odd_sized_t() {}
+   odd_sized_t(const uint8_t x) { set_em_all(x); }
+   odd_sized_t& operator=(const uint8_t x) { set_em_all(x); return *this; }
+   odd_sized_t operator-() const { return odd_sized_t(-_data[0]); }
+   bool operator==(const odd_sized_t &other) const { return _data[0] == other._data[0]; };
+   private:
+      void set_em_all(const uint8_t x)
+         {
+         for (auto i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
+            _data[i] = x;
+         }
+      uint8_t _data[7];
+   };
+
+using CCDataTestTypes = testing::Types<uint8_t, uint16_t, uint32_t, uint64_t,
+                                       int8_t, int16_t, int32_t, int64_t, odd_sized_t
+                                       /* Floats and doubles don't have unique object representations.
+                                       See the documentation for CCData::key().
+                                       The templated tests below would need to be re-written to create keys
+                                       differently for at least floats and doubles.*/
+                                       //,float, double
+                                      >;
+
+TYPED_TEST_CASE(CCDataTest, CCDataTestTypes);
+
+TYPED_TEST(CCDataTest, test_basics_templated)
+   {
+   CCData               table(256);
+   const TypeParam      data = 99;
+   // Generate a key from the data being stored.
+   const CCData::key_t  key = CCData::key(data);
+
+   // Nothing should be found by this key yet.
+   EXPECT_FALSE(table.find(key));
+
+   CCData::index_t index = INVALID_INDEX;
+
+   // Put the data in the table, associate it with the key, retrieve the index.
+   EXPECT_TRUE(table.put(data, &key, index));
+   // Make sure the index was written.
+   EXPECT_NE(index, INVALID_INDEX);
+
+   const TypeParam * const dataPtr = table.get<TypeParam>(index);
+
+   // Make sure the data was written.
+   EXPECT_NE(dataPtr, nullptr);
+   // Make sure it was written to an aligned address.
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   // Make sure it was written correctly.
+   EXPECT_EQ(*dataPtr, data);
+   // We should be able to find something with this key now.
+   EXPECT_TRUE(table.find(CCData::key(data)));
+
+   TypeParam out_data = -data;
+
+   // Retrieve the data via the index.
+   EXPECT_TRUE(table.get(index, out_data));
+   // Make sure it matches what was stored.
+   EXPECT_EQ(data, out_data);
+   // Make sure both copies generate equal keys.
+   EXPECT_EQ(CCData::key(data), CCData::key(out_data));
+
+   CCData::index_t find_index = INVALID_INDEX;
+
+   // Find the index via the key.
+   EXPECT_TRUE(table.find(CCData::key(data), &find_index));
+   // Make sure it's the same index.
+   EXPECT_EQ(index, find_index);
+
+   // Make sure we can fill the table.
+   while (table.put(data, nullptr, index));
+   }
+
+TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
+   {
+   CCData               table(256);
+   const TypeParam      d = 99;
+   const TypeParam      data[3] = {d, d, d};
+   // Generate a key from the data being stored.
+   const CCData::key_t  key = CCData::key(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data));
+
+   // Nothing should be found by this key yet.
+   EXPECT_FALSE(table.find(key));
+
+   CCData::index_t index = INVALID_INDEX;
+
+   // Put the data in the table, associate it with the key, retrieve the index.
+   EXPECT_TRUE(table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), &key, index));
+   // Make sure the index was written.
+   EXPECT_NE(index, INVALID_INDEX);
+
+   const TypeParam * const dataPtr = table.get<TypeParam>(index);
+
+   // Make sure the data was written.
+   EXPECT_NE(dataPtr, nullptr);
+   // Make sure it was written to an aligned address.
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   // Make sure it was written correctly.
+   EXPECT_TRUE(std::equal(data, data + sizeof(data)/sizeof(data[0]), dataPtr));
+   // We should be able to find something with this key now.
+   EXPECT_TRUE(table.find(CCData::key(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data))));
+
+   const TypeParam dminus = -d; // Negating `d` here avoids narrowing conversion warnings/errors on the next line.
+   TypeParam out_data[3] = {dminus, dminus, dminus};
+
+   // Retrieve the data via the index.
+   EXPECT_TRUE(table.get(index, reinterpret_cast<uint8_t *>(&out_data[0]), sizeof(out_data)));
+   // Make sure it matches what was stored.
+   EXPECT_TRUE(std::equal(data, data + sizeof(data)/sizeof(data[0]), out_data));
+   // Make sure both copies generate equal keys.
+   EXPECT_EQ(CCData::key(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data)), CCData::key(reinterpret_cast<const uint8_t *>(&out_data[0]), sizeof(out_data)));
+
+   CCData::index_t find_index = INVALID_INDEX;
+
+   // Find the index via the key.
+   EXPECT_TRUE(table.find(CCData::key(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data)), &find_index));
+   // Make sure it's the same index.
+   EXPECT_EQ(index, find_index);
+
+   // Make sure we can fill the table.
+   while (table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), nullptr, index));
+   }
+
+TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
+   {
+   CCData               table(256);
+   size_t               reservationSize = 32, reservationAlignment = 16;
+   // Generate an arbitrary key.
+   const CCData::key_t  key = CCData::key("It was the best of times, it was the worst of times.");
+
+   // Nothing should be found by this key yet.
+   EXPECT_FALSE(table.find(key));
+
+   CCData::index_t index = INVALID_INDEX;
+   CCData::index_t index2 = INVALID_INDEX;
+
+   // Reserve space in the table, associate it with the key, retrieve the index.
+   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index));
+   // Make sure the index was written.
+   EXPECT_NE(index, INVALID_INDEX);
+   // Try to update the value via the key.
+   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index2));
+   // Make sure the index was written.
+   EXPECT_EQ(index2, index);
+
+   const TypeParam * const dataPtr = table.get<TypeParam>(index);
+
+   // Make sure the reservation was done.
+   EXPECT_NE(dataPtr, nullptr);
+   // Make sure we got an aligned address.
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (reservationAlignment - 1), 0);
+   // We should be able to find something with this key now.
+   EXPECT_TRUE(table.find(key));
+
+   CCData::index_t find_index = INVALID_INDEX;
+
+   // Find the index via the key.
+   EXPECT_TRUE(table.find(key, &find_index));
+   // Make sure it's the same index.
+   EXPECT_EQ(index, find_index);
+
+   // Make sure we can fill the table.
+   while (table.put(nullptr, reservationSize, reservationAlignment, nullptr, index));
+   }
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+TYPED_TEST(CCDataTest, test_arbitrary_keys_templated)
+   {
+   CCData               table(256);
+   const TypeParam      data = 99;
+   const CCData::key_t  keyFromData = CCData::key(data);
+   const CCData::key_t  keyFromFileAndLine = CCData::key(__FILE__ ":" TOSTRING(__LINE__));
+
+   // Nothing should be found by either key yet.
+   EXPECT_FALSE(table.find(keyFromData));
+   EXPECT_FALSE(table.find(keyFromFileAndLine));
+
+   CCData::index_t index1 = INVALID_INDEX;
+   CCData::index_t index2 = INVALID_INDEX;
+
+   // Put the data in the table twice, associate it with each key, retrieve the indices.
+   EXPECT_TRUE(table.put(data, &keyFromData, index1));
+   EXPECT_TRUE(table.put(data, &keyFromFileAndLine, index2));
+   // Make sure the indices were written.
+   EXPECT_NE(index1, INVALID_INDEX);
+   EXPECT_NE(index2, INVALID_INDEX);
+   // We should be able to find something with both keys now.
+   EXPECT_TRUE(table.find(CCData::key(data)));
+   EXPECT_TRUE(table.find(keyFromFileAndLine));
+   // The data should be in two different indices, based on key.
+   EXPECT_NE(index1, index2);
+   }
+
+TYPED_TEST(CCDataTest, test_error_conditions_templated)
+   {
+      {
+      CCData            zeroTable(0);
+      const TypeParam   data = 99;
+      CCData::index_t   index = INVALID_INDEX;
+
+      // Shouldn't be able to put.
+      EXPECT_FALSE(zeroTable.put(data, nullptr, index));
+      // Make sure the index didn't change.
+      EXPECT_EQ(index, INVALID_INDEX);
+      }
+
+      {
+      const size_t      smallSize = 16;
+      CCData            smallTable(sizeof(TypeParam) * smallSize);
+      const TypeParam   data = 99;
+      CCData::index_t   lastIndex = INVALID_INDEX;
+      CCData::index_t   curIndex = INVALID_INDEX;
+
+      int count = 0;
+
+      while (smallTable.put(data, nullptr, curIndex))
+         {
+         // Make sure the index changed.
+         EXPECT_NE(curIndex, lastIndex);
+         lastIndex = curIndex;
+         ++count;
+         }
+
+      // Make sure the index didn't change on the last iteration.
+      EXPECT_EQ(curIndex, lastIndex);
+
+      // Make sure we put at least some data in the table.
+      EXPECT_GT(count, 0);
+      }
+   }
+
+TYPED_TEST(CCDataTest, test_updating_templated)
+   {
+   CCData               table(256);
+   const TypeParam      data1 = 99;
+   const TypeParam      data2 = -data1;
+   const CCData::key_t  key = CCData::key("data");
+   CCData::index_t      index1 = INVALID_INDEX;
+   CCData::index_t      index2 = INVALID_INDEX;
+
+   // Put the data in the table, associate it with the key, retrieve the index.
+   EXPECT_TRUE(table.put(data1, &key, index1));
+   // Make sure the index was written.
+   EXPECT_NE(index1, INVALID_INDEX);
+   // Update the value via the key.
+   EXPECT_TRUE(table.put(data2, &key, index2));
+   // Make sure the index was written.
+   EXPECT_EQ(index2, index1);
+
+   TypeParam * const dataPtr = table.get<TypeParam>(index1);
+
+   // Make sure the data was written.
+   EXPECT_NE(dataPtr, nullptr);
+   // Make sure it wasn't updated.
+   EXPECT_EQ(*dataPtr, data1);
+   // Change the value via a pointer.
+   *dataPtr = data2;
+
+   TypeParam out_data;
+   // Make sure the data was written.
+   EXPECT_TRUE(table.get(index1, out_data));
+   // Make sure it matches.
+   EXPECT_EQ(out_data, data2);
+   }
+
+TEST(AllTypesCCDataTest, test_basics)
+   {
+   CCData         table(256);
+   const void     * const classAptr = reinterpret_cast<void *>(0x1), * const classBptr = reinterpret_cast<void *>(0x2);
+   const void     * const funcAptr = reinterpret_cast<void *>(0x100), * const funcBptr = reinterpret_cast<void *>(0x200);
+   const int      intA = 99, intB = 101;
+   const short    shortA = 999, shortB = -999;
+   const float    floatA = 10000.99f, floatB = 0.99999f;
+   const double   doubleA = 1245.6789, doubleB = 3.14159;
+
+   const CCData::key_t classAptrKey = CCData::key(classAptr);
+   const CCData::key_t classBptrKey = CCData::key(classBptr);
+   const CCData::key_t funcAptrKey = CCData::key(funcAptr);
+   const CCData::key_t funcBptrKey = CCData::key(funcBptr);
+   const CCData::key_t intAKey = CCData::key(intA);
+   const CCData::key_t intBKey = CCData::key(intB);
+   const CCData::key_t shortAKey = CCData::key(shortA);
+   const CCData::key_t shortBKey = CCData::key(shortB);
+   // Can't use float and double values for keys, see the documentation for CCData::key().
+   const CCData::key_t floatAKey = CCData::key("floatA");
+   const CCData::key_t floatBKey = CCData::key("floatB");
+   const CCData::key_t doubleAKey = CCData::key("doubleA");
+   const CCData::key_t doubleBKey = CCData::key("doubleB");
+
+   EXPECT_FALSE(table.find(classAptrKey));
+   EXPECT_FALSE(table.find(classBptrKey));
+   EXPECT_FALSE(table.find(funcAptrKey));
+   EXPECT_FALSE(table.find(funcBptrKey));
+   EXPECT_FALSE(table.find(intAKey));
+   EXPECT_FALSE(table.find(intBKey));
+   EXPECT_FALSE(table.find(shortAKey));
+   EXPECT_FALSE(table.find(shortBKey));
+   EXPECT_FALSE(table.find(floatAKey));
+   EXPECT_FALSE(table.find(floatBKey));
+   EXPECT_FALSE(table.find(doubleAKey));
+   EXPECT_FALSE(table.find(doubleBKey));
+
+   CCData::index_t classAptrIndex = INVALID_INDEX;
+   CCData::index_t classBptrIndex = INVALID_INDEX;
+   CCData::index_t funcAptrIndex = INVALID_INDEX;
+   CCData::index_t funcBptrIndex = INVALID_INDEX;
+   CCData::index_t intAIndex = INVALID_INDEX;
+   CCData::index_t intBIndex = INVALID_INDEX;
+   CCData::index_t shortAIndex = INVALID_INDEX;
+   CCData::index_t shortBIndex = INVALID_INDEX;
+   CCData::index_t floatAIndex = INVALID_INDEX;
+   CCData::index_t floatBIndex = INVALID_INDEX;
+   CCData::index_t doubleAIndex = INVALID_INDEX;
+   CCData::index_t doubleBIndex = INVALID_INDEX;
+
+   EXPECT_TRUE(table.put(classAptr, &classAptrKey, classAptrIndex));
+   EXPECT_TRUE(table.put(classBptr, &classBptrKey, classBptrIndex));
+   EXPECT_TRUE(table.put(funcAptr, &funcAptrKey, funcAptrIndex));
+   EXPECT_TRUE(table.put(funcBptr, &funcBptrKey, funcBptrIndex));
+   EXPECT_TRUE(table.put(intA, &intAKey, intAIndex));
+   EXPECT_TRUE(table.put(intB, &intBKey, intBIndex));
+   EXPECT_TRUE(table.put(shortA, &shortAKey, shortAIndex));
+   EXPECT_TRUE(table.put(shortB, &shortBKey, shortBIndex));
+   EXPECT_TRUE(table.put(floatA, &floatAKey, floatAIndex));
+   EXPECT_TRUE(table.put(floatB, &floatBKey, floatBIndex));
+   EXPECT_TRUE(table.put(doubleA, &doubleAKey, doubleAIndex));
+   EXPECT_TRUE(table.put(doubleB, &doubleBKey, doubleBIndex));
+
+   EXPECT_NE(classAptrIndex, INVALID_INDEX);
+   EXPECT_NE(classBptrIndex, INVALID_INDEX);
+   EXPECT_NE(funcAptrIndex, INVALID_INDEX);
+   EXPECT_NE(funcBptrIndex, INVALID_INDEX);
+   EXPECT_NE(intAIndex, INVALID_INDEX);
+   EXPECT_NE(intBIndex, INVALID_INDEX);
+   EXPECT_NE(shortAIndex, INVALID_INDEX);
+   EXPECT_NE(shortBIndex, INVALID_INDEX);
+   EXPECT_NE(floatAIndex, INVALID_INDEX);
+   EXPECT_NE(floatBIndex, INVALID_INDEX);
+   EXPECT_NE(doubleAIndex, INVALID_INDEX);
+   EXPECT_NE(doubleBIndex, INVALID_INDEX);
+
+   EXPECT_TRUE(table.find(CCData::key(classAptr)));
+   EXPECT_TRUE(table.find(CCData::key(classBptr)));
+   EXPECT_TRUE(table.find(CCData::key(funcAptr)));
+   EXPECT_TRUE(table.find(CCData::key(funcBptr)));
+   EXPECT_TRUE(table.find(CCData::key(intA)));
+   EXPECT_TRUE(table.find(CCData::key(intB)));
+   EXPECT_TRUE(table.find(CCData::key(shortA)));
+   EXPECT_TRUE(table.find(CCData::key(shortB)));
+   EXPECT_TRUE(table.find(CCData::key("floatA")));
+   EXPECT_TRUE(table.find(CCData::key("floatB")));
+   EXPECT_TRUE(table.find(CCData::key("doubleA")));
+   EXPECT_TRUE(table.find(CCData::key("doubleB")));
+
+   const void* * const ptr_classAptr = table.get<const void*>(classAptrIndex);
+   const void* * const ptr_classBptr = table.get<const void*>(classBptrIndex);
+   const void* * const ptr_funcAptr = table.get<const void*>(funcAptrIndex);
+   const void* * const ptr_funcBptr = table.get<const void*>(funcBptrIndex);
+   const int * const ptr_intA = table.get<const int>(intAIndex);
+   const int * const ptr_intB = table.get<const int>(intBIndex);
+   const short * const ptr_shortA = table.get<const short>(shortAIndex);
+   const short * const ptr_shortB = table.get<const short>(shortBIndex);
+   const float * const ptr_floatA = table.get<const float>(floatAIndex);
+   const float * const ptr_floatB = table.get<const float>(floatBIndex);
+   const double * const ptr_doubleA = table.get<const double>(doubleAIndex);
+   const double * const ptr_doubleB = table.get<const double>(doubleBIndex);
+
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classAptr) & (alignof(*ptr_classAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classBptr) & (alignof(*ptr_classBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcAptr) & (alignof(*ptr_funcAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcBptr) & (alignof(*ptr_funcBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intA) & (alignof(*ptr_intA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intB) & (alignof(*ptr_intB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortA) & (alignof(*ptr_shortA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortB) & (alignof(*ptr_shortB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatA) & (alignof(*ptr_floatA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatB) & (alignof(*ptr_floatB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleA) & (alignof(*ptr_doubleA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleB) & (alignof(*ptr_doubleB) - 1), 0);
+
+   void     *out_classAptr = nullptr, *out_classBptr = nullptr;
+   void     *out_funcAptr = nullptr, *out_funcBptr = nullptr;
+   int      out_intA = ~intA, out_intB = ~intB;
+   short    out_shortA = ~shortA, out_shortB = ~shortB;
+   float    out_floatA = -floatA, out_floatB = -floatB;
+   double   out_doubleA = -doubleA, out_doubleB = -doubleB;
+
+   EXPECT_TRUE(table.get(classAptrIndex, out_classAptr));
+   EXPECT_TRUE(table.get(classBptrIndex, out_classBptr));
+   EXPECT_TRUE(table.get(funcAptrIndex, out_funcAptr));
+   EXPECT_TRUE(table.get(funcBptrIndex, out_funcBptr));
+   EXPECT_TRUE(table.get(intAIndex, out_intA));
+   EXPECT_TRUE(table.get(intBIndex, out_intB));
+   EXPECT_TRUE(table.get(shortAIndex, out_shortA));
+   EXPECT_TRUE(table.get(shortBIndex, out_shortB));
+   EXPECT_TRUE(table.get(floatAIndex, out_floatA));
+   EXPECT_TRUE(table.get(floatBIndex, out_floatB));
+   EXPECT_TRUE(table.get(doubleAIndex, out_doubleA));
+   EXPECT_TRUE(table.get(doubleBIndex, out_doubleB));
+
+   EXPECT_EQ(classAptr, out_classAptr);
+   EXPECT_EQ(classBptr, out_classBptr);
+   EXPECT_EQ(funcAptr, out_funcAptr);
+   EXPECT_EQ(funcBptr, out_funcBptr);
+   EXPECT_EQ(intA, out_intA);
+   EXPECT_EQ(intB, out_intB);
+   EXPECT_EQ(shortA, out_shortA);
+   EXPECT_EQ(shortB, out_shortB);
+   EXPECT_EQ(floatA, out_floatA);
+   EXPECT_EQ(floatB, out_floatB);
+   EXPECT_EQ(doubleA, out_doubleA);
+   EXPECT_EQ(doubleB, out_doubleB);
+
+   EXPECT_EQ(CCData::key(classAptr), CCData::key(out_classAptr));
+   EXPECT_EQ(CCData::key(classBptr), CCData::key(out_classBptr));
+   EXPECT_EQ(CCData::key(funcAptr), CCData::key(out_funcAptr));
+   EXPECT_EQ(CCData::key(funcBptr), CCData::key(out_funcBptr));
+   EXPECT_EQ(CCData::key(intA), CCData::key(out_intA));
+   EXPECT_EQ(CCData::key(intB), CCData::key(out_intB));
+   EXPECT_EQ(CCData::key(shortA), CCData::key(out_shortA));
+   EXPECT_EQ(CCData::key(shortB), CCData::key(out_shortB));
+
+   CCData::index_t find_classAptrIndex = INVALID_INDEX;
+   CCData::index_t find_classBptrIndex = INVALID_INDEX;
+   CCData::index_t find_funcAptrIndex = INVALID_INDEX;
+   CCData::index_t find_funcBptrIndex = INVALID_INDEX;
+   CCData::index_t find_intAIndex = INVALID_INDEX;
+   CCData::index_t find_intBIndex = INVALID_INDEX;
+   CCData::index_t find_shortAIndex = INVALID_INDEX;
+   CCData::index_t find_shortBIndex = INVALID_INDEX;
+   CCData::index_t find_floatAIndex = INVALID_INDEX;
+   CCData::index_t find_floatBIndex = INVALID_INDEX;
+   CCData::index_t find_doubleAIndex = INVALID_INDEX;
+   CCData::index_t find_doubleBIndex = INVALID_INDEX;
+
+   EXPECT_TRUE(table.find(CCData::key(classAptr), &find_classAptrIndex));
+   EXPECT_TRUE(table.find(CCData::key(classBptr), &find_classBptrIndex));
+   EXPECT_TRUE(table.find(CCData::key(funcAptr), &find_funcAptrIndex));
+   EXPECT_TRUE(table.find(CCData::key(funcBptr), &find_funcBptrIndex));
+   EXPECT_TRUE(table.find(CCData::key(intA), &find_intAIndex));
+   EXPECT_TRUE(table.find(CCData::key(intB), &find_intBIndex));
+   EXPECT_TRUE(table.find(CCData::key(shortA), &find_shortAIndex));
+   EXPECT_TRUE(table.find(CCData::key(shortB), &find_shortBIndex));
+   EXPECT_TRUE(table.find(CCData::key("floatA"), &find_floatAIndex));
+   EXPECT_TRUE(table.find(CCData::key("floatB"), &find_floatBIndex));
+   EXPECT_TRUE(table.find(CCData::key("doubleA"), &find_doubleAIndex));
+   EXPECT_TRUE(table.find(CCData::key("doubleB"), &find_doubleBIndex));
+
+   EXPECT_EQ(classAptrIndex, find_classAptrIndex);
+   EXPECT_EQ(classBptrIndex, find_classBptrIndex);
+   EXPECT_EQ(funcAptrIndex, find_funcAptrIndex);
+   EXPECT_EQ(funcBptrIndex, find_funcBptrIndex);
+   EXPECT_EQ(intAIndex, find_intAIndex);
+   EXPECT_EQ(intBIndex, find_intBIndex);
+   EXPECT_EQ(shortAIndex, find_shortAIndex);
+   EXPECT_EQ(shortBIndex, find_shortBIndex);
+   EXPECT_EQ(floatAIndex, find_floatAIndex);
+   EXPECT_EQ(floatBIndex, find_floatBIndex);
+   EXPECT_EQ(doubleAIndex, find_doubleAIndex);
+   EXPECT_EQ(doubleBIndex, find_doubleBIndex);
+   }

--- a/fvtest/compilertest/tests/CCDataTest.hpp
+++ b/fvtest/compilertest/tests/CCDataTest.hpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CCDATA_TEST_INCL
+#define CCDATA_TEST_INCL
+
+#include "gtest/gtest.h"
+
+#endif // !defined(CCDATA_TEST_INCL)

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <omrcomp.h>
 #include <OMR/Bytes.hpp>
 #include <gtest/gtest.h>
 
@@ -187,7 +188,7 @@ TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
 TEST(TestBytes, AlignPointers)
 {
 	const size_t size = sizeof(void*);
-	const size_t alignment = alignof(void*);
+	const size_t alignment = OMR_ALIGNOF(void*);
 	const size_t totalSpace = size * 3 - 1;
 	char buffer[totalSpace] = {0};
 	void * const lastValidAddress = &buffer[totalSpace - size];

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -184,4 +184,49 @@ TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
 	EXPECT_EQ(std::numeric_limits<size_t>::max(), align(std::numeric_limits<size_t>::max(), 1));
 }
 
+TEST(TestBytes, AlignPointers)
+{
+	const size_t size = sizeof(void*);
+	const size_t alignment = alignof(void*);
+	const size_t totalSpace = size * 3 - 1;
+	char buffer[totalSpace] = {0};
+	void * const lastValidAddress = &buffer[totalSpace - size];
+
+	for (size_t i = 0; i < totalSpace; i++) {
+		size_t space = totalSpace - i;
+		void *ptr = &buffer[i];
+		const size_t initialSpace = space;
+		void * const initialPtr = ptr;
+		uintptr_t ptrValue = reinterpret_cast<uintptr_t>(ptr);
+
+		const void *alignedPtr = OMR::align(alignment, size, ptr, space);
+		const uintptr_t alignedPtrValue = reinterpret_cast<uintptr_t>(alignedPtr);
+
+		// Whatever was returned must be aligned.
+		EXPECT_EQ(alignedPtrValue & (alignment - 1), 0);
+
+		if (alignedPtr != NULL) {
+			// The passed-in ptr reference must be updated to match the returned pointer.
+			EXPECT_EQ(ptr, alignedPtr);
+			// The returned pointer must be aligned in the expected manner.
+			const void *expectedPtr = reinterpret_cast<void *>((ptrValue + (alignment - 1)) & ~(alignment - 1));
+			EXPECT_EQ(alignedPtr, expectedPtr);
+			// The passed-in space reference must be updated to subtract the bytes lost to obtain the desired alignment.
+			const size_t expectedAdjustment = (alignment - (ptrValue & (alignment - 1))) % alignment;
+			EXPECT_EQ(space, initialSpace - expectedAdjustment);
+			// The data must not overflow the buffer.
+			EXPECT_LE(alignedPtr, lastValidAddress);
+		}
+		else {
+			// The passed-in ptr reference must not have been updated.
+			EXPECT_EQ(ptr, initialPtr);
+			// The passed-in space reference must not have been updated.
+			EXPECT_EQ(space, initialSpace);
+			// The returned pointer must be NULL because we don't have any space left to make the adjustment.
+			const size_t alignmentAdjustment = (alignment - (ptrValue & (alignment - 1))) % alignment;
+			EXPECT_LT(initialSpace, size + alignmentAdjustment);
+		}
+	}
+}
+
 }  // namespace OMR

--- a/include_core/OMR/Bytes.hpp
+++ b/include_core/OMR/Bytes.hpp
@@ -108,6 +108,28 @@ align(size_t size, size_t alignment)
 	return alignNoCheck(size, alignment);
 }
 
+/// Returns an aligned pointer.
+///
+/// This function has the same semantics as C++11's std::align() and
+/// exists to support old compilers that don't provide it.
+inline void*
+align(size_t alignment, size_t size, void* &ptr, size_t &space)
+{
+	if (size > space) {
+		return NULL;
+	}
+	uintptr_t p = reinterpret_cast<uintptr_t>(ptr);
+	uintptr_t alignedP = (p + (alignment - 1)) & ~(alignment - 1);
+	uintptr_t adjustment = alignedP - p;
+	if (adjustment > (space - size)) {
+		return NULL;
+	}
+	space -= adjustment;
+	void *alignedPtr = reinterpret_cast<void*>(alignedP);
+	ptr = alignedPtr;
+	return alignedPtr;
+}
+
 } // namespace OMR
 
 #endif // OMR_BYTES_HPP_

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -601,4 +601,12 @@ typedef struct U_128 {
 #define OMR_LOG_POINTER_SIZE 2
 #endif /* defined(OMR_ENV_DATA64) */
 
+#if defined(_MSC_VER) && (1900 > _MSC_VER) /* MSVC versions prior to Visual Studio 2015 (14.0) */
+#define OMR_ALIGNOF(x) __alignof(x)
+#elif defined(__IBMC__) || defined(__IBMCPP__) /* XL C/C++ versions prior to xlclang/xlclang++ */
+#define OMR_ALIGNOF(x) __alignof__(x)
+#else /* All other compilers that support C11 and C++11 */
+#define OMR_ALIGNOF(x) alignof(x)
+#endif /* defined(_MSC_VER) && (1900 > _MSC_VER) */
+
 #endif /* OMRCOMP_H */


### PR DESCRIPTION
`CCData` is a simple linear buffer that can be used to store arbitrary data that can then be referenced from compiled code. The intention is for it to be used to store data that would otherwise be stored in the instruction stream (as immediate operands, in snippets, etc) in cases where that is undesirable. This is not unlike GOTs, TOCs, PLTs, and so on in other ABIs that store pointers and constants.

The PPC codegen has a similar structure called the pseudo-TOC, with most of the implementation living in OpenJ9, but its interface is very Java-specific and it stores both the user's data and its own internal book-keeping data (in the form of a hash table) in the same memory space. `CCData` on the other hand uses an `std::map` and has a language-agnostic interface.