### PR TITLE
Remove @andrewcraik as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,8 +38,8 @@
 
 # Compiler
 /compiler/ @0xdaryl @mstoodle
-/compiler/optimizer/ @vijaysun-omr @andrewcraik
-/compiler/il/ @vijaysun-omr @Leonardo2718 @andrewcraik
+/compiler/optimizer/ @vijaysun-omr
+/compiler/il/ @vijaysun-omr @Leonardo2718
 /compiler/arm/ @0xdaryl @knn-k
 /compiler/aarch64/ @0xdaryl @knn-k
 /compiler/p/ @aviansie-ben


### PR DESCRIPTION
@andrewcraik has retired from his position as a project committer and
has requested to be removed as a code owner. He no longer has a valid
ECA so I am committing the change for him.

Thanks for all your contributions and for serving as a project
committer, Andrew!

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>