### PR TITLE
Add memory object type for OpenJ9 JITServer AOT cache

### DIFF
--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -305,8 +305,10 @@ const char * objectName[] =
 
    "Debug",
 
+   // JITServer types
    "ClientSessionData",
    "ROMClass",
+   "JITServerAOTCache",
 
    "SymbolValidationManager",
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -451,8 +451,10 @@ public:
 
       Debug,
 
+      // JITServer types
       ClientSessionData,
       ROMClass,
+      JITServerAOTCache,
 
       SymbolValidationManager,
 


### PR DESCRIPTION
This PR adds a new memory object type that will be used by the JITServer AOT cache in OpenJ9.