### PR TITLE
VerboseGC Initialized Stanza Print Fix

### DIFF
--- a/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
@@ -124,7 +124,7 @@ MM_VerboseWriterFileLoggingBuffered::openFile(MM_EnvironmentBase *env, bool prin
 		MM_VerboseBuffer* buffer = MM_VerboseBuffer::newInstance(env, INITIAL_BUFFER_SIZE);
 		if (NULL != buffer) {
 			_manager->getVerboseHandlerOutput()->outputInitializedStanza(env, buffer);
-			omrfilestream_printf(_logFileStream, buffer->contents());
+			outputString(env, buffer->contents());
 			buffer->kill(env);
 		}
 	}

--- a/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
@@ -125,7 +125,7 @@ MM_VerboseWriterFileLoggingSynchronous::openFile(MM_EnvironmentBase *env, bool p
 		MM_VerboseBuffer* buffer = MM_VerboseBuffer::newInstance(env, INITIAL_BUFFER_SIZE);
 		if (NULL != buffer) {
 			_manager->getVerboseHandlerOutput()->outputInitializedStanza(env, buffer);
-			omrfile_printf(_logFileDescriptor, buffer->contents());
+			outputString(env, buffer->contents());
 			buffer->kill(env);
 		}
 	}


### PR DESCRIPTION
Using `printf` methods to write to files _(e.g `omrfile_printf` & `omrfilestream_printf`)_ is problematic when the output buffer contains a string with specifier characters (e.g %s). In such a case, the format specifiers are intended to be outputted raw to the file rather than evaluated/expanded. `printf` will treat the string as a format string and attempt to evaluate the specifiers **(and crash)** whereas the buffer must be printed raw. Currently, `printf` methods are used when outputting verbose initialized block (string).

When outputting the init block, **use the verbose writer's `outputString` method** rather than using
- `omrfilestream_printf` for FileLoggingSynchronous Writer
- `omrfile_printf` for FileLoggingBuffered Writer

`outputString` will use `omrfile_write_text` and just print the raw characters.

Signed-off-by: Salman Rana <salman.rana@ibm.com>