### PR TITLE
Replacing isAbstractClass() and isInterfaceClass() with isConcreteClass()

### DIFF
--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -82,6 +82,7 @@ public:
 
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer) { return false; }
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer) { return false; }
+   bool isConcreteClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer) { return true; }
    bool isPrimitiveClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return false; }
    bool isAnonymousClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return false; }
    bool isValueTypeClass(TR_OpaqueClassBlock *) { return false; }

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7127,8 +7127,7 @@ TR_InvariantArgumentPreexistence::ParmInfo *TR_InvariantArgumentPreexistence::ge
 
 bool TR_InvariantArgumentPreexistence::classIsCurrentlyFinal(TR_OpaqueClassBlock* clazz)
    {
-   if (!TR::Compiler->cls.isInterfaceClass(comp(), clazz) &&
-       !TR::Compiler->cls.isAbstractClass(comp(), clazz) &&
+   if (TR::Compiler->cls.isConcreteClass(comp(), clazz) &&
        !fe()->classHasBeenExtended(clazz))
       return true;
 


### PR DESCRIPTION
isConcreteClass() checks to see if the class is an interface or Abstract class.This
will reduce overhead resulting from calling two queries.
Issue in OpenJ9: https://github.com/eclipse/openj9/issues/11029

Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>