### PR TITLE
Correct formating to clarify code in for loop

### DIFF
--- a/compiler/codegen/ELFGenerator.cpp
+++ b/compiler/codegen/ELFGenerator.cpp
@@ -59,7 +59,7 @@ TR::ELFGenerator::initializeELFHeaderForPlatform(void)
     
     for (auto b = EI_PAD;b < EI_NIDENT;b++)
         _header->e_ident[b] = 0;
-        _header->e_ident[EI_OSABI] = ELFOSABI_LINUX; // Current support for Linux only. AIX would use the macro ELFOSABI_AIX.
+    _header->e_ident[EI_OSABI] = ELFOSABI_LINUX; // Current support for Linux only. AIX would use the macro ELFOSABI_AIX.
     
     if (TR::Compiler->target.cpu.isX86())
     {


### PR DESCRIPTION
Formating implies that e_ident is set in the loop but
it's only set once, after the loop.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>