### PR TITLE
Unblock synchronous signals when in use and ensure registering handler before unblocking a signal 

### DIFF
--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1269,16 +1269,6 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 		return OMRPORT_SIG_ERROR;
 	}
 
-	/* If a process has blocked a signal, then the signal stays blocked
-	 * in the sub-processes across fork(s) and exec(s). A blocked
-	 * signal prevents its OS signal handler to be invoked. A signal is
-	 * unblocked as an OS signal handler is installed for it in case a
-	 * parent process has blocked it.
-	 */
-	if (0 != unblockSignal(unixSignalNo)) {
-		return OMRPORT_SIG_ERROR;
-	}
-
 	memset(&newAction, 0, sizeof(struct sigaction));
 
 	/* Do not block any signals. */
@@ -1378,6 +1368,17 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 		setBitMaskSignalsWithMainHandlers(portLibrarySignalNo);
 	} else {
 		unsetBitMaskSignalsWithMainHandlers(portLibrarySignalNo);
+	}
+
+
+	/* If a process has blocked a signal, then the signal stays blocked
+	 * in the sub-processes across fork(s) and exec(s). A blocked
+	 * signal prevents its OS signal handler to be invoked. A signal is
+	 * unblocked as an OS signal handler is installed for it in case a
+	 * parent process has blocked it.
+	 */
+	if (0 != unblockSignal(unixSignalNo)) {
+		return OMRPORT_SIG_ERROR;
 	}
 
 	return 0;

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1269,16 +1269,14 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 		return OMRPORT_SIG_ERROR;
 	}
 
-	/* If a process has blocked an asynchronous signal, then the signal stays
-	 * blocked in the sub-processes across fork(s) and exec(s). A blocked
+	/* If a process has blocked a signal, then the signal stays blocked
+	 * in the sub-processes across fork(s) and exec(s). A blocked
 	 * signal prevents its OS signal handler to be invoked. A signal is
 	 * unblocked as an OS signal handler is installed for it in case a
 	 * parent process has blocked it.
 	 */
-	if (OMR_ARE_ALL_BITS_SET(OMRPORT_SIG_FLAG_SIGALLASYNC, portLibrarySignalNo)) {
-		if (0 != unblockSignal(unixSignalNo)) {
-			return OMRPORT_SIG_ERROR;
-		}
+	if (0 != unblockSignal(unixSignalNo)) {
+		return OMRPORT_SIG_ERROR;
 	}
 
 	memset(&newAction, 0, sizeof(struct sigaction));


### PR DESCRIPTION
When signals are blocked, it stays blocked across sub-processes through inheritance of the SignalMask.
Keeping synchronous signals blocked cause external effect with specific environments on signal control causing unexpected change in signal mask/handler [1].

Allowing synchronous signals to get unblocked when used, as asynchronous signals do, fix the issue and ensure signals don't get received by a wrong handler and for the process to terminates abruptly. This PR also moves unblocking signals to after registering the signal handler with the OS instead of before to ensure no signals get received between the unblocking and registering of signals.

> As per the Notes in https://man7.org/linux/man-pages/man2/sigprocmask.2.html, there are only side-effects for blocking signals such as SIGBUS, SIGFPE, SIGILL and SIGSEGV . Unblocking signals doesn't have any side-effects. So, we can unblock all signals (synchronous + asynchronous) after registering a handler against the signal in OMR. This can be treated as a permanent fix. This will also add consistency to unblocking signals. [2]



[1]
https://github.com/eclipse/openj9/issues/10744#issuecomment-750893654
[2]
https://github.com/eclipse/openj9/issues/10744#issuecomment-754907388

Issue: eclipse/openj9#10744
Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>