### PR TITLE
Supporting changes to add fences after volatile field stores

### DIFF
--- a/compiler/runtime/Helpers.inc
+++ b/compiler/runtime/Helpers.inc
@@ -605,6 +605,7 @@ SETVAL(TR_S390OutlinedNewArray,TR_FSRH+95)
 SETVAL(TR_S390jitResolveHandleMethod,TR_FSRH+96)
 SETVAL(TR_S390jitResolveConstantDynamic, TR_FSRH+97)
 SETVAL(TR_S390jitResolveConstantDynamicGlue, TR_FSRH+98)
-SETVAL(TR_S390numRuntimeHelpers,TR_FSRH+99)
+SETVAL(TR_S390jitResolvedFieldIsVolatile, TR_FSRH+99)
+SETVAL(TR_S390numRuntimeHelpers,TR_FSRH+100)
 
 SETVAL(TR_RISCVnumRuntimeHelpers,TR_FSRH+1)

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5693,7 +5693,7 @@ astoreHelper(TR::Node * node, TR::CodeGenerator * cg)
             }
          }
       // aload is the child, then don't evaluate the child, generate MVC to move directly among memory
-      else if(!node->getOpCode().isIndirect() &&
+      else if(!node->getOpCode().isIndirect() && !node->getSymbolReference()->isUnresolved() &&
               valueChild->getOpCodeValue() == TR::aload &&
               valueChild->getReferenceCount() == 1 &&
               valueChild->getRegister() == NULL &&


### PR DESCRIPTION
Changes in PR adds supporting changes to add fences after volatile field stores made in https://github.com/eclipse/openj9/pull/11262.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>