### PR TITLE
Enable RISC-V cross-compile and comptest Jenkins job

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -34,6 +34,7 @@ def setBuildStatus(String message, String state, String sha) {
 
 def defaultCompile = 'make -j4'
 def defaultReference = '${HOME}/gitcache'
+def defaultTestCmd = 'cmake -V'
 def autoconfBuildDir = '.'
 def cmakeBuildDir = 'build'
 def workspaceName = 'Build'
@@ -58,6 +59,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -78,6 +80,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -136,6 +139,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -155,6 +159,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -164,21 +169,24 @@ def SPECS = [
         'environment' : [
             'PATH+CCACHE=/usr/lib/ccache/'
         ],
-        'ccache' : true,
+        'ccache' : false,
         'buildSystem' : 'cmake',
         'builds' : [
             [
-                'buildDir' : 'build_native',
+                'buildDir' : 'build-native',
                 'configureArgs' : '-DOMR_THREAD=OFF -DOMR_PORT=OFF -DOMR_OMRSIG=OFF -DOMR_GC=OFF -DOMR_FVTEST=OFF',
                 'compile' : defaultCompile
             ],
             [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64} -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake',
+                'configureArgs' : 'cmake .. -Wdev -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOMR_COMPILER=ON -DOMR_TEST_COMPILER=ON -DOMR_JITBUILDER=ON -DOMR_JITBUILDER_TEST=ON -DCMAKE_FIND_ROOT_PATH=/home/jenkins/riscv-debian/rootfs -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build-native/tools/ImportTools.cmake',
                 'compile' : defaultCompile
             ]
         ],
-        'test' : false
+        'test' : true,
+        'testCmd' : '~/qemu/build/qemu-riscv64 -L ~/riscv-debian/rootfs ./fvtest/compilertriltest/comptest',
+        'testArgs' : '',
+        'junitPublish' : true
     ],
     'linux_x86' : [
         'label' : 'Linux && x86',
@@ -197,6 +205,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -217,6 +226,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -237,6 +247,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -258,6 +269,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : true
     ],
@@ -278,6 +290,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '-C Debug -j1',
         'junitPublish' : true
     ],
@@ -297,6 +310,7 @@ def SPECS = [
             ]
         ],
         'test' : true,
+        'testCmd' : defaultTestCmd,
         'testArgs' : '',
         'junitPublish' : false
     ]
@@ -375,7 +389,7 @@ timestamps {
                                         switch (SPECS[params.BUILDSPEC].buildSystem) {
                                             case 'cmake':
                                                 dir("${cmakeBuildDir}") {
-                                                    sh "ctest -V ${SPECS[params.BUILDSPEC].testArgs}"
+                                                    sh "${SPECS[params.BUILDSPEC].testCmd} ${SPECS[params.BUILDSPEC].testArgs}"
                                                     if (SPECS[params.BUILDSPEC].junitPublish) {
                                                         junit '**/*results.xml'
                                                     }

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -1352,6 +1352,7 @@ class Int32SelectInt8CompareTest : public SelectCompareTest<int8_t, int32_t> {};
 
 TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1386,6 +1387,7 @@ TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1421,6 +1423,7 @@ TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1465,6 +1468,7 @@ class Int32SelectInt16CompareTest : public SelectCompareTest<int16_t, int32_t> {
 
 TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1499,6 +1503,7 @@ TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1534,6 +1539,7 @@ TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";


### PR DESCRIPTION
- Add `testCmd` to allow the test command to be configurable
- Modify `linux_riscv64_cross` for cross compile
- Enable `comptest` to run on the RISC-V emulated image

Fixes: #4641

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>