### PR TITLE
Guard internal pointer logic with checks for code generator support

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1133,11 +1133,12 @@ static TR::SymbolReference * createSymRefForNode(TR::Compilation *comp, TR::Reso
    else
       {
       bool isInternalPointer = false;
-      if ((value->hasPinningArrayPointer() &&
+      if (comp->cg()->supportsInternalPointers() &&
+          ((value->hasPinningArrayPointer() &&
             value->computeIsInternalPointer()) ||
                (value->getOpCode().isLoadVarDirect() &&
                   value->getSymbolReference()->getSymbol()->isAuto() &&
-                  value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer()))
+                  value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer())))
          isInternalPointer = true;
       
       if (value->isNotCollected() && dataType == TR::Address)

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3808,11 +3808,12 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
    TR::TreeTop *newStoreTree = NULL;
 
    bool isInternalPointer = false;
-   if ((self()->hasPinningArrayPointer() &&
-        self()->computeIsInternalPointer()) ||
+   if (comp->cg()->supportsInternalPointers() &&
+       ((self()->hasPinningArrayPointer() &&
+         self()->computeIsInternalPointer()) ||
        (self()->getOpCode().isLoadVarDirect() &&
         self()->getSymbolReference()->getSymbol()->isAuto() &&
-        self()->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer()))
+        self()->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer())))
       isInternalPointer = true;
 
    bool storesNeedToBeCreated = true;
@@ -3887,7 +3888,8 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       nodeRef = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR::Address, isInternalPointer);
       TR::Node* storeNode = TR::Node::createStore(nodeRef, self());
 
-      if (self()->hasPinningArrayPointer() &&
+      if (comp->cg()->supportsInternalPointers() &&
+          self()->hasPinningArrayPointer() &&
           self()->computeIsInternalPointer())
          self()->setIsInternalPointer(true);
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3311,11 +3311,12 @@ TR::TreeTop * OMR_InlinerUtil::storeValueInATemp(
       bool isInternalPointer = false;
 
       // disable internal pointer symbols for C/C++
-      if ((value->hasPinningArrayPointer() &&
-           value->computeIsInternalPointer()) ||
+      if (comp->cg()->supportsInternalPointers() &&
+          ((value->hasPinningArrayPointer() &&
+            value->computeIsInternalPointer()) ||
             (value->getOpCode().isLoadVarDirect() &&
              value->getSymbolReference()->getSymbol()->isAuto() &&
-             value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer()))
+             value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer())))
          isInternalPointer = true;
 
       if ((value->isNotCollected() && dataType == TR::Address) || isIndirect)


### PR DESCRIPTION
Internal pointers should only be generated if the target code generator
has support for them.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>