### PR TITLE
RISC-V: Refactor linkage properties

### DIFF
--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -31,6 +31,58 @@
 #include "il/Node_inlines.hpp"
 #include "il/ParameterSymbol.hpp"
 
+void TR::RVLinkageProperties::initialize()
+   {
+   /*
+    * Note: following code depends on zero initialization of all members!
+    */
+
+   _numAllocatableIntegerRegisters = TR::RealRegister::LastGPR - TR::RealRegister::FirstGPR + 1;
+   _numAllocatableFloatRegisters = TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR + 1;
+
+   _firstIntegerArgumentRegister = 0;
+   _numIntegerArgumentRegisters = 0;
+   _firstIntegerReturnRegister = 0;
+   int numIntegerReturnRegisters = 0;
+
+   for (auto regNum = TR::RealRegister::FirstGPR; regNum <= TR::RealRegister::LastGPR; regNum++)
+      {
+      if (_registerFlags[regNum] & RV_Reserved)
+         {
+         _numAllocatableIntegerRegisters--;
+         }
+      if (_registerFlags[regNum] & IntegerArgument)
+         {
+         _argumentRegisters[_firstIntegerArgumentRegister + _numIntegerArgumentRegisters++] = regNum;
+         }
+      if (_registerFlags[regNum] & IntegerReturn)
+         {
+         _returnRegisters[_firstIntegerReturnRegister + numIntegerReturnRegisters++] = regNum;
+         }
+      }
+
+   _firstFloatArgumentRegister = _firstIntegerArgumentRegister + _numIntegerArgumentRegisters;
+   _numFloatArgumentRegisters = 0;
+   _firstFloatReturnRegister = _firstIntegerArgumentRegister + numIntegerReturnRegisters;
+   int numFloatReturnRegisters = 0;
+
+   for (auto regNum = TR::RealRegister::FirstFPR; regNum <= TR::RealRegister::LastFPR; regNum++)
+         {
+         if (_registerFlags[regNum] & RV_Reserved)
+            {
+            _numAllocatableFloatRegisters--;
+            }
+         if (_registerFlags[regNum] & FloatArgument)
+            {
+            _argumentRegisters[_firstFloatArgumentRegister + _numFloatArgumentRegisters++] = regNum;
+            }
+         if (_registerFlags[regNum] & FloatReturn)
+            {
+            _returnRegisters[_firstFloatReturnRegister + numFloatReturnRegisters++] = regNum;
+            }
+         }
+   }
+
 void OMR::RV::Linkage::mapStack(TR::ResolvedMethodSymbol *method)
    {
    /* do nothing */

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -298,9 +298,7 @@ struct RVLinkageProperties
     * after _registerFlags are populated.
     */
    void initialize();
-
    }; // struct RVLinkageProperties
-
 }; // namespace TR
 
 namespace OMR

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -79,6 +79,39 @@ class RVMemoryArgument
 #define CallerAllocatesBackingStore 0x20
 #define RV_Reserved                 0x40
 
+#define FOR_EACH_REGISTER(machine, block)                                        \
+   for (int regNum = TR::RealRegister::FirstGPR; regNum <= TR::RealRegister::LastGPR; regNum++) \
+      {                                                                          \
+      TR::RealRegister *reg                                                      \
+                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
+      { block; }                                                                 \
+      }                                                                          \
+   for (int regNum = TR::RealRegister::FirstFPR; regNum <= TR::RealRegister::FirstFPR; regNum++) \
+      {                                                                          \
+      TR::RealRegister *reg                                                      \
+                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
+      { block; }                                                                 \
+      }
+
+#define FOR_EACH_RESERVED_REGISTER(machine, props, block)                        \
+   FOR_EACH_REGISTER(machine,                                                    \
+   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] & RV_Reserved)     \
+      { block; }                                                                 \
+   )
+
+#define FOR_EACH_CALLEE_SAVED_REGISTER(machine, props, block)                    \
+   FOR_EACH_REGISTER(machine,                                                    \
+   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] == Preserved)      \
+      { block; }                                                                 \
+   )
+
+#define FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(machine, props, block)           \
+   FOR_EACH_CALLEE_SAVED_REGISTER(machine, props,                                \
+   if (reg->getHasBeenAssignedInMethod())                                        \
+      { block; }                                                                 \
+   )
+
+
 struct RVLinkageProperties
    {
    uint32_t _properties;

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -292,9 +292,16 @@ struct RVLinkageProperties
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 
    uint32_t getNumberOfDependencyGPRegisters() const {return _numberOfDependencyGPRegisters;}
-   };
 
-}
+   /**
+    * @brief Initialize derived properties from register flags. This *must* be called
+    * after _registerFlags are populated.
+    */
+   void initialize();
+
+   }; // struct RVLinkageProperties
+
+}; // namespace TR
 
 namespace OMR
 {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -53,100 +53,105 @@ addDependency(
    dep->addPreCondition(vreg, rnum);
    dep->addPostCondition(vreg, rnum);
    }
+
+TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
+   : TR::RVLinkageProperties()
+   {
+   _properties = IntegersInRegisters|FloatsInRegisters|RightToLeft;
+
+   _registerFlags[TR::RealRegister::zero] = Preserved|RV_Reserved; // zero
+   _registerFlags[TR::RealRegister::ra]   = Preserved|RV_Reserved; // return address
+   _registerFlags[TR::RealRegister::sp]   = Preserved|RV_Reserved; // sp
+   _registerFlags[TR::RealRegister::gp]   = Preserved|RV_Reserved; // gp
+   _registerFlags[TR::RealRegister::tp]   = Preserved|RV_Reserved; // tp
+
+   _registerFlags[TR::RealRegister::t0]   = Preserved|RV_Reserved; // fp
+   _registerFlags[TR::RealRegister::t1]   = 0;
+   _registerFlags[TR::RealRegister::t2]   = 0;
+
+   _registerFlags[TR::RealRegister::s0]   = Preserved;
+   _registerFlags[TR::RealRegister::s1]   = Preserved;
+
+   _registerFlags[TR::RealRegister::a0]   = IntegerArgument | IntegerReturn;
+   _registerFlags[TR::RealRegister::a1]   = IntegerArgument | IntegerReturn;
+   _registerFlags[TR::RealRegister::a2]   = IntegerArgument;
+   _registerFlags[TR::RealRegister::a3]   = IntegerArgument;
+   _registerFlags[TR::RealRegister::a4]   = IntegerArgument;
+   _registerFlags[TR::RealRegister::a5]   = IntegerArgument;
+   _registerFlags[TR::RealRegister::a6]   = IntegerArgument;
+   _registerFlags[TR::RealRegister::a7]   = IntegerArgument;
+
+   _registerFlags[TR::RealRegister::s2]   = Preserved;
+   _registerFlags[TR::RealRegister::s3]   = Preserved;
+   _registerFlags[TR::RealRegister::s4]   = Preserved;
+   _registerFlags[TR::RealRegister::s5]   = Preserved;
+   _registerFlags[TR::RealRegister::s6]   = Preserved;
+   _registerFlags[TR::RealRegister::s7]   = Preserved;
+   _registerFlags[TR::RealRegister::s8]   = Preserved;
+   _registerFlags[TR::RealRegister::s9]   = Preserved;
+   _registerFlags[TR::RealRegister::s10]  = Preserved;
+   _registerFlags[TR::RealRegister::s11]  = Preserved;
+
+   _registerFlags[TR::RealRegister::t3]   = 0;
+   _registerFlags[TR::RealRegister::t4]   = 0;
+   _registerFlags[TR::RealRegister::t5]   = 0;
+   _registerFlags[TR::RealRegister::t6]   = 0;
+
+   _registerFlags[TR::RealRegister::ft0]  = 0;
+   _registerFlags[TR::RealRegister::ft1]  = 0;
+   _registerFlags[TR::RealRegister::ft2]  = 0;
+   _registerFlags[TR::RealRegister::ft3]  = 0;
+   _registerFlags[TR::RealRegister::ft4]  = 0;
+   _registerFlags[TR::RealRegister::ft5]  = 0;
+   _registerFlags[TR::RealRegister::ft6]  = 0;
+   _registerFlags[TR::RealRegister::ft7]  = 0;
+
+   _registerFlags[TR::RealRegister::fs0]  = Preserved;
+   _registerFlags[TR::RealRegister::fs1]  = Preserved;
+
+   _registerFlags[TR::RealRegister::fa0]  = FloatArgument | FloatReturn;
+   _registerFlags[TR::RealRegister::fa1]  = FloatArgument | FloatReturn;
+   _registerFlags[TR::RealRegister::fa2]  = FloatArgument;
+   _registerFlags[TR::RealRegister::fa3]  = FloatArgument;
+   _registerFlags[TR::RealRegister::fa4]  = FloatArgument;
+   _registerFlags[TR::RealRegister::fa5]  = FloatArgument;
+   _registerFlags[TR::RealRegister::fa6]  = FloatArgument;
+   _registerFlags[TR::RealRegister::fa7]  = FloatArgument;
+
+   _registerFlags[TR::RealRegister::fs2]  = Preserved;
+   _registerFlags[TR::RealRegister::fs3]  = Preserved;
+   _registerFlags[TR::RealRegister::fs4]  = Preserved;
+   _registerFlags[TR::RealRegister::fs5]  = Preserved;
+   _registerFlags[TR::RealRegister::fs6]  = Preserved;
+   _registerFlags[TR::RealRegister::fs7]  = Preserved;
+   _registerFlags[TR::RealRegister::fs8]  = Preserved;
+   _registerFlags[TR::RealRegister::fs9]  = Preserved;
+   _registerFlags[TR::RealRegister::fs10] = Preserved;
+   _registerFlags[TR::RealRegister::fs11] = Preserved;
+   _registerFlags[TR::RealRegister::ft8]  = 0;
+   _registerFlags[TR::RealRegister::ft9]  = 0;
+   _registerFlags[TR::RealRegister::ft10] = 0;
+   _registerFlags[TR::RealRegister::ft11] = 0;
+
+   _methodMetaDataRegister      = TR::RealRegister::NoReg;
+   _stackPointerRegister        = TR::RealRegister::sp;
+   _framePointerRegister        = TR::RealRegister::s0;
+
+   _computedCallTargetRegister  = TR::RealRegister::NoReg;
+   _vtableIndexArgumentRegister = TR::RealRegister::NoReg;
+   _j9methodArgumentRegister    = TR::RealRegister::NoReg;
+
+   _numberOfDependencyGPRegisters = 32; // To be determined
+   _offsetToFirstLocal            = 0; // To be determined
+
+   initialize();
+   }
+
+
 TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
    {
-   int i;
-
-   _properties._properties = IntegersInRegisters|FloatsInRegisters|RightToLeft;
-
-   _properties._registerFlags[TR::RealRegister::zero] = Preserved|RV_Reserved; // zero
-   _properties._registerFlags[TR::RealRegister::ra]   = Preserved|RV_Reserved; // return address
-   _properties._registerFlags[TR::RealRegister::sp]   = Preserved|RV_Reserved; // sp
-   _properties._registerFlags[TR::RealRegister::gp]   = Preserved|RV_Reserved; // gp
-   _properties._registerFlags[TR::RealRegister::tp]   = Preserved|RV_Reserved; // tp
-
-   _properties._registerFlags[TR::RealRegister::t0]   = Preserved|RV_Reserved; // fp
-   _properties._registerFlags[TR::RealRegister::t1]   = 0;
-   _properties._registerFlags[TR::RealRegister::t2]   = 0;
-
-   _properties._registerFlags[TR::RealRegister::s0]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s1]   = Preserved;
-
-   _properties._registerFlags[TR::RealRegister::a0]   = IntegerArgument | IntegerReturn;
-   _properties._registerFlags[TR::RealRegister::a1]   = IntegerArgument | IntegerReturn;
-   _properties._registerFlags[TR::RealRegister::a2]   = IntegerArgument;
-   _properties._registerFlags[TR::RealRegister::a3]   = IntegerArgument;
-   _properties._registerFlags[TR::RealRegister::a4]   = IntegerArgument;
-   _properties._registerFlags[TR::RealRegister::a5]   = IntegerArgument;
-   _properties._registerFlags[TR::RealRegister::a6]   = IntegerArgument;
-   _properties._registerFlags[TR::RealRegister::a7]   = IntegerArgument;
-
-   _properties._registerFlags[TR::RealRegister::s2]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s3]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s4]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s5]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s6]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s7]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s8]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s9]   = Preserved;
-   _properties._registerFlags[TR::RealRegister::s10]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::s11]  = Preserved;
-
-   _properties._registerFlags[TR::RealRegister::t3]   = 0;
-   _properties._registerFlags[TR::RealRegister::t4]   = 0;
-   _properties._registerFlags[TR::RealRegister::t5]   = 0;
-   _properties._registerFlags[TR::RealRegister::t6]   = 0;
-
-   _properties._registerFlags[TR::RealRegister::ft0]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft1]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft2]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft3]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft4]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft5]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft6]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft7]  = 0;
-
-   _properties._registerFlags[TR::RealRegister::fs0]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs1]  = Preserved;
-
-   _properties._registerFlags[TR::RealRegister::fa0]  = FloatArgument | FloatReturn;
-   _properties._registerFlags[TR::RealRegister::fa1]  = FloatArgument | FloatReturn;
-   _properties._registerFlags[TR::RealRegister::fa2]  = FloatArgument;
-   _properties._registerFlags[TR::RealRegister::fa3]  = FloatArgument;
-   _properties._registerFlags[TR::RealRegister::fa4]  = FloatArgument;
-   _properties._registerFlags[TR::RealRegister::fa5]  = FloatArgument;
-   _properties._registerFlags[TR::RealRegister::fa6]  = FloatArgument;
-   _properties._registerFlags[TR::RealRegister::fa7]  = FloatArgument;
-
-   _properties._registerFlags[TR::RealRegister::fs2]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs3]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs4]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs5]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs6]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs7]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs8]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs9]  = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs10] = Preserved;
-   _properties._registerFlags[TR::RealRegister::fs11] = Preserved;
-   _properties._registerFlags[TR::RealRegister::ft8]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft9]  = 0;
-   _properties._registerFlags[TR::RealRegister::ft10] = 0;
-   _properties._registerFlags[TR::RealRegister::ft11] = 0;
-
-   _properties._methodMetaDataRegister      = TR::RealRegister::NoReg;
-   _properties._stackPointerRegister        = TR::RealRegister::sp;
-   _properties._framePointerRegister        = TR::RealRegister::s0;
-
-   _properties._computedCallTargetRegister  = TR::RealRegister::NoReg;
-   _properties._vtableIndexArgumentRegister = TR::RealRegister::NoReg;
-   _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
-
-   _properties.initialize();
-
-   _properties._numberOfDependencyGPRegisters = 32; // To be determined
    setOffsetToFirstParm(0); // To be determined
-   _properties._offsetToFirstLocal            = 0; // To be determined
    }
 
 

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -58,6 +58,13 @@ TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
    {
    _properties = IntegersInRegisters|FloatsInRegisters|RightToLeft;
 
+   /*
+    * _registerFlags for each register are defined in architectural order,
+    * that is, from x0 to x31, f0 to f31.
+    *
+    * See https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#integer-register-convention
+    */
+
    _registerFlags[TR::RealRegister::zero] = Preserved|RV_Reserved; // zero
    _registerFlags[TR::RealRegister::ra]   = Preserved|RV_Reserved; // return address
    _registerFlags[TR::RealRegister::sp]   = Preserved|RV_Reserved; // sp

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -34,39 +34,6 @@
 #include "il/ParameterSymbol.hpp"
 
 
-//getRegisterNumber
-
-#define FOR_EACH_REGISTER(machine, block)                                        \
-   for (int regNum = TR::RealRegister::x0; regNum <= TR::RealRegister::x31; regNum++) \
-      {                                                                          \
-      TR::RealRegister *reg                                                      \
-                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
-      { block; }                                                                 \
-      }                                                                          \
-   for (int regNum = TR::RealRegister::f0; regNum <= TR::RealRegister::f31; regNum++) \
-      {                                                                          \
-      TR::RealRegister *reg                                                      \
-                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
-      { block; }                                                                 \
-      }
-
-#define FOR_EACH_RESERVED_REGISTER(machine, props, block)                        \
-   FOR_EACH_REGISTER(machine,                                                    \
-   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] & RV_Reserved)     \
-      { block; }                                                                 \
-   )
-
-#define FOR_EACH_CALLEE_SAVED_REGISTER(machine, props, block)                    \
-   FOR_EACH_REGISTER(machine,                                                    \
-   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] == Preserved)      \
-      { block; }                                                                 \
-   )
-
-#define FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(machine, props, block)           \
-   FOR_EACH_CALLEE_SAVED_REGISTER(machine, props,                                \
-   if (reg->getHasBeenAssignedInMethod())                                        \
-      { block; }                                                                 \
-   )
 /**
  * @brief Adds dependency
  */
@@ -86,7 +53,6 @@ addDependency(
    dep->addPreCondition(vreg, rnum);
    dep->addPostCondition(vreg, rnum);
    }
-
 TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)
    {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -55,7 +55,6 @@ addDependency(
    }
 
 TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
-   : TR::RVLinkageProperties()
    {
    _properties = IntegersInRegisters|FloatsInRegisters|RightToLeft;
 
@@ -147,6 +146,8 @@ TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
    initialize();
    }
 
+const TR::RVSystemLinkageProperties
+TR::RVSystemLinkage::_properties;
 
 TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    : TR::Linkage(cg)

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -134,42 +134,6 @@ TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    _properties._registerFlags[TR::RealRegister::ft10] = 0;
    _properties._registerFlags[TR::RealRegister::ft11] = 0;
 
-
-   _properties._numIntegerArgumentRegisters  = 8;
-   _properties._firstIntegerArgumentRegister = 0;
-
-   _properties._argumentRegisters[0]  = TR::RealRegister::a0;
-   _properties._argumentRegisters[1]  = TR::RealRegister::a1;
-   _properties._argumentRegisters[2]  = TR::RealRegister::a2;
-   _properties._argumentRegisters[3]  = TR::RealRegister::a3;
-   _properties._argumentRegisters[4]  = TR::RealRegister::a4;
-   _properties._argumentRegisters[5]  = TR::RealRegister::a5;
-   _properties._argumentRegisters[6]  = TR::RealRegister::a6;
-   _properties._argumentRegisters[7]  = TR::RealRegister::a7;
-
-   _properties._firstIntegerReturnRegister = 0;
-   _properties._returnRegisters[0]  = TR::RealRegister::a0;
-   _properties._returnRegisters[1]  = TR::RealRegister::a1;
-
-   _properties._numFloatArgumentRegisters    = 8;
-   _properties._firstFloatArgumentRegister   = 8;
-
-   _properties._argumentRegisters[8+0]  = TR::RealRegister::fa0;
-   _properties._argumentRegisters[8+1]  = TR::RealRegister::fa1;
-   _properties._argumentRegisters[8+2]  = TR::RealRegister::fa2;
-   _properties._argumentRegisters[8+3]  = TR::RealRegister::fa3;
-   _properties._argumentRegisters[8+4]  = TR::RealRegister::fa4;
-   _properties._argumentRegisters[8+5]  = TR::RealRegister::fa5;
-   _properties._argumentRegisters[8+6]  = TR::RealRegister::fa6;
-   _properties._argumentRegisters[8+7]  = TR::RealRegister::fa7;
-
-   _properties._firstFloatReturnRegister   = 2;
-   _properties._returnRegisters[2+0]  = TR::RealRegister::fa0;
-   _properties._returnRegisters[2+1]  = TR::RealRegister::fa1;
-
-   _properties._numAllocatableIntegerRegisters = 7 + 11 + 6; // t0-t6 + s1-s11 + a2-a7
-   _properties._numAllocatableFloatRegisters   = 32;
-
    _properties._methodMetaDataRegister      = TR::RealRegister::NoReg;
    _properties._stackPointerRegister        = TR::RealRegister::sp;
    _properties._framePointerRegister        = TR::RealRegister::s0;
@@ -177,6 +141,8 @@ TR::RVSystemLinkage::RVSystemLinkage(TR::CodeGenerator *cg)
    _properties._computedCallTargetRegister  = TR::RealRegister::NoReg;
    _properties._vtableIndexArgumentRegister = TR::RealRegister::NoReg;
    _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
+
+   _properties.initialize();
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
    setOffsetToFirstParm(0); // To be determined

--- a/compiler/riscv/codegen/RVSystemLinkage.hpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,11 +38,15 @@ template <class T> class List;
 
 namespace TR {
 
+struct RVSystemLinkageProperties : public RVLinkageProperties {
+   RVSystemLinkageProperties();
+};
+
 class RVSystemLinkage : public TR::Linkage
    {
    protected:
 
-   TR::RVLinkageProperties _properties;
+   TR::RVSystemLinkageProperties _properties;
 
    public:
 

--- a/compiler/riscv/codegen/RVSystemLinkage.hpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.hpp
@@ -46,7 +46,7 @@ class RVSystemLinkage : public TR::Linkage
    {
    protected:
 
-   TR::RVSystemLinkageProperties _properties;
+   static const TR::RVSystemLinkageProperties _properties;
 
    public:
 

--- a/compiler/riscv/codegen/RealRegister.hpp
+++ b/compiler/riscv/codegen/RealRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,4 +57,17 @@ inline TR::RealRegister *toRealRegister(TR::Register *r)
    return static_cast<TR::RealRegister *>(r);
    }
 
+
+inline TR::RealRegister::RegNum& operator++(TR::RealRegister::RegNum& rn)
+   {
+   rn = static_cast<TR::RealRegister::RegNum>(static_cast<int>(rn + 1));
+   return rn;
+   }
+
+inline TR::RealRegister::RegNum operator++(TR::RealRegister::RegNum& in, int)
+   {
+   TR::RealRegister::RegNum out = in;
+   ++in;
+   return out;
+   }
 #endif


### PR DESCRIPTION
This PR contains changes to RISC-V linkage properties - the aim is to reduce code duplication when implementing private linkage in consumer projects (e.g. OpenJ9). 

These changes are along the lines of earlier draft - #5836 which has been discusses on OMR Arch meeting on 2021-03-04 (#5816). 

This PR changes *only* the RISC-V codegen. Last two commits:
 
  * RISC-V: move initialization of (system) linkage properties
  * RISC-V: make system linkage properties static
  
make the linkage property instance shared among all instances of linkage as discusses. This perhaps  makes it quite different from all other backends. If this is considered too radical, I'm happy to drop these commits from this PR - they do not affect usefulness of the rest in consuming projects, just that it seems a logical step to me. 
