### PR TITLE
Deprecate global allocator and misc. cleanup

### DIFF
--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,7 +74,7 @@ class FEBase : public FECommon
    JitConfig            _config;
    TR::CodeCacheManager _codeCacheManager;
 
-   // these two are deprecated in favour of TR::GlobalAllocator and TR::Allocator
+   // this is deprecated in favour of TR::Allocator
    TR_PersistentMemory       _persistentMemory; // global memory
 
    public:

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -416,16 +416,6 @@ TR_Memory::freeMemory(void *p, TR_AllocationKind kind, ObjectType ot)
 
 namespace TR
    {
-   GlobalSingletonAllocator* GlobalSingletonAllocator::_instance = NULL;
-
-   void GlobalSingletonAllocator::createInstance()
-      {
-      TR_ASSERT(::trPersistentMemory != NULL, "Attempting to use GlobalAllocator too early. It cannot be used until TR_PersistentMemory has been initialized.");
-      static CS2PersistentAllocator persistentAllocator(::trPersistentMemory);
-      static GlobalBaseAllocator globalBaseAllocator(persistentAllocator);
-      static GlobalSingletonAllocator globalSingletonAllocator(globalBaseAllocator);
-      }
-
    AllocatedMemoryMeter::Metric AllocatedMemoryMeter::_currentMemUsage = 0;
    // profile everything until read options
    uint8_t AllocatedMemoryMeter::_enabled = heapAlloc | stackAlloc | persistentAlloc;

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1003,10 +1003,6 @@ namespace TR
    typedef CS2::heap_allocator< 65536, 12, TRCS2MemoryAllocator > ThreadLocalAllocator;
    typedef CS2::shared_allocator < ThreadLocalAllocator > Allocator;
 
-   typedef TRPersistentMemoryAllocator CS2PersistentAllocator;
-
-   typedef CS2::stat_allocator    < CS2PersistentAllocator > GlobalBaseAllocator;
-
    /*
     * some common CS2 datatypes
     */

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1007,28 +1007,6 @@ namespace TR
 
    typedef CS2::stat_allocator    < CS2PersistentAllocator > GlobalBaseAllocator;
 
-   class GlobalSingletonAllocator: public GlobalBaseAllocator
-      {
-   public:
-      static GlobalSingletonAllocator &instance()
-         {
-         if (_instance == NULL)
-            createInstance();
-
-         return *_instance;
-         }
-
-   private:
-      GlobalSingletonAllocator(const GlobalBaseAllocator &a) : GlobalBaseAllocator(a)
-         {
-         TR_ASSERT(!_instance, "GlobalSingletonAllocator must be initialized only once");
-         _instance = this;
-         }
-
-      static void createInstance();
-      static GlobalSingletonAllocator *_instance;
-      };
-
    /*
     * some common CS2 datatypes
     */

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1029,21 +1029,11 @@ namespace TR
       static GlobalSingletonAllocator *_instance;
       };
 
-   typedef CS2::shared_allocator < GlobalSingletonAllocator > GlobalAllocator;
-
-   static GlobalAllocator globalAllocator(const char *name = NULL)
-      {
-      return GlobalAllocator(GlobalSingletonAllocator::instance());
-      }
-
    /*
     * some common CS2 datatypes
     */
    typedef CS2::ASparseBitVector<TR::Allocator> SparseBitVector;
    typedef CS2::ABitVector<TR::Allocator>       BitVector;
-
-   typedef CS2::ASparseBitVector<TR::GlobalAllocator> GlobalSparseBitVector;
-   typedef CS2::ABitVector<TR::GlobalAllocator>       GlobalBitVector;
 
    class AllocatedMemoryMeter
       {

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1711,7 +1711,7 @@ void TR_UseDefInfo::insertData(TR::Block *block, TR::Node *node,TR::Node *parent
          aux._defsForSymbol[j]->set(k);
          aux._expandedAtoms[k] = std::make_pair(node, treeTop);
          }
-      TR::GlobalSparseBitVector *mustKill = NULL;
+
       TR::Symbol *callSym = NULL;
       TR::Method *callMethod = NULL;
 

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,26 +84,27 @@ void TR_PPCCallStackIterator::_set_tb_table()
       ++pc;
       _tb_table = (struct tbtable *)pc;
       if (_tb_table->tb.has_tboff)
-    {
-    char *x = (char *)(&_tb_table->tb_ext);
-    if (_tb_table->tb.fixedparms + _tb_table->tb.floatparms != 0)
-       {
-       x += sizeof(_tb_table->tb_ext.parminfo);
-       }
-    if (((unsigned int *) (uintptr_t) _tb_table - *((unsigned int *) x)) > pc)
-       {
-       _tb_table = NULL;
-       return;
-       }
-    else
-       {
-       _offset_in_proc = ((uintptr_t) pc) - ((uintptr_t) _tb_table - *((unsigned int *) x));
-       }
-    }
+         {
+         char *x = (char *)(&_tb_table->tb_ext);
+         if (_tb_table->tb.fixedparms + _tb_table->tb.floatparms != 0)
+            {
+            x += sizeof(_tb_table->tb_ext.parminfo);
+            }
+         if (((unsigned int *) (uintptr_t) _tb_table - *((unsigned int *) x)) > pc)
+            {
+            _tb_table = NULL;
+            return;
+            }
+         else
+            {
+            _offset_in_proc = ((uintptr_t) pc) - ((uintptr_t) _tb_table - *((unsigned int *) x));
+            }
+         }
       else
-    {
-    _offset_in_proc = 0;
-    }
+         {
+         _offset_in_proc = 0;
+         }
+
       return;
       }
    }
@@ -125,17 +126,19 @@ bool TR_PPCCallStackIterator::getNext()
       {
       // We're going to assume that the LR is always saved
       struct stack_mark_t
-    {
-    struct stack_mark_t *  back_chain;
-    uintptr_t     saved_cr;
-    uintptr_t     saved_lr;
-    } *stack_mark = (struct stack_mark_t *) _tos;
+         {
+         struct stack_mark_t *  back_chain;
+         uintptr_t     saved_cr;
+         uintptr_t     saved_lr;
+         } *stack_mark = (struct stack_mark_t *) _tos;
+
       _tos = (void *) stack_mark->back_chain;
       _pc = (void *) stack_mark->back_chain->saved_lr;
       _set_tb_table();
       _done = (_tb_table == NULL);
       if (_tos == NULL) _done = true;
       }
+
    return !_done;
    }
 
@@ -148,45 +151,47 @@ const char *TR_PPCCallStackIterator::getProcedureName()
    else
       {
       if (_tb_table->tb.name_present)
-    {
-    char *x = (char *)(&_tb_table->tb_ext);
-    if (_tb_table->tb.fixedparms + _tb_table->tb.floatparms != 0)
-       {
-       x += sizeof(_tb_table->tb_ext.parminfo);
-       }
-    if (_tb_table->tb.has_tboff)
-       {
-       x += sizeof(_tb_table->tb_ext.tb_offset);
-       }
-    if (_tb_table->tb.int_hndl)
-       {
-       x += sizeof(_tb_table->tb_ext.hand_mask);
-       }
-    if (_tb_table->tb.has_ctl)
-       {
-       int y = *((int *) x);
-       x += sizeof(_tb_table->tb_ext.ctl_info) + (y * sizeof(_tb_table->tb_ext.ctl_info_disp[0]));
-       }
-    short name_len = *((short *) x);
-    x += sizeof(_tb_table->tb_ext.name_len);
-    char *z = (char*) TR::globalAllocator().allocate(name_len+4);
-    strncpy(z, x, name_len);
-    z[name_len] = '\0';
+         {
+         char *x = (char *)(&_tb_table->tb_ext);
+         if (_tb_table->tb.fixedparms + _tb_table->tb.floatparms != 0)
+            {
+            x += sizeof(_tb_table->tb_ext.parminfo);
+            }
+         if (_tb_table->tb.has_tboff)
+            {
+            x += sizeof(_tb_table->tb_ext.tb_offset);
+            }
+         if (_tb_table->tb.int_hndl)
+            {
+            x += sizeof(_tb_table->tb_ext.hand_mask);
+            }
+         if (_tb_table->tb.has_ctl)
+            {
+            int y = *((int *) x);
+            x += sizeof(_tb_table->tb_ext.ctl_info) + (y * sizeof(_tb_table->tb_ext.ctl_info_disp[0]));
+            }
+
+         short name_len = *((short *) x);
+         x += sizeof(_tb_table->tb_ext.name_len);
+         char *z = (char*) TR::globalAllocator().allocate(name_len+4);
+         strncpy(z, x, name_len);
+         z[name_len] = '\0';
+
 #if defined (__clang__)
-    int status = 0;
-    size_t demangled_name_length = 0;
-    char *n = abi::__cxa_demangle(z, NULL, &demangled_name_length, &status);
-    return n;
+         int status = 0;
+         size_t demangled_name_length = 0;
+         char *n = abi::__cxa_demangle(z, NULL, &demangled_name_length, &status);
+         return n;
 #else
-    char *ptoc;
-    Name *n = Demangle(z, ptoc); // Probably does a new...which is bad!
-    return n == NULL ? z : n->Text();
+         char *ptoc;
+         Name *n = Demangle(z, ptoc); // Probably does a new...which is bad!
+         return n == NULL ? z : n->Text();
 #endif
-    }
+         }
       else
-    {
-    return NULL;
-    }
+         {
+         return NULL;
+         }
       }
    }
 


### PR DESCRIPTION
* Misc. source formatting cleanup in CallStack.cpp
* Replace globalAllocator with TR::CompilerEnv rawAllocator
* Remove deprecated GlobalAllocator
* Remove deprecated GlobalSingletonAllocator
* Remove deprecated CS2::stat_allocator