### PR TITLE
RISC-V: refactor instruction encoding macros

### DIFF
--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -24,8 +24,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <riscv.h>
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Register.hpp"
+#include "codegen/InstOpCode.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "il/LabelSymbol.hpp"
@@ -34,6 +37,90 @@
 namespace TR { class SymbolReference; }
 
 #define RISCV_INSTRUCTION_LENGTH 4
+
+static inline uint32_t
+TR_RISCV_RTYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t rs2)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2));
+   }
+
+static inline uint32_t
+TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, TR::Register *rs2)
+   {
+   return TR_RISCV_RTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode());
+   }
+
+
+static inline uint32_t
+TR_RISCV_ITYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t imm)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ENCODE_ITYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, uint32_t imm)
+   {
+   return TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_STYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
+   {
+   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_STYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_STYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_SBTYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
+   {
+   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_SBTYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_SBTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_UTYPE(uint32_t insn, uint32_t rd, uint32_t bigimm)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UTYPE_IMM(bigimm));
+   }
+
+static inline uint32_t
+TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t bigimm)
+   {
+   return TR_RISCV_UTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), bigimm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_UJTYPE(uint32_t insn, uint32_t rd, uint32_t target)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UJTYPE_IMM(target));
+   }
+
+static inline uint32_t
+TR_RISCV_UJTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t target)
+   {
+   return TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), target);
+   }
+
+static inline uint32_t
+TR_RISCV_UJTYPE(TR::InstOpCode &insn, TR::Register *rd, uint32_t target)
+   {
+   return TR_RISCV_UJTYPE(insn.getMnemonic(), rd, target);
+   }
+
 
 namespace TR
 {


### PR DESCRIPTION
This commit replaces `TR_RISCV_?TYPE()` macros with (inline) functions
and provide overloaded versions for easier use. This provides a nicer
instruction encoding interface for encoding snippets.
