### PR TITLE
Remove unused applyUserOptions

### DIFF
--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -166,7 +166,6 @@ public:
    void setMinorArch(TR::MinorArchitecture a) { _minorArch = a; }
    bool isI386() { return _minorArch == TR::m_arch_i386; }
    bool isAMD64() { return _minorArch == TR::m_arch_amd64; }
-   void applyUserOptions() {}
 
    /** 
     * @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,19 +192,3 @@ OMR::Power::CPU::getOldProcessorTypeFromNewProcessorType(OMRProcessorArchitectur
    return TR_FirstPPCProcessor;
    }
 
-void
-OMR::Power::CPU::applyUserOptions()
-   {
-   // P10 support is not yet well-tested, so it's currently gated behind an environment
-   // variable to prevent it from being used by accident by users who use old versions of
-   // OMR once P10 chips become available.
-   if (_processorDescription.processor == OMR_PROCESSOR_PPC_P10)
-      {
-      static bool enableP10 = feGetEnv("TR_EnableExperimentalPower10Support");
-      if (!enableP10)
-         {
-         _processorDescription.processor = OMR_PROCESSOR_PPC_P9;
-         _processorDescription.physicalProcessor = OMR_PROCESSOR_PPC_P9;
-         }
-      }
-   }

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -130,7 +130,6 @@ public:
    bool is(OMRProcessorArchitecture p);
    bool isAtLeast(OMRProcessorArchitecture p);
    bool isAtMost(OMRProcessorArchitecture p);
-   void applyUserOptions();
 
 private:
    


### PR DESCRIPTION
Removing the unused implementation of applyUserOptions.
applyUserOptions was implemented only on Power so that on startup it was possible to disable P10 support when TR_EnableExperimentalPower10Support is not set.
applyUserOptions was ultimately implemented but never used.
Since the method is not implemented on any other platform, it should be removed from the class.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>