### PR TITLE
[WIP] Remove old double map API

### DIFF
--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,7 +178,6 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrvmem_vmem_params_init, /* vmem_vmem_params_init */
 	omrvmem_reserve_memory, /* vmem_reserve_memory */
 	omrvmem_reserve_memory_ex, /* vmem_reserve_memory_ex */
-	omrvmem_get_contiguous_region_memory, /* vmem_get_contiguous_region_memory */
 	omrvmem_create_double_mapped_region, /* vmem_create_double_mapped_region */
 	omrvmem_release_double_mapped_region, /* omrvmem_release_double_mapped_region */
 	omrvmem_get_page_size, /* vmem_get_page_size */

--- a/port/common/omrvmem.c
+++ b/port/common/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -212,12 +212,6 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
  * @paramuintptr_t             pageSize,       [in] onstant describing pageSize
  * @param OMRMemCategory       *category       [in] Memory allocation category
  */
-
-void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	return NULL;
-}
 
 /**
  * Restores memory region associated with double mapped region, to what it was

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1307,7 +1307,7 @@ omrvmem_release_double_mapped_region(struct OMRPortLibrary *portLibrary, void *a
  *  @param uintptr_t                    pageSize            [in] Constant describing page size
  *  @param OMRMemCategory               *category           [in] Memory allocation category
  *  @param void                         *preferredAddress    [in] Prefered address of contiguous region to be double mapped
- * 
+ *
  * @return pointer to contiguous region to which regions were double mapped into, NULL is returned if unsuccessful
  */
 
@@ -1444,35 +1444,6 @@ omrvmem_create_double_mapped_region(struct OMRPortLibrary *portLibrary, void* re
 	Trc_PRT_double_map_regions_Create_Exit(contiguousMap);
 	return contiguousMap;
 }
-
-/**
- *  Maps a contiguous region of memory to double map addresses[] passed in.
- *
- *  @param OMRPortLibrary*              portLibrary         [in] The port library object
- *  @param void*                        addressesOffeset[]  [in] Addresses to be double mapped
- *  @param uintptr_t                    byteAmount          [in] Total size to allocate for contiguous block of memory
- *  @param struct J9PortVmemIdentifier* oldIdentifier       [in]  Old Identifier containing file descriptor
- *  @param struct J9PortVmemIdentifier* newIdentifier       [out] New Identifier for new block of memory. The structure to be updated
- *  @param uintptr_t                    mode,               [in] Access mode
- *  @param uintptr_t                    pageSize,           [in] Constant describing page size
- *  @param OMRMemCategory*              category            [in] Memory allocation category
- */
-
-void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	Trc_PRT_double_map_getContiguousMem_Entry((void *)addresses, addressesCount, addressSize, byteAmount, pageSize);
-	int protectionFlags = PROT_READ | PROT_WRITE;
-	int flags = MAP_PRIVATE | MAP_ANON;
-	int fd = -1;
-	void* contiguousMap = NULL;
-	byteAmount = addressesCount * addressSize;
-	BOOLEAN successfulContiguousMap = FALSE;
-	BOOLEAN shouldUnmapAddr = FALSE;
-
-	if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
-		protectionFlags = get_protectionBits(mode);
-	}
 
 	if (0 != (OMRPORT_VMEM_MEMORY_MODE_MMAP_HUGE_PAGES & oldIdentifier->mode)) {
 		flags |= MAP_HUGETLB;

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -623,7 +623,7 @@ extern J9_CFUNC intptr_t
 omrsysinfo_get_cwd(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen);
 extern J9_CFUNC intptr_t
 omrsysinfo_get_tmp(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen, BOOLEAN ignoreEnvVariable);
-extern J9_CFUNC int32_t 
+extern J9_CFUNC int32_t
 omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *count);
 extern J9_CFUNC intptr_t
 omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc);
@@ -631,11 +631,11 @@ extern J9_CFUNC BOOLEAN
 omrsysinfo_os_has_feature(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc, uint32_t feature);
 extern J9_CFUNC BOOLEAN
 omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernelInfo *kernelInfo);
-extern J9_CFUNC BOOLEAN 
+extern J9_CFUNC BOOLEAN
 omrsysinfo_cgroup_is_system_available(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC uint64_t
 omrsysinfo_cgroup_get_available_subsystems(struct OMRPortLibrary *portLibrary);
-extern J9_CFUNC uint64_t 
+extern J9_CFUNC uint64_t
 omrsysinfo_cgroup_are_subsystems_available(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlags);
 extern J9_CFUNC uint64_t
 omrsysinfo_cgroup_get_enabled_subsystems(struct OMRPortLibrary *portLibrary);
@@ -643,7 +643,7 @@ extern J9_CFUNC uint64_t
 omrsysinfo_cgroup_enable_subsystems(struct OMRPortLibrary *portLibrary, uint64_t requestedSubsystems);
 extern J9_CFUNC uint64_t
 omrsysinfo_cgroup_are_subsystems_enabled(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlags);
-extern J9_CFUNC int32_t 
+extern J9_CFUNC int32_t
 omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
 extern J9_CFUNC BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary);
@@ -881,8 +881,6 @@ extern J9_CFUNC void *
 omrvmem_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, uint32_t category);
 extern J9_CFUNC void *
 omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params);
-extern J9_CFUNC void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 extern J9_CFUNC void *
 omrvmem_create_double_mapped_region(struct OMRPortLibrary *portLibrary, void* regionAddresses[], uintptr_t regionsCount, uintptr_t regionSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category, void *preferredAddress);
 extern J9_CFUNC int32_t

--- a/port/osx/omrvmem.c
+++ b/port/osx/omrvmem.c
@@ -676,7 +676,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 			currentAddress = (void *)alignmentInBytes;
 		}
 	}
-	
+
 #if defined(VM_FLAGS_SUPERPAGE_SIZE_2MB)
 	if (PPG_vmem_pageSize[2] == pageSize) {
 		/* Don't bother scanning the entire address space if the request can't be satisfied. */
@@ -687,7 +687,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 		omrvmem_free_memory(portLibrary, tmpPointer, byteAmount, identifier);
 	}
 #endif /* defined(VM_FLAGS_SUPERPAGE_SIZE_2MB) */
-	
+
 	/* Try all addresses within range */
 	while ((startAddress <= currentAddress) && (endAddress >= currentAddress)) {
 		memoryPointer = reserveMemory(portLibrary, currentAddress, byteAmount, identifier, mode, pageSize, pageFlags, category);
@@ -928,7 +928,7 @@ omrvmem_release_double_mapped_region(struct OMRPortLibrary *portLibrary, void *a
  *  @param uintptr_t                    pageSize            [in] Constant describing page size
  *  @param OMRMemCategory               *category           [in] Memory allocation category
  *  @param void                         *preferredAddress    [in] Prefered address of contiguous region to be double mapped
- * 
+ *
  * @return pointer to contiguous region to which regions were double mapped into, NULL is returned if unsuccessful
  */
 
@@ -1055,11 +1055,4 @@ omrvmem_create_double_mapped_region(struct OMRPortLibrary *portLibrary, void* re
 
 	Trc_PRT_double_map_regions_Create_Exit(contiguousMap);
 	return contiguousMap;
-}
-
-void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return NULL;
 }

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -1561,20 +1561,6 @@ OLD_IMPL:
 }
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return NULL;
-}
-
-int32_t
-omrvmem_release_double_mapped_region(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier)
-{
-	portLibrary->error_set_last_error(portLibrary, errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return -1;
-}
-
-void *
 omrvmem_create_double_mapped_region(struct OMRPortLibrary *portLibrary, void* regionAddresses[], uintptr_t regionsCount, uintptr_t regionSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category, void *preferredAddress)
 {
 	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);

--- a/port/zos390/omrvmem.c
+++ b/port/zos390/omrvmem.c
@@ -1313,7 +1313,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t
 		}
 	}
 
-	/* 
+	/*
 	 * When mode is OMRPORT_VMEM_MEMORY_EXECUTE we will only consider pagable large pages. Return pageSize of 0 if 1M pageable is not configured on the system.
 	 * When flag is OMRPORT_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE, we prefer pageable 1M large pages unless they're not provisioned.
 	 */
@@ -1372,7 +1372,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		/* If the page type is PREFER_PAGEABLE try to get 1M pageable large pages. Otherwise, use a fixed large page. */
 		if ((IS_VMEM_PAGE_FLAG_PAGEABLE_PREFERABLE(validPageFlags))) {
 
-			/* Try 1M large pages */ 
+			/* Try 1M large pages */
 			if (ONE_M == validPageSize) {
 				/* Keep from calling this again if ONE_M fails. */
 				isPageableAttempted = TRUE;
@@ -1415,7 +1415,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 
 	if (FALSE == isPageableAttempted) {
 		pageSizeFound = isLargePageSizeSupported(portLibrary, ONE_M, OMRPORT_VMEM_PAGE_FLAG_PAGEABLE);
-	
+
 		if (TRUE == pageSizeFound) {
 			validPageSize = ONE_M;
 			SET_PAGE_TYPE(validPageFlags, OMRPORT_VMEM_PAGE_FLAG_PAGEABLE);
@@ -1632,13 +1632,6 @@ isRmode64Supported()
 	return FALSE;
 }
 #endif
-
-void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return NULL;
-}
 
 int32_t
 omrvmem_release_double_mapped_region(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier)

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1881,13 +1881,6 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary,
 	return result;
 }
 
-void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
-{
-	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return NULL;
-}
-
 int32_t
 omrvmem_release_double_mapped_region(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier)
 {


### PR DESCRIPTION
Remove old double map API as mentioned in issue #5650 

This will remove all the functions and anything associated with ```omrvmem_get_contiguous_region_memory```.

Closes:  #5650 

Signed-off-by: J. Cody Arnholt <j.cody.tbone@gmail.com>