### PR TITLE
Implement a new API for performing node-based loads and stores on Power

### DIFF
--- a/compiler/p/CMakeLists.txt
+++ b/compiler/p/CMakeLists.txt
@@ -50,5 +50,6 @@ compiler_library(p
 	${CMAKE_CURRENT_LIST_DIR}/codegen/TreeEvaluatorVMX.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRConstantDataSnippet.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRLoadStoreHandler.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
 )

--- a/compiler/p/CMakeLists.txt
+++ b/compiler/p/CMakeLists.txt
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -605,19 +605,10 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       return resReg;
       }
-   else if (child->getRegister() == NULL &&
-            child->getOpCode().isLoadVar())
+   else if (!child->getRegister() && child->getReferenceCount() == 1 && child->getOpCode().isLoadVar())
       {
-      if (child->getReferenceCount() > 1)
-         {
-         TR::Node *newNode = child->duplicateTree(false);
-
-         cg->evaluate(child);
-         cg->decReferenceCount(child);
-         child = newNode;
-         }
-
-      return TR::TreeEvaluator::dloadHelper(child, cg, resReg, TR::InstOpCode::lxvdsx);
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, resReg, child, TR::InstOpCode::lxvdsx, 8, true);
+      return resReg;
       }
    else
       {

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -689,21 +689,12 @@ TR::Register *OMR::Power::TreeEvaluator::vdsetelemEvaluator(TR::Node *node, TR::
       int elem = thirdChild->getInt();
       TR_ASSERT(elem == 0 || elem == 1, "Element can only be 0 or 1\n");
 
-      if (secondChild->getRegister() == NULL &&
-         secondChild->getOpCode().isLoadVar())
+      if (!secondChild->getRegister() && secondChild->getReferenceCount() == 1 && secondChild->getOpCode().isLoadVar())
          {
-         if (secondChild->getReferenceCount() > 1)
-            {
-            TR::Node *newNode = secondChild->duplicateTree(false);
-             cg->evaluate(secondChild);
-            cg->decReferenceCount(secondChild);
-            secondChild = newNode;
-            }
-
-         TR::TreeEvaluator::dloadHelper(secondChild, cg, resReg, TR::InstOpCode::lxsdx);
-	      }
-         else
-	      {
+         TR::LoadStoreHandler::generateLoadNodeSequence(cg, resReg, secondChild, TR::InstOpCode::lxsdx, 8, true);
+         }
+      else
+         {
          TR::Register *fprReg = cg->evaluate(secondChild);
          generateTrg1Src2Instruction(cg, TR::InstOpCode::xxlor, node, resReg, fprReg, fprReg);
 

--- a/compiler/p/codegen/LoadStoreHandler.hpp
+++ b/compiler/p/codegen/LoadStoreHandler.hpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_LOADSTOREHANDLER_INCL
+#define TR_LOADSTOREHANDLER_INCL
+
+#include "codegen/OMRLoadStoreHandler.hpp"
+
+namespace TR
+{
+class OMR_EXTENSIBLE LoadStoreHandler : public OMR::Power::LoadStoreHandler {};
+class OMR_EXTENSIBLE LoadStoreHandlerImpl : public OMR::Power::LoadStoreHandlerImpl {};
+}
+
+#endif

--- a/compiler/p/codegen/LoadStoreHandler.hpp
+++ b/compiler/p/codegen/LoadStoreHandler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRLoadStoreHandler.cpp
+++ b/compiler/p/codegen/OMRLoadStoreHandler.cpp
@@ -1,0 +1,395 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/LoadStoreHandler.hpp"
+
+#include "codegen/BackingStore.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/CodeGeneratorUtils.hpp"
+#include "codegen/GenerateInstructions.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/RegisterDependency.hpp"
+#include "codegen/UnresolvedDataSnippet.hpp"
+#include "il/Node_inlines.hpp"
+
+void OMR::Power::LoadStoreHandler::generateComputeAddressSequence(TR::CodeGenerator *cg, TR::Register *addrReg, TR::Node *node, int64_t extraOffset)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(
+        node,
+        node->getOpCode().isLoadAddr() || node->getOpCode().isLoadVar() || node->getOpCode().isStore(),
+        "Attempt to use generateComputeAddressSequence for non-memory node"
+    );
+
+    auto ref = TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, 0, false, extraOffset);
+
+    if (ref.getMemoryReference()->getIndexRegister())
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, addrReg, ref.getMemoryReference()->getBaseRegister(), ref.getMemoryReference()->getIndexRegister());
+    else
+        generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, addrReg, ref.getMemoryReference());
+
+    ref.decReferenceCounts(cg);
+    }
+
+TR::MemoryReference *createAddressMemoryReference(TR::CodeGenerator *cg, TR::Register *addrReg, uint32_t length, bool requireIndexForm)
+    {
+    if (requireIndexForm)
+        return TR::MemoryReference::createWithIndexReg(cg, NULL, addrReg, length);
+    else
+        return TR::MemoryReference::createWithDisplacement(cg, addrReg, 0, length);
+    }
+
+void OMR::Power::LoadStoreHandler::generateLoadAddressSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::Register *addrReg, TR::InstOpCode::Mnemonic loadOp, uint32_t length, bool requireIndexForm)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isLoadVar(), "Attempt to use generateLoadAddressSequence for non-load node");
+    TR::LoadStoreHandlerImpl::generateLoadSequence(cg, trgReg, node, createAddressMemoryReference(cg, addrReg, length, requireIndexForm), loadOp);
+    }
+
+void OMR::Power::LoadStoreHandler::generatePairedLoadAddressSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::Register *addrReg)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isLoadVar(), "Attempt to use generatePairedLoadAddressSequence for non-load node");
+    TR::LoadStoreHandlerImpl::generatePairedLoadSequence(cg, trgReg, node, createAddressMemoryReference(cg, addrReg, 8, false));
+    }
+
+void OMR::Power::LoadStoreHandler::generateStoreAddressSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::Register *addrReg, TR::InstOpCode::Mnemonic storeOp, uint32_t length, bool requireIndexForm)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isStore(), "Attempt to use generateStoreAddressSequence for non-store node");
+    TR::LoadStoreHandlerImpl::generateStoreSequence(cg, srcReg, node, createAddressMemoryReference(cg, addrReg, length, requireIndexForm), storeOp);
+    }
+
+void OMR::Power::LoadStoreHandler::generatePairedStoreAddressSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::Register *addrReg)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isStore(), "Attempt to use generatePairedStoreAddressSequence for non-store node");
+    TR::LoadStoreHandlerImpl::generatePairedStoreSequence(cg, srcReg, node, createAddressMemoryReference(cg, addrReg, 8, false));
+    }
+
+void OMR::Power::LoadStoreHandler::generateLoadNodeSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::InstOpCode::Mnemonic loadOp, uint32_t length, bool requireIndexForm, int64_t extraOffset)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isLoadVar(), "Attempt to use generateLoadNodeSequence for non-load node");
+
+    auto ref = TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, length, requireIndexForm, extraOffset);
+
+    TR::LoadStoreHandlerImpl::generateLoadSequence(cg, trgReg, node, ref.getMemoryReference(), loadOp);
+    ref.decReferenceCounts(cg);
+    }
+
+void OMR::Power::LoadStoreHandler::generatePairedLoadNodeSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isLoadVar(), "Attempt to use generatePairedLoadNodeSequence for non-load node");
+
+    auto ref = TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, 8, false, 0);
+
+    TR::LoadStoreHandlerImpl::generatePairedLoadSequence(cg, trgReg, node, ref.getMemoryReference());
+    ref.decReferenceCounts(cg);
+    }
+
+void OMR::Power::LoadStoreHandler::generateStoreNodeSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::InstOpCode::Mnemonic storeOp, uint32_t length, bool requireIndexForm, int64_t extraOffset)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isStore(), "Attempt to use generateStoreNodeSequence for non-store node");
+    auto ref = TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, length, requireIndexForm, extraOffset);
+
+    TR::LoadStoreHandlerImpl::generateStoreSequence(cg, srcReg, node, ref.getMemoryReference(), storeOp);
+    ref.decReferenceCounts(cg);
+    }
+
+void OMR::Power::LoadStoreHandler::generatePairedStoreNodeSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, node->getOpCode().isStore(), "Attempt to use generatePairedStoreNodeSequence for non-store node");
+    auto ref = TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, 8, false, 0);
+
+    TR::LoadStoreHandlerImpl::generatePairedStoreSequence(cg, srcReg, node, ref.getMemoryReference());
+    ref.decReferenceCounts(cg);
+    }
+
+bool OMR::Power::LoadStoreHandler::isSimpleLoad(TR::CodeGenerator *cg, TR::Node *node)
+    {
+    if (!node->getOpCode().isLoad())
+        return false;
+
+#ifdef J9_PROJECT_SPECIFIC
+    if (node->getSymbolReference()->isUnresolved())
+        return false;
+
+    if (node->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP())
+        return false;
+#endif
+
+    return cg->comp()->target().is64Bit() || node->getOpCode().getDataType() != TR::Int64;
+    }
+
+OMR::Power::NodeMemoryReference OMR::Power::LoadStoreHandler::generateSimpleLoadMemoryReference(TR::CodeGenerator *cg, TR::Node *node, uint32_t length, bool requireIndexForm, int64_t extraOffset)
+    {
+    TR_ASSERT_FATAL_WITH_NODE(node, TR::LoadStoreHandler::isSimpleLoad(cg, node), "Attempt to use generateSimpleLoadMemoryReference for a node which is not a simple load");
+    return TR::LoadStoreHandlerImpl::generateMemoryReference(cg, node, length, requireIndexForm, extraOffset);
+    }
+
+OMR::Power::NodeMemoryReference OMR::Power::LoadStoreHandlerImpl::generateMemoryReference(TR::CodeGenerator *cg, TR::Node *node, uint32_t length, bool requireIndexForm, int64_t extraOffset)
+    {
+    TR::MemoryReference *memRef = TR::MemoryReference::createWithRootLoadOrStore(cg, node, length);
+
+    if (extraOffset != 0)
+        memRef->addToOffset(node, extraOffset, cg);
+
+    if (requireIndexForm)
+        memRef->forceIndexedForm(node, cg);
+
+    return OMR::Power::NodeMemoryReference(memRef);
+    }
+
+void OMR::Power::LoadStoreHandlerImpl::generateLoadSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::MemoryReference *memRef, TR::InstOpCode::Mnemonic loadOp)
+    {
+    generateTrg1MemInstruction(cg, loadOp, node, trgReg, memRef);
+    cg->insertPrefetchIfNecessary(node, trgReg);
+
+#ifdef J9_PROJECT_SPECIFIC
+    if (node->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP())
+        TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, memRef, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
+#endif
+    }
+
+void OMR::Power::LoadStoreHandlerImpl::generatePairedLoadSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::MemoryReference *memRef)
+    {
+    #ifdef J9_PROJECT_SPECIFIC
+    // Since non-volatiles are implemented as two separate loads, we must use a special sequence to perform the load in
+    // a single instruction even when SMP is disabled.
+    if (node->getSymbol()->isSyncVolatile())
+        {
+        if (node->getSymbolReference()->isUnresolved())
+            {
+            TR::SymbolReference *vrlSymRef = cg->comp()->getSymRefTab()->findOrCreateVolatileReadLongSymbolRef(cg->comp()->getMethodSymbol());
+
+            memRef->getUnresolvedSnippet()->setIs32BitLong();
+
+            TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(4, 4, cg->trMemory());
+            TR::addDependency(deps, trgReg->getHighOrder(), TR::RealRegister::gr3, TR_GPR, cg);
+            TR::addDependency(deps, trgReg->getLowOrder(), TR::RealRegister::gr4, TR_GPR, cg);
+            TR::addDependency(deps, NULL, TR::RealRegister::gr11, TR_GPR, cg);
+
+            TR::addDependency(deps, memRef->getBaseRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
+            deps->getPreConditions()->getRegisterDependency(3)->setExcludeGPR0();
+            deps->getPostConditions()->getRegisterDependency(3)->setExcludeGPR0();
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, trgReg->getHighOrder(), memRef);
+            generateDepImmSymInstruction(
+                cg,
+                TR::InstOpCode::bl,
+                node,
+                reinterpret_cast<uintptr_t>(vrlSymRef->getSymbol()->castToMethodSymbol()->getMethodAddress()),
+                deps,
+                vrlSymRef
+            );
+
+            cg->machine()->setLinkRegisterKilled(true);
+            }
+        else if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX))
+            {
+            TR::Register *tempHiReg = cg->allocateRegister(TR_FPR);
+            TR::Register *tempLoReg = cg->allocateRegister(TR_FPR);
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, tempLoReg, memRef);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, tempHiReg, tempLoReg, 0);
+            generateTrg1Src1Instruction(cg, TR::InstOpCode::mfvsrwz, node, trgReg->getHighOrder(), tempHiReg);
+            generateTrg1Src1Instruction(cg, TR::InstOpCode::mfvsrwz, node, trgReg->getLowOrder(), tempLoReg);
+
+            if (cg->comp()->target().isSMP())
+                generateInstruction(cg, TR::InstOpCode::lwsync, node);
+
+            cg->stopUsingRegister(tempLoReg);
+            cg->stopUsingRegister(tempHiReg);
+            }
+        else
+            {
+            TR::Register *tempReg = cg->allocateRegister(TR_FPR);
+            TR_BackingStore *spillLocation = cg->allocateSpill(8, false, NULL);
+
+            TR::MemoryReference *spillRef = TR::MemoryReference::createWithSymRef(cg, node, spillLocation->getSymbolReference(), 8);
+            TR::MemoryReference *spillRefHi = TR::MemoryReference::createWithMemRef(cg, node, *spillRef, 0, 4);
+            TR::MemoryReference *spillRefLo = TR::MemoryReference::createWithMemRef(cg, node, *spillRef, 4, 4);
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, tempReg, memRef);
+            generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, spillRef, tempReg);
+
+            if (cg->comp()->target().isSMP())
+                generateInstruction(cg, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync, node);
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg->getHighOrder(), spillRefHi);
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg->getLowOrder(), spillRefLo);
+
+            cg->freeSpill(spillLocation, 8, 0);
+            cg->stopUsingRegister(tempReg);
+            }
+        }
+    else
+#endif
+        {
+        TR::MemoryReference *memRefHi = TR::MemoryReference::createWithMemRef(cg, node, *memRef, 0, 4);
+        TR::MemoryReference *memRefLo = TR::MemoryReference::createWithMemRef(cg, node, *memRef, 4, 4);
+
+        generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg->getHighOrder(), memRefHi);
+        generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg->getLowOrder(), memRefLo);
+        }
+    }
+
+#ifdef J9_PROJECT_SPECIFIC
+enum class StoreSyncRequirements
+    {
+    None,
+    AtomicWrite,
+    LazySet,
+    Full
+    };
+
+StoreSyncRequirements getStoreSyncRequirements(TR::CodeGenerator *cg, TR::Node *node)
+    {
+    if (node->getSymbol()->isSyncVolatile())
+        {
+        // Even when SMP is disabled, we need to ensure that the write is performed in a single instruction to prevent
+        // the current thread from being pre-empted during the store. This really only affects writes to longs on
+        // ppc32, which are normally done as 2 separate stores. For other platforms and types of stores, AtomicWrite is
+        // equivalent to None.
+        if (!cg->comp()->target().isSMP())
+            return StoreSyncRequirements::AtomicWrite;
+
+        TR_OpaqueMethodBlock *caller = node->getOwningMethod();
+
+        if (caller && !cg->comp()->compileRelocatableCode())
+            {
+            TR_ResolvedMethod *m = cg->comp()->fe()->createResolvedMethod(cg->trMemory(), caller, node->getSymbolReference()->getOwningMethod(cg->comp()));
+            if (m->getRecognizedMethod() == TR::java_util_concurrent_atomic_AtomicInteger_lazySet)
+                return StoreSyncRequirements::LazySet;
+            }
+
+        return StoreSyncRequirements::Full;
+        }
+    else if (node->getSymbol()->isShadow() && node->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
+        {
+        return StoreSyncRequirements::LazySet;
+        }
+
+    return StoreSyncRequirements::None;
+    }
+#endif
+
+void OMR::Power::LoadStoreHandlerImpl::generateStoreSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::MemoryReference *memRef, TR::InstOpCode::Mnemonic storeOp)
+    {
+#ifdef J9_PROJECT_SPECIFIC
+    StoreSyncRequirements sync = getStoreSyncRequirements(cg, node);
+
+    if (sync == StoreSyncRequirements::LazySet || sync == StoreSyncRequirements::Full)
+        generateInstruction(cg, TR::InstOpCode::lwsync, node);
+#endif
+
+    generateMemSrc1Instruction(cg, storeOp, node, memRef, srcReg);
+
+#ifdef J9_PROJECT_SPECIFIC
+    if (sync == StoreSyncRequirements::Full)
+        TR::TreeEvaluator::postSyncConditions(node, cg, srcReg, memRef, TR::InstOpCode::sync);
+#endif
+    }
+
+void OMR::Power::LoadStoreHandlerImpl::generatePairedStoreSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::MemoryReference *memRef)
+    {
+#ifdef J9_PROJECT_SPECIFIC
+    StoreSyncRequirements sync = getStoreSyncRequirements(cg, node);
+
+    if (sync != StoreSyncRequirements::None)
+        {
+        if (node->getSymbolReference()->isUnresolved())
+            {
+            TR::Register *addrReg = cg->allocateRegister();
+            TR::SymbolReference *vwlSymRef = cg->comp()->getSymRefTab()->findOrCreateVolatileWriteLongSymbolRef(cg->comp()->getMethodSymbol());
+
+            memRef->getUnresolvedSnippet()->setIs32BitLong();
+
+            TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(5, 5, cg->trMemory());
+            TR::addDependency(deps, addrReg, TR::RealRegister::gr3, TR_GPR, cg);
+            TR::addDependency(deps, srcReg->getHighOrder(), TR::RealRegister::gr4, TR_GPR, cg);
+            TR::addDependency(deps, srcReg->getLowOrder(), TR::RealRegister::gr5, TR_GPR, cg);
+            TR::addDependency(deps, NULL, TR::RealRegister::gr11, TR_GPR, cg);
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, addrReg, memRef);
+            generateDepImmSymInstruction(
+                cg,
+                TR::InstOpCode::bl,
+                node,
+                reinterpret_cast<uintptr_t>(vwlSymRef->getSymbol()->castToMethodSymbol()->getMethodAddress()),
+                deps,
+                vwlSymRef
+            );
+
+            cg->machine()->setLinkRegisterKilled(true);
+            cg->stopUsingRegister(addrReg);
+            }
+        else if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX))
+            {
+            TR::Register *tempHiReg = cg->allocateRegister(TR_FPR);
+            TR::Register *tempLoReg = cg->allocateRegister(TR_FPR);
+
+            generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, tempHiReg, srcReg->getHighOrder());
+            generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, tempLoReg, srcReg->getLowOrder());
+            generateTrg1Src2Instruction(cg, TR::InstOpCode::xxmrghw, node, tempHiReg, tempHiReg, tempLoReg);
+            generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxpermdi, node, tempHiReg, tempHiReg, tempHiReg, 2);
+
+            if (sync == StoreSyncRequirements::LazySet || sync == StoreSyncRequirements::Full)
+                generateInstruction(cg, TR::InstOpCode::lwsync, node);
+
+            generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, memRef, tempHiReg);
+
+            if (sync == StoreSyncRequirements::Full)
+                generateInstruction(cg, TR::InstOpCode::sync, node);
+
+            cg->stopUsingRegister(tempLoReg);
+            cg->stopUsingRegister(tempHiReg);
+            }
+        else
+            {
+            TR::Register *tempReg = cg->allocateRegister(TR_FPR);
+            TR_BackingStore *spillLocation = cg->allocateSpill(8, false, NULL);
+
+            TR::MemoryReference *spillRef = TR::MemoryReference::createWithSymRef(cg, node, spillLocation->getSymbolReference(), 8);
+            TR::MemoryReference *spillRefHi = TR::MemoryReference::createWithMemRef(cg, node, *spillRef, 0, 4);
+            TR::MemoryReference *spillRefLo = TR::MemoryReference::createWithMemRef(cg, node, *spillRef, 4, 4);
+
+            generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, spillRefHi, srcReg->getHighOrder());
+            generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, spillRefLo, srcReg->getLowOrder());
+
+            if (sync == StoreSyncRequirements::LazySet || sync == StoreSyncRequirements::Full)
+                generateInstruction(cg, TR::InstOpCode::lwsync, node);
+
+            generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, tempReg, spillRef);
+            generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, memRef, tempReg);
+
+            if (sync == StoreSyncRequirements::Full)
+                generateInstruction(cg, TR::InstOpCode::sync, node);
+
+            cg->freeSpill(spillLocation, 8, 0);
+            cg->stopUsingRegister(tempReg);
+            }
+        }
+    else
+#endif
+        {
+        TR::MemoryReference *memRefHi = TR::MemoryReference::createWithMemRef(cg, node, *memRef, 0, 4);
+        TR::MemoryReference *memRefLo = TR::MemoryReference::createWithMemRef(cg, node, *memRef, 4, 4);
+
+        generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, memRefHi, srcReg->getHighOrder());
+        generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, memRefLo, srcReg->getLowOrder());
+        }
+    }

--- a/compiler/p/codegen/OMRLoadStoreHandler.cpp
+++ b/compiler/p/codegen/OMRLoadStoreHandler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRLoadStoreHandler.hpp
+++ b/compiler/p/codegen/OMRLoadStoreHandler.hpp
@@ -1,0 +1,319 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_POWER_LOADSTOREHANDLER_INCL
+#define OMR_POWER_LOADSTOREHANDLER_INCL
+
+#include "codegen/InstOpCode.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "codegen/Register.hpp"
+#include "il/Node.hpp"
+#include "infra/Annotations.hpp"
+
+namespace OMR
+{
+
+namespace Power
+{
+
+/**
+ * \brief A memory reference alongside information about operations to perform when its lifetime
+ *        is complete.
+ */
+class NodeMemoryReference
+    {
+    TR::MemoryReference *_memRef;
+
+    public:
+    NodeMemoryReference() : _memRef(NULL) {}
+    explicit NodeMemoryReference(TR::MemoryReference *memRef) : _memRef(memRef) {}
+
+    TR::MemoryReference *getMemoryReference() { return _memRef; }
+    void decReferenceCounts(TR::CodeGenerator *cg) { return _memRef->decNodeReferenceCounts(cg); }
+    };
+
+/**
+ * \brief An extensible class containing static methods for evaluating loads and stores.
+ *
+ * This class contains static methods for assisting evaluators in generating load and store sequences. These methods
+ * are meant to be used from evaluators and are capable of some limited customization of how a load or store is
+ * performed to allow for codegen optimizations.
+ *
+ * This class is meant to be extended by downstream projects that require special handling for emitting load and store
+ * sequences for certain types of symbol references, e.g. unresolved symbols in OpenJ9.
+ *
+ * \warning Unless otherwise mentioned, methods on this class are free to emit arbitrary instructions at the append
+ *          cursor, and so should never be called during internal control flow.
+ */
+class OMR_EXTENSIBLE LoadStoreHandler
+    {
+    public:
+
+    /**
+     * \brief Generate a sequence of instructions to compute the effective address of a load, store, or loadaddr.
+     *
+     * This method generates a sequence of instructions at the append cursor that compute the effective address of a
+     * load, store, or loadaddr node. This is useful for evaluators that need to check or change the address of a
+     * load/store before it is performed, such as some forms of GC write barrier.
+     *
+     * For load nodes, the address computed by this method can be used with generateLoadAddressSequence to actually
+     * perform the load. For stores, the address computed by this method can be used with generateStoreAddressSequence
+     * to actually perform the store.
+     *
+     * \warning While it is possible to emit a load or store directly using the computed address, this should be done
+     *          with extreme caution and only in the most derived project. Downstream projects are free to customize
+     *          how load/store sequences are emitted, so this should never be done in projects where overriding
+     *          implementations could exist.
+     *
+     * \param cg The code generator
+     * \param addrReg The register into which the effective address should be computed
+     * \param node The load, store, or loadaddr node whose effective address should be computed
+     * \param extraOffset An extra offset in bytes to add to the effective address
+     */
+    static void generateComputeAddressSequence(TR::CodeGenerator *cg, TR::Register *addrReg, TR::Node *node, int64_t extraOffset=0);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a load whose effective address has already been computed.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a load given a load node and
+     * the effective address of the load, as computed by generateComputeAddressSequence.
+     *
+     * \param cg The code generator
+     * \param trgReg The register into which the value should be loaded
+     * \param node The load node to emit a load for
+     * \param addrRef The register containing the effective address of the load
+     * \param loadOp The opcode to use to perform the load
+     * \param length The length of the data being loaded in bytes
+     * \param requireIndexForm true if an indexed-form instruction must be used; false otherwise
+     */
+    static void generateLoadAddressSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::Register *addrReg, TR::InstOpCode::Mnemonic loadOp, uint32_t length, bool requireIndexForm=false);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a paired load whose effective address has already been
+     *        computed.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a 64-bit load using 32-bit
+     * instructions into a register pair given a load node and the effective address of the load, as computed by
+     * generateComputeAddressSequence.
+     *
+     * \param cg The code generator
+     * \param trgReg The register pair into which the value should be loaded
+     * \param node The load node to emit a load for
+     * \param addrReg The register containing the effective address of the load
+     */
+    static void generatePairedLoadAddressSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::Register *addrReg);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a store whose effective address has already been computed.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a store given a store node
+     * and the effective address of the store, as computed by generateComputeAddressSequence.
+     *
+     * \param cg The code generator
+     * \param srcReg The register whose value should be stored
+     * \param node The store node to emit a store for
+     * \param addrReg The register containing the effective address of the store
+     * \param storeOp The opcode to use to perform the store
+     * \param length The length of the data being stored in bytes
+     * \param requireIndexForm true if an indexed-form instruction must be used; false otherwise
+     */
+    static void generateStoreAddressSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::Register *addrReg, TR::InstOpCode::Mnemonic storeOp, uint32_t length, bool requireIndexForm=false);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a paired store whose effective address has already been
+     *        computed.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a 64-bit store using 32-bit
+     * instructions from a register pair given a store node and the effective address of the store, as computed
+     * by generateComputeAddressSequence.
+     *
+     * \param cg The code generator
+     * \param srcReg The register pair whose value should be stored
+     * \param node The store node to emit a store for
+     * \param addrReg The register containing the effective address of the store
+     */
+    static void generatePairedStoreAddressSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::Register *addrReg);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a load for a given node.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a load at the location
+     * specified by the given load node.
+     *
+     * \param cg The code generator
+     * \param trgReg The register into which the value should be loaded
+     * \param node The load node to emit a load for
+     * \param loadOp The opcode to use to perform the load
+     * \param length The length of the data being loaded in bytes
+     * \param requireIndexForm true if an indexed-form instruction must be used; false otherwise
+     * \param extraOffset An extra offset in bytes to add to the effective address of the load
+     */
+    static void generateLoadNodeSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::InstOpCode::Mnemonic loadOp, uint32_t length, bool requireIndexForm=false, int64_t extraOffset=0);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a paired load for a given node.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a 64-bit load using 32-bit
+     * instructions into a register pair at the location specified by the given load node.
+     *
+     * \param cg The code generator
+     * \param trgReg The register pair into which the value should be loaded
+     * \param node The load node to emit a load for
+     */
+    static void generatePairedLoadNodeSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a store for a given node.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a store at the location
+     * specified by the given store node.
+     *
+     * \param cg The code generator
+     * \param srcReg The register whose value should be stored
+     * \param node The store node to emit a store for
+     * \param storeOp The opcode to use to perform the store
+     * \param length The length of the data being stored in bytes
+     * \param requireIndexForm true if an indexed-form instruction must be used; false otherwise
+     * \param extraOffset An extra offset in bytes to add to the effective address of the store
+     */
+    static void generateStoreNodeSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::InstOpCode::Mnemonic storeOp, uint32_t length, bool requireIndexForm=false, int64_t extraOffset=0);
+
+    /**
+     * \brief Generate a sequence of instructions to execute a paired store for a given node.
+     *
+     * This method generates a sequence of instructions at the append cursor that perform a 64-bit store using 32-bit
+     * instructions from a register pair at the location specified by the given store node.
+     *
+     * \param cg The code generator
+     * \param srcReg The register pair whose value should be stored
+     * \param node The store node to emit a store for
+     */
+    static void generatePairedStoreNodeSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node);
+
+    /**
+     * \brief Determines whether the provided node represents a "simple" load.
+     *
+     * This method determines whether the provided node represents a "simple" load. Simple loads are those for which it
+     * is correct to emit a single load instruction without any other surrounding instructions or other setup. Such
+     * loads can, as an optimization, be performed within internal control flow with minimal restrictions.
+     *
+     * This method is guaranteed not to emit any instructions or change any global state.
+     *
+     * \param cg The code generator
+     * \param node The node to check
+     *
+     * \return true if the provided node represents a "simple" load; false otherwise
+     */
+    static bool isSimpleLoad(TR::CodeGenerator *cg, TR::Node *node);
+
+    /**
+     * \brief Evaluate the effective address of a "simple" load node into a memory reference
+     *
+     * This method generates a memory reference for a load which was determined to be simple according to isSimpleLoad.
+     * Managing the lifetime of the returned memory reference's registers is left to the caller.
+     *
+     * \warning While the returned memory reference can be used within internal control flow, calling this method may
+     *          emit arbitrary instructions at the append instruction that may not be safe to perform during internal
+     *          control flow. Hence, this method should always be called before beginning internal control flow.
+     *
+     * \param cg The code generator
+     * \param node The node representing a "simple" load which should be evaluated to a memory reference
+     * \param length The length of data represented by the returned memory reference in bytes
+     * \param requireIndexForm true if the returned memory reference must be indexed-form; false otherwise
+     * \param extraOffset An extra offset in bytes to add to the effective address of the store
+     */
+    static NodeMemoryReference generateSimpleLoadMemoryReference(TR::CodeGenerator *cg, TR::Node *node, uint32_t length, bool requireIndexForm=false, int64_t extraOffset=0);
+    };
+
+/**
+ * \brief An extensible class containing implementation methods for evaluating loads and stores.
+ *
+ * This class is meant to be used as an extension point to customize the default implementations of the methods on
+ * LoadStoreHandler provided by OMR without needing to duplicate code between them.
+ *
+ * \warning This class's methods should only be used within the LoadStoreHandler and LoadStoreHandlerImpl classes.
+ *          Downstream projects are free to add extra functionality to LoadStoreHandler that may not work correctly if
+ *          LoadStoreHandlerImpl is used directly.
+ */
+class OMR_EXTENSIBLE LoadStoreHandlerImpl
+    {
+    public:
+
+    /**
+     * \brief Generate a memory reference corresponding to the effective address of a given load, store, or loadaddr
+     *        node.
+     *
+     * \param cg The code generator
+     * \param node The load, store, or loadaddr node whose effective address should be computed
+     * \param length The length of data represented by the returned memory reference
+     * \param requireIndexForm true if the returned memory reference must be indexed-form; false otherwise
+     * \param extraOffset An extra offset in bytes to add to the effective address
+     */
+    static NodeMemoryReference generateMemoryReference(TR::CodeGenerator *cg, TR::Node *node, uint32_t length, bool requireIndexForm, int64_t extraOffset);
+
+    /**
+     * \brief Generate a sequence of instructions for performing a load given a load node and memory reference.
+     *
+     * \param cg The code generator
+     * \param trgReg The register into which the value should be loaded
+     * \param node The load node to emit a load for
+     * \param memRef The memory reference for the effective address of the load
+     * \param loadOp The opcode to use to perform the load
+     */
+    static void generateLoadSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::MemoryReference *memRef, TR::InstOpCode::Mnemonic loadOp);
+
+    /**
+     * \brief Generate a sequence of instructions for performing a paired load given a load node and memory reference.
+     *
+     * \param cg The code generator
+     * \param trgReg The register pair into which the value should be loaded
+     * \param node The load node to emit a load for
+     * \param memRef The memory reference for the effective address of the load
+     */
+    static void generatePairedLoadSequence(TR::CodeGenerator *cg, TR::Register *trgReg, TR::Node *node, TR::MemoryReference *memRef);
+
+    /**
+     * \brief Generate a sequence of instructions for performing a store given a store node and memory reference.
+     *
+     * \param cg The code generator
+     * \param srcReg The register whose value should be stored
+     * \param node The store node to emit a store for
+     * \param memRef The memory reference for the effective address of the store
+     * \param storeOp The opcode to use to perform the store
+     */
+    static void generateStoreSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::MemoryReference *memRef, TR::InstOpCode::Mnemonic storeOp);
+
+    /**
+     * \brief Generate a sequence of instructions for performing a paired store given a store node and memory
+     *        reference.
+     *
+     * \param cg The code generator
+     * \param srcReg The register pair whose value should be stored
+     * \param node The store node to emit a store for
+     * \param memRef The memory reference for the effective address of the store
+     */
+    static void generatePairedStoreSequence(TR::CodeGenerator *cg, TR::Register *srcReg, TR::Node *node, TR::MemoryReference *memRef);
+    };
+}
+
+}
+
+#endif

--- a/compiler/p/codegen/OMRLoadStoreHandler.hpp
+++ b/compiler/p/codegen/OMRLoadStoreHandler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5069,17 +5069,16 @@ TR::Register *OMR::Power::TreeEvaluator::sbyteswapEvaluator(TR::Node *node, TR::
        firstNonConversionOpCodeNode->getReferenceCount() == 1 &&
        (nodeType.isInt16() || nodeType.isInt32() || nodeType.isInt64()))
       {
-      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, firstNonConversionOpCodeNode, 2);
+      int64_t extraOffset = 0;
+
 #ifndef __LITTLE_ENDIAN__
-      //On Big Endian Machines
       if (nodeType.isInt32())
-         tempMR->addToOffset(node,2,cg);
+         extraOffset = 2;
       else if (nodeType.isInt64())
-         tempMR->addToOffset(node,6,cg);
+         extraOffset = 6;
 #endif
-      tempMR->forceIndexedForm(firstNonConversionOpCodeNode, cg);
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lhbrx, node, tgtRegister, tempMR);
-      tempMR->decNodeReferenceCounts(cg);
+
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, tgtRegister, firstNonConversionOpCodeNode, TR::InstOpCode::lhbrx, 2, true, extraOffset);
 
       //Decrement Ref count for the intermediate conversion nodes
       firstNonConversionOpCodeNode = node->getFirstChild();
@@ -5133,10 +5132,7 @@ TR::Register * OMR::Power::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR:
        firstChild->getOpCode().isMemoryReference() &&
        firstChild->getReferenceCount() == 1)
       {
-      TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, firstChild, 4);
-      tempMR->forceIndexedForm(firstChild, cg);
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lwbrx, node, tgtRegister, tempMR);
-      tempMR->decNodeReferenceCounts(cg);
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, tgtRegister, firstChild, TR::InstOpCode::lwbrx, 4, true);
       }
    else
       {
@@ -5190,10 +5186,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbyteswapEvaluator(TR::Node *node, TR::
           firstChild->getOpCode().isMemoryReference() &&
           firstChild->getReferenceCount() == 1)
          {
-         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, firstChild, 8);
-         tempMR->forceIndexedForm(firstChild, cg);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ldbrx, node, tgtRegister, tempMR);
-         tempMR->decNodeReferenceCounts(cg);
+         TR::LoadStoreHandler::generateLoadNodeSequence(cg, tgtRegister, firstChild, TR::InstOpCode::ldbrx, 8, true);
          }
       else
          {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -80,6 +80,7 @@
 #include "optimizer/Structure.hpp"
 #include "p/codegen/OMRCodeGenerator.hpp"
 #include "p/codegen/GenerateInstructions.hpp"
+#include "p/codegen/LoadStoreHandler.hpp"
 #include "p/codegen/PPCAOTRelocation.hpp"
 #include "p/codegen/PPCHelperCallSnippet.hpp"
 #include "p/codegen/PPCOpsDefines.hpp"
@@ -501,39 +502,21 @@ TR::Instruction *fixedSeqMemAccess(TR::CodeGenerator *cg, TR::Node *node, intptr
 
 
 
-// also handles iiload, iiuload
+// Also handles iloadi
 TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *tempReg;
-   TR::MemoryReference *tempMR = NULL;
-   TR::Compilation *comp = cg->comp();
+   TR::Register *trgReg;
 
-   tempReg = cg->allocateRegister();
-   if (node->getSymbolReference()->getSymbol()->isInternalPointer())
+   trgReg = cg->allocateRegister();
+   if (node->getSymbol()->isInternalPointer())
       {
-      tempReg->setPinningArrayPointer(node->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
-      tempReg->setContainsInternalPointer();
+      trgReg->setPinningArrayPointer(node->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
+      trgReg->setContainsInternalPointer();
       }
 
-   node->setRegister(tempReg);
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-
-   cg->insertPrefetchIfNecessary(node, tempReg);
-
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-      }
-
-   tempMR->decNodeReferenceCounts(cg);
-
-   return tempReg;
+   TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::lwz, 4);
+   node->setRegister(trgReg);
+   return trgReg;
    }
 
 static bool nodeIsNeeded(TR::Node *checkNode, TR::Node *node)
@@ -559,7 +542,7 @@ static bool nodeIsNeeded(TR::Node *checkNode, TR::Node *node)
    return result;
    }
 
-// handles 32-bit and 64-bit aload and iaload
+// Also handles aloadi
 TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
@@ -618,324 +601,92 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
          }
       }
 
-   TR::Register *tempReg;
-   TR::MemoryReference *tempMR = NULL;
+   TR::Register *trgReg;
 
    if (!node->getSymbolReference()->getSymbol()->isInternalPointer())
       {
       if (node->getSymbolReference()->getSymbol()->isNotCollected())
-         tempReg = cg->allocateRegister();
+         trgReg = cg->allocateRegister();
       else
-         tempReg = cg->allocateCollectedReferenceRegister();
+         trgReg = cg->allocateCollectedReferenceRegister();
       }
    else
       {
-      tempReg = cg->allocateRegister();
-      tempReg->setPinningArrayPointer(node->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
-      tempReg->setContainsInternalPointer();
+      trgReg = cg->allocateRegister();
+      trgReg->setPinningArrayPointer(node->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer());
+      trgReg->setContainsInternalPointer();
       }
 
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
+   // TODO Will this cause problems with evaluators that will inline aload and aloadi nodes?
+#ifdef J9_PROJECT_SPECIFIC
+   bool isCompressedVft = TR::Compiler->om.generateCompressedObjectHeaders() && node->getSymbol()->isClassObject() && node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef();
+#else
+   bool isCompressedVft = false;
+#endif
 
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   if (cg->comp()->target().is64Bit())
-      {
-      int32_t numBytes = 8;
-      if (TR::Compiler->om.generateCompressedObjectHeaders() &&
-            (node->getSymbol()->isClassObject() ||
-             (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())))
-         numBytes = 4; // read only 4 bytes
-
-      tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, numBytes);
-      }
+   if (cg->comp()->target().is64Bit() && !isCompressedVft)
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::ld, 8);
    else
-      {
-      tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
-      }
-
-   node->setRegister(tempReg);
-
-   if (cg->comp()->target().is64Bit())
-      {
-      if (TR::Compiler->om.generateCompressedObjectHeaders() &&
-            (node->getSymbol()->isClassObject() ||
-             (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())))
-         {
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-         }
-      else
-         {
-         generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, tempReg, tempMR);
-         }
-      }
-   else
-      {
-      generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, tempReg, tempMR);
-      }
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::lwz, 4);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())
-      TR::TreeEvaluator::generateVFTMaskInstruction(cg, node, tempReg);
+      TR::TreeEvaluator::generateVFTMaskInstruction(cg, node, trgReg);
 #endif
-
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-      }
-   tempMR->decNodeReferenceCounts(cg);
-
-   return tempReg;
-   }
-
-// also handles ilload, iluload
-TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Compilation *comp = cg->comp();
-   bool needSync;
-
-   if (cg->comp()->target().is64Bit())
-      {
-      TR::Register     *trgReg = cg->allocateRegister();
-      // need to test isInternalPointer?
-      node->setRegister(trgReg);
-      TR::MemoryReference *tempMR;
-
-      needSync = node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP();
-
-      // If the reference is volatile or potentially volatile, we keep a fixed instruction
-      // layout in order to patch if it turns out that the reference isn't really volatile.
-      //
-      tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-
-      generateTrg1MemInstruction(cg, TR::InstOpCode::ld, node, trgReg, tempMR);
-      if (needSync)
-         {
-         TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-         }
-
-      tempMR->decNodeReferenceCounts(cg);
-      return trgReg;
-      }
-   else // 32 bit target
-      {
-      TR::Register *lowReg  = cg->allocateRegister();
-      TR::Register *highReg = cg->allocateRegister();
-      TR::RegisterPair *trgReg = cg->allocateRegisterPair(lowReg, highReg);
-
-      // 32bit long is accessed in 2 instructions such that uniprocessor cannot
-      // guarantee atomicity either.
-      //
-      needSync = node->getSymbolReference()->getSymbol()->isSyncVolatile();
-
-      if (needSync)
-         {
-         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-
-         if (!node->getSymbolReference()->isUnresolved() && cg->is64BitProcessor()) //resolved as volatile
-            {
-            TR::Register *doubleReg = cg->allocateRegister(TR_FPR);
-            generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, doubleReg, tempMR);
-
-            if (cg->comp()->target().isSMP())
-               {
-               TR_BackingStore * location;
-               location = cg->allocateSpill(8, false, NULL);
-               TR::MemoryReference *tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8);
-               TR::MemoryReference *tempMRLoad1 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 0, 4);
-               TR::MemoryReference *tempMRLoad2 = TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 4, 4);
-               generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, tempMRStore1, doubleReg);
-               generateInstruction(cg, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync, node);
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, highReg, tempMRLoad1);
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, lowReg, tempMRLoad2);
-               cg->freeSpill(location, 8, 0);
-               }
-            else
-               {
-               if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8))
-                  {
-                  TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
-                  generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
-                  cg->stopUsingRegister(tmp1);
-                  }
-               else
-                  generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg);
-               }
-            cg->stopUsingRegister(doubleReg);
-            }
-         else
-            {
-            TR::SymbolReference *vrlRef;
-
-            if (node->getSymbolReference()->isUnresolved())
-               {
-#ifdef J9_PROJECT_SPECIFIC
-               tempMR->getUnresolvedSnippet()->setIs32BitLong();
-#endif
-               }
-
-            vrlRef = comp->getSymRefTab()->findOrCreateVolatileReadLongSymbolRef(comp->getMethodSymbol());
-
-            // If the following needs to be patched for performance reasons, the layout needs to
-            // be fixed and the dependency needs to be enhanced to guarantee the layout.
-            //
-            if (tempMR->getIndexRegister() != NULL)
-                generateTrg1Src2Instruction (cg, TR::InstOpCode::add, node, highReg, tempMR->getBaseRegister(), tempMR->getIndexRegister());
-            else
-               generateTrg1MemInstruction (cg, TR::InstOpCode::addi2, node, highReg, tempMR);
-
-            TR::RegisterDependencyConditions *dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(6, 6, cg->trMemory());
-            TR::addDependency(dependencies, lowReg, TR::RealRegister::gr4, TR_GPR, cg);
-            TR::addDependency(dependencies, highReg, TR::RealRegister::gr3, TR_GPR, cg);
-            TR::addDependency(dependencies, NULL, TR::RealRegister::gr11, TR_GPR, cg);
-
-            if (node->getSymbolReference()->isUnresolved())
-               {
-               if (tempMR->getBaseRegister() != NULL)
-                  {
-                  TR::addDependency(dependencies, tempMR->getBaseRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
-                  dependencies->getPreConditions()->getRegisterDependency(3)->setExcludeGPR0();
-                  dependencies->getPostConditions()->getRegisterDependency(3)->setExcludeGPR0();
-                  }
-
-               if (tempMR->getIndexRegister() != NULL)
-                  TR::addDependency(dependencies, tempMR->getIndexRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
-               }
-
-            generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node,
-                   (uintptr_t)vrlRef->getSymbol()->castToMethodSymbol()->getMethodAddress(),
-                   dependencies, vrlRef);
-
-            dependencies->stopUsingDepRegs(cg, lowReg, highReg);
-            cg->machine()->setLinkRegisterKilled(true);
-            }
-         tempMR->decNodeReferenceCounts(cg);
-         }
-      else
-         {
-         TR::MemoryReference *highMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
-
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, highReg, highMR);
-         TR::MemoryReference *lowMR       = TR::MemoryReference::createWithMemRef(cg, node, *highMR, 4, 4);
-         generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, lowReg, lowMR);
-         highMR->decNodeReferenceCounts(cg);
-         lowMR->decNodeReferenceCounts(cg);
-         }
-
-      node->setRegister(trgReg);
-      return trgReg;
-      }
-   }
-
-TR::Register *OMR::Power::TreeEvaluator::commonByteLoadEvaluator(TR::Node *node, bool signExtend, TR::CodeGenerator *cg)
-   {
-   TR::Register *trgReg = cg->allocateRegister();
-   TR::MemoryReference *tempMR;
-
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 1);
-
-   generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, trgReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-      }
-
-   if (signExtend)
-      generateTrg1Src1Instruction(cg, TR::InstOpCode::extsb, node, trgReg, trgReg);
 
    node->setRegister(trgReg);
-   tempMR->decNodeReferenceCounts(cg);
    return trgReg;
    }
 
-// also handles ibuload
-TR::Register *OMR::Power::TreeEvaluator::buloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+// Also handles lloadi
+TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   // Never sign extend an unsigned byte load.
-   return TR::TreeEvaluator::commonByteLoadEvaluator(node, false, cg);
+   TR::Register *trgReg;
+
+   if (cg->comp()->target().is64Bit())
+      {
+      trgReg = cg->allocateRegister();
+      TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::ld, 8);
+      }
+   else
+      {
+      trgReg = cg->allocateRegisterPair(cg->allocateRegister(), cg->allocateRegister());
+      TR::LoadStoreHandler::generatePairedLoadNodeSequence(cg, trgReg, node);
+      }
+
+   node->setRegister(trgReg);
+   return trgReg;
    }
 
-// also handles ibload
+// Also handles bloadi
 TR::Register *OMR::Power::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   // Java only loads and stores byte values so sign extension after the lbz is not required.
-   return TR::TreeEvaluator::commonByteLoadEvaluator(node, false, cg);
+   TR::Register *trgReg = cg->allocateRegister();
+   TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::lbz, 1);
+
+   node->setRegister(trgReg);
+   return trgReg;
    }
 
-// also handles isload
+// Also handles sloadi
 TR::Register *OMR::Power::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *tempReg = node->setRegister(cg->allocateRegister());
-   TR::MemoryReference *tempMR;
+   TR::Register *trgReg = cg->allocateRegister();
+   TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, node, TR::InstOpCode::lha, 2);
 
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 2);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::lha, node, tempReg, tempMR);
-
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-      }
-
-   tempMR->decNodeReferenceCounts(cg);
-   return tempReg;
+   node->setRegister(trgReg);
+   return trgReg;
    }
 
-// also handles icload
-TR::Register *OMR::Power::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Register *tempReg = node->setRegister(cg->allocateRegister());
-   TR::MemoryReference *tempMR;
-
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 2);
-
-   generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, tempReg, tempMR);
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, tempReg, tempMR, cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::InstOpCode::lwsync : TR::InstOpCode::isync);
-      }
-
-   tempMR->decNodeReferenceCounts(cg);
-   return tempReg;
-   }
-
-// iiload handled by iloadEvaluator
-
-// ilload handled by lloadEvaluator
-
-// ialoadEvaluator handled by iloadEvaluator
-
-// ibloadEvaluator handled by bloadEvaluator
-
-// isloadEvaluator handled by sloadEvaluator
-
-// icloadEvaluator handled by cloadEvaluator
-
-// also used for iistore, iustore, iiustore
+// Also handles istorei
 TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR::MemoryReference *tempMR = NULL;
    TR::Node *valueChild;
 
    if (node->getOpCode().isIndirect())
       {
-      valueChild = node->getSecondChild(); //handles iistore
+      valueChild = node->getSecondChild();
       }
    else
       {
@@ -966,158 +717,56 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
       if (valueChild->getOpCodeValue() == TR::fbits2i &&
           !valueChild->normalizeNanValues())
          {
-         if (node->getOpCode().isIndirect())
-            {
-            node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreate(node, TR::fstorei);
-            TR::TreeEvaluator::fstoreEvaluator(node, cg);
-            node->setChild(1, valueChild);
-            TR::Node::recreate(node, TR::istorei);
-            }
-         else
-            {
-            node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreate(node, TR::fstore);
-            TR::TreeEvaluator::fstoreEvaluator(node, cg);
-            node->setChild(0, valueChild);
-            TR::Node::recreate(node, TR::istore);
-            }
+         TR::LoadStoreHandler::generateStoreNodeSequence(cg, cg->evaluate(valueChild->getFirstChild()), node, TR::InstOpCode::stfs, 4);
+         cg->decReferenceCount(valueChild->getFirstChild());
          cg->decReferenceCount(valueChild);
          return NULL;
          }
       }
 
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-   bool    lazyVolatile = false;
-   if (node->getSymbolReference()->getSymbol()->isShadow() &&
-       node->getSymbolReference()->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
-      {
-      needSync = true;
-      lazyVolatile = true;
-      }
+   TR::Register *valueReg = cg->evaluate(valueChild);
 
-   TR_OpaqueMethodBlock *caller = NULL;
-   if (needSync)
-      caller = node->getOwningMethod();
-
-#ifdef J9_PROJECT_SPECIFIC
-   if (needSync && caller && !comp->compileRelocatableCode())
-      {
-      TR_ResolvedMethod *m = comp->fe()->createResolvedMethod(cg->trMemory(), caller, node->getSymbolReference()->getOwningMethod(comp));
-      if (m->getRecognizedMethod() == TR::java_util_concurrent_atomic_AtomicInteger_lazySet)
-         {
-         lazyVolatile = true;
-         }
-      }
-#endif
-
-
-   TR::Register *srcReg = cg->evaluate(valueChild);
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
-   if (needSync)
-      generateInstruction(cg, TR::InstOpCode::lwsync, node);
    if (reverseStore)
-      {
-      tempMR->forceIndexedForm(node, cg);
-      generateMemSrc1Instruction(cg, TR::InstOpCode::stwbrx, node, tempMR, srcReg);
-      }
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::stwbrx, 4, true);
    else
-      generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMR, srcReg);
-   if (needSync)
-      {
-      // ordered and lazySet operations will not generate a post-write sync
-      // and will not mark unresolved snippets with in sync sequence to avoid
-      // PicBuilder overwriting the instruction that normally would have been sync
-      TR::TreeEvaluator::postSyncConditions(node, cg, srcReg, tempMR, TR::InstOpCode::sync, lazyVolatile);
-      }
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::stw, 4);
 
    cg->decReferenceCount(valueChild);
-   tempMR->decNodeReferenceCounts(cg);
    if (comp->useCompressedPointers() && node->getOpCode().isIndirect())
       node->setStoreAlreadyEvaluated(true);
    return NULL;
    }
 
-// handles 32-bit and 64-bit astore iastore ibm@59591
+// Also handles astorei
 TR::Register *OMR::Power::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR::Node *nodeChild;
-   TR::Register *valueChild;
-   TR::MemoryReference *tempMR = NULL;
+   TR::Node *valueChild;
+
    if (node->getOpCode().isIndirect())
-      {
-      nodeChild = node->getSecondChild();
-      }
+      valueChild = node->getSecondChild();
    else
-      {
-      nodeChild = node->getFirstChild();
-      }
-   valueChild = cg->evaluate(nodeChild);
+      valueChild = node->getFirstChild();
 
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   bool    lazyVolatile = false;
-   if (node->getSymbolReference()->getSymbol()->isShadow() &&
-       node->getSymbolReference()->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
-      {
-      needSync = true;
-      lazyVolatile = true;
-      }
-
-   TR_OpaqueMethodBlock *caller = NULL;
-   if (needSync)
-      caller = node->getOwningMethod();
+   TR::Register *valueReg = cg->evaluate(valueChild);
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (needSync && caller && !comp->compileRelocatableCode())
-      {
-      TR_ResolvedMethod *m = comp->fe()->createResolvedMethod(cg->trMemory(), caller, node->getSymbolReference()->getOwningMethod(comp));
-      if (m->getRecognizedMethod() == TR::java_util_concurrent_atomic_AtomicReference_lazySet)
-         {
-         lazyVolatile = true;
-         }
-      }
+   bool isCompressedVft = TR::Compiler->om.generateCompressedObjectHeaders() && (node->getSymbol()->isClassObject() || node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef());
+#else
+   bool isCompressedVft = false;
 #endif
 
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-   if (cg->comp()->target().is64Bit())
-      tempMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-   else // 32 bit target
-      tempMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
+   if (comp->target().is64Bit() && !isCompressedVft)
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::std, 8);
+   else
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::stw, 4);
 
-   if (needSync)
-      generateInstruction(cg, TR::InstOpCode::lwsync, node);
-
-   // generate the store instruction appropriately
-   //
-   bool isClass = (node->getSymbol()->isClassObject() ||
-                     (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()));
-   TR::InstOpCode::Mnemonic storeOp = TR::InstOpCode::stw;
-   if (cg->comp()->target().is64Bit() &&
-         !(isClass && TR::Compiler->om.generateCompressedObjectHeaders()))
-      storeOp = TR::InstOpCode::std;
-
-   generateMemSrc1Instruction(cg, storeOp, node, tempMR, valueChild);
-
-   if (needSync)
-      {
-      // ordered and lazySet operations will not generate a post-write sync
-      // and will not mark unresolved snippets with in sync sequence to avoid
-      // PicBuilder overwriting the instruction that normally would have been sync
-      TR::TreeEvaluator::postSyncConditions(node, cg, valueChild, tempMR, TR::InstOpCode::sync, lazyVolatile);
-      }
-   tempMR->decNodeReferenceCounts(cg);
-   cg->decReferenceCount(nodeChild);
+   cg->decReferenceCount(valueChild);
    return NULL;
    }
 
 
-// also handles ilstore, ilustore
+// Also handles lstorei
 TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
@@ -1156,251 +805,34 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
       if (valueChild->getOpCodeValue() == TR::dbits2l &&
           !valueChild->normalizeNanValues())
          {
-         if (node->getOpCode().isIndirect())
-            {
-            node->setChild(1, valueChild->getFirstChild());
-            TR::Node::recreate(node, TR::dstorei);
-            TR::TreeEvaluator::dstoreEvaluator(node, cg);
-            node->setChild(1, valueChild);
-            TR::Node::recreate(node, TR::lstorei);
-            }
-         else
-            {
-            node->setChild(0, valueChild->getFirstChild());
-            TR::Node::recreate(node, TR::dstore);
-            TR::TreeEvaluator::dstoreEvaluator(node, cg);
-            node->setChild(0, valueChild);
-            TR::Node::recreate(node, TR::lstore);
-            }
+         TR::LoadStoreHandler::generateStoreNodeSequence(cg, cg->evaluate(valueChild->getFirstChild()), node, TR::InstOpCode::stfd, 8);
+         cg->decReferenceCount(valueChild->getFirstChild());
          cg->decReferenceCount(valueChild);
          return NULL;
          }
       }
 
-   bool    needSync;
-   bool    lazyVolatile = false;
-   if (cg->comp()->target().is64Bit())
+   TR::Register *valueReg = cg->evaluate(valueChild);
+
+   if (comp->target().is64Bit())
       {
-      TR::Register *valueReg = cg->evaluate(valueChild);
-
-      needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-      if (node->getSymbolReference()->getSymbol()->isShadow() &&
-          node->getSymbolReference()->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
-         {
-         needSync = true;
-         lazyVolatile = true;
-         }
-
-      TR_OpaqueMethodBlock *caller = NULL;
-      if (needSync)
-         caller = node->getOwningMethod();
-
-#ifdef J9_PROJECT_SPECIFIC
-      if (needSync && caller && !comp->compileRelocatableCode())
-         {
-         TR_ResolvedMethod *m = comp->fe()->createResolvedMethod(cg->trMemory(), caller, node->getSymbolReference()->getOwningMethod(comp));
-         if (m->getRecognizedMethod() == TR::java_util_concurrent_atomic_AtomicLong_lazySet)
-            {
-            lazyVolatile = true;
-            }
-         }
-#endif
-
-      // If the reference is volatile or potentially volatile, we keep a fixed instruction
-      // layout in order to patch if it turns out that the reference isn't really volatile.
-      TR::MemoryReference *tempMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-      if (needSync)
-         generateInstruction(cg, TR::InstOpCode::lwsync, node);
       if (reverseStore)
-         {
-         tempMR->forceIndexedForm(node, cg);
-         generateMemSrc1Instruction(cg, TR::InstOpCode::stdbrx, node, tempMR, valueReg);
-         }
+         TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::stdbrx, 8, true);
       else
-         generateMemSrc1Instruction(cg, TR::InstOpCode::std, node, tempMR, valueReg);
-      if (needSync)
-         {
-         // ordered and lazySet operations will not generate a post-write sync
-         // and will not mark unresolved snippets with in sync sequence to avoid
-         // PicBuilder overwriting the instruction that normally would have been sync
-         TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
-         }
-      tempMR->decNodeReferenceCounts(cg);
+         TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::std, 8);
       }
-   else // 32 bit target
+   else
       {
-      TR::Register *valueReg = cg->evaluate(valueChild);
-
-      // Two instruction sequence is not atomic even on uniprocessor.
-      needSync = node->getSymbolReference()->getSymbol()->isSyncVolatile();
-
-      if (node->getSymbolReference()->getSymbol()->isShadow() &&
-          node->getSymbolReference()->getSymbol()->isOrdered() && cg->comp()->target().isSMP())
-         {
-         needSync = true;
-         lazyVolatile = true;
-         }
-
-      TR_OpaqueMethodBlock *caller = NULL;
-      if (needSync)
-         caller = node->getOwningMethod();
-
-#ifdef J9_PROJECT_SPECIFIC
-      if (needSync && caller && !comp->compileRelocatableCode())
-         {
-         TR_ResolvedMethod *m = comp->fe()->createResolvedMethod(cg->trMemory(), caller, node->getSymbolReference()->getOwningMethod(comp));
-         if (m->getRecognizedMethod() == TR::java_util_concurrent_atomic_AtomicLong_lazySet)
-            {
-            lazyVolatile = true;
-            }
-         }
-#endif
-
-      if (needSync)
-         {
-         TR::MemoryReference *tempMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-
-         if (!node->getSymbolReference()->isUnresolved() && cg->is64BitProcessor()) //resolved as volatile
-            {
-            TR::Register *doubleReg = cg->allocateRegister(TR_FPR);
-
-            if (cg->comp()->target().isSMP())
-               {
-               TR_BackingStore * location;
-               location = cg->allocateSpill(8, false, NULL);
-               TR::MemoryReference *tempMRStore1 = TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 4);
-               TR::MemoryReference *tempMRStore2 =  TR::MemoryReference::createWithMemRef(cg, node, *tempMRStore1, 4, 4);
-               generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMRStore1, valueReg->getHighOrder());
-               generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMRStore2, valueReg->getLowOrder());
-               generateInstruction(cg, TR::InstOpCode::lwsync, node);
-               generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, doubleReg, TR::MemoryReference::createWithSymRef(cg, node, location->getSymbolReference(), 8));
-               if (reverseStore)
-                  {
-                  tempMRStore1->forceIndexedForm(node, cg);
-                  tempMRStore2->forceIndexedForm(node, cg);
-                  TR::Register *highReg = cg->allocateRegister();
-                  TR::Register *lowReg = cg->allocateRegister();
-                  if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8))
-                     {
-                     TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
-                     generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
-                     cg->stopUsingRegister(tmp1);
-                     }
-                  else
-                     generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg);
-
-                  generateMemSrc1Instruction(cg, TR::InstOpCode::stwbrx, node, tempMRStore1, lowReg);
-                  generateMemSrc1Instruction(cg, TR::InstOpCode::stwbrx, node, tempMRStore2, highReg);
-                  cg->stopUsingRegister(highReg);
-                  cg->stopUsingRegister(lowReg);
-                  }
-               else
-                  generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, tempMR, doubleReg);
-               if (!lazyVolatile)
-                  generateInstruction(cg, TR::InstOpCode::sync, node);
-               cg->freeSpill(location, 8, 0);
-               }
-            else
-               {
-               if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8))
-                  {
-                  TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
-                  generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, doubleReg, valueReg->getHighOrder(), valueReg->getLowOrder(), tmp1);
-                  cg->stopUsingRegister(tmp1);
-                  }
-               else
-                  generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, doubleReg, valueReg->getHighOrder(), valueReg->getLowOrder());
-               generateMemSrc1Instruction(cg, TR::InstOpCode::stfd, node, tempMR, doubleReg);
-               }
-            cg->stopUsingRegister(doubleReg);
-            }
-         else
-            {
-            // If the following needs to be patched for performance reasons, the layout needs to
-            // be fixed and the dependency needs to be enhanced to guarantee the layout.
-            TR::Register           *addrReg  = cg->allocateRegister();
-            TR::SymbolReference    *vwlRef;
-
-            if (node->getSymbolReference()->isUnresolved())
-               {
-#ifdef J9_PROJECT_SPECIFIC
-               tempMR->getUnresolvedSnippet()->setIs32BitLong();
-#endif
-               }
-
-            vwlRef = comp->getSymRefTab()->findOrCreateVolatileWriteLongSymbolRef(comp->getMethodSymbol());
-
-            if (tempMR->getIndexRegister() != NULL)
-                generateTrg1Src2Instruction (cg, TR::InstOpCode::add, node, addrReg, tempMR->getBaseRegister(), tempMR->getIndexRegister());
-            else
-                generateTrg1MemInstruction (cg, TR::InstOpCode::addi2, node, addrReg, tempMR);
-
-            TR::RegisterDependencyConditions *dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(7, 7, cg->trMemory());
-            TR::addDependency(dependencies, valueReg->getHighOrder(), TR::RealRegister::gr4, TR_GPR, cg);
-            TR::addDependency(dependencies, valueReg->getLowOrder(), TR::RealRegister::gr5, TR_GPR, cg);
-            TR::addDependency(dependencies, addrReg, TR::RealRegister::gr3, TR_GPR, cg);
-            TR::addDependency(dependencies, NULL, TR::RealRegister::gr11, TR_GPR, cg);
-
-            if (node->getSymbolReference()->isUnresolved())
-               {
-               if (tempMR->getBaseRegister() != NULL)
-                  {
-                  TR::addDependency(dependencies, tempMR->getBaseRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
-                  dependencies->getPreConditions()->getRegisterDependency(4)->setExcludeGPR0();
-                  dependencies->getPostConditions()->getRegisterDependency(4)->setExcludeGPR0();
-                  }
-
-               if (tempMR->getIndexRegister() != NULL)
-                  TR::addDependency(dependencies, tempMR->getIndexRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
-               }
-
-            generateDepImmSymInstruction(cg, TR::InstOpCode::bl, node,
-                   (uintptr_t)vwlRef->getSymbol()->castToMethodSymbol()->getMethodAddress(),
-                   dependencies, vwlRef);
-
-            dependencies->stopUsingDepRegs(cg, valueReg->getLowOrder(), valueReg->getHighOrder());
-            cg->machine()->setLinkRegisterKilled(true);
-            }
-         tempMR->decNodeReferenceCounts(cg);
-         }
-      else
-         {
-         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-         TR::MemoryReference *highMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 0, 4);
-
-         if (reverseStore)
-            {
-            highMR->forceIndexedForm(node, cg);
-            generateMemSrc1Instruction(cg, TR::InstOpCode::stwbrx, node, highMR, valueReg->getLowOrder());
-            }
-         else
-            generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, highMR, valueReg->getHighOrder());
-
-         // This ordering is important at this stage unless the base is guaranteed to be non-modifiable.
-         TR::MemoryReference *lowMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 4, 4);
-         if (reverseStore)
-            {
-            lowMR->forceIndexedForm(node, cg);
-            generateMemSrc1Instruction(cg, TR::InstOpCode::stwbrx, node, lowMR, valueReg->getHighOrder());
-            }
-         else
-            generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, lowMR, valueReg->getLowOrder());
-
-         tempMR->decNodeReferenceCounts(cg);
-         highMR->decNodeReferenceCounts(cg);
-         lowMR->decNodeReferenceCounts(cg);
-         }
+      TR::LoadStoreHandler::generatePairedStoreNodeSequence(cg, valueReg, node);
       }
 
    cg->decReferenceCount(valueChild);
    return NULL;
    }
 
-// also handles ibstore, ibustore
+// Also handles bstorei
 TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::MemoryReference *tempMR;
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
       {
@@ -1413,31 +845,21 @@ TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
    if ((valueChild->getOpCodeValue()==TR::i2b   ||
         valueChild->getOpCodeValue()==TR::s2b) &&
        valueChild->getReferenceCount()==1 && valueChild->getRegister()==NULL)
-       {
-       valueChild = valueChild->getFirstChild();
-       }
-   TR::Register *valueReg=cg->evaluate(valueChild);
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 1);
-   if (needSync)
-      generateInstruction(cg, TR::InstOpCode::lwsync, node);
-   generateMemSrc1Instruction(cg, TR::InstOpCode::stb, node, tempMR, valueReg);
-   if (needSync)
       {
-      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
+      cg->decReferenceCount(valueChild);
+      valueChild = valueChild->getFirstChild();
       }
+
+   TR::Register *valueReg = cg->evaluate(valueChild);
+   TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::stb, 1);
+
    cg->decReferenceCount(valueChild);
-   tempMR->decNodeReferenceCounts(cg);
    return NULL;
    }
 
 // also handles isstore
 TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::MemoryReference *tempMR;
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
       {
@@ -1463,80 +885,21 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
 
    if ((valueChild->getOpCodeValue()==TR::i2s) &&
        valueChild->getReferenceCount()==1 && valueChild->getRegister()==NULL)
-       {
-       valueChild = valueChild->getFirstChild();
-       }
-   TR::Register *valueReg=cg->evaluate(valueChild);
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
+      {
+      cg->decReferenceCount(valueChild);
+      valueChild = valueChild->getFirstChild();
+      }
 
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 2);
-   if (needSync)
-      generateInstruction(cg, TR::InstOpCode::lwsync, node);
+   TR::Register *valueReg = cg->evaluate(valueChild);
+
    if (reverseStore)
-      {
-      tempMR->forceIndexedForm(node, cg);
-      generateMemSrc1Instruction(cg, TR::InstOpCode::sthbrx, node, tempMR, valueReg);
-      }
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::sthbrx, 2, true);
    else
-      generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, tempMR, valueReg);
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
-      }
+      TR::LoadStoreHandler::generateStoreNodeSequence(cg, valueReg, node, TR::InstOpCode::sth, 2);
+
    cg->decReferenceCount(valueChild);
-   tempMR->decNodeReferenceCounts(cg);
    return NULL;
    }
-
-// also handles icstore
-TR::Register *OMR::Power::TreeEvaluator::cstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::MemoryReference *tempMR;
-   TR::Node *valueChild;
-   if (node->getOpCode().isIndirect())
-      {
-      valueChild = node->getSecondChild();
-      }
-   else
-      {
-      valueChild = node->getFirstChild();
-      }
-   if ((valueChild->getOpCodeValue()==TR::i2s) &&
-       valueChild->getReferenceCount()==1 && valueChild->getRegister()==NULL)
-       {
-       valueChild = valueChild->getFirstChild();
-       }
-   TR::Register *valueReg=cg->evaluate(valueChild);
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
-
-   // If the reference is volatile or potentially volatile, we keep a fixed instruction
-   // layout in order to patch if it turns out that the reference isn't really volatile.
-   tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 2);
-   if (needSync)
-      generateInstruction(cg, TR::InstOpCode::lwsync, node);
-   generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, tempMR, valueReg);
-   if (needSync)
-      {
-      TR::TreeEvaluator::postSyncConditions(node, cg, valueReg, tempMR, TR::InstOpCode::sync);
-      }
-   cg->decReferenceCount(valueChild);
-   tempMR->decNodeReferenceCounts(cg);
-   return NULL;
-   }
-
-// iistore handled by istoreEvaluator
-
-// ilstore handled by lstoreEvaluator
-
-// iastoreEvaluator handled by istoreEvaluator
-
-// ibstoreEvaluator handled by bstoreEvaluator
-
-// isstoreEvaluator handled by sstoreEvaluator
-
-// icstoreEvaluator handled by cstoreEvaluator
 
 
 TR::Register *OMR::Power::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -70,10 +70,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dloadHelper(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, TR::InstOpCode::Mnemonic op);
    static TR::Register *bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *buloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *commonByteLoadEvaluator(TR::Node *node, bool signExtend, TR::CodeGenerator *cg);
    static TR::Register *sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg); // ibm@59591
    static TR::Register *istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -81,7 +78,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *cstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ilstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);  // ibm@59591
    static TR::Register *dwrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -184,6 +184,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *i2bEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *i2cEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *i2sEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *i2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2bEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2buEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -68,7 +68,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *floadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *dloadHelper(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, TR::InstOpCode::Mnemonic op);
    static TR::Register *bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg); // ibm@59591

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -187,8 +187,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *i2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2bEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *l2buEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *l2cEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2sEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *l2fEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -173,7 +173,7 @@
 #define _lxorEvaluator TR::TreeEvaluator::lxorEvaluator
 #define _bxorEvaluator TR::TreeEvaluator::ixorEvaluator
 #define _sxorEvaluator TR::TreeEvaluator::ixorEvaluator
-#define _i2lEvaluator TR::TreeEvaluator::s2lEvaluator
+#define _i2lEvaluator TR::TreeEvaluator::i2lEvaluator
 #define _i2fEvaluator TR::TreeEvaluator::i2fEvaluator
 #define _i2dEvaluator TR::TreeEvaluator::i2dEvaluator
 #define _i2bEvaluator TR::TreeEvaluator::i2bEvaluator

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -518,10 +518,10 @@
 #define _vdRegStoreEvaluator TR::TreeEvaluator::fRegStoreEvaluator
 #define _iuloadEvaluator TR::TreeEvaluator::iloadEvaluator
 #define _luloadEvaluator TR::TreeEvaluator::lloadEvaluator
-#define _buloadEvaluator TR::TreeEvaluator::buloadEvaluator
+#define _buloadEvaluator TR::TreeEvaluator::bloadEvaluator
 #define _iuloadiEvaluator TR::TreeEvaluator::iloadEvaluator
 #define _luloadiEvaluator TR::TreeEvaluator::lloadEvaluator
-#define _buloadiEvaluator TR::TreeEvaluator::buloadEvaluator
+#define _buloadiEvaluator TR::TreeEvaluator::bloadEvaluator
 #define _iustoreEvaluator TR::TreeEvaluator::istoreEvaluator
 #define _lustoreEvaluator TR::TreeEvaluator::lstoreEvaluator
 #define _bustoreEvaluator TR::TreeEvaluator::bstoreEvaluator
@@ -548,10 +548,10 @@
 #define _luRegLoadEvaluator TR::TreeEvaluator::gprRegLoadEvaluator
 #define _iuRegStoreEvaluator TR::TreeEvaluator::gprRegStoreEvaluator
 #define _luRegStoreEvaluator TR::TreeEvaluator::gprRegStoreEvaluator
-#define _cloadEvaluator TR::TreeEvaluator::cloadEvaluator
-#define _cloadiEvaluator TR::TreeEvaluator::cloadEvaluator
-#define _cstoreEvaluator TR::TreeEvaluator::cstoreEvaluator
-#define _cstoreiEvaluator TR::TreeEvaluator::cstoreEvaluator
+#define _cloadEvaluator TR::TreeEvaluator::sloadEvaluator
+#define _cloadiEvaluator TR::TreeEvaluator::sloadEvaluator
+#define _cstoreEvaluator TR::TreeEvaluator::sstoreEvaluator
+#define _cstoreiEvaluator TR::TreeEvaluator::sstoreEvaluator
 #define _monentEvaluator TR::TreeEvaluator::badILOpEvaluator
 #define _monexitEvaluator TR::TreeEvaluator::badILOpEvaluator
 #define _monexitfenceEvaluator TR::TreeEvaluator::badILOpEvaluator
@@ -756,4 +756,3 @@
 
 #include "il/Opcodes.enum"
 #undef OPCODE_MACRO
-

--- a/fvtest/compilertest/build/files/target/p.mk
+++ b/fvtest/compilertest/build/files/target/p.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corp. and others
+# Copyright (c) 2016, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/fvtest/compilertest/build/files/target/p.mk
+++ b/fvtest/compilertest/build/files/target/p.mk
@@ -47,6 +47,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/codegen/TreeEvaluatorVMX.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/UnaryEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/OMRConstantDataSnippet.cpp \
+    $(JIT_OMR_DIRTY_DIR)/p/codegen/OMRLoadStoreHandler.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/env/OMRCPU.cpp
 
 JIT_PRODUCT_SOURCE_FILES+=\


### PR DESCRIPTION
This PR introduces the new API proposed by #5630 to clean up generation of loads and stores from nodes for codegen optimization purposes. This new API should correct issues related to missing volatile memory barriers and eliminate a lot of unnecessary duplicate code. Note that a lot of code is currently present in this implementation which is guarded under `J9_PROJECT_SPECIFIC` guards. The plan is for this code to be sunk down to OpenJ9 by extending the `LoadStoreHandler` and `LoadStoreHandlerImpl` classes after this PR is merged.

This PR should be merged simultaneously with eclipse/openj9#11305.