### PR TITLE
Fix to OMR ILBuilder ConstInt64 logging problem

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -925,7 +925,7 @@ TR::IlValue *
 OMR::IlBuilder::ConstInt64(int64_t value)
    {
    TR::IlValue *returnValue = newValue(Int64, TR::Node::lconst(value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstInt64 %d\n", this, returnValue->getID(), value);
+   TraceIL("IlBuilder[ %p ]::%d is ConstInt64 %lld\n", this, returnValue->getID(), value);
    return returnValue;
    }
 


### PR DESCRIPTION
This PR addresses #5775
Credit for the fix of the problem goes to Mark Stoodley (@mstoodle).
The changes were tested with OMR compiler test and JitBuilder test.