### PR TITLE
Fix the badIlOp node generated by RegDepCopyRemoval

### DIFF
--- a/compiler/optimizer/RegDepCopyRemoval.cpp
+++ b/compiler/optimizer/RegDepCopyRemoval.cpp
@@ -442,13 +442,13 @@ TR::RegDepCopyRemoval::makeFreshCopy(TR_GlobalRegisterNumber reg)
       TR_ASSERT_FATAL_WITH_NODE(dep.node,
                                  dep.node->getOpCode().isLoadReg()
                                  || (dep.node->getOpCodeValue() == TR::PassThrough
-                                    && dep.node->getFirstChild()->getOpCode().isLoadReg()
-                                    && dep.node->getGlobalRegisterNumber() == dep.node->getFirstChild()->getGlobalRegisterNumber()),
+                                    && dep.value->getOpCode().isLoadReg()
+                                    && dep.node->getGlobalRegisterNumber() == dep.value->getGlobalRegisterNumber()),
                                  "Only PassThrough (with corresponding regStore appeared before or using same Global Register as child) or regLoad nodes are expected as children of GlRegDeps.");
-      choice.regStoreNode = TR::Node::create(dep.node, comp()->il.opCodeForRegisterStore(dep.node->getDataType()), 1, copyNode);
+      choice.regStoreNode = TR::Node::create(dep.node, comp()->il.opCodeForRegisterStore(dep.value->getDataType()), 1, copyNode);
       _treetop->insertBefore(TR::TreeTop::create(comp(), choice.regStoreNode));
       choice.regStoreNode->setGlobalRegisterNumber(dep.node->getGlobalRegisterNumber());
-      choice.regStoreNode->setRegLoadStoreSymbolReference(dep.node->getRegLoadStoreSymbolReference());
+      choice.regStoreNode->setRegLoadStoreSymbolReference(dep.value->getRegLoadStoreSymbolReference());
       }
    else
       {


### PR DESCRIPTION
For creating a fresh copy for RegDepCopyRemoval optimization, there was a case when a regLoad is under PassThrough node in which case we would not have corresponding regStore. To handle this case we were creating a regStore by getting the type from PassThrough node which would cause badIlOp. This commit fixes that issue.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>