### PR TITLE
RISC-V: implement data instruction

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -380,7 +380,7 @@ namespace TR { class ARM64UnresolvedCallSnippet; }
 namespace TR { class ARM64VirtualUnresolvedSnippet; }
 #endif
 
-
+namespace TR { class DataInstruction; }
 namespace TR { class RtypeInstruction; }
 namespace TR { class ItypeInstruction; }
 namespace TR { class StypeInstruction; }
@@ -1178,6 +1178,7 @@ public:
 
    void print(TR::FILE *, TR::LabelInstruction *);
    void print(TR::FILE *, TR::AdminInstruction *);
+   void print(TR::FILE *, TR::DataInstruction *);
 
    void print(TR::FILE *, TR::RtypeInstruction *);
    void print(TR::FILE *, TR::ItypeInstruction *);

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -136,9 +136,7 @@ OMR::RV::CodeGenerator::beginInstructionSelection()
    TR::Node *startNode = comp->getStartTree()->getNode();
    if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private)
       {
-      TR_UNIMPLEMENTED();
-
-      //_returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::RVImmInstruction(TR::InstOpCode::dd, startNode, 0, self());
+      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::DataInstruction(TR::InstOpCode::dd, startNode, 0, self());
       }
    else
       {
@@ -153,9 +151,7 @@ OMR::RV::CodeGenerator::endInstructionSelection()
    {
    if (_returnTypeInfoInstruction != NULL)
       {
-      TR_UNIMPLEMENTED();
-
-      //_returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));
+      _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));
       }
    }
 

--- a/compiler/riscv/codegen/OMRCodeGenerator.hpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.hpp
@@ -314,6 +314,24 @@ public:
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
    TR_GlobalRegisterNumber _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
 
+
+   /**
+    * @return Retrieves the cached returnTypeInfo instruction
+    */
+   TR::DataInstruction* getReturnTypeInfoInstruction()
+      {
+      return _returnTypeInfoInstruction;
+      }
+
+   /**
+    * @brief Caches the returnTypeInfo instruction
+    * @param[in] rtii : the returnTypeInfo instruction
+    */
+   void setReturnTypeInfoInstruction(TR::DataInstruction *rtii)
+      {
+      _returnTypeInfoInstruction = rtii;
+      }
+
    private:
 
    enum // flags
@@ -329,7 +347,7 @@ public:
 
    TR::RealRegister *_stackPtrRegister;
    TR::RealRegister *_methodMetaDataRegister;
-   TR::Instruction *_returnTypeInfoInstruction;
+   TR::DataInstruction *_returnTypeInfoInstruction;
    TR::ConstantDataSnippet *_constantData;
    const TR::RVLinkageProperties *_linkageProperties;
    TR::list<TR_RVOutOfLineCodeSection*> _outOfLineCodeSectionList;

--- a/compiler/riscv/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/riscv/codegen/OMRInstructionKindEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
    IsNotExtended,
    IsAdmin,
    IsLabel,
+   IsData,
 
    IsRTYPE,
    IsITYPE,

--- a/compiler/riscv/codegen/RVDebug.cpp
+++ b/compiler/riscv/codegen/RVDebug.cpp
@@ -73,6 +73,14 @@ TR_Debug::printMemoryReferenceComment(TR::FILE *pOutFile, TR::MemoryReference *m
    }
 
 void
+TR_Debug::print(TR::FILE *pOutFile, TR::DataInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t0x%08x (%d)", getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate(), instr->getSourceImmediate());
+   trfflush(_comp->getOutFile());
+   }
+
+void
 TR_Debug::print(TR::FILE *pOutFile, TR::RtypeInstruction *instr)
    {
    printPrefix(pOutFile, instr);
@@ -190,6 +198,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
          break;
       case OMR::Instruction::IsAdmin:
          print(pOutFile, (TR::AdminInstruction *)instr);
+         break;
+      case OMR::Instruction::IsData:
+         print(pOutFile, (TR::DataInstruction *)instr);
          break;
       case OMR::Instruction::IsRTYPE:
          print(pOutFile, (TR::RtypeInstruction *)instr);

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -566,3 +566,16 @@ int32_t TR::AdminInstruction::estimateBinaryLength(int32_t currentEstimate)
    setEstimatedBinaryLength(0);
    return currentEstimate;
    }
+
+// TR::DataInstruction:: member functions
+
+uint8_t *TR::DataInstruction::generateBinaryEncoding() {
+   uint8_t *cursor =  cg()->getBinaryBufferCursor();
+
+   *(uint32_t*)cursor = getSourceImmediate();
+
+   setBinaryLength(RISCV_INSTRUCTION_LENGTH);
+   setBinaryEncoding(cursor);
+   cursor += RISCV_INSTRUCTION_LENGTH;
+   return cursor;
+}

--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -1298,6 +1298,65 @@ class AdminInstruction : public TR::Instruction
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
+class DataInstruction : public TR::Instruction
+   {
+   uint32_t _sourceImmediate;
+
+public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] imm : immediate value
+    * @param[in] cg : CodeGenerator
+    */
+   DataInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cg), _sourceImmediate(imm)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(node, op == TR::InstOpCode::dd, "Opcode of data instruction is not dd");
+      }
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] imm : immediate value
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   DataInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
+                       TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm)
+      {
+      TR_ASSERT_FATAL_WITH_NODE(node, op == TR::InstOpCode::dd, "Opcode of data instruction is not dd");
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsData; }
+
+   /**
+    * @brief Gets source immediate
+    * @return source immediate
+    */
+   uint32_t getSourceImmediate() {return _sourceImmediate;}
+   /**
+    * @brief Sets source immediate
+    * @param[in] si : immediate value
+    * @return source immediate
+    */
+   uint32_t setSourceImmediate(uint32_t si) {return (_sourceImmediate = si);}
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
+
 } // namespace TR
 
 #endif // RVINSTRUCTION_INCL


### PR DESCRIPTION
This PR introduces new (pseude) instruction  class - `DataInstruction`. 
This is then used as return type info instruction. 