### PR TITLE
Changes to support sequentialStoreSimplification opt

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1200,6 +1200,9 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceSamplingJProfiling",          "L\ttrace samplingjProfiling",                     TR::Options::traceOptimization, samplingJProfiling, 0, "P"},
    {"traceSEL",                         "L\ttrace sign extension load",                    TR::Options::traceOptimization, signExtendLoads, 0, "P"},
    {"traceSequenceSimplification",      "L\ttrace arithmetic sequence simplification",     TR::Options::traceOptimization, expressionsSimplification, 0, "P"},
+#ifdef J9_PROJECT_SPECIFIC
+   {"traceSequentialStoreSimplification", "L\ttrace sequential load or store simplification", TR::Options::traceOptimization, sequentialStoreSimplification, 0, "P"},
+#endif
    {"traceStaticFinalFieldFolding",     "L\ttrace generic static final field folding",             TR::Options::traceOptimization, staticFinalFieldFolding, 0, "P"},
    {"traceStringBuilderTransformer",    "L\ttrace StringBuilder tranfsofermer optimization", TR::Options::traceOptimization, stringBuilderTransformer, 0, "P"},
    {"traceStringPeepholes",             "L\ttrace string peepholes",                       TR::Options::traceOptimization, stringPeepholes, 0, "P"},

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -278,10 +278,11 @@ OMR::Power::CodeGenerator::initialize()
    if (cg->is64BitProcessor())
       cg->setSupportsInlinedAtomicLongVolatiles();
 
-   // Standard allows only offset multiple of 4
-   // TODO: either improves the query to be size-based or gets the offset into a register
-   if (comp->target().is64Bit())
+   if (!comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9) &&
+       !(comp->target().cpu.isBigEndian() && comp->target().cpu.is(OMR_PROCESSOR_PPC_P8)))
+      {
       cg->setSupportsAlignedAccessOnly();
+      }
 
    // TODO: distinguishing among OOO and non-OOO implementations
    if (comp->target().isSMP())


### PR DESCRIPTION
The changes in this PR are tied to the `sequentialStoreSimplification` opt in OpenJ9.

`setSupportsAlignedAccessOnly` sets the `SupportsAlignedAccessOnly` flag. The `SequentialStoreSimplification` optimization checks on the status of this flag to determine whether it should proceed or not. Currently, this is the only place in OMR and OpenJ9 that queries the flag. Due to updates to the `sequentialStoreSimplification` opt in OpenJ9, it became desireable to update how the `SupportsAlignedAccessOnly` flag is set on Power to be a bit more accurate. As such the following changes are made:

`SupportsAlignedAccessOnly` flag is no longer set for 64 bit Power 9.
`SupportsAlignedAccessOnly` flag is no longer set for 64 bit BE Power 8.
`SupportsAlignedAccessOnly` flag is now set for 32 bit Power 7.

This was done to more accurately represent which cases has performance issues with unaligned accesses.

Also added new trace option, traceSequentialStoreSimplification. It enables tracing for the `sequentialStoreSimplification` opt.

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>