### PR TITLE
Adaptive GC Threading

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -517,6 +517,13 @@ public:
 	bool enableSplitHeap; /**< true if we are using gencon with -Xgc:splitheap (we will fail to boostrap if we can't allocate both ranges) */
 	double aliasInhibitingThresholdPercentage; /**< percentage of threads that can be blocked before copy cache aliasing is inhibited (set through aliasInhibitingThresholdPercentage=) */
 
+	/* Start of variables relating to Adaptive Threading */
+	bool adaptiveGCThreading; /**< Flag to indicate whether the Scavenger Adaptive Threading Optimization is enabled*/
+	float adaptiveThreadingSensitivityFactor; /**<  Used by Adaptive Model to determine sensitivity/tolerance to stalling, higher number translates to less stall being tolerated (set through adaptiveThreadingSensitivityFactor=) */
+	float adaptiveThreadingWeightActiveThreads; /**< Weight given to current active threads when averaging projected threads with current active threads (set through adaptiveThreadingWeightActiveThreads=) */
+	float adaptiveThreadBooster; /**< Used to boost calculated thread count, gives opportunity for low thread count to grow. */
+	/* End of variables relating to Adaptive Threading */
+
 	enum HeapInitializationSplitHeapSection {
 		HEAP_INITIALIZATION_SPLIT_HEAP_UNKNOWN = 0,
 		HEAP_INITIALIZATION_SPLIT_HEAP_TENURE,
@@ -1094,6 +1101,16 @@ public:
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 	/**
+	 * Determine whether Adaptive Threading is enabled. AdaptiveGCThreading flag
+	 * is not sufficient; Adaptive threading must be ignored if GC thread count is forced.
+	 * @return TRUE if adaptive threading routines can proceed, FALSE otherwise
+	 */
+	MMINLINE bool adaptiveThreadigEnabled()
+	{
+		return (adaptiveGCThreading && !gcThreadCountForced);
+	}
+
+	/**
 	 * Returns TRUE if an object is old, FALSE otherwise.
 	 * @param objectPtr Pointer to an object
 	 * @return TRUE if an object is in the old area, FALSE otherwise
@@ -1595,6 +1612,10 @@ public:
 		, dnssMinimumContraction(0.0)
 		, enableSplitHeap(false)
 		, aliasInhibitingThresholdPercentage(0.20)
+		, adaptiveGCThreading(true)
+		, adaptiveThreadingSensitivityFactor(1.0f)
+		, adaptiveThreadingWeightActiveThreads(0.50f)
+		, adaptiveThreadBooster(0.85f)
 		, splitHeapSection(HEAP_INITIALIZATION_SPLIT_HEAP_UNKNOWN)
 #endif /* OMR_GC_MODRON_SCAVENGER */
 		, globalMaximumContraction(0.05) /* by default, contract must be at most 5% of the committed heap */

--- a/gc/base/ParallelTask.cpp
+++ b/gc/base/ParallelTask.cpp
@@ -214,6 +214,14 @@ done:
 void
 MM_ParallelTask::releaseSynchronizedGCThreads(MM_EnvironmentBase *env)
 {
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+	if (_syncCriticalSectionStartTime != 0) {
+		/* Critical section complete, synced threads are about to be released. Record the duration. */
+		_syncCriticalSectionDuration = (omrtime_hires_clock() - _syncCriticalSectionStartTime);
+		_syncCriticalSectionStartTime = 0;
+	}
+
 	if (1 == _totalThreadCount) {
 		_synchronized = false;
 		return;
@@ -225,7 +233,11 @@ MM_ParallelTask::releaseSynchronizedGCThreads(MM_EnvironmentBase *env)
 	omrthread_monitor_enter(_synchronizeMutex);
 	_synchronizeCount = 0;
 	_synchronizeIndex += 1;
+	uint64_t notifyStartTime = omrtime_hires_clock();
 	omrthread_monitor_notify_all(_synchronizeMutex);
+
+	addToNotifyStallTime(env, notifyStartTime, omrtime_hires_clock());
+
 	omrthread_monitor_exit(_synchronizeMutex);
 }
 

--- a/gc/base/ParallelTask.hpp
+++ b/gc/base/ParallelTask.hpp
@@ -48,6 +48,9 @@ class MM_ParallelTask : public MM_Task
 	 */
 private:
 protected:
+	uint64_t _syncCriticalSectionStartTime; /**< Timestamp taken when a critical section of the task starts execution. */
+	uint64_t _syncCriticalSectionDuration; /**< The time, in hi-res ticks, it took to execute the lastest critical section. */
+
 	bool _synchronized;
 	const char *_syncPointUniqueId;
 	uintptr_t _syncPointWorkUnitIndex; /**< The _workUnitIndex of the first thread to sync. All threads should have the same index once sync'ed. */
@@ -84,6 +87,7 @@ public:
 		_totalThreadCount = threadCount;
 	}
 	MMINLINE virtual uintptr_t getThreadCount() { return _totalThreadCount; }
+	MMINLINE virtual void addToNotifyStallTime(MM_EnvironmentBase *env, uint64_t startTime, uint64_t endTime) {}
 	
 	virtual bool isSynchronized();
 
@@ -92,6 +96,8 @@ public:
 	 */
 	MM_ParallelTask(MM_EnvironmentBase *env, MM_ParallelDispatcher *dispatcher) :
 		MM_Task(env, dispatcher)
+		,_syncCriticalSectionStartTime(0)
+		,_syncCriticalSectionDuration(0)
 		,_synchronized(false)
 		,_syncPointUniqueId(NULL)
 		,_syncPointWorkUnitIndex(0)

--- a/gc/base/Task.hpp
+++ b/gc/base/Task.hpp
@@ -65,6 +65,8 @@ public:
 	virtual void run(MM_EnvironmentBase *env) = 0;
 	virtual void cleanup(MM_EnvironmentBase *env);
 
+	virtual uintptr_t getRecommendedWorkingThreads() { return UDATA_MAX; }
+
 	/**
 	 * Single call setup routine for tasks invoked by the main thread before the task is dispatched.
 	 */

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -928,3 +928,10 @@ TraceEvent=Trc_MM_Scavenger_percolate_delegate Overhead=1 Level=1 Group=percolat
 
 TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMaximumHeuristicMultiplier Maximum free multiplier = %zu"
 TraceEntry=Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Overhead=1 Level=1 Group=resize Template="Trc_MM_MemorySubSpaceUniSpace_getHeapFreeMinimumHeuristicMultiplier Minimum free multiplier = %zu"
+
+TraceEntry=Trc_MM_Scavenger_calculateRecommendedWorkingThreads_entry Overhead=1 Level=1 Group=adaptivethread Template="[%u] MM_Scavenger_calculateRecommendedWorkingThreads entry"
+TraceExit=Trc_MM_Scavenger_calculateRecommendedWorkingThreads_exitOverflow Overhead=1 Level=1 Group=adaptivethread Template="Scavenge ignored for recommending threads (Irregular stalling with SyncAndReleaseMaster)"
+TraceExit=Trc_MM_Scavenger_calculateRecommendedWorkingThreads_setRecommendedThreads Overhead=1 Level=1 Group=adaptivethread Template="ScavengeTime: %5llu  Avg.StallTime: %5llu (%.2f%%)  Threads [Current: %2u Ideal: %.2f Weighted: %.2f Boosted: %.2f Recommend: %2u]"
+TraceEvent=Trc_MM_Scavenger_calculateRecommendedWorkingThreads_averageStallBreakDown Overhead=1 Level=1 Group=adaptivethread Template="Average for: %u threads -> avgTimeToStartCollection: %5llu  avgTimeIdleAfterCollection: %5llu  avgScanStallTime: %5llu  avgSyncStallTime: %5llu  avgNotifyStallTime: %5llu"
+TraceEvent=Trc_MM_Scavenger_calculateRecommendedWorkingThreads_threadStallBreakDown Overhead=1 Level=1 Group=adaptivethread Template="Thread: %2u -> timeToStartCollection: %5llu  scanStall: %5llu  syncStall: %5llu  notifyStall: %5llu"
+TraceEvent=Trc_MM_ParallelDispatcher_recomputeActiveThreadCountForTask_useCollectorRecommendedThreads noEnv Overhead=1 Level=1 Group=adaptivethread Template="Attempting to use Task Recommended Threads: %u -> Adjusting to Bounds: %u"

--- a/gc/base/standard/ConcurrentScavengeTask.hpp
+++ b/gc/base/standard/ConcurrentScavengeTask.hpp
@@ -69,7 +69,7 @@ public:
 			MM_Scavenger *scavenger,
 			ConcurrentAction action,
 			MM_CycleState *cycleState) :
-		MM_ParallelScavengeTask(env, dispatcher, scavenger, cycleState)
+		MM_ParallelScavengeTask(env, dispatcher, scavenger, cycleState, UDATA_MAX)
 		, _bytesScanned(0)
 		, _action(action)
 	{

--- a/gc/base/standard/ParallelScavengeTask.hpp
+++ b/gc/base/standard/ParallelScavengeTask.hpp
@@ -50,6 +50,7 @@ class MM_ParallelScavengeTask : public MM_ParallelTask
 protected:
 	MM_Scavenger *_collector;
 	MM_CycleState *_cycleState;  /**< Collection cycle state active for the task */
+	uintptr_t _recommendedThreads;  /**< Collector recommended threads for the task */
 
 public:
 	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SCAVENGE; };
@@ -77,15 +78,20 @@ public:
 	 * @see MM_ParallelTask::synchronizeGCThreadsAndReleaseSingleThread
 	 */
 	virtual bool synchronizeGCThreadsAndReleaseSingleThread(MM_EnvironmentBase *env, const char *id);
+
+	virtual void addToNotifyStallTime(MM_EnvironmentBase *env, uint64_t startTime, uint64_t endTime);
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+
+	virtual uintptr_t getRecommendedWorkingThreads() { return _recommendedThreads; };
 
 	/**
 	 * Create a ParallelScavengeTask object.
 	 */
-	MM_ParallelScavengeTask(MM_EnvironmentBase *env, MM_ParallelDispatcher *dispatcher, MM_Scavenger *collector,MM_CycleState *cycleState) :
+	MM_ParallelScavengeTask(MM_EnvironmentBase *env, MM_ParallelDispatcher *dispatcher, MM_Scavenger *collector,MM_CycleState *cycleState, uintptr_t recommendedThreads) :
 		MM_ParallelTask(env, dispatcher)
 		,_collector(collector)
 		,_cycleState(cycleState)
+		,_recommendedThreads(recommendedThreads)
 	{
 		_typeId = __FUNCTION__;
 	};

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -66,6 +66,10 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_depthDeepestStructure(0)
 	,_copyScanUpdates(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+	,_workerScavengeStartTime(0)
+	,_workerScavengeEndTime(0)
+	,_notifyStallTime(0)
+	,_adjustedSyncStallTime(0)
 	,_avgInitialFree(0)
 	,_avgTenureBytes(0)
 	,_avgTenureBytesDeviation(0)
@@ -194,6 +198,11 @@ MM_ScavengerStats::clear(bool firstIncrement)
 
 	_slotsCopied = 0;
 	_slotsScanned = 0;
+
+	_adjustedSyncStallTime = 0;
+	_notifyStallTime = 0;
+	_workerScavengeEndTime = 0;
+	_workerScavengeStartTime = 0;
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	_readObjectBarrierCopy = 0;

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -75,6 +75,7 @@ public:
 	uintptr_t _failedFlipCount;
 	uintptr_t _failedFlipBytes;
 	uintptr_t _tenureAge;
+	/* The following start/end times are not used as thread local, but to record total cycle duration, done only by main thread. Ideally, these should be moved to the collector. */
 	uint64_t _startTime;
 	uint64_t _endTime;
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
@@ -97,6 +98,17 @@ public:
 	uintptr_t _depthDeepestStructure; /**< Length of longest deep structure that is special treated */
 	uintptr_t _copyScanUpdates;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+
+	/* Stats Used Specifically for Adaptive Threading */
+	uint64_t _workerScavengeStartTime; /**< Timestamp taken when worker starts the scavenge task */
+	uint64_t _workerScavengeEndTime; /**< Timestamp taken when worker completes the scavenge task */
+
+	/* The time, in hi-res ticks, the thread spent stalled notifying other
+	 * threads during scavenge. Note: this is not all inclusive, it records notify
+	 * stall times only relevant to adaptive threading (e.g doesn't include backout cases)
+	 */
+	uint64_t _notifyStallTime;
+	uint64_t _adjustedSyncStallTime; /**< The time, in hi-res ticks, the thread spent stalled at a sync point ADJUSTED to account for critical section time */
 
 	/* Average (weighted) number of bytes free after a collection and
 	 * average number of bytes promoted by a collection. Used by 
@@ -182,12 +194,19 @@ public:
 	}
 
 	MMINLINE void 
-	addToSyncStallTime(uint64_t startTime, uint64_t endTime)
+	addToSyncStallTime(uint64_t startTime, uint64_t endTime, uint64_t criticalSectionDuration = 0)
 	{
 		_syncStallCount += 1;
 		_syncStallTime += (endTime - startTime);
+		_adjustedSyncStallTime += ((endTime - startTime) - criticalSectionDuration);
 	}
 	
+	MMINLINE void
+	addToNotifyStallTime(uint64_t startTime, uint64_t endTime)
+	{
+		_notifyStallTime += (endTime - startTime);
+	}
+
 	/**
 	 * Get the total stall time
 	 * @return the time in hi-res ticks


### PR DESCRIPTION
#### **_For background and results see https://github.com/eclipse/omr/issues/5829_** 

> Using overhead data (busy/stall times for managing and synchronizing threads), Adaptive Threading aims to identify sub-optimal/detrimental parallelism and continuously adjusts the GC thread count to reach optimal parallelism.

_Adaptive Threading changes are implemented at the various phases of GC as follows, during:_

1. **Pre-collection _(during to task/thread dispatch)_:** to adjust thread count based on the previous cycle’s recommendation
2. **Collection:** to gather data for parallelization overhead for the running cycle
3. **Post-collection _(after worker threads are suspended)_:** to project/calculate optimal thread count and give recommendation for the next cycle based on the current GC that’s completed

 Adaptive threading will be enabled by default. The user may choose to enable/disable adaptive threading through the `-XX:[+-]AdaptiveGCThreading` options. However Adaptive Threading is ignored, even if it is enabled, when GC thread count is forced (e.g user specifics Xgcthreads). The user can also specify upper thread limit for adaptive threading using  `-Xgcmaxthreads` option.

_The specifics of the implementation are as follows:_

#### Introduced concept of recommended threads:
 -  Thread count associated with a parallel task instance, indicates the projected optimal number of threads to complete the task. 
 - Drives Adaptive Threading - changes with each dispatch of the task, based on observations made when previously completing the same task
 - Currently, adaptive threading is only used with  _Scavenger_,  hence this is only applies to tasks of type `MM_ParallelScavengeTask` so a recommended thread count is provided with a new `ParallelScavengeTask` instance (i.e when scavenge is run)
 -  `getRecommendedWorkingThreads` introduced to `MM_Task` base class, base implementation returns `UDATA_MAX` (signifies no adaptive threading), overridden  by `ParallelScavengeTask` to return adaptive thread count.

#### Introduced the following ScavengerStats (New set of stats gathered during collection):
- ` _workerScavengeStartTime` and `_workerScavengeEndTime`
  - Thread local task (scavenge) start/end timestamps taken when worker thread starts/competes a task (scavenge). This is used to determine the time it takes a worker to start collection task from the time a cycle starts and how long a worker waits for others when it is completed its task.
- `_adjustedSyncStallTime`
  - Similar to the existing `_SyncStallTime` stat **except** it accounts for Critical Section duration. That is, it subtracts   critical section duration from stall time of synced thread. This is because the stall time being added from critical section is independent of number of the threads being synchronized. This independent stall time can not be adjusted for, hence it must be ignored. This is relevant for `syncAndRealeaseSingle/Master` APIs as they are the only APIs that record a stall time with critical sections, without these, `_SyncStallTime` == `_adjustedSyncStallTime`
  - existing `addToSyncStallTime` method extended  to update `_adjustedSyncStallTime` in addition to `_SyncStallTime`.  `addToSyncStallTime` now takes  `criticalSectionDuration` (defaults to 0) as an input, a value for it passed when a critical section is executed prior to updating stall stats .
 - `_notifyStallTime `
   - Used to record the stall times resulting from notifying other waiting threads. Note, this stat is not inclusive, it only records notify times relevant to adaptive threading.
   - We are more concerned about recording 'notify_all' rather than 'notify_one' as 'notify_all' is dependent on the number of threads being notified.

#### Collector changes, Scavenger updates:
- Introduced `calculateRecommendedWorkingThreads` routine
  - Called at the end of each successful scavenge to project optimal threads for next scavenge
  - Implements Adaptive Model _(see background for more info)_
  - Calculates averages of stall stats and uses them as inputs to adaptive model, projected optimal thread count output is stored to new member `_recommendedThreads`.
- Timestamps taken for worker thread scavenge start/end time
 - `notifyStallTime` recorded  for `notify_all` on `_scanCacheMonitor` _(some instances are ignored as they are not relevant to adaptive threading such as backout cases)_
- `MergeThreadGCStats` updated to merge new scavenger stats (discussed above)
  - trace point added here to breakdown thread local stats for adaptive threading

#### Dispatcher's `recomputeActiveThreadCountForTask` updated to account for Adaptive Threading
- Dispatcher now queries the task for the recommended thread count when determining the number of threads to release from thread pool to complete the task
  - Ensures thread count is bounded properly to respect max thread count, either user provided adaptiveThreadCount or default max.

#### Synchronization API updates:
- `_syncCriticalSectionStartTime` & `_syncCriticalSectionDuration` introduced to record Critical Section times for adjusted stall time
  -  `_syncCriticalSectionStartTime` recorded when all threads are synced and the released thread is about to exit sync api to execute critical section
  - `_syncCriticalSectionDuration` is recored when thread executing critical section is about to release the synced thread (indicating critical section is complete). As synced threads are released, they update their stall time with the newly set critical section duration.
- `notifyStallTime` recorded  for `notify_all` on synced threads  

Signed-off-by: Salman Rana <salman.rana@ibm.com>