### PR TITLE
RISC-V add OpenJ9 specific members to linkage properties

### DIFF
--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -96,6 +96,9 @@ struct RVLinkageProperties
    TR::RealRegister::RegNum _methodMetaDataRegister;
    TR::RealRegister::RegNum _stackPointerRegister;
    TR::RealRegister::RegNum _framePointerRegister;
+   TR::RealRegister::RegNum _computedCallTargetRegister; // for icallVMprJavaSendPatchupVirtual
+   TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
+   TR::RealRegister::RegNum _j9methodArgumentRegister; // for icallVMprJavaSendStatic
    uint8_t _numberOfDependencyGPRegisters;
    int8_t _offsetToFirstLocal;
 
@@ -223,6 +226,10 @@ struct RVLinkageProperties
       {
       return _methodMetaDataRegister;
       }
+   TR::RealRegister::RegNum getVMThreadRegister() const
+       {
+       return _methodMetaDataRegister;
+       }
 
    TR::RealRegister::RegNum getStackPointerRegister() const
       {
@@ -232,6 +239,21 @@ struct RVLinkageProperties
    TR::RealRegister::RegNum getFramePointerRegister() const
       {
       return _framePointerRegister;
+      }
+
+   TR::RealRegister::RegNum getComputedCallTargetRegister() const
+      {
+      return _computedCallTargetRegister;
+      }
+
+   TR::RealRegister::RegNum getVTableIndexArgumentRegister() const
+      {
+      return _vtableIndexArgumentRegister;
+      }
+
+   TR::RealRegister::RegNum getJ9MethodArgumentRegister() const
+      {
+      return _j9methodArgumentRegister;
       }
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -202,6 +202,10 @@ TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    _properties._methodMetaDataRegister      = TR::RealRegister::NoReg;
    _properties._stackPointerRegister        = TR::RealRegister::sp;
    _properties._framePointerRegister        = TR::RealRegister::s0;
+
+   _properties._computedCallTargetRegister  = TR::RealRegister::NoReg;
+   _properties._vtableIndexArgumentRegister = TR::RealRegister::NoReg;
+   _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
    setOffsetToFirstParm(0); // To be determined


### PR DESCRIPTION
This PR adds members required/used by OpenJ9 to RISC-V linkage properties. 

Since they are (seem to be) OpenJ9 specific, I added them conditionally using `#ifdef J9_PROJECT_SPECIFIC`. I also took the opportunity to do the same for AArch64 in order to keep the code similar. If this is not desirable, I'm happy to drop these `#ifdef`s.

FYI: @0xdaryl , @knn-k 