### PR TITLE
Require address load instruction for statics in JITServer

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -295,6 +295,8 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
       return true; // If a class gets replaced, it may no longer fit in an immediate
    else if (IS_32BIT_SIGNED(displacement))
       return false;
+   else if (cg->comp()->isOutOfProcessCompilation() && sr.getSymbol() && sr.getSymbol()->isStatic() && !sr.getSymbol()->isNotDataAddress())
+      return true;
    else if (IS_32BIT_RIP(displacement, nextInstructionAddress))
       return false;
    else


### PR DESCRIPTION
In some cases, e.g. method enter/exit hooks,
JITServer takes the static hook address directly from the client,
but the address load might be encoded using offset relative
to server's RIP, which results in an invalid address.
This commit ensures that static address loads for out-of-process
compilations always get loaded in a register first, preventing
relative access.