### PR TITLE
Deprecate get and setAccessStaticsIndirectly API

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1577,9 +1577,6 @@ public:
    bool getMethodContainsBinaryCodedDecimal() { return _flags3.testAny(MethodContainsBinaryCodedDecimal);}
    void setMethodContainsBinaryCodedDecimal() { _flags3.set(MethodContainsBinaryCodedDecimal);}
 
-   bool getAccessStaticsIndirectly() {return _flags1.testAny(AccessStaticsIndirectly);}
-   void setAccessStaticsIndirectly(bool b) {_flags1.set(AccessStaticsIndirectly, b);}
-
    bool getSupportsBDLLHardwareOverflowCheck() { return _flags3.testAny(SupportsBDLLHardwareOverflowCheck);}
    void setSupportsBDLLHardwareOverflowCheck() { _flags3.set(SupportsBDLLHardwareOverflowCheck);}
 
@@ -1762,7 +1759,7 @@ public:
       // AVAILABLE                                       = 0x02000000,
       UsesRegisterPairsForLongs                          = 0x04000000,
       SupportsArraySet                                   = 0x08000000,
-      AccessStaticsIndirectly                            = 0x10000000,
+      // AVAILABLE                                       = 0x10000000,
       SupportsArrayCmp                                   = 0x20000000,
       DisableLongGRA                                     = 0x40000000,
       DummyLastEnum1

--- a/compiler/il/OMRTreeTop.cpp
+++ b/compiler/il/OMRTreeTop.cpp
@@ -74,26 +74,10 @@ OMR::TreeTop::createIncTree(TR::Compilation * comp, TR::Node *node, TR::SymbolRe
    TR::StaticSymbol * symbol = symRef->getSymbol()->castToStaticSymbol();
    TR::DataType type = symbol->getDataType();
    TR::Node * storeNode;
-   if (comp->cg()->getAccessStaticsIndirectly() && !symRef->isUnresolved() && type != TR::Address)
-      {
-      TR::SymbolReference * symRefShadow;
-      if (isRecompCounter)
-         symRefShadow = comp->getSymRefTab()->findOrCreateCounterAddressSymbolRef();
-      else
-         symRefShadow = comp->getSymRefTab()->createKnownStaticDataSymbolRef(symbol->getStaticAddress(), TR::Address);
-      TR::Node * loadaddrNode = TR::Node::createWithSymRef(node, TR::loadaddr, 0, symRefShadow);
-      storeNode = TR::Node::createWithSymRef(TR::istorei, 2, 2, loadaddrNode,
+   storeNode = TR::Node::createWithSymRef(TR::istore, 1, 1,
                     TR::Node::create(TR::iadd, 2,
-                      TR::Node::createWithSymRef(TR::iloadi, 1, 1, loadaddrNode, symRef),
-                        TR::Node::create(node, TR::iconst, 0, incAmount)), symRef);
-      }
-   else
-      {
-      storeNode = TR::Node::createWithSymRef(TR::istore, 1, 1,
-                    TR::Node::create(TR::iadd, 2,
-                      TR::Node::createWithSymRef(node, TR::iload, 0, symRef),
-                        TR::Node::create(node, TR::iconst, 0, incAmount)), symRef);
-      }
+                    TR::Node::createWithSymRef(node, TR::iload, 0, symRef),
+                    TR::Node::create(node, TR::iconst, 0, incAmount)), symRef);
    return precedingTreeTop == NULL ? TR::TreeTop::create(comp, storeNode) : TR::TreeTop::create(comp, precedingTreeTop, storeNode);
    }
 
@@ -103,22 +87,8 @@ OMR::TreeTop::createResetTree(TR::Compilation * comp, TR::Node *node, TR::Symbol
    TR::StaticSymbol * symbol = symRef->getSymbol()->castToStaticSymbol();
    TR::DataType type = symbol->getDataType();
    TR::Node * storeNode;
-   if (comp->cg()->getAccessStaticsIndirectly() && !symRef->isUnresolved() && type != TR::Address)
-      {
-      TR::SymbolReference * symRefShadow;
-      if (isRecompCounter)
-         symRefShadow = comp->getSymRefTab()->findOrCreateCounterAddressSymbolRef();
-      else
-         symRefShadow = comp->getSymRefTab()->createKnownStaticDataSymbolRef(symbol->getStaticAddress(), TR::Address);
-      TR::Node * loadaddrNode = TR::Node::createWithSymRef(node, TR::loadaddr, 0, symRefShadow);
-      storeNode = TR::Node::createWithSymRef(TR::istorei, 2, 2, loadaddrNode,
-                      TR::Node::create(node, TR::iconst, 0, resetAmount), symRef);
-      }
-   else
-      {
-      storeNode = TR::Node::createWithSymRef(TR::istore, 1, 1,
+   storeNode = TR::Node::createWithSymRef(TR::istore, 1, 1,
                     TR::Node::create(node, TR::iconst, 0, resetAmount), symRef);
-      }
    return precedingTreeTop == NULL ? TR::TreeTop::create(comp, storeNode) : TR::TreeTop::create(comp, precedingTreeTop, storeNode);
    }
 

--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -192,8 +192,7 @@ const bool TR_LoadExtensions::isSupportedType(TR::Node* node) const
    bool result = node->getType().isIntegral() || node->getType().isAddress();
 
    // Disallow static integral loads of size smaller than an int
-   if (!TR::comp()->cg()->getAccessStaticsIndirectly() &&
-      node->getOpCode().isLoadDirect() &&
+   if (node->getOpCode().isLoadDirect() &&
       node->getOpCode().hasSymbolReference() && node->getSymbol()->isStatic() &&
       !node->getOpCode().isInt() && !node->getOpCode().isLong())
       {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -194,10 +194,6 @@ OMR::Power::CodeGenerator::initialize()
 
    cg->setEnableRefinedAliasSets();
 
-   static char * accessStaticsIndirectly = feGetEnv("TR_AccessStaticsIndirectly");
-   if (accessStaticsIndirectly)
-      cg->setAccessStaticsIndirectly(true);
-
    if (!debug("noLiveRegisters"))
       {
       cg->addSupportedLiveRegisterKind(TR_GPR);

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -78,10 +78,6 @@ void OMR::X86::AMD64::CodeGenerator::initialize()
    if (c)
       comp->setOption(TR_DisableValueProfiling);
 
-   static char *accessStaticsIndirectly = feGetEnv("TR_AccessStaticsIndirectly");
-   if (accessStaticsIndirectly)
-      cg->setAccessStaticsIndirectly(true);
-
    cg->setSupportsDoubleWordCAS();
    cg->setSupportsDoubleWordSet();
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -438,7 +438,6 @@ public:
    bool loadAndStoreMayOverlap(TR::Node *store, size_t storeSize, TR::Node *load, size_t loadSize);
 
    bool checkIfcmpxx(TR::Node *node);
-   bool checkSimpleLoadStore(TR::Node *loadNode, TR::Node *storeNode, TR::Block *block);
    bool checkBitWiseChild(TR::Node *node);
 
    TR_StorageDestructiveOverlapInfo getStorageDestructiveOverlapInfo(TR::Node *src, size_t srcLength, TR::Node *dst, size_t dstLength);


### PR DESCRIPTION
This PR removes the use of `getAccessStaticsIndirectly` and `setAccessStaticsIndirectly` APIs as it no longer makes sense to use them. We also remove the `checkSimpleLoadStore` routine in the Z codegen since it has no consumers.