### PR TITLE
Use TR_BitVector instead of CS2::ABitVector in TR_InterferenceGraph

### DIFF
--- a/compiler/infra/InterferenceGraph.hpp
+++ b/compiler/infra/InterferenceGraph.hpp
@@ -76,9 +76,9 @@ class TR_InterferenceGraph : public TR_IGBase
    TR_StackMemory            trStackMemory()               { return _trMemory; }
    TR_HeapMemory             trHeapMemory()                { return _trMemory; }
 
-   void partitionNodesIntoDegreeSets(CS2::ABitVector<TR::Allocator> &workingSet,
-                                     CS2::ABitVector<TR::Allocator> &colourableDegreeSet,
-                                     CS2::ABitVector<TR::Allocator> &notColourableDegreeSet);
+   void partitionNodesIntoDegreeSets(TR_BitVector *workingSet,
+                                     TR_BitVector *colourableDegreeSet,
+                                     TR_BitVector *notColourableDegreeSet);
 
    TR::Compilation *_compilation;
    TR_Memory *_trMemory;


### PR DESCRIPTION
Some of the largest symbols in the compiler obj files originates
from TR_InterferenceGraph resulting from its use of
CS2::ABitVector, while providing no real benefits in terms
of capabilities or performance. Use of CS2::ABitVector has been
replaced with TR_BitVector in TR_InterferenceGraph, which results
in significant reduction in the size of the Compiler component's
obj files, whether it is part of a standalone OMR build or part of
a downstream project.

With this fairly small change, compiler builds will see a 41.5 KB
reduction in the on-disk size of the obj files.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>