### PR TITLE
Use a default empty message when NULL passed to set error api

### DIFF
--- a/port/common/omrerror.c
+++ b/port/common/omrerror.c
@@ -257,8 +257,8 @@ omrerror_set_last_error(struct OMRPortLibrary *portLibrary,  int32_t platformCod
 int32_t
 omrerror_set_last_error_with_message(struct OMRPortLibrary *portLibrary, int32_t portableCode, const char *errorMessage)
 {
-	PortlibPTBuffers_t ptBuffers;
-	uint32_t requiredSize;
+	PortlibPTBuffers_t ptBuffers = NULL;
+	uint32_t requiredSize = 0;
 
 	/* get the buffers, allocate if necessary.
 	 * Silently return if not present, what else would the caller do anyway?
@@ -266,6 +266,13 @@ omrerror_set_last_error_with_message(struct OMRPortLibrary *portLibrary, int32_t
 	ptBuffers = omrport_tls_get(portLibrary);
 	if (NULL == ptBuffers) {
 		return portableCode;
+	}
+	if (NULL == errorMessage) {
+		/* Unexpectedly got here with a NULL message.  Ensure we
+		 * set an empty string as the message to clear any previously
+		 * set message.
+		 */
+		errorMessage = "";
 	}
 
 	/* Save the last error */


### PR DESCRIPTION
`omrerror_set_last_error_with_message` expects a non-null message
though the API doesn't indicate that in the documentation.

Protect against the inadvertant passing of NULL by defaulting to
an empty string for the message.  This ensures that anyone checking
for a message after this call won't get stale data.

Fixes segfaults when the NLS catalog can't be found as it's a common
pattern to pass the NLS result directly to this call.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>