### PR TITLE
CMake: enable tests on cross-compilation jobs 

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -174,7 +174,7 @@ def SPECS = [
             ],
             [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64} -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake',
+                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF -DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64} -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake',
                 'compile' : defaultCompile
             ]
         ],

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -162,7 +162,7 @@ def SPECS = [
         'label' : 'Linux && x86 && compile:riscv64',
         'reference' : defaultReference,
         'environment' : [
-            'PATH+CCACHE=/usr/lib/ccache/'
+            'PATH+CCACHE_AND_QEMU=/usr/lib/ccache/:/home/jenkins/qemu/build'
         ],
         'ccache' : true,
         'buildSystem' : 'cmake',
@@ -174,11 +174,11 @@ def SPECS = [
             ],
             [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF -DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64} -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake',
+                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF "-DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake "-DOMR_TEST_LAUNCHER=qemu-riscv64;-L;${CROSS_SYSROOT_RISCV64}"',
                 'compile' : defaultCompile
             ]
         ],
-        'test' : false
+        'test' : true,
         'testArgs' : '',
         'junitPublish' : true
     ],

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -179,6 +179,8 @@ def SPECS = [
             ]
         ],
         'test' : false
+        'testArgs' : '',
+        'junitPublish' : true
     ],
     'linux_x86' : [
         'label' : 'Linux && x86',

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2020 IBM Corp. and others
+# Copyright (c) 2018, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,10 @@ include(ExternalProject)
 
 # Make sure we have performed platform detection
 include(OmrPlatform)
+
+if(OMR_DDR AND CMAKE_CROSSCOMPILING)
+	message(FATAL_ERROR "DDR is not supported when cross-compiling. Use -DOMR_DDR=OFF to disable DDR.")
+endif()
 
 set(OMR_MODULES_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(DDR_INFO_DIR "${CMAKE_BINARY_DIR}/ddr_info")

--- a/cmake/modules/OmrTest.cmake
+++ b/cmake/modules/OmrTest.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2021, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,30 +19,25 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-omr_add_executable(omrthreadextendedtest
-	processTimeTest.cpp
-	threadCpuTimeTest.cpp
-	threadExtendedTestHelpers.cpp
-	threadExtendedTestMain.cpp
-	timeBaseTest.cpp
-)
+if(OMR_TEST_)
+	return()
+endif()
+set(OMR_TEST_ 1)
 
-
-target_link_libraries(omrthreadextendedtest
-	omrGtestGlue
-	omrtestutil
-	omrutil
-	omrcore
-	omrvmstartup
-	${OMR_PORT_LIB}
-)
-
-if(OMR_HOST_OS STREQUAL "zos")
-	target_link_libraries(omrthreadextendedtest j9a2e)
+if(NOT OMR_TEST_LAUNCHER)
+	if(OMR_EXE_LAUNCHER)
+		set(OMR_TEST_LAUNCHER "${OMR_EXE_LAUNCHER}")
+	endif()
 endif()
 
-set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
+function(omr_add_test)
+	cmake_parse_arguments(opt "" "NAME;COMMAND" "" ${ARGN})
+	if(NOT opt_COMMAND)
+		message(FATAL_ERROR "omr_add_test used without specifying COMMAND")
+	endif()
+	if(NOT opt_NAME)
+		message(FATAL_ERROR "omr_add_test used without specifying NAME")
+	endif()
 
-if (NOT OMR_HOST_OS STREQUAL "zos")
-	omr_add_test(NAME threadextendedtest COMMAND $<TARGET_FILE:omrthreadextendedtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadextendedtest-results.xml)
-endif()
+	add_test(NAME "${opt_NAME}" COMMAND ${OMR_TEST_LAUNCHER} ${opt_COMMAND} ${opt_UNPARSED_ARGUMENTS})
+endfunction()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ if(OMR_GC)
 		${OMR_PORT_LIB}
 	)
 
-	add_test(NAME gcexample COMMAND gcexample)
+	add_test(NAME gcexample COMMAND $<TARGET_FILE:gcexample>)
 endif(OMR_GC)
 
 add_subdirectory(glue)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,6 +20,7 @@
 ###############################################################################
 
 include(OmrAssert)
+include(OmrTest)
 
 omr_assert(TEST OMR_EXAMPLE)
 
@@ -50,7 +51,7 @@ if(OMR_GC)
 		${OMR_PORT_LIB}
 	)
 
-	add_test(NAME gcexample COMMAND $<TARGET_FILE:gcexample>)
+	omr_add_test(NAME gcexample COMMAND $<TARGET_FILE:gcexample>)
 endif(OMR_GC)
 
 add_subdirectory(glue)

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@
 ###############################################################################
 
 include(OmrAssert)
+include(OmrTest)
 
 omr_assert(TEST OMR_FVTEST)
 

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -64,4 +64,4 @@ endif()
 
 set_property(TARGET omralgotest PROPERTY FOLDER fvtest)
 
-add_test(NAME algotest COMMAND $<TARGET_FILE:omralgotest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)
+omr_add_test(NAME algotest COMMAND $<TARGET_FILE:omralgotest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,4 +64,4 @@ endif()
 
 set_property(TARGET omralgotest PROPERTY FOLDER fvtest)
 
-add_test(NAME algotest COMMAND omralgotest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)
+add_test(NAME algotest COMMAND $<TARGET_FILE:omralgotest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,5 +124,5 @@ target_link_libraries(compilertest
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
 if (NOT OMR_HOST_OS STREQUAL "aix")
-	add_test(NAME CompilerTest COMMAND compilertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
+	add_test(NAME CompilerTest COMMAND $<TARGET_FILE:compilertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
 endif()

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -124,5 +124,5 @@ target_link_libraries(compilertest
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
 if (NOT OMR_HOST_OS STREQUAL "aix")
-	add_test(NAME CompilerTest COMMAND $<TARGET_FILE:compilertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
+	omr_add_test(NAME CompilerTest COMMAND $<TARGET_FILE:compilertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
 endif()

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 set_property(TARGET comptest PROPERTY FOLDER fvtest)
 
-add_test(
+omr_add_test(
 	NAME comptest
 	COMMAND $<TARGET_FILE:comptest> --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/comptest-results.xml
 )

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,5 +72,5 @@ set_property(TARGET comptest PROPERTY FOLDER fvtest)
 
 add_test(
 	NAME comptest
-	COMMAND comptest --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/comptest-results.xml
+	COMMAND $<TARGET_FILE:comptest> --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/comptest-results.xml
 )

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -1352,6 +1352,7 @@ class Int32SelectInt8CompareTest : public SelectCompareTest<int8_t, int32_t> {};
 
 TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1386,6 +1387,7 @@ TEST_P(Int32SelectInt8CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1421,6 +1423,7 @@ TEST_P(Int32SelectInt8CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt8CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode bcmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1465,6 +1468,7 @@ class Int32SelectInt16CompareTest : public SelectCompareTest<int16_t, int32_t> {
 
 TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1499,6 +1503,7 @@ TEST_P(Int32SelectInt16CompareTest, UsingLoadParam) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";
@@ -1534,6 +1539,7 @@ TEST_P(Int32SelectInt16CompareTest, UsingConstCompare) {
 
 TEST_P(Int32SelectInt16CompareTest, UsingConstValues) {
     SKIP_ON_ARM(MissingImplementation);
+    SKIP_ON_RISCV(MissingImplementation) << "Opcode scmpeq is not implemented";
     SKIP_ON_S390(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_S390X(KnownBug) << "The Z code generator crashes when a sub-integer compare is the first child of an integral select (#5499)";
     SKIP_ON_X86(KnownBug) << "The x86 code generator returns wrong results when a sub-integer compare is the first child of a select (#5501)";

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,5 +66,5 @@ set_property(TARGET compunittest PROPERTY FOLDER fvtest)
 
 add_test(
 	NAME compunittest
-	COMMAND compunittest --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compunittest-results.xml
+	COMMAND $<TARGET_FILE:compunittest> --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compunittest-results.xml
 )

--- a/fvtest/compilerunittest/CMakeLists.txt
+++ b/fvtest/compilerunittest/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(compunittest
 
 set_property(TARGET compunittest PROPERTY FOLDER fvtest)
 
-add_test(
+omr_add_test(
 	NAME compunittest
 	COMMAND $<TARGET_FILE:compunittest> --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compunittest-results.xml
 )

--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2020 IBM Corp. and others
+# Copyright (c) 2018, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ function(omr_add_core_test testname)
 			omrvmstartup
 			omrGtestGlue
 	)
-	add_test(
+	omr_add_test(
 		NAME    "${testname}"
 		COMMAND "${testname}" --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml
 	)

--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -36,6 +36,6 @@ function(omr_add_gc_test testname)
 	)
 	add_test(
 		NAME    "${testname}"
-		COMMAND "${testname}" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml"
+		COMMAND "$<TARGET_FILE:${testname}>" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml"
 	)
 endfunction(omr_add_gc_test)

--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2020 IBM Corp. and others
+# Copyright (c) 2018, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ function(omr_add_gc_test testname)
 			omrgc
 			omrGtestGlue
 	)
-	add_test(
+	omr_add_test(
 		NAME    "${testname}"
 		COMMAND "$<TARGET_FILE:${testname}>" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml"
 	)

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 set_property(TARGET omrgctest PROPERTY FOLDER fvtest)
 
-add_test(NAME gctest
+omr_add_test(NAME gctest
 	COMMAND $<TARGET_FILE:omrgctest> "--gtest_filter=gcFunctionalTest*" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrgctest-results.xml"
 	WORKING_DIRECTORY "${omr_SOURCE_DIR}"
 )

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,6 @@ endif()
 set_property(TARGET omrgctest PROPERTY FOLDER fvtest)
 
 add_test(NAME gctest
-	COMMAND omrgctest "--gtest_filter=gcFunctionalTest*" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrgctest-results.xml"
+	COMMAND $<TARGET_FILE:omrgctest> "--gtest_filter=gcFunctionalTest*" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrgctest-results.xml"
 	WORKING_DIRECTORY "${omr_SOURCE_DIR}"
 )

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,5 +60,5 @@ set_property(TARGET jitbuildertest PROPERTY FOLDER fvtest)
 # Disable JitBuilder tests on RISC-V. This is essentially a workaround
 # until #4764 is addressed. Once done, tests should be properly skipped.
 if(NOT OMR_HOST_ARCH STREQUAL "riscv")
-	add_test(NAME JitBuilderTest COMMAND jitbuildertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
+	add_test(NAME JitBuilderTest COMMAND $<TARGET_FILE:jitbuildertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
 endif()

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -60,5 +60,5 @@ set_property(TARGET jitbuildertest PROPERTY FOLDER fvtest)
 # Disable JitBuilder tests on RISC-V. This is essentially a workaround
 # until #4764 is addressed. Once done, tests should be properly skipped.
 if(NOT OMR_HOST_ARCH STREQUAL "riscv")
-	add_test(NAME JitBuilderTest COMMAND $<TARGET_FILE:jitbuildertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
+	omr_add_test(NAME JitBuilderTest COMMAND $<TARGET_FILE:jitbuildertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)
 endif()

--- a/fvtest/lljbtest/CMakeLists.txt
+++ b/fvtest/lljbtest/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(lljb_run
 
 function(add_lljb_test test)
 	generate_module_from_cxx(${test})
-	add_test(
+	omr_add_test(
 		NAME lljb_${test}_test
 		COMMAND $<TARGET_FILE:lljb>_run ${test}.ll
 	)

--- a/fvtest/lljbtest/CMakeLists.txt
+++ b/fvtest/lljbtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2020 IBM Corp. and others
+# Copyright (c) 2020, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,7 +61,7 @@ function(add_lljb_test test)
 	generate_module_from_cxx(${test})
 	add_test(
 		NAME lljb_${test}_test
-		COMMAND lljb_run ${test}.ll
+		COMMAND $<TARGET_FILE:lljb>_run ${test}.ll
 	)
 endfunction(add_lljb_test)
 

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,13 +139,13 @@ endif()
 if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos")
 	add_test(
 		NAME porttest
-		COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
+		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
 	)
 endif()
 
 if(OMR_OPT_CUDA)
 	add_test(
 		NAME cuda_porttest
-		COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter="Cuda*" -earlyExit
+		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter="Cuda*" -earlyExit
 	)
 endif()

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -124,7 +124,7 @@ if(OMR_HOST_OS STREQUAL "aix")
 		PRIVATE
 			${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
 	)
-	
+
 	set_target_properties(aixbaddep
 		PROPERTIES
 			LINK_FLAGS "-bI:${CMAKE_CURRENT_SOURCE_DIR}/aixbaddep/dummy.imp"
@@ -136,10 +136,10 @@ if(OMR_HOST_OS STREQUAL "aix")
 	)
 endif()
 
-if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos")
+if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos" AND NOT CMAKE_CROSSCOMPILING)
 	omr_add_test(
 		NAME porttest
-		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
+		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter=${porttest_filter}
 	)
 endif()
 

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -137,14 +137,14 @@ if(OMR_HOST_OS STREQUAL "aix")
 endif()
 
 if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos")
-	add_test(
+	omr_add_test(
 		NAME porttest
 		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
 	)
 endif()
 
 if(OMR_OPT_CUDA)
-	add_test(
+	omr_add_test(
 		NAME cuda_porttest
 		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter="Cuda*" -earlyExit
 	)

--- a/fvtest/rastest/CMakeLists.txt
+++ b/fvtest/rastest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -244,9 +244,9 @@ add_dependencies(omrtraceoptiontest
 	traceOptionAgent
 )
 
-add_test(NAME rastest COMMAND omrrastest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrrastest-results.xml)
-add_test(NAME subscribertest COMMAND omrsubscribertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsubscribertest-results.xml)
-add_test(NAME traceoptiontest COMMAND omrtraceoptiontest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrtraceoptiontest-results.xml)
+add_test(NAME rastest COMMAND $<TARGET_FILE:omrrastest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrrastest-results.xml)
+add_test(NAME subscribertest COMMAND $<TARGET_FILE:omrsubscribertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsubscribertest-results.xml)
+add_test(NAME traceoptiontest COMMAND $<TARGET_FILE:omrtraceoptiontest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrtraceoptiontest-results.xml)
 
 set_target_properties(
 	omrrastest

--- a/fvtest/rastest/CMakeLists.txt
+++ b/fvtest/rastest/CMakeLists.txt
@@ -244,9 +244,9 @@ add_dependencies(omrtraceoptiontest
 	traceOptionAgent
 )
 
-add_test(NAME rastest COMMAND $<TARGET_FILE:omrrastest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrrastest-results.xml)
-add_test(NAME subscribertest COMMAND $<TARGET_FILE:omrsubscribertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsubscribertest-results.xml)
-add_test(NAME traceoptiontest COMMAND $<TARGET_FILE:omrtraceoptiontest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrtraceoptiontest-results.xml)
+omr_add_test(NAME rastest COMMAND $<TARGET_FILE:omrrastest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrrastest-results.xml)
+omr_add_test(NAME subscribertest COMMAND $<TARGET_FILE:omrsubscribertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsubscribertest-results.xml)
+omr_add_test(NAME traceoptiontest COMMAND $<TARGET_FILE:omrtraceoptiontest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrtraceoptiontest-results.xml)
 
 set_target_properties(
 	omrrastest

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -87,4 +87,4 @@ endif()
 
 set_property(TARGET omrsigtest PROPERTY FOLDER fvtest)
 
-add_test(NAME sigtest COMMAND $<TARGET_FILE:omrsigtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsigtest-results.xml)
+omr_add_test(NAME sigtest COMMAND $<TARGET_FILE:omrsigtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsigtest-results.xml)

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,4 +87,4 @@ endif()
 
 set_property(TARGET omrsigtest PROPERTY FOLDER fvtest)
 
-add_test(NAME sigtest COMMAND omrsigtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsigtest-results.xml)
+add_test(NAME sigtest COMMAND $<TARGET_FILE:omrsigtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsigtest-results.xml)

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,5 +44,5 @@ endif()
 set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
 
 if (NOT OMR_HOST_OS STREQUAL "zos")
-	add_test(NAME threadextendedtest COMMAND omrthreadextendedtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadextendedtest-results.xml)
+	add_test(NAME threadextendedtest COMMAND $<TARGET_FILE:omrthreadextendedtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadextendedtest-results.xml)
 endif()

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -79,8 +79,8 @@ endif()
 
 set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
 
-add_test(NAME threadtest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
-add_test(NAME threadSetAttrThreadWeightTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
+omr_add_test(NAME threadtest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
+omr_add_test(NAME threadSetAttrThreadWeightTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
 if(OMR_HOST_OS STREQUAL "linux")
-	add_test(NAME threadRealtimeTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
+	omr_add_test(NAME threadRealtimeTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
 endif()

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,8 +79,8 @@ endif()
 
 set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
 
-add_test(NAME threadtest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
-add_test(NAME threadSetAttrThreadWeightTest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
+add_test(NAME threadtest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
+add_test(NAME threadSetAttrThreadWeightTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
 if(OMR_HOST_OS STREQUAL "linux")
-	add_test(NAME threadRealtimeTest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
+	add_test(NAME threadRealtimeTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
 endif()

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,5 +57,5 @@ set_property(TARGET triltest PROPERTY FOLDER fvtest/tril)
 
 add_test(
 	NAME triltest
-	COMMAND triltest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/triltest-results.xml
+	COMMAND $<TARGET_FILE:triltest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/triltest-results.xml
 )

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -55,7 +55,7 @@ target_compile_options(triltest
 
 set_property(TARGET triltest PROPERTY FOLDER fvtest/tril)
 
-add_test(
+omr_add_test(
 	NAME triltest
 	COMMAND $<TARGET_FILE:triltest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/triltest-results.xml
 )

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -40,4 +40,4 @@ endif()
 
 set_property(TARGET omrutiltest PROPERTY FOLDER fvtest)
 
-add_test(NAME utiltest COMMAND $<TARGET_FILE:omrutiltest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrutiltest-results.xml)
+omr_add_test(NAME utiltest COMMAND $<TARGET_FILE:omrutiltest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrutiltest-results.xml)

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,4 +40,4 @@ endif()
 
 set_property(TARGET omrutiltest PROPERTY FOLDER fvtest)
 
-add_test(NAME utiltest COMMAND omrutiltest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrutiltest-results.xml)
+add_test(NAME utiltest COMMAND $<TARGET_FILE:omrutiltest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrutiltest-results.xml)

--- a/fvtest/vmtest/CMakeLists.txt
+++ b/fvtest/vmtest/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(omrvmtest
 
 set_property(TARGET omrvmtest PROPERTY FOLDER fvtest)
 
-add_test(NAME vmtest COMMAND $<TARGET_FILE:omrvmtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrvmtest-results.xml)
+omr_add_test(NAME vmtest COMMAND $<TARGET_FILE:omrvmtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrvmtest-results.xml)

--- a/fvtest/vmtest/CMakeLists.txt
+++ b/fvtest/vmtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,4 +40,4 @@ target_link_libraries(omrvmtest
 
 set_property(TARGET omrvmtest PROPERTY FOLDER fvtest)
 
-add_test(NAME vmtest COMMAND omrvmtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrvmtest-results.xml)
+add_test(NAME vmtest COMMAND $<TARGET_FILE:omrvmtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrvmtest-results.xml)

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+include(OmrTest)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
@@ -31,7 +32,7 @@ macro(create_jitbuilder_test target)
 	target_link_libraries(${target}
 		jitbuilder
 		${CMAKE_DL_LIBS})
-	add_test(NAME ${target}_example_as_test COMMAND $<TARGET_FILE:${target}>)
+	omr_add_test(NAME ${target}_example_as_test COMMAND $<TARGET_FILE:${target}>)
 endmacro(create_jitbuilder_test)
 
 # Basic Tests: These should run properly on all platforms.

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -31,7 +31,7 @@ macro(create_jitbuilder_test target)
 	target_link_libraries(${target}
 		jitbuilder
 		${CMAKE_DL_LIBS})
-	add_test(NAME ${target}_example_as_test COMMAND ${target})
+	add_test(NAME ${target}_example_as_test COMMAND $<TARGET_FILE:${target}>)
 endmacro(create_jitbuilder_test)
 
 # Basic Tests: These should run properly on all platforms.


### PR DESCRIPTION
This PR provides CMake-based support for running tests under simlator such as QEMU.
This can be used to run tests as part of cross-compilation pipelines - this PR enables it on RISC-V. 

This is an alternative to what has been proposed an implemented by @fjeremic in PR #5753 

As of now, not all tests pass (for example, some port tests fail but I suppose that's because of the use of emulator). 

I did not spend time fixing them yet - the aim of this (draft) PR is to demonstrate an alternative and spark
discussion. 

FYI: @fjeremic , @AdamBrousseau 