### PR TITLE
CMake: Fix handling of ddr scanner

### DIFF
--- a/cmake/modules/FindLibDwarf.cmake
+++ b/cmake/modules/FindLibDwarf.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,19 @@
 #   LIBDWARF_DEFINITIONS
 
 find_package(LibElf)
-find_package(LibZ)
+
+if(NOT OMR_OS_ZOS)
+	# On z/OS we don't want libz.
+	find_package(LibZ)
+else()
+	# For technical reasons this is hard to autodetect on zos.
+	# Note: the value can still be overridden on the command line.
+	if(OMR_ENV_DATA64)
+		set(LIBDWARF_LIBRARY "/usr/lpp/cbclib/lib/libelfdwarf64.x" CACHE FILEPATH "")
+	else()
+		set(LIBDWARF_LIBRARY "/usr/lpp/cbclib/lib/libelfdwarf32.x" CACHE FILEPATH "")
+	endif()
+endif()
 
 # Find dwarf.h
 # Will set:

--- a/cmake/modules/FindLibElf.cmake
+++ b/cmake/modules/FindLibElf.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,18 @@
 #  LIBELF_LIBRARIES
 #  LIBELF_DEFINITIONS
 
-find_package(LibZ)
+if(NOT OMR_OS_ZOS)
+	# On z/OS we don't want libz.
+	find_package(LibZ)
+else()
+	# For technical reasons this is hard to autodetect on zos.
+	# Note: the value can still be overridden on the command line.
+	if(OMR_ENV_DATA64)
+		set(LIBELF_LIBRARY "/usr/lpp/cbclib/lib/libelfdwarf64.x" CACHE FILEPATH "")
+	else()
+		set(LIBELF_LIBRARY "/usr/lpp/cbclib/lib/libelfdwarf32.x" CACHE FILEPATH "")
+	endif()
+endif()
 
 # First we try getting the info we need from pkg-config
 find_package(PkgConfig QUIET)

--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -37,6 +37,9 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 list(REMOVE_ITEM CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES /usr/include)
 list(REMOVE_ITEM CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES /usr/include)
 
+# Make sure that cmake can find libelf/libdwarf headers.
+list(APPEND CMAKE_INCLUDE_PATH "/usr/lpp/cbclib/include")
+
 # Create helper targets for specifying ascii/ebcdic options
 add_library(omr_ascii INTERFACE)
 target_compile_definitions(omr_ascii INTERFACE -DIBM_ATOE)

--- a/ddr/lib/ddr-scanner/CMakeLists.txt
+++ b/ddr/lib/ddr-scanner/CMakeLists.txt
@@ -43,7 +43,7 @@ if(OMR_OS_WINDOWS)
 		PUBLIC
 			DiaSDK::diasdk
 	)
-elseif(OMR_OS_LINUX)
+elseif(OMR_OS_LINUX OR OMR_OS_ZOS)
 	find_package(LibDwarf REQUIRED)
 
 	target_link_libraries(omr_ddr_scanner
@@ -53,7 +53,6 @@ elseif(OMR_OS_LINUX)
 
 	target_sources(omr_ddr_scanner
 		PRIVATE
-			dwarf/DwarfFunctions.cpp
 			dwarf/DwarfScanner.cpp
 	)
 elseif(OMR_OS_OSX)


### PR DESCRIPTION
- Enable support for z/OS
- Don't compile DwarfFunctions on linux (matches behaviour of makefiles)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>