### PR TITLE
Changes for Object Format API on Z

### DIFF
--- a/compiler/objectfmt/OMRObjectFormat.hpp
+++ b/compiler/objectfmt/OMRObjectFormat.hpp
@@ -124,7 +124,7 @@ public:
     * @param[in] data : a populated \c TR::FunctionCallData structure with valid parameters
     *          for an encoded function call.
     */
-   virtual void printEncodedFunctionCall(TR::FILE *file, TR::FunctionCallData &data) = 0;
+   virtual uint8_t* printEncodedFunctionCall(TR::FILE *file, TR::FunctionCallData &data) = 0;
 
    };
 

--- a/compiler/z/codegen/CallSnippet.hpp
+++ b/compiler/z/codegen/CallSnippet.hpp
@@ -82,6 +82,19 @@ class S390CallSnippet : public TR::Snippet
    static uint8_t *S390flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
    static int32_t instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg);
 
+   /**
+    * @brief For a given call from snippet (Usually helper calls) calculate the
+    * offset needed for RIL type instructions and if the call is not reachable,
+    * create trampoline.
+    *
+    * @param targetAddr : address of the target function for call
+    * @param currentInst : bufferAddress where call instruction will be encoded
+    *
+    * @return return number of halfwords required to add to the currentInst to
+    *         get the targetAddress
+    */
+   static int32_t adjustCallOffsetWithTrampoline(uintptr_t targetAddr, uint8_t *currentInst, TR::SymbolReference *callSymRef, TR::Snippet *snippet);
+
    };
 
 }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -5794,3 +5794,4 @@ OMR::Z::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddress, intp
       !self()->comp()->target().cpu.isTargetWithinBranchRelativeRILRange(targetAddress, sourceAddress) ||
       self()->comp()->getOption(TR_StressTrampolines);
    }
+

--- a/compiler/z/objectfmt/FunctionCallData.hpp
+++ b/compiler/z/objectfmt/FunctionCallData.hpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_FUNCTIONCALLDATA_INCL
+#define TR_FUNCTIONCALLDATA_INCL
+
+#include "infra/Annotations.hpp"
+#include "objectfmt/OMRFunctionCallData.hpp"
+#include "runtime/Runtime.hpp"
+
+namespace TR { class Instruction; }
+namespace TR { class SymbolReference; }
+namespace TR { class Node; }
+namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
+namespace TR { class CodeGenerator; }
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE FunctionCallData : public OMR::FunctionCallDataConnector
+   {
+public:
+
+   /**
+    * @brief Constructor for FunctionCallData used to generate instruction for
+    *     helper calls
+    *
+    * @param methodSymRef : \c TR::SymbolReference of the function to call.
+    * @param callNode : \c TR::Node node associated with this function call
+    * @param cg : \c TR::CodeGenerator object.
+    * @param returnAddressReg : \c TR::Register used to hold the return address
+    *           for the call instruction.
+    * @param entryPointReg : \c TR::Register used as entry point register where
+    *           target address can not be addressible using Long relative instruction.
+    * @param regDeps : \c TR::RegisterDependencyConditions to be attached to the
+    *           call instruction.
+    * @param prevInstr : \c TR::Instruction preceding to function call.
+    */
+   FunctionCallData(
+         TR::CodeGenerator *cg,
+         TR::SymbolReference *methodSymRef,
+         TR::Node *callNode,
+         TR::Register *returnAddressReg,
+         TR::Register *entryPointReg = NULL,
+         TR::RegisterDependencyConditions *regDeps = NULL,
+         TR::Instruction *prevInstr = NULL) :
+      OMR::FunctionCallDataConnector(cg, methodSymRef, callNode, NULL,
+         static_cast<intptr_t>(0), returnAddressReg, entryPointReg, regDeps, prevInstr,
+         (TR_RuntimeHelper)0, TR_NoRelocation, NULL) {}
+
+   /**
+    * @brief Constructor for FunctionCallData used to encode a function call
+    *
+    * @param methodSymRef : \c TR::SymbolReference of the function to call
+    * @param callNode : \c TR::Node node associated with this function call
+    * @param bufferAddress : \c Buffer address where this function call will be
+    *          encoded from.
+    * @param cg : \c TR::CodeGenerator object
+    * @param snippet : \c TR::Snippet where this function call is encoded
+    * @param reloKind : \c External relocation kind
+    */
+   FunctionCallData(
+         TR::CodeGenerator *cg,
+         TR::SymbolReference *methodSymRef,
+         TR::Node *callNode,
+         uint8_t *bufferAddress,
+         TR::Snippet *snippet,
+         TR_ExternalRelocationTargetKind reloKind = TR_NoRelocation) : 
+      OMR::FunctionCallDataConnector(cg, methodSymRef, callNode, bufferAddress,
+         static_cast<intptr_t>(0), NULL, NULL, NULL, NULL,
+         (TR_RuntimeHelper)0, reloKind, snippet) {}
+   };
+
+}
+#endif

--- a/compiler/z/objectfmt/OMRFunctionCallData.hpp
+++ b/compiler/z/objectfmt/OMRFunctionCallData.hpp
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_Z_FUNCTIONCALLDATA_INCL
+#define OMR_Z_FUNCTIONCALLDATA_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_FUNCTIONCALLDATA_CONNECTOR
+#define OMR_FUNCTIONCALLDATA_CONNECTOR
+namespace OMR { namespace Z { class FunctionCallData; } }
+namespace OMR { typedef OMR::Z::FunctionCallData FunctionCallDataConnector; }
+#endif
+
+#include "compiler/objectfmt/OMRFunctionCallData.hpp"
+#include "runtime/Runtime.hpp"
+
+namespace TR { class Instruction; }
+namespace TR { class SymbolReference; }
+namespace TR { class Node; }
+namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
+namespace TR { class CodeGenerator; }
+namespace TR { class Snippet; }
+
+namespace OMR
+{
+
+namespace Z
+{
+
+class OMR_EXTENSIBLE FunctionCallData : public OMR::FunctionCallData
+   {
+public:
+
+   /**
+    * @brief Z specific implementation of FunctionCallData
+    *
+    * @param methodSymRef : \c TR::SymbolReference of the function to call
+    * @param callNode : \c TR::Node associcated with the function call
+    * @param bufferAddress : \c In case encoding a function call, instruction
+    *          for call will be encoded from this address. 
+    * @param targetAddress : \c a specific function address to call that
+    *          overrides the address in the symbol reference; or 0 if none
+    * @param returnAddressReg : \c A register to be used to hold the return
+    *          address for the call instruction
+    * @param entryPointReg : \c A register to use as Entry Point Register where
+    *          target address is out of the relative addresssible range of BRASL
+    * @param regDeps : \c TR::RegisterDependencyConditions to be attach to the
+    *          call
+    * @param prevInstr : \c TR::Instruction of the previous instruction, if any
+    * @param runtimeHelperInder : \c the runtime helper index if calling a helper
+    * @param reloKind : \c the external relocation kind associated with this
+    *          function call
+    * @param snippet : \c TR::Snippet in which call is encoded if function is
+    *          called from the snippet.
+    * @param cg : \c TR::CodeGenerator object
+    */
+   FunctionCallData(
+         TR::CodeGenerator *cg,
+         TR::SymbolReference *methodSymRef,
+         TR::Node *callNode,
+         uint8_t *bufferAddress,
+         intptr_t targetAddress,
+         TR::Register *returnAddressReg,
+         TR::Register *entryPointReg,
+         TR::RegisterDependencyConditions *regDeps,
+         TR::Instruction *prevInstr,
+         TR_RuntimeHelper runtimeHelperIndex,
+         TR_ExternalRelocationTargetKind reloKind,
+         TR::Snippet *snippet) :
+      OMR::FunctionCallData(cg, methodSymRef, callNode, bufferAddress),
+         targetAddress(targetAddress),
+         returnAddressReg(returnAddressReg),
+         entryPointReg(entryPointReg),
+         regDeps(regDeps),
+         prevInstr(prevInstr),
+         runtimeHelperIndex(runtimeHelperIndex),
+         reloKind(reloKind),
+         snippet(snippet),
+         out_loadInstr(NULL),
+         out_callInstr(NULL) {}
+         
+
+   
+   /**
+    * If a non-zero targetAddress is provided, use that as the address of the function to call
+    */
+   uintptr_t targetAddress;
+
+   TR::Register *returnAddressReg;
+
+   TR::Register *entryPointReg;
+
+   TR::RegisterDependencyConditions *regDeps;
+
+   TR::Instruction *prevInstr;
+
+   /**
+    * If an intermediate load instruction was used to materialize the function to
+    * call then it may be set in this field.
+    */
+   TR::Instruction *out_loadInstr;
+
+   /**
+    * The call instruction that was generated to dispatch to the function.
+    */
+   TR::Instruction *out_callInstr;
+
+   TR_RuntimeHelper runtimeHelperIndex;
+
+   TR::Snippet *snippet;
+
+   TR_ExternalRelocationTargetKind reloKind;
+
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.cpp
+++ b/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.cpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "env/FilePointerDecl.hpp"
+#include "il/MethodSymbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "infra/Assert.hpp"
+#include "objectfmt/FunctionCallData.hpp"
+#include "objectfmt/JitCodeRWXObjectFormat.hpp"
+#include "objectfmt/OMRJitCodeRWXObjectFormat.hpp"
+#include "runtime/CodeMetaDataManager.hpp"
+#include "runtime/Runtime.hpp"
+#include "z/codegen/CallSnippet.hpp"
+#include "z/codegen/S390GenerateInstructions.hpp"
+
+TR::Instruction *
+OMR::Z::JitCodeRWXObjectFormat::emitFunctionCall(TR::FunctionCallData &data)
+   {
+   TR::SymbolReference *callSymRef = data.methodSymRef;
+   TR::CodeGenerator *cg = data.cg;
+   TR::Node *callNode = data.callNode;
+
+   if (callSymRef == NULL)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(callNode, data.runtimeHelperIndex > 0, "FunctionCallData does not contain symbol reference for call or valid TR_RuntimeHelper");
+      callSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(data.runtimeHelperIndex, false, false, false);
+      }
+
+   uintptr_t targetAddress = data.targetAddress != NULL ? data.targetAddress : reinterpret_cast<uintptr_t>(callSymRef->getMethodAddress());
+
+
+   TR_ASSERT_FATAL_WITH_NODE(callNode, targetAddress != NULL, "Unable to make a call as targetAddress for the Call is not found.");
+
+
+   // Now as we are going to make call, we need Return Address register. 
+   TR_ASSERT_FATAL_WITH_NODE(callNode, data.returnAddressReg != NULL, "returnAddressReg should be set to make a function call.");
+
+   
+   // We do not need to check if the address is addressible using RIL type
+   // instruction, as the instruction API will check for it and generate
+   // trampolines if needed.
+
+   TR::Instruction *callInstr = generateRILInstruction(cg, TR::InstOpCode::BRASL, callNode, data.returnAddressReg, callSymRef, reinterpret_cast<void*>(targetAddress), data.prevInstr);
+
+   data.out_callInstr = callInstr;
+
+   if (data.regDeps != NULL)
+      {
+      callInstr->setDependencyConditions(data.regDeps);
+      }
+
+   return callInstr;
+   }
+
+uint8_t *
+OMR::Z::JitCodeRWXObjectFormat::encodeFunctionCall(TR::FunctionCallData &data)
+   {
+   TR::SymbolReference *callSymRef = data.methodSymRef;
+   TR::CodeGenerator *cg = data.cg;
+   TR::Node *callNode = data.callNode;
+
+   if (callSymRef == NULL)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(callNode, data.runtimeHelperIndex > 0, "FunctionCallData does not contain symbol reference for call or valid TR_RuntimeHelper");
+      callSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(data.runtimeHelperIndex, false, false, false);
+      }
+
+   uintptr_t targetAddress = data.targetAddress != NULL ? data.targetAddress : reinterpret_cast<uintptr_t>(callSymRef->getMethodAddress());
+
+   uint8_t *cursor = data.bufferAddress;
+   TR_ASSERT_FATAL_WITH_NODE(callNode, targetAddress != NULL, "Unable to make a call as targetAddress for the Call is not found.");
+
+   if (data.snippet->getKind() == TR::Snippet::IsUnresolvedCall || data.snippet->getKind() == TR::Snippet::IsUnresolvedData)
+      {
+      // LARL r14,AddressOfConstantDataArea
+      uintptr_t larlInstructionAddress = reinterpret_cast<uintptr_t>(cursor);
+      *reinterpret_cast<int16_t *>(cursor) = 0xC0E0;
+      cursor += sizeof(int16_t);
+      uint8_t *larlOffsetAddress = cursor;
+      // For now skipping the encoding of offsetInHalfwords for LARL, will be updated later.
+      cursor += sizeof(int32_t);
+
+      *reinterpret_cast<int32_t *>(cursor) = 0xe300e000 + ((static_cast<int32_t>(cg->getEntryPointRegister()) - 1 ) << 20 );
+      cursor += sizeof(int32_t);
+
+      *reinterpret_cast<int16_t *>(cursor) = cg->comp()->target().is64Bit() ? 0x0004 : 0x0014;
+      cursor += sizeof(int16_t);
+      
+		// BCR   rEP
+      *reinterpret_cast<int16_t *>(cursor) = 0x07F0 + static_cast<int16_t>(cg->getEntryPointRegister() - 1);
+      cursor += sizeof(int16_t);
+
+      // Now updating the offset in LARL instruction
+      *reinterpret_cast<int32_t *>(larlOffsetAddress) = static_cast<int32_t>(((uintptr_t)cursor + data.snippet->getPadBytes() - larlInstructionAddress ) / 2); 
+      }
+   else
+      {
+      uint8_t *instrAddr = cursor;
+      *reinterpret_cast<int16_t *>(cursor) = 0xC0E5;
+      cursor += sizeof(int16_t);
+      *reinterpret_cast<int32_t *>(cursor) = TR::S390CallSnippet::adjustCallOffsetWithTrampoline(targetAddress, instrAddr, callSymRef, data.snippet);
+      // TODO: We should be able to use reloKind field from the FunctionCallData to add relocation.
+      // Probably only change apart from the hardcoded TR_HelperAddress is to get the correct Diagnostic message for AOT.
+      AOTcgDiag1(cg->comp(), "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
+      cg->addProjectSpecializedRelocation(cursor, (uint8_t*) callSymRef, NULL, TR_HelperAddress,
+                                    __FILE__, __LINE__, callNode);
+      cursor += sizeof(int32_t);
+      }
+
+   return cursor;
+   }
+
+uint8_t *
+OMR::Z::JitCodeRWXObjectFormat::printEncodedFunctionCall(TR::FILE *pOutFile, TR::FunctionCallData &data)
+   {
+   uint8_t *bufferPos = data.bufferAddress;
+   TR_Debug *debug = data.cg->getDebug();
+   if (data.snippet->getKind() == TR::Snippet::IsUnresolvedCall || data.snippet->getKind() == TR::Snippet::IsUnresolvedData)
+      {
+      debug->printPrefix(pOutFile, NULL, bufferPos, 6);
+      trfprintf(pOutFile, "LARL \tGPR14, <%p>\t# Start of Data Const.",
+               bufferPos + 6 /*LARL*/ + 6 /*LG/LGF*/ + 2 /*BRC*/ + data.snippet->getPadBytes());
+      bufferPos += 6;
+
+      debug->printPrefix(pOutFile, NULL, bufferPos, 6);
+      trfprintf(pOutFile, data.cg->comp()->target().is64Bit() ? "LG \tGPR_EP, 0(GPR14)" : "LGF \tGPR_EP, 0(GPR14)");
+      bufferPos += 6;
+
+      debug->printPrefix(pOutFile, NULL, bufferPos, 2);
+      trfprintf(pOutFile, "BCR \tGPR_EP");
+      bufferPos += 2;
+      }
+   else
+      {
+      debug->printPrefix(pOutFile, NULL, bufferPos, 6);
+      trfprintf(pOutFile, "BRASL \tGPR14, <%p>\t# Branch to Helper Method %s",
+                     data.snippet->getSnippetDestAddr(),
+                     data.snippet->usedTrampoline() ? "- Trampoline Used. " : "");
+      bufferPos += 6;
+      }
+   return bufferPos;
+   }

--- a/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.hpp
+++ b/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.hpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_Z_JITCODERWX_OBJECTFORMAT_INCL
+#define OMR_Z_JITCODERWX_OBJECTFORMAT_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#include "objectfmt/OMRObjectFormat.hpp"
+#ifndef OMR_JITCODERWX_OBJECTFORMAT_CONNECTOR
+#define OMR_JITCODERWX_OBJECTFORMAT_CONNECTOR
+namespace OMR { namespace Z { class JitCodeRWXObjectFormat; } }
+namespace OMR { typedef OMR::Z::JitCodeRWXObjectFormat JitCodeRWXObjectFormatConnector; }
+#else
+#error OMR::Z::JitCodeObjectFormat expected to be a primary connector, but a OMR connector is already defined
+#endif
+
+#include "compiler/objectfmt/OMRJitCodeRWXObjectFormat.hpp"
+
+namespace TR { class Instruction; }
+namespace TR { class FunctionCallData; }
+namespace OMR
+{
+
+namespace Z
+{
+
+class OMR_EXTENSIBLE JitCodeRWXObjectFormat : public OMR::JitCodeRWXObjectFormat
+   {
+public:
+
+   virtual TR::Instruction *emitFunctionCall(TR::FunctionCallData &data);
+
+   virtual uint8_t *encodeFunctionCall(TR::FunctionCallData &data);
+
+   virtual int32_t estimateBinaryLength()
+      {
+      return 14;
+      }
+
+   virtual uint8_t* printEncodedFunctionCall(TR::FILE *pOutFile, TR::FunctionCallData &data);
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/z/objectfmt/OMRJitCodeRXObjectFormat.cpp
+++ b/compiler/z/objectfmt/OMRJitCodeRXObjectFormat.cpp
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/MemoryReference.hpp"
+#include "il/MethodSymbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/StaticSymbol.hpp"
+#include "infra/Assert.hpp"
+#include "objectfmt/FunctionCallData.hpp"
+#include "objectfmt/JitCodeRXObjectFormat.hpp"
+#include "runtime/CodeCache.hpp"
+#include "runtime/CodeCacheManager.hpp"
+#include "runtime/Runtime.hpp"
+#include "z/codegen/S390GenerateInstructions.hpp"
+
+TR::Instruction *
+OMR::Z::JitCodeRXObjectFormat::emitFunctionCall(TR::FunctionCallData &data)
+   {
+   TR::SymbolReference *callSymRef = data.methodSymRef;
+   TR::CodeGenerator *cg = data.cg;
+   TR::Node *callNode = data.callNode;
+   
+
+   if (callSymRef == NULL)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(callNode, data.runtimeHelperIndex > 0, "GlobalFunctionCallData does not contain symbol reference for call or valid TR_RuntimeHelper.");
+      callSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(data.runtimeHelperIndex, false, false, false);
+      }
+   
+   uintptr_t targetAddress = data.targetAddress ? data.targetAddress : reinterpret_cast<uintptr_t>(callSymRef->getMethodAddress());
+
+   TR_ASSERT_FATAL_WITH_NODE(callNode, targetAddress != NULL, "Unable to make a call as targetAddress for the Call is not found.");
+
+   ccGlobalFunctionData *ccGlobalFunctionDataAddress = reinterpret_cast<ccGlobalFunctionData *>(cg->allocateCodeMemory(sizeof(ccGlobalFunctionData), false));
+
+   if (ccGlobalFunctionDataAddress == NULL)
+      {
+      cg->comp()->failCompilation<TR::CompilationException>("Could not allocate global function data");
+      }
+	
+   TR_ASSERT_FATAL_WITH_NODE(callNode, cg->canUseRelativeLongInstructions(reinterpret_cast<int64_t>(ccGlobalFunctionDataAddress)), "ccGlobalFunctionDataAddress is outside relative immediate range.");
+   ccGlobalFunctionDataAddress->address = targetAddress;
+
+   TR::StaticSymbol *globalFunctionDataSymbol =
+      TR::StaticSymbol::createWithAddress(cg->trHeapMemory(), TR::Address, reinterpret_cast<void *>(ccGlobalFunctionDataAddress));
+   globalFunctionDataSymbol->setNotDataAddress();
+
+   TR_ASSERT_FATAL_WITH_NODE(callNode, data.returnAddressReg != NULL, "returnAddressReg should be set to make a call.");
+
+   if (data.entryPointReg == NULL)
+      data.entryPointReg = data.returnAddressReg;
+   
+   data.out_loadInstr = generateRILInstruction(cg, TR::InstOpCode::LGRL, callNode, data.entryPointReg, reinterpret_cast<void *>(ccGlobalFunctionDataAddress), data.prevInstr);   
+
+   data.out_callInstr = generateRRInstruction(cg, TR::InstOpCode::BASR, callNode, data.returnAddressReg, data.entryPointReg, data.out_loadInstr);
+
+   if (data.regDeps != NULL)
+      {
+      data.out_callInstr->setDependencyConditions(data.regDeps);
+      }
+
+   return data.out_callInstr;
+   }
+
+
+uint8_t *
+OMR::Z::JitCodeRXObjectFormat::encodeFunctionCall(TR::FunctionCallData &data)
+   {
+   TR::SymbolReference *callSymRef = data.methodSymRef;
+   TR::CodeGenerator *cg = data.cg;
+   TR::Node *callNode = data.callNode;
+
+   if (callSymRef == NULL)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(callNode, data.runtimeHelperIndex > 0, "GlobalFunctionCallData does not contain symbol reference for call or valid TR_RuntimeHelper");
+      callSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(data.runtimeHelperIndex, false, false, false);
+      }
+   
+   uintptr_t targetAddress = data.targetAddress != NULL ? data.targetAddress : reinterpret_cast<uintptr_t>(callSymRef->getMethodAddress());
+
+   uint8_t *cursor = data.bufferAddress;
+
+   TR_ASSERT_FATAL_WITH_NODE(callNode, targetAddress != NULL, "Unable to make a call as targetAddress for the Call is not found.");
+
+   ccGlobalFunctionData *ccGlobalFunctionDataAddress = reinterpret_cast<ccGlobalFunctionData *>(cg->allocateCodeMemory(sizeof(ccGlobalFunctionData), false));
+
+   if (ccGlobalFunctionDataAddress == NULL)
+      {
+      cg->comp()->failCompilation<TR::CompilationException>("Could not allocate global function data");
+      }
+
+	TR_ASSERT_FATAL_WITH_NODE(callNode, cg->canUseRelativeLongInstructions(reinterpret_cast<int64_t>(ccGlobalFunctionDataAddress)), "ccGlobalFunctionDataAddress is outside relative immediate range.");
+   ccGlobalFunctionDataAddress->address = targetAddress;
+
+   // LGRL R14,<displacementForMemoryReferencePointingToCCGlobalFunctionCallData>
+   // BASR R14,R14
+
+   *reinterpret_cast<int16_t *>(cursor) = 0xC4E8;
+   cursor += sizeof(int16_t);
+   *reinterpret_cast<int32_t *>(cursor) = static_cast<int32_t>((reinterpret_cast<intptr_t>(ccGlobalFunctionDataAddress) - (intptr_t)cursor + 2) / 2);
+   cursor += sizeof(int32_t);
+   *reinterpret_cast<int16_t *>(cursor) = 0x0DEE;
+   cursor += sizeof(int16_t);
+   data.bufferAddress = cursor;
+   return data.bufferAddress;
+   }
+
+uint8_t *
+OMR::Z::JitCodeRXObjectFormat::printEncodedFunctionCall(TR::FILE *pOutFile, TR::FunctionCallData &data)
+   {
+   uint8_t *bufferPos = data.bufferAddress;
+   TR_Debug *debug = data.cg->getDebug();
+
+   uintptr_t ccFunctionCallDataAddress = static_cast<uintptr_t>(*(reinterpret_cast<int32_t*>(bufferPos + sizeof(int16_t))) * 2) + reinterpret_cast<uintptr_t>(bufferPos);
+   debug->printPrefix(pOutFile, NULL, bufferPos, 6);
+   trfprintf(pOutFile, "LGRL \tGPR14, <%p>\t# Target Address = <%p>.",
+                        ccFunctionCallDataAddress, *reinterpret_cast<uint8_t *>(ccFunctionCallDataAddress));
+   bufferPos += 6;
+
+   debug->printPrefix(pOutFile, NULL, bufferPos, 2);
+   trfprintf(pOutFile, "BASR \tGPR_14, GPR14");
+   bufferPos += 2;
+
+   return bufferPos;
+   }

--- a/compiler/z/objectfmt/OMRJitCodeRXObjectFormat.hpp
+++ b/compiler/z/objectfmt/OMRJitCodeRXObjectFormat.hpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_Z_JITCODERX_OBJECTFORMAT_INCL
+#define OMR_Z_JITCODERX_OBJECTFORMAT_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_JITCODERX_OBJECTFORMAT_CONNECTOR
+#define OMR_JITCODERX_OBJECTFORMAT_CONNECTOR
+namespace OMR { namespace Z { class JitCodeRXObjectFormat; } }
+namespace OMR { typedef OMR::Z::JitCodeRXObjectFormat JitCodeRXObjectFormatConnector; }
+#else
+#error OMR::Z::JitCodeRXObjectFormat expected to be a primary connector, but a OMR connector is already defined
+#endif
+
+#include "compiler/objectfmt/OMRJitCodeRXObjectFormat.hpp"
+
+namespace TR { class Instruction; }
+namespace TR { class FunctionCallData; }
+
+namespace OMR
+{
+
+namespace Z
+{
+
+class OMR_EXTENSIBLE JitCodeRXObjectFormat : public OMR::JitCodeRXObjectFormat
+   {
+public:
+
+   virtual TR::Instruction *emitFunctionCall(TR::FunctionCallData &data);
+
+   virtual uint8_t *encodeFunctionCall(TR::FunctionCallData &data);
+
+   virtual int32_t estimateBinaryLength()
+      {
+      return 8;
+      }
+
+   virtual uint8_t* printEncodedFunctionCall(TR::FILE *pOutFile, TR::FunctionCallData &data);
+
+   struct ccGlobalFunctionData
+      {
+      uintptr_t address;
+      };
+
+   };
+
+}
+
+}
+
+#endif


### PR DESCRIPTION
In https://github.com/eclipse/omr/pull/5575 ObjectFormat API alongside FunctionCallData to generate/emit function calls were introduced. Changes in this PR contains supporting changes for the API. 

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>