### PR TITLE
Convert `concurrent-mark-end` to `gc-op` in GMP concurrent increment

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -30,6 +30,7 @@
 
 #include "modronbase.h"
 
+#include "ConcurrentPhaseStatsBase.hpp"
 #include "LightweightNonReentrantLock.hpp"
 
 class MM_CollectionStatistics;
@@ -336,6 +337,21 @@ public:
 	 * @param buf character buffer in which to create to tag template.
 	 * @param bufsize maximum size allowed in the character buffer.
 	 * @param id unique id of the tag being built.
+	 * @param type Human readable name for the type of the tag.
+	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
+	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.
+	 * @param reasonForTermination termination reason.
+	 * @return number of bytes consumed in the buffer.
+	 *
+	 * @note should be moved to protected once all standard usage is converted.
+	 */
+	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t wallTimeMs, const char *reasonForTermination);
+
+	/**
+	 * Build the standard top level tag template.
+	 * @param buf character buffer in which to create to tag template.
+	 * @param bufsize maximum size allowed in the character buffer.
+	 * @param id unique id of the tag being built.
 	 * @param type Human readable name for the type of the tag - old cycle that has finished.
 	 * @param type Human readable name for the type of the tag - new cycle that is starting.
 	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
@@ -377,6 +393,13 @@ public:
 	 * @note should be moved to protected once all standard usage is converted.
 	 */
 	uintptr_t getTagTemplateWithDuration(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t durationus, uint64_t usertimeus, uint64_t cputimeus, uint64_t wallTimeMs, uint64_t stalltimeus);
+
+	/**
+	 * Get termination reason for concurrent collection.
+	 * @param stats concurrent stats
+	 * @return string representing the reason for termination
+	 */ 
+	virtual const char *getConcurrentTerminationReason(MM_ConcurrentPhaseStatsBase *stats);
 
 	/**
 	 * Handle any output or data tracking for the initialized phase of verbose GC.
@@ -496,11 +519,13 @@ public:
 	void handleConcurrentEnd(J9HookInterface** hook, UDATA eventNum, void* eventData);
 	
 	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
-	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData);
+	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {};
 	virtual const char *getConcurrentTypeString() { return NULL; }
 	
 	virtual void handleConcurrentGCOpStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
-	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
+
+	void handleGCOPOuterStanzaStart(MM_EnvironmentBase* env, const char *type, uintptr_t contextID, uint64_t duration, bool deltaTimeSuccess);
+	void handleGCOPOuterStanzaEnd(MM_EnvironmentBase* env);
 
 	void handleHeapResize(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -261,30 +261,6 @@ MM_VerboseHandlerOutputStandard::handleGCOPStanza(MM_EnvironmentBase* env, const
 }
 
 void
-MM_VerboseHandlerOutputStandard::handleGCOPOuterStanzaStart(MM_EnvironmentBase* env, const char *type, uintptr_t contextID, uint64_t duration, bool deltaTimeSuccess)
-{
-	MM_VerboseManager* manager = getManager();
-	MM_VerboseWriterChain* writer = manager->getWriterChain();
-	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-
-	if (!deltaTimeSuccess) {
-		writer->formatAndOutput(env, 0, "<warning details=\"clock error detected, following timing may be inaccurate\" />");
-	}
-
-	char tagTemplate[200];
-	getTagTemplate(tagTemplate, sizeof(tagTemplate), manager->getIdAndIncrement(), type ,contextID, duration, omrtime_current_time_millis());
-	writer->formatAndOutput(env, 0, "<gc-op %s>", tagTemplate);
-}
-
-void
-MM_VerboseHandlerOutputStandard::handleGCOPOuterStanzaEnd(MM_EnvironmentBase* env)
-{
-	MM_VerboseManager* manager = getManager();
-	MM_VerboseWriterChain* writer = manager->getWriterChain();
-	writer->formatAndOutput(env, 0, "</gc-op>");
-}
-
-void
 MM_VerboseHandlerOutputStandard::handleMarkEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData)
 {
 	MM_MarkEndEvent* event = (MM_MarkEndEvent*)eventData;
@@ -468,7 +444,7 @@ MM_VerboseHandlerOutputStandard::handleScavengeEnd(J9HookInterface** hook, uintp
 }
 
 void
-MM_VerboseHandlerOutputStandard::handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData)
+MM_VerboseHandlerOutputStandard::handleConcurrentEndInternal(J9HookInterface** hook, uintptr_t eventNum, void* eventData)
 {
 	/* convert event from concurrent-end to scavenge-end */
 	MM_ScavengeEndEvent scavengeEndEvent;

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -53,8 +53,6 @@ protected:
 	virtual const char *getCycleType(uintptr_t type);
 
 	void handleGCOPStanza(MM_EnvironmentBase* env, const char *type, uintptr_t contextID, uint64_t duration, bool deltaTimeSuccess);
-	void handleGCOPOuterStanzaStart(MM_EnvironmentBase* env, const char *type, uintptr_t contextID, uint64_t duration, bool deltaTimeSuccess);
-	void handleGCOPOuterStanzaEnd(MM_EnvironmentBase* env);
 
 	virtual bool hasOutputMemoryInfoInnerStanza();
 	virtual void outputMemoryInfoInnerStanzaInternal(MM_EnvironmentBase *env, uintptr_t indent, MM_CollectionStatistics *stats);
@@ -140,7 +138,7 @@ public:
 	
 	virtual const char *getConcurrentTypeString() { return "scavenge"; }
 	
-	virtual void handleConcurrentGCOpEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	virtual void handleConcurrentEndInternal(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)


### PR DESCRIPTION
https://github.com/eclipse/openj9/issues/11239

- Replace `concurrent-mark-end` in `concurrent-end` with `gc-op`
- moved `terminationReason` as one attribute to `concurrent-end` stanza
	for both concurrent marking and concurrent scavenging
- delete warning for reporting termination reason in scavenging (rare case)
- report concurrent marking duration `timems` in gc-op
- Add new API to get termination reason
	`MM_VerboseHandlerOutput::getReasonForTermination`
- Consolidate `handleConcurrentGCOpEnd` into `handleConcurrentEndInternal`