### PR TITLE
AArch64: Add debug print of register dependencies to branch instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -787,6 +787,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CompareBranchInstruction *instr)
       {
       trfprintf(pOutFile, " (%s)", getName(snippet));
       }
+   if (instr->getDependencyConditions())
+      print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());
    }
 
@@ -805,6 +807,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64TestBitBranchInstruction *instr)
       {
       trfprintf(pOutFile, " (%s)", getName(snippet));
       }
+   if (instr->getDependencyConditions())
+      print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());
    }
 


### PR DESCRIPTION
This commit changes the debug print function for `compare and branch` and
`test bit and branch` instructions to print out register dependencies.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>