### PR TITLE
Add `contextid` in `concurrent-collection-start` 

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -335,6 +335,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t"  name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
+		<data type="uintptr_t" name="contextid" description="unique identifier of the associated event this is associated with (parent/sibling relationship)" />
 		<data type="struct MM_CommonGCStartData*" name="gcStartData" description="common data for GC start events" />
 		<data type="uintptr_t" name="traceTarget" description="the targetted number of bytes to be concurrently traced" />
 		<data type="uintptr_t" name="tracedTotal" description="the number of bytes concurrently traced" />

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -365,6 +365,7 @@ MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentBase *env)
 			env->getOmrVMThread(),
 			omrtime_hires_clock(),
 			J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_START,
+			_concurrentCycleState._verboseContextID,
 			&commonData,
 			_stats.getTraceSizeTarget(),
 			_stats.getTotalTraced(),
@@ -384,8 +385,6 @@ MM_ConcurrentGC::reportConcurrentCollectionStart(MM_EnvironmentBase *env)
 void
 MM_ConcurrentGC::reportConcurrentCollectionEnd(MM_EnvironmentBase *env, uint64_t duration)
 {
-	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
-
 	Trc_MM_ConcurrentCollectionEnd(env->getLanguageVMThread(),
 		_extensions->heap->getApproximateActiveFreeMemorySize(MEMORY_TYPE_NEW),
 		_extensions->heap->getActiveMemorySize(MEMORY_TYPE_NEW),
@@ -394,21 +393,6 @@ MM_ConcurrentGC::reportConcurrentCollectionEnd(MM_EnvironmentBase *env, uint64_t
 		(_extensions-> largeObjectArea ? _extensions->heap->getApproximateActiveFreeLOAMemorySize(MEMORY_TYPE_OLD) : 0 ),
 		(_extensions-> largeObjectArea ? _extensions->heap->getActiveLOAMemorySize(MEMORY_TYPE_OLD) : 0 )
 	);
-
-	if (J9_EVENT_IS_HOOKED(_extensions->privateHookInterface, J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_END)) {
-		MM_CommonGCEndData commonData;
-		_extensions->heap->initializeCommonGCEndData(env, &commonData);
-
-		ALWAYS_TRIGGER_J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_END(
-				_extensions->privateHookInterface,
-				env->getOmrVMThread(),
-				omrtime_hires_clock(),
-				J9HOOK_MM_PRIVATE_CONCURRENT_COLLECTION_END,
-				duration,
-				env->getExclusiveAccessTime(),
-				&commonData
-		);
-	}
 }
 
 void

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -162,6 +162,17 @@ MM_VerboseHandlerOutput::getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t 
 }
 
 uintptr_t
+MM_VerboseHandlerOutput::getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, uintptr_t contextId, uint64_t wallTimeMs)
+{
+	OMRPORT_ACCESS_FROM_OMRVM(_omrVM);
+	uintptr_t bufPos = 0;
+	bufPos += getTagTemplate(buf, bufsize, id, wallTimeMs);
+	bufPos += omrstr_printf(buf + bufPos, bufsize - bufPos, " contextid=\"%zu\"", contextId);
+
+	return bufPos;
+}
+
+uintptr_t
 MM_VerboseHandlerOutput::getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t wallTimeMs)
 {
 	OMRPORT_ACCESS_FROM_OMRVM(_omrVM);

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -301,6 +301,19 @@ public:
 	 * @param buf character buffer in which to create to tag template.
 	 * @param bufsize maximum size allowed in the character buffer.
 	 * @param id unique id of the tag being built.
+	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
+	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.
+	 * @return number of bytes consumed in the buffer.
+	 *
+	 * @note should be moved to protected once all standard usage is converted.
+	 */
+	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, uintptr_t contextId, uint64_t wallTimeMs);
+
+	/**
+	 * Build the standard top level tag template.
+	 * @param buf character buffer in which to create to tag template.
+	 * @param bufsize maximum size allowed in the character buffer.
+	 * @param id unique id of the tag being built.
 	 * @param type Human readable name for the type of the tag.
 	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
 	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -79,7 +79,6 @@ protected:
 	virtual const char* getConcurrentKickoffReason(void *eventData);
 	virtual void handleConcurrentHaltedInternal(MM_EnvironmentBase *env, void* eventData);
 	virtual void handleConcurrentCollectionStartInternal(MM_EnvironmentBase *env, void* eventData);
-	virtual void handleConcurrentCollectionEndInternal(MM_EnvironmentBase *env, void* eventData);
 	virtual void handleConcurrentAbortedInternal(MM_EnvironmentBase *env, void* eventData);
 #endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 
@@ -192,14 +191,6 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleConcurrentCollectionStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
-
-	/**
-	 * Write verbose stanza for concurrent collection end event.
-	 * @param hook Hook interface used by the JVM.
-	 * @param eventNum The hook event number.
-	 * @param eventData hook specific event data.
-	 */
-	void handleConcurrentCollectionEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 
 	/**
 	 * Write verbose stanza for concurrent aborted event.

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -47,9 +47,8 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="af-start" type="vgc:af-start" />
 	<element name="af-end" type="vgc:af-end" />
 	<element name="allocation-taxation" type="vgc:allocation-taxation" />
-	<element name="concurrent-collection-start" type="vgc:concurrent-collection-start" />
+	<element name="concurrent-global-final" type="vgc:concurrent-global-final" />
 	<element name="concurrent-trace-info" type="vgc:concurrent-trace-info" />
-	<element name="concurrent-collection-end" type="vgc:concurrent-collection-end" />
 	<element name="cycle-start" type="vgc:cycle-start" />
 	<element name="cycle-continue" type="vgc:cycle-continue" />
 	<element name="cycle-end" type="vgc:cycle-end" />
@@ -133,8 +132,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 				<element ref="vgc:af-start" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:af-end" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:allocation-taxation" maxOccurs="1" minOccurs="1" />
-				<element ref="vgc:concurrent-collection-start" maxOccurs="1" minOccurs="1" />
-				<element ref="vgc:concurrent-collection-end" maxOccurs="1" minOccurs="1" />
+				<element ref="vgc:concurrent-global-final" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:cycle-start" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:cycle-continue" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:cycle-end" maxOccurs="1" minOccurs="1" />
@@ -296,11 +294,12 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="intervalms" type="float" use="required" />
 	</complexType>	
 
-	<complexType name="concurrent-collection-start">
+	<complexType name="concurrent-global-final">
 		<sequence maxOccurs="1" minOccurs="1">
 			<element ref="vgc:concurrent-trace-info" maxOccurs="1" minOccurs="1" />
 		</sequence>
 		<attribute name="id" type="integer" use="required" />
+		<attribute name="contextid" type="integer" use="required" />
 		<attribute name="timestamp" type="dateTime" use="required" />
 		<attribute name="intervalms" type="float" use="required" />
 	</complexType>
@@ -311,11 +310,6 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="tracedByHelpers" type="integer" use="required" />
 		<attribute name="cardsCleaned" type="integer" use="required" />
 		<attribute name="workStackOverflowCount" type="integer" use="required" />
-	</complexType>
-
-	<complexType name="concurrent-collection-end">
-		<attribute name="id" type="integer" use="required" />
-		<attribute name="timestamp" type="dateTime" use="required" />
 	</complexType>
 
 	<complexType name="cycle-start">


### PR DESCRIPTION
https://github.com/eclipse/openj9/issues/11237

Added attribute `contextid` to `concurrent-collection-start` stanza. 
Changed name of `concurrent-collection-start` stanza to `conurrent-global-final` to show its relation to `cycle-end` stanza which follows it.
Removed `concurrent-collection-end` to reduce redundancy with `exclusive` stanza follows it.
Overloaded `MM_VerboseHandlerOutput::getTagTemplate()` to take `contextid`

Signed-off-by: Enson Guo <enson.guo@ibm.com>