### PR TITLE
Fix lbyteswap store optimization on ppc32

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1380,7 +1380,8 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          }
       else
          {
-         TR::MemoryReference *highMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
+         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
+         TR::MemoryReference *highMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 0, 4);
 
          if (reverseStore)
             {
@@ -1391,7 +1392,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
             generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, highMR, valueReg->getHighOrder());
 
          // This ordering is important at this stage unless the base is guaranteed to be non-modifiable.
-         TR::MemoryReference *lowMR = TR::MemoryReference::createWithMemRef(cg, node, *highMR, 4, 4);
+         TR::MemoryReference *lowMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 4, 4);
          if (reverseStore)
             {
             lowMR->forceIndexedForm(node, cg);
@@ -1400,6 +1401,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          else
             generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, lowMR, valueReg->getLowOrder());
 
+         tempMR->decNodeReferenceCounts(cg);
          highMR->decNodeReferenceCounts(cg);
          lowMR->decNodeReferenceCounts(cg);
          }


### PR DESCRIPTION
As it turns out, the previous code for performing a byteswapped store of
a long on ppc32 was broken and would end up creating a memory reference
with both an index register and an offset. This has been corrected.

Signed-off-by: Ben Thomas <ben@benthomas.ca>