### PR TITLE
AArch64: Use b.cond instead of cbz/cbnz when all register are used up

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,14 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
       {
       int64_t secondChildValue = is64bit ? secondChild->getLongInt() : secondChild->getInt();
       if ((cc == TR::CC_EQ || cc == TR::CC_NE)
-            && secondChildValue == 0)
+            && (secondChildValue == 0)
+            /* If the node has the third child (TR::GlRegDeps)
+             * and if the number of children of it equals to the number of allocatable integer registers,
+             * we cannot assign a register for a cbz/cbnz instruction because all registers are used up.
+             * We need to use a b.cond instruction instead for that case.
+             */
+            && ((node->getNumChildren() != 3) ||
+             (node->getChild(2)->getNumChildren() != cg->getLinkage()->getProperties().getNumAllocatableIntegerRegisters())))
          {
          TR::InstOpCode::Mnemonic op;
          if (cc == TR::CC_EQ )


### PR DESCRIPTION
`ificmpeq` and its variant nodes have 3 children and the third child is
`GlRegDeps` whose children are `aRegLoad`/`iRegLoad`/`PassThrough` of global registers.
In some cases, `GlRegDeps` node uses all the allocatable integer registers.
If this happens, we cannot use `cbz`/`cbnz` instruction for branch
because `cbz`/`cbnz` requires a register in addition to those global registers.
This commit changes `ificmpHelper` to use `b.cond` instruction for that case.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>