### PR TITLE
Add %sysname dump token on z/OS

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,9 +102,10 @@ else()
 endif()
 
 list(APPEND OBJECTS
-	omrgetjobname.c
-	omrgetjobid.c
 	omrgetasid.c
+	omrgetjobid.c
+	omrgetjobname.c
+	omrgetsysname.c
 )
 
 if(OMR_ARCH_S390)

--- a/port/common/omrgetsysname.c
+++ b/port/common/omrgetsysname.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,21 +27,24 @@
  */
 #include <string.h>
 #include "omrport.h"
-#include "omrgetasid.h"
+#include "omrgetsysname.h"
 
-#define ASID_STRING "%asid"
-#define ASID_STRING_LENGTH sizeof(ASID_STRING)
+#define SYSNAME_STRING "%sysname"
+#define SYSNAME_STRING_LENGTH sizeof(SYSNAME_STRING)
 
-/* Generic version of omrget_asid() */
+/* Generic version of omrget_sysname() */
 uintptr_t
-omrget_asid(struct OMRPortLibrary *portLibrary, char *asid, uintptr_t length)
+omrget_sysname(struct OMRPortLibrary *portLibrary, char *sysname, uintptr_t length)
 {
-	/* Check that caller provided enough space for the string */
-	if ((NULL == asid) || (length < ASID_STRING_LENGTH)) {
-		return ASID_STRING_LENGTH;
-	}
-	/* Default behaviour for platforms other than zOS, simply return the ASID string token */
-	strcpy(asid, ASID_STRING);
+	uintptr_t result = 0;
 
-	return 0;
+	/* Check that caller provided enough space for the string. */
+	if ((NULL == sysname) || (length < SYSNAME_STRING_LENGTH)) {
+		result = SYSNAME_STRING_LENGTH;
+	} else {
+		/* Default behaviour for platforms other than zOS, simply return the sysname string token. */
+		strcpy(sysname, SYSNAME_STRING);
+	}
+
+	return result;
 }

--- a/port/common/omrgetsysname.h
+++ b/port/common/omrgetsysname.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,28 +20,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#ifndef omrgetsysname_h
+#define omrgetsysname_h
+
+#include "omrcomp.h"
+
 /**
- * @file
- * @ingroup Port
- * @brief shared library
+ * Get the zOS SYSNAME sysparm.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in/out] sysname Pointer to string to populate with the SYSNAME.
+ * 		On z/OS an empty string is returned if the SYSNAME is not available.
+ * 		Other platforms return the "%sysname" token.
+ * @param[in] length The length of the data area addressed by sysname.
+ *
+ * @return 0 on success, size of required buffer when the buffer is not big enough
  */
-#include <string.h>
-#include "omrport.h"
-#include "omrgetasid.h"
+uintptr_t omrget_sysname(struct OMRPortLibrary *portLibrary, char *sysname, uintptr_t length);
 
-#define ASID_STRING "%asid"
-#define ASID_STRING_LENGTH sizeof(ASID_STRING)
-
-/* Generic version of omrget_asid() */
-uintptr_t
-omrget_asid(struct OMRPortLibrary *portLibrary, char *asid, uintptr_t length)
-{
-	/* Check that caller provided enough space for the string */
-	if ((NULL == asid) || (length < ASID_STRING_LENGTH)) {
-		return ASID_STRING_LENGTH;
-	}
-	/* Default behaviour for platforms other than zOS, simply return the ASID string token */
-	strcpy(asid, ASID_STRING);
-
-	return 0;
-}
+#endif /* omrgetsysname_h */

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,9 +61,10 @@ typedef void *charconvState_t; /*dummy type */
 #include "omrutil.h"
 #include "omrcomp.h"
 #include "omrport.h"
-#include "omrgetjobname.h"
-#include "omrgetjobid.h"
 #include "omrgetasid.h"
+#include "omrgetjobid.h"
+#include "omrgetjobname.h"
+#include "omrgetsysname.h"
 #include "omrstdarg.h"
 #include "hashtable_api.h"
 
@@ -1767,11 +1768,13 @@ populateWithDefaultTokens(struct OMRPortLibrary *portLibrary, struct J9StringTok
 #define JOBNAME_BUF_LEN 128
 #define JOBID_BUF_LEN 16
 #define ASID_BUF_LEN 16
+#define SYSNAME_BUF_LEN 32
 	uintptr_t pid;
 	char username[USERNAME_BUF_LEN];
 	char jobname[JOBNAME_BUF_LEN];
 	char jobid[JOBID_BUF_LEN];
 	char asid[ASID_BUF_LEN];
+	char sysname[SYSNAME_BUF_LEN];
 
 	if (NULL == tokens) {
 		return -1;
@@ -1782,6 +1785,7 @@ populateWithDefaultTokens(struct OMRPortLibrary *portLibrary, struct J9StringTok
 	omrget_jobname(portLibrary, jobname, JOBNAME_BUF_LEN);
 	omrget_jobid(portLibrary, jobid, JOBID_BUF_LEN);
 	omrget_asid(portLibrary, asid, ASID_BUF_LEN);
+	omrget_sysname(portLibrary, sysname, SYSNAME_BUF_LEN);
 
 	portLibrary->str_set_time_tokens(portLibrary, tokens, timeMillis);
 
@@ -1791,7 +1795,8 @@ populateWithDefaultTokens(struct OMRPortLibrary *portLibrary, struct J9StringTok
 		|| portLibrary->str_set_token(portLibrary, tokens, "last", "%s", "")
 		|| portLibrary->str_set_token(portLibrary, tokens, "seq", "%04u", 0)
 		|| portLibrary->str_set_token(portLibrary, tokens, "jobid", "%s", jobid)
-		|| portLibrary->str_set_token(portLibrary, tokens, "asid", "%s", asid)) {
+		|| portLibrary->str_set_token(portLibrary, tokens, "asid", "%s", asid)
+		|| portLibrary->str_set_token(portLibrary, tokens, "sysname", "%s", sysname)) {
 		/* If any of the above fail, we're out of memory */
 		return -1;
 	}

--- a/port/port_objects.mk
+++ b/port/port_objects.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2019 IBM Corp. and others
+# Copyright (c) 2015, 2021 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,9 +68,10 @@ else
   OBJECTS += protect_helpers
 endif
 
-OBJECTS += omrgetjobname
-OBJECTS += omrgetjobid
 OBJECTS += omrgetasid
+OBJECTS += omrgetjobid
+OBJECTS += omrgetjobname
+OBJECTS += omrgetsysname
 
 ifeq ($(OMR_HOST_ARCH),$(filter $(OMR_HOST_ARCH),s390 s390x))
   # z/OS and zLinux


### PR DESCRIPTION
Populate the %sysname token using __osname() nodename, which provides
the SYSNAME sysparm.