### PR TITLE
Revert "Fix lbyteswap store optimization on ppc32"

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1397,8 +1397,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          }
       else
          {
-         TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 8);
-         TR::MemoryReference *highMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 0, 4);
+         TR::MemoryReference *highMR  = TR::MemoryReference::createWithRootLoadOrStore(cg, node, 4);
 
          if (reverseStore)
             {
@@ -1409,7 +1408,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
             generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, highMR, valueReg->getHighOrder());
 
          // This ordering is important at this stage unless the base is guaranteed to be non-modifiable.
-         TR::MemoryReference *lowMR = TR::MemoryReference::createWithMemRef(cg, node, *tempMR, 4, 4);
+         TR::MemoryReference *lowMR = TR::MemoryReference::createWithMemRef(cg, node, *highMR, 4, 4);
          if (reverseStore)
             {
             lowMR->forceIndexedForm(node, cg);
@@ -1418,7 +1417,6 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
          else
             generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, lowMR, valueReg->getLowOrder());
 
-         tempMR->decNodeReferenceCounts(cg);
          highMR->decNodeReferenceCounts(cg);
          lowMR->decNodeReferenceCounts(cg);
          }


### PR DESCRIPTION
As discussed in eclipse/omr#5717, this fix uses a temp memory
reference that is not used in an instr. When the symbol is
unresolved the MemRef constructor creates an UnresolvedDataSnippet
that does not have an address in mainline code to return to.
Which causes an assert to fail. Fix is safe to remove as the
reverseStore path is temporarily disabled (eclipse/omr#5685)

This reverts commit 9b282a1136f078ff0d04b5719948b06137628d48.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>