### PR TITLE
Remove unused _gpuParms and _gpuBlockDimX fields from Compilation class

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -360,10 +360,6 @@ OMR::Compilation::Compilation(
 
       if (optimizationPlan->isGPUCompileCPUCode())
           _flags.set(IsGPUCompileCPUCode);
-
-
-      self()->setGPUBlockDimX(optimizationPlan->getGPUBlockDimX());
-      self()->setGPUParms(optimizationPlan->getGPUParms());
       }
 
    // if we are not in the selective NoOptServer mode

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -290,7 +290,7 @@ class OMR_EXTENSIBLE Compilation
    friend class ::TR_DebugExt;
 
 protected:
-   
+
    inline TR::Compilation *self();
 
 public:
@@ -314,7 +314,7 @@ public:
 
    ~Compilation() throw();
 
-   
+
 
    TR::Region &region() { return _heapMemoryRegion; }
 
@@ -1007,10 +1007,6 @@ public:
 #endif
 
    bool isGPUCompileCPUCode() { return _flags.testAny(IsGPUCompileCPUCode);}
-   void setGPUBlockDimX(int32_t dim) { _gpuBlockDimX = dim; }
-   int32_t getGPUBlockDimX() { return _gpuBlockDimX; }
-   void setGPUParms(void * parms) { _gpuParms = parms; }
-   void *getGPUParms() { return _gpuParms; }
    ListHeadAndTail<char*>& getGPUPtxList() { return _gpuPtxList; }
    ListHeadAndTail<int32_t>& getGPUKernelLineNumberList() { return _gpuKernelLineNumberList; } //TODO: fix to get real line numbers
    void incGPUPtxCount() { _gpuPtxCount++; }
@@ -1316,8 +1312,6 @@ private:
 
    TR::IlVerifier                    *_ilVerifier;
 
-   int32_t _gpuBlockDimX;
-   void * _gpuParms;
    ListHeadAndTail<char*> _gpuPtxList;
    ListHeadAndTail<int32_t> _gpuKernelLineNumberList; //TODO: fix to get real line numbers
    int32_t _gpuPtxCount;


### PR DESCRIPTION
Signed-off-by: Daryl Maier <maier@ca.ibm.com>