### PR TITLE
Change self() to protected in Method, SymbolReferenceTable, AliasBuilder

### DIFF
--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,8 +63,6 @@ public:
    AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t sizeHintInElements, TR::Compilation *comp);
 
    void createAliasInfo();
-
-   TR::AliasBuilder *self();
 
    TR::SymbolReferenceTable *symRefTab() { return _symRefTab; }
    TR::Compilation *comp() { return _compilation; }
@@ -137,6 +135,8 @@ public:
    void addIntArrayShadows(TR_BitVector *);
 
 protected:
+
+   TR::AliasBuilder *self();
 
    TR::Compilation *_compilation;
    TR_Memory *_trMemory;

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,8 +118,6 @@ class Method
 
    TR_ALLOC(TR_Memory::Method);
 
-   TR::Method *self();
-
    enum Type {J9, Test, JitBuilder};
 
 
@@ -172,6 +170,10 @@ class Method
 
    void setRecognizedMethod(TR::RecognizedMethod rm) { _recognizedMethod = rm; }
    void setMandatoryRecognizedMethod(TR::RecognizedMethod rm) { _mandatoryRecognizedMethod = rm; }
+
+   protected:
+
+   TR::Method *self();
 
    private:
 

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -70,8 +70,6 @@ class SymbolReferenceTable
 
    TR_ALLOC(TR_Memory::SymbolReferenceTable)
 
-   TR::SymbolReferenceTable *self();
-
    TR::Compilation *comp() { return _compilation; }
    TR_FrontEnd *fe() { return _fe; }
    TR_Memory *trMemory() { return _trMemory; }
@@ -761,6 +759,9 @@ class SymbolReferenceTable
    TR::SymbolReference *getOriginalUnimprovedSymRef(TR::SymbolReference *symRef);
 
    protected:
+
+   TR::SymbolReferenceTable *self();
+
    /** \brief
     *    This function creates the symbol reference given a temp symbol and the known object index
     *


### PR DESCRIPTION
The self() instance method is not supposed to be publicly visible in
extensible classes like `OMR::AliasBuilder`, `OMR::Method`, `OMR::SymbolReferenceTable` ; It should be made protected

Issue: #5780