### PR TITLE
NULL ptr field `_postDominators` to avoid scope issues in future

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -192,8 +192,15 @@ int32_t TR_LoopVersioner::performWithDominators()
       {
          printf("WARNING: method may have infinite loops\n");
       }
+   auto result = performWithoutDominators();
 
-   return performWithoutDominators();
+   /* Local variable postDominators is about to go out of scope.
+    * NULL this field to prevent illegal access to a stack
+    * allocated object.
+    */
+   _postDominators = NULL;
+
+   return result;
    }
 
 


### PR DESCRIPTION
Pointer field `_postDominator` gets initialized to a local variable.
As of right now all access points of the variable are guarded by NULL
checks. Setting it to NULL before we exit the method to avoid bugs which
may arise from accidental use of the variable without a NULL check.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>