### PR TITLE
Eliminate vm.heapBaseAddress()

### DIFF
--- a/compiler/env/OMRVMEnv.cpp
+++ b/compiler/env/OMRVMEnv.cpp
@@ -44,15 +44,6 @@ OMR::VMEnv::self()
    return static_cast<TR::VMEnv *>(this);
    }
 
-
-uintptr_t
-OMR::VMEnv::heapBaseAddress()
-   {
-   TR_UNIMPLEMENTED();
-   return 0;
-   }
-
-
 uintptr_t
 OMR::VMEnv::heapTailPaddingSizeInBytes()
    {

--- a/compiler/env/OMRVMEnv.hpp
+++ b/compiler/env/OMRVMEnv.hpp
@@ -51,8 +51,6 @@ public:
 
    int64_t maxHeapSizeInBytes() { return -1; }
 
-   uintptr_t heapBaseAddress();
-
    uintptr_t heapTailPaddingSizeInBytes();
 
    // Perhaps 'false' would be a better default

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1547,7 +1547,6 @@ TR::Node*
 OMR::Node::createCompressedRefsAnchor(TR::Node *firstChild)
    {
    TR::Node *heapBaseKonst = TR::Node::create(firstChild, TR::lconst, 0, 0);
-   heapBaseKonst->setLongInt(TR::Compiler->vm.heapBaseAddress());
    return TR::Node::create(TR::compressedRefs, 2, firstChild, heapBaseKonst);
    }
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -261,8 +261,8 @@ static void changeHeapBaseConstToLoad(TR::Compilation *comp, TR::SymbolReference
 
    node->setVisitCount(visitCount);
 
-   if ((node->getOpCodeValue() == TR::lconst) &&
-       (node->getLongInt() == TR::Compiler->vm.heapBaseAddress()))
+   if (node->getOpCodeValue() == TR::lconst &&
+       node->getLongInt() == 0)
       {
       if (!autoSymRef)
          {
@@ -349,20 +349,6 @@ TR_GlobalRegisterAllocator::perform()
    comp()->getOptimizer()->setResetExitsGRA(0);
    comp()->getOptimizer()->setSeenBlocksGRA(0);
    comp()->getOptimizer()->setSuccessorBitsGRA(0);
-
-   if (comp()->useCompressedPointers() &&
-       comp()->cg()->materializesHeapBase() &&
-       TR::Compiler->vm.heapBaseAddress() != 0)
-      {
-      TR::SymbolReference *autoSymRef = NULL;
-      vcount_t visitCount = comp()->incVisitCount();
-      for (TR::TreeTop * tt = comp()->getStartTree(); tt; tt = tt->getNextTreeTop())
-         {
-         changeHeapBaseConstToLoad(comp(), autoSymRef, tt->getNode(), visitCount);
-         }
-      if (autoSymRef)
-         comp()->getSymRefTab()->aliasBuilder.createAliasInfo();
-      }
 
    bool globalFPAssignmentDone = false;
    _appendBlock = 0;

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -933,8 +933,6 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
    TR::MemoryReference *tempMR = NULL;
    TR::Node *valueChild;
 
-   bool usingCompressedPointers = false;
-
    if (node->getOpCode().isIndirect())
       {
       valueChild = node->getSecondChild(); //handles iistore
@@ -965,11 +963,6 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
             translatedNode = translatedNode->getFirstChild();
          if (translatedNode->getOpCode().isRightShift()) // optional
             translatedNode = translatedNode->getFirstChild();
-
-         if ((translatedNode->getOpCode().isSub()) ||
-               valueChild->isNull() ||
-               TR::Compiler->vm.heapBaseAddress() == 0)
-            usingCompressedPointers = true;
          }
       }
    else

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -936,34 +936,6 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
    if (node->getOpCode().isIndirect())
       {
       valueChild = node->getSecondChild(); //handles iistore
-
-      if (comp->useCompressedPointers() &&
-            (node->getSymbolReference()->getSymbol()->getDataType() == TR::Address))
-         {
-         // pattern match the sequence
-         //     iistore f     iistore f         <- node
-         //       aload O       aload O
-         //     value           l2i
-         //                       lshr         <- translatedNode
-         //                         lsub
-         //                           a2l
-         //                             value   <- valueChild
-         //                           lconst HB
-         //                         iconst shftKonst
-         //
-         // -or- if the field is known to be null
-         // iistore f
-         //    aload O
-         //    l2i
-         //      a2l
-         //        value  <- valueChild
-         //
-         TR::Node *translatedNode = valueChild;
-         if (translatedNode->getOpCodeValue() == TR::l2i)
-            translatedNode = translatedNode->getFirstChild();
-         if (translatedNode->getOpCode().isRightShift()) // optional
-            translatedNode = translatedNode->getFirstChild();
-         }
       }
    else
       {

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -512,7 +512,6 @@ TR_Debug::dumpOptions(
       {
       TR_VerboseLog::writeLine("");
       TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs shiftAmount=%d", TR::Compiler->om.compressedReferenceShift());
-      TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs isLowMemHeap=%d", (TR::Compiler->vm.heapBaseAddress() == 0));
       }
 #endif
       TR_VerboseLog::vlogRelease();

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -755,7 +755,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
           (secondChild->getRegister() == NULL)                            &&
           ((TR::TreeEvaluator::constNodeValueIs32BitSigned(secondChild, &constValue, cg)) ||
            (comp->useCompressedPointers() &&
-           (constValue == TR::Compiler->vm.heapBaseAddress()) &&
+           (constValue == 0) &&
             firstChild->getReferenceCount() > 1 && !isMemOp))             &&
             performTransformation(comp, "O^O analyseAddForLEA: checking that second node is a memory reference %x\n", constValue))
          {
@@ -3024,7 +3024,6 @@ TR::Register *OMR::X86::TreeEvaluator::integerUshrEvaluator(TR::Node *node, TR::
       }
 
    if (comp->useCompressedPointers() && nodeIs64Bit &&
-         (TR::Compiler->vm.heapBaseAddress() == 0) &&
          (node->getFirstChild()->getOpCodeValue() == TR::a2l))
       {
       node->setIsHighWordZero(true);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -676,8 +676,7 @@ bool OMR::X86::TreeEvaluator::genNullTestSequence(TR::Node *node,
          TR::Register *tempReg = cg->allocateRegister();
          // addition of the negative number should result in 0
          //
-         int64_t value = -(int64_t)TR::Compiler->vm.heapBaseAddress();
-         generateRegImm64Instruction(MOV8RegImm64, node, tempReg, value, cg);
+         generateRegImm64Instruction(MOV8RegImm64, node, tempReg, 0, cg);
          if (n->getFirstChild()->getOpCode().isShift() && n->getFirstChild()->getFirstChild()->getRegister())
             {
             TR::Register * r = n->getFirstChild()->getFirstChild()->getRegister();
@@ -840,27 +839,10 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
          if (translatedNode->getOpCode().isRightShift())
             translatedNode = translatedNode->getFirstChild(); //optional
 
-         if (TR::Compiler->vm.heapBaseAddress() == 0 ||
-               valueChild->isNull())
-            usingLowMemHeap = true;
+         usingLowMemHeap = true;
 
-         if (isSequence && (translatedNode->getOpCode().isSub() || usingLowMemHeap))
+         if (isSequence)
             usingCompressedPointers = true;
-
-         if (usingCompressedPointers)
-            {
-            if (!usingLowMemHeap)
-               {
-               while ((valueChild->getNumChildren() > 0) &&
-                        (valueChild->getOpCodeValue() != TR::a2l))
-                  valueChild = valueChild->getFirstChild();
-               if (valueChild->getOpCodeValue() == TR::a2l)
-               valueChild = valueChild->getFirstChild();
-               // this is required so that different registers are
-               // allocated for the actual store and translated values
-               valueChild->incReferenceCount();
-               }
-            }
          }
       }
    else

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1304,7 +1304,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
    if (integerChild->getOpCode().isLoadConst() &&
        (!comp->useCompressedPointers() ||
        (integerChild->getOpCodeValue() != TR::lconst) ||
-       (integerChild->getLongInt() != TR::Compiler->vm.heapBaseAddress())))
+       (integerChild->getLongInt() != 0)))
       {
       self()->populateMemoryReference(addressChild, cg);
       if ((subTree->getOpCodeValue() != TR::iadd) && (subTree->getOpCodeValue() != TR::aiadd) && (subTree->getOpCodeValue() != TR::isub))

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5415,39 +5415,11 @@ istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
 
    TR::Node *unCompressedValue = NULL;
    TR::Compilation *comp = cg->comp();
-   TR::Node *translatedNode = NULL;
 
    if (node->getOpCode().isIndirect())
       {
       valueChild = node->getSecondChild();
       addrChild = node->getFirstChild();
-      if (comp->useCompressedPointers() &&
-            (node->getSymbolReference()->getSymbol()->getDataType() == TR::Address))
-         {
-         // pattern match the sequence
-         //     iistore f     iistore f         <- node
-         //       aload O       aload O         <- addrChild
-         //     value           l2i
-         //                       lshr
-         //                         lsub        <- translatedNode
-         //                           a2l
-         //                             value   <- valueChild
-         //                           lconst HB
-         //                         iconst shftKonst
-         //
-         // -or- if the field is known to be null
-         // iistore f
-         //    aload O
-         //    l2i
-         //      a2l
-         //        value  <- valueChild
-         //
-         translatedNode = valueChild;
-         if (translatedNode->getOpCodeValue() == TR::l2i)
-            translatedNode = translatedNode->getFirstChild();
-         if (translatedNode->getOpCode().isRightShift()) // optional
-            translatedNode = translatedNode->getFirstChild();
-         }
       }
    else
       {

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5413,8 +5413,6 @@ istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
       //      node->getFirstChild()->getFirstChild()->setIsProfilingCode(cg->comp());
       }
 
-
-   bool usingCompressedPointers = false;
    TR::Node *unCompressedValue = NULL;
    TR::Compilation *comp = cg->comp();
    TR::Node *translatedNode = NULL;
@@ -5449,34 +5447,6 @@ istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
             translatedNode = translatedNode->getFirstChild();
          if (translatedNode->getOpCode().isRightShift()) // optional
             translatedNode = translatedNode->getFirstChild();
-
-         bool usingLowMemHeap = false;
-         if (TR::Compiler->vm.heapBaseAddress() == 0 ||
-               valueChild->isNull())
-            usingLowMemHeap = true;
-
-         if (translatedNode->getOpCode().isSub() || usingLowMemHeap)
-            usingCompressedPointers = true;
-         // valueChild is not updated, the compression is taken care of
-         // by the lsub (which is already tagged with a nodeflag)
-         //
-         if (usingCompressedPointers && !usingLowMemHeap)
-            {
-            unCompressedValue = valueChild;
-            while (unCompressedValue->getNumChildren() > 0 &&
-                     unCompressedValue->getOpCodeValue() != TR::a2l)
-               unCompressedValue = unCompressedValue->getFirstChild();
-            if (unCompressedValue->getOpCodeValue() == TR::a2l)
-               unCompressedValue = unCompressedValue->getFirstChild();
-            // this allows separate registers to be allocated if the base
-            // of the indirect access is the same as the value thats being
-            // compressed (e.g. O.f = O)
-            //
-            if (unCompressedValue == addrChild)
-               unCompressedValue->incReferenceCount();
-            else
-               unCompressedValue = NULL;
-            }
          }
       }
    else


### PR DESCRIPTION
This commit removes `OMR::VMEnv::heapBaseAddress()` as this routine always returns 0. It was introduced in the codebase early on in the codebase and has since been superseded by a shift-based solution. Hence this is no longer needed. See https://github.com/eclipse/openj9/issues/11263 for original issue and discussion.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>