### PR TITLE
REVIEW : self changed to protected 

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -288,6 +288,11 @@ namespace OMR
 class OMR_EXTENSIBLE Compilation
    {
    friend class ::TR_DebugExt;
+
+protected:
+   
+   inline TR::Compilation *self();
+
 public:
 
    TR_ALLOC(TR_Memory::Compilation)
@@ -309,7 +314,7 @@ public:
 
    ~Compilation() throw();
 
-   inline TR::Compilation *self();
+   
 
    TR::Region &region() { return _heapMemoryRegion; }
 


### PR DESCRIPTION
I had made changes to only one class as said and written the self class of `OMRCompilation.hpp`  from `public` to `protected`.
Please check that is this the right way or some more changes needed. @mstoodle @0xdaryl 