### PR TITLE
Change self() to protected in OMR::Method

### DIFF
--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -118,8 +118,6 @@ class Method
 
    TR_ALLOC(TR_Memory::Method);
 
-   TR::Method *self();
-
    enum Type {J9, Test, JitBuilder};
 
 
@@ -172,6 +170,9 @@ class Method
 
    void setRecognizedMethod(TR::RecognizedMethod rm) { _recognizedMethod = rm; }
    void setMandatoryRecognizedMethod(TR::RecognizedMethod rm) { _mandatoryRecognizedMethod = rm; }
+
+   protected:
+   TR::Method *self();
 
    private:
 


### PR DESCRIPTION
The self() instance method is not supposed to be publicly visible in extensible classes like OMR::Method; it should be made protected.

Signed-off-by: Abhi <abhiasawale510@gmail.com>