### PR TITLE
AArch64: Workaround for huge methods

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -366,6 +366,13 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
          }
       }
 
+   if (!constantIsSignedImm21((intptr_t)self()->getBinaryBufferCursor() - (intptr_t)self()->getBinaryBufferStart()))
+      {
+      // Workaround for huge code
+      // Range of conditional branch instruction is +/- 1MB
+      self()->comp()->failCompilation<TR::AssertionFailure>("Generated code is too large");
+      }
+
    self()->getLinkage()->performPostBinaryEncoding();
    }
 


### PR DESCRIPTION
This commit is a temporary workaround for huge methods.
The range of AArch64 conditional branch instruction is +/- 1MB.
This commit gives up compilation when the size of the generated code
exceeds that range.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>