### PR TITLE
Add support for lowering optimization

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1175,6 +1175,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceNonLinearRA",                 "L\ttrace non-linear RA",                          SET_OPTION_BIT(TR_TraceNonLinearRegisterAssigner), "F"},
    {"traceOpts",                        "L\tdump each optimization name",                 SET_OPTION_BIT(TR_TraceOpts), "P" },
    {"traceOpts=",                       "L{regex}\tlist of optimizations to trace", TR::Options::setRegex, offsetof(OMR::Options, _optsToTrace), 0, "P"},
+   {"traceOptTreeLowering",             "L\ttrace tree lowering optimization",             TR::Options::traceOptimization, treeLowering,   0, "P"},
    {"traceOSR",                         "L\ttrace OSR",                                    SET_OPTION_BIT(TR_TraceOSR), "P"},
    {"traceOSRDefAnalysis",              "L\ttrace OSR reaching defintions analysis",       TR::Options::traceOptimization, osrDefAnalysis, 0, "P"},
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/optimizer/OMROptimizations.enum
+++ b/compiler/optimizer/OMROptimizations.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,6 +81,7 @@
    OPTIMIZATION(stringPeepholes)
    OPTIMIZATION(switchAnalyzer)
    OPTIMIZATION(compactLocals)
+   OPTIMIZATION(treeLowering)
    OPTIMIZATION(varHandleTransformer)
    OPTIMIZATION(unsafeFastPath)
    OPTIMIZATION(recognizedCallTransformer)


### PR DESCRIPTION
This commit adds a few support pieces that must be in OMR but will be used by the new optimization being added in OpenJ9 in https://github.com/eclipse/openj9/pull/11968.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>