### PR TITLE
Use portable formats from omrformatconsts.h

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -106,6 +106,8 @@
 #include "runtime/CodeCacheExceptions.hpp"
 #include "ilgen/IlGen.hpp"
 #include "env/RegionProfiler.hpp"
+#include "omrformatconsts.h"
+
 // this ratio defines how full the alias memory region is allowed to become before
 // it is recreated after an optimization finishes
 #define ALIAS_REGION_LOAD_FACTOR 0.75
@@ -956,7 +958,7 @@ int32_t OMR::Compilation::compile()
       {
       uint64_t limit = (uint64_t)self()->getOptions()->getDelayCompile();
       uint64_t starttime = self()->getPersistentInfo()->getElapsedTime();
-      fprintf(stderr,"\nDelayCompile: Starting a delay of length %d for method %s at time %d.",limit,self()->signature(),starttime);
+      fprintf(stderr,"\nDelayCompile: Starting a delay of length %" OMR_PRIu64 " for method %s at time %" OMR_PRIu64 ".", limit, self()->signature(), starttime);
       fflush(stderr);
       uint64_t temp=0;
       while(1)
@@ -964,7 +966,7 @@ int32_t OMR::Compilation::compile()
          temp = self()->getPersistentInfo()->getElapsedTime();
          if( ( temp - starttime ) > limit)
             {
-            fprintf(stderr,"\nDelayCompile: Finished delay at time  = %d, elapsed time = %d\n",temp,(temp-starttime));
+            fprintf(stderr,"\nDelayCompile: Finished delay at time = %" OMR_PRIu64 ", elapsed time = %" OMR_PRIu64 "\n", temp, (temp - starttime));
             break;
             }
          }

--- a/compiler/env/OMRIO.hpp
+++ b/compiler/env/OMRIO.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,8 @@ namespace OMR { typedef OMR::IO IOConnector; }
 #include <stdint.h>
 #include "env/FilePointerDecl.hpp"
 #include "infra/Annotations.hpp"
-
 #include "env/FilePointer.hpp"
+#include "omrformatconsts.h"
 
 /* All compilers now use the same format string for signed/unsigned 64-bit values.
  *
@@ -44,10 +44,10 @@ namespace OMR { typedef OMR::IO IOConnector; }
  *       library.  If you call a C runtime "printf" or "sprintf", for example, then
  *       that runtime may dictate the format specifiers you may use.
 */
-#define INT64_PRINTF_FORMAT  "%lld"
-#define INT64_PRINTF_FORMAT_HEX "0x%llx"
-#define UINT64_PRINTF_FORMAT "%llu"
-#define UINT64_PRINTF_FORMAT_HEX "0x%llx"
+#define INT64_PRINTF_FORMAT "%" OMR_PRId64
+#define INT64_PRINTF_FORMAT_HEX "0x%" OMR_PRIx64
+#define UINT64_PRINTF_FORMAT "%" OMR_PRIu64
+#define UINT64_PRINTF_FORMAT_HEX "0x%" OMR_PRIx64
 
 #ifdef _MSC_VER
    #define POINTER_PRINTF_FORMAT "0x%p"

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include "env/TRMemory.hpp"
 #include "ras/CallStackIterator.hpp"
 #include "compile/Compilation.hpp"
+#include "omrformatconsts.h"
 
 
 void TR_CallStackIterator::printStackBacktrace(TR::Compilation *comp)
@@ -33,9 +34,9 @@ void TR_CallStackIterator::printStackBacktrace(TR::Compilation *comp)
    while (!isDone())
       {
       if (comp)
-         traceMsg(comp, "%s+0x%lx\n", getProcedureName(), getOffsetInProcedure());
+         traceMsg(comp, "%s+0x%" OMR_PRIxPTR "\n", getProcedureName(), getOffsetInProcedure());
       else
-         fprintf(stderr, "%s+0x%lx\n", getProcedureName(), getOffsetInProcedure());
+         fprintf(stderr, "%s+0x%" OMR_PRIxPTR "\n", getProcedureName(), getOffsetInProcedure());
       getNext();
       }
    }
@@ -210,13 +211,13 @@ void TR_LinuxCallStackIterator::printSymbol(int32_t frame, char *sig, TR::Compil
       char *demangled = abi::__cxa_demangle(func, buffer, &length, &status);
       if (status == 0) funcToPrint = demangled;
       if (comp)
-         traceMsg(comp, "#%d: function %s+%#lx [%#p]\n",
+         traceMsg(comp, "#%" OMR_PRId32 ": function %s+%#" OMR_PRIxPTR " [%#" OMR_PRIxPTR "]\n",
               frame,
               funcToPrint,
               offset,
               address);
       else
-         fprintf(stderr, "#%d: function %s+%#lx [%#p]\n",
+         fprintf(stderr, "#%" OMR_PRId32 ": function %s+%#" OMR_PRIxPTR" [%#" OMR_PRIxPTR "]\n",
                  frame,
                  funcToPrint,
                  offset,
@@ -226,9 +227,9 @@ void TR_LinuxCallStackIterator::printSymbol(int32_t frame, char *sig, TR::Compil
    else
       {
       if (comp)
-         traceMsg(comp, "#%d: %s\n", frame, sig);
+         traceMsg(comp, "#%" OMR_PRId32 ": %s\n", frame, sig);
       else
-         fprintf(stderr, "#%d: %s\n", frame, sig);
+         fprintf(stderr, "#%" OMR_PRId32 ": %s\n", frame, sig);
       }
    }
 
@@ -449,7 +450,7 @@ TR_WinCallStackIterator::TR_WinCallStackIterator() :
    if (!(* SymInitialize)(hProcess, userSearchPath, TRUE))
       {
       // SymInitialize failed
-      fprintf(stderr, "Unable to retrieve symbol informaton. SymInitialize returned error : %d\n", GetLastError());
+      fprintf(stderr, "Unable to retrieve symbol informaton. SymInitialize returned error : %" PRIid32 "\n", GetLastError());
       }
 
    //Initialize StackFrame

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1980,7 +1980,7 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
                      }
                }
             char *result = (char*)_comp->trMemory()->allocateHeapMemory(length+20);
-            sprintf(result, "<string \"%.*s%s%s\">", prefixLength, contents, etc, contents+suffixOffset);
+            sprintf(result, "<string \"%.*s%s%s\">", (int)prefixLength, contents, etc, contents+suffixOffset);
             return result;
             }
 #endif
@@ -2959,7 +2959,7 @@ TR_Debug::getName(TR::Register *reg, TR_RegisterSizes size)
       {
       // Prefix checking for register pairs is a bit complex, and likely irrelevant since they
       // can't contain collected refs or internal pointers anyway.  Let's not worry about it.
-      sprintf(prefix, "");
+      prefix[0] = '\0';
       }
    else
       {


### PR DESCRIPTION
Eliminates numerous `-Wformat` warnings.