### PR TITLE
Add support for relo records for block freqeuncy and recomp queued flag

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -481,6 +481,8 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_MethodCallAddress (99)",
    "TR_DiscontiguousSymbolFromManager (100)",
    "TR_ResolvedTrampolines (101)",
+   "TR_BlockFrequency (102)",
+   "TR_RecompQueuedFlag (103)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -275,6 +275,12 @@ public:
 
    void setIsDebugCounter()                 { _flags2.set(DebugCounter); }
    bool isDebugCounter()                    { return _flags2.testAny(DebugCounter); }
+
+   void setIsBlockFrequency()               { _flags2.set(BlockFrequency); }
+   bool isBlockFrequency()                  { return _flags2.testAny(BlockFrequency); }
+
+   void setIsRecompQueuedFlag()             { _flags2.set(RecompQueuedFlag); }
+   bool isRecompQueuedFlag()                { return _flags2.testAny(RecompQueuedFlag); }
 
    inline bool isNamed();
 
@@ -558,6 +564,8 @@ public:
       PendingPush               = 0x00000800,
       ConstantDynamic           = 0x00001000,
       NonSpecificConstObject    = 0x00002000, // Constant object not specific to a type
+      BlockFrequency            = 0x00004000,
+      RecompQueuedFlag          = 0x00008000,
       };
 
 protected:

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -327,7 +327,9 @@ typedef enum
    TR_MethodCallAddress                   = 99,
    TR_DiscontiguousSymbolFromManager      = 100,
    TR_ResolvedTrampolines                 = 101,
-   TR_NumExternalRelocationKinds          = 102,
+   TR_BlockFrequency                      = 102,
+   TR_RecompQueuedFlag                    = 103,
+   TR_NumExternalRelocationKinds          = 104,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 


### PR DESCRIPTION
In OpenJ9 the JProfiling framework is used to create profiled code
which contains references to internal data structures like block
frequencies stored in `TR_BlockFrequencInfo` class, or the flag for
checking if the method is already in recompilation queue.
To support AOT compilation for such code, we need to generate relocation
records for such data structures referenced by the compiled code.
OpenJ9 PR https://github.com/eclipse/openj9/pull/9591 creates the necessary
structures representing the relocation record for this data.
This commit adds the changes required by the OpenJ9 PR by adding
required enum for new relocation records and providing API for tagging
the symbols appropriately.

Signed-off-by: Ashutosh Mehra <asmehra@redhat.com>