### PR TITLE
Trim inlines header of extensible classes

### DIFF
--- a/compiler/codegen/OMRCodeGenerator_inlines.hpp
+++ b/compiler/codegen/OMRCodeGenerator_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_CODEGENERATOR_INLINE_INCL
-#define OMR_CODEGENERATOR_INLINE_INCL
+#ifndef OMR_CODEGENERATOR_INLINES_INCL
+#define OMR_CODEGENERATOR_INLINES_INCL
 
-#include "codegen/OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 inline TR::CodeGenerator* OMR::CodeGenerator::self()
    {

--- a/compiler/codegen/OMRInstruction_inlines.hpp
+++ b/compiler/codegen/OMRInstruction_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_INSTRUCTION_INLINE_INCL
-#define OMR_INSTRUCTION_INLINE_INCL
+#ifndef OMR_INSTRUCTION_INLINES_INCL
+#define OMR_INSTRUCTION_INLINES_INCL
 
-#include "codegen/OMRInstruction.hpp"
+#include "codegen/Instruction.hpp"
 
 TR::Instruction *
 OMR::Instruction::self()

--- a/compiler/codegen/OMRMachine_inlines.hpp
+++ b/compiler/codegen/OMRMachine_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_MACHINE_INLINE_INCL
-#define OMR_MACHINE_INLINE_INCL
+#ifndef OMR_MACHINE_INLINES_INCL
+#define OMR_MACHINE_INLINES_INCL
 
-#include "codegen/OMRMachine.hpp"
+#include "codegen/Machine.hpp"
 
 TR::Machine *
 OMR::Machine::self()

--- a/compiler/compile/OMRCompilation_inlines.hpp
+++ b/compiler/compile/OMRCompilation_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_COMPILATION_INLINE_INCL
-#define OMR_COMPILATION_INLINE_INCL
+#ifndef OMR_COMPILATION_INLINES_INCL
+#define OMR_COMPILATION_INLINES_INCL
 
-#include "compile/OMRCompilation.hpp"
+#include "compile/Compilation.hpp"
 
 TR::Compilation *
 OMR::Compilation::self()

--- a/compiler/control/OMROptions_inlines.hpp
+++ b/compiler/control/OMROptions_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,11 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_OPTIONS_INLINE_INCL
-#define OMR_OPTIONS_INLINE_INCL
+#ifndef OMR_OPTIONS_INLINES_INCL
+#define OMR_OPTIONS_INLINES_INCL
 
 #include "control/Options.hpp"
-#include "control/Options_inlines.hpp"
 
 /*
  * Performance sensitive implementations are included here

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_NODE_INLINE_INCL
-#define OMR_NODE_INLINE_INCL
+#ifndef OMR_NODE_INLINES_INCL
+#define OMR_NODE_INLINES_INCL
 
-#include "il/OMRNode.hpp"
+#include "il/Node.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #ifndef OMR_SYMBOL_INLINES_INCL
 #define OMR_SYMBOL_INLINES_INCL
 
-#include "il/OMRSymbol.hpp"
+#include "il/Symbol.hpp"
 
 /**
  * Downcast to concrete instance

--- a/compiler/il/OMRTreeTop_inlines.hpp
+++ b/compiler/il/OMRTreeTop_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,12 +19,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_TREETOP_INLINE_INCL
-#define OMR_TREETOP_INLINE_INCL
+#ifndef OMR_TREETOP_INLINES_INCL
+#define OMR_TREETOP_INLINES_INCL
 
 #include "il/ILOps.hpp"
 #include "il/Node.hpp"
-#include "il/OMRTreeTop.hpp"
 #include "il/TreeTop.hpp"
 #include "infra/Assert.hpp"
 

--- a/compiler/il/TreeTop_inlines.hpp
+++ b/compiler/il/TreeTop_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,6 @@
 #ifndef TREETOP_INLINES_INCL
 #define TREETOP_INLINES_INCL
 
-#include "compiler/il/OMRTreeTop_inlines.hpp"
+#include "il/OMRTreeTop_inlines.hpp"
 
 #endif

--- a/compiler/ilgen/OMRIlGeneratorMethodDetails_inlines.hpp
+++ b/compiler/ilgen/OMRIlGeneratorMethodDetails_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 #define OMR_ILGENERATOR_METHOD_DETAILS_INLINES_INCL
 
 #include "ilgen/IlGeneratorMethodDetails.hpp"
-#include "ilgen/OMRIlGeneratorMethodDetails.hpp"
 
 class TR_ResolvedMethod;
 

--- a/compiler/optimizer/OMROptimizationManager_inlines.hpp
+++ b/compiler/optimizer/OMROptimizationManager_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #ifndef OMR_OPTIMIZATIONMANAGER_INLINES_INCL
 #define OMR_OPTIMIZATIONMANAGER_INLINES_INCL
 
-#include "optimizer/OMROptimizationManager.hpp"
+#include "optimizer/OptimizationManager.hpp"
 
 inline
 TR::OptimizationManager *OMR::OptimizationManager::self()


### PR DESCRIPTION
  modify macro guard to INLINES
  include header same as for cpp file but not extended ones

Signed-off-by: James Guan <jamesgua@ca.ibm.com>