### PR TITLE
AArch64: Add a method for setting up implicit exception point to InstructionDelegate

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -22,6 +22,7 @@
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64OutOfLineCodeSection.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/InstructionDelegate.hpp"
 #include "codegen/RegisterDependency.hpp"
 
 void TR::ARM64LabelInstruction::assignRegistersForOutOfLineCodeSection(TR_RegisterKinds kindToBeAssigned)
@@ -452,6 +453,27 @@ void TR::ARM64MemSrc2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssig
 
 // TR::ARM64Trg1MemInstruction:: member functions
 
+TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op,
+                           TR::Node *node,
+                           TR::Register *treg,
+                           TR::MemoryReference *mr, TR::CodeGenerator *cg)
+   : ARM64Trg1Instruction(op, node, treg, cg), _memoryReference(mr)
+   {
+   mr->bookKeepingRegisterUses(self(), cg);
+   TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
+   }
+
+TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op,
+                           TR::Node *node,
+                           TR::Register *treg,
+                           TR::MemoryReference *mr,
+                           TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+   : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _memoryReference(mr)
+   {
+   mr->bookKeepingRegisterUses(self(), cg);
+   TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
+   }
+
 bool TR::ARM64Trg1MemInstruction::refsRegister(TR::Register *reg)
    {
    return (reg == getTargetRegister() || getMemoryReference()->refsRegister(reg));
@@ -491,6 +513,27 @@ void TR::ARM64Trg1MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssig
 
    if (getDependencyConditions())
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
+   }
+
+// TR::ARM64MemInstruction:: member functions
+
+TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op,
+                     TR::Node *node,
+                     TR::MemoryReference *mr, TR::CodeGenerator *cg)
+   : TR::Instruction(op, node, cg), _memoryReference(mr)
+   {
+   mr->bookKeepingRegisterUses(self(), cg);
+   TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
+   }
+
+TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op,
+                     TR::Node *node,
+                     TR::MemoryReference *mr,
+                     TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+   : TR::Instruction(op, node, precedingInstruction, cg), _memoryReference(mr)
+   {
+   mr->bookKeepingRegisterUses(self(), cg);
+   TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
    }
 
 // TR::ARM64Trg1MemSrc1Instruction:: member functions

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2805,11 +2805,7 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
    ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op,
                             TR::Node *node,
                             TR::Register *treg,
-                            TR::MemoryReference *mr, TR::CodeGenerator *cg)
-      : ARM64Trg1Instruction(op, node, treg, cg), _memoryReference(mr)
-      {
-      mr->bookKeepingRegisterUses(self(), cg);
-      }
+                            TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
    /*
     * @brief Constructor
@@ -2824,11 +2820,7 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
                             TR::Node *node,
                             TR::Register *treg,
                             TR::MemoryReference *mr,
-                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _memoryReference(mr)
-      {
-      mr->bookKeepingRegisterUses(self(), cg);
-      }
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    /**
     * @brief Gets instruction kind
@@ -2928,11 +2920,7 @@ class ARM64MemInstruction : public TR::Instruction
     */
    ARM64MemInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node *node,
-                        TR::MemoryReference *mr, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _memoryReference(mr)
-      {
-      mr->bookKeepingRegisterUses(self(), cg);
-      }
+                        TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
    /*
     * @brief Constructor
@@ -2945,11 +2933,7 @@ class ARM64MemInstruction : public TR::Instruction
    ARM64MemInstruction(TR::InstOpCode::Mnemonic op,
                         TR::Node *node,
                         TR::MemoryReference *mr,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _memoryReference(mr)
-      {
-      mr->bookKeepingRegisterUses(self(), cg);
-      }
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    /**
     * @brief Gets instruction kind

--- a/compiler/aarch64/codegen/OMRInstructionDelegate.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,9 +33,13 @@ namespace OMR { typedef OMR::ARM64::InstructionDelegate InstructionDelegateConne
 #error OMR::ARM64::InstructionDelegate expected to be a primary connector, but an OMR connector is already defined
 #endif
 
-#include "codegen/ARM64Instruction.hpp"
+#include "codegen/MemoryReference.hpp"
 #include "compiler/codegen/OMRInstructionDelegate.hpp"
 #include "infra/Annotations.hpp"
+
+namespace TR { class ARM64ImmSymInstruction; }
+namespace TR { class ARM64Trg1MemInstruction; }
+namespace TR { class ARM64MemInstruction; }
 
 namespace OMR
 {
@@ -62,6 +66,25 @@ public:
       // Do nothing in OMR
       }
 
+   /**
+    * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+    * @param[in] cg    : CodeGenerator
+    * @param[in] instr : instruction with memory reference
+    */
+   static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64Trg1MemInstruction *instr)
+      {
+      // Do nothing in OMR
+      }
+
+   /**
+    * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+    * @param[in] cg    : CodeGenerator
+    * @param[in] instr : instruction with memory reference
+    */
+   static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::ARM64MemInstruction *instr)
+      {
+      // Do nothing in OMR
+      }
    };
 
 }


### PR DESCRIPTION

Add `setupImplicitNullPointerException` method to InstructionDelegate class
and change instruction classes with memory reference to call it from their constructor.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>