### PR TITLE
Support TR_AbsoluteHelperAddress constant address loads on power

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1934,7 +1934,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          }
 
       case TR_BlockFrequency:
-	 {
+         {
          TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof(TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data1 = (uintptr_t)node->getSymbolReference();
          recordInfo->data2 = (uintptr_t)seqKind;
@@ -1942,6 +1942,12 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             firstInstruction,
             (uint8_t *)recordInfo,
             TR_BlockFrequency, self());
+         break;
+         }
+
+      case TR_AbsoluteHelperAddress:
+         {
+         value = (uintptr_t)node->getSymbolReference();
          break;
          }
       }


### PR DESCRIPTION
Add support to create relocations for absolute helper addresses when loading constant addresses on power.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>