### PR TITLE
Reduce use of OMR_HOST_OS

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -208,11 +208,11 @@ set(OMRTHREAD_UNIX_DEFAULT OFF)
 set(OMRTHREAD_AIX_DEFAULT OFF)
 set(OMRTHREAD_ZOS_DEFAULT OFF)
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	set(OMRTHREAD_WIN32_DEFAULT ON)
-elseif(OMR_HOST_OS STREQUAL "aix")
+elseif(OMR_OS_AIX)
 	set(OMRTHREAD_AIX_DEFAULT ON)
-elseif(OMR_HOST_OS STREQUAL "zos")
+elseif(OMR_OS_ZOS)
 	set(OMRTHREAD_ZOS_DEFAULT ON)
 else()
 	set(OMRTHREAD_UNIX_DEFAULT ON)
@@ -236,7 +236,7 @@ set(OMR_OPT_CUDA OFF CACHE BOOL "Enable CUDA support in OMR. See also: OMR_CUDA_
 
 set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang")
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	set(OMR_WINDOWS_NOMINMAX ON CACHE BOOL "Define NOMINMAX in every compilation unit; prevents Windows headers from polluting the global namespace with 'min' and 'max' macros.")
 endif()
 

--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,10 +28,9 @@ include(OmrAssert)
 include(OmrDetectSystemInformation)
 include(OmrUtility)
 
-
 omr_detect_system_information()
 
-if(NOT OMR_HOST_OS STREQUAL "zos")
+if(NOT OMR_OS_ZOS)
 	enable_language(ASM)
 endif()
 

--- a/ddr/lib/ddr-scanner/CMakeLists.txt
+++ b/ddr/lib/ddr-scanner/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ target_link_libraries(omr_ddr_scanner
 		omr_ddr_ir
 )
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	find_package(DiaSDK REQUIRED)
 
 	target_sources(omr_ddr_scanner
@@ -43,7 +43,7 @@ if(OMR_HOST_OS STREQUAL "win")
 		PUBLIC
 			DiaSDK::diasdk
 	)
-elseif(OMR_HOST_OS STREQUAL "linux")
+elseif(OMR_OS_LINUX)
 	find_package(LibDwarf REQUIRED)
 
 	target_link_libraries(omr_ddr_scanner
@@ -56,14 +56,14 @@ elseif(OMR_HOST_OS STREQUAL "linux")
 			dwarf/DwarfFunctions.cpp
 			dwarf/DwarfScanner.cpp
 	)
-elseif(OMR_HOST_OS STREQUAL "osx")
+elseif(OMR_OS_OSX)
 	target_sources(omr_ddr_scanner
 		PRIVATE
 			dwarf/DwarfFunctions.cpp
 			dwarf/DwarfParser.cpp
 			dwarf/DwarfScanner.cpp
 	)
-elseif(OMR_HOST_OS STREQUAL "aix")
+elseif(OMR_OS_AIX)
 	target_sources(omr_ddr_scanner
 		PRIVATE
 			dwarf/AixSymbolTableParser.cpp

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(omralgotest
 target_include_directories(omralgotest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 #TODO hack to get building
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_link_libraries(omralgotest
 		ws2_32
 		shell32
@@ -58,7 +58,7 @@ if(OMR_HOST_OS STREQUAL "win")
 	)
 endif()
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omralgotest j9a2e)
 endif()
 

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -123,6 +123,6 @@ target_link_libraries(compilertest
 
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
-if (NOT OMR_HOST_OS STREQUAL "aix")
+if (NOT OMR_OS_AIX)
 	omr_add_test(NAME CompilerTest COMMAND $<TARGET_FILE:compilertest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
 endif()

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Add bigobj compiler options for TypeConversionTest.cpp under Windows
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	add_compile_options(-bigobj)
 endif()
 
@@ -64,7 +64,7 @@ target_link_libraries(comptest
 	tril
 )
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(comptest j9a2e)
 endif()
 

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -52,22 +52,7 @@ target_link_libraries(omrgctest
 	${OMR_PORT_LIB}
 )
 
-# TODO check linker flags from makefile are ported properly.
-# Relevant section from makefile below
-#ifeq (linux,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += rt pthread
-#endif
-#ifeq (osx,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += iconv pthread
-#endif
-#ifeq (aix,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += iconv perfstat
-#endif
-#ifeq (win,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
-#endif
-
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrgctest j9a2e)
 endif()
 

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -40,7 +40,7 @@ omr_add_executable(jitbuildertest NOWARNINGS
 )
 
 if(OMR_HOST_ARCH STREQUAL "x86")
-	if(OMR_HOST_OS STREQUAL "linux" OR OMR_HOST_OS STREQUAL "osx")
+	if(OMR_OS_LINUX OR OMR_OS_OSX)
 		target_sources(jitbuildertest PRIVATE CallReturnTest.cpp)
 	endif()
 endif()

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,15 +57,13 @@ target_link_libraries(omrGtestGlue
 		omr_main_function
 )
 
-#TODO  system thread library should be linked in a more generic way.
-if(NOT OMR_HOST_OS STREQUAL "win")
-	if(NOT OMR_HOST_OS STREQUAL "zos")
-		target_link_libraries(omrGtest pthread)
-	endif()
+# TODO system thread library should be linked in a more generic way.
+if(NOT (OMR_OS_WINDOWS OR OMR_OS_ZOS))
+	target_link_libraries(omrGtest pthread)
 endif()
 #target_link_libraries(omrGtest INTERFACE omrGtestGlue)
 
-if(OMR_HOST_OS STREQUAL "zos" OR OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX OR OMR_OS_ZOS)
 	list(APPEND OMR_GTEST_DEFINITIONS
 		-DGTEST_ENV_HAS_STD_TUPLE_
 		-D__IBMCPP_TR1__

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -66,8 +66,8 @@ if(OMR_OPT_CUDA)
 	)
 endif()
 
-# TODO: Remove if(NOT OMR_HOST_OS STREQUAL "win") after OMRSOCK API is implemented on Windows.
-if(NOT OMR_HOST_OS STREQUAL "win")
+# TODO: Remove if(NOT OMR_OS_WINDOWS) after OMRSOCK API is implemented on Windows.
+if(NOT OMR_OS_WINDOWS)
 	target_sources(omrporttest
 		PRIVATE
 			omrsockTest.cpp
@@ -85,13 +85,13 @@ target_link_libraries(omrporttest
 	${OMR_PORT_LIB}
 )
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_link_libraries(omrporttest
 		ws2_32
 	)
 endif()
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrporttest
 		j9a2e
 	)
@@ -115,7 +115,7 @@ omr_add_exports(sltestlib
 	sl_test1_function
 )
 
-if(OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX)
 	omr_add_library(aixbaddep SHARED
 		aixbaddep/sltest.c
 	)
@@ -136,7 +136,7 @@ if(OMR_HOST_OS STREQUAL "aix")
 	)
 endif()
 
-if (NOT OMR_HOST_OS STREQUAL "aix" AND NOT OMR_HOST_OS STREQUAL "zos" AND NOT CMAKE_CROSSCOMPILING)
+if (NOT (OMR_OS_AIX OR OMR_OS_ZOS OR CMAKE_CROSSCOMPILING))
 	omr_add_test(
 		NAME porttest
 		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter=${porttest_filter}

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -26,7 +26,7 @@ omr_add_executable(omrsigtest
 )
 
 #TODO: hack for windows. These libraries should be linked on dependants
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_link_libraries(omrsigtest
 		ws2_32
 		shell32
@@ -36,7 +36,7 @@ if(OMR_HOST_OS STREQUAL "win")
 	)
 endif()
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrsigtest j9a2e)
 endif()
 

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -27,7 +27,6 @@ omr_add_executable(omrthreadextendedtest
 	timeBaseTest.cpp
 )
 
-
 target_link_libraries(omrthreadextendedtest
 	omrGtestGlue
 	omrtestutil
@@ -37,12 +36,12 @@ target_link_libraries(omrthreadextendedtest
 	${OMR_PORT_LIB}
 )
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrthreadextendedtest j9a2e)
 endif()
 
 set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
 
-if (NOT OMR_HOST_OS STREQUAL "zos")
+if(NOT OMR_OS_ZOS)
 	omr_add_test(NAME threadextendedtest COMMAND $<TARGET_FILE:omrthreadextendedtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadextendedtest-results.xml)
 endif()

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -42,18 +42,6 @@ omr_add_executable(omrthreadtest
 	#OBJECTS += forkResetTest forkResetRWMutexTest
 #endif
 
-
-#ifeq (linux,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += rt pthread
-#endif
-#ifeq (osx,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += iconv pthread
-#endif
-#ifeq (aix,$(OMR_HOST_OS))
-	#MODULE_SHARED_LIBS += iconv perfstat
-#endif
-
-
 target_link_libraries(omrthreadtest
 	omrGtestGlue
 	omrtestutil
@@ -63,7 +51,7 @@ target_link_libraries(omrthreadtest
 	${OMR_PORT_LIB}
 	${OMR_THREAD_LIB}
 )
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_link_libraries(omrthreadtest
 		ws2_32
 		shell32
@@ -73,7 +61,7 @@ if(OMR_HOST_OS STREQUAL "win")
 	)
 endif()
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrthreadtest j9a2e)
 endif()
 
@@ -81,6 +69,6 @@ set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
 
 omr_add_test(NAME threadtest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
 omr_add_test(NAME threadSetAttrThreadWeightTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
-if(OMR_HOST_OS STREQUAL "linux")
+if(OMR_OS_LINUX)
 	omr_add_test(NAME threadRealtimeTest COMMAND $<TARGET_FILE:omrthreadtest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
 endif()

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,13 +54,10 @@ target_link_libraries(tril PUBLIC
 	${CMAKE_DL_LIBS}
 )
 
-#TODO  system thread library should be linked in a more generic way.
-if(NOT OMR_HOST_OS STREQUAL "win")
-	if(NOT OMR_HOST_OS STREQUAL "zos")
-		target_link_libraries(tril PUBLIC pthread)
-	endif()
+# TODO system thread library should be linked in a more generic way.
+if(NOT (OMR_OS_WINDOWS OR OMR_OS_ZOS))
+	target_link_libraries(tril PUBLIC pthread)
 endif()
-
 
 omr_add_executable(tril_dumper NOWARNINGS compiler.cpp)
 target_link_libraries(tril_dumper tril)

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(omrutiltest
 	$<TARGET_PROPERTY:omrGtestGlue,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrutiltest j9a2e)
 endif()
 

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,7 @@ omr_add_library(omrsig SHARED
 	omrsig.cpp
 )
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_compile_definitions(omrsig PRIVATE -DMSVC_RUNTIME_DLL="${OMR_MSVC_CRT}")
 endif()
 
@@ -76,17 +76,9 @@ target_compile_options(omrsig
 if(OMR_HOST_OS MATCHES "linux|osx")
 	target_link_libraries(omrsig PRIVATE dl)
 endif()
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	target_link_libraries(omrsig PRIVATE j9a2e)
 endif()
-#TODO ensure we are linking in the same way as source makefile:
-#MODULE_STATIC_LIBS += omrutil
-#ifneq (,$(findstring linux,$(OMR_HOST_OS)))
-	#MODULE_SHARED_LIBS += pthread
-#endif
-#ifneq (,$(findstring osx,$(OMR_HOST_OS)))
-	#MODULE_SHARED_LIBS += pthread
-#endif
 
 install(
 	TARGETS omrsig

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -26,7 +26,7 @@ if(OMR_OPT_CUDA)
 	find_package(OmrCuda REQUIRED)
 endif()
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	include(OmrMetalC)
 endif()
 
@@ -60,15 +60,15 @@ target_compile_definitions(omrport_obj
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-if(OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX)
 	list(APPEND OBJECTS omrgetsp.s)
 endif()
 
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	omr_compile_metalc(
-	    zos390/omrlpdat.mc
-	    zos390/omrlpdat.o
+		zos390/omrlpdat.mc
+		zos390/omrlpdat.o
 	)
 	target_sources(omrport_obj
 		PRIVATE
@@ -110,18 +110,12 @@ list(APPEND OBJECTS
 
 if(OMR_ARCH_S390)
 	list(APPEND OBJECTS omrrttime.s)
-else()
-	if(OMR_ARCH_POWER)
-		if(OMR_ENV_DATA64)
-			if(OMR_HOST_OS STREQUAL "linux")
-				list(APPEND OBJECTS omrrttime.s)
-			endif()
-		endif()
-	endif()
+elseif(OMR_ARCH_POWER AND OMR_ENV_DATA64 AND OMR_OS_LINUX)
+	list(APPEND OBJECTS omrrttime.s)
 endif()
 
 if(OMR_ARCH_S390)
-	if(OMR_HOST_OS STREQUAL "linux")
+	if(OMR_OS_LINUX)
 		list(APPEND OBJECTS omrgetstfle.s)
 	else()
 		if(OMR_ENV_DATA64)
@@ -132,10 +126,9 @@ if(OMR_ARCH_S390)
 	endif()
 endif()
 
-
 #TODO another if block @port_objects.mk:89
 
-if(OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX)
 	list(APPEND OBJECTS
 		rt_divu64.s
 		rt_time.s
@@ -153,13 +146,13 @@ list(APPEND OBJECTS
 	omrfilestreamtext.c
 )
 
-if(NOT OMR_HOST_OS STREQUAL "win")
+if(NOT OMR_OS_WINDOWS)
 	list(APPEND OBJECTS omriconvhelpers.c)
 endif()
 
 list(APPEND OBJECTS omrfile_blockingasync.c)
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	list(APPEND OBJECTS omrfilehelpers.c)
 endif()
 
@@ -189,7 +182,7 @@ list(APPEND OBJECTS
 	omrsockptb.c
 )
 
-if(NOT OMR_HOST_OS STREQUAL "win")
+if(NOT OMR_OS_WINDOWS)
 	list(APPEND OBJECTS omrsignal_context.c)
 endif()
 
@@ -203,7 +196,7 @@ list(APPEND OBJECTS omrsysinfo_helpers.c)
 
 list(APPEND OBJECTS omrsyslog.c)
 
-if(OMR_HOST_OS STREQUAL win)
+if(OMR_OS_WINDOWS)
 	#TODO hack to compile mc files
 	enable_language(RC)
 	add_custom_command(
@@ -224,15 +217,13 @@ list(APPEND OBJECTS
 	omrmemtag_checks.c
 )
 
-if(OMR_HOST_OS STREQUAL aix)
+if(OMR_OS_AIX)
 	list(APPEND OBJECTS omrosdump_helpers.c)
-elseif(OMR_HOST_OS STREQUAL linux)
+elseif(OMR_OS_LINUX)
 	list(APPEND OBJECTS omrosdump_helpers.c)
-elseif(OMR_HOST_OS STREQUAL osx)
+elseif(OMR_OS_OSX)
 	list(APPEND OBJECTS omrosdump_helpers.c)
-endif()
-
-if(OMR_HOST_OS STREQUAL zos)
+elseif(OMR_OS_ZOS)
 	if(NOT OMR_ENV_DATA64)
 		list(APPEND OBJECTS
 			omrsignal_ceehdlr.c
@@ -242,11 +233,11 @@ if(OMR_HOST_OS STREQUAL zos)
 endif()
 
 if(OMR_HOST_ARCH STREQUAL ppc)
-	if(OMR_HOST_OS STREQUAL linux)
+	if(OMR_OS_LINUX)
 		list(APPEND OBJECTS auxv.c)
 	endif()
 elseif(OMR_ARCH_S390)
-	if(OMR_HOST_OS STREQUAL linux)
+	if(OMR_OS_LINUX)
 		list(APPEND OBJECTS auxv.c)
 	endif()
 endif()
@@ -265,22 +256,21 @@ if(NOT OMR_OS_WINDOWS)
 	)
 endif()
 
-
 #Setup paths and include directories
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	list(APPEND VPATH zos390)
 	target_include_directories(omrport_obj PRIVATE zos390)
 endif()
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	if(OMR_ENV_DATA64)
 		list(APPEND VPATH win64amd)
 		target_include_directories(omrport_obj PRIVATE win64amd)
 	endif()
 endif()
 
-if(OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX)
 	#ifdef I5_VERSION
 		#ifeq (1,$(OMR_ENV_DATA64))
 			#vpath % $(PORT_SRCDIR)iseries64
@@ -298,7 +288,7 @@ if(OMR_HOST_OS STREQUAL "aix")
 	target_include_directories(omrport_obj PRIVATE aix)
 endif()
 
-if(OMR_HOST_OS STREQUAL "linux")
+if(OMR_OS_LINUX)
 	if(OMR_ARCH_ARM)
 		list(APPEND VPATH linuxarm)
 		target_include_directories(omrport_obj PRIVATE linuxarm)
@@ -332,7 +322,7 @@ if(OMR_HOST_OS STREQUAL "linux")
 		list(APPEND VPATH linuxppc)
 		target_include_directories(omrport_obj PRIVATE linuxppc)
 	endif()
-	
+
 	if(OMR_ARCH_RISCV)
 		if(OMR_ENV_DATA64)
 			list(APPEND VPATH linuxriscv64)
@@ -366,14 +356,12 @@ if(OMR_HOST_OS STREQUAL "linux")
 	target_include_directories(omrport_obj PRIVATE linux)
 endif()
 
-
-if(OMR_HOST_OS STREQUAL "osx")
+if(OMR_OS_OSX)
 	list(APPEND VPATH osx)
 	target_include_directories(omrport_obj PRIVATE osx)
 endif()
 
-
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	list(APPEND VPATH win32_include win32)
 	target_include_directories(omrport_obj PRIVATE win32_include win32)
 else()
@@ -391,7 +379,7 @@ omr_find_files(resolvedPaths
 	FILES ${OBJECTS}
 )
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	list(APPEND resolvedPaths win32/omrsyslogmessages.rc)
 endif()
 
@@ -419,8 +407,6 @@ ddr_add_headers(omrport_obj
 	${omr_SOURCE_DIR}/include_core/omrport.h
 )
 ddr_set_add_targets(omrddr omrport_obj)
-
-
 
 ###
 ### omrport static lib

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,6 @@ include(OmrFindFiles)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_tracegen(j9thr.tdf)
-
 
 set(OBJECTS "")
 set(VPATHS "")
@@ -53,18 +52,16 @@ if(OMR_THR_JLM)
 	list(APPEND OBJECTS omrthreadjlm.c)
 endif(OMR_THR_JLM)
 
-if(NOT OMR_HOST_OS STREQUAL "win")
+if(NOT OMR_OS_WINDOWS)
 	list(APPEND OBJECTS unixpriority.c)
 else()
 	list(APPEND OBJECTS dllmain.c)
 	list(APPEND VPATHS win32)
 endif()
 
-
 include_directories(.)
 
-
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	list(APPEND VPATHS
 		zos390
 		unix
@@ -73,21 +70,20 @@ if(OMR_HOST_OS STREQUAL "zos")
 	list(APPEND OBJECTS thrcputime.s)
 endif()
 
-if(OMR_HOST_OS STREQUAL "linux")
+if(OMR_OS_LINUX)
 	list(APPEND VPATHS
 		linux
 		unix
 	)
 	include_directories(linux unix)
-
 endif()
 
-if(OMR_HOST_OS STREQUAL "osx")
+if(OMR_OS_OSX)
 	list(APPEND VPATHS osx unix)
 	include_directories(osx unix)
 endif()
 
-if(OMR_HOST_OS STREQUAL "aix")
+if(OMR_OS_AIX)
 	list(APPEND VPATHS aix unix)
 	include_directories(aix unix)
 endif()
@@ -100,7 +96,6 @@ list(APPEND VPATHS common)
 #ifeq ($(OMR_TOOLCHAIN),gcc)
 #  MODULE_CFLAGS += -Wno-unused
 #endif
-
 
 omr_find_files(resolvedPaths
 	PATHS ${VPATHS}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_OS_ZOS)
 	add_subdirectory(a2e)
 endif()
 add_subdirectory(avl)

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ target_compile_definitions(omrutil_obj
 list(APPEND VPATH .)
 
 if(OMR_ARCH_S390)
-	if(OMR_HOST_OS STREQUAL zos)
+	if(OMR_OS_ZOS)
 		if(OMR_ENV_DATA64)
 			list(APPEND OBJECTS j9memclrz10_64.s)
 			list(APPEND OBJECTS omrget_userExtendedPrivateAreaMemoryType.s)
@@ -96,19 +96,15 @@ if(OMR_ARCH_S390)
 endif()
 
 if(OMR_ARCH_POWER)
-	if(OMR_HOST_OS STREQUAL linux)
-		if(OMR_ENV_DATA64)
-			if(OMR_ENV_LITTLE_ENDIAN)
-				list(APPEND OBJECTS gettoc.s)
+	if(OMR_OS_LINUX AND OMR_ENV_DATA64 AND OMR_ENV_LITTLE_ENDIAN)
+		list(APPEND OBJECTS gettoc.s)
 
-				list(APPEND VPATH unix/linux/ppc/64le)
-				target_include_directories(omrutil_obj PRIVATE unix/linux/ppc/64le)
-			endif()
-		endif()
+		list(APPEND VPATH unix/linux/ppc/64le)
+		target_include_directories(omrutil_obj PRIVATE unix/linux/ppc/64le)
 	endif()
 	if(NOT OMR_ENV_DATA64)
 		list(APPEND OBJECTS cas8help.s)
-		if(OMR_HOST_OS STREQUAL linux)
+		if(OMR_OS_LINUX)
 			list(APPEND VPATH unix/linux/ppc/32)
 			target_include_directories(omrutil_obj PRIVATE unix/linux/ppc/32)
 		else()
@@ -119,7 +115,7 @@ if(OMR_ARCH_POWER)
 endif()
 
 if(OMR_ARCH_RISCV)
-	if(OMR_HOST_OS STREQUAL linux)
+	if(OMR_OS_LINUX)
 		list(APPEND OBJECTS cas32helper.s)
 		list(APPEND VPATH unix/linux/riscv/32)
 		target_include_directories(omrutil_obj PRIVATE unix/linux/riscv/32)
@@ -153,7 +149,7 @@ list(APPEND OBJECTS
 	xml.c
 )
 
-if(OMR_HOST_OS STREQUAL "win")
+if(OMR_OS_WINDOWS)
 	target_sources(omrutil_obj
 		PRIVATE
 			win/omrgetdbghelp.c
@@ -172,7 +168,6 @@ target_sources(omrutil_obj PRIVATE ${resolvedPaths})
 # So instead we manually apply the interface properties
 target_sources(omrutil_obj PRIVATE $<TARGET_PROPERTY:${OMR_UTIL_GLUE_TARGET},INTERFACE_SOURCES>)
 target_include_directories(omrutil_obj PUBLIC $<TARGET_PROPERTY:${OMR_UTIL_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
-
 
 target_enable_ddr(omrutil_obj)
 ddr_set_add_targets(omrddr omrutil_obj)


### PR DESCRIPTION
* prefer flags over string comparisons

Flag            | Replaces
:---            | :-------
OMR_OS_AIX      | OMR_HOST_OS STREQUAL "aix"
OMR_OS_BSD      | OMR_HOST_OS STREQUAL "bsd"
OMR_OS_LINUX    | OMR_HOST_OS STREQUAL "linux"
OMR_OS_OSX      | OMR_HOST_OS STREQUAL "osx"
OMR_OS_WINDOWS  | OMR_HOST_OS STREQUAL "win"
OMR_OS_ZOS      | OMR_HOST_OS STREQUAL "zos"

See OmrDetectSystemInformation.cmake.
See also eclipse/openj9#12048.