### PR TITLE
AArch64: Add a variant of helper method for creating constant data snippet

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -430,6 +430,11 @@ TR::ARM64ConstantDataSnippet *OMR::ARM64::CodeGenerator::findOrCreateConstantDat
    return snippet;
    }
 
+TR::ARM64ConstantDataSnippet *OMR::ARM64::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c)
+   {
+   return self()->findOrCreateConstantDataSnippet(n, &c, 4);
+   }
+
 TR::ARM64ConstantDataSnippet *OMR::ARM64::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c)
    {
    return self()->findOrCreateConstantDataSnippet(n, &c, 8);

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -279,6 +279,16 @@ public:
    void apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label);
 
    /**
+    * @brief find or create a constant data snippet for 4 byte constant.
+    *
+    * @param[in] node : the node which this constant data snippet belongs to
+    * @param[in] c    : 4 byte constant
+    *
+    * @return : a constant data snippet
+    */
+   TR::ARM64ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *node, int32_t c);
+
+   /**
     * @brief find or create a constant data snippet for 8 byte constant.
     *
     * @param[in] node : the node which this constant data snippet belongs to


### PR DESCRIPTION
This commit adds `findOrCreate4ByteConstant()` helper method
which finds or creates ConstantDataSnippet with 4byte data.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>