### PR TITLE
Swap dequeue and decrement in Scavenger scan queue

### DIFF
--- a/gc/base/standard/CopyScanCacheList.cpp
+++ b/gc/base/standard/CopyScanCacheList.cpp
@@ -288,7 +288,6 @@ MM_CopyScanCacheList::decrementCount(CopyScanCacheSublist *sublist, uintptr_t va
 
 	if ((0 == sublist->_entryCount) && (NULL != _cachedEntryCount)) {
 		Assert_MM_true(*_cachedEntryCount >= 1);
-		Assert_MM_true(NULL == sublist->_cacheHead);
 		if (1 == _sublistCount) {
 			*_cachedEntryCount -= 1;
 		} else {
@@ -332,8 +331,8 @@ MM_CopyScanCacheList::popCache(MM_EnvironmentBase *env)
 			list->_cacheLock.acquire();
 			cache = list->_cacheHead;
 			if (NULL != cache) {
-				list->_cacheHead = (MM_CopyScanCacheStandard *)cache->next;
 				decrementCount(list, 1);
+				list->_cacheHead = (MM_CopyScanCacheStandard *)cache->next;
 
 				if (NULL == list->_cacheHead) {
 					Assert_MM_true(0 == list->_entryCount);


### PR DESCRIPTION
Currently, we decrement the counter of non-empty sub-queues after we
remove an element from a sub-queue. In a corner case, when this is the
last element of the last non-empty queue, for a moment there will be
effectively no elements in the queue, but the counter will not be zero.
If the GC thread doing dequeue is stalled (by OS due to overloaded CPUs)
at that moment, other worker GC threads may spin in a higher level scan
loop trying to dequeue a (non-existent) element from seemingly non-empty
queue. The spinning takes CPU resources and does not help the stalled
thread resume.

By re-ordering these 2 steps, if a thread stalls between them, the queue
will appear as empty before the dequeue, what will make other GC threads
quickly block (although they may shortly spin on spinlock of the that
non-empty sub-queue). That in turn will release CPU resources and give a
chance to the stalled thread to resume running.

This new order of operation in dequeue will now be a mirrored order of
what occurs in enqueue steps (first add element and then increment),
what indeed makes sense.

The explained problematic scenario is extremely rare, and this change
for the most part is not expected to change Scavenge behavior.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>