### PR TITLE
Remove reverse load and store opcodes from ValuePropagationTable.hpp

### DIFF
--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1345,15 +1345,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::de2pdSetSign
    constrainChildren,           // TR::de2pdClean
    constrainBCDCHK,          // TR::BCDCHK
-   constrainIiload,             // TR::ircload
-   constrainIiload,             // TR::irsload
-   constrainIiload,             // TR::iruiload
-   constrainIiload,             // TR::iriload
-   constrainLload,              // TR::irulload
-   constrainLload,              // TR::irlload
-   constrainStore,              // TR::irsstore
-   constrainStore,              // TR::iristore
-   constrainStore,              // TR::irlstore
 #endif
 
    };


### PR DESCRIPTION
These were guarded with `J9_PROJECT_SPECIFIC` and were accidentally left
as part of centralizing the opcode enum.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>