### PR TITLE
Add support for mixed references mode in CMake builds

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -105,6 +105,7 @@ set(OMR_TOOLS_USE_NATIVE_ENCODING ON CACHE BOOL
 ###
 
 set(OMR_GC_LIB "omrgc" CACHE STRING "Name of the GC library to use")
+set(OMR_GC_FULL_LIB "omrgc_full" CACHE STRING "Name of the Full References GC library to use for Mixed References Mode")
 set(OMR_HOOK_LIB "j9hookstatic" CACHE STRING "Name of the hook library to link against")
 set(OMR_PORT_LIB "omrport" CACHE STRING "Name of the port library to link against")
 set(OMR_THREAD_LIB "j9thrstatic" CACHE STRING "Name of the thread library to link against")
@@ -115,6 +116,7 @@ set(OMR_TRACE_LIB "omrtrace" CACHE STRING "Name of the trace library to link aga
 ###
 
 set(OMR_GC_GLUE_TARGET "NOTFOUND" CACHE STRING "The gc glue target, must be interface library")
+set(OMR_GC_GLUE_FULL_TARGET "NOTFOUND" CACHE STRING "The gc glue full target, must be interface library")
 set(OMR_UTIL_GLUE_TARGET "NOTFOUND" CACHE STRING "The util glue target, must be interface library")
 set(OMR_RAS_GLUE_TARGET "NOTFOUND" CACHE STRING "The ras glue target, must be interface library")
 set(OMR_CORE_GLUE_TARGET "NOTFOUND" CACHE STRING "The core glue target, must be and interface library")
@@ -161,14 +163,21 @@ set_property(CACHE OMR_GC_POINTER_MODE PROPERTY STRINGS "full" "compressed" "mix
 if(OMR_GC_POINTER_MODE STREQUAL "full")
 	set(OMR_GC_COMPRESSED_POINTERS OFF CACHE INTERNAL "")
 	set(OMR_GC_FULL_POINTERS ON CACHE INTERNAL "")
+	set(OMR_MIXED_REFERENCES_MODE_STATIC OFF CACHE INTERNAL "")
 elseif(OMR_GC_POINTER_MODE STREQUAL "compressed")
 	omr_assert(FATAL_ERROR TEST NOT OMR_ENV_DATA32 MESSAGE "OMR_GC_POINTER_MODE must be \"full\" on 32 bit platforms")
 	set(OMR_GC_COMPRESSED_POINTERS ON CACHE INTERNAL "")
 	set(OMR_GC_FULL_POINTERS OFF CACHE INTERNAL "")
+	set(OMR_MIXED_REFERENCES_MODE_STATIC OFF CACHE INTERNAL "")
 elseif(OMR_GC_POINTER_MODE STREQUAL "mixed")
 	omr_assert(FATAL_ERROR TEST NOT OMR_ENV_DATA32 MESSAGE "OMR_GC_POINTER_MODE must be \"full\" on 32 bit platforms")
 	set(OMR_GC_COMPRESSED_POINTERS ON CACHE INTERNAL "")
 	set(OMR_GC_FULL_POINTERS ON CACHE INTERNAL "")
+	if(OMR_MIXED_REFERENCES_MODE STREQUAL "static")
+		set(OMR_MIXED_REFERENCES_MODE_STATIC ON CACHE INTERNAL "")
+	else()
+		set(OMR_MIXED_REFERENCES_MODE_STATIC OFF CACHE INTERNAL "")
+	endif()
 else()
 	message(FATAL_ERROR "OMR_GC_FULL_POINTERS must be set to one of \"full\", \"compressed\", or \"mixed\"")
 endif()

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -66,7 +66,7 @@ target_compile_definitions(omrgc_tracegen
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-omr_add_library(omrgc STATIC
+set(omrgc_sources
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp
 	base/AllocationInterfaceGeneric.cpp
@@ -201,6 +201,11 @@ omr_add_library(omrgc STATIC
 	verbose/handler_standard/VerboseHandlerOutputStandard.cpp
 	$<TARGET_OBJECTS:omrgc_tracegen>
 )
+
+omr_add_library(omrgc STATIC
+	${omrgc_sources}
+)
+
 target_enable_ddr(omrgc EARLY_SOURCE_EVAL)
 ddr_set_add_targets(omrddr omrgc)
 ddr_add_headers(omrgc
@@ -210,43 +215,56 @@ ddr_add_headers(omrgc
 )
 
 if(OMR_GC_OBJECT_MAP)
+	set(objmap_sources
+		base/ObjectMap.cpp
+	)
+
 	target_sources(omrgc
 		PRIVATE
-			base/ObjectMap.cpp
+			${objmap_sources}
 	)
 endif()
 
 if(OMR_GC_MODRON_STANDARD)
+	set(modronstandard_sources
+		base/standard/ConfigurationFlat.cpp
+		base/standard/ConfigurationStandard.cpp
+		base/standard/CopyScanCacheChunk.cpp
+		base/standard/CopyScanCacheChunkInHeap.cpp
+		base/standard/EnvironmentStandard.cpp
+		base/standard/HeapMemoryPoolIterator.cpp
+		base/standard/HeapRegionDescriptorStandard.cpp
+		base/standard/HeapRegionManagerStandard.cpp
+		base/standard/HeapWalker.cpp
+		base/standard/OverflowStandard.cpp
+		base/standard/ParallelGlobalGC.cpp
+		base/standard/ParallelSweepScheme.cpp
+		base/standard/SweepHeapSectioningSegmented.cpp
+		base/standard/WorkPacketsStandard.cpp
+	)
+
 	target_sources(omrgc
 		PRIVATE
-			base/standard/ConfigurationFlat.cpp
-			base/standard/ConfigurationStandard.cpp
-			base/standard/CopyScanCacheChunk.cpp
-			base/standard/CopyScanCacheChunkInHeap.cpp
-			base/standard/EnvironmentStandard.cpp
-			base/standard/HeapMemoryPoolIterator.cpp
-			base/standard/HeapRegionDescriptorStandard.cpp
-			base/standard/HeapRegionManagerStandard.cpp
-			base/standard/HeapWalker.cpp
-			base/standard/OverflowStandard.cpp
-			base/standard/ParallelGlobalGC.cpp
-			base/standard/ParallelSweepScheme.cpp
-			base/standard/SweepHeapSectioningSegmented.cpp
-			base/standard/WorkPacketsStandard.cpp
+			${modronstandard_sources}
 	)
-	if (OMR_GC_MODRON_COMPACTION)
-		target_sources(omrgc
-			PRIVATE
+
+	if(OMR_GC_MODRON_COMPACTION)
+		set(modroncompaction_sources
 				base/standard/CompactFixHeapForWalkTask.cpp
 				base/standard/CompactScheme.cpp
 				base/standard/ParallelCompactTask.cpp
-				
+
 				stats/CompactStats.cpp
 		)
-	endif()
-	if(OMR_GC_MODRON_CONCURRENT_MARK)
+
 		target_sources(omrgc
 			PRIVATE
+				${modroncompaction_sources}
+		)
+	endif()
+
+	if(OMR_GC_MODRON_CONCURRENT_MARK)
+		set(modronconcurrentmark_sources
 				base/standard/ConcurrentCardTable.cpp
 				base/standard/ConcurrentCardTableForWC.cpp
 				base/standard/ConcurrentClearNewMarkBitsTask.cpp
@@ -261,120 +279,274 @@ if(OMR_GC_MODRON_STANDARD)
 				base/standard/RememberedSetSATB.cpp
 				base/standard/WorkPacketsConcurrent.cpp
 				base/standard/WorkPacketsSATB.cpp
-				
+
 				stats/ConcurrentGCStats.cpp
 		)
+
+		target_sources(omrgc
+			PRIVATE
+				${modronconcurrentmark_sources}
+		)
+
 		if(OMR_GC_MODRON_SCAVENGER)
+			set(mcm_modronscavenger_sources
+				base/standard/ConcurrentScanRememberedSetTask.cpp
+			)
+
 			target_sources(omrgc
 				PRIVATE
-					base/standard/ConcurrentScanRememberedSetTask.cpp
+					${mcm_modronscavenger_sources}
 			)
 		endif()
 	endif()
+
 	if(OMR_GC_CONCURRENT_SWEEP)
+		set(concurrentsweep_sources
+			base/standard/ConcurrentSweepScheme.cpp
+		)
+
 		target_sources(omrgc
 			PRIVATE
-				base/standard/ConcurrentSweepScheme.cpp
+				${concurrentsweep_sources}
 		)
 	endif()
+
 	if(OMR_GC_MODRON_SCAVENGER)
-		target_sources(omrgc
-			PRIVATE
+		set(modronscavenger_sources
 				base/HeapSplit.cpp # TODO delete as this should not be used anymore!
 				base/MemorySubSpaceGenerational.cpp
 				base/MemorySubSpaceSemiSpace.cpp
-				
+
 				base/standard/ConfigurationGenerational.cpp
 				base/standard/CopyScanCacheList.cpp
 				base/standard/ParallelScavengeTask.cpp
 				base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
 				base/standard/RSOverflow.cpp
 				base/standard/Scavenger.cpp
-				
+
 				stats/ScavengerCopyScanRatio.cpp
 		)
+
+		target_sources(omrgc
+			PRIVATE
+				${modronscavenger_sources}
+		)
+
 		if(OMR_GC_CONCURRENT_SCAVENGER)
+			set(ms_concurrentscavenger_sources
+				base/standard/ConcurrentScavengeTask.cpp
+			)
+
 			target_sources(omrgc
 				PRIVATE
-					base/standard/ConcurrentScavengeTask.cpp
+					${ms_concurrentscavenger_sources}
 			)
 		endif()
 	endif()
 endif()
 
 if(OMR_GC_SEGREGATED_HEAP)
+	set(segregatedheap_sources
+		base/segregated/AllocationContextSegregated.cpp
+		base/segregated/ConfigurationSegregated.cpp
+		base/segregated/GlobalAllocationManagerSegregated.cpp
+		base/segregated/HeapRegionDescriptorSegregated.cpp
+		base/segregated/LockingFreeHeapRegionList.cpp
+		base/segregated/LockingHeapRegionQueue.cpp
+		base/segregated/MemoryPoolAggregatedCellList.cpp
+		base/segregated/MemoryPoolSegregated.cpp
+		base/segregated/MemorySubSpaceSegregated.cpp
+		base/segregated/ObjectHeapIteratorSegregated.cpp
+		base/segregated/OverflowSegregated.cpp
+		base/segregated/RegionPoolSegregated.cpp
+		base/segregated/SegregatedAllocationInterface.cpp
+		base/segregated/SegregatedAllocationTracker.cpp
+		base/segregated/SegregatedGC.cpp
+		base/segregated/SegregatedListPopulator.cpp
+		base/segregated/SegregatedMarkingScheme.cpp
+		base/segregated/SegregatedSweepTask.cpp
+		base/segregated/SizeClasses.cpp
+		base/segregated/SweepSchemeSegregated.cpp
+		base/segregated/WorkPacketsSegregated.cpp
+	)
+
 	target_sources(omrgc
 		PRIVATE
-			base/segregated/AllocationContextSegregated.cpp
-			base/segregated/ConfigurationSegregated.cpp
-			base/segregated/GlobalAllocationManagerSegregated.cpp
-			base/segregated/HeapRegionDescriptorSegregated.cpp
-			base/segregated/LockingFreeHeapRegionList.cpp
-			base/segregated/LockingHeapRegionQueue.cpp
-			base/segregated/MemoryPoolAggregatedCellList.cpp
-			base/segregated/MemoryPoolSegregated.cpp
-			base/segregated/MemorySubSpaceSegregated.cpp
-			base/segregated/ObjectHeapIteratorSegregated.cpp
-			base/segregated/OverflowSegregated.cpp
-			base/segregated/RegionPoolSegregated.cpp
-			base/segregated/SegregatedAllocationInterface.cpp
-			base/segregated/SegregatedAllocationTracker.cpp
-			base/segregated/SegregatedGC.cpp
-			base/segregated/SegregatedListPopulator.cpp
-			base/segregated/SegregatedMarkingScheme.cpp
-			base/segregated/SegregatedSweepTask.cpp
-			base/segregated/SizeClasses.cpp
-			base/segregated/SweepSchemeSegregated.cpp
-			base/segregated/WorkPacketsSegregated.cpp
+			${segregatedheap_sources}
 	)
 	ddr_add_headers(omrgc base/segregated/RegionPoolSegregated.hpp)
 endif()
 
 if(OMR_GC_VLHGC)
+	set(vlhgc_sources
+		base/vlhgc/HeapRegionStateTable.cpp
+	)
+
 	target_sources(omrgc
 		PRIVATE
-			base/vlhgc/HeapRegionStateTable.cpp
+			${vlhgc_sources}
+	)
+
+	set(vlhgc_include
+		base/vlhgc
 	)
 
 	target_include_directories(omrgc
 		PUBLIC
-			base/vlhgc
+			${vlhgc_include}
 	)
 endif()
 
 add_dependencies(omrgc omrgc_hookgen)
 
+set(gc_include_public
+	.
+	${CMAKE_CURRENT_BINARY_DIR}  #Ideally this should be private, but the glue pulls this in
+	base
+	base/segregated
+	base/standard
+	include
+	startup
+	stats
+	structs
+	verbose
+	verbose/handler_standard
+)
+
 target_include_directories(omrgc
 	PUBLIC
-		.
-		${CMAKE_CURRENT_BINARY_DIR}  #Ideally this should be private, but the glue pulls this in
-		base
-		base/segregated
-		base/standard
-		include
-		startup
-		stats
-		structs
-		verbose
-		verbose/handler_standard
+		${gc_include_public}
 	INTERFACE
 		$<TARGET_PROPERTY:${OMR_GC_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-target_link_libraries(omrgc
-	PUBLIC
-		omr_base
-	PRIVATE
-		${OMR_GC_GLUE_TARGET}
-		omrutil
-		omrcore
-		${OMR_THREAD_LIB}
-		${OMR_PORT_LIB}
-		${OMR_HOOK_LIB}
+set(gc_link_libraries_public
+	omr_base
+)
+set(gc_link_libraries_private
+	omrutil
+	omrcore
+	${OMR_THREAD_LIB}
+	${OMR_PORT_LIB}
+	${OMR_HOOK_LIB}
 )
 
-
+target_link_libraries(omrgc
+	PUBLIC
+		${gc_link_libraries_public}
+	PRIVATE
+		${OMR_GC_GLUE_TARGET}
+		${gc_link_libraries_private}
+)
 set_target_properties(omrgc omrgc_hookgen omrgc_tracegen PROPERTIES FOLDER gc)
+
+if(OMR_MIXED_REFERENCES_MODE_STATIC)
+	target_compile_definitions(omrgc PUBLIC -DOMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES=1)
+
+	omr_assert(
+		TEST OMR_GC_GLUE_FULL_TARGET
+		MESSAGE "OMR_GC_GLUE_TARGET must be set."
+	)
+
+	omr_add_library(omrgc_full STATIC
+		${omrgc_sources}
+	)
+
+	if(OMR_GC_OBJECT_MAP)
+		target_sources(omrgc_full
+			PRIVATE
+				${objmap_sources}
+		)
+	endif()
+
+	if(OMR_GC_MODRON_STANDARD)
+		target_sources(omrgc_full
+			PRIVATE
+				${modronstandard_sources}
+		)
+
+		if(OMR_GC_MODRON_COMPACTION)
+			target_sources(omrgc_full
+				PRIVATE
+					${modroncompaction_sources}
+			)
+		endif()
+
+		if(OMR_GC_MODRON_CONCURRENT_MARK)
+			target_sources(omrgc_full
+				PRIVATE
+					${modronconcurrentmark_sources}
+			)
+
+			if(OMR_GC_MODRON_SCAVENGER)
+				target_sources(omrgc_full
+					PRIVATE
+						${mcm_modronscavenger_sources}
+				)
+			endif()
+		endif()
+
+		if(OMR_GC_CONCURRENT_SWEEP)
+			target_sources(omrgc_full
+				PRIVATE
+					${concurrentsweep_sources}
+			)
+		endif()
+
+		if(OMR_GC_MODRON_SCAVENGER)
+			target_sources(omrgc_full
+				PRIVATE
+					${modronscavenger_sources}
+			)
+
+			if(OMR_GC_CONCURRENT_SCAVENGER)
+				target_sources(omrgc_full
+					PRIVATE
+						${ms_concurrentscavenger_sources}
+				)
+			endif()
+		endif()
+	endif()
+
+	if(OMR_GC_SEGREGATED_HEAP)
+		target_sources(omrgc_full
+			PRIVATE
+				${segregatedheap_sources}
+		)
+	endif()
+
+	if(OMR_GC_VLHGC)
+		target_sources(omrgc_full
+			PRIVATE
+				${vlhgc_sources}
+		)
+
+		target_include_directories(omrgc_full
+			PUBLIC
+				${vlhgc_include}
+		)
+	endif()
+
+	add_dependencies(omrgc_full omrgc_hookgen)
+
+	target_include_directories(omrgc_full
+		PUBLIC
+			${gc_include_public}
+		INTERFACE
+			$<TARGET_PROPERTY:${OMR_GC_GLUE_FULL_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
+	)
+
+	target_link_libraries(omrgc_full
+		PUBLIC
+			${gc_link_libraries_public}
+		PRIVATE
+			${OMR_GC_GLUE_FULL_TARGET}
+			${gc_link_libraries_private}
+	)
+	set_target_properties(omrgc_full omrgc_hookgen omrgc_tracegen PROPERTIES FOLDER gc)
+
+	target_compile_definitions(omrgc_full PUBLIC -DOMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES=0)
+endif()
 
 if(OMR_GC_API)
 	add_subdirectory(api)

--- a/gc/api/CMakeLists.txt
+++ b/gc/api/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,21 +28,39 @@ omr_assert(TEST OMR_GC_API)
 ### OMR GC
 ###
 
-target_include_directories(omrgc
-	PUBLIC
-		glue/
-		include/
+set(gc_include_directories
+	glue/
+	include/
 )
 
+set(gc_compile_features
+	cxx_constexpr
+	cxx_deleted_functions
+	cxx_delegating_constructors
+	cxx_noexcept
+	cxx_nullptr
+	cxx_override
+	cxx_right_angle_brackets
+	cxx_variadic_templates
+	cxx_template_template_parameters
+)
+
+target_include_directories(omrgc
+	PUBLIC
+		${gc_include_directories}
+)
 target_compile_features(omrgc
 	PUBLIC
-		cxx_constexpr
-		cxx_deleted_functions
-		cxx_delegating_constructors
-		cxx_noexcept
-		cxx_nullptr
-		cxx_override
-		cxx_right_angle_brackets
-		cxx_variadic_templates
-		cxx_template_template_parameters
+		${gc_compile_features}
 )
+
+if(OMR_MIXED_REFERENCES_MODE_STATIC)
+	target_include_directories(omrgc_full
+		PUBLIC
+			${gc_include_directories}
+	)
+	target_compile_features(omrgc_full
+		PUBLIC
+			${gc_compile_features}
+	)
+endif()

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -76,9 +76,9 @@ typedef enum {
 class MM_EnvironmentBase : public MM_BaseVirtual
 {
 private:
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool const _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	uintptr_t _workerID;
 	uintptr_t _environmentId;
 
@@ -675,9 +675,9 @@ public:
 	 */
 	MM_EnvironmentBase(OMR_VMThread *omrVMThread) :
 		MM_BaseVirtual()
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		, _compressObjectReferences(OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread))
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		,_workerID(0)
 		,_environmentId(0)
 		,_omrVM(omrVMThread->_vm)
@@ -733,9 +733,9 @@ public:
 
 	MM_EnvironmentBase(OMR_VM *omrVM) :
 		MM_BaseVirtual()
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		,_workerID(0)
 		,_environmentId(0)
 		,_omrVM(omrVM)

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -68,9 +68,9 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	uintptr_t *pageSizes = NULL;
 	uintptr_t *pageFlags = NULL;
 
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	_compressObjectReferences = env->compressObjectReferences();
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 
 	_omrVM = env->getOmrVM();
 

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -190,9 +190,9 @@ public:
 class MM_GCExtensionsBase : public MM_BaseVirtual {
 	/* Data Members */
 private:
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	void* _guaranteedNurseryStart; /**< lowest address guaranteed to be in the nursery */
 	void* _guaranteedNurseryEnd; /**< highest address guaranteed to be in the nursery */
@@ -1343,9 +1343,9 @@ public:
 
 	MM_GCExtensionsBase()
 		: MM_BaseVirtual()
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		, _compressObjectReferences(false)
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		, _guaranteedNurseryStart(NULL)
 		, _guaranteedNurseryEnd(NULL)

--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,9 +64,9 @@ class MM_MemoryPool : public MM_BaseVirtual
 	 * Data members
 	 */
 private:
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool const _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	MM_MemoryPool *_next;
 	MM_MemoryPool *_previous;
 	MM_MemoryPool *_children;
@@ -368,9 +368,9 @@ public:
 	 */
 	MM_MemoryPool(MM_EnvironmentBase *env, uintptr_t minimumFreeEntrySize) :
 		MM_BaseVirtual(),
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		_compressObjectReferences(env->compressObjectReferences()),
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		_next(NULL),
 		_previous(NULL),
 		_children(NULL),
@@ -400,9 +400,9 @@ public:
 	 */
 	MM_MemoryPool(MM_EnvironmentBase *env, uintptr_t minimumFreeEntrySize, const char *name) :
 		MM_BaseVirtual(),
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		_compressObjectReferences(env->compressObjectReferences()),
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		_next(NULL),
 		_previous(NULL),
 		_children(NULL),

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -61,9 +61,9 @@ class GC_ObjectModelBase : public MM_BaseVirtual
  * Member data and types
  */
 private:
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	GC_ObjectModelDelegate _delegate;	/**< instance of object model delegate class */
 
 protected:
@@ -330,9 +330,9 @@ public:
 	MMINLINE void
 	setObjectAlignment(OMR_VM *omrVM)
 	{
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		_compressObjectReferences = OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM);
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 		_objectAlignmentInBytes = OMR_MAX((uintptr_t)1 << omrVM->_compressedPointersShift, OMR_MINIMUM_OBJECT_ALIGNMENT);
 		_objectAlignmentShift = OMR_MAX(omrVM->_compressedPointersShift, OMR_MINIMUM_OBJECT_ALIGNMENT_SHIFT);
 

--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -62,9 +62,9 @@ protected:
 	fomrobject_t *_scanPtr;					/**< Pointer to base of object slots mapped by current _scanMap */
 	GC_SlotObject _slotObject;				/**< Create own SlotObject class to provide output */
 	uintptr_t _flags;						/**< Scavenger context flags (scanRoots, scanHeap, ...) */
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool const _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	
 public:
 	/**
@@ -104,9 +104,9 @@ protected:
 		, _scanPtr(scanPtr)
 		, _slotObject(env->getOmrVM(), NULL)
 		, _flags(flags | headObjectScanner)
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 		, _compressObjectReferences(env->compressObjectReferences())
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -38,10 +38,10 @@ private:
 	volatile fomrobject_t* _slot;		/**< stored slot address (volatile, because in concurrent GC the mutator can change the value in _slot) */
 #if defined (OMR_GC_COMPRESSED_POINTERS)
 	uintptr_t _compressedPointersShift; /**< the number of bits to shift by when converting between the compressed pointers heap and real heap */
-#if defined (OMR_GC_FULL_POINTERS)
+#if defined (OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool _compressObjectReferences;
-#endif /* OMR_GC_FULL_POINTERS */
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined (OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 protected:
 public:
@@ -252,10 +252,10 @@ public:
 	: _slot(slot)
 #if defined (OMR_GC_COMPRESSED_POINTERS)
 	, _compressedPointersShift(omrVM->_compressedPointersShift)
-#if defined (OMR_GC_FULL_POINTERS)
+#if defined (OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
-#endif /* OMR_GC_FULL_POINTERS */
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined (OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 	{}
 };
 #endif /* SLOTOBJECT_HPP_ */

--- a/gc/structs/ForwardedHeader.hpp
+++ b/gc/structs/ForwardedHeader.hpp
@@ -81,9 +81,9 @@ protected:
 private:
 	omrobjectptr_t _objectPtr;					/**< the object on which to act */
 	uintptr_t _preserved; 						/**< a backup copy of the header fields which may be modified by this class */
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	bool const _compressObjectReferences;
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 
 	static const uintptr_t _forwardedTag = OMR_FORWARDED_TAG;	/**< bit mask used to mark forwarding slot value as forwarding pointer */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
@@ -548,9 +548,9 @@ public:
 	MM_ForwardedHeader(omrobjectptr_t objectPtr, bool compressed)
 	: _objectPtr(objectPtr)
 	, _preserved(*(volatile uintptr_t *)_objectPtr)
-#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 	, _compressObjectReferences(compressed)
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) && !defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES) */
 	{
 	}
 

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -153,6 +153,7 @@
 #cmakedefine OMR_GC_REALTIME
 #cmakedefine OMR_GC_TLH_PREFETCH_FTA
 #cmakedefine OMR_GC_VLHGC
+#cmakedefine OMR_MIXED_REFERENCES_MODE_STATIC
 
 /**
  * Add support for CUDA

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -146,6 +146,7 @@
 #undef OMR_GC_REALTIME
 #undef OMR_GC_TLH_PREFETCH_FTA
 #undef OMR_GC_VLHGC
+#undef OMR_MIXED_REFERENCES_MODE_STATIC
 
 /**
  * Add support for CUDA


### PR DESCRIPTION
These are the CMake GC changes needed to enable mixed references mode for https://github.com/eclipse/openj9/issues/8878.

OpenJ9 changes: https://github.com/eclipse/openj9/pull/11166

**Set _compressObjectReferences if mixed build override not defined**
`_compressObjectReferences` should only be defined if `OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES` is not defined. Otherwise, when mixed mode is enabled and the override is defined, `_compressObjectReferences` is considered a private field that is declared, but never used, which the compiler may complain about.

**Add support for mixed references mode in CMake builds**
In mixed references static mode, split the omr gc library into `omrgc` and `omrgc_full` so that the appropriate library can be used. `omrgc` has `OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES=1` and `omrgc_full` has `OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES=0`.

Note that this will only work with an OpenJ9 CMake build. OpenJ9 UMA changes will be implemented after the CMake work is completed and the corresponding OMR changes will be provided in an upcoming PR.

---

Something I'm not entirely sure about is how we'd like to work with `OMR_GC_LIB` in tests and in `omrvmstartup`. In these changes, we use `omrgc` in compressed and full mode, but in mixed mode, we have a separate library `omrgc_full` for full references.

Files currently using `OMR_GC_LIB`:
https://github.com/eclipse/omr/blob/f8c4f85b726259de9286943d84f7151aed7eb1c1/example/CMakeLists.txt#L49
- do we want to have `gcexample` and `gcexample_full`?

https://github.com/eclipse/omr/blob/f8c4f85b726259de9286943d84f7151aed7eb1c1/fvtest/gctest/CMakeLists.txt#L51
- do we want to have `omrgctest` and `omrgctest_full` (this test also uses `omrvmstartup`, mentioned below)

https://github.com/eclipse/omr/blob/f8c4f85b726259de9286943d84f7151aed7eb1c1/omr/CMakeLists.txt#L74
- this is just for include directories, so either lib will do?

https://github.com/eclipse/omr/blob/f8c4f85b726259de9286943d84f7151aed7eb1c1/omr/startup/CMakeLists.txt#L50
- `omrvmstartup` is used in a bunch of places (i.e. fvtest), so if we want `omrvmstartup` and `omrvmstartup_full`, then all those tests will need to get split into regular (compressed) and full references versions