### PR TITLE
Facilitate improvements for AOT

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -876,6 +876,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
          case TR_AbstractGuard:
+         case TR_BreakpointGuard:
             aotSite->setGuard(virtualGuard);
             break;
 

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -336,6 +336,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_InterfaceGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
+         case TR_BreakpointGuard:
             aotSite->setGuard(virtualGuard);
             break;
 

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -483,6 +483,10 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ResolvedTrampolines (101)",
    "TR_BlockFrequency (102)",
    "TR_RecompQueuedFlag (103)",
+   "TR_InlinedStaticMethod (104",
+   "TR_InlinedSpecialMethod (105)",
+   "TR_InlinedAbstractMethod (106)",
+   "TR_Breakpoint (107)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1301,6 +1301,7 @@ bool OMR::Compilation::incInlineDepth(TR::ResolvedMethodSymbol * method, TR::Nod
       aotMethodInfo->cpIndex = cpIndex;
       aotMethodInfo->receiver = receiverClass;
       aotMethodInfo->callSymRef = callSymRef;
+      aotMethodInfo->reloKind = self()->getReloTypeForMethodToBeInlined(guard, callNode, receiverClass);
 
       return self()->incInlineDepth(reinterpret_cast<TR_OpaqueMethodBlock *>(aotMethodInfo), method, bcInfo, callSymRef, directCall, argInfo);
       }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -87,6 +87,7 @@ class TR_ResolvedMethod;
 namespace OMR { class RuntimeAssumption; }
 class TR_VirtualGuard;
 class TR_VirtualGuardSite;
+struct TR_VirtualGuardSelection;
 namespace TR { class Block; }
 namespace TR { class CFG; }
 namespace TR { class CodeCache; }
@@ -614,6 +615,7 @@ public:
    TR_Stack<int32_t> & getInlinedCallStack() {return _inlinedCallStack; }
    uint16_t getInlineDepth() {return _inlinedCallStack.size();}
    uint16_t getMaxInlineDepth() {return _maxInlineDepth;}
+   bool incInlineDepth(TR::ResolvedMethodSymbol *, TR::Node *callNode, bool directCall, TR_VirtualGuardSelection *guard, TR_OpaqueClassBlock *receiverClass, TR_PrexArgInfo *argInfo = 0);
    bool incInlineDepth(TR::ResolvedMethodSymbol *, TR_ByteCodeInfo &, int32_t cpIndex, TR::SymbolReference *callSymRef, bool directCall, TR_PrexArgInfo *argInfo = 0);
    bool incInlineDepth(TR_OpaqueMethodBlock *, TR::ResolvedMethodSymbol *, TR_ByteCodeInfo &, TR::SymbolReference *callSymRef, bool directCall, TR_PrexArgInfo *argInfo = 0);
    void decInlineDepth(bool removeInlinedCallSitesEntries = false);

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -627,6 +627,8 @@ public:
    int32_t getInlinedCalls() { return _inlinedCalls; }
    void incInlinedCalls() { _inlinedCalls++; }
 
+   TR_ExternalRelocationTargetKind getReloTypeForMethodToBeInlined(TR_VirtualGuardSelection *guard, TR::Node *callNode, TR_OpaqueClassBlock *receiverClass) { return TR_NoRelocation; }
+
    class TR_InlinedCallSiteInfo
       {
       TR_InlinedCallSite _site;

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -40,6 +40,7 @@ namespace OMR { typedef OMR::Method MethodConnector; }
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
 #include "infra/Annotations.hpp"
+#include "runtime/Runtime.hpp"
 
 class TR_OpaqueClassBlock;
 class TR_ResolvedMethod;
@@ -101,6 +102,8 @@ typedef struct TR_AOTMethodInfo
    {
    TR_ResolvedMethod *resolvedMethod;
    int32_t cpIndex;
+   TR_ExternalRelocationTargetKind reloKind;
+   TR_OpaqueClassBlock *receiver;
    } TR_AOTMethodInfo;
 
 

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -46,6 +46,7 @@ class TR_OpaqueClassBlock;
 class TR_ResolvedMethod;
 namespace TR { class Compilation; }
 namespace TR { class Method; }
+namespace TR { class SymbolReference; }
 
 // Method indexes
 //
@@ -104,6 +105,7 @@ typedef struct TR_AOTMethodInfo
    int32_t cpIndex;
    TR_ExternalRelocationTargetKind reloKind;
    TR_OpaqueClassBlock *receiver;
+   TR::SymbolReference *callSymRef;
    } TR_AOTMethodInfo;
 
 

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -4575,6 +4575,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_AbstractGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
+         case TR_BreakpointGuard:
             aotSite->setGuard(virtualGuard);
             break;
 

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -329,7 +329,11 @@ typedef enum
    TR_ResolvedTrampolines                 = 101,
    TR_BlockFrequency                      = 102,
    TR_RecompQueuedFlag                    = 103,
-   TR_NumExternalRelocationKinds          = 104,
+   TR_InlinedStaticMethod                 = 104,
+   TR_InlinedSpecialMethod                = 105,
+   TR_InlinedAbstractMethod               = 106,
+   TR_Breakpoint                          = 107,
+   TR_NumExternalRelocationKinds          = 108,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2254,6 +2254,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
          case TR_AbstractGuard:
+         case TR_BreakpointGuard:
             aotSite->setGuard(virtualGuard);
             break;
 

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -147,6 +147,7 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
          case TR_AbstractGuard:
+         case TR_BreakpointGuard:
             aotSite->setGuard(virtualGuard);
             break;
 


### PR DESCRIPTION
This PR contains changes mostly necessary to improve AOT in Eclipse OpenJ9. It contains:

- Addition of new relo types
- Addition of new fields to `TR_AOTMethodInfo`
- New incInlineDepth API
- New API to determine relo type for method to be inlined
- Adding Breakpoint Guards to the list of guards AOT will be able to handle