### PR TITLE
Update pointer offset addition for dbf Scan Ordering

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1700,11 +1700,12 @@ MM_Scavenger::depthCopyHotFields(MM_EnvironmentStandard *env, MM_ForwardedHeader
 
 MMINLINE void
 MM_Scavenger::copyHotField(MM_EnvironmentStandard *env, omrobjectptr_t destinationObjectPtr, uint8_t offset) {
-	GC_SlotObject hotFieldObject(_omrVM, (fomrobject_t*)(destinationObjectPtr + offset));
+	bool const compressed = _extensions->compressObjectReferences();
+	GC_SlotObject hotFieldObject(_omrVM, GC_SlotObject::addToSlotAddress((fomrobject_t*)((uintptr_t)destinationObjectPtr), offset, compressed));
 	omrobjectptr_t objectPtr = hotFieldObject.readReferenceFromSlot();
 	if (isObjectInEvacuateMemory(objectPtr)) {
 		/* Hot field needs to be copy and forwarded.  Check if the work has already been done */
-		MM_ForwardedHeader forwardHeaderHotField(objectPtr, _extensions->compressObjectReferences());
+		MM_ForwardedHeader forwardHeaderHotField(objectPtr, compressed);
 		if (!forwardHeaderHotField.isForwardedPointer()) {
 			env->_hotFieldCopyDepthCount += 1;
 			copyObject(env, &forwardHeaderHotField);


### PR DESCRIPTION
Update pointer offset addition for adding a hot field
offset to an object pointer in order to copy the hot
field of the object for dbf Scan Ordering in gencon GC.

Issue:  eclipse/openj9#11819
Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>