### PR TITLE
Add NonSpecificConstObject flag

### DIFF
--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -401,6 +401,9 @@ public:
    inline void setConstMethodHandle();
    inline bool isConstMethodHandle();
 
+   inline void setNonSpecificConstObject();
+   inline bool isNonSpecificConstObject();
+
    inline bool isConstObjectRef();
    inline bool isStaticField();
    inline bool isFixedObjectRef();
@@ -554,6 +557,7 @@ public:
       ImmutableField            = 0x00000400,
       PendingPush               = 0x00000800,
       ConstantDynamic           = 0x00001000,
+      NonSpecificConstObject    = 0x00002000, // Constant object not specific to a type
       };
 
 protected:

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -601,10 +601,23 @@ OMR::Symbol::isConstMethodHandle()
    return self()->isStatic() && _flags2.testAny(ConstMethodHandle);
    }
 
+void
+OMR::Symbol::setNonSpecificConstObject()
+   {
+   TR_ASSERT(self()->isStatic(), "assert failure");
+   _flags2.set(NonSpecificConstObject);
+   }
+
+bool
+OMR::Symbol::isNonSpecificConstObject()
+   {
+   return self()->isStatic() && _flags2.testAny(NonSpecificConstObject);
+   }
+
 bool
 OMR::Symbol::isConstObjectRef()
    {
-   return self()->isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(ConstMethodType|ConstMethodHandle|ConstantDynamic));
+   return self()->isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(NonSpecificConstObject|ConstMethodType|ConstMethodHandle|ConstantDynamic));
    }
 
 bool


### PR DESCRIPTION
The existing flags are used for a limited types of objects, add a flag
for any types of objects.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>