### PR TITLE
Update dataAddr whenever GC moves indexable object

### DIFF
--- a/example/glue/ArrayletObjectModel.hpp
+++ b/example/glue/ArrayletObjectModel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,6 +55,14 @@ public:
 	expandArrayletSubSpaceRange(MM_MemorySubSpace * subSpace, void * rangeBase, void * rangeTop, uintptr_t largestDesirableArraySpineSize)
 	{
 		/* No-op */
+	}
+
+	MMINLINE void
+	fixupDataAddr(omrobjectptr_t arrayPtr)
+	{
+#if defined(OMR_ENV_DATA64)
+		Assert_MM_unreachable();
+#endif /* defined(OMR_ENV_DATA64) */
 	}
 	
 	/**

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -219,6 +219,37 @@ public:
 
 	MMINLINE MM_MemorySpace *getMemorySpace() { return (MM_MemorySpace*)(_omrVMThread->memorySpace); }
 
+	/**
+	 * This method is responsible for remembering object information before object is moved. Differently than
+	 * evacuation, we're sliding the object; therefore, we need to remember object's original information
+	 * before object moves
+	 *
+	 * @param[in] objectPtr points to the object that is about to be moved
+	 * @see postObjectMoveForCompact(omrobjectptr_t)
+	 */
+	MMINLINE void
+	preObjectMoveForCompact(omrobjectptr_t objectPtr)
+	{
+#if defined(OMR_GC_DEFERRED_HASHCODE_INSERTION)
+		_delegate.preObjectMoveForCompact(objectPtr);
+#endif /* defined(OMR_GC_DEFERRED_HASHCODE_INSERTION) */
+	}
+
+	/**
+	 * This method may be called during heap compaction, after the object has been moved to a new location.
+	 * The implementation may apply any information extracted and cached in the calling thread at this point.
+	 *
+	 * @param[in] objectPtr points to the object that has just been moved
+	 * @see preObjectMoveForCompact(omrobjectptr_t)
+	 */
+	MMINLINE void
+	postObjectMoveForCompact(omrobjectptr_t objectPtr)
+	{
+#if defined(OMR_GC_DEFERRED_HASHCODE_INSERTION)
+		_delegate.postObjectMoveForCompact(objectPtr);
+#endif /* defined(OMR_GC_DEFERRED_HASHCODE_INSERTION) */
+	}
+
 	MM_MemorySubSpace *getDefaultMemorySubSpace();
 	MM_MemorySubSpace *getTenureMemorySubSpace();
 

--- a/gc/base/standard/CompactScheme.cpp
+++ b/gc/base/standard/CompactScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -337,6 +337,28 @@ MM_CompactScheme::setFreeChunk(omrobjectptr_t from, omrobjectptr_t to)
 	size_t size = (size_t)to - (size_t)from;
 	setFreeChunkSize(from, size);
 	return size;
+}
+
+MMINLINE void
+MM_CompactScheme::preObjectMove(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
+{
+	env->preObjectMoveForCompact(objectPtr);
+}
+
+MMINLINE void
+MM_CompactScheme::postObjectMove(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
+{
+	env->postObjectMoveForCompact(objectPtr);
+
+	if(_extensions->objectModel.isIndexable(objectPtr)) {
+		/* Updates internal field of indexable objects. Every indexable object have an extra field
+		 * that can be used to store any extra information about the indexable object. One use case is
+		 * OpenJ9 where we use this field to point to array data. In this case it will always point to
+		 * the address right after the header, in case of contiguous data it will point to the data
+		 * itself, and in case of discontiguous arraylet it will point to the first arrayiod. How to
+		 * updated dataAddr is up to the target language that must override fixupDataAddr */
+		_extensions->indexableObjectModel.fixupDataAddr(objectPtr);
+	}
 }
 
 void
@@ -1231,9 +1253,7 @@ MM_CompactScheme::doCompact(MM_EnvironmentStandard *env, MM_MemorySubSpace *memo
 		nobjects++;
 		nbytes += objectSizeAfterMove;
 
-#if defined(OMR_GC_DEFERRED_HASHCODE_INSERTION)
-		_extensions->objectModel.preMove(env->getOmrVMThread(), objectPtr);
-#endif /* defined(OMR_GC_DEFERRED_HASHCODE_INSERTION) */
+		preObjectMove(env, objectPtr);
 
 		if (evacuate) {
 			deadObjectSize -= objectSizeAfterMove;
@@ -1243,9 +1263,7 @@ MM_CompactScheme::doCompact(MM_EnvironmentStandard *env, MM_MemorySubSpace *memo
 			memmove(deadObject, objectPtr, objectSize);
 		}
 
-#if defined(OMR_GC_DEFERRED_HASHCODE_INSERTION)
-		_extensions->objectModel.postMove(env->getOmrVMThread(), deadObject);
-#endif /* defined(OMR_GC_DEFERRED_HASHCODE_INSERTION) */
+		postObjectMove(env, deadObject);
 
 		deadObject = (omrobjectptr_t)((uintptr_t)deadObject+objectSizeAfterMove);
 	}

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,14 +51,14 @@ class CompactTableEntry;
 class MM_CompactMemoryPoolState : public MM_BaseVirtual
 {
 public :
-	MM_MemoryPool				*_memoryPool;
-	MM_HeapLinkedFreeHeader		*_freeListHead;
-	uintptr_t 						_freeBytes;
-	uintptr_t 						_freeHoles;
-	uintptr_t 						_largestFreeEntry;
+	MM_MemoryPool              *_memoryPool;
+	MM_HeapLinkedFreeHeader    *_freeListHead;
+	uintptr_t                  _freeBytes;
+	uintptr_t                  _freeHoles;
+	uintptr_t                  _largestFreeEntry;
 
-	MM_HeapLinkedFreeHeader		*_previousFreeEntry;
-	uintptr_t 						_previousFreeEntrySize;
+	MM_HeapLinkedFreeHeader    *_previousFreeEntry;
+	uintptr_t                  _previousFreeEntrySize;
 
 	MM_CompactMemoryPoolState() :
 		_memoryPool(NULL),
@@ -77,124 +77,125 @@ public :
 		_freeBytes = 0;
 		_freeHoles = 0;
 		_largestFreeEntry = 0;
-
-		_previousFreeEntry=NULL;
-		_previousFreeEntrySize=0;
+		_previousFreeEntry = NULL;
+		_previousFreeEntrySize = 0;
 	}
 };
 
 class MM_CompactScheme : public MM_BaseVirtual
 {
 private:
-    /* As usual, region addresses are up to, but not including, hi. */
-    struct SubAreaEntry {
-    	MM_MemoryPool *memoryPool;
+	/* As usual, region addresses are up to, but not including, hi. */
+	struct SubAreaEntry {
+		MM_MemoryPool *memoryPool;
 		omrobjectptr_t firstObject;
 		omrobjectptr_t freeChunk;
-        volatile uintptr_t state;
-        volatile uintptr_t currentAction; /**< record the status of the subarea for parallelization */
+		volatile uintptr_t state;
+		volatile uintptr_t currentAction; /**< record the status of the subarea for parallelization */
         
-    	/* legal values for currentAction */
-    	enum {
-    		none = 0,
-    		setting_real_limits,
-    		evacuating,
-    		fixing_up,
-    		rebuilding_mark_bits,
-    		fixing_heap_for_walk
-    	};
+		/* legal values for currentAction */
+		enum {
+			none = 0,
+			setting_real_limits,
+			evacuating,
+			fixing_up,
+			rebuilding_mark_bits,
+			fixing_heap_for_walk
+		};
     	
-    	/* legal values for state
-    	 * there are 4 dynamic states that change this way:
-    	 * init --> ready <--> busy --> full
-    	 * The rest are set once during setupSubAreaTable and doesn't change
-    	 * during compaction.
-    	 * The end_segment sub areas at the end of each segment are used also to
-    	 * hold the segment's top address
-    	 */
-    	enum State { 
-    		init = 0,
-    		busy,
-    		ready,
-    		full,
-    		fixup_only,
-    		end_segment,
-    		end_heap
-    	};
-    };
+		/* legal values for state
+		 * there are 4 dynamic states that change this way:
+		 * init --> ready <--> busy --> full
+		 * The rest are set once during setupSubAreaTable and doesn't change
+		 * during compaction.
+		 * The end_segment sub areas at the end of each segment are used also to
+		 * hold the segment's top address
+		 */
+		enum State { 
+			init = 0,
+			busy,
+			ready,
+			full,
+			fixup_only,
+			end_segment,
+			end_heap
+		};
+	};
 
 protected:
-    OMR_VM *_omrVM;
-    MM_GCExtensionsBase *_extensions;
-    MM_ParallelDispatcher *_dispatcher;
-    MM_MarkingScheme *_markingScheme;
-	MM_HeapRegionManager *_rootManager; /**< The root region manager which holds the MM_HeapRegionDescriptor instances which manage the properties of the regions */
+	OMR_VM                 *_omrVM;
+	MM_GCExtensionsBase    *_extensions;
+	MM_ParallelDispatcher  *_dispatcher;
+	MM_MarkingScheme       *_markingScheme;
+	MM_HeapRegionManager   *_rootManager; /**< The root region manager which holds the MM_HeapRegionDescriptor instances which manage the properties of the regions */
 
-    MM_Heap *_heap;
-    uintptr_t _heapBase;
-    CompactTableEntry *_compactTable;
-    MM_MarkMap *_markMap;
-	uintptr_t _subAreaTableSize;  /**< Size of the subAreaTable */
-    SubAreaEntry *_subAreaTable;  /**< Reference to the subAreaTable which is shared data from the SweepHeapSectioning */
-    omrobjectptr_t _compactFrom;
-    omrobjectptr_t _compactTo;
-    MM_CompactDelegate _delegate;
+	MM_Heap                *_heap;
+	uintptr_t              _heapBase;
+	CompactTableEntry      *_compactTable;
+	MM_MarkMap             *_markMap;
+	uintptr_t              _subAreaTableSize;  /**< Size of the subAreaTable */
+	SubAreaEntry           *_subAreaTable;  /**< Reference to the subAreaTable which is shared data from the SweepHeapSectioning */
+	omrobjectptr_t         _compactFrom;
+	omrobjectptr_t         _compactTo;
+	MM_CompactDelegate     _delegate;
 
 public:
 
-    /*
-     * Page represents space can be marked by one slot(uintptr_t) of Compressed Mark Map
-     * In Compressed Mark Map one bit represents twice more space then one bit of regular Mark Map
-     * So, sizeof_page should be double of number of bytes represented by one uintptr_t in Mark Map
-     */
-    ddr_constant(sizeof_page, 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT);
+	/*
+	 * Page represents space can be marked by one slot(uintptr_t) of Compressed Mark Map
+	 * In Compressed Mark Map one bit represents twice more space then one bit of regular Mark Map
+	 * So, sizeof_page should be double of number of bytes represented by one uintptr_t in Mark Map
+	 */
+	ddr_constant(sizeof_page, 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT);
 
 private:
-    omrobjectptr_t freeChunkEnd(omrobjectptr_t chunk);
+	omrobjectptr_t freeChunkEnd(omrobjectptr_t chunk);
 	size_t getFreeChunkSize(omrobjectptr_t freeChunk);
 	void setFreeChunkSize(omrobjectptr_t deadObject, uintptr_t deadObjectSize);
 	size_t setFreeChunk(omrobjectptr_t from, omrobjectptr_t to);
+	MMINLINE void preObjectMove(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
+	MMINLINE void postObjectMove(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
 
-    void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded);
-    /**
-     * Set the real limits for a specific subArea
-     *
-     * @param env[in] the current thread
-     */
-    void setRealLimitsSubAreas(MM_EnvironmentStandard *env);
-    void removeNullSubAreas(MM_EnvironmentStandard *env);
-    void completeSubAreaTable(MM_EnvironmentStandard *env);
+	void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded);
+	/**
+	 * Set the real limits for a specific subArea
+	 *
+	 * @param env[in] the current thread
+	 */
+	void setRealLimitsSubAreas(MM_EnvironmentStandard *env);
+	void removeNullSubAreas(MM_EnvironmentStandard *env);
+	void completeSubAreaTable(MM_EnvironmentStandard *env);
 
-    void saveForwardingPtr(class CompactTableEntry&,
-                            omrobjectptr_t objectPtr,
-                            omrobjectptr_t forwardingPtr,
-                            intptr_t &page,
-                            intptr_t &counter);
+	void saveForwardingPtr(class CompactTableEntry&,
+					omrobjectptr_t objectPtr,
+					omrobjectptr_t forwardingPtr,
+					intptr_t &page,
+					intptr_t &counter);
 
-    omrobjectptr_t doCompact(MM_EnvironmentStandard *env,
-						MM_MemorySubSpace *memorySubSpace,
-                        omrobjectptr_t start,
-                        omrobjectptr_t finish,
-                        omrobjectptr_t &deadObject,
-                        uintptr_t &objectCount,
-                        uintptr_t &byteCount,
-                        bool evacuate);
+	omrobjectptr_t doCompact(MM_EnvironmentStandard *env,
+					MM_MemorySubSpace *memorySubSpace,
+					omrobjectptr_t start,
+					omrobjectptr_t finish,
+					omrobjectptr_t &deadObject,
+					uintptr_t &objectCount,
+					uintptr_t &byteCount,
+					bool evacuate);
 
-    /**
-     * Attempt to evacuate objects from the specified subArea.
-     *
-     * @param env[in] the current thread
-     * @param[in] subAreaRegion the region which contains the subArea
-     * @param[in] subAreaTableEvacuate the subArea for subAreaRegion
-     * @param[in] i The current subArea index
-     * @param[in/out] objectCount the number of objects moved (accumulated)
-     * @param[in/out] byteCount the number of bytes moved (accumulated)
-     * @param[in/out] the number of objects skipped (accumulated)
-     */
+	/**
+	 * Attempt to evacuate objects from the specified subArea.
+	 *
+	 * @param env[in] the current thread
+	 * @param[in] subAreaRegion the region which contains the subArea
+	 * @param[in] subAreaTableEvacuate the subArea for subAreaRegion
+	 * @param[in] i The current subArea index
+	 * @param[in/out] objectCount the number of objects moved (accumulated)
+	 * @param[in/out] byteCount the number of bytes moved (accumulated)
+	 * @param[in/out] the number of objects skipped (accumulated)
+	 */
 	void evacuateSubArea(MM_EnvironmentStandard *env,
 	    	MM_HeapRegionDescriptorStandard *subAreaRegion,
 	    	SubAreaEntry *subAreaTableEvacuate,
@@ -203,113 +204,113 @@ protected:
 	    	uintptr_t &byteCount,
 	    	uintptr_t &skippedObjectCount);
 
-    void moveObjects(MM_EnvironmentStandard *env, uintptr_t &objectCount, uintptr_t &byteCount, uintptr_t &skippedObjectCount);
+	void moveObjects(MM_EnvironmentStandard *env, uintptr_t &objectCount, uintptr_t &byteCount, uintptr_t &skippedObjectCount);
 
-    /**
-     * Fix up all references to moved objects in the specified subArea
-     *
-     * @param env[in] the current thread
-     * @param[in] firstObject The first object in the subArea
-     * @param[in] finish The last object in the subArea
-     * @param markedOnly[in] Should only marked objects be walked
-     * @param[in/out] objectCount the number of objects fixed up (accumulated)
-     */
-    void fixupSubArea(MM_EnvironmentStandard *env, omrobjectptr_t firstObject, omrobjectptr_t finish,  bool markedOnly, uintptr_t& objectCount);
+	/**
+	 * Fix up all references to moved objects in the specified subArea
+	 *
+	 * @param env[in] the current thread
+	 * @param[in] firstObject The first object in the subArea
+	 * @param[in] finish The last object in the subArea
+	 * @param markedOnly[in] Should only marked objects be walked
+	 * @param[in/out] objectCount the number of objects fixed up (accumulated)
+	 */
+	void fixupSubArea(MM_EnvironmentStandard *env, omrobjectptr_t firstObject, omrobjectptr_t finish,  bool markedOnly, uintptr_t& objectCount);
 	void fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCount);
 
-    void rebuildFreelist(MM_EnvironmentStandard *env);
+	void rebuildFreelist(MM_EnvironmentStandard *env);
 
-    void addFreeEntry(MM_EnvironmentStandard *env,
+	void addFreeEntry(MM_EnvironmentStandard *env,
 					MM_MemorySubSpace *memorySubSpace,
 					MM_CompactMemoryPoolState *poolState,
 					void *currentFreeBase,
 					uintptr_t currentFreeSize);
 
 	/**
-     * Return the page index for an object.
-     * long int, always positive (in particular, -1 is an invalid value)
-     */
-    MMINLINE intptr_t pageIndex(omrobjectptr_t objectPtr) const
-    {
-        uintptr_t markIndex = (uintptr_t)objectPtr - _heapBase;
-        return markIndex / sizeof_page;
-    }
+	 * Return the page index for an object.
+	 * long int, always positive (in particular, -1 is an invalid value)
+	 */
+	MMINLINE intptr_t pageIndex(omrobjectptr_t objectPtr) const
+	{
+		uintptr_t markIndex = (uintptr_t)objectPtr - _heapBase;
+		return markIndex / sizeof_page;
+	}
 
 	/**
 	 * Return the offset in the page for an object
 	 */
-    MMINLINE intptr_t pageOffset(omrobjectptr_t objectPtr) const
-    {
-        uintptr_t markIndex = (uintptr_t)objectPtr - _heapBase;
-        return markIndex % sizeof_page;
-    }
+	MMINLINE intptr_t pageOffset(omrobjectptr_t objectPtr) const
+	{
+		uintptr_t markIndex = (uintptr_t)objectPtr - _heapBase;
+		return markIndex % sizeof_page;
+	}
 
 	/**
 	 * Return the bit number in Compressed Mark Map slot responsible for this object
 	 * Each bit in Compressed Mark Map represents twice more heap bytes then regular mark map
 	 * Each page represents number of bytes in heap might be covered by one Compressed Mark Map slot (uintptr_t)
 	 */
-    MMINLINE intptr_t compressedPageOffset(omrobjectptr_t objectPtr) const
-    {
-        return pageOffset(objectPtr) / (2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_BIT);
-    }
+	MMINLINE intptr_t compressedPageOffset(omrobjectptr_t objectPtr) const
+	{
+		return pageOffset(objectPtr) / (2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_BIT);
+	}
 
 	/**
 	 * Return the start of a page
 	 */
-    MMINLINE omrobjectptr_t pageStart(uintptr_t i) const
-    {
-        return (omrobjectptr_t) (_heapBase + (i * sizeof_page));
-    }
+	MMINLINE omrobjectptr_t pageStart(uintptr_t i) const
+	{
+		return (omrobjectptr_t) (_heapBase + (i * sizeof_page));
+	}
 
 	/**
 	 * Return the next page
 	 */
-    MMINLINE omrobjectptr_t nextPage(omrobjectptr_t objectPtr) const
-    {
-        return pageStart(pageIndex(objectPtr)+1);
-    }
+	MMINLINE omrobjectptr_t nextPage(omrobjectptr_t objectPtr) const
+	{
+		return pageStart(pageIndex(objectPtr)+1);
+	}
 
-    /**
-     * If to is page-aligned, create one chunk (from:to).  Otherwise, create
-     * two free chunks: one (from:to_aligned), and the other (to_aligned:to),
-     * where to_aligned=ALIGN_DOWNWARDS(to,PAGE_SIZE).
-     *
-     */
-    size_t setFreeChunkPageAligned(omrobjectptr_t from, omrobjectptr_t to);
+	/**
+	 * If to is page-aligned, create one chunk (from:to).  Otherwise, create
+	 * two free chunks: one (from:to_aligned), and the other (to_aligned:to),
+	 * where to_aligned=ALIGN_DOWNWARDS(to,PAGE_SIZE).
+	 *
+	 */
+	size_t setFreeChunkPageAligned(omrobjectptr_t from, omrobjectptr_t to);
 
-    void rebuildMarkbits(MM_EnvironmentStandard *env);
+	void rebuildMarkbits(MM_EnvironmentStandard *env);
 
-    /**
-     * Rebuild mark bits within the specified subArea
-     *
-     * @param env[in] the current thread
-     * @param region[in] the region which contains the subArea
-     * @param subAreaTable[in] an entry describing the subArea to be rebuilt
-     */
+	/**
+	 * Rebuild mark bits within the specified subArea
+	 *
+	 * @param env[in] the current thread
+	 * @param region[in] the region which contains the subArea
+	 * @param subAreaTable[in] an entry describing the subArea to be rebuilt
+	 */
 	void rebuildMarkbitsInSubArea(MM_EnvironmentStandard *env, MM_HeapRegionDescriptorStandard *region, SubAreaEntry *subAreaTable, intptr_t i);
 
-    /**
-     * Atomically change the currentAction value of the subArea to the specified action. This allows
-     * a worker thread to claim responsibility for performing the specified action on the specified
-     * area.
-     *
-     * @param env[in] the current thread
-     * @param entry[in] the subArea to change
-     * @param newAction the desired action for the subArea
-     *
-     * @return true if the action was changed, or false if another thread already changed it to newAction
-     */
-    bool changeSubAreaAction(MM_EnvironmentBase *env, SubAreaEntry * entry, uintptr_t newAction);
+	/**
+	 * Atomically change the currentAction value of the subArea to the specified action. This allows
+	 * a worker thread to claim responsibility for performing the specified action on the specified
+	 * area.
+	 *
+	 * @param env[in] the current thread
+	 * @param entry[in] the subArea to change
+	 * @param newAction the desired action for the subArea
+	 *
+	 * @return true if the action was changed, or false if another thread already changed it to newAction
+	 */
+	bool changeSubAreaAction(MM_EnvironmentBase *env, SubAreaEntry * entry, uintptr_t newAction);
 public:
 	static MM_CompactScheme *newInstance(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme);
 	
 	void kill(MM_EnvironmentBase *env);
 
-    void workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded);
+	void workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded);
 	void mainSetupForGC(MM_EnvironmentStandard *env);
-    virtual void compact(MM_EnvironmentBase *env, bool rebuildMarkBits, bool aggressive);
-    omrobjectptr_t getForwardingPtr(omrobjectptr_t objectPtr) const;
+	virtual void compact(MM_EnvironmentBase *env, bool rebuildMarkBits, bool aggressive);
+	omrobjectptr_t getForwardingPtr(omrobjectptr_t objectPtr) const;
 	void flushPool(MM_EnvironmentStandard *env, MM_CompactMemoryPoolState *freeListState);
 	void fixHeapForWalk(MM_EnvironmentBase *env);
 	void parallelFixHeapForWalk(MM_EnvironmentBase *env);
@@ -325,19 +326,19 @@ public:
 	/**
 	 * Create a CompactScheme object.
 	 */
-    MM_CompactScheme(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme)
-        : MM_BaseVirtual()
-    	, _omrVM(env->getOmrVM())
-        , _extensions(env->getExtensions())
-        , _dispatcher(_extensions->dispatcher)
-        , _markingScheme(markingScheme)
-        , _markMap(markingScheme->getMarkMap())
-        , _subAreaTableSize(0)
-    	, _subAreaTable(NULL)
-    	, _delegate()
-    {
-    	_typeId = __FUNCTION__;
-    }
+	MM_CompactScheme(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme)
+		: MM_BaseVirtual()
+		, _omrVM(env->getOmrVM())
+		, _extensions(env->getExtensions())
+		, _dispatcher(_extensions->dispatcher)
+		, _markingScheme(markingScheme)
+		, _markMap(markingScheme->getMarkMap())
+		, _subAreaTableSize(0)
+		, _subAreaTable(NULL)
+		, _delegate()
+	{
+		_typeId = __FUNCTION__;
+	}
 };
 
 #endif /* OMR_GC_MODRON_COMPACTION */

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1581,8 +1581,8 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 			/* Fixup most of the destination object (part that overlaps with forwarded header) */
 			forwardedHeader->commenceFixup(destinationObjectPtr);
 
-			/* Object model specific fixup, like age */
-			_extensions->objectModel.fixupForwardedObject(forwardedHeader, destinationObjectPtr, objectAge);
+			/* Object model specific update, like age */
+			fixupForwardedObject(forwardedHeader, destinationObjectPtr, objectAge);
 
 			/* Final fixup step - the object is available for usage by mutator threads */
 			forwardedHeader->commitFixup(destinationObjectPtr);
@@ -1594,7 +1594,7 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 			/* Copy the preserved fields from the forwarded header into the destination object */
 			forwardedHeader->fixupForwardedObject(destinationObjectPtr);
 
-			_extensions->objectModel.fixupForwardedObject(forwardedHeader, destinationObjectPtr, objectAge);
+			fixupForwardedObject(forwardedHeader, destinationObjectPtr, objectAge);
 		}
 
 #if defined(OMR_VALGRIND_MEMCHECK)
@@ -1675,6 +1675,22 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 	}
 	/* return value for updating the slot */
 	return destinationObjectPtr;
+}
+
+MMINLINE void
+MM_Scavenger::fixupForwardedObject(MM_ForwardedHeader* forwardedHeader, omrobjectptr_t destinationObjectPtr, uintptr_t objectAge) {
+	/* Object model specific fixup, like age */
+	_extensions->objectModel.fixupForwardedObject(forwardedHeader, destinationObjectPtr, objectAge);
+
+	if(_extensions->objectModel.isIndexable(destinationObjectPtr)) {
+		/* Updates internal field of indexable objects. Every indexable object have an extra field
+		 * that can be used to store any extra information about the indexable object. One use case is
+		 * OpenJ9 where we use this field to point to array data. In this case it will always point to
+		 * the address right after the header, in case of contiguous data it will point to the data
+		 * itself, and in case of discontiguous arraylet it will point to the first arrayiod. How to
+		 * updated dataAddr is up to the target language that must override fixupDataAddr */
+		_extensions->indexableObjectModel.fixupDataAddr(destinationObjectPtr);
+	}
 }
 
 MMINLINE void

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -165,6 +165,15 @@ private:
 	
 	void setBackOutFlag(MM_EnvironmentBase *env, BackOutState value);
 	MMINLINE bool isBackOutFlagRaised() { return _extensions->isScavengerBackOutFlagRaised(); }
+
+	/**
+	 * Update forwarded object. It fixes up forwarded object and sets extra field for indexable object accordingly
+	 *
+	 * @param forwardedHeader Forwarded header of an object
+	 * @param destinationObjectPtr DestinationObjectPtr of the object described by the forwardedHeader
+	 * @param objectAge object's ages
+	 */
+	MMINLINE void fixupForwardedObject(MM_ForwardedHeader* forwardedHeader, omrobjectptr_t destinationObjectPtr, uintptr_t objectAge);
 	
 	/**
 	 * Check if concurrent phase of the cycle should yield to an external activity. If so, set the flag so that other GC threads react appropriately


### PR DESCRIPTION
Update GC code to make sure whenever an indexable object moves, the object  will always contain the correct `dataAddr`
value, which is the address pointing right after array header.

Introduce pre/postObjectCompact wrapers for EnvironmentDeletegate pre/postObjectCompact API for object compaction fixup.

This is phase 2 of https://github.com/eclipse/openj9/issues/11438

Signed-off-by: Igor Braga <higorb1@gmail.com>