### PR TITLE
Add Dynamic Breadth First Scan Ordering to Balanced GC

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2247,6 +2247,11 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
             TR::Options::createDebug();
          }
 
+      if (!TR::Options::getCmdLineOptions()->isAnyReductionAlgorithmSet())
+         {
+         _hotFieldReductionAlgorithms.set(TR_HotFieldReductionAlgorithmMax);
+         }
+
       if (self()->setCounts())
          return false; // bad string count
 
@@ -4998,8 +5003,8 @@ char *OMR::Options::setHotFieldReductionAlgorithm(char *option, void *base, TR::
       }
    if (!foundMatch)
       {
-      TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "<JIT: Reduction algorithm not found.  Default sum reduction algorithm set.>");
-      _hotFieldReductionAlgorithms.set(TR_HotFieldReductionAlgorithmSum);
+      TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "<JIT: Invalid reduction algorithm option provided. Default max reduction algorithm set.>");
+      _hotFieldReductionAlgorithms.set(TR_HotFieldReductionAlgorithmMax);
       }
    return option;
    }

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1452,6 +1452,8 @@ public:
 
    static bool  getReductionAlgorithm(TR_ReductionAlgorithms op)     {  return _hotFieldReductionAlgorithms.isSet(op); }
    static void  setReductionAlgorithm(TR_ReductionAlgorithms op)     { _hotFieldReductionAlgorithms.set(op); }
+   static void  resetReductionAlgorithm(TR_SamplingJProfilingFlags op) { _hotFieldReductionAlgorithms.reset(op); }
+   static bool  isAnyReductionAlgorithmSet()                   { return !_hotFieldReductionAlgorithms.isEmpty(); }
    static bool  getVerboseOption(TR_VerboseFlags op)     {  return _verboseOptionFlags.isSet(op); }
    static void  setVerboseOption(TR_VerboseFlags op)     { _verboseOptionFlags.set(op); }
    static void  setVerboseOptions(uint64_t mask)         { _verboseOptionFlags.maskWord(0, mask); }

--- a/example/glue/ObjectModelDelegate.hpp
+++ b/example/glue/ObjectModelDelegate.hpp
@@ -182,25 +182,7 @@ public:
 		return false;
 	}
 
-	/**
-	 * The following methods (defined(OMR_GC_MODRON_SCAVENGER)) are required if generational GC is
- 	 * configured for the build (--enable-OMR_GC_MODRON_SCAVENGER in configure_includes/configure_*.mk).
- 	 * They typically involve a MM_ForwardedHeader object, and allow information about the forwarded
- 	 * object to be obtained.
-	 */
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	/**
-	 * Returns TRUE if the object referred to by the forwarded header is indexable.
-	 *
-	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @return TRUE if object is indexable, FALSE otherwise
-	 */
-	MMINLINE bool
-	isIndexable(MM_ForwardedHeader *forwardedHeader)
-	{
-		return false;
-	}
-
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	/**
 	 * Returns the field offset of the hottest field of the object referred to by the forwarded header.
 	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled.
@@ -225,6 +207,26 @@ public:
 	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
 	{
 		return U_8_MAX;
+	}
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
+
+	/**
+	 * The following methods (defined(OMR_GC_MODRON_SCAVENGER)) are required if generational GC is
+ 	 * configured for the build (--enable-OMR_GC_MODRON_SCAVENGER in configure_includes/configure_*.mk).
+ 	 * They typically involve a MM_ForwardedHeader object, and allow information about the forwarded
+ 	 * object to be obtained.
+	 */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	/**
+	 * Returns TRUE if the object referred to by the forwarded header is indexable.
+	 *
+	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @return TRUE if object is indexable, FALSE otherwise
+	 */
+	MMINLINE bool
+	isIndexable(MM_ForwardedHeader *forwardedHeader)
+	{
+		return false;
 	}
 
 	/**

--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -99,12 +99,12 @@ MM_EnvironmentBase::initialize(MM_GCExtensionsBase *extensions)
 		}
 	}
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	/* Disable dynamic depth copying if scavengerDynamicBreadthFirstScanOrdering is not selected */
-	if (extensions->scavengerScanOrdering != MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST) {
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
+	/* Disable dynamic depth copying if scavengerDynamicBreadthFirstScanOrdering is not selected */ 
+	if (MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST != extensions->scavengerScanOrdering) {
 		disableHotFieldDepthCopy();
 	}
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 
 #if defined(OMR_GC_SEGREGATED_HEAP)
 	if (extensions->isSegregatedHeap()) {

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -152,10 +152,6 @@ public:
 
 	uintptr_t approxScanCacheCount; /**< Local copy of approximate entries in global Cache Scan List. Updated upon allocation of new cache. */
 
-	#if defined(OMR_GC_MODRON_SCAVENGER)
-	uintptr_t _hotFieldCopyDepthCount; /**< Used for dynamic breadth first scan ordering. Counter for the current copying depth based on the initial object copied. */
-	#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
-	
 	MM_Validator *_activeValidator; /**< Used to identify and report crashes inside Validators */
 
 	MM_MarkStats _markStats;
@@ -179,6 +175,7 @@ public:
 #endif /* OMR_GC_MODRON_STANDARD || OMR_GC_REALTIME */
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	MM_ScavengerStats _scavengerStats;
+	uintptr_t _hotFieldCopyDepthCount; /**< Used for dynamic breadth first scan ordering. Counter for the current copying depth based on the initial object copied. */
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	uint64_t _concurrentScavengerSwitchCount; /**< local counter of cycle start and cycle end transitions */
@@ -533,7 +530,7 @@ public:
 	 */
 	void forceOutOfLineVMAccess() { _delegate.forceOutOfLineVMAccess(); }
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	/**
 	 * Disable scavenger hot field depth copying for dynamicBreadthFirstScanOrdering
 	 */
@@ -550,7 +547,7 @@ public:
 			_hotFieldCopyDepthCount = 0;
 		}
 	}
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 
 #if defined (OMR_GC_THREAD_LOCAL_HEAP)
 	/**
@@ -718,14 +715,14 @@ public:
 		,_traceAllocationBytes(0)
 		,_traceAllocationBytesCurrentTLH(0)
 		,approxScanCacheCount(0)
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		,_hotFieldCopyDepthCount(0)
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
+		,_hotFieldCopyDepthCount(0)
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		,_concurrentScavengerSwitchCount(0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
@@ -775,14 +772,14 @@ public:
 		,_traceAllocationBytes(0)
 		,_traceAllocationBytesCurrentTLH(0)
 		,approxScanCacheCount(0)
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		,_hotFieldCopyDepthCount(0)
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		,_allocationTracker(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
+		,_hotFieldCopyDepthCount(0)
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		,_concurrentScavengerSwitchCount(0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -448,7 +448,6 @@ public:
 		OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL,
 	};
 	ScavengerScanOrdering scavengerScanOrdering; /**< scan ordering in Scavenger */
-#if defined(OMR_GC_MODRON_SCAVENGER)
 	/* Start of options relating to dynamicBreadthFirstScanOrdering */
 	uintptr_t gcCountBetweenHotFieldSort;
 	uintptr_t gcCountBetweenHotFieldSortMax;
@@ -464,6 +463,7 @@ public:
 	uint32_t maxHotFieldListLength;
 	uintptr_t minCpuUtil;
 	/* End of options relating to dynamicBreadthFirstScanOrdering */
+#if defined(OMR_GC_MODRON_SCAVENGER) 
 	uintptr_t scvTenureRatioHigh;
 	uintptr_t scvTenureRatioLow;
 	uintptr_t scvTenureFixedTenureAge; /**< The tenure age to use for the Fixed scavenger tenure strategy. */
@@ -1537,8 +1537,6 @@ public:
 		, dispatcherHybridNotifyThreadBound(16)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
-#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
-#if defined(OMR_GC_MODRON_SCAVENGER)
 		/* Start of options relating to dynamicBreadthFirstScanOrdering */
 		, gcCountBetweenHotFieldSort(1)
 		, gcCountBetweenHotFieldSortMax(6)
@@ -1554,6 +1552,8 @@ public:
 		, maxHotFieldListLength(10)
 		, minCpuUtil (1)
 		/* End of options relating to dynamicBreadthFirstScanOrdering */
+#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
+#if defined(OMR_GC_MODRON_SCAVENGER)
 		, scvTenureRatioHigh(OMR_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(OMR_SCV_TENURE_RATIO_LOW)
 		, scvTenureFixedTenureAge(OBJECT_HEADER_AGE_MAX)

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -785,6 +785,48 @@ public:
 		return result;
 	}
 
+#if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
+	/**
+	 * Returns the field offset of the hottest field of the object referred to by the forwarded header.
+	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled.
+	 *
+	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @return the offset of the hottest field of the given object referred to by the forwarded header, return U_8_MAX if a hot field does not exist
+	 */
+	MMINLINE uint8_t
+	getHotFieldOffset(MM_ForwardedHeader *forwardedHeader)
+	{
+		return _delegate.getHotFieldOffset(forwardedHeader);
+	}
+
+	/**
+	 * Returns the field offset of the second hottest field of the object referred to by the forwarded header.
+	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
+	 *
+	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @return the offset of the second hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
+	 */
+	MMINLINE uint8_t
+	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
+	{
+		return _delegate.getHotFieldOffset2(forwardedHeader);
+	}
+
+	/**
+	 * Returns the field offset of the third hottest field of the object referred to by the forwarded header.
+	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
+	 *
+	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @return the offset of the third hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
+	 */
+	MMINLINE uint8_t
+	getHotFieldOffset3(MM_ForwardedHeader *forwardedHeader)
+	{
+		return _delegate.getHotFieldOffset3(forwardedHeader);
+	}
+
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
+
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/**
 	 * Returns TRUE if the object referred to by the forwarded header is indexable.
@@ -824,45 +866,6 @@ public:
 	getForwardedObjectSizeInBytes(MM_ForwardedHeader *forwardedHeader)
 	{
 		return _delegate.getForwardedObjectSizeInBytes(forwardedHeader);
-	}
-
-	/**
-	 * Returns the field offset of the hottest field of the object referred to by the forwarded header.
-	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled.
-	 *
-	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @return the offset of the hottest field of the given object referred to by the forwarded header, return U_8_MAX if a hot field does not exist
-	 */
-	MMINLINE uint8_t
-	getHotFieldOffset(MM_ForwardedHeader *forwardedHeader)
-	{
-		return _delegate.getHotFieldOffset(forwardedHeader);
-	}
-
-	/**
-	 * Returns the field offset of the second hottest field of the object referred to by the forwarded header.
-	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
-	 *
-	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @return the offset of the second hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
-	 */
-	MMINLINE uint8_t
-	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
-	{
-		return _delegate.getHotFieldOffset2(forwardedHeader);
-	}
-
-		/**
-	 * Returns the field offset of the third hottest field of the object referred to by the forwarded header.
-	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
-	 *
-	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @return the offset of the third hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
-	 */
-	MMINLINE uint8_t
-	getHotFieldOffset3(MM_ForwardedHeader *forwardedHeader)
-	{
-		return _delegate.getHotFieldOffset3(forwardedHeader);
 	}
 
 	/**


### PR DESCRIPTION
Add a gc scavenger scan ordering feature that enables the
copying of a hot field marked by the JIT immediately after the
object containing the hot field is copied for balanced GC policy.

Issue: eclipse/openj9#7552
Signed-off-by: Jonathan Oommen jon.oommen@gmail.com