### PR TITLE
AArch64: Add class unloading pic site to address constant

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -73,10 +73,11 @@ extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node *nod
  * @param[in] address : address
  * @param[in] trgReg : target register
  * @param[in] reloKind : relocation kind
+ * @param[in] isClassUnloadingConst : true if the node is class unloading const
  * @param[in] cursor : instruction cursor
  * @return generated instruction
  */
-extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, intptr_t address, TR::Register *trgReg, TR_ExternalRelocationTargetKind reloKind, TR::Instruction *cursor=NULL);
+extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, intptr_t address, TR::Register *trgReg, TR_ExternalRelocationTargetKind reloKind, bool isClassUnloadingConst=false, TR::Instruction *cursor=NULL);
 
 /**
  * @brief Generates instructions for adding 64-bit integer value to a register


### PR DESCRIPTION
This commit changes `aconstEvaluator` to load address constant
with `ConstantDataSnippet` if unloading assumption is required.
It also changes `loadAddressConstantInSnippet` to add
class unloading pic site to those snippets.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>