### PR TITLE
Deprecate isSingleRefUnevaluated

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -3190,9 +3190,12 @@ OMR::CodeGenerator::isInMemoryInstructionCandidate(TR::Node * node)
    // 2) valueChild
    // 3) address under valueChild
 
-   if (node->getFirstChild()->isSingleRefUnevaluated() &&
-       valueChild->isSingleRefUnevaluated() &&
-       valueChild->getFirstChild()->isSingleRefUnevaluated())
+   if (node->getFirstChild()->getReferenceCount() == 1 &&
+       node->getFirstChild()->getRegister() == NULL &&
+       valueChild->getReferenceCount() == 1 &&
+       valueChild->getRegister() == NULL &&
+       valueChild->getFirstChild()->getReferenceCount() == 1 &&
+       valueChild->getFirstChild()->getRegister() == NULL)
       {
       }
    else

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -601,9 +601,6 @@ public:
    // A common query used by the optimizer
    inline bool            isSingleRef();
 
-   // A common query used by the code generators
-   inline bool            isSingleRefUnevaluated();
-
    TR_YesNoMaybe          hasBeenRun();
 
    /// Given a monenter node, return the persistent class identifer that's being synchronized

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -597,9 +597,6 @@ public:
     *    Return true if the node is a call with eaEscapeHelperSymbol
     */
    bool                   isEAEscapeHelperCall();
-
-   // A common query used by the optimizer
-   inline bool            isSingleRef();
 
    TR_YesNoMaybe          hasBeenRun();
 

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,20 +132,6 @@ OMR::Node::createWithSymRef(TR::ILOpCodes op, uint16_t numChildren,
 /**
  * Misc public functions
  */
-
-// A common query used by the optimizer
-bool
-OMR::Node::isSingleRef()
-   {
-   return self()->getReferenceCount() == 1;
-   }
-
-// A common query used by the code generators
-bool
-OMR::Node::isSingleRefUnevaluated()
-   {
-   return self()->isSingleRef() && !self()->getRegister();
-   }
 
 int32_t
 OMR::Node::getNumArguments()

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -980,7 +980,9 @@ TR::Register *OMR::Power::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
    bool reverseStore = false;
    // TODO(#5684): Re-enable once issues with delayed indexed-form are corrected
    static bool reverseStoreEnabled = feGetEnv("TR_EnableReverseLoadStore");
-   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::ibyteswap && valueChild->isSingleRefUnevaluated())
+   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::ibyteswap && 
+      valueChild->getReferenceCount() == 1 &&
+      valueChild->getRegister() == NULL)
       {
       reverseStore = true;
 
@@ -1167,7 +1169,9 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
    bool reverseStore = false;
    // TODO(#5684): Re-enable once issues with delayed indexed-form are corrected
    static bool reverseStoreEnabled = feGetEnv("TR_EnableReverseLoadStore");
-   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::lbyteswap && valueChild->isSingleRefUnevaluated() &&
+   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::lbyteswap && 
+      valueChild->getReferenceCount() == 1 &&
+      valueChild->getRegister() == NULL &&
       cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7))
       {
       reverseStore = true;
@@ -1482,7 +1486,9 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
    bool reverseStore = false;
    // TODO(#5684): Re-enable once issues with delayed indexed-form are corrected
    static bool reverseStoreEnabled = feGetEnv("TR_EnableReverseLoadStore");
-   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::sbyteswap && valueChild->isSingleRefUnevaluated())
+   if (reverseStoreEnabled && valueChild->getOpCodeValue() == TR::sbyteswap && 
+      valueChild->getReferenceCount() == 1 &&
+      valueChild->getRegister() == NULL)
       {
       reverseStore = true;
 

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -113,8 +113,10 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
    bool is16BitMemory2Operand = false;
    if (secondChild->getOpCodeValue() == TR::s2i &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-       secondChild->isSingleRefUnevaluated() &&
-       secondChild->getFirstChild()->isSingleRefUnevaluated())
+       secondChild->getReferenceCount() == 1 &&
+       secondChild->getRegister() == NULL &&
+       secondChild->getFirstChild()->getReferenceCount() == 1 &&
+       secondChild->getFirstChild()->getRegister() == NULL)
       {
       bool supported = true;
 
@@ -314,8 +316,10 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    if (cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z14) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-       secondChild->isSingleRefUnevaluated() &&
-       secondChild->getFirstChild()->isSingleRefUnevaluated())
+       secondChild->getReferenceCount() == 1 &&
+       secondChild->getRegister() == NULL &&
+       secondChild->getFirstChild()->getReferenceCount() == 1 &&
+       secondChild->getFirstChild()->getRegister() == NULL)
       {
       setMem2();
       memToRegOpCode = TR::InstOpCode::SGH;

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -257,8 +257,10 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
          {
          if(firstChild->getOpCodeValue() == TR::s2l &&
                  firstChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-                 firstChild->isSingleRefUnevaluated() &&
-                 firstChild->getFirstChild()->isSingleRefUnevaluated())
+                 firstChild->getReferenceCount() == 1 &&
+                 firstChild->getRegister() == NULL &&
+                 firstChild->getFirstChild()->getReferenceCount() == 1 &&
+                 firstChild->getFirstChild()->getRegister() == NULL)
             {
             /* Use MGH when 64<-64x16 and the multiplier is a short int in storage
              * AND it's never loaded before. */
@@ -267,7 +269,8 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
             memToRegOpCode = TR::InstOpCode::MGH;
             }
          else if(firstChild->getOpCodeValue() == TR::lloadi &&
-                 firstChild->isSingleRefUnevaluated())
+                 firstChild->getReferenceCount() == 1 &&
+                 firstChild->getRegister() == NULL)
             {
             /* Use MSGC when 64<-64x64 and the multiplier is a long in storage
              * AND it's never loaded before */
@@ -278,7 +281,8 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
       else if(root->getOpCodeValue() == TR::imul)
          {
          if(firstChild->getOpCodeValue() == TR::iloadi &&
-                 firstChild->isSingleRefUnevaluated())
+                 firstChild->getReferenceCount() == 1 &&
+                 firstChild->getRegister() == NULL)
             {
              /* Use MSC when 32<-32x32 and the multiplier is an int in storage
               * AND it's never loaded before */
@@ -733,8 +737,10 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
     */
    if (secondChild->getOpCodeValue() == TR::s2i &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-       secondChild->isSingleRefUnevaluated() &&
-       secondChild->getFirstChild()->isSingleRefUnevaluated())
+       secondChild->getReferenceCount() == 1 &&
+       secondChild->getRegister() == NULL &&
+       secondChild->getFirstChild()->getReferenceCount() == 1 &&
+       secondChild->getFirstChild()->getRegister() == NULL)
       {
       setMem2();
       memToRegOpCode = TR::InstOpCode::AH;
@@ -745,8 +751,10 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
    if (cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_2) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
-       secondChild->isSingleRefUnevaluated() &&
-       secondChild->getFirstChild()->isSingleRefUnevaluated())
+       secondChild->getReferenceCount() == 1 &&
+       secondChild->getRegister() == NULL &&
+       secondChild->getFirstChild()->getReferenceCount() == 1 &&
+       secondChild->getFirstChild()->getRegister() == NULL)
       {
       setMem2();
       memToRegOpCode = TR::InstOpCode::AGH;

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -959,10 +959,13 @@ FPtoIntBitsTypeCoercionHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * sourceReg = NULL;
    TR::DataType nodeType = node->getDataType();
 
-   if (node->getFirstChild()->isSingleRefUnevaluated() &&
-          node->getFirstChild()->getOpCode().isLoadVar())
+   TR::Node* firstChild = node->getFirstChild();
+
+   if (firstChild->getOpCode().isLoadVar() &&
+       firstChild->getReferenceCount() == 1 &&
+       firstChild->getRegister() == NULL)
       {
-      TR::MemoryReference * tempmemref = TR::MemoryReference::create(cg, node->getFirstChild());
+      TR::MemoryReference * tempmemref = TR::MemoryReference::create(cg, firstChild);
       if (nodeType == TR::Int64)
          targetReg = genericLoadHelper<64, 64, MemReg>(node, cg, tempmemref, NULL, false, true);
       else
@@ -971,7 +974,7 @@ FPtoIntBitsTypeCoercionHelper(TR::Node * node, TR::CodeGenerator * cg)
    else
       {
       // Evaluate child, where sourceReg should be an FPR.
-      sourceReg = cg->evaluate(node->getFirstChild());
+      sourceReg = cg->evaluate(firstChild);
       TR::SymbolReference * f2iSR = cg->allocateLocalTemp(nodeType);
 
       // It seems the FP instruction performance is sub-optimal (i.e. LGDR), and we're better
@@ -1046,7 +1049,7 @@ FPtoIntBitsTypeCoercionHelper(TR::Node * node, TR::CodeGenerator * cg)
           }
        }
     node->setRegister(targetReg);
-    cg->decReferenceCount(node->getFirstChild());
+    cg->decReferenceCount(firstChild);
 
     if (node->getNumChildren() == 2)
        cg->decReferenceCount(node->getSecondChild());

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1990,7 +1990,7 @@ tryGenerateSIComparisons(TR::Node *node, TR::Node *constNode, TR::Node *otherNod
 
       // The conversion must not be in a register or want to be in a register
       //
-      if (!otherNode->isSingleRefUnevaluated())
+      if (otherNode->getReferenceCount() != 1 || otherNode->getRegister() != NULL)
          return 0;
       }
 
@@ -2001,7 +2001,7 @@ tryGenerateSIComparisons(TR::Node *node, TR::Node *constNode, TR::Node *otherNod
 
    // The operand must not be in a register, or want to be in a register
    //
-   if (!operand->isSingleRefUnevaluated())
+   if (operand->getReferenceCount() != 1 || operand->getRegister() != NULL)
       return 0;
 
    uint8_t operandSize = operand->getSize();
@@ -2247,8 +2247,8 @@ tryGenerateCLCForComparison(TR::Node *node, TR::CodeGenerator *cg)
       // The conversions must not be in registers, or want to
       // be in registers
       //
-      if (!firstChild ->isSingleRefUnevaluated() ||
-          !secondChild->isSingleRefUnevaluated())
+      if (firstChild->getReferenceCount() != 1 || firstChild->getRegister() != NULL ||
+          secondChild->getReferenceCount() != 1 || secondChild->getRegister() != NULL)
          return 0;
 
       operand1 = firstChild ->getFirstChild();
@@ -2268,8 +2268,8 @@ tryGenerateCLCForComparison(TR::Node *node, TR::CodeGenerator *cg)
    // Make sure that neither operand is in a register, or wants to be a in
    // a register.
    //
-   if (!operand1->isSingleRefUnevaluated() ||
-       !operand2->isSingleRefUnevaluated())
+   if (operand1->getReferenceCount() != 1 || operand1->getRegister() != NULL ||
+       operand2->getReferenceCount() != 1 || operand2->getRegister() != NULL)
       return 0;
 
    // the operands must both be memory references
@@ -2561,7 +2561,7 @@ tryGenerateConversionRXComparison(TR::Node *node, TR::CodeGenerator *cg, bool *i
       // The conversion must not be in a register, or want to be in a
       // register
       //
-      if (!conversion->isSingleRefUnevaluated())
+      if (conversion->getReferenceCount() != 1 || conversion->getRegister() != NULL)
          {
          return 0;
          }
@@ -2600,7 +2600,8 @@ tryGenerateConversionRXComparison(TR::Node *node, TR::CodeGenerator *cg, bool *i
          // otherwise an su2i will be changed to an s2i and then a CR could be used and this would be incorrect
          if (regNode->isZeroExtension()               &&
              regNode->getFirstChild()->getSize() == 2 &&
-             regNode->isSingleRefUnevaluated() &&
+             regNode->getReferenceCount() == 1 &&
+             regNode->getRegister() == NULL &&
              performTransformation(comp,
                                     "O^O Convert zero extension node [%p] to sign extension so that we can use CH/CGH\n",
                                      regNode))
@@ -2620,7 +2621,7 @@ tryGenerateConversionRXComparison(TR::Node *node, TR::CodeGenerator *cg, bool *i
    // Make sure the mem ref node isn't in a register, and doesn't
    // need to be in a register
    //
-   if (!memNode->isSingleRefUnevaluated())
+   if (memNode->getReferenceCount() != 1 || memNode->getRegister() != NULL)
       {
       return 0;
       }
@@ -5242,7 +5243,10 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
          {
          TR::Node* valueNode = storeNode->getOpCode().isIndirect() ? storeNode->getChild(1) : storeNode->getChild(0);
 
-         if (valueNode->getOpCode().isLoadVar() && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
+         if (valueNode->getOpCode().isLoadVar() && 
+             valueNode->getReferenceCount() == 1 &&
+             valueNode->getRegister() == NULL &&
+             !valueNode->hasUnresolvedSymbolReference())
             {
             // Pattern match the following trees:
             //
@@ -5276,16 +5280,20 @@ bool directMemoryStoreHelper(TR::CodeGenerator* cg, TR::Node* storeNode)
 
             return true;
             }
-         else if (valueNode->getOpCode().isConversion() && valueNode->isSingleRefUnevaluated() && !valueNode->hasUnresolvedSymbolReference())
+         else if (valueNode->getOpCode().isConversion() && 
+                  valueNode->getReferenceCount() == 1 &&
+                  valueNode->getRegister() == NULL &&
+                  !valueNode->hasUnresolvedSymbolReference())
             {
             TR::Node* conversionNode = valueNode;
 
             TR::Node* valueNode = conversionNode->getChild(0);
 
             // Make sure this is an integral truncation conversion
-            if (valueNode->getOpCode().isIntegralLoadVar()
-                    && valueNode->isSingleRefUnevaluated()
-                    && !valueNode->hasUnresolvedSymbolReference())
+            if (valueNode->getOpCode().isIntegralLoadVar() &&
+                valueNode->getReferenceCount() == 1 &&
+                valueNode->getRegister() == NULL &&
+                !valueNode->hasUnresolvedSymbolReference())
                {
                if (valueNode->getSize() > storeNode->getSize())
                   {
@@ -16497,7 +16505,7 @@ OMR::Z::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *returnReg = cg->allocateRegister(TR_VRF);
    uint8_t ESMask = getVectorElementSizeMask(firstChild->getSize());
-   bool inRegister = !firstChild->isSingleRefUnevaluated();
+   bool inRegister = firstChild->getReferenceCount() != 1 || firstChild->getRegister() != NULL;
 
    if (firstChild->getOpCode().isLoadConst() &&
        firstChild->getOpCode().isInteger() &&
@@ -16680,7 +16688,7 @@ OMR::Z::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    // if elementNode is constant then we can use the Vector Load Element version of the instructions
    // but only if valueNode is a constant or a memory reference
    // otherwise we have to use the Vector Load GR From VR Element version
-   bool inRegister = !valueNode->isSingleRefUnevaluated();
+   bool inRegister = valueNode->getReferenceCount() != 1 || valueNode->getRegister() != NULL;
 
    int32_t size = valueNode->getSize();
 

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -294,7 +294,9 @@ OMR::Z::TreeEvaluator::dsqrtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * targetRegister = cg->allocateRegister(TR_FPR);
 
-   if (firstChild->isSingleRefUnevaluated() && firstChild->getOpCodeValue() == TR::dloadi)
+   if (firstChild->getOpCodeValue() == TR::dloadi &&
+       firstChild->getReferenceCount() == 1 && 
+       firstChild->getRegister() == NULL)
       {
       generateRXEInstruction(cg, TR::InstOpCode::SQDB, node, targetRegister, TR::MemoryReference::create(cg, firstChild), 0);
       }


### PR DESCRIPTION
See eclipse/omr#5648 for discussion. It was decided during the OMR
architecture meeting that this API is not very clear and that inlining
it's uses is more understandable as it is very explicit as to what is
being checked.

Closes: #5648

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>