### PR TITLE
Set up AIX XLClang flags for JDK 16+ CMake builds

### DIFF
--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ function(ppc_spp2s_files out_var compiler)
 			file(MAKE_DIRECTORY ${out_dir}) # just in case it doesn't exist already
 
 			add_custom_command(OUTPUT ${ipp_out_f}
-				COMMAND ${SPP_CMD} ${SPP_FLAGS} ${SPP_DEFINES} ${SPP_INCLUDES} -E -P ${absolute_in_f} > ${ipp_out_f}
+				COMMAND ${SPP_CMD} ${SPP_FLAGS} ${SPP_DEFINES} ${SPP_INCLUDES} ${absolute_in_f} > ${ipp_out_f}
 				DEPENDS ${in_f}
 				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 				COMMENT "Running preprocessing ${in_f} to create ${ipp_out_f}"

--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,7 @@ endfunction()
 
 # Translate from CMake's view of the system to the OMR view of the system.
 # Exports a number of variables indicating platform, os, endianness, etc.
-# - OMR_ARCH_{AARCH64,X86,ARM,S390} # TODO: Add POWER
+# - OMR_ARCH_{AARCH64,X86,ARM,S390,POWER}
 # - OMR_ENV_DATA{32,64}
 # - OMR_ENV_TARGET_DATASIZE (either 32 or 64)
 # - OMR_ENV_LITTLE_ENDIAN
@@ -198,8 +198,17 @@ macro(omr_detect_system_information)
 				# just use GNU config
 				set(_OMR_TOOLCONFIG "gnu")
 			endif()
-		elseif(CMAKE_C_COMPILER_ID STREQUAL "XL" OR CMAKE_C_COMPILER_ID STREQUAL "zOS")
+		elseif(CMAKE_C_COMPILER_ID MATCHES "^XL(Clang)?$" OR CMAKE_C_COMPILER_ID STREQUAL "zOS")
+			# In CMake 3.14 and prior, XLClang uses CMAKE_C_COMPILER_ID "XL"
+			# In CMake 3.15 and beyond, XLClang uses CMAKE_C_COMPILER_ID "XLClang"
 			set(_OMR_TOOLCONFIG "xlc")
+			if(CMAKE_C_COMPILER MATCHES ".*xlclang$")
+				# Checking the CMAKE_C_COMPILER command is necessary to determine if XLClang is
+				# the compiler, since XLClang might have CMAKE_C_COMPILER_ID "XL" or "XLClang"
+				# depending on the CMake version. Without this check, it's ambiguous whether the
+				# compiler is XLC or XLClang.
+				set(CMAKE_C_COMPILER_IS_XLCLANG TRUE CACHE BOOL "XLClang is the C compiler")
+			endif()
 		else()
 			message(FATAL_ERROR "OMR: Unknown compiler ID: '${CMAKE_CXX_COMPILER_ID}'")
 		endif()

--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2020 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,6 +141,12 @@ function(process_source_files src_files)
 		)
 
 		set(pp_command "@CMAKE_C_COMPILER@")
+		if("@CMAKE_C_COMPILER_IS_XLCLANG@")
+			# XLClang seems to have trouble with *.h and *.hpp files here, claiming:
+			# "error: invalid argument '-std=gnu++0x' not allowed with 'C/ObjC'"
+			# Adding this option to the command alleviates this issue.
+			list(APPEND pp_command "-xc++")
+		endif()
 		list(APPEND pp_command ${BASE_ARGS} "-E" "${stub_file}")
 		add_custom_command(
 			OUTPUT "${annt_file}"


### PR DESCRIPTION
This allows AIX XLClang CMake builds to work for JDK16.

Note: The new compiler ID `XLClang` is for CMake 3.15 and beyond. `XL` represents both `XLC and XLClang` as the `CMAKE_<LANG>_COMPILER_ID` in CMake 3.14 and prior. Latest CMake Compiler ID Documentation: [here](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html).

Existing xlc/xlclang files for reference
- [omrmakefiles/rules.aix.mk](https://github.com/eclipse/omr/blob/master/omrmakefiles/rules.aix.mk)

Successfully ran personal builds `JDK16_ppc64_aix_cm` and `JDK16_ppc64_aix_mixed` with these changes + corresponding OpenJ9 changes: https://github.com/eclipse/openj9/pull/11889.