### PR TITLE
Increase size of buffer in block validation

### DIFF
--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2595,8 +2595,8 @@ TR_Debug::verifyBlocksPass2(TR::Node *node)
 
       if (node->getLocalIndex() != 0)
          {
-         char buffer[100];
-         sprintf(buffer, "BLOCK VERIFICATION ERROR -- node [%s] accessed outside of its (extended) basic block: %d time(s)",
+         char buffer[150];
+         sprintf(buffer, "BLOCK VERIFICATION ERROR -- node [%s] accessed outside of its (extended) basic block: %d time(s)\n",
                  getName(node), node->getLocalIndex());
          if (getFile() != NULL)
             trfprintf(getFile(), buffer);


### PR DESCRIPTION
Previously, a buffer size of 100 characters was passed to sprintf in the
block validator. However, the format string itself is 94 characters,
which doesn't leave enough room in the buffer for the print arguments.
As a result, running the block validator (e.g. with paranoidOptCheck)
can lead to a buffer overflow.

This commit fixes the issue by increasing the size of the buffer to 150
characters.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>