### PR TITLE
Adding `concurrent-start/end` for Concurrent Global/Marking

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -23,6 +23,7 @@
 #include "AllocateDescription.hpp"
 #include "Collector.hpp"
 #include "GCExtensionsBase.hpp"
+#include "GlobalCollector.hpp"
 #include "FrequentObjectsStats.hpp"
 #include "Heap.hpp"
 #include "MemorySubSpace.hpp"
@@ -575,4 +576,12 @@ MM_Collector::isMarked(void *objectPtr)
 {
 	Assert_MM_unreachable();
 	return false;
+}
+
+void
+MM_Collector::notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env)
+{
+	if (!_globalCollector) {
+		env->getExtensions()->getGlobalCollector()->notifyAcquireExclusiveVMAccess(env);
+	}
 }

--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -294,7 +294,7 @@ public:
 	 * Notify any (concurrent) collector that might block and hold VM access
 	 * that an Exclusive VM Access is to be requested so that VM access can be released
 	 */
-	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env) {}
+	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env);
 	virtual bool isDisabled(MM_EnvironmentBase *env) { return _disableGC; }
 	/**
 	 * @return pointer to collector/phase specific concurrent stats structure

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -32,6 +32,7 @@
 
 #include "ConcurrentCardTable.hpp"
 #include "ConcurrentMarkingDelegate.hpp"
+#include "ConcurrentMarkPhaseStats.hpp"
 #include "Collector.hpp"
 #include "CollectorLanguageInterface.hpp"
 #include "ConcurrentGCStats.hpp"
@@ -279,6 +280,7 @@ protected:
 
 	MM_ConcurrentSafepointCallback *_callback;
 	MM_ConcurrentGCStats _stats;
+	MM_ConcurrentMarkPhaseStats _concurrentPhaseStats;
 
 
 public:
@@ -335,6 +337,9 @@ private:
 	
 	void reportConcurrentRememberedSetScanStart(MM_EnvironmentBase *env);
 	void reportConcurrentRememberedSetScanEnd(MM_EnvironmentBase *env, uint64_t duration);
+
+	virtual void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats = NULL);
+	virtual void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats = NULL, UDATA bytesConcurrentlyScanned = 0);
 
 	virtual bool internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription);
 
@@ -470,6 +475,7 @@ public:
 	MMINLINE MM_ConcurrentGCStats *getConcurrentGCStats() { return &_stats; }
 
 	void concurrentWorkStackOverflow();
+	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env);
 	
 	MM_ConcurrentGC(MM_EnvironmentBase *env)
 		: MM_ParallelGlobalGC(env)
@@ -518,6 +524,7 @@ public:
 		,_retuneAfterHeapResize(false)
 		,_callback(NULL)
 		,_stats()
+		,_concurrentPhaseStats()
 		{
 			_typeId = __FUNCTION__;
 		}

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -942,7 +942,7 @@ public:
 		, _currentPhaseConcurrent(false)
 		, _concurrentScavengerSwitchCount(0)
 		, _shouldYield(false)
-		, _concurrentPhaseStats()
+		, _concurrentPhaseStats(OMR_GC_CYCLE_TYPE_SCAVENGE)
 #endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 		, _omrVM(env->getOmrVM())

--- a/gc/stats/ConcurrentMarkPhaseStats.hpp
+++ b/gc/stats/ConcurrentMarkPhaseStats.hpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Stats
+ */
+#ifndef CONCURRENTMARKPHASESTATS_HPP_
+#define CONCURRENTMARKPHASESTATS_HPP_
+
+#include "ConcurrentCardTableStats.hpp"
+#include "ConcurrentGCStats.hpp"
+#include "ConcurrentPhaseStatsBase.hpp"
+
+/**
+  * @ingroup GC_Stats ConcurrentMarkPhaseStats
+ */
+class MM_ConcurrentMarkPhaseStats : public MM_ConcurrentPhaseStatsBase
+{
+	/* Data Members */
+private:
+protected:
+public:
+	uint64_t _startTime;
+	uint64_t _endTime;
+	MM_ConcurrentCardTableStats *_cardTableStats;
+	MM_ConcurrentGCStats *_collectionStats;
+
+	/* Member Functions */
+private:
+protected:
+public:
+	virtual void clear() {
+		MM_ConcurrentPhaseStatsBase::clear();
+		_startTime = 0;
+		_endTime = 0;
+		_cardTableStats = NULL;
+		_collectionStats = NULL;
+	}
+
+	MM_ConcurrentMarkPhaseStats()
+		: MM_ConcurrentPhaseStatsBase(OMR_GC_CYCLE_TYPE_GLOBAL)
+		, _startTime(0)
+		, _endTime(0)
+		, _cardTableStats(NULL)
+		, _collectionStats(NULL)
+		{}
+}; 
+
+#endif /* CONCURRENTMARKPHASESTATS_HPP_ */

--- a/gc/stats/ConcurrentPhaseStatsBase.hpp
+++ b/gc/stats/ConcurrentPhaseStatsBase.hpp
@@ -46,6 +46,7 @@ public:
 	uintptr_t _scanTargetInBytes;	/**< The number of bytes a given concurrent task was expected to scan before terminating */
 	uintptr_t _bytesScanned;	/**< The number of bytes a given concurrent task did scan before it terminated (can be lower than _scanTargetInBytes if the termination was asynchronously requested) */
 	bool _terminationWasRequested;	/**< todo: remove after downstream projects start using _terminationRequestType */
+	uintptr_t _concurrentCycleType;	/**< The "type" of the corresponding cycle */
 	enum TerminationRequestType {
 		terminationRequest_None,
 		terminationRequest_ByGC,
@@ -65,7 +66,7 @@ public:
 		return terminationRequest_External == _terminationRequestType;
 	}
 	
-	void clear() {
+	virtual void clear() {
 		_cycleID = 0;
 		_scanTargetInBytes = 0;
 		_bytesScanned = 0;
@@ -73,12 +74,13 @@ public:
 		_terminationRequestType = terminationRequest_None;
 	}
 	 
-	MM_ConcurrentPhaseStatsBase()
+	MM_ConcurrentPhaseStatsBase(uintptr_t concurrentCycleType = OMR_GC_CYCLE_TYPE_DEFAULT)
 		: MM_Base()
 		, _cycleID(0)
 		, _scanTargetInBytes(0)
 		, _bytesScanned(0)
 		, _terminationWasRequested(false)
+		, _concurrentCycleType(concurrentCycleType)
 		, _terminationRequestType(terminationRequest_None)
 	{}
 }; 

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -104,8 +104,14 @@ protected:
 	 * @param[IN] cycle type
 	 * @return string representing the human readable "type" of the cycle.
 	 */	
-	virtual const char *getCycleType(uintptr_t type);
+	virtual const char *getCycleType(uintptr_t type) { return "unknown"; };
 
+	/**
+	 * Answer a string representation of a given cycle type.
+	 * @param[IN] cycle type
+	 * @return string representing the human readable "type" of the cycle.
+	 */
+	virtual const char *getConcurrentTypeString(uintptr_t type) { return "unknown"; };
 
 	/**
      * Output a stanza on data tracking for the initialized phase of verbose GC into a verbose buffer.
@@ -316,11 +322,12 @@ public:
 	 * @param type Human readable name for the type of the tag.
 	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
 	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.
+	 * @param reasonForTermination termination reason.
 	 * @return number of bytes consumed in the buffer.
 	 *
 	 * @note should be moved to protected once all standard usage is converted.
 	 */
-	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t wallTimeMs);
+	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t wallTimeMs, const char *reasonForTermination = NULL);
 
 	/**
 	 * Build the standard top level tag template.
@@ -329,13 +336,13 @@ public:
 	 * @param id unique id of the tag being built.
 	 * @param type Human readable name for the type of the tag.
 	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
+	 * @param timeus the time in microseconds taken for this piece of work.
 	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.
-	 * @param reasonForTermination termination reason.
 	 * @return number of bytes consumed in the buffer.
 	 *
 	 * @note should be moved to protected once all standard usage is converted.
 	 */
-	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t wallTimeMs, const char *reasonForTermination);
+	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t timeus, uint64_t wallTimeMs);
 
 	/**
 	 * Build the standard top level tag template.
@@ -351,21 +358,6 @@ public:
 	 * @note should be moved to protected once all standard usage is converted.
 	 */
 	uintptr_t getTagTemplateWithOldType(char *buf, uintptr_t bufsize, uintptr_t id, const char *oldType, const char *newType, uintptr_t contextId, uint64_t wallTimeMs);
-
-	/**
-	 * Build the standard top level tag template.
-	 * @param buf character buffer in which to create to tag template.
-	 * @param bufsize maximum size allowed in the character buffer.
-	 * @param id unique id of the tag being built.
-	 * @param type Human readable name for the type of the tag.
-	 * @param contextId unique identifier of the associated event this is associated with (parent/sibling relationship).
-	 * @param timeus the time in microseconds taken for this piece of work
-	 * @param wallTimeMs wall clock time to be used as the timestamp for the tag.
-	 * @return number of bytes consumed in the buffer.
-	 *
-	 * @note should be moved to protected once all standard usage is converted.
-	 */
-	uintptr_t getTagTemplate(char *buf, uintptr_t bufsize, uintptr_t id, const char *type, uintptr_t contextId, uint64_t timeus, uint64_t wallTimeMs);
 
 	/**
 	 * Build the standard top level tag template.
@@ -510,7 +502,6 @@ public:
 	
 	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
 	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {};
-	virtual const char *getConcurrentTypeString() { return NULL; }
 	
 	virtual void handleConcurrentGCOpStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}
 

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -52,6 +52,13 @@ protected:
 	 */	
 	virtual const char *getCycleType(uintptr_t type);
 
+	/**
+	 * Answer a string representation of a given cycle type.
+	 * @param[IN] cycle type
+	 * @return string representing the human readable "type" of the cycle.
+	 */
+	virtual const char *getConcurrentTypeString(uintptr_t type);
+
 	void handleGCOPStanza(MM_EnvironmentBase* env, const char *type, uintptr_t contextID, uint64_t duration, bool deltaTimeSuccess);
 
 	virtual bool hasOutputMemoryInfoInnerStanza();
@@ -70,6 +77,12 @@ protected:
 	virtual void handleScavengePercolateInternal(MM_EnvironmentBase* env, void* eventData);
 #endif /*defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+	/**
+	 * Answer a string representation of a given card cleaning reason.
+	 * @param[IN] card cleaning reason
+	 * @return string representing the human readable "reason" of card cleaning.
+	 */ 
+	const char *getCardCleaningReasonString(uintptr_t type);
 	virtual void handleConcurrentRememberedSetScanEndInternal(MM_EnvironmentBase *env, void* eventData);
 	virtual void handleConcurrentCardCleaningEndInternal(MM_EnvironmentBase *env, void* eventData);
 	virtual void handleConcurrentTracingEndInternal(MM_EnvironmentBase *env, void* eventData);
@@ -136,12 +149,18 @@ public:
 	 */
 	void handleScavengePercolate(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 	
-	virtual const char *getConcurrentTypeString() { return "scavenge"; }
-	
 	virtual void handleConcurrentEndInternal(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+	/**
+	 * Write verbose stanza for a global mark end event.
+	 * @param hook Hook interface used by the JVM.
+	 * @param eventNum The hook event number.
+	 * @param eventData hook specific event data.
+	 */
+	void handleConcurrentMarkEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+
 	/**
 	 * Write verbose stanza for concurrent remembered set scan event.
 	 * @param hook Hook interface used by the JVM.


### PR DESCRIPTION
Introduce `concurrent-start/end` stanza pair for Concurrent Global Marking to match with scavenging. Concurrent-start stanza is printed in initial STW phase as we transition away from init complete and concurrent-end can be printed either before final STW (when we exhaust concurrent work) or during STW (if halted).

- New API in `MM_Collector`:
    - `notifyAcquireExclusiveVMAccess` to notify local collector
- New API in `MM_ConcurrentGC`:
    - `preConcurrentInitializeStatsAndReport` for triggering concurrent-start event
    - `postConcurrentUpdateStatsAndReport` for triggering concurrent-end event
    - `notifyAcquireExclusiveVMAccess` to recored time stamp when concurrent marking is halted or completed in STW
- Introduce a subclass `MM_ConcurrentMarkPhaseStats` of `MM_ConcurrentPhaseStatsBase`
- New fields in `MM_ConcurrentPhaseStatsBase`
    - `_concurrentCycleType`
- New API in `MM_VerboseHandlerOutput`
    - `getTagTemplate` to print with optional `reasonForTermination`
- New API in `MM_VerboseHandlerOutputStandard`
    - `getConcurrentTypeString`
    - `getCardCleaningReasonString`
    - `handleGlobalMarkEndNoLock`


Signed-off-by: Enson Guo <enson.guo@ibm.com>