### PR TITLE
AArch64: Unset hasResumableTrapHandler if TR_DisableTrap is set

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -94,11 +94,18 @@ OMR::ARM64::CodeGenerator::initialize()
 
    cg->setSupportsSelect();
 
-   _numberBytesReadInaccessible = 0;
-   _numberBytesWriteInaccessible = 0;
 
-   if (TR::Compiler->vm.hasResumableTrapHandler(comp))
+   if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
+      {
+      _numberBytesReadInaccessible = 4096;
+      _numberBytesWriteInaccessible = 4096;
       cg->setHasResumableTrapHandler();
+      }
+   else
+      {
+      _numberBytesReadInaccessible = 0;
+      _numberBytesWriteInaccessible = 0;
+      }
 
    if (!comp->getOption(TR_DisableRegisterPressureSimulation))
       {


### PR DESCRIPTION
Change initializer of `OMRCodeGenerator` not to set `hasResumableTrapHandler`
if `TR_DisableTrap` is set.
Set `_numberBytesReadInaccessible` and `_numberBytesWriteInaccessible` to 4096
if `TR_DisableTrap` is not set.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>