### PR TITLE
Fold TR_ S390LinkageConventions into TR_LinkageConventions

### DIFF
--- a/compiler/codegen/OMRLinkageConventions.enum
+++ b/compiler/codegen/OMRLinkageConventions.enum
@@ -29,3 +29,11 @@
    TR_System,
    TR_Helper,
    TR_J9JNILinkage,
+   TR_SystemXPLink,                     // zOS XPLink convention
+
+   // zOS Type 1 linkages - all have bit 0x40 set
+   // zOS Type 1 linkage - C++ Fastlink
+   TR_SystemFastLink,                   // zOS (C++) FastLink convention
+
+   // Linux Platform Linkages
+   TR_SystemLinux,//          = 60     // zLinux convention

--- a/compiler/z/codegen/Linkage.hpp
+++ b/compiler/z/codegen/Linkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/Linkage.hpp
+++ b/compiler/z/codegen/Linkage.hpp
@@ -39,7 +39,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::LinkageConnector
    Linkage(TR::CodeGenerator *cg)
       : OMR::LinkageConnector(cg) {}
 
-   Linkage(TR::CodeGenerator *cg, TR_S390LinkageConventions elc)
+   Linkage(TR::CodeGenerator *cg, TR_LinkageConventions elc)
       : OMR::LinkageConnector(cg, elc) {}
    };
 }

--- a/compiler/z/codegen/Linkage.hpp
+++ b/compiler/z/codegen/Linkage.hpp
@@ -39,8 +39,8 @@ class OMR_EXTENSIBLE Linkage : public OMR::LinkageConnector
    Linkage(TR::CodeGenerator *cg)
       : OMR::LinkageConnector(cg) {}
 
-   Linkage(TR::CodeGenerator *cg, TR_S390LinkageConventions elc, TR_LinkageConventions le)
-      : OMR::LinkageConnector(cg, elc, le) {}
+   Linkage(TR::CodeGenerator *cg, TR_S390LinkageConventions elc)
+      : OMR::LinkageConnector(cg, elc) {}
    };
 }
 

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -102,7 +102,7 @@ extern bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGener
 
 OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
    : OMR::Linkage(codeGen),
-      _explicitLinkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),
@@ -135,9 +135,9 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * convention.
  * Even though this method is common, its implementation is machine-specific.
  */
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_LinkageConventions elc)
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_LinkageConventions lc)
    : OMR::Linkage(codeGen),
-      _explicitLinkageType(elc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _linkageType(lc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),
@@ -2838,29 +2838,21 @@ OMR::Z::Linkage::getLastMaskedBit(int16_t mask)
    }
 
 bool
-OMR::Z::Linkage::isOSLinkageType()
-   {
-   // #define TR_SystemOS_MASK  0x40
-   // zOS Type 1 linkages (non-Java) - all have bit 0x40 set
-   return (self()->getExplicitLinkageType() & 0x40) != 0;
-   }
-
-bool
 OMR::Z::Linkage::isXPLinkLinkageType()
    {
-   return self()->getExplicitLinkageType() == TR_SystemXPLink;
+   return self()->getLinkageType() == TR_SystemXPLink;
    }
 
 bool
 OMR::Z::Linkage::isFastLinkLinkageType()
    {
-   return self()->getExplicitLinkageType() == TR_SystemFastLink;
+   return self()->getLinkageType() == TR_SystemFastLink;
    }
 
 bool
 OMR::Z::Linkage::isZLinuxLinkageType()
    {
-   return self()->getExplicitLinkageType() == TR_SystemLinux;
+   return self()->getLinkageType() == TR_SystemLinux;
    }
 
 TR::Register *

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,7 +102,7 @@ extern bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGener
 
 OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
    : OMR::Linkage(codeGen),
-      _explicitLinkageType(TR_S390LinkageDefault), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _explicitLinkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -102,7 +102,7 @@ extern bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGener
 
 OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
    : OMR::Linkage(codeGen),
-      _explicitLinkageType(TR_S390LinkageDefault), _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _explicitLinkageType(TR_S390LinkageDefault), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),
@@ -135,9 +135,9 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * convention.
  * Even though this method is common, its implementation is machine-specific.
  */
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc)
    : OMR::Linkage(codeGen),
-      _explicitLinkageType(elc), _linkageType(lc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _explicitLinkageType(elc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -135,7 +135,7 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * convention.
  * Even though this method is common, its implementation is machine-specific.
  */
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc)
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_LinkageConventions elc)
    : OMR::Linkage(codeGen),
       _explicitLinkageType(elc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
@@ -2840,7 +2840,9 @@ OMR::Z::Linkage::getLastMaskedBit(int16_t mask)
 bool
 OMR::Z::Linkage::isOSLinkageType()
    {
-   return (self()->getExplicitLinkageType() & TR_SystemOS_MASK) != 0;
+   // #define TR_SystemOS_MASK  0x40
+   // zOS Type 1 linkages (non-Java) - all have bit 0x40 set
+   return (self()->getExplicitLinkageType() & 0x40) != 0;
    }
 
 bool

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -62,25 +62,6 @@ template <class T> class List;
 /**
  * 390 Explicit linkage conventions
  */
-enum TR_S390LinkageConventions
-   {
-   TR_S390LinkageDefault   = 0,     ///< reserved for default construction
-
-   // Java specific linkages
-   TR_JavaPrivate          = 0x1,   ///< Java private linkage
-   TR_JavaHelper           = 0x2,   ///< Java helper linkage
-
-   TR_SystemXPLink         = 0x20,  ///< (Java) zOS XPLink convention
-
-   // zOS Type 1 linkages (non-Java) - all have bit 0x40 set
-   #define TR_SystemOS_MASK  0x40
-
-   // zOS Type 1 linkage - C++ Fastlink
-   TR_SystemFastLink       = 0x4D,  ///< (non-Java) zOS (C++) FastLink convention
-
-   // Linux Platform Linkages
-   TR_SystemLinux          = 60     ///< (Java) Linux convention
-   };
 
 ////////////////////////////////////////////////////////////////////////////////
 // linkage properties
@@ -191,7 +172,7 @@ namespace Z
 class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    {
 private:
-   TR_S390LinkageConventions _explicitLinkageType;
+   TR_LinkageConventions _explicitLinkageType;
    uint32_t _properties;
    uint32_t _registerFlags[TR::RealRegister::NumRegisters];
    uint8_t _numIntegerArgumentRegisters;
@@ -252,10 +233,10 @@ enum TR_DispatchType
 
    Linkage(TR::CodeGenerator *);
 
-   Linkage(TR::CodeGenerator *, TR_S390LinkageConventions);
+   Linkage(TR::CodeGenerator *, TR_LinkageConventions);
 
-   TR_S390LinkageConventions getExplicitLinkageType() { return _explicitLinkageType; }
-   void setExplicitLinkageType(TR_S390LinkageConventions lc ) { _explicitLinkageType = lc; }
+   TR_LinkageConventions getExplicitLinkageType() { return _explicitLinkageType; }
+   void setExplicitLinkageType(TR_LinkageConventions lc ) { _explicitLinkageType = lc; }
 
    bool isOSLinkageType();
    bool isXPLinkLinkageType();

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -191,7 +191,6 @@ namespace Z
 class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    {
 private:
-   TR_LinkageConventions _linkageType;
    TR_S390LinkageConventions _explicitLinkageType;
    uint32_t _properties;
    uint32_t _registerFlags[TR::RealRegister::NumRegisters];
@@ -253,7 +252,7 @@ enum TR_DispatchType
 
    Linkage(TR::CodeGenerator *);
 
-   Linkage(TR::CodeGenerator *, TR_S390LinkageConventions, TR_LinkageConventions);
+   Linkage(TR::CodeGenerator *, TR_S390LinkageConventions);
 
    TR_S390LinkageConventions getExplicitLinkageType() { return _explicitLinkageType; }
    void setExplicitLinkageType(TR_S390LinkageConventions lc ) { _explicitLinkageType = lc; }

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -172,7 +172,7 @@ namespace Z
 class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    {
 private:
-   TR_LinkageConventions _explicitLinkageType;
+   TR_LinkageConventions _linkageType;
    uint32_t _properties;
    uint32_t _registerFlags[TR::RealRegister::NumRegisters];
    uint8_t _numIntegerArgumentRegisters;
@@ -235,10 +235,9 @@ enum TR_DispatchType
 
    Linkage(TR::CodeGenerator *, TR_LinkageConventions);
 
-   TR_LinkageConventions getExplicitLinkageType() { return _explicitLinkageType; }
-   void setExplicitLinkageType(TR_LinkageConventions lc ) { _explicitLinkageType = lc; }
+   TR_LinkageConventions getLinkageType() { return _linkageType; }
+   void setLinkageType(TR_LinkageConventions lc ) { _linkageType = lc; }
 
-   bool isOSLinkageType();
    bool isXPLinkLinkageType();
    bool isFastLinkLinkageType();
 

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -69,9 +69,9 @@
 #include "z/codegen/S390Instruction.hpp"
 #include "z/codegen/SystemLinkage.hpp"
 
-TR::SystemLinkage::SystemLinkage(TR::CodeGenerator* cg, TR_S390LinkageConventions elc, TR_LinkageConventions lc)
+TR::SystemLinkage::SystemLinkage(TR::CodeGenerator* cg, TR_S390LinkageConventions elc)
    :
-      TR::Linkage(cg, elc,lc),
+      TR::Linkage(cg, elc),
       _GPRSaveMask(0),
       _FPRSaveMask(0)
    {

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -296,7 +296,7 @@ TR::SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stackInd
 
       setFPRSaveMask(FPRSaveMask);
 
-      if (FPRSaveMask != 0 && isOSLinkageType())
+      if (FPRSaveMask != 0)
          {
          #define DELTA_ALIGN(x, align) ((x & (align-1)) ? (align -((x)&(align-1))) : 0)
          stackIndex -= DELTA_ALIGN(stackIndex, 16);

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -69,7 +69,7 @@
 #include "z/codegen/S390Instruction.hpp"
 #include "z/codegen/SystemLinkage.hpp"
 
-TR::SystemLinkage::SystemLinkage(TR::CodeGenerator* cg, TR_S390LinkageConventions elc)
+TR::SystemLinkage::SystemLinkage(TR::CodeGenerator* cg, TR_LinkageConventions elc)
    :
       TR::Linkage(cg, elc),
       _GPRSaveMask(0),

--- a/compiler/z/codegen/SystemLinkage.hpp
+++ b/compiler/z/codegen/SystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ class SystemLinkage : public TR::Linkage
    {
    public:
 
-   SystemLinkage(TR::CodeGenerator * cg, TR_LinkageConventions elc = TR_S390LinkageDefault);
+   SystemLinkage(TR::CodeGenerator * cg, TR_LinkageConventions elc = TR_None);
 
    TR::SystemLinkage * self();
 

--- a/compiler/z/codegen/SystemLinkage.hpp
+++ b/compiler/z/codegen/SystemLinkage.hpp
@@ -56,7 +56,7 @@ class SystemLinkage : public TR::Linkage
    {
    public:
 
-   SystemLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc = TR_S390LinkageDefault);
+   SystemLinkage(TR::CodeGenerator * cg, TR_LinkageConventions elc = TR_S390LinkageDefault);
 
    TR::SystemLinkage * self();
 

--- a/compiler/z/codegen/SystemLinkage.hpp
+++ b/compiler/z/codegen/SystemLinkage.hpp
@@ -56,7 +56,7 @@ class SystemLinkage : public TR::Linkage
    {
    public:
 
-   SystemLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc = TR_S390LinkageDefault, TR_LinkageConventions lc = TR_System);
+   SystemLinkage(TR::CodeGenerator * cg, TR_S390LinkageConventions elc = TR_S390LinkageDefault);
 
    TR::SystemLinkage * self();
 


### PR DESCRIPTION
These enums serve the same purpose, and so this PR merges the specialized S390 enum into the common one.

Fixes: #2911