### PR TITLE
Fix byteswapped store optimization on Power

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -966,9 +966,11 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
       }
 
    bool reverseStore = false;
-   if (valueChild->getOpCodeValue() == TR::ibyteswap)
+   if (valueChild->getOpCodeValue() == TR::ibyteswap && valueChild->isSingleRefUnevaluated())
       {
       reverseStore = true;
+
+      cg->decReferenceCount(valueChild);
       valueChild = valueChild->getFirstChild();
       }
 
@@ -1149,9 +1151,11 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
       }
 
    bool reverseStore = false;
-   if (valueChild->getOpCodeValue() == TR::lbyteswap)
+   if (valueChild->getOpCodeValue() == TR::lbyteswap && valueChild->isSingleRefUnevaluated())
       {
       reverseStore = true;
+
+      cg->decReferenceCount(valueChild);
       valueChild = valueChild->getFirstChild();
       }
 
@@ -1457,9 +1461,11 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
       }
 
    bool reverseStore = false;
-   if (valueChild->getOpCodeValue() == TR::sbyteswap)
+   if (valueChild->getOpCodeValue() == TR::sbyteswap && valueChild->isSingleRefUnevaluated())
       {
       reverseStore = true;
+
+      cg->decReferenceCount(valueChild);
       valueChild = valueChild->getFirstChild();
       }
 


### PR DESCRIPTION
Previously, the Power codegen contained an optimization for performing a
store of a byteswapped value in a single instruction. Unfortunately, the
initial implementation of this optimization did not correctly check that
the byteswap node in question was not commoned, which could result in
erratic behaviour. This has now been corrected.

Issue: #5642
Signed-off-by: Ben Thomas <ben@benthomas.ca>