### PR TITLE
Explicitly specify output for resource compiler

### DIFF
--- a/omrmakefiles/rules.win.mk
+++ b/omrmakefiles/rules.win.mk
@@ -190,7 +190,7 @@ RC_INCLUDES=$(call buildCPPIncludeFlags,$(MODULE_INCLUDES) $(GLOBAL_INCLUDES))
 
 # compilation rule for text resource files on Windows
 %.res: %.rc
-	$(RC) $(RC_INCLUDES) $<
+	$(RC) /fo $@ $(RC_INCLUDES) $<
 
 define AR_COMMAND
 $(AR) -out:$@ $(OBJECTS)


### PR DESCRIPTION
Without `/fo`, `rc` writes the `*.res` file in the same directory as the `*.rc` file. Some versions of `make` form the command as:
```
  rc {options} ./win32/omrsyslogmessages.rc
```
which yields the `*.res` file in the win32 directory which then won't be found at the link step.