### PR TITLE
Get TR_OpaqueMethodBlock correctly under relocatable compilations

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -460,7 +460,13 @@ void TR_OSRCompilationData::checkOSRLimits()
       {
       TR_InlinedCallSite &callSite = comp->getInlinedCallSite(i);
       TR_ByteCodeInfo &bcInfo = callSite._byteCodeInfo;
-      frameSizes[i] = TR::Compiler->vm.OSRFrameSizeInBytes(comp, callSite._methodInfo);
+
+      TR_OpaqueMethodBlock *methodInfo
+            = comp->compileRelocatableCode()
+              ? reinterpret_cast<TR_AOTMethodInfo *>(callSite._methodInfo)->resolvedMethod->getPersistentIdentifier()
+              : callSite._methodInfo;
+
+      frameSizes[i] = TR::Compiler->vm.OSRFrameSizeInBytes(comp, methodInfo);
       frameSizes[i] += (bcInfo.getCallerIndex() == -1) ? rootFrameSize : frameSizes[bcInfo.getCallerIndex()];
       stackFrameSizes[i] = getOSRStackFrameSize(i + 1);
       stackFrameSizes[i] = (bcInfo.getCallerIndex() == -1) ? rootStackFrameSize : stackFrameSizes[bcInfo.getCallerIndex()];


### PR DESCRIPTION
The `_methodInfo` field of `TR_InlinedCallSite` actually holds a `TR_ResolvedMethod` under relocatable compilation. As such, `checkOSRLimits` was incorrect passing in the `TR_ResolvedMethod` to `OSRFrameSizeInBytes`. This PR fixes this.

I recognize that this is a band-aid solution to a deeper problem. However, I'm opening this PR as a tactical fix because
1. There are a lot of crashes in OpenJ9 under JITServer when running FSD tests
2. There is some urgency to get the FSD feature functional in OpenJ9 for the next release, as well as for IBM releases which is based off of OpenJ9.

This PR solves the immediate JITServer issues and fixes what could be an extremely subtle bug - the emergency OSR buffer only comes into play when a thread that's trying to OSR out to the runtime fails to allocate a buffer necessary to record the current stack/local variables.

I've opened https://github.com/eclipse/omr/issues/5844 to address fixing the underlying issue.
