### PR TITLE
Move snippets-to-be-patched lists from Compilation to CodeGenerator

### DIFF
--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,17 +98,17 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       }
    else
       {
-      if (std::find(comp->getSnippetsToBePatchedOnClassRedefinition()->begin(), comp->getSnippetsToBePatchedOnClassRedefinition()->end(), this) != comp->getSnippetsToBePatchedOnClassRedefinition()->end())
+      if (std::find(cg()->getSnippetsToBePatchedOnClassRedefinition()->begin(), cg()->getSnippetsToBePatchedOnClassRedefinition()->end(), this) != cg()->getSnippetsToBePatchedOnClassRedefinition()->end())
          {
          cg()->jitAddPicToPatchOnClassRedefinition(getData<void *>(), static_cast<void *>(cursor));
          }
 
-      if (std::find(comp->getSnippetsToBePatchedOnClassUnload()->begin(), comp->getSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getSnippetsToBePatchedOnClassUnload()->begin(), cg()->getSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getSnippetsToBePatchedOnClassUnload()->end())
          {
          cg()->jitAddPicToPatchOnClassUnload(getData<void *>(), static_cast<void *>(cursor));
          }
 
-      if (std::find(comp->getMethodSnippetsToBePatchedOnClassUnload()->begin(), comp->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getMethodSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getMethodSnippetsToBePatchedOnClassUnload()->begin(), cg()->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getMethodSnippetsToBePatchedOnClassUnload()->end())
          {
          auto classPointer = cg()->fe()->createResolvedMethod(cg()->trMemory(), getData<TR_OpaqueMethodBlock *>(), comp->getCurrentMethod())->classOfMethod();
          cg()->jitAddPicToPatchOnClassUnload(static_cast<void *>(classPointer), static_cast<void *>(cursor));

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -245,7 +245,10 @@ OMR::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
       _codeGenPhase(self()),
       _symbolDataTypeMap(comp->allocator()),
       _lmmdFailed(false),
-      _objectFormat(NULL)
+      _objectFormat(NULL),
+      _snippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(comp->allocator())),
+      _methodSnippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(comp->allocator())),
+      _snippetsToBePatchedOnClassRedefinition(getTypedAllocator<TR::Snippet*>(comp->allocator()))
    {
    }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1202,6 +1202,12 @@ public:
    bool hasDataSnippets() {return false;}
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
 
+   TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassUnload() { return &_snippetsToBePatchedOnClassUnload; }
+
+   TR::list<TR::Snippet*> *getMethodSnippetsToBePatchedOnClassUnload() { return &_methodSnippetsToBePatchedOnClassUnload; }
+
+   TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition() { return &_snippetsToBePatchedOnClassRedefinition; }
+
    // --------------------------------------------------------------------------
    // Register pressure
    //
@@ -2045,6 +2051,10 @@ public:
     * The binary object format to generate code for in this compilation
     */
    TR::ObjectFormat *_objectFormat;
+
+   TR::list<TR::Snippet *> _snippetsToBePatchedOnClassUnload;
+   TR::list<TR::Snippet *> _methodSnippetsToBePatchedOnClassUnload;
+   TR::list<TR::Snippet *> _snippetsToBePatchedOnClassRedefinition;
 
    };
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -242,7 +242,6 @@ OMR::Compilation::Compilation(
    _staticMethodPICSites(getTypedAllocator<TR::Instruction*>(self()->allocator())),
    _snippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(self()->allocator())),
    _methodSnippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(self()->allocator())),
-   _snippetsToBePatchedOnClassRedefinition(getTypedAllocator<TR::Snippet*>(self()->allocator())),
    _genILSyms(getTypedAllocator<TR::ResolvedMethodSymbol*>(self()->allocator())),
    _noEarlyInline(true),
    _returnInfo(TR_VoidReturn),
@@ -2797,4 +2796,10 @@ const TR::TypeLayout* OMR::Compilation::typeLayout(TR_OpaqueClassBlock * clazz)
       _typeLayoutMap.insert(std::make_pair(clazz, layout));
       return layout;
       }
+   }
+
+TR::list<TR::Snippet*> *
+OMR::Compilation::getSnippetsToBePatchedOnClassRedefinition()
+   {
+   return self()->cg()->getSnippetsToBePatchedOnClassRedefinition();
    }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -290,7 +290,7 @@ class OMR_EXTENSIBLE Compilation
    friend class ::TR_DebugExt;
 
 protected:
-   
+
    inline TR::Compilation *self();
 
 public:
@@ -314,7 +314,7 @@ public:
 
    ~Compilation() throw();
 
-   
+
 
    TR::Region &region() { return _heapMemoryRegion; }
 
@@ -566,9 +566,7 @@ public:
 
    bool isPICSite(TR::Instruction *instruction);
 
-   TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassUnload() { return &_snippetsToBePatchedOnClassUnload; }
-   TR::list<TR::Snippet*> *getMethodSnippetsToBePatchedOnClassUnload() { return &_methodSnippetsToBePatchedOnClassUnload; }
-   TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition() { return &_snippetsToBePatchedOnClassRedefinition; }
+   TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition();
 
    TR_RegisterCandidates *getGlobalRegisterCandidates() { return _globalRegisterCandidates; }
    void setGlobalRegisterCandidates(TR_RegisterCandidates *t) { _globalRegisterCandidates = t; }
@@ -1218,7 +1216,6 @@ private:
    TR::list<TR::Instruction*>               _staticMethodPICSites;
    TR::list<TR::Snippet*>                   _snippetsToBePatchedOnClassUnload;
    TR::list<TR::Snippet*>                   _methodSnippetsToBePatchedOnClassUnload;
-   TR::list<TR::Snippet*>                   _snippetsToBePatchedOnClassRedefinition;
 
    TR::list<TR::ResolvedMethodSymbol*>      _genILSyms;
 

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -276,15 +276,15 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
    if (comp->getOption(TR_EnableHCR))
       {
-      if (std::find(comp->getSnippetsToBePatchedOnClassRedefinition()->begin(), comp->getSnippetsToBePatchedOnClassRedefinition()->end(), this) != comp->getSnippetsToBePatchedOnClassRedefinition()->end())
+      if (std::find(cg()->getSnippetsToBePatchedOnClassRedefinition()->begin(), cg()->getSnippetsToBePatchedOnClassRedefinition()->end(), this) != cg()->getSnippetsToBePatchedOnClassRedefinition()->end())
          {
          cg()->jitAddPicToPatchOnClassRedefinition(((void *) (*(uintptr_t *) cursor)), (void *) (uintptr_t *) cursor);
          }
 
-      if (std::find(comp->getSnippetsToBePatchedOnClassUnload()->begin(), comp->getSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getSnippetsToBePatchedOnClassUnload()->begin(), cg()->getSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getSnippetsToBePatchedOnClassUnload()->end())
          cg()->jitAddPicToPatchOnClassUnload(((void *) (*(uintptr_t *) cursor)), (void *) (uintptr_t *) cursor);
 
-      if (std::find(comp->getMethodSnippetsToBePatchedOnClassUnload()->begin(), comp->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getMethodSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getMethodSnippetsToBePatchedOnClassUnload()->begin(), cg()->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getMethodSnippetsToBePatchedOnClassUnload()->end())
          {
          void *classPointer = (void *) cg()->fe()->createResolvedMethod(cg()->trMemory(), (TR_OpaqueMethodBlock *) (*(uintptr_t *) cursor), comp->getCurrentMethod())->classOfMethod();
          cg()->jitAddPicToPatchOnClassUnload(classPointer, (void *) (uintptr_t *) cursor);
@@ -292,12 +292,12 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       }
    else
       {
-      if (std::find(comp->getSnippetsToBePatchedOnClassUnload()->begin(), comp->getSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getSnippetsToBePatchedOnClassUnload()->begin(), cg()->getSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getSnippetsToBePatchedOnClassUnload()->end())
          {
          cg()->jitAddPicToPatchOnClassUnload(((void *) (*(uintptr_t *) cursor)), (void *) (uintptr_t *) cursor);
          }
 
-      if (std::find(comp->getMethodSnippetsToBePatchedOnClassUnload()->begin(), comp->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getMethodSnippetsToBePatchedOnClassUnload()->end())
+      if (std::find(cg()->getMethodSnippetsToBePatchedOnClassUnload()->begin(), cg()->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != cg()->getMethodSnippetsToBePatchedOnClassUnload()->end())
          {
          void *classPointer = (void *) cg()->fe()->createResolvedMethod(cg()->trMemory(), (TR_OpaqueMethodBlock *) (*(uintptr_t *) cursor), comp->getCurrentMethod())->classOfMethod();
          cg()->jitAddPicToPatchOnClassUnload(classPointer, (void *) (uintptr_t *) cursor);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -3838,9 +3838,9 @@ OMR::Z::CodeGenerator::createLiteralPoolSnippet(TR::Node * node)
                targetSnippet = self()->Create4ByteConstant(node, value, true);
                }
             if (node->isMethodPointerConstant())
-               self()->comp()->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetSnippet);
+               self()->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetSnippet);
             else
-               self()->comp()->getSnippetsToBePatchedOnClassUnload()->push_front(targetSnippet);
+               self()->getSnippetsToBePatchedOnClassUnload()->push_front(targetSnippet);
             }
          else
             {
@@ -5794,4 +5794,3 @@ OMR::Z::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddress, intp
       !self()->comp()->target().cpu.isTargetWithinBranchRelativeRILRange(targetAddress, sourceAddress) ||
       self()->comp()->getOption(TR_StressTrampolines);
    }
-

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -360,7 +360,7 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
 
    return returnInstruction;
    }
-   
+
 /**
  * Generate a compare and a branch instruction.  if z10 is available, this will
  * attempt to generate a COMPARE AND BRANCH instruction, otherwise the a
@@ -2345,7 +2345,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    // HCR in generateRegLitRefInstruction 32-bit: register const data snippet for common case
    if (comp->getOption(TR_EnableHCR) && isPICCandidate )
       {
-      comp->getSnippetsToBePatchedOnClassRedefinition()->push_front(targetsnippet);
+      cg->getSnippetsToBePatchedOnClassRedefinition()->push_front(targetsnippet);
       if (node->isClassUnloadingConst())
          {
          TR_OpaqueClassBlock* unloadableClass = NULL;
@@ -2355,13 +2355,13 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
             unloadableClass = (TR_OpaqueClassBlock *) cg->fe()->createResolvedMethod(cg->trMemory(), (TR_OpaqueMethodBlock *)(intptr_t)imm,
                comp->getCurrentMethod())->classOfMethod();
             if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-               comp->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
+               cg->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
             }
          else
             {
             unloadableClass = (TR_OpaqueClassBlock *) (intptr_t)imm;
             if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-               comp->getSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
+               cg->getSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
             }
          }
       }
@@ -2501,7 +2501,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       // HCR in generateRegLitRefInstruction 64-bit: register const data snippet used by z10
       if (comp->getOption(TR_EnableHCR) && isPICCandidate)
          {
-         comp->getSnippetsToBePatchedOnClassRedefinition()->push_front(constDataSnip);
+         cg->getSnippetsToBePatchedOnClassRedefinition()->push_front(constDataSnip);
          if (node->isClassUnloadingConst())
             {
             TR_OpaqueClassBlock* unloadableClass = NULL;
@@ -2511,13 +2511,13 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
                unloadableClass = (TR_OpaqueClassBlock *) cg->fe()->createResolvedMethod(cg->trMemory(), (TR_OpaqueMethodBlock *) imm,
                   comp->getCurrentMethod())->classOfMethod();
                if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-                  comp->getMethodSnippetsToBePatchedOnClassUnload()->push_front(constDataSnip);
+                  cg->getMethodSnippetsToBePatchedOnClassUnload()->push_front(constDataSnip);
                }
             else
                {
                unloadableClass = (TR_OpaqueClassBlock *) imm;
                if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-                  comp->getSnippetsToBePatchedOnClassUnload()->push_front(constDataSnip);
+                  cg->getSnippetsToBePatchedOnClassUnload()->push_front(constDataSnip);
                }
             }
          }
@@ -2557,7 +2557,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    // HCR in generateRegLitRefInstruction 64-bit: register const data snippet for common case
    if (comp->getOption(TR_EnableHCR) && isPICCandidate )
       {
-      comp->getSnippetsToBePatchedOnClassRedefinition()->push_front(targetsnippet);
+      cg->getSnippetsToBePatchedOnClassRedefinition()->push_front(targetsnippet);
       if (node->isClassUnloadingConst())
          {
          TR_OpaqueClassBlock* unloadableClass = NULL;
@@ -2567,13 +2567,13 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
             unloadableClass = (TR_OpaqueClassBlock *) cg->fe()->createResolvedMethod(cg->trMemory(), (TR_OpaqueMethodBlock *) imm,
                comp->getCurrentMethod())->classOfMethod();
             if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-               comp->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
+               cg->getMethodSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
             }
          else
             {
             unloadableClass = (TR_OpaqueClassBlock *) imm;
             if (!TR::Compiler->cls.sameClassLoaders(comp, unloadableClass, comp->getCurrentMethod()->classOfMethod()))
-               comp->getSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
+               cg->getSnippetsToBePatchedOnClassUnload()->push_front(targetsnippet);
             }
          }
       }
@@ -3041,13 +3041,13 @@ generateReplicateNodeInVectorReg(TR::Node * node, TR::CodeGenerator *cg, TR::Reg
  * \brief
  *    Shift the source register to the left and put its selected bits into the target register
  *    and clear the rest of target register's bits.
- * 
+ *
  * \note
  *    In this API, we try to follow the restrictions which can be applied to all paths. The restrictions include:
  *    1. If targetRegister and sourceRegister designate the same reg, it will first shift and then the selected bits of the shifted value are inserted
  *       into the corresponding bits of the unshifted register contents.
  *    2. The shift direction of sourceRegister cannot be negative(right) direction. So shiftAmount cannot be negative.
- *    3. toBit must be larger or equal to fromBit in the API. 
+ *    3. toBit must be larger or equal to fromBit in the API.
  *    4. Considering restrictions above, we can conclude the following value restrictions for the parameters:
  *       1) fromBit <= toBit    2) 0 <= fromBit <= 0b00111111 = 63     3) 0 <= toBit <= 0b00111111 = 63      4) shiftAmount >= 0
 */
@@ -3073,9 +3073,9 @@ void generateShiftThenKeepSelected64Bit(TR::Node * node, TR::CodeGenerator *cg,
  * \brief
  *    Shift the source register to the left and put its selected bits into the target register
  *    and clear the rest of target register's bits.
- * 
+ *
  * \note
- *    The usage of this API will be the same as the 64-bit version. 
+ *    The usage of this API will be the same as the 64-bit version.
  *    The API's corresponding value restrictions are:
  *       1) fromBit <= toBit    2) 0 <= fromBit <= 0b00011110 = 31     3) 0 <= toBit <= 0b00011111 = 31      4) shiftAmount >= 0
 */
@@ -3225,7 +3225,7 @@ template TR::Instruction * generateS390CompareAndBranchInstruction<int64_t>(
                     bool needsCC = true,
                     bool targetIsFarAndCold = false,
                     TR::Instruction        *preced = 0,
-                    TR::RegisterDependencyConditions *cond = 0); 
+                    TR::RegisterDependencyConditions *cond = 0);
 
 TR::Instruction*
 generateAlignmentNopInstruction(TR::CodeGenerator *cg, TR::Node *node, uint32_t alignment, TR::Instruction *preced)


### PR DESCRIPTION
* Move snippets-to-be-patched lists from Compilation to CodeGenerator
* Consolidate duplicate code to remember snippets containing class pointers