### PR TITLE
Exclude percolate GC CPU time from stats

### DIFF
--- a/gc/base/MemorySubSpaceUniSpace.cpp
+++ b/gc/base/MemorySubSpaceUniSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -286,8 +286,7 @@ MM_MemorySubSpaceUniSpace::timeForHeapContract(MM_EnvironmentBase *env, MM_Alloc
 	}
 	
 	/* Don't shrink if -Xmaxf1.0 specfied, i.e max free is 100% */
-	uintptr_t heapFreeMaximumHeuristicMultiplier = getHeapFreeMaximumHeuristicMultiplier(env);
-	if (100 == _extensions->heapFreeMaximumRatioMultiplier || heapFreeMaximumHeuristicMultiplier >= 100) {
+	if (100 == _extensions->heapFreeMaximumRatioMultiplier) {
 		Trc_MM_MemorySubSpaceUniSpace_timeForHeapContract_Exit2(env->getLanguageVMThread());
 		return false;
 	}

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1419,7 +1419,8 @@ globalGCHookAFCycleStart(J9HookInterface** hook, uintptr_t eventNum, void* event
 	OMR_VMThread *omrVMThread = event->currentThread;
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVMThread->_vm);
 	OMRPORT_ACCESS_FROM_OMRVMTHREAD(omrVMThread);
-	
+
+	extensions->heap->getResizeStats()->resetExcludeCurrentGCTimeFromStats();
 	extensions->heap->getResizeStats()->setThisAFStartTime(omrtime_hires_clock());
 	extensions->heap->getResizeStats()->setLastTimeOutsideGC();
 	extensions->heap->getResizeStats()->setGlobalGCCountAtAF(extensions->globalGCStats.gcCount);
@@ -1436,7 +1437,11 @@ globalGCHookAFCycleEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventDa
 	if((event->subSpaceType == MEMORY_TYPE_NEW) && ((extensions->heap->getResizeStats()->getGlobalGCCountAtAF()) == (extensions->globalGCStats.gcCount))){
 		return;
 	}
-		
+
+	if (extensions->heap->getResizeStats()->getExcludeCurrentGCTimeFromStats()) {
+		return;
+	}
+
 	/* ..and remember time of last AF end */
 	extensions->heap->getResizeStats()->setLastAFEndTime(omrtime_hires_clock());
 	

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4629,6 +4629,11 @@ MM_Scavenger::percolateGarbageCollect(MM_EnvironmentBase *env,  MM_MemorySubSpac
 	/* Set last percolate reason */
 	_extensions->heap->getPercolateStats()->setLastPercolateReason(percolateReason);
 
+	/* Percolate Global due to Critical regions was not due to tight (Tenure) heap, hence should not really affect its resizing. */
+	if (CRITICAL_REGIONS == percolateReason) {
+		_extensions->heap->getResizeStats()->setExcludeCurrentGCTimeFromStats();
+	}
+
 	/* Percolate the collect to parent MSS */
 	bool result = subSpace->percolateGarbageCollect(env, allocDescription, gcCode);
 

--- a/gc/stats/HeapResizeStats.hpp
+++ b/gc/stats/HeapResizeStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,6 +69,7 @@ private:
 
 	uint64_t 				_ticksInGC[RATIO_RESIZE_HISTORIES];
 	uint64_t 				_ticksOutsideGC[RATIO_RESIZE_HISTORIES];
+	bool					_excludeCurrentGCTimeFromStats;
 
 protected:
 public:
@@ -173,7 +174,11 @@ public:
 			return 0;
 		}			
 	}
-	
+
+	MMINLINE void resetExcludeCurrentGCTimeFromStats() { _excludeCurrentGCTimeFromStats = FALSE; }
+	MMINLINE void setExcludeCurrentGCTimeFromStats() { _excludeCurrentGCTimeFromStats = TRUE; }
+	MMINLINE bool getExcludeCurrentGCTimeFromStats() { return _excludeCurrentGCTimeFromStats; }
+
 	MM_HeapResizeStats() :
 		MM_Base(),
 		_lastAFEndTime(0),
@@ -190,7 +195,8 @@ public:
 		_lastContractTime(0),
 		_lastGCPercentage(0),
 		_lastTimeOutsideGC(0),
-		_globalGCCountAtAF(0)
+		_globalGCCountAtAF(0),
+		_excludeCurrentGCTimeFromStats(true)
 	{
 		resetRatioTicks();
 	}


### PR DESCRIPTION
Add a new flag to GC heap stats and set it on percolate start
for JNI Critical Region percolates. On GC cycle end, exclude
the GC time from the GC CPU time if the flag is set.

The extra condition added to maximum heap heuristic checks
causing no contraction when the computed heuristic was arbitrarily
greater than 100 has also been removed.

Signed-off-by: Jason <jasonhal@ca.ibm.com>