### PR TITLE
Using more readable and shorted method where possible

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,11 +51,11 @@ genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstO
    TR::Register *trgReg = NULL;
    int64_t value = 0;
 
-   if(1 == firstChild->getReferenceCount())
+   if(firstChild->isSingleRef())
       {
       trgReg = src1Reg;
       }
-   else if(1 == secondChild->getReferenceCount() && secondChild->getRegister() != NULL)
+   else if(secondChild->isSingleRef() && secondChild->getRegister() != NULL)
       {
       trgReg = secondChild->getRegister();
       }
@@ -136,8 +136,7 @@ static TR::Register *
 generateMaddOrMsub(TR::Node *node, TR::Node *mulNode, TR::Node *anotherNode, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {
    if ((mulNode->getOpCodeValue() == TR::imul || mulNode->getOpCodeValue() == TR::lmul) &&
-       mulNode->getReferenceCount() == 1 &&
-       mulNode->getRegister() == NULL)
+       mulNode->isSingleRefUnevaluated())
       {
       TR::Register *trgReg = cg->allocateRegister();
       TR::Register *mulSrc1Reg = cg->evaluate(mulNode->getFirstChild());
@@ -301,11 +300,11 @@ OMR::ARM64::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       }
 
-   if(1 == firstChild->getReferenceCount())
+   if(firstChild->isSingleRef())
       {
       trgReg = src1Reg;
       }
-   else if(1 == secondChild->getReferenceCount() && (src2Reg = secondChild->getRegister()) != NULL)
+   else if(secondChild->isSingleRef() && (src2Reg = secondChild->getRegister()) != NULL)
       {
       trgReg = src2Reg;
       }
@@ -394,11 +393,11 @@ OMR::ARM64::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       }
 
-   if(1 == firstChild->getReferenceCount())
+   if(firstChild->isSingleRef())
       {
       trgReg = src1Reg;
       }
-   else if(1 == secondChild->getReferenceCount() && (src2Reg = secondChild->getRegister()) != NULL)
+   else if(secondChild->isSingleRef() && (src2Reg = secondChild->getRegister()) != NULL)
       {
       trgReg = src2Reg;
       }
@@ -627,7 +626,7 @@ OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       TR::Register *tempReg;
       bool useTempReg;
 
-      if (secondChild->getOpCode().isNeg() && secondChild->getRegister() == NULL && secondChild->getReferenceCount() == 1)
+      if (secondChild->getOpCode().isNeg() && secondChild->isSingleRefUnevaluated())
          {
          // If the second child is `ineg` and not commoned, cancel out double negation
          auto shiftAmountNode = secondChild->getFirstChild();
@@ -872,11 +871,11 @@ logicBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstOpC
    TR::Register *trgReg = NULL;
    int64_t value = 0;
 
-   if (1 == firstChild->getReferenceCount())
+   if (firstChild->isSingleRef())
       {
       trgReg = src1Reg;
       }
-   else if (1 == secondChild->getReferenceCount() && secondChild->getRegister() != NULL)
+   else if (secondChild->isSingleRef() && secondChild->getRegister() != NULL)
       {
       trgReg = secondChild->getRegister();
       }

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -417,7 +417,7 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
    {
    if (cg->comp()->useCompressedPointers())
       {
-      if (subTree->getOpCodeValue() == TR::l2a && subTree->getReferenceCount() == 1 && subTree->getRegister() == NULL)
+      if (subTree->getOpCodeValue() == TR::l2a && subTree->isSingleRefUnevaluated())
          {
          cg->decReferenceCount(subTree);
          subTree = subTree->getFirstChild();

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -137,7 +137,7 @@ static TR::Register *commonUnaryHelper(TR::Node *node, TR::InstOpCode::Mnemonic 
    {
    TR::Node *child = node->getFirstChild();
    TR::Register *srcReg = cg->evaluate(child);
-   TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+   TR::Register *trgReg = (child->isSingleRef()) ? srcReg : cg->allocateRegister();
 
    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
    node->setRegister(trgReg);
@@ -228,7 +228,7 @@ static TR::Register *notzHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
    {
    TR::Node *child = node->getFirstChild();
    TR::Register *srcReg = cg->evaluate(child);
-   TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+   TR::Register *trgReg = (child->isSingleRef()) ? srcReg : cg->allocateRegister();
    TR::InstOpCode::Mnemonic op;
 
    op = is64bit ? TR::InstOpCode::rbitx : TR::InstOpCode::rbitw;
@@ -265,7 +265,7 @@ static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mne
    {
    TR::Node *child = node->getFirstChild();
    TR::Register *srcReg = cg->evaluate(child);
-   TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+   TR::Register *trgReg = (child->isSingleRef()) ? srcReg : cg->allocateRegister();
 
    // signed extension: alias of SBFM
    // unsigned extension: alias of UBFM
@@ -330,9 +330,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeG
    {
    TR::Node *child = node->getFirstChild();
 
-   if (child->getReferenceCount() == 1
-       && (child->getOpCodeValue() == TR::bload || child->getOpCodeValue() == TR::bloadi)
-       && child->getRegister() == NULL)
+   if (child->isSingleRefUnevaluated() && 
+       (child->getOpCodeValue() == TR::bload || child->getOpCodeValue() == TR::bloadi))
       {
       // Use unsigned load
       TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrbimm, cg);
@@ -350,9 +349,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
    {
    TR::Node *child = node->getFirstChild();
 
-   if (child->getReferenceCount() == 1
-       && (child->getOpCodeValue() == TR::sload || child->getOpCodeValue() == TR::sloadi)
-       && child->getRegister() == NULL)
+   if (child->isSingleRefUnevaluated() && 
+       (child->getOpCodeValue() == TR::sload || child->getOpCodeValue() == TR::sloadi))
       {
       // Use unsigned load
       TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrhimm, cg);

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -814,7 +814,7 @@ static TR::Register *ishiftEvaluator(TR::Node *node, TR_ARMOperand2Type shiftTyp
       {
       if ((secondChild->getInt() & 0x1f) == 0)
          {
-         if (firstChild->getReferenceCount() == 1)
+         if (firstChild->isSingleRef())
             {
             trgReg = src1Reg;
             }
@@ -1219,13 +1219,13 @@ static TR::Register *ishiftAnalyser(TR::Node *node, TR::CodeGenerator *cg,TR_ARM
    TR::Node *mulSecondChild;
 
    if((secondChild->getOpCode().isLeftShift() || secondChild->getOpCode().isRightShift() ||  secondChild->getOpCode().isShiftLogical()) &&
-             !firstChild->getOpCode().isLoadConst() && secondChild->getReferenceCount() == 1 && secondChild->getRegister() == NULL )
+             !firstChild->getOpCode().isLoadConst() && secondChild->isSingleRefUnevaluated() )
       {
       canCombine = true;
       shiftIsFirstChild = false;
       }
    else if(secondChild->getOpCode().isMul() &&  secondChild->getOpCode().isInt() &&
-            !firstChild->getOpCode().isLoadConst() && secondChild->getReferenceCount() == 1 && secondChild->getRegister() == NULL )
+            !firstChild->getOpCode().isLoadConst() && secondChild->isSingleRefUnevaluated() )
       {
       mulSecondChild = secondChild->getSecondChild();
       if(mulSecondChild->getOpCodeValue() == TR::iconst && mulSecondChild->getInt() > 0 && cg->convertMultiplyToShift(secondChild))
@@ -1235,7 +1235,7 @@ static TR::Register *ishiftAnalyser(TR::Node *node, TR::CodeGenerator *cg,TR_ARM
          }
       }
    else if((firstChild->getOpCode().isLeftShift() || firstChild->getOpCode().isRightShift() ||  firstChild->getOpCode().isShiftLogical()) &&
-           !secondChild->getOpCode().isLoadConst() && firstChild->getReferenceCount() == 1 && firstChild->getRegister() == NULL)
+           !secondChild->getOpCode().isLoadConst() && firstChild->isSingleRefUnevaluated())
       {
       canCombine = true;
       shiftIsFirstChild = true;
@@ -1243,7 +1243,7 @@ static TR::Register *ishiftAnalyser(TR::Node *node, TR::CodeGenerator *cg,TR_ARM
          regOp = ARMOp_rsb;
       }
     else if(firstChild->getOpCode().isMul() &&  firstChild->getOpCode().isInt() &&
-             !secondChild->getOpCode().isLoadConst() && firstChild->getReferenceCount() == 1 && firstChild->getRegister() == NULL )
+             !secondChild->getOpCode().isLoadConst() && firstChild->isSingleRefUnevaluated() )
       {
       mulSecondChild = firstChild->getSecondChild();
       if(mulSecondChild->getOpCodeValue() == TR::iconst && mulSecondChild->getInt() > 0 && cg->convertMultiplyToShift(firstChild))

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -815,7 +815,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Code
    TR::Node                *child  = node->getFirstChild();
    TR::Register            *target = NULL;
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -871,7 +871,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Code
    TR::Register            *target = cg->allocateRegister();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -905,7 +905,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
    TR::Register            *highReg = NULL;
    TR::Compilation *comp = cg->comp();
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *highMem, *lowMem;
@@ -975,7 +975,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
    TR::Compilation         *comp = cg->comp();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *highMem, *lowMem;
@@ -1634,8 +1634,8 @@ TR::Register *OMR::ARM::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGen
    // TODO: Check conditions to use fmacs if possible
    TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
-   if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->getReferenceCount() == 1)) ||
-        (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->getReferenceCount() == 1))) &&
+   if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->isSingleRef())) ||
+        (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->isSingleRef()))) &&
          performTransformation(comp, "O^O Changing [%p] to fmacs\n", node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fmacs, cg);
@@ -1652,8 +1652,8 @@ TR::Register *OMR::ARM::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGen
    // TODO: Check conditions to use fmacd if possible
    TR::Register *result = NULL;
    TR::Compilation *comp = cg->comp();
-   if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->getReferenceCount() == 1)) ||
-        (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->getReferenceCount() == 1))) &&
+   if (((isFPStrictMul(node->getFirstChild(), comp) && (node->getSecondChild()->isSingleRef())) ||
+        (isFPStrictMul(node->getSecondChild(), comp) && (node->getFirstChild()->isSingleRef()))) &&
          performTransformation(comp, "O^O Changing [%p] to fmacd\n", node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fmacd, cg);
@@ -1671,13 +1671,13 @@ TR::Register *OMR::ARM::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGen
    TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
    if (isFPStrictMul(node->getFirstChild(), comp) &&
-      (node->getSecondChild()->getReferenceCount() == 1) &&
+      (node->getSecondChild()->isSingleRef()) &&
        performTransformation(comp, "O^O Changing [%p] to fmscd\n",node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fmscd, cg);
       }
    else if (isFPStrictMul(node->getSecondChild(), comp) &&
-      (node->getFirstChild()->getReferenceCount() == 1) &&
+      (node->getFirstChild()->isSingleRef()) &&
        performTransformation(comp, "O^O Changing [%p] to fnmacd\n",node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fnmacd, cg);
@@ -1695,13 +1695,13 @@ TR::Register *OMR::ARM::TreeEvaluator::fsubEvaluator(TR::Node *node, TR::CodeGen
    TR::Compilation *comp = cg->comp();
    TR::Register *result = NULL;
    if (isFPStrictMul(node->getFirstChild(), comp) &&
-      (node->getSecondChild()->getReferenceCount() == 1) &&
+      (node->getSecondChild()->isSingleRef()) &&
        performTransformation(comp, "O^O Changing [%p] to fmscs\n",node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fmscs, cg);
       }
    else if (isFPStrictMul(node->getSecondChild(), comp) &&
-      (node->getFirstChild()->getReferenceCount() == 1) &&
+      (node->getFirstChild()->isSingleRef()) &&
        performTransformation(comp, "O^O Changing [%p] to fnmacs\n",node))
       {
       result = generateFusedMultiplyAdd(node, ARMOp_fnmacs, cg);
@@ -1770,9 +1770,9 @@ TR::Register *OMR::ARM::TreeEvaluator::fnegEvaluator(TR::Node *node, TR::CodeGen
       {
       // fneg(node) -> fadd(firstChild) -> a multiply in one of the children
       if (((isFPStrictMul(firstChild->getFirstChild(), comp) &&
-         firstChild->getSecondChild()->getReferenceCount() == 1) ||
+         firstChild->getSecondChild()->isSingleRef()) ||
          (isFPStrictMul(firstChild->getSecondChild(), comp) &&
-         firstChild->getFirstChild()->getReferenceCount() == 1)) &&
+         firstChild->getFirstChild()->isSingleRef())) &&
          performTransformation(comp, "O^O Changing [%p] to fnmscs\n", node))
          {
          result = generateFusedMultiplyAdd(node, ARMOp_fnmscs, cg);
@@ -1826,9 +1826,9 @@ TR::Register *OMR::ARM::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGen
       {
       // dneg(node) -> dadd(firstChild) -> a multiply in one of the children
       if (((isFPStrictMul(firstChild->getFirstChild(), comp) &&
-         firstChild->getSecondChild()->getReferenceCount() == 1) ||
+         firstChild->getSecondChild()->isSingleRef()) ||
          (isFPStrictMul(firstChild->getSecondChild(), comp) &&
-         firstChild->getFirstChild()->getReferenceCount() == 1)) &&
+         firstChild->getFirstChild()->isSingleRef())) &&
          performTransformation(comp, "O^O Changing [%p] to fnmscd\n", node))
          {
          result = generateFusedMultiplyAdd(node, ARMOp_fnmscd, cg);
@@ -1877,8 +1877,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGene
    TR::Register *trgReg = NULL;
    TR_ARMOpCodes opcode = (node->getOpCodeValue() == TR::iu2f) ? ARMOp_fuitos : ARMOp_fsitos;
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -1930,8 +1929,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGene
 
    TR_ARMOpCodes opcode = (node->getOpCodeValue() != TR::iu2d && node->getOpCodeValue() != TR::su2d) ? ARMOp_fsitod : ARMOp_fuitod;  // D[t], S[s]
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -2002,8 +2000,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGene
    TR::Register *trgReg = NULL; // NEW
    TR::Register *doubleTrgReg = cg->allocateRegister(TR_FPR);
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -2057,8 +2054,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
    TR_ARMOpCodes opcode = (node->getOpCodeValue() == TR::f2i) ? ARMOp_ftosizs : ARMOp_ftouizs;
    TR::Register *floatTrgReg = cg->allocateSinglePrecisionRegister();
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -2097,8 +2093,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
    TR_ARMOpCodes opcode = (node->getOpCodeValue() == TR::d2i) ? ARMOp_ftosizd : ARMOp_ftouizd;
    TR::Register *floatTrgReg = cg->allocateSinglePrecisionRegister();
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -2170,8 +2165,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGene
    TR::Register *trgReg = NULL;
    TR::Register *floatTrgReg = cg->allocateSinglePrecisionRegister(); // NEW
 
-   if (firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == NULL &&
+   if (firstChild->isSingleRefUnevaluated() &&
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
@@ -2668,7 +2662,7 @@ TR::Register *OMR::ARM::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Code
    TR::Node                *child  = node->getFirstChild();
    TR::Register            *target = cg->allocateRegister();
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -2690,7 +2684,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Code
    TR::Register            *target = cg->allocateRegister();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -2715,7 +2709,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
    TR::Register            *highReg = NULL;
    TR::Compilation *comp = cg->comp();
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *highMem, *lowMem;
@@ -2752,7 +2746,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
    TR::Compilation *comp = cg->comp();
 
    TR_ASSERT(!node->normalizeNanValues(), "Check NAN\n");
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *highMem, *lowMem;

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1447,7 +1447,7 @@ TR::Register *OMR::ARM::TreeEvaluator::conversionAnalyser(TR::Node          *nod
    TR::Register *sourceRegister;
    TR::Register *targetRegister;
 
-   if (child->getReferenceCount() == 1 && child->getRegister() == NULL && child->getOpCode().isMemoryReference())
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isMemoryReference())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, dstBits >> 3, cg);
       if (cg->comp()->target().cpu.isBigEndian() && node->getSize() < child->getSize())

--- a/compiler/arm/codegen/UnaryEvaluator.cpp
+++ b/compiler/arm/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -256,8 +256,7 @@ TR::Register *OMR::ARM::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGene
    TR::Register *temp;
 
    temp = child->getRegister();
-   if (child->getReferenceCount() == 1 &&
-       child->getOpCode().isMemoryReference() && (temp == NULL))
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isMemoryReference())
       {
       trgReg = cg->allocateRegister();
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -269,7 +268,7 @@ TR::Register *OMR::ARM::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGene
    else
       {
       temp = cg->evaluate(child);
-      if (child->getReferenceCount() == 1 || !cg->useClobberEvaluate())
+      if (child->isSingleRef() || !cg->useClobberEvaluate())
          {
          trgReg = temp->getLowOrder();
          }
@@ -300,10 +299,8 @@ TR::Register *OMR::ARM::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeGen
    TR::Node *child  = node->getFirstChild();
    TR::Register *sourceRegister = NULL;
    TR::Register *trgReg = cg->allocateRegisterPair(cg->gprClobberEvaluate(child), cg->allocateRegister());
-   TR::Register *temp;
-   temp = child->getRegister();
-   if (child->getReferenceCount()==1 &&
-       child->getOpCode().isMemoryReference() && (temp == NULL))
+   if (child->isSingleRefUnevaluated() &&
+       child->getOpCode().isMemoryReference())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(temp, 2, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldrh, node, trgReg->getLowOrder(), tempMR);
@@ -327,11 +324,9 @@ TR::Register *OMR::ARM::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeGen
    TR::Node *child  = node->getFirstChild();
    TR::Register *sourceRegister = NULL;
    TR::Register *trgReg = cg->allocateRegister();
-   TR::Register *temp;
 
-   temp = child->getRegister();
-   if (child->getReferenceCount()==1 &&
-       child->getOpCode().isMemoryReference() && (temp == NULL))
+   if (child->isSingleRefUnevaluated() &&
+       child->getOpCode().isMemoryReference())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 1, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldrb, node, trgReg, tempMR);
@@ -351,10 +346,8 @@ TR::Register *OMR::ARM::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeGen
    TR::Node *child  = node->getFirstChild();
    TR::Register *sourceRegister = NULL;
    TR::Register *trgReg = cg->allocateRegisterPair(cg->gprClobberEvaluate(child), cg->allocateRegister());
-   TR::Register *temp;
-   temp = child->getRegister();
-   if (child->getReferenceCount()==1 &&
-       child->getOpCode().isMemoryReference() && (temp == NULL))
+   if (child->isSingleRefUnevaluated() &&
+       child->getOpCode().isMemoryReference())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(temp, 1, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldrb, node, trgReg->getLowOrder(), tempMR);

--- a/compiler/codegen/Analyser.cpp
+++ b/compiler/codegen/Analyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
 
    if (  firstChild->getOpCode().isMemoryReference()
       && firstChild->getSymbolReference() != vftPointerSymRef
-      && firstChild->getReferenceCount() == 1
+      && firstChild->isSingleRef()
       && !lockedIntoRegister1)
       {
       setMem1();
@@ -67,7 +67,7 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
 
    if (  secondChild->getOpCode().isMemoryReference()
       && secondChild->getSymbolReference() != vftPointerSymRef
-      && secondChild->getReferenceCount() == 1
+      && secondChild->isSingleRef()
       && !lockedIntoRegister2)
       {
       setMem2();
@@ -84,12 +84,12 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
             setClob2();
             }
 
-         if (firstChild->getReferenceCount() == 1)
+         if (firstChild->isSingleRef())
             {
             setClob1();
             }
 
-         if (secondChild->getReferenceCount() == 1)
+         if (secondChild->isSingleRef())
             {
             setClob2();
             }

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,7 +242,7 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
             {
             if (value > 0)
                {
-               if (secondChild->getReferenceCount()==1)
+               if (secondChild->isSingleRef())
                   {
                   if (is32BitOp)
                      {
@@ -266,7 +266,7 @@ OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * 
                }
             else //negative value of the multiply constant
                {
-               if (secondChild->getReferenceCount() == 1)
+               if (secondChild->isSingleRef())
                   {
                   TR::Node * newChild = TR::Node::create(parent, is32BitOp ? TR::ishl : TR::lshl, 2);;
 
@@ -357,7 +357,7 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
       //  load auto2 (colour x)
       if (node->getOpCode().isStoreDirect() &&
           node->getSymbolReference()->getSymbol()->isAuto() &&
-          node->getFirstChild()->getReferenceCount() == 1 &&
+          node->getFirstChild()->isSingleRef() &&
           node->getFirstChild()->getOpCode().isLoadVarDirect() &&
           node->getFirstChild()->getSymbolReference()->getSymbol()->isAuto())
          {
@@ -563,7 +563,7 @@ void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::Tr
                   child->setUnneededConversion(true);
                }
 
-            if (child->getReferenceCount() == 1)
+            if (child->isSingleRef())
                self()->identifyUnneededByteConvNodes(child, treeTop, visitCount, storeType);
 
             }

--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -193,7 +193,7 @@ OMR::CodeGenerator::evaluate(TR::Node * node)
          {
          TR::Node * artificiallyInflatedNode = _stackOfArtificiallyInflatedNodes.pop();
 
-         if (artificiallyInflatedNode->getReferenceCount() == 1)
+         if (artificiallyInflatedNode->isSingleRef())
             {
             // When inflating reference counts, two cases exist:
             //
@@ -351,7 +351,7 @@ OMR::CodeGenerator::decReferenceCount(TR::Node * node)
    {
    TR::Register *reg = node->getRegister();
 
-   if ((node->getReferenceCount() == 1) &&
+   if ((node->isSingleRef()) &&
        reg && self()->getLiveRegisters(reg->getKind()))
        {
       TR_ASSERT(reg->isLive() ||
@@ -386,7 +386,7 @@ OMR::CodeGenerator::decReferenceCount(TR::Node * node)
       TR_StorageReference *storageReference = pseudoReg->getStorageReference();
       TR_ASSERT(storageReference,"the pseudoReg should have a non-null storage reference\n");
       storageReference->decrementTemporaryReferenceCount();
-      if (node->getReferenceCount() == 1)
+      if (node->isSingleRef())
          {
          storageReference->decOwningRegisterCount();
          if (self()->traceBCDCodeGen())

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3782,7 +3782,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
    {
    TR::Compilation * comp = TR::comp();
    TR::TreeTop *storeTree = NULL;
-   if ((self()->getReferenceCount() == 1) &&
+   if ((self()->isSingleRef()) &&
        self()->getOpCode().hasSymbolReference() &&
        self()->getSymbolReference()->getSymbol()->isAuto())
       {
@@ -3832,7 +3832,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
        self()->getOpCode().isArrayRef() &&
        (comp->getSymRefTab()->getNumInternalPointers() >= (comp->maxInternalPointers()/2) ||
         comp->cg()->supportsComplexAddressing()) &&
-       (self()->getReferenceCount() == 1))
+       (self()->isSingleRef()))
       {
       storesNeedToBeCreated = false;
       TR::Node *firstChild = self()->getFirstChild();

--- a/compiler/optimizer/ExpressionsSimplification.cpp
+++ b/compiler/optimizer/ExpressionsSimplification.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -306,7 +306,7 @@ void TR_ExpressionsSimplification::setSummationReductionCandidates(TR::Node *nod
 
       if (firstNode->getOpCode().hasSymbolReference() &&
             node->getSymbolReference() == firstNode->getSymbolReference() &&
-            opNode->getReferenceCount() == 1 && firstNode->getReferenceCount() == 1)
+            opNode->isSingleRef() && firstNode->isSingleRef())
          {
          // The second node must be loop invariant
          //
@@ -334,7 +334,7 @@ void TR_ExpressionsSimplification::setSummationReductionCandidates(TR::Node *nod
          }
       else if (secondNode->getOpCode().hasSymbolReference() &&
             node->getSymbolReference() == secondNode->getSymbolReference() &&
-            opNode->getReferenceCount() == 1 && secondNode->getReferenceCount() == 1 &&
+            opNode->isSingleRef() && secondNode->isSingleRef() &&
             _currentRegion->isExprInvariant(firstNode))
          {
          _candidateTTs->add(tt);
@@ -345,12 +345,12 @@ void TR_ExpressionsSimplification::setSummationReductionCandidates(TR::Node *nod
       {
       if (opNode->getFirstChild()->getOpCode().hasSymbolReference() &&
             node->getSymbolReference() == opNode->getFirstChild()->getSymbolReference() &&
-            opNode->getReferenceCount() == 1 && opNode->getFirstChild()->getReferenceCount() == 1 &&
+            opNode->isSingleRef() && opNode->getFirstChild()->isSingleRef() &&
             (opNode->getOpCodeValue() == TR::ineg || _currentRegion->isExprInvariant(opNode->getSecondChild())))
          _candidateTTs->add(tt);
       else if (opNode->getOpCodeValue() == TR::ixor && opNode->getSecondChild()->getOpCode().hasSymbolReference() &&
             node->getSymbolReference() == opNode->getSecondChild()->getSymbolReference() &&
-            opNode->getReferenceCount() == 1 && opNode->getSecondChild()->getReferenceCount() == 1 &&
+            opNode->isSingleRef() && opNode->getSecondChild()->isSingleRef() &&
             _currentRegion->isExprInvariant(opNode->getFirstChild()))
          _candidateTTs->add(tt);
       }

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1437,7 +1437,7 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
     if (firstChildIsConversion && !usingAladd)
       {
       prevFirst = firstChildIsConversion->getFirstChild();
-      if (firstChildIsConversion->getReferenceCount() == 1)
+      if (firstChildIsConversion->isSingleRef())
          firstChildIsConversion->setAndIncChild(0, firstOperand);
       else
          {
@@ -1458,7 +1458,7 @@ void TR_LoopStrider::changeLoopCondition(TR_BlockStructure *loopInvariantBlock, 
       {
       prevSecond = secondChildIsConversion->getFirstChild();
 
-      if (secondChildIsConversion->getReferenceCount() == 1)
+      if (secondChildIsConversion->isSingleRef())
          secondChildIsConversion->setAndIncChild(0, secondOperand);
       else
          {

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1381,7 +1381,7 @@ TR_InlinerBase::cloneChildren(TR::Node * to, TR::Node * from, uint32_t fromStart
       {
       TR::Node * fromChild = from->getChild(i);
       TR::Node * toChild;
-      if (fromChild->getReferenceCount() == 1)
+      if (fromChild->isSingleRef())
          {
          toChild = TR::Node::copy(fromChild);
          cloneChildren(toChild, fromChild, 0);
@@ -2307,7 +2307,7 @@ TR_ParameterToArgumentMapper::initialize(TR_CallStack *callStack)
             {
             if (parmMap->_addressTaken)
                {
-               if (arg->getOpCode().isLoadVarDirect() && arg->getReferenceCount() == 1 &&
+               if (arg->getOpCode().isLoadVarDirect() && arg->isSingleRef() &&
                      arg->getSymbol()->isAutoOrParm())
                   parmMap->_replacementSymRef = arg->getSymbolReference();
                }
@@ -2321,7 +2321,7 @@ TR_ParameterToArgumentMapper::initialize(TR_CallStack *callStack)
 
                if (disableParmTempOpt)
                   {
-                  if (arg->getOpCode().isLoadVarDirect() && arg->getReferenceCount() == 1 && arg->getSymbol()->isAutoOrParm())
+                  if (arg->getOpCode().isLoadVarDirect() && arg->isSingleRef() && arg->getSymbol()->isAutoOrParm())
                      parmMap->_replacementSymRef = arg->getSymbolReference();
                   else if (rematerializeConstant(arg, comp()))
                      parmMap->_isConst = true;
@@ -2329,7 +2329,7 @@ TR_ParameterToArgumentMapper::initialize(TR_CallStack *callStack)
                else
                   {
                   if ( (arg->getOpCode().isLoadVarDirect() && arg->getSymbol()->isAutoOrParm()) &&
-                       ( (arg->getReferenceCount() == 1)
+                       ( (arg->isSingleRef())
                          || (_callNode->getOpCode().isCallIndirect() &&
                                (argIndex == _callNode->getFirstArgumentIndex()) && (_callNode->getFirstChild()->getNumChildren() > 0) &&
                                (arg == _callNode->getFirstChild()->getFirstChild()) && arg->getSymbol()->isAuto() && (arg->getReferenceCount() == 2))

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -627,7 +627,7 @@ int32_t TR_IsolatedStoreElimination::performWithUseDefInfo()
             collectDefParentInfo(useDefIndex,node,info);
             TR::Node *firstChild = node->getFirstChild();
             if (firstChild->getOpCode().isLoadVarDirect() &&
-                firstChild->getReferenceCount() == 1 &&
+                firstChild->isSingleRef() &&
                 (firstChild->getSymbolReference() == node->getSymbolReference()))
                   {
                _trivialDefs->set(i);
@@ -689,7 +689,7 @@ void TR_IsolatedStoreElimination::collectDefParentInfo(int32_t defIndex,TR::Node
       {
       TR::Node *child = node->getChild(childNum);
 
-      if ((child->getReferenceCount() == 1) &&
+      if ((child->isSingleRef()) &&
           child->getOpCode().isLoadVar())
         {
         int32_t index = child->getUseDefIndex();
@@ -1579,10 +1579,10 @@ void TR_IsolatedStoreElimination::analyzeSingleBlockLoop(TR_RegionStructure *reg
                TR::SymbolReference *symRef = node->getSymbolReference();
                TR::Node *rhsOfStoreDefNode = node->getFirstChild();
                if ((rhsOfStoreDefNode->getOpCode().getOpCodeValue() == TR::ixor) &&
-                   (rhsOfStoreDefNode->getReferenceCount() == 1) &&
+                   (rhsOfStoreDefNode->isSingleRef()) &&
                    rhsOfStoreDefNode->getSecondChild()->getOpCode().isLoadConst() &&
                    (rhsOfStoreDefNode->getSecondChild()->getInt() == 1) &&
-                   (rhsOfStoreDefNode->getFirstChild()->getReferenceCount() == 1) &&
+                   (rhsOfStoreDefNode->getFirstChild()->isSingleRef()) &&
                    (rhsOfStoreDefNode->getFirstChild()->getOpCode().hasSymbolReference() &&
                    ((rhsOfStoreDefNode->getFirstChild()->getSymbolReference()->getReferenceNumber() == symRef->getReferenceNumber()))))
                   {

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -540,7 +540,7 @@ bool TR::LocalDeadStoreElimination::isIdentityStore(TR::Node *storeNode)
 
    // This is an identity store
    //
-   if ((storedValue->getReferenceCount() == 1) || isFirstReferenceToNode(storeNode, storedValueChildIndex, storedValue))
+   if ((storedValue->isSingleRef()) || isFirstReferenceToNode(storeNode, storedValueChildIndex, storedValue))
       return true;
 
    bool doChecksForAnchors = false;

--- a/compiler/optimizer/LocalLiveRangeReducer.cpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -399,7 +399,7 @@ void TR_LocalLiveRangeReduction::populatePotentialDeps(TR_TreeRefInfo *treeRefIn
 
       //don't recurse over references (nodes which are not the first reference)
       //
-      if (child->getReferenceCount()==1 || treeRefInfo->getFirstRefNodesList()->find(child))
+      if (child->isSingleRef() || treeRefInfo->getFirstRefNodesList()->find(child))
          populatePotentialDeps(treeRefInfo,child );
       }
    return;
@@ -574,7 +574,7 @@ bool TR_LocalLiveRangeReduction::isAnySymInDefinedOrUsedBy(TR_TreeRefInfo *curre
          }
 
       //don't recurse over nodes each are not the first reference
-      if (child->getReferenceCount()==1 || currentTreeRefInfo->getFirstRefNodesList()->find(child))
+      if (child->isSingleRef() || currentTreeRefInfo->getFirstRefNodesList()->find(child))
          {
          if (isAnySymInDefinedOrUsedBy(currentTreeRefInfo, child, movingTreeRefInfo ))
             return true;
@@ -796,7 +796,7 @@ bool TR_LocalLiveRangeReduction::isNeedToBeInvestigated(TR_TreeRefInfo *treeRefI
 bool TR_LocalLiveRangeReduction::containsCallOrCheck(TR_TreeRefInfo *treeRefInfo, TR::Node *node)
    {
    if ((node->getOpCode().isCall() &&
-        (node->getReferenceCount()==1 || treeRefInfo->getFirstRefNodesList()->find(node))) ||
+        (node->isSingleRef() || treeRefInfo->getFirstRefNodesList()->find(node))) ||
        node->getOpCode().isCheck())
       {
       return true;
@@ -805,7 +805,7 @@ bool TR_LocalLiveRangeReduction::containsCallOrCheck(TR_TreeRefInfo *treeRefInfo
    for (int32_t i = 0; i < node->getNumChildren(); i++)
       {
       TR::Node *child = node->getChild(i);
-      if (child->getReferenceCount()==1 || treeRefInfo->getFirstRefNodesList()->find(child))
+      if (child->isSingleRef() || treeRefInfo->getFirstRefNodesList()->find(child))
          return containsCallOrCheck(treeRefInfo, child);
       }
    return false;

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2914,7 +2914,7 @@ void TR_LoopCanonicalizer::rewritePostToPreIncrementTestInBlock(
    TR::Node * const left = test->getChild(i);
    TR::Node * const right = test->getChild(1 - i);
 
-   if (left->getReferenceCount() == 1)
+   if (left->isSingleRef())
       return;
 
    TR::Node * const updated = store->getChild(0);

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -854,7 +854,7 @@ void OMR::LocalCSE::doCommoningIfAvailable(TR::Node *node, TR::Node *parent, int
                      }
                   else
                      {
-                     TR_ASSERT(node->getFirstChild()->getReferenceCount() == 1, "Local CSE, treetop child of NULLCHK has other uses");
+                     TR_ASSERT(node->getFirstChild()->isSingleRef(), "Local CSE, treetop child of NULLCHK has other uses");
                      // Make sure the child doesn't get removed too
                      //
                      node->getFirstChild()->incReferenceCount();
@@ -1225,12 +1225,12 @@ bool OMR::LocalCSE::canBeAvailable(TR::Node *parent, TR::Node *node, TR_BitVecto
    int32_t numChildren = node->getNumChildren();
    while (i < numChildren)
       {
-      if (node->getChild(i)->getReferenceCount() == 1)
+      if (node->getChild(i)->isSingleRef())
          {
          if (node->getChild(i)->getOpCode().isArrayRef())
             {
-            if ((node->getChild(i)->getFirstChild()->getReferenceCount() == 1) ||
-                (node->getChild(i)->getSecondChild()->getReferenceCount() == 1))
+            if ((node->getChild(i)->getFirstChild()->isSingleRef()) ||
+                (node->getChild(i)->getSecondChild()->isSingleRef()))
                return false;
             }
          else

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -465,7 +465,7 @@ OMR::Optimization::replaceNodeWithChild(TR::Node *node, TR::Node *child, TR::Tre
          {
          dumpOptDetails(self()->comp(), "%sPrecision mismatch when replacing parent %s [" POINTER_PRINTF_FORMAT "] with child %s [" POINTER_PRINTF_FORMAT "] so change parent op to ",
                           self()->optDetailString(),node->getOpCode().getName(),node,child->getOpCode().getName(),child);
-         TR_ASSERT(node->getReferenceCount() == 1,"node %p refCount should be 1 and not %d\n",node,node->getReferenceCount());
+         TR_ASSERT(node->isSingleRef(),"node %p refCount should be 1 and not %d\n",node,node->getReferenceCount());
          child->incReferenceCount();
          // zd2pd    <- node - change to zdModifyPrecision (must use child type as modPrec is being applied to the child)
          //    zdX   <- child

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2312,7 +2312,7 @@ bool OMR::Optimizer::prepareForNodeRemoval(TR::Node *node , bool deferInvalidati
    for (int32_t i = node->getNumChildren()-1; i >= 0; i--)
       {
       TR::Node *child = node->getChild(i);
-      if (child != NULL && child->getReferenceCount() == 1)
+      if (child != NULL && child->isSingleRef())
          if (prepareForNodeRemoval(child))
             useDefInfoAreInvalid = true;
       }

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -369,7 +369,7 @@ TR::Node *foldRedundantAND(TR::Node * node, TR::ILOpCodes andOpCode, TR::ILOpCod
    else
       return 0;
 
-   if (((val & andVal) == andVal) && (andChild->getReferenceCount() == 1) &&
+   if (((val & andVal) == andVal) && (andChild->isSingleRef()) &&
     performTransformation(s->comp(), "%sFolding redundant AND node [%s] and its children [%s, %s]\n",
                            s->optDetailString(), node->getName(s->getDebug()), lhsChild->getName(s->getDebug()), constChild->getName(s->getDebug())))
       {
@@ -940,7 +940,7 @@ void removePaddingNode(TR::Node *node, TR::Simplifier *s)
 // the usual behaviour is to remove the padding node except in cases where the caller is already dealing with this
 void stopUsingSingleNode(TR::Node *node, bool removePadding, TR::Simplifier *s)
    {
-   TR_ASSERT(node->getReferenceCount() == 1, "stopUsingSingleNode only valid for nodes with a referenceCount of 1 and not %d\n",
+   TR_ASSERT(node->isSingleRef(), "stopUsingSingleNode only valid for nodes with a referenceCount of 1 and not %d\n",
          node->getReferenceCount());
    if (removePadding)
       removePaddingNode(node, s);

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1573,7 +1573,7 @@ TR::TreeTop *TR_OSRLiveRangeAnalysis::collectPendingPush(TR_ByteCodeInfo bci, TR
           && node->getFirstChild()->getOpCode().isLoad()
           && node->getFirstChild()->getOpCode().hasSymbolReference())
          {
-         if (node->getFirstChild()->getReferenceCount() == 1)
+         if (node->getFirstChild()->isSingleRef())
             {
             TR::AutomaticSymbol *local = node->getFirstChild()->getSymbolReference()->getSymbol()->getAutoSymbol();
             int32_t localIndex = local->getLiveLocalIndex();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -11269,7 +11269,7 @@ TR::Node *constrainNullChk(OMR::ValuePropagation *vp, TR::Node *node)
             }
          else
             {
-            TR_ASSERT(child->getReferenceCount() == 1, "Treetop child of NULLCHK has other uses");
+            TR_ASSERT(child->isSingleRef(), "Treetop child of NULLCHK has other uses");
 
             // Increment the reference count on the child so that we know it is
             // going to be kept.
@@ -11371,7 +11371,7 @@ TR::Node *constrainResolveChk(OMR::ValuePropagation *vp, TR::Node *node)
             }
          else
             {
-            TR_ASSERT(child->getReferenceCount() == 1, "Treetop child of ResolveCHK has other uses");
+            TR_ASSERT(child->isSingleRef(), "Treetop child of ResolveCHK has other uses");
 
             // Increment the reference count on the child so that we know it is
             // going to be kept.

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -516,7 +516,7 @@ CompareCondition evaluateDualIntCompareToConditionRegister(
    TR::Register *condReg2 = cg->allocateRegister(TR_CCR);
    TR::Register *firstReg = cg->evaluate(firstChild);
 
-   if (secondChild->getOpCode().isLoadConst() && !secondChild->getRegister() && secondChild->getReferenceCount() == 1)
+   if (secondChild->getOpCode().isLoadConst() && secondChild->isSingleRefUnevaluated())
       {
       int32_t secondHi = secondChild->getLongIntHigh();
       int32_t secondLo = secondChild->getLongIntLow();
@@ -1042,7 +1042,7 @@ CompareCondition evaluateToConditionRegister(TR::Register *condReg, TR::Node *no
    {
    static bool disableCondRegEval = feGetEnv("TR_DisableCondRegEval") != NULL;
 
-   if (!disableCondRegEval && !condNode->getRegister() && condNode->getReferenceCount() == 1)
+   if (!disableCondRegEval && condNode->isSingleRefUnevaluated())
       {
       auto compareInfo = getCompareInfo(condNode->getOpCode());
 
@@ -1288,7 +1288,7 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       {
       firstHighZero = true;
       TR::ILOpCodes firstOp = firstChild->getOpCodeValue();
-      if (firstChild->getReferenceCount() == 1 && src1Reg == NULL)
+      if (firstChild->isSingleRefUnevaluated())
          {
 	 if (firstOp == TR::iu2l || firstOp == TR::su2l ||
 	     (firstOp == TR::lushr &&
@@ -1308,7 +1308,7 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       {
       secondHighZero = true;
       TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
-      if (secondChild->getReferenceCount() == 1 && src2Reg == NULL)
+      if (secondChild->isSingleRefUnevaluated())
          {
 	 if (secondOp == TR::iu2l || secondOp == TR::su2l ||
 	     (secondOp == TR::lushr &&
@@ -2118,7 +2118,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
    //Useful for our implementation of BigDecimal.compareTo()
    if (!disableCompareToOpt && cg->comp()->target().is32Bit() &&
        firstChild->getOpCodeValue() == TR::lshr && secondChild->getOpCodeValue() == TR::lshr &&
-       firstChild->getReferenceCount() == 1 && secondChild->getReferenceCount() == 1)
+       firstChild->isSingleRef() && secondChild->isSingleRef())
       {
       TR::Register *firstShiftResultReg = firstChild->getRegister();
       TR::Register *secondShiftResultReg = secondChild->getRegister();
@@ -2789,7 +2789,7 @@ TR::Register *intOrderEvaluator(TR::Node *node, const CompareInfo& compareInfo, 
 
             isNonNegative = src2Value >= 0;
             addImmediate = diffSubOne ? -src2Value - 1 : -src2Value;
-            useAddImmediate = is16BitSignedImmediate(addImmediate) || (!secondChild->getRegister() && secondChild->getReferenceCount() == 1);
+            useAddImmediate = is16BitSignedImmediate(addImmediate) || (secondChild->isSingleRefUnevaluated());
             }
          else
             {

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,8 +70,7 @@ TR::Register *OMR::Power::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Co
    TR::Node                *child = node->getFirstChild();
    TR::Register            *target = cg->allocateSinglePrecisionRegister();
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
-       child->getOpCode().isLoadVar())
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lfs, node, target, tempMR);
@@ -95,7 +94,7 @@ TR::Register *OMR::Power::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Co
    bool                   childEval = true;
 
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
+   if (child->isSingleRefUnevaluated() &&
        child->getOpCode().isLoadVar())
       {
       childEval = false;
@@ -151,8 +150,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
    TR::Node                *child  = node->getFirstChild();
    TR::Register            *target = cg->allocateRegister(TR_FPR);
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
-       child->getOpCode().isLoadVar())
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isLoadVar())
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 8);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, target, tempMR);
@@ -190,8 +188,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
    TR::Register            *doubleReg;
    bool                    childEval = true;
 
-   if (child->getRegister() == NULL && child->getReferenceCount() == 1 &&
-       child->getOpCode().isLoadVar())
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isLoadVar())
       {
       childEval = false;
       TR::MemoryReference  *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 8);
@@ -1322,7 +1319,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGe
        (node->getOpCodeValue() == TR::iu2f && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) ||
        (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) &&
        (node->getOpCodeValue() == TR::i2f && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi)))) &&
-       child->getReferenceCount() == 1 && child->getRegister() == NULL &&
+       child->isSingleRefUnevaluated() &&
        !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);
@@ -1370,8 +1367,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGe
        (node->getOpCodeValue() == TR::iu2d && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) ||
        (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) &&
        node->getOpCodeValue() == TR::i2d && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) &&
-       child->getReferenceCount()==1 &&
-       child->getRegister() == NULL &&
+       child->isSingleRefUnevaluated() &&
        !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // possible TODO: if refcount > 1, do both load and lfiwax?
@@ -1558,8 +1554,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::CodeGe
    if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) &&
        node->getOpCodeValue() == TR::l2f &&
        (child->getOpCodeValue() == TR::lload || child->getOpCodeValue() == TR::lloadi) &&
-       child->getReferenceCount()==1 &&
-       child->getRegister() == NULL &&
+       child->isSingleRefUnevaluated() &&
        !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);
@@ -1586,8 +1581,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::CodeGe
    if (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) &&
        node->getOpCodeValue() == TR::l2d &&
        (child->getOpCodeValue() == TR::lload || child->getOpCodeValue() == TR::lloadi) &&
-       child->getReferenceCount()==1 &&
-       child->getRegister() == NULL &&
+       child->isSingleRefUnevaluated() &&
        !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
          TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, child, 4);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1577,8 +1577,7 @@ bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
 
          (secondOp == TR::iconst &&
           contiguousBits(secondChild->getInt()) &&
-          firstChild->getReferenceCount() == 1 &&
-          firstChild->getRegister() == NULL &&
+          firstChild->isSingleRefUnevaluated() &&
           ((firstOp == TR::imul &&
              firstChild->getSecondChild()->getOpCodeValue() == TR::iconst &&
             firstChild->getSecondChild()->getInt() > 0 &&

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -586,7 +586,7 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
    {
    if (cg->comp()->useCompressedPointers())
       {
-      if (subTree->getOpCodeValue() == TR::l2a && subTree->getReferenceCount() == 1 && subTree->getRegister() == NULL)
+      if (subTree->getOpCodeValue() == TR::l2a && subTree->isSingleRefUnevaluated())
          {
          cg->decReferenceCount(subTree);
          subTree = subTree->getFirstChild();
@@ -594,7 +594,10 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
       }
 
    // Skip sign extension if the offset is known to be >= 0; this is only safe to do if the child is the result of a load, otherwise the upper 32 bits may be undefined
-   if (subTree->getOpCodeValue() == TR::i2l && subTree->isNonNegative() && subTree->getFirstChild()->getOpCode().isLoadVar() && subTree->getReferenceCount() == 1 && subTree->getRegister() == NULL)
+   if (subTree->getOpCodeValue() == TR::i2l && 
+       subTree->isNonNegative() && 
+       subTree->getFirstChild()->getOpCode().isLoadVar() && 
+       subTree->isSingleRefUnevaluated())
       {
       if (performTransformation(cg->comp(), "O^O PPC Evaluator: Skip unecessary sign extension on index [%p].\n", subTree))
          {

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,8 +82,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR
 
    // Handle special cases
    //
-   if (valueChild->getRegister() == NULL &&
-       valueChild->getReferenceCount() == 1)
+   if (valueChild->isSingleRefUnevaluated())
       {
       // Special case storing a double value into long variable
       //
@@ -315,9 +314,7 @@ static TR::Register *l2fd(TR::Node *node, TR::RealRegister *target, TR_X86OpCode
 
    TR_ASSERT(cg->useSSEForSinglePrecision(), "assertion failure");
 
-   if (child->getRegister() == NULL &&
-       child->getReferenceCount() == 1 &&
-       child->getOpCode().isLoadVar())
+   if (child->isSingleRefUnevaluated() && child->getOpCode().isLoadVar())
       {
       tempMR = generateX86MemoryReference(child, cg);
       generateRegMemInstruction(opRegMem8, node, target, tempMR, cg);

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@
 
 static bool addressIsTemporarilyInt(TR::Node *node)
    {
-   return (node->getOpCodeValue() == TR::a2i || node->getOpCodeValue() == TR::a2l) && (node->getReferenceCount() == 1);
+   return (node->getOpCodeValue() == TR::a2i || node->getOpCodeValue() == TR::a2l) && (node->isSingleRef());
    }
 
 
@@ -243,7 +243,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    if (firstChild->isHighWordZero())
       {
       firstHighZero = true;
-      if (firstChild->getReferenceCount() == 1 && firstRegister == 0)
+      if (firstChild->isSingleRefUnevaluated())
          {
          if (firstOp == TR::su2l || firstOp == TR::bu2l)
             {
@@ -284,7 +284,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    if (secondChild->isHighWordZero())
       {
       secondHighZero = true;
-      if (secondChild->getReferenceCount() == 1 && secondRegister == 0)
+      if (secondChild->isSingleRefUnevaluated())
          {
          if (secondOp == TR::su2l || secondOp == TR::bu2l)
             {
@@ -324,8 +324,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
       {
       if (getEvalChild1())
          {
-         if (firstChild->getReferenceCount() == 1 &&
-             firstChild->getRegister() == NULL    &&
+         if (firstChild->isSingleRefUnevaluated() &&
              (firstChild->getOpCodeValue() == TR::lload ||
               (firstChild->getOpCodeValue() == TR::iload &&
                firstIU2L)))
@@ -349,8 +348,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
          }
       if (getEvalChild2())
          {
-         if (secondChild->getReferenceCount() == 1 &&
-             secondChild->getRegister() == NULL    &&
+         if (secondChild->isSingleRefUnevaluated() &&
              (secondChild->getOpCodeValue() == TR::lload ||
               (secondChild->getOpCodeValue() == TR::iload &&
                secondIU2L)))
@@ -377,8 +375,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
       {
       if (getEvalChild2())
          {
-         if (secondChild->getReferenceCount() == 1 &&
-             secondChild->getRegister() == NULL    &&
+         if (secondChild->isSingleRefUnevaluated() &&
              (secondChild->getOpCodeValue() == TR::lload ||
               (secondChild->getOpCodeValue() == TR::iload &&
                secondIU2L)))
@@ -398,8 +395,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
          }
       if (getEvalChild1())
          {
-         if (firstChild->getReferenceCount() == 1 &&
-             firstChild->getRegister() == NULL    &&
+         if (firstChild->isSingleRefUnevaluated() &&
              (firstChild->getOpCodeValue() == TR::lload ||
               (firstChild->getOpCodeValue() == TR::iload &&
                firstIU2L)))

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -655,9 +655,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
             //    0
             //
             {
-            if (firstChild->getOpCode().isAnd() &&
-                (firstChild->getRegister() == NULL) &&
-                (firstChild->getReferenceCount() == 1))
+            if (firstChild->getOpCode().isAnd() && firstChild->isSingleRefUnevaluated())
                {
                // compare  (node)
                //    and   (firstChild)
@@ -690,9 +688,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                   //       const (andSecondChild)
                   //    0
                   //
-                  if (andFirstChild->getRegister()       == NULL &&
-                      andFirstChild->getReferenceCount() == 1    &&
-                      andFirstChild->getOpCode().isLoadVar())
+                  if (andFirstChild->isSingleRefUnevaluated() && andFirstChild->getOpCode().isLoadVar())
                      {
                      // memory case
                      TR::MemoryReference  *tempMR = generateX86MemoryReference(andFirstChild, cg);
@@ -794,8 +790,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                   if (compareSize > 1 &&
                       (firstChild->getOpCodeValue() == TR::b2i || firstChild->getOpCodeValue() == TR::bu2i ||
                        firstChild->getOpCodeValue() == TR::b2s || firstChild->getOpCodeValue() == TR::bu2s) &&
-                      firstChild->getRegister() == NULL &&
-                      firstChild->getReferenceCount() == 1)
+                      firstChild->isSingleRefUnevaluated())
                      {
                      compareSize = 1;
                      cg->decReferenceCount(firstChild);
@@ -803,16 +798,13 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                      }
                   if (compareSize > 2 &&
                       (firstChild->getOpCodeValue() == TR::su2i || firstChild->getOpCodeValue() == TR::s2i) &&
-                      firstChild->getRegister() == NULL &&
-                      firstChild->getReferenceCount() == 1)
+                      firstChild->isSingleRefUnevaluated())
                      {
                      compareSize = 2;
                      cg->decReferenceCount(firstChild);
                      firstChild = firstChild->getFirstChild();
                      }
-                  if (firstChild->getOpCode().isMemoryReference()  &&
-                        firstChild->getRegister() == NULL &&
-                        firstChild->getReferenceCount() == 1)
+                  if (firstChild->getOpCode().isMemoryReference() && firstChild->isSingleRefUnevaluated())
                      {
                      TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
                      if (compareSize == 1)
@@ -856,8 +848,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
             if (compareSize > 1 &&
                 (firstChild->getOpCodeValue() == TR::b2i || firstChild->getOpCodeValue() == TR::bu2i ||
                  firstChild->getOpCodeValue() == TR::b2s || firstChild->getOpCodeValue() == TR::bu2s) &&
-                firstChild->getRegister() == NULL &&
-                firstChild->getReferenceCount() == 1)
+                firstChild->isSingleRefUnevaluated())
                {
                compareSize = 1;
                cg->decReferenceCount(firstChild);
@@ -865,16 +856,14 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
                }
             if (compareSize > 2 &&
                 (firstChild->getOpCodeValue() == TR::su2i || firstChild->getOpCodeValue() == TR::s2i) &&
-                firstChild->getRegister() == NULL &&
-                firstChild->getReferenceCount() == 1)
+                firstChild->isSingleRefUnevaluated())
                {
                compareSize = 2;
                cg->decReferenceCount(firstChild);
                firstChild = firstChild->getFirstChild();
                }
             if (firstChild->getOpCode().isMemoryReference()  &&
-                  firstChild->getRegister() == NULL &&
-                  firstChild->getReferenceCount() == 1)
+                  firstChild->isSingleRefUnevaluated())
                {
                TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
                if (compareSize == 1)
@@ -1043,8 +1032,7 @@ void OMR::X86::TreeEvaluator::compareIntegersForOrder(
          //
          if (!node->getOpCode().isSpineCheck() &&
              firstChild->getOpCode().isMemoryReference()  &&
-             firstChild->getRegister() == NULL &&
-             firstChild->getReferenceCount() == 1)
+             firstChild->isSingleRefUnevaluated())
             {
             TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
             TR::TreeEvaluator::compareGPMemoryToImmediate(node, tempMR, constValue, cg);
@@ -1091,9 +1079,7 @@ void OMR::X86::TreeEvaluator::compare2BytesForOrder(TR::Node *node, TR::CodeGene
       TR::Node       *firstChild = node->getFirstChild();
       bool isByteValue = (value >= -128 && value <= 127);
 
-      if ((firstChild->getReferenceCount() == 1) &&
-          (firstChild->getRegister() == NULL)    &&
-          firstChild->getOpCode().isMemoryReference())
+      if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCode().isMemoryReference())
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
          //try to avoid Imm2 instructions
@@ -1129,9 +1115,7 @@ void OMR::X86::TreeEvaluator::compareBytesForOrder(TR::Node *node, TR::CodeGener
        secondChild->getRegister() == NULL)
       {
       TR::Node *firstChild = node->getFirstChild();
-      if ((firstChild->getReferenceCount() == 1) &&
-          (firstChild->getRegister() == NULL)    &&
-          firstChild->getOpCode().isMemoryReference())
+      if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCode().isMemoryReference())
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
          generateMemImmInstruction(CMP1MemImm1, firstChild, tempMR, secondChild->getByte(), cg);
@@ -1472,8 +1456,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
          }
 
      if ( node->getFirstChild()->getOpCodeValue() == TR::ishr &&
-            node->getFirstChild()->getRegister() == NULL &&
-            node->getFirstChild()->getReferenceCount() == 1 &&
+            node->getFirstChild()->isSingleRefUnevaluated() &&
             (node->getFirstChild()->getFirstChild()->getOpCodeValue() == TR::iloadi || node->getFirstChild()->getFirstChild()->getOpCodeValue() == TR::iload) &&
             node->getFirstChild()->getSecondChild()->getOpCodeValue() == TR::iconst &&
             node->getSecondChild()->getOpCodeValue() == TR::iconst && node->getSecondChild()->getInt() == 0 &&
@@ -1698,9 +1681,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
       {
       int32_t      value            = (int32_t)secondChild->get64bitIntegralValue();
       TR::Node     *firstChild       = node->getFirstChild();
-      if ((firstChild->getReferenceCount() == 1) &&
-          (firstChild->getRegister() == NULL)    &&
-          firstChild->getOpCode().isMemoryReference())
+      if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCode().isMemoryReference())
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
          generateMemImmInstruction(CMP1MemImm1, firstChild, tempMR, value, cg);
@@ -1709,8 +1690,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
          cg->decReferenceCount(secondChild);
          }
       else if (firstChild->getOpCode().isAnd() &&
-               firstChild->getReferenceCount() == 1 &&
-               firstChild->getRegister() == NULL &&     // TODO: we can still do better in this case
+               firstChild->isSingleRefUnevaluated() &&     // TODO: we can still do better in this case
                firstChild->getSecondChild()->getOpCode().isLoadConst() &&
                (value == 0 ||
                 (value == (int32_t)firstChild->getSecondChild()->get64bitIntegralValue() &&
@@ -1728,9 +1708,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
          if (value != 0) reverseBranch = true; // k1
          value = (int32_t)k2->get64bitIntegralValue(); // k2
 
-         if (expr->getReferenceCount() == 1 &&
-             expr->getRegister() == NULL &&
-             expr->getOpCode().isMemoryReference())
+         if (expr->isSingleRefUnevaluated() && expr->getOpCode().isMemoryReference())
             {
             TR::MemoryReference *tempMR = generateX86MemoryReference(expr, cg);
             generateMemImmInstruction(TEST1MemImm1, expr, tempMR, value, cg);
@@ -1847,9 +1825,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifscmpeqEvaluator(TR::Node *node, TR::Cod
       int32_t      value            = secondChild->getShortInt();
       TR::Node     *firstChild       = node->getFirstChild();
 
-      if ((firstChild->getReferenceCount() == 1) &&
-          (firstChild->getRegister() == NULL)    &&
-          firstChild->getOpCode().isMemoryReference())
+      if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCode().isMemoryReference())
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(firstChild, cg);
 

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,35 +81,35 @@ void TR_X86FPBinaryArithmeticAnalyser::setInputs(TR::Node     *firstChild,
       }
 
    if (firstChild->getOpCode().isMemoryReference() &&
-       firstChild->getReferenceCount() == 1)
+       firstChild->isSingleRef())
       {
       setMem1();
       }
 
    if (secondChild->getOpCode().isMemoryReference() &&
-       secondChild->getReferenceCount() == 1)
+       secondChild->isSingleRef())
       {
       setMem2();
       }
 
-   if ((firstChild->getReferenceCount() == 1) &&
+   if ((firstChild->isSingleRef()) &&
        isIntToFPConversion(firstChild))
       {
       setConv1();
       }
 
-   if ((secondChild->getReferenceCount() == 1) &&
+   if ((secondChild->isSingleRef()) &&
        isIntToFPConversion(secondChild))
       {
       setConv2();
       }
 
-   if (firstChild->getReferenceCount() == 1)
+   if (firstChild->isSingleRef())
       {
       setClob1();
       }
 
-   if (secondChild->getReferenceCount() == 1)
+   if (secondChild->isSingleRef())
       {
       setClob2();
       }
@@ -151,7 +151,7 @@ TR_X86FPBinaryArithmeticAnalyser::isIntToFPConversion(TR::Node *child)
        child->getOpCodeValue() == TR::s2d)
       {
       TR::Node *convChild = child->getFirstChild();
-      if (convChild->getRegister() == NULL && convChild->getReferenceCount() == 1)
+      if (convChild->isSingleRefUnevaluated())
          {
          if (convChild->getOpCode().isLoadVar())
             {

--- a/compiler/x/codegen/IA32LinkageUtils.cpp
+++ b/compiler/x/codegen/IA32LinkageUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,14 +84,14 @@ TR::Register *IA32LinkageUtils::pushIntegerWordArg(
          }
       else if (child->getOpCodeValue() == TR::fbits2i &&
                !child->normalizeNanValues() &&
-               child->getReferenceCount() == 1)
+               child->isSingleRef())
          {
          pushRegister = pushFloatArg(child->getFirstChild(), cg);
          cg->decReferenceCount(child);
          return pushRegister;
          }
       else if (child->getOpCode().isMemoryReference() &&
-               (child->getReferenceCount() == 1) &&
+               (child->isSingleRef()) &&
                (child->getSymbolReference() != cg->comp()->getSymRefTab()->findVftSymbolRef()))
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(child, cg);
@@ -146,14 +146,14 @@ TR::Register *IA32LinkageUtils::pushLongArg(
          }
       else if (child->getOpCodeValue() == TR::dbits2l &&
                !child->normalizeNanValues() &&
-               child->getReferenceCount() == 1)
+               child->isSingleRef())
          {
          pushRegister = pushDoubleArg(child->getFirstChild(), cg);
          cg->decReferenceCount(child);
          return pushRegister;
          }
       else if (child->getOpCode().isMemoryReference() &&
-                child->getReferenceCount() == 1)
+                child->isSingleRef())
          {
          TR::MemoryReference  *lowMR = generateX86MemoryReference(child, cg);
          generateMemInstruction(PUSHMem, child, generateX86MemoryReference(*lowMR,4, cg), cg);
@@ -194,7 +194,7 @@ TR::Register *IA32LinkageUtils::pushFloatArg(
          cg->decReferenceCount(child);
          return NULL;
          }
-      else if (child->getReferenceCount() == 1)
+      else if (child->isSingleRef())
          {
          if (child->getOpCode().isLoad())
             {
@@ -262,7 +262,7 @@ TR::Register *IA32LinkageUtils::pushDoubleArg(
          cg->decReferenceCount(child);
          return NULL;
          }
-      else if (child->getReferenceCount() == 1)
+      else if (child->isSingleRef())
          {
          if (child->getOpCode().isLoad())
             {

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -512,8 +512,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
 
    if (comp->useCompressedPointers())
        {
-       if ((subTree->getOpCodeValue() == TR::l2a) && (subTree->getReferenceCount() == 1) &&
-             (subTree->getRegister() == NULL))
+       if ((subTree->getOpCodeValue() == TR::l2a) && subTree->isSingleRefUnevaluated())
           {
           cg->decReferenceCount(subTree);
           subTree = subTree->getFirstChild();

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -912,7 +912,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
       //
       if (!usingCompressedPointers && cg->isMemoryUpdate(node))
          {
-         if (valueChild->getFirstChild()->getReferenceCount() == 1)
+         if (valueChild->getFirstChild()->isSingleRef())
             {
             // Memory update always a win if the result value is not needed again
             //
@@ -937,8 +937,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
       TR::Register *translatedReg = valueReg;
       bool valueRegNeededInFuture = true;
       // try to avoid unnecessary sign-extension
-      if (valueChild->getRegister()       == 0 &&
-          valueChild->getReferenceCount() == 1 &&
+      if (valueChild->isSingleRefUnevaluated() &&
           (valueChild->getOpCodeValue() == TR::l2i ||
            valueChild->getOpCodeValue() == TR::l2s ||
            valueChild->getOpCodeValue() == TR::l2b))
@@ -1114,8 +1113,7 @@ TR::Register *OMR::X86::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
    // will not be taken for comp->useCompressedPointers
    // Handle special cases
    //
-   if (valueChild->getRegister() == NULL &&
-       valueChild->getReferenceCount() == 1)
+   if (valueChild->isSingleRefUnevaluated())
       {
       // Special case storing a float value into an int variable
       //
@@ -2918,7 +2916,7 @@ static TR::Register * inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerato
 
   if (opRegister->getKind() == TR_FPR)
     {
-      if (operand->getReferenceCount()==1)
+      if (operand->isSingleRef())
    targetRegister = opRegister;
       else
    targetRegister = cg->allocateSinglePrecisionRegister(TR_FPR);

--- a/compiler/x/codegen/SubtractAnalyser.cpp
+++ b/compiler/x/codegen/SubtractAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,7 +169,7 @@ TR::Register* TR_X86SubtractAnalyser::integerSubtractAnalyserImpl(TR::Node     *
             }
          else
             {
-            if (secondChild->getReferenceCount() == 1 && secondRegister != 0 && !needsEflags && (borrow == 0))
+            if (secondChild->isSingleRef() && secondRegister != 0 && !needsEflags && (borrow == 0))
                {
                // use one fewer registers if we negate the clobberable secondRegister and add
                // Don't do this though if condition codes are needed.  The sequence
@@ -309,7 +309,7 @@ TR::Register* TR_X86SubtractAnalyser::longSubtractAnalyserImpl(TR::Node *root, T
       {
       secondHighZero = true;
       TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
-      if (secondChild->getReferenceCount() == 1 && secondRegister == 0)
+      if (secondChild->isSingleRefUnevaluated())
          {
          if (secondOp == TR::iu2l || secondOp == TR::su2l ||
              secondOp == TR::bu2l ||

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,8 +115,7 @@ TR::Register *OMR::X86::TreeEvaluator::i2bEvaluator(TR::Node *node, TR::CodeGene
    TR::Node *firstChild = node->getFirstChild();
    static const char *narrowLoads = feGetEnv("TR_NarrowLoads");
    if (narrowLoads &&
-       firstChild->getReferenceCount() == 1 &&
-       firstChild->getRegister() == 0       &&
+       firstChild->isSingleRefUnevaluated() &&
        firstChild->getOpCode().isLoadVar())
       {
       TR::ILOpCodes op = node->getOpCodeValue();

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -417,7 +417,7 @@ TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, boo
    //
    if ((callNode->getDataType() == TR::Float ||
         callNode->getDataType() == TR::Double) &&
-       callNode->getReferenceCount() == 1)
+       callNode->isSingleRef())
       {
       generateFPSTiST0RegRegInstruction(FSTRegReg, callNode, returnReg, returnReg, cg());
       }

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -359,9 +359,9 @@ OMR::X86::I386::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node 
                return 1;
                }
 
-            if ((firstChild->getReferenceCount() == 1 &&
+            if ((firstChild->isSingleRef() &&
                 firstChild->getOpCode().isLoadVarDirect()) ||
-                (secondChild->getReferenceCount() == 1 &&
+                (secondChild->isSingleRef() &&
                  firstChild->getOpCode().isLoadVarDirect()))
                extraRegsAvailable += 0; // TODO: put it back to 2 when looking at GRA, GRA pushes allocation of 8 registers
 

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -188,8 +188,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
    if (root->getOpCode().isBooleanCompare() || nonClobberingDestination)
       {
       if (firstChild->getOpCodeValue() == TR::bu2i &&
-          firstChild->getReferenceCount() == 1    &&
-          firstChild->getRegister() == NULL       &&
+          firstChild->isSingleRefUnevaluated()  &&
              (firstChild->getFirstChild()->getOpCodeValue() == TR::bload ||	
               firstChild->getFirstChild()->getOpCodeValue() == TR::bloadi  ))
           {
@@ -200,8 +199,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
           }
 
       if (secondChild->getOpCodeValue() == TR::bu2i &&
-          secondChild->getReferenceCount() == 1    &&
-          secondChild->getRegister() == NULL       &&
+          secondChild->isSingleRefUnevaluated() &&
              (secondChild->getFirstChild()->getOpCodeValue() == TR::bload ||	
               secondChild->getFirstChild()->getOpCodeValue() == TR::bloadi  ))
           {
@@ -214,8 +212,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
 
    if (cg()->comp()->target().is64Bit())
       {
-      if (firstChild->getOpCodeValue() == TR::l2i && firstChild->getReferenceCount() == 1 &&
-          firstChild->getRegister() == NULL && nonClobberingDestination)
+      if (firstChild->getOpCodeValue() == TR::l2i && firstChild->isSingleRefUnevaluated() && nonClobberingDestination)
          {
          initFirstChild = firstChild;
          firstChild     = firstChild->getFirstChild();
@@ -224,8 +221,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
          adjustDiplacementOnFirstChild = true;
          }
 
-      if (secondChild->getOpCodeValue() == TR::l2i && secondChild->getReferenceCount() == 1 &&
-          secondChild->getRegister() == NULL && nonClobberingDestination)
+      if (secondChild->getOpCodeValue() == TR::l2i && secondChild->isSingleRefUnevaluated() && nonClobberingDestination)
          {
          initSecondChild = secondChild;
          secondChild     = secondChild->getFirstChild();
@@ -673,9 +669,8 @@ TR_S390BinaryCommutativeAnalyser::conversionIsRemoved(TR::Node * root, TR::Node 
         (root->getDataType() == TR::Int32 && child->getOpCodeValue() == TR::a2i &&
        cg()->comp()->target().is32Bit()))  &&
        child->getFirstChild()->getOpCodeValue() == TR::aloadi &&
-       child->getFirstChild()->getRegister() == NULL &&
-       child->getFirstChild()->getReferenceCount() == 1 &&
-       child->getReferenceCount() == 1 )
+       child->getFirstChild()->isSingleRefUnevaluated() &&
+       child->isSingleRef() )
       {
       cg()->decReferenceCount(child);
       child = child->getFirstChild();

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1067,7 +1067,7 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       // make a copy of the MR
       sourceMR = generateS390MemoryReference(*divchkDivisorMR, 0, cg);
       }
-   else if ( secondChild->getRegister()==NULL && secondChild->getReferenceCount()==1 &&
+   else if ( secondChild->isSingleRefUnevaluated() &&
              secondChild->getOpCode().isMemoryReference() &&
              !needCheck)
       {
@@ -1326,7 +1326,7 @@ genericIntShift(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mnemoni
    if (node->getOpCodeValue() == TR::bushr)
       {
       if (node->getFirstChild()->getOpCodeValue() == TR::bconst &&
-          node->getReferenceCount() == 1 &&
+          node->isSingleRef() &&
           node->getFirstChild()->getRegister() == NULL)
          {
          srcReg = node->getFirstChild()->setRegister(cg->allocateRegister());
@@ -1460,8 +1460,8 @@ genericRotateLeft(TR::Node * node, TR::CodeGenerator * cg)
          }
 
       if (lushr &&
-            lushr->getOpCodeValue() == TR::lushr && lushr->getReferenceCount() == 1 && lushr->getRegister() == NULL &&
-            lshl->getOpCodeValue()  == TR::lshl &&   lshl->getReferenceCount() == 1 &&  lshl->getRegister() == NULL)
+            lushr->getOpCodeValue() == TR::lushr && lushr->isSingleRefUnevaluated() &&
+            lshl->getOpCodeValue()  == TR::lshl &&   lshl->isSingleRefUnevaluated())
          {
          int32_t rShftAmnt = lushr->getSecondChild()->getInt();
          int32_t lShftAmnt = lshl->getSecondChild()->getInt();
@@ -1509,8 +1509,7 @@ genericRotateLeft(TR::Node * node, TR::CodeGenerator * cg)
       }
    if (node->getOpCodeValue() == TR::lor &&
          andChild &&
-         andChild->getRegister() == NULL &&
-         andChild->getReferenceCount() == 1)
+         andChild->isSingleRefUnevaluated())
       {
       TR::Node* data = NULL;
       uint64_t shiftBy = 0;
@@ -1519,8 +1518,7 @@ genericRotateLeft(TR::Node * node, TR::CodeGenerator * cg)
       uint64_t bitPos = 0;
 
       if (shiftChild->getOpCodeValue() == TR::lshl &&
-            shiftChild->getRegister() == NULL &&
-            shiftChild->getReferenceCount() == 1 &&
+            shiftChild->isSingleRefUnevaluated() &&
             shiftChild->getSecondChild()->getOpCode().isLoadConst())
          {
          data = shiftChild->getFirstChild();
@@ -2215,7 +2213,7 @@ OMR::Z::TreeEvaluator::dualMulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    TR_ASSERT( (node->getOpCodeValue() == TR::lumulh) || (node->getOpCodeValue() == TR::lmul),"Unexpected operator. Expected lumulh or lmul.");
    TR_ASSERT( node->isDualCyclic() || needsUnsignedHighMulOnly, "Should be either calculating cyclic dual or just the high part of the lmul.");
-   if (node->isDualCyclic() && node->getChild(2)->getReferenceCount() == 1)
+   if (node->isDualCyclic() && node->getChild(2)->isSingleRef())
       {
       // other part of this dual is not used, and is dead
       TR::Node *pair = node->getChild(2);
@@ -3065,7 +3063,7 @@ OMR::Z::TreeEvaluator::inegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * targetRegister = cg->allocateRegister();
 
    // ineg over iabs is an integer form of pdSetSign 0xd (negative); handle it in one operation
-   if (firstChild->getOpCodeValue() == TR::iabs && firstChild->getReferenceCount() == 1 && firstChild->getRegister() == NULL)
+   if (firstChild->getOpCodeValue() == TR::iabs && firstChild->isSingleRefUnevaluated())
       {
       sourceRegister = firstChild->getFirstChild()->getRegister();
       if (sourceRegister == NULL)
@@ -3081,8 +3079,7 @@ OMR::Z::TreeEvaluator::inegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    else if (firstChild->getOpCodeValue() == TR::imul &&
             firstChild->getSecondChild()->getOpCode().isLoadConst() &&
             firstChild->getSecondChild()->getInt() != 0x80000000 &&
-            firstChild->getReferenceCount() == 1 &&
-            firstChild->getRegister() == NULL &&
+            firstChild->isSingleRefUnevaluated() &&
             performTransformation(cg->comp(), "O^O Replace ineg/imul by const with imul by -const.\n"))
       {
       TR::Node* oldConst = firstChild->getSecondChild();
@@ -3121,7 +3118,7 @@ OMR::Z::TreeEvaluator::lnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * sourceRegister;
    targetRegister = cg->allocateRegister();
 
-      if (firstChild->getOpCodeValue() == TR::labs && firstChild->getReferenceCount() == 1 && firstChild->getRegister() == NULL)
+      if (firstChild->getOpCodeValue() == TR::labs && firstChild->isSingleRefUnevaluated())
       {
       // Load Negative
       sourceRegister = firstChild->getFirstChild()->getRegister();

--- a/compiler/z/codegen/CompareAnalyser.cpp
+++ b/compiler/z/codegen/CompareAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
       {
       if (getEvalChild1())
          {
-         if (firstChild->getReferenceCount() == 1 &&
+         if (firstChild->isSingleRef() &&
             firstChild->getRegister() == NULL &&
             (firstChild->getOpCodeValue() == TR::lload || (firstChild->getOpCodeValue() == TR::iload && firstIU2L)))
             {
@@ -115,7 +115,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
          }
       if (getEvalChild2())
          {
-         if (secondChild->getReferenceCount() == 1 &&
+         if (secondChild->isSingleRef() &&
             secondChild->getRegister() == NULL &&
             (secondChild->getOpCodeValue() == TR::lload || (secondChild->getOpCodeValue() == TR::iload && secondIU2L)))
             {
@@ -137,7 +137,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
       {
       if (getEvalChild2())
          {
-         if (secondChild->getReferenceCount() == 1 &&
+         if (secondChild->isSingleRef() &&
             secondChild->getRegister() == NULL &&
             (secondChild->getOpCodeValue() == TR::lload || (secondChild->getOpCodeValue() == TR::iload && secondIU2L)))
             {
@@ -156,7 +156,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
          }
       if (getEvalChild1())
          {
-         if (firstChild->getReferenceCount() == 1 &&
+         if (firstChild->isSingleRef() &&
             firstChild->getRegister() == NULL &&
             (firstChild->getOpCodeValue() == TR::lload || (firstChild->getOpCodeValue() == TR::iload && firstIU2L)))
             {

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -520,7 +520,7 @@ lcmpHelper64(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * secondChild = node->getSecondChild();
 
    TR::Register * src1Reg = NULL;
-   if (firstChild->getReferenceCount() == 1)
+   if (firstChild->isSingleRef())
       src1Reg = (TR::Register *) cg->evaluate(firstChild);
    else
       src1Reg = (TR::Register *) cg->gprClobberEvaluate(firstChild);
@@ -1366,7 +1366,7 @@ OMR::Z::TreeEvaluator::icmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * secondChild = node->getSecondChild();
 
    if (!node->getOpCode().isUnsignedCompare() &&
-       firstChild->getReferenceCount() == 1 && firstChild->isNonNegative() && secondChild->isNonNegative() &&
+       firstChild->isSingleRef() && firstChild->isNonNegative() && secondChild->isNonNegative() &&
        performTransformation(cg->comp(), "O^O CODE GENERATION:  ===>   Use SR/SRL to perform icmplt  <==\n"))
       {
       // Even if 1st child refcount is 1, the register may be shared with other nodes and still be live.
@@ -1405,7 +1405,7 @@ OMR::Z::TreeEvaluator::icmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * secondChild = node->getSecondChild();
 
    if (!node->getOpCode().isUnsignedCompare() &&
-       secondChild->getReferenceCount()==1 && firstChild->isNonNegative() && secondChild->isNonNegative() &&
+       secondChild->isSingleRef() && firstChild->isNonNegative() && secondChild->isNonNegative() &&
        performTransformation(cg->comp(), "O^O CODE GENERATION:  ===>   Use SR/SRL to perform icmpgt  <==\n"))
       {
       TR::Register * firstReg = cg->evaluate(firstChild);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2440,7 +2440,7 @@ OMR::Z::CodeGenerator::processUnusedNodeDuringEvaluation(TR::Node *node)
          {
          self()->recursivelyDecReferenceCount(node);
          }
-      else if (node->getReferenceCount() == 1 &&
+      else if (node->isSingleRef() &&
                node->getOpCode().isLoadVar() &&
                (node->getNumChildren() == 0 || (node->getNumChildren() == 1 && node->getFirstChild()->safeToDoRecursiveDecrement())))
          {
@@ -4252,7 +4252,7 @@ OMR::Z::CodeGenerator::evaluateLengthMinusOneForMemoryOps(TR::Node *node, bool c
    {
    TR::Register *reg;
 
-   if ((node->getReferenceCount() == 1) && self()->supportsLengthMinusOneForMemoryOpts() &&
+   if ((node->isSingleRef()) && self()->supportsLengthMinusOneForMemoryOpts() &&
       ((node->getOpCodeValue()==TR::iadd &&
        node->getSecondChild()->getOpCodeValue()==TR::iconst &&
        node->getSecondChild()->getInt() == 1) ||
@@ -5572,12 +5572,12 @@ OMR::Z::CodeGenerator::checkIfcmpxx(TR::Node *node)
 
    bool firstChildOK = (firstChildNode->getOpCode().isLoadVar() || firstChildNode->getOpCode().isLoadConst()) &&
                        firstChildNode->getType().isIntegral() &&
-                       firstChildNode->getReferenceCount() == 1;
+                       firstChildNode->isSingleRef();
 
    bool secondChildOK = firstChildOK &&
                         (secondChildNode->getOpCode().isLoadVar() || secondChildNode->getOpCode().isLoadConst()) &&
                         secondChildNode->getType().isIntegral() &&
-                        secondChildNode->getReferenceCount() == 1;
+                        secondChildNode->isSingleRef();
 
    if (secondChildOK &&
        firstChildNode->getSize() == secondChildNode->getSize())
@@ -5602,7 +5602,7 @@ bool
 OMR::Z::CodeGenerator::checkBitWiseChild(TR::Node *node)
    {
    if (node->getOpCode().isLoadConst() ||
-            (node->getOpCode().isLoadVar() && node->getReferenceCount() == 1))
+            (node->getOpCode().isLoadVar() && node->isSingleRef()))
       {
       if (node->getType().isInt8() || node->getType().isInt16())
          return true;


### PR DESCRIPTION
  Node::isSingleRef()
  Node::isSingleRefUnevaluated()

Issue: #5648 
Signed-off-by: James Guan jamesgua@ca.ibm.com