### PR TITLE
Add TR::MemoryReference::create API with trivial implementation

### DIFF
--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -3300,6 +3300,12 @@ OMR::Z::MemoryReference::doEvaluate(TR::Node * subTree, TR::CodeGenerator * cg)
    return false;
    }
 
+TR::MemoryReference*
+OMR::Z::MemoryReference::create(TR::CodeGenerator* cg, TR::Node* node)
+   {
+   return generateS390MemoryReference(node, cg);
+   }
+
 ///////////////////////////////////////////
 // Generate Routines
 ///////////////////////////////////////////

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -465,6 +465,21 @@ void createPatchableDataInLitpool(TR::Node * node, TR::CodeGenerator * cg, TR::R
 
 bool symRefHasTemporaryNegativeOffset() {return false;}
 void setMemRefAndGetUnresolvedData(TR::Snippet *& snippet) {}
+
+/**
+ * \brief
+ *   Create a MemoryReference from a given node. 
+ *
+ * \param[in] node
+ *   The node which describes the memory reference.
+ *
+ * \param[in] cg
+ *   The code generator used to generate the instructions.
+ *
+ * \return
+ *   The \c TR::MemoryReference representing this node.
+ */
+static TR::MemoryReference* create(TR::CodeGenerator* cg, TR::Node* node);
 };
 }
 }


### PR DESCRIPTION
Commit in this pull request adds the trivial implementation of the TR::MemoryReference::create API before we change use of `generateS390MemoryReference(TR::Node *, TR::CodeGenerator *)` to `TR::MemoryReference::create` in the downstream OpenJ9 project. 

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>