### PR TITLE
Change self() to protected in OMR::SymbolReferenceTable.hpp

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -70,8 +70,6 @@ class SymbolReferenceTable
 
    TR_ALLOC(TR_Memory::SymbolReferenceTable)
 
-   TR::SymbolReferenceTable *self();
-
    TR::Compilation *comp() { return _compilation; }
    TR_FrontEnd *fe() { return _fe; }
    TR_Memory *trMemory() { return _trMemory; }
@@ -748,6 +746,10 @@ class SymbolReferenceTable
    TR::SymbolReference *getOriginalUnimprovedSymRef(TR::SymbolReference *symRef);
 
    protected:
+
+   TR::SymbolReferenceTable *self();
+
+
    /** \brief
     *    This function creates the symbol reference given a temp symbol and the known object index
     *


### PR DESCRIPTION
The self() instance method is not supposed to be publicly visible in
extensible classes like OMR::SymbolReferenceTable.hpp; it should be made
protected.

Signed-off-by: Abhi <abhiasawale510@gmail.com>