### PR TITLE
Guard adaptiveThreadingEnabled() for OMR_GC_MODRON_SCAVENGER only

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -362,9 +362,9 @@ public:
 	uintptr_t heapAlignment;
 	uintptr_t absoluteMinimumOldSubSpaceSize;
 	uintptr_t absoluteMinimumNewSubSpaceSize;
-	
+
 	float darkMatterCompactThreshold; /**< Value used to trigger compaction when dark matter ratio reaches this percentage of memory pools memory*/
-	
+
 	uintptr_t parSweepChunkSize;
 	uintptr_t heapExpansionMinimumSize;
 	uintptr_t heapExpansionMaximumSize;
@@ -378,12 +378,12 @@ public:
 	uintptr_t heapContractionStabilizationCount; /**< GC count required before the heap is allowed to contract due to excessvie time after last heap expansion */
 
 	float heapSizeStartupHintConservativeFactor; /**< Use only a fraction of hints stored in SC */
-	float heapSizeStartupHintWeightNewValue;		/**< Learn slowly by historic averaging of stored hints */	
+	float heapSizeStartupHintWeightNewValue;		/**< Learn slowly by historic averaging of stored hints */
 	bool useGCStartupHints; /**< Enabled/disable usage of heap sizing startup hints from Shared Cache */
 
 	uintptr_t workpacketCount; /**< this value is ONLY set if -Xgcworkpackets is specified - otherwise the workpacket count is determined heuristically */
 	uintptr_t packetListSplit; /**< the number of ways to split packet lists, set by -XXgc:packetListLockSplit=, or determined heuristically based on the number of GC threads */
-	
+
 	uintptr_t markingArraySplitMaximumAmount; /**< maximum number of elements to split array scanning work in marking scheme */
 	uintptr_t markingArraySplitMinimumAmount; /**< minimum number of elements to split array scanning work in marking scheme */
 
@@ -464,7 +464,7 @@ public:
 	uint32_t maxHotFieldListLength;
 	uintptr_t minCpuUtil;
 	/* End of options relating to dynamicBreadthFirstScanOrdering */
-#if defined(OMR_GC_MODRON_SCAVENGER) 
+#if defined(OMR_GC_MODRON_SCAVENGER)
 	uintptr_t scvTenureRatioHigh;
 	uintptr_t scvTenureRatioLow;
 	uintptr_t scvTenureFixedTenureAge; /**< The tenure age to use for the Fixed scavenger tenure strategy. */
@@ -643,7 +643,7 @@ public:
 	MM_HeapMap* previousMarkMap; /**< the previous valid mark map. This can be used to walk marked objects in regions which have _markMapUpToDate set to true */
 
 	MM_GlobalAllocationManager* globalAllocationManager; /**< Used for attaching threads to AllocationContexts */
-	
+
 #if defined(OMR_GC_REALTIME) || defined(OMR_GC_SEGREGATED_HEAP)
 	uintptr_t managedAllocationContextCount; /**< The number of allocation contexts which will be instantiated and managed by the GlobalAllocationManagerRealtime (currently 2*cpu_count) */
 #endif /* OMR_GC_REALTIME || OMR_GC_SEGREGATED_HEAP */
@@ -722,7 +722,7 @@ public:
 	bool numaForced; /**< if true, specifies if numa is disabled or enabled (actual value stored in NUMA Manager) by command line option */
 
 	bool padToPageSize;
-	
+
 	bool fvtest_disableExplictMainThread; /**< Test option to disable creation of explicit main GC thread */
 
 #if defined(OMR_GC_VLHGC)
@@ -810,7 +810,7 @@ public:
 
 	bool alwaysCallWriteBarrier; /**< was -Xgc:alwayscallwritebarrier specified? */
 	bool alwaysCallReadBarrier; /**< was -Xgc:alwaysCallReadBarrier specified? */
-	
+
 	bool _holdRandomThreadBeforeHandlingWorkUnit; /**< Whether we should randomly hold up a thread entering MM_ParallelTask::handleNextWorkUnit() */
 	uintptr_t _holdRandomThreadBeforeHandlingWorkUnitPeriod; /**< How often (in terms of number of times MM_ParallelTask::handleNextWorkUnit() is called) to randomly hold up a thread entering MM_ParallelTask::handleNextWorkUnit() */
 	bool _forceRandomBackoutsAfterScan; /**< Whether we should force MM_Scavenger::completeScan() to randomly fail due to backout */
@@ -922,7 +922,7 @@ public:
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
-	
+
 	MMINLINE bool
 	isConcurrentScavengerHWSupported()
 	{
@@ -932,7 +932,7 @@ public:
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
-	
+
    MMINLINE bool
    isSoftwareRangeCheckReadBarrierEnabled()
    {
@@ -944,7 +944,7 @@ public:
    }
 
 	bool isConcurrentScavengerInProgress();
-	
+
 	MMINLINE bool
 	isScavengerEnabled()
 	{
@@ -1086,28 +1086,28 @@ public:
 		*start = _guaranteedNurseryStart;
 		*end = _guaranteedNurseryEnd;
 	}
-	
+
 	MMINLINE bool isRememberedSetInOverflowState() { return _isRememberedSetInOverflow; }
 	MMINLINE void setRememberedSetOverflowState() { _isRememberedSetInOverflow = true; }
 	MMINLINE void clearRememberedSetOverflowState() { _isRememberedSetInOverflow = false; }
-	
+
 	MMINLINE void setScavengerBackOutState(BackOutState backOutState) { _backOutState = backOutState; }
 	MMINLINE BackOutState getScavengerBackOutState() { return _backOutState; }
 	MMINLINE bool isScavengerBackOutFlagRaised() { return backOutFlagCleared < _backOutState; }
-	
+
 	MMINLINE bool shouldScavengeNotifyGlobalGCOfOldToOldReference() { return _concurrentGlobalGCInProgress; }
 	MMINLINE void setConcurrentGlobalGCInProgress(bool inProgress) { _concurrentGlobalGCInProgress = inProgress; }
-#endif /* OMR_GC_MODRON_SCAVENGER */
 
 	/**
 	 * Determine whether Adaptive Threading is enabled. AdaptiveGCThreading flag
 	 * is not sufficient; Adaptive threading must be ignored if GC thread count is forced.
 	 * @return TRUE if adaptive threading routines can proceed, FALSE otherwise
 	 */
-	MMINLINE bool adaptiveThreadigEnabled()
+	MMINLINE bool adaptiveThreadingEnabled()
 	{
 		return (adaptiveGCThreading && !gcThreadCountForced);
 	}
+#endif /* OMR_GC_MODRON_SCAVENGER */
 
 	/**
 	 * Returns TRUE if an object is old, FALSE otherwise.
@@ -1130,7 +1130,7 @@ public:
 		return ((uintptr_t)baseSlotPtr >= (uintptr_t)_tenureBase) && ((uintptr_t)topSlotPtr - (uintptr_t)_tenureBase) < _tenureSize;
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	isFvtestForce(uintptr_t *forceMax, uintptr_t *forceCntr)
 	{
 		bool result = false;
@@ -1144,25 +1144,25 @@ public:
 		return result;
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	isFvtestForceSweepChunkArrayCommitFailure()
 	{
 		return isFvtestForce(&fvtest_forceSweepChunkArrayCommitFailure, &fvtest_forceSweepChunkArrayCommitFailureCounter);
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	isFvtestForceMarkMapCommitFailure()
 	{
 		return isFvtestForce(&fvtest_forceMarkMapCommitFailure, &fvtest_forceMarkMapCommitFailureCounter);
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	isFvtestForceMarkMapDecommitFailure()
 	{
 		return isFvtestForce(&fvtest_forceMarkMapDecommitFailure, &fvtest_forceMarkMapDecommitFailureCounter);
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	isFvtestForceReferenceChainWalkerMarkMapCommitFailure()
 	{
 		return isFvtestForce(&fvtest_forceReferenceChainWalkerMarkMapCommitFailure, &fvtest_forceReferenceChainWalkerMarkMapCommitFailureCounter);
@@ -1388,7 +1388,7 @@ public:
 		, incrementScavengerStats()
 		, scavengerStats()
 		, copyScanRatio()
-#endif /* OMR_GC_MODRON_SCAVENGER */		
+#endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMR_GC_VLHGC)
 		, globalVLHGCStats()
 #endif /* OMR_GC_VLHGC */
@@ -1412,7 +1412,7 @@ public:
 		, freeOldHeapSizeOnLastGlobalGC(UDATA_MAX)
 		, concurrentKickoffTenuringHeadroom((float)0.02)
 		, tenureBytesDeviationBoost((float)2)
-#endif /* OMR_GC_MODRON_SCAVENGER */		
+#endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMR_GC_REALTIME)
 		, sATBBarrierRememberedSet(NULL)
 #endif /* defined(OMR_GC_REALTIME) */
@@ -1490,8 +1490,8 @@ public:
 		, heapExpansionStabilizationCount(0)
 		, heapContractionStabilizationCount(3)
 		, heapSizeStartupHintConservativeFactor((float)0.7)
-		, heapSizeStartupHintWeightNewValue((float)0.8)	
-		, useGCStartupHints(true)	
+		, heapSizeStartupHintWeightNewValue((float)0.8)
+		, useGCStartupHints(true)
 		, workpacketCount(0) /* only set if -Xgcworkpackets specified */
 		, packetListSplit(0)
 		, markingArraySplitMaximumAmount(DEFAULT_ARRAY_SPLIT_MAXIMUM_SIZE)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -223,7 +223,7 @@ MM_Scavenger::initialize(MM_EnvironmentBase *env)
 
 	/* initialize the global scavenger gcCount */
 	_extensions->scavengerStats._gcCount = 0;
-	
+
 	if (!_scavengeCacheFreeList.initialize(env, NULL)) {
 		return false;
 	}
@@ -262,7 +262,7 @@ MM_Scavenger::initialize(MM_EnvironmentBase *env)
 	}
 
 	/**
-	 *incrementNewSpaceSize = 
+	 *incrementNewSpaceSize =
 	 *  Xmnx <= 32MB		---> Xmnx
 	 *  32MB < Xmnx < 4GB	---> MAX(Xmnx/16, 32MB)
 	 *  Xmnx >= 4GB			---> 256MB
@@ -409,7 +409,7 @@ MM_Scavenger::mainSetupForGC(MM_EnvironmentStandard *env)
 	_evacuateMemorySubSpace = _activeSubSpace->getMemorySubSpaceAllocate();
 	_survivorMemorySubSpace = _activeSubSpace->getMemorySubSpaceSurvivor();
 	_tenureMemorySubSpace = _activeSubSpace->getTenureMemorySubSpace();
-	
+
 	/* Accumulate pre-scavenge allocation statistics */
 	MM_HeapStats heapStatsSemiSpace;
 	MM_HeapStats heapStatsTenureSpace;
@@ -434,7 +434,7 @@ MM_Scavenger::mainSetupForGC(MM_EnvironmentStandard *env)
 
 	/* Record the tenure mask */
 	_tenureMask = calculateTenureMask();
-	
+
 	_activeSubSpace->mainSetupForGC(env);
 
 	_activeSubSpace->cacheRanges(_evacuateMemorySubSpace, &_evacuateSpaceBase, &_evacuateSpaceTop);
@@ -488,7 +488,7 @@ MM_Scavenger::calculateMaxCacheCount(uintptr_t activeMemorySize)
 void
 MM_Scavenger::calculateRecommendedWorkingThreads(MM_EnvironmentStandard *env)
 {
-	if (!_extensions->adaptiveThreadigEnabled() || _extensions->isConcurrentScavengerEnabled()) {
+	if (!_extensions->adaptiveThreadingEnabled() || _extensions->isConcurrentScavengerEnabled()) {
 		return;
 	}
 
@@ -948,22 +948,22 @@ MM_Scavenger::calcGCStats(MM_EnvironmentStandard *env)
 		/* First collection  ? */
 		if (scavengerGCStats->_gcCount > 1 ) {
 			scavengerGCStats->_avgInitialFree = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgInitialFree, (float)initialFree, INITIAL_FREE_HISTORY_WEIGHT);
-			
+
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
-			tenureAggregateBytes = scavengerGCStats->_tenureAggregateBytes - scavengerGCStats->_tenureLOABytes;															
+			tenureAggregateBytes = scavengerGCStats->_tenureAggregateBytes - scavengerGCStats->_tenureLOABytes;
 			scavengerGCStats->_avgTenureLOABytes = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgTenureLOABytes,
 																		(float)scavengerGCStats->_tenureLOABytes,
 																		TENURE_BYTES_HISTORY_WEIGHT);
 #else /* OMR_GC_LARGE_OBJECT_AREA */
 			tenureAggregateBytes = scavengerGCStats->_tenureAggregateBytes;
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
-			scavengerGCStats->_avgTenureBytes = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgTenureBytes, 
-																					(float)tenureAggregateBytes, 
+			scavengerGCStats->_avgTenureBytes = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgTenureBytes,
+																					(float)tenureAggregateBytes,
 																					TENURE_BYTES_HISTORY_WEIGHT);
 			tenureBytesDeviation = (float)tenureAggregateBytes - scavengerGCStats->_avgTenureBytes;
-			scavengerGCStats->_avgTenureBytesDeviation = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgTenureBytesDeviation, 
-																				MM_Math::abs(tenureBytesDeviation), 
-																				TENURE_BYTES_HISTORY_WEIGHT);																											
+			scavengerGCStats->_avgTenureBytesDeviation = (uintptr_t)MM_Math::weightedAverage((float)scavengerGCStats->_avgTenureBytesDeviation,
+																				MM_Math::abs(tenureBytesDeviation),
+																				TENURE_BYTES_HISTORY_WEIGHT);
 		} else {
 			scavengerGCStats->_avgInitialFree = initialFree;
 
@@ -976,10 +976,10 @@ MM_Scavenger::calcGCStats(MM_EnvironmentStandard *env)
             	omrtty_printf("Tenured bytes: %zu\navgTenureBytes: %zu\ntenureBytesDeviation: %f\navgTenureBytesDeviation: %zu\n",
 				tenureAggregateBytes,
 				scavengerGCStats->_avgTenureBytes,
-				tenureBytesDeviation, 
+				tenureBytesDeviation,
 				scavengerGCStats->_avgTenureBytesDeviation);
 			}
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */	
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 	}
 }
 
@@ -1640,7 +1640,7 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 	uintptr_t initialSizeToCopy = 0;
 	bool allowDuplicate = false;
 	bool allowDuplicateOrConcurrentDisabled = true;
-	
+
 	if (IS_CONCURRENT_ENABLED) {
 		/* For smaller objects, we allow duplicate (copy first and try to win forwarding).
 		 * For larger objects, there is only one copy (threads setup destination header, one wins, and other participate in copying or wait till copy is complete).
@@ -1703,7 +1703,7 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 
 #if defined(OMR_VALGRIND_MEMCHECK)
 		valgrindFreeObject(_extensions,(uintptr_t) forwardedHeader->getObject());
-	
+
 		// Object is definitely dead but at many places (glue : ScavangerRootScanner)
 		// We use it's forwardedHeader to check it.
 		valgrindMakeMemDefined((uintptr_t) forwardedHeader->getObject(), sizeof(MM_ForwardedHeader));
@@ -1756,7 +1756,7 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 			scavStats->getFlipHistory(0)->_flipBytes[oldObjectAge + 1] += objectReserveSizeInBytes;
 		}
 
-		/* depth copy the hot fields of an object if scavenger dynamicBreadthFirstScanOrdering is enabled */	
+		/* depth copy the hot fields of an object if scavenger dynamicBreadthFirstScanOrdering is enabled */
 		depthCopyHotFields(env, forwardedHeader, destinationObjectPtr);
 	} else {
 		/* We have not used the reserved space now, but we will for subsequent allocations. If this space was reserved for an individual object,
@@ -2188,7 +2188,7 @@ MM_Scavenger::shouldDoFinalNotify(MM_EnvironmentStandard *env)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavengeExhaustiveTermination && isCurrentPhaseConcurrent() && !_scavengeCacheFreeList.areAllCachesReturned()) {
-		
+
 		/* GC threads ran out of work, but not all copy caches are back to the global free pool. They are kept by mutator threads.
 		 * Activate Async Signal handler which will force Mutator threads to flush their copy caches for scanning. */
 		_delegate.signalThreadsToFlushCaches(env);
@@ -3199,7 +3199,7 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 
 	MM_CopyScanCacheStandard *cache = _scavengeCacheFreeList.popCache(env);
 
-	if (NULL == cache) {	
+	if (NULL == cache) {
 		env->_scavengerStats._scanCacheOverflow = 1;
 		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 		uint64_t duration = omrtime_current_time_millis();
@@ -3210,7 +3210,7 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 		cache = _scavengeCacheFreeList.popCache(env);
 		if (NULL == cache) {
 			resizePerformed = _scavengeCacheFreeList.resizeCacheEntries(env, 1+_scavengeCacheFreeList.getAllocatedCacheCount(), 0);
-		}		
+		}
 		omrthread_monitor_exit(_freeCacheMonitor);
 		if (resizePerformed) {
 			cache = _scavengeCacheFreeList.popCache(env);
@@ -3797,7 +3797,7 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 					/* A reverse forwarded object is a hole whose 'next' pointer actually points at the original object.
 					 * This keeps tenure space walkable once the reverse forwarded objects are abandoned.
 					 */
-					UDATA evacuateObjectSizeInBytes = _extensions->objectModel.getConsumedSizeInBytesWithHeader(forwardedObject);					
+					UDATA evacuateObjectSizeInBytes = _extensions->objectModel.getConsumedSizeInBytesWithHeader(forwardedObject);
 					MM_HeapLinkedFreeHeader* freeHeader = MM_HeapLinkedFreeHeader::getHeapLinkedFreeHeader(forwardedObject);
 #if defined(OMR_VALGRIND_MEMCHECK)
 					valgrindMempoolAlloc(_extensions,(uintptr_t) originalObject, (uintptr_t) evacuateObjectSizeInBytes);
@@ -3809,7 +3809,7 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 #if defined(OMR_SCAVENGER_TRACE_BACKOUT)
 					omrtty_printf("{SCAV: Back out forward pointer %p[%p]@%p -> %p[%p]}\n", objectPtr, *objectPtr, forwardedObject, freeHeader->getNext(env), freeHeader->getSize());
 					Assert_MM_true(objectPtr == originalObject);
-#endif /* OMR_SCAVENGER_TRACE_BACKOUT */			
+#endif /* OMR_SCAVENGER_TRACE_BACKOUT */
 				}
 			}
 		}
@@ -4292,7 +4292,7 @@ MM_Scavenger::mainThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_AllocateD
 }
 
 void
-MM_Scavenger::processLargeAllocateStatsBeforeGC(MM_EnvironmentBase *env) 
+MM_Scavenger::processLargeAllocateStatsBeforeGC(MM_EnvironmentBase *env)
 {
 	MM_MemorySpace *defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
 	MM_MemorySubSpace *defaultMemorySubspace = defaultMemorySpace->getDefaultMemorySubSpace();
@@ -4303,14 +4303,14 @@ MM_Scavenger::processLargeAllocateStatsBeforeGC(MM_EnvironmentBase *env)
 		/* SemiSpace stats include only Mutator stats (no Collector stats during flipping) */
 		defaultMemorySubspace->getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->mergeLargeObjectAllocateStats(env);
 	}
-	
-	/* TODO: remove the below 2 lines(resetLargeObjectAllocateStats), so that we do not loose direct mutator allocation info */ 
+
+	/* TODO: remove the below 2 lines(resetLargeObjectAllocateStats), so that we do not loose direct mutator allocation info */
 	MM_MemoryPool *tenureMemoryPool = tenureMemorySubspace->getMemoryPool();
 	tenureMemoryPool->resetLargeObjectAllocateStats();
 }
 
-void 
-MM_Scavenger::processLargeAllocateStatsAfterGC(MM_EnvironmentBase *env) 
+void
+MM_Scavenger::processLargeAllocateStatsAfterGC(MM_EnvironmentBase *env)
 {
 	MM_MemorySpace *defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
 	MM_MemorySubSpace *tenureMemorySubspace = defaultMemorySpace->getTenureMemorySubSpace();
@@ -4584,7 +4584,7 @@ MM_Scavenger::internalGarbageCollect(MM_EnvironmentBase *envBase, MM_MemorySubSp
 	 */
 	if (expandFailed()) {
 		Trc_MM_Scavenger_percolate_expandFailed(env->getLanguageVMThread());
-	
+
 		/* We do an aggressive percolate if the last scavenge also percolated */
 		uint32_t aggressivePercolate = _extensions->heap->getPercolateStats()->getScavengesSincePercolate() <= 1 ? J9MMCONSTANT_IMPLICIT_GC_PERCOLATE_AGGRESSIVE : J9MMCONSTANT_IMPLICIT_GC_PERCOLATE;
 
@@ -4660,7 +4660,7 @@ MM_Scavenger::internalGarbageCollect(MM_EnvironmentBase *envBase, MM_MemorySubSp
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 
 	/**
-	 * Language percolation trigger	
+	 * Language percolation trigger
 	 * Allow the CollectorLanguageInterface to advise if percolation should occur.
 	 */
 	PercolateReason percolateReason = NONE_SET;
@@ -5107,7 +5107,7 @@ MM_Scavenger::calculateTenureMaskUsingFixed(uintptr_t tenureAge)
 	return mask;
 }
 
-void 
+void
 MM_Scavenger::resetTenureLargeAllocateStats(MM_EnvironmentBase *env)
 {
 	MM_MemorySpace *defaultMemorySpace = _extensions->heap->getDefaultMemorySpace();
@@ -5638,7 +5638,7 @@ MM_Scavenger::mainThreadConcurrentCollect(MM_EnvironmentBase *env)
 		if (_shouldYield) {
 			if (NULL == _extensions->gcExclusiveAccessThreadId) {
 				/* We terminated concurrent cycle due to a external request. We will not move to 'complete' phase,
-				 * but stay in concurrent scan phase and try to resume work after the external party is done 
+				 * but stay in concurrent scan phase and try to resume work after the external party is done
 				 * (when we are able to regain VM access)
 				 */
 				getConcurrentPhaseStats()->_terminationRequestType = MM_ConcurrentPhaseStatsBase::terminationRequest_External;


### PR DESCRIPTION
When `OMR_GC_MODRON_SCAVENGER` is not enabled the GC fails to compile.

Also, correct the spelling in the function name and fixup references.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>