### PR TITLE
Refactor prex arg info computation and propagation

### DIFF
--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -554,6 +554,7 @@ class OMR_InlinerUtil : public TR::OptimizationUtil, public OMR_InlinerHelper
       virtual TR_PrexArgInfo *computePrexInfo(TR_CallTarget *target);
       virtual TR_PrexArgInfo *computePrexInfo(TR_CallTarget *target, TR_PrexArgInfo *callerArgInfo);
       virtual void clearArgInfoForNonInvariantArguments(TR_CallTarget *target, TR_InlinerTracer* tracer);
+      virtual void clearArgInfoForNonInvariantArguments(TR_PrexArgInfo* argInfo, TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
       virtual void collectCalleeMethodClassInfo(TR_ResolvedMethod *calleeMethod);
       /*
        * Implemented by down stream projects to request for certain optimizations based on \parm target


### PR DESCRIPTION
Part of an effort to refactor prex arg info. This commit contains the
following changes:

- Move two TR_PrexArgInfo functions from OpenJ9 to OMR such that we can
merge prex arg infos in OMR.
- When creating prex arg info for a target, propagate arg info from call
site.
- Add an inliner util to clear arg info for variant argument given a
prex arg info
- `computePrexInfo` will not assume storing the result to `_prexArgInfo`
of a target, instead, the user will take the result and store it to the
place they want.

Part of https://github.com/eclipse/openj9/issues/11584

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>