### PR TITLE
CMake: Update handling of a2e/omr_ascii

### DIFF
--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -32,16 +32,15 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 	-DZOS
 )
 
-list(APPEND OMR_PLATFORM_INCLUDE_DIRECTORIES
-	${CMAKE_SOURCE_DIR}/util/a2e/headers
-	/usr/lpp/cbclib/include
-	/usr/include
-)
+# CMake ignores any include directories which appear in IMPLICIT_INCLUDE_DIRECTORIES.
+# This causes an issue with a2e since we need to re-specify them after clearing default search path.
+list(REMOVE_ITEM CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES /usr/include)
+list(REMOVE_ITEM CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES /usr/include)
 
 # Create helper targets for specifying ascii/ebcdic options
 add_library(omr_ascii INTERFACE)
 target_compile_definitions(omr_ascii INTERFACE -DIBM_ATOE)
-target_compile_options(omr_ascii INTERFACE "-Wc,convlit(ISO8859-1)")
+target_compile_options(omr_ascii INTERFACE "-Wc,convlit(ISO8859-1),nose,se(${CMAKE_CURRENT_LIST_DIR}/../../../../util/a2e/headers)")
 target_link_libraries(omr_ascii INTERFACE j9a2e)
 
 add_library(omr_ebcdic INTERFACE)

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -58,10 +58,6 @@ if(OMR_OS_WINDOWS)
 	)
 endif()
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omralgotest j9a2e)
-endif()
-
 set_property(TARGET omralgotest PROPERTY FOLDER fvtest)
 
 omr_add_test(NAME algotest COMMAND $<TARGET_FILE:omralgotest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -64,10 +64,6 @@ target_link_libraries(comptest
 	tril
 )
 
-if(OMR_OS_ZOS)
-	target_link_libraries(comptest j9a2e)
-endif()
-
 set_property(TARGET comptest PROPERTY FOLDER fvtest)
 
 omr_add_test(

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -52,10 +52,6 @@ target_link_libraries(omrgctest
 	${OMR_PORT_LIB}
 )
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omrgctest j9a2e)
-endif()
-
 set_property(TARGET omrgctest PROPERTY FOLDER fvtest)
 
 omr_add_test(NAME gctest

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -91,12 +91,6 @@ if(OMR_OS_WINDOWS)
 	)
 endif()
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omrporttest
-		j9a2e
-	)
-endif()
-
 omr_add_library(sltestlib SHARED
 	sltestlib/sltest.c
 )

--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 #include <process.h>
 #endif /* defined(OMR_OS_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
 #endif
 

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,10 @@
  * $Revision: 1.64 $
  * $Date: 2012-12-05 05:27:54 $
  */
+#if defined(J9ZOS390)
+#define _UNIX03_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -42,8 +46,7 @@
 #include <sys/resource.h> /* For RLIM_INFINITY */
 #endif /* !defined(OMR_OS_WINDOWS) */
 
-#if defined(J9ZOS390)
-#define _UNIX03_SOURCE
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
 #endif
 
@@ -1769,11 +1772,11 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	const char *utf8 = "/tmp/test/";
 	const char *utf8_file = "/tmp/test/test.txt";
 	char *origEnvRef = getenv("TMPDIR");
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	char *envVarInEbcdic = a2e_string("TMPDIR");
 	char *origEnvInEbcdic = NULL;
 	char *utf8InEbcdic = a2e_string(utf8);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -1781,17 +1784,17 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 		origEnv = (char *)omrmem_allocate_memory(strlen(origEnvRef) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL != origEnv) {
 			strcpy(origEnv, origEnvRef);
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 			origEnvInEbcdic = a2e_string(origEnv);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 		}
 	}
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	rc = setenv(envVarInEbcdic, utf8InEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* defined(J9ZOS390)  && !defined(OMR_EBCDIC) */
 	rc = setenv("TMPDIR", (const char *)utf8, 1);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390)  && !defined(OMR_EBCDIC) */
 
 #endif /* defined(OMR_OS_WINDOWS) */
 
@@ -1845,21 +1848,21 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	if (NULL != origEnv) {
 #if defined(OMR_OS_WINDOWS)
 		_wputenv_s(L"TMP", origEnv);
-#elif defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif defined(J9ZOS390) && !defined(OMR_EBCDIC)  /* defined(OMR_OS_WINDOWS) */
 		setenv(envVarInEbcdic, origEnvInEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 		setenv("TMPDIR", origEnv, 1);
 #endif /* defined(OMR_OS_WINDOWS) */
 		omrmem_free_memory(origEnv);
 	} else {
 #if defined(OMR_OS_WINDOWS)
 		_wputenv_s(L"TMP", L"");
-#elif !defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif !defined(J9ZOS390) && !defined(OMR_EBCDIC) /* defined(OMR_OS_WINDOWS) */
 		unsetenv("TMPDIR");
 #endif /* defined(OMR_OS_WINDOWS) */
 	}
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	if (NULL != envVarInEbcdic) {
 		free(envVarInEbcdic);
 	}
@@ -1869,7 +1872,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	if (NULL != utf8InEbcdic) {
 		free(utf8InEbcdic);
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	if (NULL != buffer) {
 		omrmem_free_memory(buffer);
@@ -1891,11 +1894,11 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	char *oldTmpDir = NULL;
 	char *oldTmpDirValue = NULL;
 	const char *modifiedTmpDir = "omrsysinfo_test_get_tmp4_dir";
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	char *envVarInEbcdic = a2e_string(envVar);
 	char *oldTmpDirValueInEbcdic = NULL;
 	char *modifiedTmpDirInEbcdic = a2e_string(modifiedTmpDir);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -1904,17 +1907,17 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 		oldTmpDirValue = (char *)omrmem_allocate_memory(strlen(oldTmpDir) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL != oldTmpDirValue) {
 			strcpy(oldTmpDirValue, oldTmpDir);
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 			oldTmpDirValueInEbcdic = a2e_string(oldTmpDirValue);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 		}
 	}
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	rc = setenv(envVarInEbcdic, modifiedTmpDirInEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 	rc = setenv(envVar, modifiedTmpDir, 1);
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error in updating environment variable TMPDIR, rc: %zd\n", rc);
 	}
@@ -1960,7 +1963,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	}
 
 	/* restore TMPDIR */
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	if (NULL != oldTmpDirValue) {
 		setenv(envVarInEbcdic, oldTmpDirValueInEbcdic, 1);
 		omrmem_free_memory(oldTmpDirValue);
@@ -1974,14 +1977,14 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	if (NULL != modifiedTmpDirInEbcdic) {
 		free(modifiedTmpDirInEbcdic);
 	}
-#else /* defined(J9ZOS390) */
+#else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 	if (NULL != oldTmpDirValue) {
 		setenv(envVar, oldTmpDirValue, 1);
 		omrmem_free_memory(oldTmpDirValue);
 	} else {
 		unsetenv(envVar);
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	reportTestExit(OMRPORTLIB, testName);
 }

--- a/fvtest/porttest/testProcessHelpers.cpp
+++ b/fvtest/porttest/testProcessHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,9 +40,11 @@
 
 #if defined(J9ZOS390)
 #include <spawn.h>
+#if !defined(OMR_EBCDIC)
 #include <stdlib.h> /* for malloc for atoe */
 #include "atoe.h"
-#endif
+#endif /* !defined(OMR_EBCDIC) */
+#endif /* defined(J9ZOS390) */
 
 #include <string.h>
 

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -36,10 +36,6 @@ if(OMR_OS_WINDOWS)
 	)
 endif()
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omrsigtest j9a2e)
-endif()
-
 target_include_directories(omrsigtest
 	PRIVATE
 		.

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -36,10 +36,6 @@ target_link_libraries(omrthreadextendedtest
 	${OMR_PORT_LIB}
 )
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omrthreadextendedtest j9a2e)
-endif()
-
 set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
 
 if(NOT OMR_OS_ZOS)

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -61,10 +61,6 @@ if(OMR_OS_WINDOWS)
 	)
 endif()
 
-if(OMR_OS_ZOS)
-	target_link_libraries(omrthreadtest j9a2e)
-endif()
-
 set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
 
 omr_add_test(NAME threadtest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)

--- a/fvtest/threadtest/createTestHelper.h
+++ b/fvtest/threadtest/createTestHelper.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
 #endif
 #include <stdio.h>

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -25,6 +25,7 @@ omr_add_executable(omrutiltest
 
 target_link_libraries(omrutiltest
 	#omrGtestGlue
+	omr_base
 	omrGtest
 	omrutil
 )
@@ -33,10 +34,6 @@ target_include_directories(omrutiltest
 	PRIVATE
 	$<TARGET_PROPERTY:omrGtestGlue,INTERFACE_INCLUDE_DIRECTORIES>
 )
-
-if(OMR_OS_ZOS)
-	target_link_libraries(omrutiltest j9a2e)
-endif()
 
 set_property(TARGET omrutiltest PROPERTY FOLDER fvtest)
 

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -76,9 +76,6 @@ target_compile_options(omrsig
 if(OMR_HOST_OS MATCHES "linux|osx")
 	target_link_libraries(omrsig PRIVATE dl)
 endif()
-if(OMR_OS_ZOS)
-	target_link_libraries(omrsig PRIVATE j9a2e)
-endif()
 
 install(
 	TARGETS omrsig

--- a/omrtrace/omrtracewrappers.cpp
+++ b/omrtrace/omrtracewrappers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,9 +31,9 @@
 #include "omrtrace_internal.h"
 #include "thread_api.h"
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 void
 twFprintf(const char *formatStr, ...)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -394,6 +394,11 @@ target_include_directories(omrport_obj PRIVATE
 	../nls
 )
 
+# Ensure that we pull in options associated with omr_base.
+target_compile_options(omrport_obj PUBLIC $<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_OPTIONS>)
+target_compile_definitions(omrport_obj PUBLIC $<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>)
+target_include_directories(omrport_obj PRIVATE $<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>)
+
 # This flag indicates that we are compiling the port library
 target_compile_definitions(omrport_obj PRIVATE -DOMRPORT_LIBRARY_DEFINE)
 

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -121,6 +121,11 @@ target_compile_definitions(j9thr_obj
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
+target_compile_options(j9thr_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_OPTIONS>
+)
+
 target_enable_ddr(j9thr_obj)
 ddr_add_headers(j9thr_obj
 	${omr_SOURCE_DIR}/include_core/omrthread.h

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-if(OMR_OS_ZOS)
+if(OMR_OS_ZOS AND NOT OMR_USE_NATIVE_ENCODING)
 	add_subdirectory(a2e)
 endif()
 add_subdirectory(avl)

--- a/util/a2e/CMakeLists.txt
+++ b/util/a2e/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,8 @@ target_link_libraries(j9a2e
 
 target_include_directories(j9a2e
 	PUBLIC
+		/usr/include
+		/usr/lpp/cbclib/include
 		$<BUILD_INTERFACE:${OMR_SOURCE_DIR}/include_core>
 		$<INSTALL_INTERFACE:${OMR_INSTALL_INC_DIR}>
 	PRIVATE


### PR DESCRIPTION
- Move include folders from platform includes to omr_ascii since they
aren't required when doing an EBCDIC build

- Make omr_port_obj inherit compile options from omr_base so releveant
a2e flags get applied if required.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>