### PR TITLE
Update AliasBuilder and SymbolReferenceTable following extensible class convention

### DIFF
--- a/compiler/compile/AliasBuilder.hpp
+++ b/compiler/compile/AliasBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #define TR_ALIASBUILDER_INCL
 
 #include "compile/OMRAliasBuilder.hpp"
+#include "infra/Annotations.hpp"
 
 namespace TR { class Compilation; }
 namespace TR { class SymbolReferenceTable; }

--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ namespace OMR { typedef OMR::AliasBuilder AliasBuilderConnector; }
 #include "compile/Method.hpp"
 #include "env/TRMemory.hpp"
 #include "il/Node.hpp"
+#include "infra/Annotations.hpp"
 #include "infra/BitVector.hpp"
 #include "infra/Array.hpp"
 #include "infra/List.hpp"
@@ -67,7 +68,7 @@ public:
    TR::AliasBuilder *self();
 
    TR::SymbolReferenceTable *symRefTab() { return _symRefTab; }
-   TR::Compilation *comp() { return _compilation; }
+   TR::Compilation *comp() { return _comp; }
    TR_Memory *trMemory() { return _trMemory; }
    TR_StackMemory trStackMemory() { return _trMemory; }
    TR_HeapMemory trHeapMemory() { return _trMemory; }
@@ -138,7 +139,7 @@ public:
 
 protected:
 
-   TR::Compilation *_compilation;
+   TR::Compilation *_comp;
    TR_Memory *_trMemory;
 
    TR::SymbolReferenceTable *_symRefTab;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,6 +49,7 @@ namespace OMR { typedef OMR::SymbolReferenceTable SymbolReferenceTableConnector;
 #include "il/RegisterMappedSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/Symbol.hpp"
+#include "infra/Annotations.hpp"
 #include "infra/Array.hpp"
 #include "infra/Assert.hpp"
 #include "infra/BitVector.hpp"
@@ -56,7 +57,6 @@ namespace OMR { typedef OMR::SymbolReferenceTable SymbolReferenceTableConnector;
 #include "infra/Link.hpp"
 #include "infra/List.hpp"
 #include "runtime/Runtime.hpp"
-
 
 namespace OMR
 {
@@ -72,7 +72,7 @@ class SymbolReferenceTable
 
    TR::SymbolReferenceTable *self();
 
-   TR::Compilation *comp() { return _compilation; }
+   TR::Compilation *comp() { return _comp; }
    TR_FrontEnd *fe() { return _fe; }
    TR_Memory *trMemory() { return _trMemory; }
    TR_StackMemory trStackMemory() { return _trMemory; }
@@ -478,9 +478,9 @@ class SymbolReferenceTable
    template <class BitVector>
    void getAllSymRefs(BitVector &allSymRefs)
       {
-      for (int32_t symRefNumber = getIndexOfFirstSymRef(); symRefNumber < getNumSymRefs(); symRefNumber++)
+      for (int32_t symRefNumber = 0; symRefNumber < baseArray.size(); symRefNumber++)
          {
-         TR::SymbolReference *symRef = getSymRef(symRefNumber);
+         TR::SymbolReference *symRef = baseArray.element(symRefNumber);
          if (symRef)
             allSymRefs[symRefNumber] = true;
          }
@@ -602,7 +602,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateTransactionExitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateTransactionAbortSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreatePrefetchSymbol();
-   TR::SymbolReference * findPrefetchSymbol() { return element(prefetchSymbol); }
+   TR::SymbolReference * findPrefetchSymbol();
    TR::SymbolReference * findOrCreateStartPCSymbolRef();
    TR::SymbolReference * findOrCreateAThrowSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateCheckCastSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
@@ -639,7 +639,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findClassAndDepthFlagsSymbolRef();
    TR::SymbolReference * findArrayComponentTypeSymbolRef();
    TR::SymbolReference * findClassIsArraySymbolRef();
-   TR::SymbolReference * findHeaderFlagsSymbolRef() { return element(headerFlagsSymbol); }
+   TR::SymbolReference * findHeaderFlagsSymbolRef();
    TR::SymbolReference * createKnownStaticReferenceSymbolRef(void *address, TR::KnownObjectTable::Index knownObjectIndex=TR::KnownObjectTable::UNKNOWN);
 
    TR::SymbolReference * findOrCreateArrayTranslateSymbol();
@@ -835,7 +835,7 @@ class SymbolReferenceTable
    OriginalUnimprovedMap               _originalUnimprovedSymRefs;
 
    TR_FrontEnd *_fe;
-   TR::Compilation *_compilation;
+   TR::Compilation *_comp;
    TR_Memory *_trMemory;
 
    // J9

--- a/compiler/compile/OMRSymbolReferenceTable_inlines.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable_inlines.hpp
@@ -19,25 +19,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_SYMBOLREFERENCETABLE_INCL
-#define TR_SYMBOLREFERENCETABLE_INCL
+#ifndef OMR_SYMBOLREFERENCETABLE_INLINES_INCL
+#define OMR_SYMBOLREFERENCETABLE_INLINES_INCL
 
-#include "compile/OMRSymbolReferenceTable.hpp"
-#include "infra/Annotations.hpp"
+//#include "compile/OMRCompilation.hpp"
 
-namespace TR { class Compilation; }
 
-namespace TR
-   {
-   class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
-      {
-      public:
-
-      SymbolReferenceTable(size_t s, TR::Compilation *c) :
-         OMR::SymbolReferenceTableConnector(s, c)
-         {
-         }
-      };
-   }
 
 #endif

--- a/compiler/compile/SymbolReferenceTable_inlines.hpp
+++ b/compiler/compile/SymbolReferenceTable_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,25 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_SYMBOLREFERENCETABLE_INCL
-#define TR_SYMBOLREFERENCETABLE_INCL
+#ifndef SYMBOLREFERENCETABLE_INLINES_INCL
+#define SYMBOLREFERENCETABLE_INLINES_INCL
 
-#include "compile/OMRSymbolReferenceTable.hpp"
-#include "infra/Annotations.hpp"
-
-namespace TR { class Compilation; }
-
-namespace TR
-   {
-   class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
-      {
-      public:
-
-      SymbolReferenceTable(size_t s, TR::Compilation *c) :
-         OMR::SymbolReferenceTableConnector(s, c)
-         {
-         }
-      };
-   }
+//#include "compile/OMRSymbolReferenceTable_inlines.hpp"
 
 #endif


### PR DESCRIPTION


  - AliasBuilder
  - SymbolReferenceTable

Add OMR_EXTENSIBLE macro and using self() within member functions

Signed-off-by: James Guan <jamesgua@ca.ibm.com>