### PR TITLE
WIP: Rename codeGen to cg

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -501,18 +501,18 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor)
 void
 TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterSymbol> &parmList)
    {
-   TR::CodeGenerator *codeGen = cg();
-   TR::Machine *machine = codeGen->machine();
+   TR::CodeGenerator *cg = this->cg();
+   TR::Machine *machine = cg->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    const TR::ARM64LinkageProperties& properties = getProperties();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
    TR::Node *firstNode = comp()->getStartTree()->getNode();
 
    // allocate stack space
-   uint32_t frameSize = (uint32_t)codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = (uint32_t)cg->getFrameSizeInBytes();
    if (constantIsUnsignedImm12(frameSize))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
       }
    else
       {
@@ -522,7 +522,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
    // save link register (x30)
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
       cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::x30), cursor);
       }
 
@@ -533,7 +533,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
          cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, rr, cursor);
          offset += 8;
          }
@@ -543,7 +543,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
          cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::vstrimmd, firstNode, stackSlot, rr, cursor);
          offset += 8;
          }
@@ -555,9 +555,9 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
 void
 TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   TR::CodeGenerator *codeGen = cg();
+   TR::CodeGenerator *cg = this->cg();
    const TR::ARM64LinkageProperties& properties = getProperties();
-   TR::Machine *machine = codeGen->machine();
+   TR::Machine *machine = cg->machine();
    TR::Node *lastNode = cursor->getNode();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
@@ -569,7 +569,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
          cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, rr, stackSlot, cursor);
          offset += 8;
          }
@@ -579,7 +579,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
          cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::vldrimmd, lastNode, rr, stackSlot, cursor);
          offset += 8;
          }
@@ -589,15 +589,15 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
       cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
       }
 
    // remove space for preserved registers
-   uint32_t frameSize = codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = cg->getFrameSizeInBytes();
    if (constantIsUnsignedImm12(frameSize))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
       }
    else
       {
@@ -605,7 +605,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // return
-   cursor = generateRegBranchInstruction(codeGen, TR::InstOpCode::ret, lastNode, lr, cursor);
+   cursor = generateRegBranchInstruction(cg, TR::InstOpCode::ret, lastNode, lr, cursor);
    }
 
 

--- a/compiler/arm/codegen/ARMSystemLinkage.hpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.hpp
@@ -43,7 +43,7 @@ class ARMSystemLinkage : public TR::Linkage
 
    public:
 
-   ARMSystemLinkage(TR::CodeGenerator *codeGen);
+   ARMSystemLinkage(TR::CodeGenerator *cg);
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -47,7 +47,7 @@ namespace TR { class Register; }
 extern TR::Instruction *armLoadConstant(TR::Node     *node,
                                     int32_t         value,
                                     TR::Register    *targetRegister,
-                                    TR::CodeGenerator *codeGen,
+                                    TR::CodeGenerator *cg,
                                     TR::Instruction *cursor=NULL);
 
 extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg,

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -81,7 +81,7 @@ void OMR::ARM::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbo
 
 TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -123,7 +123,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
                if (hasToBeOnStack)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                  cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                   }
                numIntArgs++;
                break;
@@ -133,11 +133,11 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
             	if (hasToBeOnStack)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                  cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
                      argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                     cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, codeGen), argRegister, cursor);
+                     cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, cg), argRegister, cursor);
                      }
                   }
                numIntArgs += 2;
@@ -150,7 +150,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
 
 TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -177,7 +177,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+               cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                }
             numIntArgs++;
             break;
@@ -185,7 +185,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
                 argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+                cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                 }
              numIntArgs++;
             break;
@@ -196,11 +196,11 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+               cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                  cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), cursor);
+                  cursor = generateTrg1MemInstruction(cg, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, cg), cursor);
                   }
                }
             numIntArgs += 2;
@@ -213,7 +213,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
 
 TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -240,7 +240,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+               cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                }
             numIntArgs++;
             break;
@@ -248,7 +248,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
                 argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                 }
              numIntArgs++;
             break;
@@ -259,11 +259,11 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+               cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                  cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, cg), argRegister, cursor);
                   }
                }
             numIntArgs += 2;
@@ -381,16 +381,16 @@ TR::Register *OMR::ARM::Linkage::pushJNIReferenceArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushIntegerWordArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst() && (child->getDataType() != TR::Float)) /* XXX: We need to fix buildARMLinkageArgs(). */
       {
-      pushRegister = codeGen->allocateRegister();
-      armLoadConstant(child, child->getInt(), pushRegister, codeGen);
+      pushRegister = cg->allocateRegister();
+      armLoadConstant(child, child->getInt(), pushRegister, cg);
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -399,12 +399,12 @@ TR::Register *OMR::ARM::Linkage::pushIntegerWordArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
       bool isClass = child->isClassPointerConstant();
-      pushRegister = codeGen->allocateRegister();
+      pushRegister = cg->allocateRegister();
       if (isClass && self()->cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)child->getAddress(), child))
          {
          loadAddressConstantInSnippet(self()->cg(), child, child->getAddress(), pushRegister);
@@ -419,7 +419,7 @@ TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -428,22 +428,22 @@ TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushLongArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst() /* && (child->getDataType() != TR::Double) */)
       {
-      TR::Register *lowRegister  = codeGen->allocateRegister();
-      TR::Register *highRegister = codeGen->allocateRegister();
-      pushRegister = codeGen->allocateRegisterPair(lowRegister, highRegister);
+      TR::Register *lowRegister  = cg->allocateRegister();
+      TR::Register *highRegister = cg->allocateRegister();
+      pushRegister = cg->allocateRegisterPair(lowRegister, highRegister);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing long arg: low = %d, high = %d\n", child->getLongIntLow(), child->getLongIntHigh()); fflush(stdout);
 #endif
-      armLoadConstant(child, child->getLongIntLow(), lowRegister, codeGen);
-      armLoadConstant(child, child->getLongIntHigh(), highRegister, codeGen);
+      armLoadConstant(child, child->getLongIntLow(), lowRegister, cg);
+      armLoadConstant(child, child->getLongIntHigh(), highRegister, cg);
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -491,7 +491,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
    {
    const TR::ARMLinkageProperties &properties = self()->getProperties();
    TR::Compilation *comp = self()->comp();
-   TR::CodeGenerator  *codeGen      = self()->cg();
+   TR::CodeGenerator  *cg      = self()->cg();
    TR::ARMMemoryArgument *pushToMemory = NULL;
    void                 *stackMark;
 
@@ -1005,7 +1005,7 @@ printf("done\n"); fflush(stdout);
 
 TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNode, bool isSystem)
    {
-   TR::CodeGenerator *codeGen = self()->cg();
+   TR::CodeGenerator *cg = self()->cg();
 
    const TR::ARMLinkageProperties &pp = self()->getProperties();
    TR::RegisterDependencyConditions *dependencies =
@@ -1030,7 +1030,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    if ((callSymbol->isJITInternalNative() ||
         (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() && ((self()->comp()->compileRelocatableCode() && callSymbol->isHelper()) || !self()->comp()->compileRelocatableCode()))))
       {
-      gcPoint = generateImmSymInstruction(codeGen,
+      gcPoint = generateImmSymInstruction(cg,
                                           ARMOp_bl,
                                           callNode,
                                           isMyself ? 0 : (uintptr_t)callSymbol->getMethodAddress(),
@@ -1040,20 +1040,20 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    else
       {
 #ifdef J9_PROJECT_SPECIFIC
-      TR::LabelSymbol *label = generateLabelSymbol(codeGen);
+      TR::LabelSymbol *label = generateLabelSymbol(cg);
       TR::Snippet     *snippet;
 
       if (callSymRef->isUnresolved() || self()->comp()->compileRelocatableCode())
          {
-         snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(cg, callNode, label, argSize);
          }
       else
          {
-         snippet = new (self()->trHeapMemory()) TR::ARMCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMCallSnippet(cg, callNode, label, argSize);
          }
 
-      codeGen->addSnippet(snippet);
-      gcPoint = generateImmSymInstruction(codeGen,
+      cg->addSnippet(snippet);
+      gcPoint = generateImmSymInstruction(cg,
                                           ARMOp_bl,
                                           callNode,
                                           0,
@@ -1066,7 +1066,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
       }
    gcPoint->ARMNeedsGCMap(pp.getPreservedRegisterMapForGC());
    self()->machine()->setLinkRegisterKilled(true);
-   codeGen->setHasCall();
+   cg->setHasCall();
    TR::DataType resType = callNode->getType();
 
    switch(callNode->getOpCodeValue())
@@ -1079,8 +1079,8 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
          returnRegister = dependencies->searchPostConditionRegister(pp.getIntegerReturnRegister());
          if (resType.isFloatingPoint())
             {
-            TR::Register *tempReg = codeGen->allocateSinglePrecisionRegister();
-            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, ARMOp_fmsr, callNode, tempReg, returnRegister);
+            TR::Register *tempReg = cg->allocateSinglePrecisionRegister();
+            TR::Instruction *cursor = generateTrg1Src1Instruction(cg, ARMOp_fmsr, callNode, tempReg, returnRegister);
             returnRegister = tempReg;
             }
          break;
@@ -1093,11 +1093,11 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
          TR::Register *highReg;
          lowReg = dependencies->searchPostConditionRegister(pp.getLongLowReturnRegister());
          highReg = dependencies->searchPostConditionRegister(pp.getLongHighReturnRegister());
-         returnRegister = codeGen->allocateRegisterPair(lowReg, highReg);
+         returnRegister = cg->allocateRegisterPair(lowReg, highReg);
          if (resType.isDouble())
             {
-            TR::Register *tempReg = codeGen->allocateRegister(TR_FPR);
-            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, ARMOp_fmdrr, callNode, tempReg, lowReg, highReg);
+            TR::Register *tempReg = cg->allocateRegister(TR_FPR);
+            TR::Instruction *cursor = generateTrg1Src2Instruction(cg, ARMOp_fmdrr, callNode, tempReg, lowReg, highReg);
             returnRegister = tempReg;
             }
          break;

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -454,27 +454,27 @@ OMR::CodeGenerator::addToAtlas(TR::Instruction * instr)
    }
 
 void
-TR_GCStackMap::addToAtlas(TR::Instruction * instruction, TR::CodeGenerator *codeGen)
+TR_GCStackMap::addToAtlas(TR::Instruction * instruction, TR::CodeGenerator *cg)
    {
    // Fill in the code range and add this map to the atlas.
    //
-   uint8_t * codeStart = codeGen->getCodeStart();
+   uint8_t * codeStart = cg->getCodeStart();
    setLowestCodeOffset(instruction->getBinaryEncoding() - codeStart);
-   codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
+   cg->getStackAtlas()->addStackMap(this);
+   bool osrEnabled = cg->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
-      codeGen->addToOSRTable(instruction);
+      cg->addToOSRTable(instruction);
    }
 
 void
-TR_GCStackMap::addToAtlas(uint8_t * callSiteAddress, TR::CodeGenerator *codeGen)
+TR_GCStackMap::addToAtlas(uint8_t * callSiteAddress, TR::CodeGenerator *cg)
    {
    // Fill in the code range and add this map to the atlas.
    //
-   uint32_t callSiteOffset = callSiteAddress - codeGen->getCodeStart();
+   uint32_t callSiteOffset = callSiteAddress - cg->getCodeStart();
    setLowestCodeOffset(callSiteOffset - 1);
-   codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
+   cg->getStackAtlas()->addStackMap(this);
+   bool osrEnabled = cg->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
-      codeGen->addToOSRTable(callSiteOffset, getByteCodeInfo());
+      cg->addToOSRTable(callSiteOffset, getByteCodeInfo());
    }

--- a/compiler/codegen/GCStackMap.hpp
+++ b/compiler/codegen/GCStackMap.hpp
@@ -271,8 +271,8 @@ public:
       return newMap;
       }
 
-   void addToAtlas(TR::Instruction *instruction, TR::CodeGenerator *codeGen);
-   void addToAtlas(uint8_t *callSiteAddress, TR::CodeGenerator *codeGen);
+   void addToAtlas(TR::Instruction *instruction, TR::CodeGenerator *cg);
+   void addToAtlas(uint8_t *callSiteAddress, TR::CodeGenerator *cg);
 
 private:
    friend class TR_Debug;

--- a/compiler/codegen/OMRRegisterPair.cpp
+++ b/compiler/codegen/OMRRegisterPair.cpp
@@ -60,10 +60,10 @@ OMR::RegisterPair::getLowOrder()
    }
 
 TR::Register *
-OMR::RegisterPair::setLowOrder(TR::Register *lo, TR::CodeGenerator *codeGen)
+OMR::RegisterPair::setLowOrder(TR::Register *lo, TR::CodeGenerator *cg)
    {
-   if (!lo->isLive() && codeGen->getLiveRegisters(lo->getKind())!=NULL)
-      codeGen->getLiveRegisters(lo->getKind())->addRegister(lo);
+   if (!lo->isLive() && cg->getLiveRegisters(lo->getKind())!=NULL)
+      cg->getLiveRegisters(lo->getKind())->addRegister(lo);
 
    return (_lowOrder = lo);
    }
@@ -75,10 +75,10 @@ OMR::RegisterPair::getHighOrder()
    }
 
 TR::Register *
-OMR::RegisterPair::setHighOrder(TR::Register *ho, TR::CodeGenerator *codeGen)
+OMR::RegisterPair::setHighOrder(TR::Register *ho, TR::CodeGenerator *cg)
    {
-   if (!ho->isLive() && codeGen->getLiveRegisters(ho->getKind())!=NULL)
-      codeGen->getLiveRegisters(ho->getKind())->addRegister(ho);
+   if (!ho->isLive() && cg->getLiveRegisters(ho->getKind())!=NULL)
+      cg->getLiveRegisters(ho->getKind())->addRegister(ho);
 
    return (_highOrder = ho);
    }

--- a/compiler/codegen/OMRRegisterPair.hpp
+++ b/compiler/codegen/OMRRegisterPair.hpp
@@ -61,8 +61,8 @@ class OMR_EXTENSIBLE RegisterPair : public TR::Register
    virtual TR::Register     *getLowOrder();
    virtual TR::Register     *getHighOrder();
 
-   TR::Register     *setLowOrder(TR::Register *lo, TR::CodeGenerator *codeGen);
-   TR::Register     *setHighOrder(TR::Register *ho, TR::CodeGenerator *codeGen);
+   TR::Register     *setLowOrder(TR::Register *lo, TR::CodeGenerator *cg);
+   TR::Register     *setHighOrder(TR::Register *ho, TR::CodeGenerator *cg);
 
    virtual TR::Register     *getRegister();
    virtual TR::RegisterPair *getRegisterPair();

--- a/compiler/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/codegen/OMRTreeEvaluator.hpp
@@ -41,7 +41,7 @@ namespace TR { class SymbolReference; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Register; }
 
-typedef TR::Register *(* TR_TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *codeGen);
+typedef TR::Register *(* TR_TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *cg);
 
 namespace OMR
 {

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -39,7 +39,7 @@
 #include "infra/Link.hpp"
 #include "runtime/Runtime.hpp"
 
-void TR::Relocation::apply(TR::CodeGenerator *codeGen)
+void TR::Relocation::apply(TR::CodeGenerator *cg)
    {
    TR_ASSERT(0, "Should never get here");
    }
@@ -58,43 +58,43 @@ TR::RelocationDebugInfo* TR::Relocation::getDebugInfo()
    {
    return this->_genData;
    }
-void TR::LabelRelative8BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative8BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative8BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
-   codeGen->apply8BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
+   AOTcgDiag2(cg->comp(), "TR::LabelRelative8BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
+   cg->apply8BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR::LabelRelative12BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative12BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative12BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
-   codeGen->apply12BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), isCheckDisp());
+   AOTcgDiag2(cg->comp(), "TR::LabelRelative12BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
+   cg->apply12BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), isCheckDisp());
    }
 
-void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative16BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
+   AOTcgDiag2(cg->comp(), "TR::LabelRelative16BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    if(getAddressDifferenceDivisor() == 1)
-   codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
+   cg->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    else
-     codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), getAddressDifferenceDivisor(), isInstructionOffset());
+     cg->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), getAddressDifferenceDivisor(), isInstructionOffset());
    }
 
-void TR::LabelRelative24BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative24BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative24BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
-   codeGen->apply24BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
+   AOTcgDiag2(cg->comp(), "TR::LabelRelative24BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
+   cg->apply24BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative32BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
-   codeGen->apply32BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
+   AOTcgDiag2(cg->comp(), "TR::LabelRelative32BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
+   cg->apply32BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
-void TR::LabelAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::LabelAbsoluteRelocation::apply(TR::CodeGenerator *cg)
    {
    intptr_t *cursor = (intptr_t *)getUpdateLocation();
-   AOTcgDiag2(codeGen->comp(), "TR::LabelAbsoluteRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", cursor, getLabel());
+   AOTcgDiag2(cg->comp(), "TR::LabelAbsoluteRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", cursor, getLabel());
    *cursor = (intptr_t)getLabel()->getCodeLocation();
    }
 
@@ -174,14 +174,14 @@ uint8_t TR::ExternalRelocation::collectModifier()
    return 0;
    }
 
-void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *codeGen)
+void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *cg)
    {
    TR::AheadOfTimeCompile::interceptAOTRelocation(this);
 
-   TR::Compilation *comp = codeGen->comp();
+   TR::Compilation *comp = cg->comp();
    AOTcgDiag0(comp, "TR::ExternalRelocation::addExternalRelocation\n");
 
-   TR_LinkHead<TR::IteratedExternalRelocation>& aot = codeGen->getAheadOfTimeCompile()->getAOTRelocationTargets();
+   TR_LinkHead<TR::IteratedExternalRelocation>& aot = cg->getAheadOfTimeCompile()->getAOTRelocationTargets();
    uint32_t narrowSize = getNarrowSize();
    uint32_t wideSize = getWideSize();
    flags8_t modifier(collectModifier());
@@ -241,8 +241,8 @@ void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *codeGen)
          }
       }
    TR::IteratedExternalRelocation *temp =   _targetAddress2 ?
-      new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _targetAddress2, _kind, modifier, codeGen) :
-      new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _kind, modifier, codeGen);
+      new (cg->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _targetAddress2, _kind, modifier, cg) :
+      new (cg->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _kind, modifier, cg);
 
    aot.add(temp);
    if (_targetAddress2)
@@ -266,9 +266,9 @@ void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *codeGen)
 
    }
 
-void TR::ExternalRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::ExternalRelocation::apply(TR::CodeGenerator *cg)
    {
-   TR::Compilation *comp = codeGen->comp();
+   TR::Compilation *comp = cg->comp();
    AOTcgDiag1(comp, "TR::ExternalRelocation::apply updateLocation=" POINTER_PRINTF_FORMAT " \n", getUpdateLocation());
    uint8_t * relocatableMethodCodeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
    getRelocationRecord()->addRelocationEntry((uint32_t)(getUpdateLocation() - relocatableMethodCodeStart));
@@ -311,10 +311,10 @@ TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation(
                  uint8_t                         *location2,
                  uint8_t                         *target,
                  TR_ExternalRelocationTargetKind  k,
-                 TR::CodeGenerator                *codeGen) :
+                 TR::CodeGenerator                *cg) :
    TR::ExternalRelocation(), _update2Location(location2)
    {
-   AOTcgDiag0(codeGen->comp(), "TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation\n");
+   AOTcgDiag0(cg->comp(), "TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation\n");
    setUpdateLocation(location1);
    setTargetAddress(target);
    setTargetKind(k);
@@ -353,9 +353,9 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    }
 
 
-void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
+void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *cg)
    {
-   TR::Compilation *comp = codeGen->comp();
+   TR::Compilation *comp = cg->comp();
    AOTcgDiag0(comp, "TR::ExternalOrderedPair32BitRelocation::apply\n");
 
    TR::IteratedExternalRelocation *rec = getRelocationRecord();
@@ -506,7 +506,7 @@ char *TR::ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
    };
 
 
-TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
+TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg)
       : TR_Link<TR::IteratedExternalRelocation>(),
         _numberOfRelocationSites(0),
         _targetAddress(target),
@@ -514,7 +514,7 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_E
         _relocationData(NULL),
         _relocationDataCursor(NULL),
         // initial size is size of header for this type
-        _sizeOfRelocationData(codeGen->getAheadOfTimeCompile()->getSizeOfAOTRelocationHeader(k)),
+        _sizeOfRelocationData(cg->getAheadOfTimeCompile()->getSizeOfAOTRelocationHeader(k)),
         _recordModifier(modifier.getValue()),
         _full(false),
         _kind(k)
@@ -522,7 +522,7 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_E
       AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
-TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
+TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg)
       : TR_Link<TR::IteratedExternalRelocation>(),
         _numberOfRelocationSites(0),
         _targetAddress(target),
@@ -530,7 +530,7 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint
         _relocationData(NULL),
         _relocationDataCursor(NULL),
         // initial size is size of header for this type
-        _sizeOfRelocationData(codeGen->getAheadOfTimeCompile()->getSizeOfAOTRelocationHeader(k)),
+        _sizeOfRelocationData(cg->getAheadOfTimeCompile()->getSizeOfAOTRelocationHeader(k)),
         _recordModifier(modifier.getValue()),
         _full(false),
         _kind(k)
@@ -538,10 +538,10 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint
       AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
-void TR::IteratedExternalRelocation::initializeRelocation(TR::CodeGenerator *codeGen)
+void TR::IteratedExternalRelocation::initializeRelocation(TR::CodeGenerator *cg)
    {
    AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::initializeRelocation\n");
-   _relocationDataCursor = codeGen->getAheadOfTimeCompile()->initializeAOTRelocationHeader(this);
+   _relocationDataCursor = cg->getAheadOfTimeCompile()->initializeAOTRelocationHeader(this);
    }
 
 void TR::IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -101,9 +101,9 @@ class Relocation
    /**dumps a trace of the internals - override as required */
    virtual void trace(TR::Compilation* comp);
 
-   virtual void addExternalRelocation(TR::CodeGenerator *codeGen) {}
+   virtual void addExternalRelocation(TR::CodeGenerator *cg) {}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelocation : public TR::Relocation
@@ -125,7 +125,7 @@ class LabelRelative8BitRelocation : public TR::LabelRelocation
    LabelRelative8BitRelocation() : TR::LabelRelocation() {}
    LabelRelative8BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative12BitRelocation : public TR::LabelRelocation
@@ -136,7 +136,7 @@ class LabelRelative12BitRelocation : public TR::LabelRelocation
    LabelRelative12BitRelocation(uint8_t *p, TR::LabelSymbol *l, bool isCheckDisp = true)
       : TR::LabelRelocation(p, l), _isCheckDisp(isCheckDisp) {}
    bool isCheckDisp() {return _isCheckDisp;}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 
@@ -162,7 +162,7 @@ class LabelRelative16BitRelocation : public TR::LabelRelocation
    int8_t getAddressDifferenceDivisor()  {return _addressDifferenceDivisor;}
    int8_t setAddressDifferenceDivisor(int8_t d) {return (_addressDifferenceDivisor = d);}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative24BitRelocation : public TR::LabelRelocation
@@ -171,7 +171,7 @@ class LabelRelative24BitRelocation : public TR::LabelRelocation
    LabelRelative24BitRelocation() : TR::LabelRelocation() {}
    LabelRelative24BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative32BitRelocation : public TR::LabelRelocation
@@ -180,7 +180,7 @@ class LabelRelative32BitRelocation : public TR::LabelRelocation
    LabelRelative32BitRelocation() : TR::LabelRelocation() {}
    LabelRelative32BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 /** \brief
@@ -263,7 +263,7 @@ class LabelAbsoluteRelocation : public TR::LabelRelocation
    LabelAbsoluteRelocation() : TR::LabelRelocation() {}
    LabelAbsoluteRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 
@@ -285,8 +285,8 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
                                   _full(false),
                                   _kind(TR_ConstantPool) {}
 
-   IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
-   IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
+   IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg);
+   IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg);
 
    uint32_t getNumberOfRelocationSites() {return _numberOfRelocationSites;}
    uint32_t setNumberOfRelocationSites(uint32_t s)
@@ -303,7 +303,7 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
    uint8_t *getRelocationDataCursor()           {return _relocationDataCursor;}
    uint8_t *setRelocationDataCursor(uint8_t *p) {return (_relocationDataCursor = p);}
 
-   void initializeRelocation(TR::CodeGenerator * codeGen);
+   void initializeRelocation(TR::CodeGenerator * cg);
    void addRelocationEntry(uint32_t locationOffset);
 
    uint16_t getSizeOfRelocationData()             {return _sizeOfRelocationData;}
@@ -352,7 +352,7 @@ class ExternalRelocation : public TR::Relocation
    ExternalRelocation(uint8_t                        *p,
                       uint8_t                        *target,
                       TR_ExternalRelocationTargetKind kind,
-                      TR::CodeGenerator *codeGen)
+                      TR::CodeGenerator *cg)
       : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(NULL),
@@ -364,7 +364,7 @@ class ExternalRelocation : public TR::Relocation
                       uint8_t                        *target,
                       uint8_t                        *target2,
                       TR_ExternalRelocationTargetKind  kind,
-                      TR::CodeGenerator *codeGen)
+                      TR::CodeGenerator *cg)
       : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(target2),
@@ -385,12 +385,12 @@ class ExternalRelocation : public TR::Relocation
 
    void trace(TR::Compilation* comp);
 
-   void addExternalRelocation(TR::CodeGenerator *codeGen);
+   void addExternalRelocation(TR::CodeGenerator *cg);
    virtual uint8_t collectModifier();
    virtual uint32_t getNarrowSize() {return 2;}
    virtual uint32_t getWideSize() {return 4;}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
 
    virtual bool isExternalRelocation() { return true; }
 
@@ -429,7 +429,7 @@ class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
                                       uint8_t *location2,
                                       uint8_t *target,
                                       TR_ExternalRelocationTargetKind  k,
-                                      TR::CodeGenerator *codeGen);
+                                      TR::CodeGenerator *cg);
 
    uint8_t *getLocation2() {return _update2Location;}
    void setLocation2(uint8_t *l) {_update2Location = l;}
@@ -437,7 +437,7 @@ class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
    virtual uint8_t collectModifier();
    virtual uint32_t getNarrowSize() {return 4;}
    virtual uint32_t getWideSize() {return 8;}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
 
    private:
    uint8_t                         *_update2Location;
@@ -456,8 +456,8 @@ class BeforeBinaryEncodingExternalRelocation : public TR::ExternalRelocation
    BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
-                                          TR::CodeGenerator *codeGen)
-      : TR::ExternalRelocation(NULL, target, kind, codeGen),
+                                          TR::CodeGenerator *cg)
+      : TR::ExternalRelocation(NULL, target, kind, cg),
         _instruction(instr)
          {}
 
@@ -465,8 +465,8 @@ class BeforeBinaryEncodingExternalRelocation : public TR::ExternalRelocation
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
-                                          TR::CodeGenerator *codeGen)
-      : TR::ExternalRelocation(NULL, target, target2, kind, codeGen),
+                                          TR::CodeGenerator *cg)
+      : TR::ExternalRelocation(NULL, target, target2, kind, cg),
         _instruction(instr)
          {}
 

--- a/compiler/il/LabelSymbol.hpp
+++ b/compiler/il/LabelSymbol.hpp
@@ -37,11 +37,11 @@ protected:
    LabelSymbol() :
       OMR::LabelSymbolConnector() { }
 
-   LabelSymbol(TR::CodeGenerator *codeGen) :
-      OMR::LabelSymbolConnector(codeGen) { }
+   LabelSymbol(TR::CodeGenerator *cg) :
+      OMR::LabelSymbolConnector(cg) { }
 
-   LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb):
-      OMR::LabelSymbolConnector(codeGen, labb) { }
+   LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb):
+      OMR::LabelSymbolConnector(cg, labb) { }
 
 private:
 

--- a/compiler/il/OMRLabelSymbol.cpp
+++ b/compiler/il/OMRLabelSymbol.cpp
@@ -79,7 +79,7 @@ OMR::LabelSymbol::LabelSymbol() :
       comp->getDebug()->newLabelSymbol(self());
    }
 
-OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen) :
+OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *cg) :
    TR::Symbol(),
    _instruction(NULL),
    _codeLocation(NULL),
@@ -93,7 +93,7 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen) :
       comp->getDebug()->newLabelSymbol(self());
    }
 
-OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb) :
+OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb) :
    TR::Symbol(),
    _instruction(NULL),
    _codeLocation(NULL),

--- a/compiler/il/OMRLabelSymbol.hpp
+++ b/compiler/il/OMRLabelSymbol.hpp
@@ -78,8 +78,8 @@ public:
 protected:
 
    LabelSymbol();
-   LabelSymbol(TR::CodeGenerator *codeGen);
-   LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb);
+   LabelSymbol(TR::CodeGenerator *cg);
+   LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb);
 
 public:
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -4503,7 +4503,7 @@ OMR::Node::unsetRegister()
 
 
 int32_t
-OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
+OMR::Node::getEvaluationPriority(TR::CodeGenerator * cg)
    {
    if (_unionA._register == 0) // not evaluated into register & priority unknown
       {
@@ -4512,7 +4512,7 @@ OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
       // This way we don't need to resort to visit counts
       self()->setEvaluationPriority(0); // FIXME: remove this once we have
       // dealt with the issue of cycles in nodes
-      return self()->setEvaluationPriority(codeGen->getEvaluationPriority(self()));
+      return self()->setEvaluationPriority(cg->getEvaluationPriority(self()));
       }
    if ((uintptr_t)(_unionA._register) & 1) // evaluation priority
       return (uintptr_t)(_unionA._register) >> 1;

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -891,7 +891,7 @@ public:
    TR::Register *  setRegister(TR::Register *reg);
    void *          unsetRegister();
 
-   int32_t         getEvaluationPriority(TR::CodeGenerator *codeGen);
+   int32_t         getEvaluationPriority(TR::CodeGenerator *cg);
    int32_t         setEvaluationPriority(int32_t p);
 
    /**

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -475,7 +475,7 @@ public:
    int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget) { return 8; } //FIXME
    int32_t arrayTranslateAndTestMinimumNumberOfIterations() { return 8; } //FIXME
 
-   // Provide codeGen-specific hooks for class unloading events
+   // Provide cg-specific hooks for class unloading events
    static void ppcCGOnClassUnloading(void * loaderPtr);
 
    TR::Instruction *loadAddressConstantFixed(

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -68,14 +68,14 @@ class PPCAlignmentNopInstruction : public TR::Instruction
       }
 
 public:
-   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen)
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg)
       {
       setAlignment(alignment);
       }
 
-   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen)
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg)
       {
       setAlignment(alignment);
       }
@@ -103,43 +103,43 @@ public:
    // 3. Has a specified preceding instruction, or it does not.
 
    //Without relocation types here.
-   PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+   PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t       imm,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
    //With relocation types here.
    PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
+                        TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
    //With relocation types and associated symbol references here.
    PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
+                        TR::SymbolReference *sr, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
+                        TR::SymbolReference *sr, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
       }
@@ -175,14 +175,14 @@ class PPCImm2Instruction : public PPCImmInstruction
 
    public:
 
-   PPCImm2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, uint32_t imm2, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, codeGen), _sourceImmediate2(imm2)
+   PPCImm2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, uint32_t imm2, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, cg), _sourceImmediate2(imm2)
       {
       }
 
    PPCImm2Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t       imm, uint32_t imm2,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, precedingInstruction, codeGen), _sourceImmediate2(imm2)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, precedingInstruction, cg), _sourceImmediate2(imm2)
       {
       }
 
@@ -201,15 +201,15 @@ class PPCSrc1Instruction : public PPCImmInstruction
    public:
 
    PPCSrc1Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Register   *sreg,
-                         uint32_t       imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, precedingInstruction, codeGen),
+                         uint32_t       imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, precedingInstruction, cg),
         _source1Register(sreg)
       {
       useRegister(sreg);
       }
 
-   PPCSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register *sreg, uint32_t imm, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, codeGen), _source1Register(sreg)
+   PPCSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register *sreg, uint32_t imm, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, cg), _source1Register(sreg)
       {
       useRegister(sreg);
       }
@@ -242,21 +242,21 @@ class PPCDepInstruction : public TR::Instruction
    public:
 
    PPCDepInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
-      TR::RegisterDependencyConditions *cond, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _conditions(cond)
+      TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _conditions(cond)
       {
       if( op != TR::InstOpCode::assocreg )
-         cond->bookKeepingRegisterUses(this, codeGen);
+         cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepInstruction(TR::InstOpCode::Mnemonic                       op,
                         TR::Node                            *n,
                         TR::RegisterDependencyConditions *cond,
-                        TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _conditions(cond)
+                        TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _conditions(cond)
       {
       if( op != TR::InstOpCode::assocreg )
-         cond->bookKeepingRegisterUses(this, codeGen);
+         cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDep; }
@@ -300,8 +300,8 @@ class PPCLabelInstruction : public TR::Instruction
 
    public:
 
-   PPCLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _symbol(sym)
+   PPCLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _symbol(sym)
       {
       if (sym!=NULL && op==TR::InstOpCode::label)
          sym->setInstruction(this);
@@ -310,8 +310,8 @@ class PPCLabelInstruction : public TR::Instruction
       }
 
    PPCLabelInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                          TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _symbol(sym)
+                          TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _symbol(sym)
       {
       if (sym!=NULL && op==TR::InstOpCode::label)
          sym->setInstruction(this);
@@ -348,21 +348,21 @@ class PPCDepLabelInstruction : public PPCLabelInstruction
    PPCDepLabelInstruction(TR::InstOpCode::Mnemonic                       op,
                              TR::Node                            *n,
                              TR::LabelSymbol                      *sym,
-                             TR::RegisterDependencyConditions *cond, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditions(cond)
+                             TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, cg), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepLabelInstruction(TR::InstOpCode::Mnemonic                        op,
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::RegisterDependencyConditions  *cond,
-                             TR::Instruction             *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                             TR::Instruction             *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDepLabel; }
@@ -411,8 +411,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
    public:
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                                      TR::Register    *cr, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditionRegister(cr),
+                                      TR::Register    *cr, TR::CodeGenerator *cg, bool likeliness)
+      : PPCLabelInstruction(op, n, sym, cg), _conditionRegister(cr),
         _estimatedBinaryLocation(0),  _farRelocation(false),_exceptBranch(false),
         _haveHint(true),  _likeliness(likeliness)
       {
@@ -420,8 +420,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
       }
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                                      TR::Register    *cr, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditionRegister(cr),
+                                      TR::Register    *cr, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, cg), _conditionRegister(cr),
         _estimatedBinaryLocation(0),  _farRelocation(false),_exceptBranch(false),
         _haveHint(false), _likeliness(false)
       {
@@ -430,8 +430,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
                                       TR::Register    *cr,
-                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, bool likeliness)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditionRegister(cr), _estimatedBinaryLocation(0),_exceptBranch(false),
         _farRelocation(false), _haveHint(true), _likeliness(likeliness)
       {
@@ -440,8 +440,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
                                       TR::Register    *cr,
-                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditionRegister(cr), _estimatedBinaryLocation(0),_exceptBranch(false),
         _farRelocation(false), _haveHint(false), _likeliness(false)
       {
@@ -495,10 +495,10 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::Register                         *cr,
-                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, codeGen, likeliness), _conditions(cond)
+                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg, bool likeliness)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, cg, likeliness), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -506,10 +506,10 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::Register                         *cr,
-                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *codeGen)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, codeGen), _conditions(cond)
+                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, cg), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -518,11 +518,11 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::LabelSymbol                      *sym,
                              TR::Register                        *cr,
                              TR::RegisterDependencyConditions *cond,
-                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, codeGen, likeliness),
+                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg, bool likeliness)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, cg, likeliness),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -531,11 +531,11 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::LabelSymbol                      *sym,
                              TR::Register                        *cr,
                              TR::RegisterDependencyConditions *cond,
-                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, codeGen),
+                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, cg),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDepConditionalBranch; }
@@ -578,12 +578,12 @@ class PPCAdminInstruction : public TR::Instruction
 
    public:
 
-   PPCAdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Node * fenceNode, TR::CodeGenerator *codeGen) :
-      TR::Instruction(op, n, codeGen), _fenceNode(fenceNode) {}
+   PPCAdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Node * fenceNode, TR::CodeGenerator *cg) :
+      TR::Instruction(op, n, cg), _fenceNode(fenceNode) {}
 
    PPCAdminInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Node *fenceNode,
-                          TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen) :
-      TR::Instruction(op, n, precedingInstruction, codeGen), _fenceNode(fenceNode) {}
+                          TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
+      TR::Instruction(op, n, precedingInstruction, cg), _fenceNode(fenceNode) {}
 
    virtual Kind getKind() { return IsAdmin; }
 
@@ -611,8 +611,8 @@ class PPCDepImmSymInstruction : public PPCDepInstruction
                               uintptr_t                           imm,
                               TR::RegisterDependencyConditions *cond,
                               TR::SymbolReference                 *sr,
-                              TR::Snippet                         *s, TR::CodeGenerator *codeGen)
-      : PPCDepInstruction(op, n, cond, codeGen), _addrImmediate(imm), _symbolReference(sr),
+                              TR::Snippet                         *s, TR::CodeGenerator *cg)
+      : PPCDepInstruction(op, n, cond, cg), _addrImmediate(imm), _symbolReference(sr),
         _snippet(s) {}
 
    PPCDepImmSymInstruction(
@@ -622,8 +622,8 @@ class PPCDepImmSymInstruction : public PPCDepInstruction
                               TR::RegisterDependencyConditions *cond,
                               TR::SymbolReference                 *sr,
                               TR::Snippet                         *s,
-                              TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCDepInstruction(op, n, cond, precedingInstruction, codeGen),
+                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCDepInstruction(op, n, cond, precedingInstruction, cg),
         _addrImmediate(imm), _symbolReference(sr), _snippet(s) {}
 
    virtual Kind getKind() { return IsDepImmSym; }
@@ -651,15 +651,15 @@ class PPCTrg1Instruction : public TR::Instruction
 
    public:
 
-   PPCTrg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *reg, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _target1Register(reg)
+   PPCTrg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *reg, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _target1Register(reg)
       {
       useRegister(reg);
       }
 
    PPCTrg1Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Register *reg,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _target1Register(reg)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _target1Register(reg)
       {
       useRegister(reg);
       }
@@ -697,13 +697,13 @@ class PPCTrg1ImmInstruction : public PPCTrg1Instruction
    public:
 
    PPCTrg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
-                            uint32_t     imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Instruction(op, n, treg, codeGen), _sourceImmediate(imm) {};
+                            uint32_t     imm, TR::CodeGenerator *cg)
+           : PPCTrg1Instruction(op, n, treg, cg), _sourceImmediate(imm) {};
 
    PPCTrg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                             uint32_t       imm,
-                            TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Instruction(op, n, treg, precedingInstruction, codeGen), _sourceImmediate(imm) {};
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Instruction(op, n, treg, precedingInstruction, cg), _sourceImmediate(imm) {};
 
    virtual Kind getKind() { return IsTrg1Imm; }
 
@@ -724,11 +724,11 @@ class PPCSrc2Instruction : public TR::Instruction
    public:
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register   *s1reg,
-                         TR::Register   *s2reg, TR::CodeGenerator *codeGen);
+                         TR::Register   *s2reg, TR::CodeGenerator *cg);
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register   *s1reg,
                          TR::Register    *s2reg,
-                         TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsSrc2; }
 
@@ -806,11 +806,11 @@ class PPCTrg1Src1Instruction : public PPCTrg1Instruction
    public:
 
    PPCTrg1Src1Instruction(TR::InstOpCode::Mnemonic op,  TR::Node * n, TR::Register   *treg,
-                             TR::Register   *sreg, TR::CodeGenerator *codeGen);
+                             TR::Register   *sreg, TR::CodeGenerator *cg);
 
    PPCTrg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,  TR::Register   *treg,
                              TR::Register    *sreg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsTrg1Src1; }
 
@@ -841,37 +841,37 @@ class PPCTrg1Src1ImmInstruction : public PPCTrg1Src1Instruction
    public:
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
-                                TR::Register    *sreg, uintptr_t imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, codeGen),
+                                TR::Register    *sreg, uintptr_t imm, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, cg),
              _source1Immediate(imm) {};
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
                                 TR::Register    *sreg, uintptr_t imm,
-                                TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, codeGen),
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, cg),
              _source1Immediate(imm) {};
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
-                                TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, codeGen),
+                                TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, cg),
              _source1Immediate(imm)
       {
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
                                 TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm,
-                                TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, codeGen),
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, cg),
              _source1Immediate(imm)
       {
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsTrg1Src1Imm; }
@@ -900,8 +900,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *sreg,
                                  uint32_t       imm,
                                  uint64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, precedingInstruction, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -909,8 +909,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *treg,
                                  TR::Register    *sreg,
                                  uint32_t       imm,
-                                 uint64_t       m, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, codeGen),
+                                 uint64_t       m, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -919,8 +919,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *sreg,
                                  TR::Register    *cr0reg,
                                  uint32_t       imm,
-                                 uint64_t       m, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, codeGen),
+                                 uint64_t       m, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -930,8 +930,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *cr0reg,
                                  uint32_t       imm,
                                  uint64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, precedingInstruction, cg),
              _mask(m) {}
 
    virtual Kind getKind() { return IsTrg1Src1Imm2; }
@@ -955,8 +955,8 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Node       *n,
                               TR::Register   *treg,
                               TR::Register   *s1reg,
-                              TR::Register   *s2reg, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, codeGen), _source2Register(s2reg)
+                              TR::Register   *s2reg, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, cg), _source2Register(s2reg)
       {
       useRegister(s2reg);
       }
@@ -966,8 +966,8 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Register   *treg,
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, codeGen),
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
       useRegister(s2reg);
@@ -979,15 +979,15 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
                               TR::Register   *cr0reg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, codeGen),
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
       useRegister(s2reg);
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsTrg1Src2; }
@@ -1023,8 +1023,8 @@ class PPCTrg1Src2ImmInstruction : public PPCTrg1Src2Instruction
                                  TR::Register   *treg,
                                  TR::Register   *s1reg,
                                  TR::Register   *s2reg,
-                                 int64_t       m, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, codeGen),
+                                 int64_t       m, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, cg),
       _mask(m) {}
 
    PPCTrg1Src2ImmInstruction( TR::InstOpCode::Mnemonic op,
@@ -1033,8 +1033,8 @@ class PPCTrg1Src2ImmInstruction : public PPCTrg1Src2Instruction
                                  TR::Register   *s1reg,
                                  TR::Register   *s2reg,
                                  int64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, cg),
       _mask(m) {}
 
    virtual Kind getKind() { return IsTrg1Src2Imm; }
@@ -1058,8 +1058,8 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
                               TR::Register   *treg,
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
-                              TR::Register   *s3reg, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, codeGen), _source3Register(s3reg)
+                              TR::Register   *s3reg, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, cg), _source3Register(s3reg)
       {
       useRegister(s3reg);
       }
@@ -1070,8 +1070,8 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
                               TR::Register   *s3reg,
-                              TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, codeGen),
+                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, cg),
                              _source3Register(s3reg)
       {
       useRegister(s3reg);
@@ -1152,13 +1152,13 @@ class PPCMemSrc1Instruction : public PPCMemInstruction
    PPCMemSrc1Instruction(TR::InstOpCode::Mnemonic op,
                             TR::Node *n,
                             TR::MemoryReference *mf,
-                            TR::Register *sreg, TR::CodeGenerator *codeGen);
+                            TR::Register *sreg, TR::CodeGenerator *cg);
 
    PPCMemSrc1Instruction(TR::InstOpCode::Mnemonic op,
                             TR::Node *n,
                             TR::MemoryReference *mf,
                             TR::Register *sreg,
-                            TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsMemSrc1; }
 
@@ -1229,13 +1229,13 @@ class PPCTrg1MemInstruction : public PPCTrg1Instruction
    PPCTrg1MemInstruction(TR::InstOpCode::Mnemonic          op,
                             TR::Node                *n,
                             TR::Register            *treg,
-                            TR::MemoryReference *mf, TR::CodeGenerator *codeGen, int32_t hint = PPCOpProp_NoHint);
+                            TR::MemoryReference *mf, TR::CodeGenerator *cg, int32_t hint = PPCOpProp_NoHint);
 
    PPCTrg1MemInstruction(TR::InstOpCode::Mnemonic          op,
                             TR::Node                *n,
                             TR::Register            *treg,
                             TR::MemoryReference *mf,
-                            TR::Instruction         *precedingInstruction, TR::CodeGenerator *codeGen, int32_t hint = PPCOpProp_NoHint);
+                            TR::Instruction         *precedingInstruction, TR::CodeGenerator *cg, int32_t hint = PPCOpProp_NoHint);
 
    virtual Kind getKind() { return IsTrg1Mem; }
 
@@ -1353,28 +1353,28 @@ class PPCControlFlowInstruction : public TR::Instruction
    public:
 
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
-      TR::CodeGenerator *codeGen,
+      TR::CodeGenerator *cg,
       TR::RegisterDependencyConditions *deps=NULL,
       bool useRegPairForResult=false,
       bool useRegPairForCond=false)
-      : TR::Instruction(op, n, codeGen), _numSources(0), _numTargets(0), _label(NULL),
+      : TR::Instruction(op, n, cg), _numSources(0), _numTargets(0), _label(NULL),
         _opCode2(TR::InstOpCode::bad), _conditions(deps), _useRegPairForResult(useRegPairForResult),
         _useRegPairForCond(useRegPairForCond)
       {
-      if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
+      if (deps!=NULL) deps->bookKeepingRegisterUses(this, cg);
       }
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
       TR::Instruction *preceedingInstruction,
-      TR::CodeGenerator *codeGen,
+      TR::CodeGenerator *cg,
       TR::RegisterDependencyConditions *deps=NULL,
       bool useRegPairForResult=false,
       bool useRegPairForCond=false)
-      : TR::Instruction(op, n, preceedingInstruction, codeGen),
+      : TR::Instruction(op, n, preceedingInstruction, cg),
         _numSources(0), _numTargets(0), _label(NULL), _opCode2(TR::InstOpCode::bad),
         _conditions(deps), _useRegPairForResult(useRegPairForResult),
          _useRegPairForCond(useRegPairForCond)
       {
-      if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
+      if (deps!=NULL) deps->bookKeepingRegisterUses(this, cg);
       }
 
    bool useRegPairForResult() { return _useRegPairForResult; }
@@ -1463,16 +1463,16 @@ class PPCVirtualGuardNOPInstruction : public PPCDepLabelInstruction
                                     TR_VirtualGuardSite     *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                  *label,
-                                    TR::CodeGenerator               *codeGen)
-      : PPCDepLabelInstruction(TR::InstOpCode::vgdnop, node, label, cond, codeGen), _site(site) {}
+                                    TR::CodeGenerator               *cg)
+      : PPCDepLabelInstruction(TR::InstOpCode::vgdnop, node, label, cond, cg), _site(site) {}
 
    PPCVirtualGuardNOPInstruction(TR::Node                        *node,
                                     TR_VirtualGuardSite     *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                  *label,
                                     TR::Instruction                 *precedingInstruction,
-                                    TR::CodeGenerator               *codeGen)
-      : PPCDepLabelInstruction(TR::InstOpCode::vgdnop, node, label, cond, precedingInstruction, codeGen), _site(site) {}
+                                    TR::CodeGenerator               *cg)
+      : PPCDepLabelInstruction(TR::InstOpCode::vgdnop, node, label, cond, precedingInstruction, cg), _site(site) {}
 
    virtual Kind getKind() { return IsVirtualGuardNOP; }
 

--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -51,8 +51,8 @@ class RtypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::Register      *s1reg,
          TR::Register      *s2reg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _source2Register(s2reg)
@@ -68,8 +68,8 @@ class RtypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          TR::Register      *s2reg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _source2Register(s2reg)
@@ -182,9 +182,9 @@ class ItypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::Register      *s1reg,
          uint32_t          imm,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : TR::Instruction(op, n, codeGen),
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -199,8 +199,8 @@ class ItypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          uint32_t          imm,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -215,8 +215,8 @@ class ItypeInstruction : public TR::Instruction
             TR::Register      *s1reg,
             uint32_t          imm,
             TR::RegisterDependencyConditions *cond,
-            TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, codeGen),
+            TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -232,8 +232,8 @@ class ItypeInstruction : public TR::Instruction
             uint32_t          imm,
             TR::RegisterDependencyConditions *cond,
             TR::Instruction   *precedingInstruction,
-            TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, precedingInstruction, codeGen),
+            TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -333,13 +333,13 @@ class LoadInstruction : public TR::Instruction
          TR::Node          *n,
          TR::Register      *treg,
          TR::MemoryReference *mr,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _memoryReference(mr)
       {
       useRegister(treg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    LoadInstruction(TR::InstOpCode::Mnemonic op,
@@ -347,16 +347,16 @@ class LoadInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::MemoryReference *mr,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _memoryReference(mr)
       {
       useRegister(treg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       // TODO: why incRegisterTotalUseCounts() here but not above?
       // This is how it's done in Aarch64. but could be wrong. Investigate.
-      //mr->incRegisterTotalUseCounts(codeGen);
+      //mr->incRegisterTotalUseCounts(cg);
       }
 
    /**
@@ -456,8 +456,8 @@ class StypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          TR::Register      *s2reg,
          uint32_t          imm,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _source1Register(s1reg),
         _source2Register(s2reg),
         _imm(imm)
@@ -472,8 +472,8 @@ class StypeInstruction : public TR::Instruction
          TR::Register      *s2reg,
          uint32_t          imm,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _source1Register(s1reg),
         _source2Register(s2reg),
         _imm(imm)
@@ -572,13 +572,13 @@ class StoreInstruction : public TR::Instruction
          TR::Node          *n,
          TR::MemoryReference *mr,
          TR::Register      *sreg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _source1Register(sreg),
         _memoryReference(mr)
       {
       useRegister(sreg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    StoreInstruction(TR::InstOpCode::Mnemonic op,
@@ -586,13 +586,13 @@ class StoreInstruction : public TR::Instruction
          TR::MemoryReference *mr,
          TR::Register      *sreg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _source1Register(sreg),
         _memoryReference(mr)
       {
       useRegister(sreg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    /**
@@ -788,8 +788,8 @@ class UtypeInstruction : public TR::Instruction
          TR::Node          *n,
          uint32_t          imm,
          TR::Register      *treg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -801,8 +801,8 @@ class UtypeInstruction : public TR::Instruction
          uint32_t          imm,
          TR::Register      *treg,
          TR::RegisterDependencyConditions *cond,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -814,8 +814,8 @@ class UtypeInstruction : public TR::Instruction
          uint32_t          imm,
          TR::Register      *treg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -828,8 +828,8 @@ class UtypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::RegisterDependencyConditions *cond,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, precedingInstruction, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -917,8 +917,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::RegisterDependencyConditions *cond,
          TR::SymbolReference *sr,
          TR::Snippet       *s, // unused for now
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, cond, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, cond, cg),
         _symbolReference(sr),
         _symbol(nullptr)
       {
@@ -932,8 +932,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::SymbolReference *sr,
          TR::Snippet       *s,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, cg),
         _symbolReference(sr),
         _symbol(nullptr)
       {
@@ -943,9 +943,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::Node          *n,
          TR::Register      *treg,
          TR::LabelSymbol   *label,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -956,9 +956,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::Register      *treg,
          TR::LabelSymbol   *label,
          TR::RegisterDependencyConditions *cond,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -969,8 +969,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::Register      *treg,
          TR::LabelSymbol   *label,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, precedingInstruction, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -982,9 +982,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::LabelSymbol   *label,
          TR::RegisterDependencyConditions *cond,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -424,8 +424,8 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor)
 void
 TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterSymbol> &parmList)
    {
-   TR::CodeGenerator *codeGen = cg();
-   TR::Machine *machine = codeGen->machine();
+   TR::CodeGenerator *cg = this->cg();
+   TR::Machine *machine = cg->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    const TR::RVLinkageProperties& properties = getProperties();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
@@ -433,10 +433,10 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
    TR::Node *firstNode = comp()->getStartTree()->getNode();
 
    // allocate stack space
-   uint32_t frameSize = (uint32_t)codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = (uint32_t)cg->getFrameSizeInBytes();
    if (VALID_ITYPE_IMM(frameSize))
       {
-      cursor = generateITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, codeGen, cursor);
+      cursor = generateITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, cg, cursor);
       }
    else
       {
@@ -446,8 +446,8 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
    // save link register (ra)
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
-      cursor = generateSTORE(TR::InstOpCode::_sd, firstNode, stackSlot, ra, codeGen, cursor);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
+      cursor = generateSTORE(TR::InstOpCode::_sd, firstNode, stackSlot, ra, cg, cursor);
       }
 
    // spill argument registers
@@ -458,7 +458,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
         parameter != NULL && (nextIntArgReg < getProperties().getNumIntArgRegs() || nextFltArgReg < getProperties().getNumFloatArgRegs());
         parameter = parameterIterator.getNext())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, parameter->getParameterOffset(), codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, parameter->getParameterOffset(), cg);
       TR::InstOpCode::Mnemonic op;
 
       switch (parameter->getDataType())
@@ -471,7 +471,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
             if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
-               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::a0 + nextIntArgReg)), codeGen, cursor);
+               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::a0 + nextIntArgReg)), cg, cursor);
                nextIntArgReg++;
                }
             else
@@ -484,7 +484,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
             if (nextFltArgReg < getProperties().getNumFloatArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::_fsd : TR::InstOpCode::_fsw;
-               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::fa0 + nextFltArgReg)), codeGen, cursor);
+               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::fa0 + nextFltArgReg)), cg, cursor);
                nextFltArgReg++;
                }
             else
@@ -503,7 +503,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
    // save callee-saved registers
    uint32_t offset = bodySymbol->getLocalMappingCursor();
    FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(machine,
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
       cursor = generateSTORE(TR::InstOpCode::_sd, firstNode, stackSlot, reg, cg(), cursor);
       offset += 8;)
    }
@@ -512,9 +512,9 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
 void
 TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   TR::CodeGenerator *codeGen = cg();
+   TR::CodeGenerator *cg = this->cg();
    const TR::RVLinkageProperties& properties = getProperties();
-   TR::Machine *machine = codeGen->machine();
+   TR::Machine *machine = cg->machine();
    TR::Node *lastNode = cursor->getNode();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
@@ -523,7 +523,7 @@ TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
    // restore callee-saved registers
    uint32_t offset = bodySymbol->getLocalMappingCursor();
    FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(machine,
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
       cursor = generateLOAD(TR::InstOpCode::_ld, lastNode, reg, stackSlot, cg(), cursor);
       offset += 8;)
 
@@ -531,15 +531,15 @@ TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *ra = machine->getRealRegister(TR::RealRegister::ra);
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
+      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
       cursor = generateLOAD(TR::InstOpCode::_ld, lastNode, ra, stackSlot, cg(), cursor);
       }
 
    // remove space for preserved registers
-   uint32_t frameSize = codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = cg->getFrameSizeInBytes();
    if (VALID_ITYPE_IMM(frameSize))
       {
-      cursor = generateITYPE(TR::InstOpCode::_addi, lastNode, sp, sp, frameSize, codeGen, cursor);
+      cursor = generateITYPE(TR::InstOpCode::_addi, lastNode, sp, sp, frameSize, cg, cursor);
       }
    else
       {
@@ -547,7 +547,7 @@ TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // return
-   cursor = generateITYPE(TR::InstOpCode::_jalr, lastNode, zero, ra, 0, codeGen, cursor);
+   cursor = generateITYPE(TR::InstOpCode::_jalr, lastNode, zero, ra, 0, cg, cursor);
    }
 
 

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -228,7 +228,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *minmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zccAddSubEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   typedef TR::Register *(* EvaluatorComputesCarry)(TR::Node *node, TR::CodeGenerator *codeGen, bool computesCarry);
+   typedef TR::Register *(* EvaluatorComputesCarry)(TR::Node *node, TR::CodeGenerator *cg, bool computesCarry);
    // routines for integers (or addresses) that can fit in one register
    // (see also the integerPair*Evaluator functions)
    static TR::Register *integerStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/X86FPConversionSnippet.hpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.hpp
@@ -42,12 +42,12 @@ class X86FPConversionSnippet : public TR::X86RestartSnippet
 
    public:
 
-   X86FPConversionSnippet(TR::CodeGenerator   *codeGen,
+   X86FPConversionSnippet(TR::CodeGenerator   *cg,
                           TR::Node            *node,
                           TR::LabelSymbol      *restartlab,
                           TR::LabelSymbol      *snippetlab,
                           TR::SymbolReference *helperSymRef)
-      : TR::X86RestartSnippet(codeGen, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
+      : TR::X86RestartSnippet(cg, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
            _helperSymRef(helperSymRef)
       {
       // The code generation for this snippet does not allow a proper GC map
@@ -76,8 +76,8 @@ class X86FPConvertToIntSnippet  : public TR::X86FPConversionSnippet
                             TR::LabelSymbol            *snippetlab,
                             TR::SymbolReference       *helperSymRef,
                             TR::X86RegInstruction     *convertInstr,
-                            TR::CodeGenerator *codeGen)
-      : TR::X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
+                            TR::CodeGenerator *cg)
+      : TR::X86FPConversionSnippet(cg, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _convertInstruction(convertInstr) {}
 
    TR::X86RegInstruction  * getConvertInstruction() {return _convertInstruction;}
@@ -119,8 +119,8 @@ class X86FPConvertToLongSnippet  : public TR::X86FPConversionSnippet
                              TR::X86FPST0STiRegRegInstruction  *clobInstr,
                              TR::X86RegMemInstruction          *loadHighInstr,
                              TR::X86RegMemInstruction          *loadLowInstr,
-                             TR::CodeGenerator *codeGen)
-      : TR::X86FPConversionSnippet(codeGen, clobInstr->getNode(), restartlab, snippetlab, helperSymRef),
+                             TR::CodeGenerator *cg)
+      : TR::X86FPConversionSnippet(cg, clobInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _loadHighInstruction(loadHighInstr),
            _loadLowInstruction(loadLowInstr),
            _clobberInstruction(clobInstr),

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -100,8 +100,8 @@ extern bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGener
 // TR::S390Linkage member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
-   : OMR::Linkage(codeGen),
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * cg)
+   : OMR::Linkage(cg),
       _explicitLinkageType(TR_S390LinkageDefault), _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
@@ -135,8 +135,8 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * convention.
  * Even though this method is common, its implementation is machine-specific.
  */
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
-   : OMR::Linkage(codeGen),
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * cg,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
+   : OMR::Linkage(cg),
       _explicitLinkageType(elc), _linkageType(lc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
@@ -2349,12 +2349,12 @@ OMR::Z::Linkage::storeLongDoubleArgumentOnStack(TR::Node * callNode, TR::DataTyp
 int64_t
 OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
    TR::Register ** virtualRegPtr, TR::RealRegister::RegNum regNum,
-   TR::CodeGenerator * codeGen, bool isAllocate, bool isDummy)
+   TR::CodeGenerator * cg, bool isAllocate, bool isDummy)
    {
    TR::Register * depVirReg = deps->searchPostConditionRegister(regNum);
    if (depVirReg)
       {
-      if (*virtualRegPtr) codeGen->stopUsingRegister(*virtualRegPtr);
+      if (*virtualRegPtr) cg->stopUsingRegister(*virtualRegPtr);
       *virtualRegPtr = depVirReg;
       return killMask;
       }
@@ -2374,7 +2374,7 @@ OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyC
 
       deps->addPostCondition(*virtualRegPtr, regNum, DefinesDependentRegister);
       if (isAllocate)
-         codeGen->stopUsingRegister(*virtualRegPtr);
+         cg->stopUsingRegister(*virtualRegPtr);
 
       if (isDummy)
          {
@@ -2391,24 +2391,24 @@ OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyC
 int64_t
 OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
    TR::Register ** virtualRegPtr, TR::RealRegister* realReg,
-   TR::CodeGenerator * codeGen, bool isAllocate, bool isDummy)
+   TR::CodeGenerator * cg, bool isAllocate, bool isDummy)
    {
-   return self()->killAndAssignRegister(killMask, deps, virtualRegPtr, realReg->getRegisterNumber(), codeGen, isAllocate, isDummy );
+   return self()->killAndAssignRegister(killMask, deps, virtualRegPtr, realReg->getRegisterNumber(), cg, isAllocate, isDummy );
    }
 
 
-void OMR::Z::Linkage::generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * codeGen, TR::RegisterDependencyConditions * &deps,
+void OMR::Z::Linkage::generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * cg, TR::RegisterDependencyConditions * &deps,
       TR::Register * javaReturnRegister, bool hasGlRegDeps, TR::Node *GlobalRegDeps)
    {
    TR::LabelSymbol * endOfDirectToJNILabel = generateLabelSymbol(self()->cg());
    TR::RegisterDependencyConditions * postDeps = new (self()->trHeapMemory())
                TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), self()->cg());
 
-   generateS390LabelInstruction(codeGen, TR::InstOpCode::LABEL, callNode, endOfDirectToJNILabel, postDeps);
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, endOfDirectToJNILabel, postDeps);
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (codeGen->getSupportsRuntimeInstrumentation())
-      TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(codeGen, TR::InstOpCode::RION, callNode);
+   if (cg->getSupportsRuntimeInstrumentation())
+      TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(cg, TR::InstOpCode::RION, callNode);
 #endif
 
    callNode->setRegister(javaReturnRegister);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -359,13 +359,13 @@ enum TR_DispatchType
 
    int64_t killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
       TR::Register ** virtualReg, TR::RealRegister::RegNum regNum,
-      TR::CodeGenerator * codeGen, bool isAllocate=false, bool isDummy=false);
+      TR::CodeGenerator * cg, bool isAllocate=false, bool isDummy=false);
 
    int64_t killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
       TR::Register ** virtualReg, TR::RealRegister* realReg,
-      TR::CodeGenerator * codeGen, bool isAllocate=false, bool isDummy=false);
+      TR::CodeGenerator * cg, bool isAllocate=false, bool isDummy=false);
 
-   virtual void generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * codeGen,
+   virtual void generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * cg,
 			TR::RegisterDependencyConditions * &deps, TR::Register * javaReturnRegister,bool hasGlRegDeps, TR::Node *GlobalRegDeps);
    virtual TR::Register * buildNativeDispatch(TR::Node * callNode, TR_DispatchType dispatchType);
    virtual TR::Register * buildNativeDispatch(TR::Node * callNode, TR_DispatchType dispatchType,

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -403,10 +403,10 @@ TR::S390zLinuxSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethod
 void
 TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR::RegisterDependencyConditions* deps, intptr_t targetAddress, TR::Register* methodAddressReg, TR::Register* javaLitOffsetReg, TR::LabelSymbol* returnFromJNICallLabel, TR::Snippet* callDataSnippet, bool isJNIGCPoint)
    {
-   TR::CodeGenerator * codeGen = cg();
+   TR::CodeGenerator * cg = this->cg();
 
    TR::RegisterDependencyConditions * postDeps = new (trHeapMemory())
-      TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), cg());
+      TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), this->cg());
 
    TR::Register * systemReturnAddressRegister =
       deps->searchPostConditionRegister(getReturnAddressRegister());
@@ -420,15 +420,15 @@ TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR:
          {
          TR_ASSERT(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->isComputed(), "system linkage only supports computed indirect call for now %p\n", callNode);
          // get the address of the function descriptor
-         TR::Register *targetReg = codeGen->evaluate(callNode->getFirstChild());
-         generateRRInstruction(codeGen, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, targetReg, deps);
+         TR::Register *targetReg = cg->evaluate(callNode->getFirstChild());
+         generateRRInstruction(cg, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, targetReg, deps);
          }
       else
          {
          TR::SymbolReference *callSymRef = callNode->getSymbolReference();
          TR::Symbol *callSymbol = callSymRef->getSymbol();
          TR::Register * fpReg = systemReturnAddressRegister;
-         TR::Instruction * callInstr = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, codeGen);
+         TR::Instruction * callInstr = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, cg);
          callInstr->setDependencyConditions(deps);
          }
       }

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -403,7 +403,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
    generateInstructionsForCall(callNode, deps, targetAddress, methodAddressReg,
          javaLitOffsetReg, returnFromJNICallLabel, callDataSnippet, isJNIGCPoint);
 
-   TR::CodeGenerator * codeGen = cg();
+   TR::CodeGenerator * cg = this->cg();
 
    TR::Register * retReg = NULL;
    TR::Register * returnRegister = NULL;
@@ -441,11 +441,11 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
             lowReg = deps->searchPostConditionRegister(getLongLowReturnRegister());
             highReg = deps->searchPostConditionRegister(getLongHighReturnRegister());
 
-            generateRSInstruction(codeGen, TR::InstOpCode::SLLG, callNode, highReg, highReg, 32);
+            generateRSInstruction(cg, TR::InstOpCode::SLLG, callNode, highReg, highReg, 32);
             cursor =
-               generateRRInstruction(codeGen, TR::InstOpCode::LR, callNode, highReg, lowReg);
+               generateRRInstruction(cg, TR::InstOpCode::LR, callNode, highReg, lowReg);
 
-            codeGen->stopUsingRegister(lowReg);
+            cg->stopUsingRegister(lowReg);
             retReg = highReg;
             returnRegister = retReg;
             }
@@ -469,7 +469,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
       case TR::decalli:
          highReg = deps->searchPostConditionRegister(getLongDoubleReturnRegister0());
          lowReg = deps->searchPostConditionRegister(getLongDoubleReturnRegister2());
-         retReg = codeGen->allocateFPRegisterPair(lowReg, highReg);
+         retReg = cg->allocateFPRegisterPair(lowReg, highReg);
          returnRegister = retReg;
          break;
 #endif
@@ -487,7 +487,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
 
    if (returnRegister != retReg)
       {
-      generateRRInstruction(codeGen, TR::InstOpCode::getLoadRegOpCode(), callNode, returnRegister, retReg);
+      generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), callNode, returnRegister, retReg);
       }
 
    return returnRegister;


### PR DESCRIPTION
This patch makes all instances of CodeGenerator variables from `codeGen` to `cg`.

Issue: #5594
Signed-off-by: Prakhar Yadav <pkrc267@gmail.com>