### PR TITLE
Change self() to protected in OMR::AliasBuilder

### DIFF
--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -64,8 +64,6 @@ public:
 
    void createAliasInfo();
 
-   TR::AliasBuilder *self();
-
    TR::SymbolReferenceTable *symRefTab() { return _symRefTab; }
    TR::Compilation *comp() { return _compilation; }
    TR_Memory *trMemory() { return _trMemory; }
@@ -138,6 +136,8 @@ public:
 
 protected:
 
+   TR::AliasBuilder *self();
+   
    TR::Compilation *_compilation;
    TR_Memory *_trMemory;
 


### PR DESCRIPTION
The self() instance method is not supposed to be publicly visible in
extensible classes like OMR::AliasBuilder; it should be made protected.

Signed-off-by: Abhi <abhiasawale510@gmail.com>