### PR TITLE
Cleanup softmx check and apply softmx to nursery expansion

### DIFF
--- a/gc/base/Heap.cpp
+++ b/gc/base/Heap.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -531,7 +531,7 @@ MM_Heap::initializeCommonGCData(MM_EnvironmentBase* env, struct MM_CommonGCData*
  * @return Size of the adjustable heap memory
  */
 uintptr_t
-MM_Heap::getActualSoftMxSize(MM_EnvironmentBase* env)
+MM_Heap::getActualSoftMxSize(MM_EnvironmentBase* env, uintptr_t memoryType)
 {
 	uintptr_t actualSoftMX = 0;
 	MM_GCExtensionsBase* extensions = env->getExtensions();
@@ -544,8 +544,10 @@ MM_Heap::getActualSoftMxSize(MM_EnvironmentBase* env)
 
 		uintptr_t nurserySize = totalHeapSize - tenureSize;
 
-		if (nurserySize <= extensions->softMx) {
+		if (MEMORY_TYPE_OLD == memoryType && nurserySize <= extensions->softMx) {
 			actualSoftMX = extensions->softMx - nurserySize;
+		} else if (MEMORY_TYPE_NEW == memoryType) {
+			actualSoftMX = extensions->softMx / 4;
 		} else {
 			actualSoftMX = 0;
 		}

--- a/gc/base/Heap.hpp
+++ b/gc/base/Heap.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,7 +165,7 @@ public:
 	void initializeCommonGCStartData(MM_EnvironmentBase *env, struct MM_CommonGCStartData *data);
 	void initializeCommonGCEndData(MM_EnvironmentBase *env, struct MM_CommonGCEndData *data);
 
-	uintptr_t getActualSoftMxSize(MM_EnvironmentBase *env);
+	uintptr_t getActualSoftMxSize(MM_EnvironmentBase *env, uintptr_t memoryType = MEMORY_TYPE_OLD);
 
 	/**
 	 * Create a Heap object.

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1128,6 +1128,38 @@ MM_MemorySubSpace::canExpand(MM_EnvironmentBase* env, uintptr_t expandSize)
 }
 
 /**
+ * Compare the specified expand amount with -XsoftMX value
+ * @return Updated expand size
+ */
+uintptr_t
+MM_MemorySubSpace::adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, uintptr_t expandSize, uintptr_t minimumBytesRequired, uintptr_t memoryType)
+{
+	MM_Heap *heap = env->getExtensions()->getHeap();
+
+	uintptr_t actualSoftMx = heap->getActualSoftMxSize(env, memoryType);
+	uintptr_t activeMemorySize = getActiveMemorySize();
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+	if (0 != actualSoftMx) {
+		if ((0 != minimumBytesRequired) && ((activeMemorySize + minimumBytesRequired) > actualSoftMx)) {
+			if (J9_EVENT_IS_HOOKED(env->getExtensions()->omrHookInterface, J9HOOK_MM_OMR_OOM_DUE_TO_SOFTMX)) {
+				ALWAYS_TRIGGER_J9HOOK_MM_OMR_OOM_DUE_TO_SOFTMX(env->getExtensions()->omrHookInterface, env->getOmrVMThread(), omrtime_hires_clock(),
+						heap->getMaximumMemorySize(), heap->getActiveMemorySize(), env->getExtensions()->softMx, minimumBytesRequired);
+				actualSoftMx = heap->getActualSoftMxSize(env);
+			}
+		}
+		if (actualSoftMx < activeMemorySize) {
+			/* if our softmx is smaller than our currentsize, we should be contracting not expanding */
+			expandSize = 0;
+		} else if ((activeMemorySize + expandSize) > actualSoftMx) {
+			/* we would go past our -XsoftMx so just expand up to it instead */
+			expandSize = actualSoftMx - activeMemorySize;
+		}
+	}
+	return expandSize;
+}
+
+/**
  * Adjust the specified expansion amount by the specified user increment amount (i.e. -Xmoi)
  * @return the updated expand size
  */

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -365,6 +365,7 @@ public:
 	bool setResizable(bool resizable);
 
 	bool canExpand(MM_EnvironmentBase *env, uintptr_t expandSize);
+	virtual uintptr_t adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, uintptr_t expandSize, uintptr_t minimumBytesRequired, uintptr_t memoryType = MEMORY_TYPE_OLD);
 	virtual uintptr_t adjustExpansionWithinUserIncrement(MM_EnvironmentBase *env, uintptr_t expandSize);
 	uintptr_t maxExpansion(MM_EnvironmentBase *env);
 	virtual uintptr_t maxExpansionInSpace(MM_EnvironmentBase *env);

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -960,6 +960,9 @@ MM_MemorySubSpaceSemiSpace::checkSubSpaceMemoryPostCollectResize(MM_EnvironmentB
 
 				_expansionSize = MM_Math::roundToCeiling(extensions->heapAlignment, (uintptr_t)(getCurrentSize() * adjustedExpansionFactor));
 				_expansionSize = MM_Math::roundToCeiling(2 * regionSize, _expansionSize);
+
+				/* Adjust within -XsoftMx limit */
+				_expansionSize = adjustExpansionWithinSoftMax(env, _expansionSize, 0, MEMORY_TYPE_NEW);
 
 				if(debug) {
 					omrtty_printf("\tExpand decision - expandFactor desired: %lf adjusted: %lf size: %u\n", desiredExpansionFactor, adjustedExpansionFactor, _expansionSize);

--- a/gc/base/MemorySubSpaceUniSpace.hpp
+++ b/gc/base/MemorySubSpaceUniSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,6 @@ class MM_MemorySubSpaceUniSpace : public MM_MemorySubSpace
 {
 protected:
 	uintptr_t adjustExpansionWithinFreeLimits(MM_EnvironmentBase *env, uintptr_t expandSize);
-	uintptr_t adjustExpansionWithinSoftMax(MM_EnvironmentBase *env, uintptr_t expandSize, uintptr_t minimumBytesRequired);
 	uintptr_t checkForRatioExpand(MM_EnvironmentBase *env, uintptr_t bytesRequired);	
 	bool checkForRatioContract(MM_EnvironmentBase *env);
 	uintptr_t calculateExpandSize(MM_EnvironmentBase *env, uintptr_t bytesRequired, bool expandToSatisfy);


### PR DESCRIPTION
Nursery expansion does not respect the softmx heap limit.
Instead the softmx limit and the heap size it is compared
to were both arbitrarily offset by the nursery size. The
softmx limit was also ignored if nursery size exceeds softmx.

Signed-off-by: Jason <jasonhal@ca.ibm.com>