### PR TITLE
Increase build & test timeout to 2 hours

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -319,7 +319,7 @@ timestamps {
                 scmVars = null
                 ws(customWorkspace) {
                     try {
-                        timeout(time: 1, unit: 'HOURS') {
+                        timeout(time: 2, unit: 'HOURS') {
                             def tmpDesc = (currentBuild.description) ? currentBuild.description + "<br>" : ""
                             currentBuild.description = tmpDesc + "<a href=${JENKINS_URL}computer/${NODE_NAME}>${NODE_NAME}</a>"
 


### PR DESCRIPTION
Particularly due to riscv hitting the 1 hour timeout.

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>