### PR TITLE
Avoid duplicate work in non-cmake builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2019 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 all : postbuild
 .DEFAULT : all
 clean :
-.PHONY : all clean
+.PHONY : all clean help
 
 help :
 	@echo "help   Display this help message."
@@ -39,7 +39,6 @@ help :
 	@echo "clean  Clean OMR build artifacts."
 	@echo "test   Run functional verification tests."
 	@echo "lint   Run the OMR linter."
-.PHONY : help
 
 # recursively find files in directory $1 matching the pattern $2
 FindAllFiles = \
@@ -186,9 +185,9 @@ endif
 
 ifeq (yes,$(ENABLE_DDR))
   postbuild_targets += ddr
-  ddr :: staticlib
+  ddr : staticlib
 ifeq (zos,$(OMR_HOST_OS))
-  ddr :: util/a2e
+  ddr : util/a2e
 endif
 endif
 
@@ -244,15 +243,13 @@ tools :
 ### Inter-target Dependencies
 ###
 
-# These rules must be specified before $(targets) ::
-
 # If a prereq directory is not also defined in $(targets),
 # then we won't execute 'make' in the prereq directory.
 
 ifeq (zos,$(OMR_HOST_OS))
-tools/hookgen :: util/a2e
-tools/tracegen :: util/a2e
-tools/tracemerge :: util/a2e
+tools/hookgen : util/a2e
+tools/tracegen : util/a2e
+tools/tracemerge : util/a2e
 endif
 
 hook_definition_sentinel_all : $(HOOK_DEFINITION_SENTINELS)
@@ -267,41 +264,42 @@ $(HOOK_DEFINITION_SENTINELS) : $(exe_output_dir)/hookgen$(EXEEXT)
 hook_definition_sentinel_clean :
 	rm -f $(HOOK_DEFINITION_SENTINELS)
 
-omrsigcompat :: util/omrutil
+omrsigcompat : util/omrutil
 
-example :: $(test_prereqs)
+example : $(test_prereqs)
 
-fvtest/algotest ::$(test_prereqs)
-fvtest/gctest :: $(test_prereqs)
-fvtest/jitbuildertest :: $(test_prereqs)
-fvtest/porttest :: $(test_prereqs)
-fvtest/rastest :: $(test_prereqs)
-fvtest/sigtest :: $(test_prereqs)
-fvtest/threadextendedtest :: $(test_prereqs)
-fvtest/threadtest :: $(test_prereqs)
-fvtest/utiltest :: $(test_prereqs)
-fvtest/vmtest :: $(test_prereqs)
+fvtest/algotest : $(test_prereqs)
+fvtest/gctest : $(test_prereqs)
+fvtest/jitbuildertest : $(test_prereqs)
+fvtest/porttest : $(test_prereqs)
+fvtest/rastest : $(test_prereqs)
+fvtest/sigtest : $(test_prereqs)
+fvtest/threadextendedtest : $(test_prereqs)
+fvtest/threadtest : $(test_prereqs)
+fvtest/utiltest : $(test_prereqs)
+fvtest/vmtest : $(test_prereqs)
 
-perftest/gctest :: $(test_prereqs)
+perftest/gctest : $(test_prereqs)
 
 # Test Compiler dependencies
 ifeq (1,$(OMR_TEST_COMPILER))
-  fvtest/compilertest :: $(compiler_prereqs)
+  fvtest/compilertest : $(compiler_prereqs)
 endif
 
 # JitBuilder dependencies
 ifeq (1,$(OMR_JITBUILDER))
-  fvtest/jitbuildertest :: $(compiler_prereqs)
-  jitbuilder :: $(compiler_prereqs)
-  jitbuilder/release/cpp :: $(compiler_prereqs)
+  fvtest/jitbuildertest : $(compiler_prereqs)
+  jitbuilder : $(compiler_prereqs)
+  jitbuilder/release/cpp : $(compiler_prereqs)
 endif
 
 ###
 ### Targets
 ###
 
-$(targets) ::
+$(targets) :
 	$(MAKE) -C $@ all
+
 .PHONY : $(targets)
 
 % :
@@ -309,7 +307,7 @@ $(targets) ::
 	@exit -1
 
 clean : $(targets_clean) hook_definition_sentinel_clean
-$(targets_clean) ::
+$(targets_clean) :
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
 .PHONY : $(targets_clean)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -297,6 +297,13 @@ endif
 ### Targets
 ###
 
+# Because we haven't expressed dependencies of these targets clearly, we can't
+# allow make to build them in parallel (at least at this level). Otherwise,
+# things like util/a2e (a prerequisite of several targets) get built twice.
+# Often we get lucky and both branches leave things in a reasonable state for
+# dependents, but not always.
+.NOTPARALLEL :
+
 $(targets) :
 	$(MAKE) -C $@ all
 

--- a/ddr/Makefile
+++ b/ddr/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2018 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,6 @@ test: tools lib
 
 targets_clean := $(addsuffix _clean,$(targets))
 clean: $(targets_clean)
-$(targets_clean)::
+$(targets_clean):
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
 .PHONY: $(targets_clean)

--- a/ddr/lib/Makefile
+++ b/ddr/lib/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,6 @@ $(targets):
 
 targets_clean := $(addsuffix _clean,$(targets))
 clean: $(targets_clean)
-$(targets_clean)::
+$(targets_clean):
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
 .PHONY: $(targets_clean)

--- a/ddr/tools/Makefile
+++ b/ddr/tools/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
+# Copyright (c) 2015, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,6 @@ $(targets):
 
 targets_clean := $(addsuffix _clean,$(targets))
 clean: $(targets_clean)
-$(targets_clean)::
+$(targets_clean):
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
 .PHONY: $(targets_clean)

--- a/fvtest/compilertest/iwyu.mk
+++ b/fvtest/compilertest/iwyu.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,8 +71,7 @@
 #
 
 .PHONY: iwyu
-iwyu::
-
+iwyu:
 
 # default paths, unless overriden
 export CC_PATH?=include-what-you-use
@@ -145,7 +144,7 @@ define DEF_RULE.iwyu
 $(1).iwyu: $(1)
 	- $$(CXX_CMD) $(LINTER_FLAGS) $$(patsubst %,-D%,$$(CXX_DEFINES)) $$(patsubst %,-I'%',$$(CXX_INCLUDES)) $$<
 
-iwyu:: $(1).iwyu
+iwyu: $(1).iwyu
 
 endef # DEF_RULE.iwyu
 

--- a/fvtest/compilertest/linter.mk
+++ b/fvtest/compilertest/linter.mk
@@ -19,20 +19,20 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-# To lint: 
+# To lint:
 #
-# PLATFORM=foo-bar-clang make -f linter.mk 
+# PLATFORM=foo-bar-clang make -f linter.mk
 #
 
 .PHONY: linter
-linter::
+linter:
 
 ifeq ($(PLATFORM),ppc64-linux64-clangLinter)
     export LLVM_CONFIG?=/tr/llvm_checker/ppc-64/sles11/bin/llvm-config
     export CC_PATH?=/tr/llvm_checker/ppc-64/sles11/bin/clang
     export CXX_PATH?=/tr/llvm_checker/ppc-64/sles11/bin/clang++
-else 
-    #default paths, unless overriden 
+else
+    #default paths, unless overriden
     export LLVM_CONFIG?=llvm-config
     export CC_PATH?=clang
     export CXX_PATH?=clang++
@@ -63,7 +63,7 @@ BUILD_CONFIG?=debug
 #
 # This is where we setup our component dirs
 # Note these are all relative to JIT_SRCBASE and JIT_OBJBASE
-# It just makes sense since source and build dirs may be in different places 
+# It just makes sense since source and build dirs may be in different places
 # in the filesystem :)
 #
 JIT_OMR_DIRTY_DIR?=compiler
@@ -101,9 +101,9 @@ include $(JIT_MAKE_DIR)/toolcfg/common.mk
 #
 # Add OMRChecker targets
 #
-# This likely ought to be using the OMRChecker fragment that 
-# exists in that repo, but in the mean time, this is fine. 
-# 
+# This likely ought to be using the OMRChecker fragment that
+# exists in that repo, but in the mean time, this is fine.
+#
 
 OMRCHECKER_DIR?=$(JIT_SRCBASE)/tools/compiler/OMRChecker
 
@@ -131,45 +131,45 @@ omrchecker_cleanall:
 	cd $(OMRCHECKER_DIR); make cleanall
 
 
-# The core linter bits.  
-# 
-# linter:: is the default target, and we construct a pre-req for each
+# The core linter bits.
+#
+# linter is the default target, and we construct a pre-req for each
 #  .cpp file.
 #
-linter:: omrchecker 
+linter: omrchecker
 
 # It seems that different versions of clang either do or do not define these,
 # however, it appears that it's not possible to check for definitions
-# using macros. 
+# using macros.
 #
 # Given that the purpose of linting is categorically not to produce a
 # functional binary, and to ease our progress right now, we choose to exclude
-# the problematic builtins, wiping out their definitions with nothing. 
+# the problematic builtins, wiping out their definitions with nothing.
 #
 # A longer term answer might involve autoconf detection in the omr project,
 # however, that doesn't fix all of our problems, as we are typically not
 # reconfiguring for clang when running lint (though, perhaps this is an early
-# indicator that we really should be.  
+# indicator that we really should be.
 EXCLUDED_DEFINES='-D__sync()=' '-D__lwsync()=' '-D__isync()='
 
 # The clang invocation magic line.
-LINTER_EXTRA=-Xclang -load -Xclang $(OMRCHECKER_OBJECT) -Xclang -add-plugin -Xclang omr-checker 
+LINTER_EXTRA=-Xclang -load -Xclang $(OMRCHECKER_OBJECT) -Xclang -add-plugin -Xclang omr-checker
 LINTER_FLAGS=-std=c++0x -w -fsyntax-only $(EXCLUDED_DEFINES) -ferror-limit=0 $(LINTER_FLAGS_EXTRA)
 
 define DEF_RULE.linter
-.PHONY: $(1).linted 
+.PHONY: $(1).linted
 
-$(1).linted: $(1) omrchecker 
+$(1).linted: $(1) omrchecker
 	$$(CXX_CMD) $(LINTER_FLAGS) $(LINTER_EXTRA)  $$(patsubst %,-D%,$$(CXX_DEFINES)) $$(patsubst %,-I'%',$$(CXX_INCLUDES)) -o $$@ -c $$<
-linter:: $(1).linted 
+linter: $(1).linted
 
 endef # DEF_RULE.linter
 
 RULE.linter=$(eval $(DEF_RULE.linter))
 
-# The list of sources. 
+# The list of sources.
 JIT_CPP_FILES=$(filter %.cpp,$(JIT_PRODUCT_SOURCE_FILES) $(JIT_PRODUCT_BACKEND_SOURCES))
 
-# Construct lint dependencies. 
+# Construct lint dependencies.
 $(foreach SRCFILE,$(JIT_CPP_FILES),\
    $(call RULE.linter,$(FIXED_SRCBASE)/$(SRCFILE)))


### PR DESCRIPTION
Run select parts of make-based builds sequentially.
 - Because we haven't expressed dependencies of these targets clearly, we can't allow make to build them in parallel (at least at this level). Otherwise, things like util/a2e (a prerequisite of several targets) get built twice. Often we get lucky and both branches leave things in a reasonable state for dependents, but not always.

Remove unnecessary uses of double-colon rules in makefiles.