### PR TITLE
Add missing switch case statements for Eflags

### DIFF
--- a/port/linuxamd64/omrsignal_context.c
+++ b/port/linuxamd64/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,6 +240,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 		*name = "RSP";
 		*value = (void *)&(context->rsp);
 		return OMRPORT_SIG_VALUE_ADDRESS;
+	case OMRPORT_SIG_CONTROL_X86_EFLAGS:
 	case 4:
 		*name = "EFlags";
 		*value = (void *)&(context->eflags);

--- a/port/osx/omrsignal_context.c
+++ b/port/osx/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -276,6 +276,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 		*name = "RSP";
 		*value = (void *)&(threadState->__rsp);
 		return OMRPORT_SIG_VALUE_ADDRESS;
+	case OMRPORT_SIG_CONTROL_X86_EFLAGS:
 	case 4:
 		*name = "RFlags";
 		*value = (void *)&(threadState->__rflags);

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -979,6 +979,12 @@ infoForControl(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *in
 		case 2:
 			*name = "RBP";
 			*value = &info->ContextRecord->Rbp;
+			return OMRPORT_SIG_VALUE_ADDRESS;
+
+		case OMRPORT_SIG_CONTROL_X86_EFLAGS:
+		case 3:
+			*name = "EFLAGS";
+			*value = &info->ContextRecord->EFlags;
 			return OMRPORT_SIG_VALUE_ADDRESS;
 		}
 	}


### PR DESCRIPTION
The fix has been applied to `win64amd`, `linuxamd64` and `osx`.

On `osx`, `rflags` is available instead of `eflags`. Since `eflags` is analogous
to `rflags`, `OMRPORT_SIG_CONTROL_X86_EFLAGS` is used for `rflags` on `osx`.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>