### PR TITLE
Fix invalid use of stdbrx on P6 and before

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1151,7 +1151,8 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
       }
 
    bool reverseStore = false;
-   if (valueChild->getOpCodeValue() == TR::lbyteswap && valueChild->isSingleRefUnevaluated())
+   if (valueChild->getOpCodeValue() == TR::lbyteswap && valueChild->isSingleRefUnevaluated() &&
+      cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7))
       {
       reverseStore = true;
 


### PR DESCRIPTION
Previously, the codegen optimization for performing an lbyteswap and an
lstore in one stdbrx instruction was not properly checking that the
stdbrx instruction was actually available on the current processor.
Since this instruction was only added in P7, this could result in P6 and
earlier processors encountering an illegal instruction.

Signed-off-by: Ben Thomas <ben@benthomas.ca>