### PR TITLE
Add missing return statement

### DIFF
--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -177,6 +177,8 @@ omrsysinfo_get_processor_feature_name(struct OMRPortLibrary *portLibrary, uint32
 intptr_t
 omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char *buffer, const size_t length)
 {
+	memset(buffer, 0, length);
+	return -1;
 }
 
 /**

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -730,7 +730,7 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 	size_t numberOfBits = 0;
 	size_t bufferLength = 0;
 
-	memset(buffer, 0, length * sizeof(char));
+	memset(buffer, 0, length);
 
 	for (i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++) {
 		numberOfBits = CHAR_BIT * sizeof(desc->features[i]);
@@ -740,12 +740,11 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 				uint32_t feature = (uint32_t)(i * numberOfBits + j);
 				const char * featureName = omrsysinfo_get_processor_feature_name(portLibrary, feature);
 				size_t featureLength = strlen(featureName);
-				
+
 				if (start == FALSE) {
 					strncat(buffer, " ", length - bufferLength - 1);
 					bufferLength += 1;
-				}
-				else {
+				} else {
 					start = FALSE;
 				}
 
@@ -755,7 +754,7 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 
 				strncat(buffer, featureName, length - bufferLength - 1);
 				bufferLength += featureLength;
-		    }
+			}
 		}
 	}
 	return 0;

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -176,7 +176,7 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 	size_t numberOfBits = 0;
 	size_t bufferLength = 0;
 
-	memset(buffer, 0, length * sizeof(char));
+	memset(buffer, 0, length);
 
 	for (i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++) {
 		numberOfBits = CHAR_BIT * sizeof(desc->features[i]);
@@ -186,12 +186,11 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 				uint32_t feature = (uint32_t)(i * numberOfBits + j);
 				const char * featureName = omrsysinfo_get_processor_feature_name(portLibrary, feature);
 				size_t featureLength = strlen(featureName);
-				
+
 				if (start == FALSE) {
 					strncat(buffer, " ", length - bufferLength - 1);
 					bufferLength += 1;
-				}
-				else {
+				} else {
 					start = FALSE;
 				}
 
@@ -201,7 +200,7 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 
 				strncat(buffer, featureName, length - bufferLength - 1);
 				bufferLength += featureLength;
-		    }
+			}
 		}
 	}
 	return 0;


### PR DESCRIPTION
Also:
* clear output buffer as documented
* minor formatting fixes
* no need to multiply by `sizeof(char)`