### PR TITLE
Remove inline keyword from OMR::Optimizer::self in cpp file

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -21,6 +21,7 @@
 
 #include "optimizer/Optimizer.hpp"
 
+#include "optimizer/Optimizer_inlines.hpp"
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -2793,8 +2794,6 @@ OMR::Optimizer::valueNumberInfoBuildType()
    return PrePartitionVN;
    }
 
-
-inline
 TR::Optimizer *OMR::Optimizer::self()
    {
    return (static_cast<TR::Optimizer *>(this));

--- a/compiler/optimizer/Optimizer.hpp
+++ b/compiler/optimizer/Optimizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/optimizer/Optimizer_inlines.hpp
+++ b/compiler/optimizer/Optimizer_inlines.hpp
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_OPTIMIZER_INLINES_INCL
-#define TR_OPTIMIZER_INLINES_INCL
+#ifndef OPTIMIZER_INLINES_INCL
+#define OPTIMIZER_INLINES_INCL
 
 #include "optimizer/OMROptimizer_inlines.hpp"
 


### PR DESCRIPTION
enable self method to be referenced in extended Optimizer

Signed-off-by: Tao Guan <james_mango@yahoo.com>