### PR TITLE
Fix b2iEvaluator in power for bRegLoad

### DIFF
--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -249,7 +249,8 @@ TR::Register *OMR::Power::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
         child->getOpCodeValue() != TR::d2b &&
         child->getOpCodeValue() != TR::i2b &&
         child->getOpCodeValue() != TR::l2b &&
-        child->getOpCodeValue() != TR::iRegLoad ))
+        child->getOpCodeValue() != TR::iRegLoad &&
+        child->getOpCodeValue() != TR::bRegLoad ))
       {
       trgReg = cg->gprClobberEvaluate(child);
       }


### PR DESCRIPTION
The b2iEvaluator currently does not generate sign extension for
bRegLoad. While it will work for sign extended bRegLoad, it may
yield wrong result if the byte was not sign extended. This commit
cover such cases, by making sure bRegLoad is always sign extended.

Fixes: eclipse/openj9#11192
Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>