### PR TITLE
Remove unused _noEarlyInline field from Compilation class

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -243,7 +243,6 @@ OMR::Compilation::Compilation(
    _snippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(self()->allocator())),
    _methodSnippetsToBePatchedOnClassUnload(getTypedAllocator<TR::Snippet*>(self()->allocator())),
    _genILSyms(getTypedAllocator<TR::ResolvedMethodSymbol*>(self()->allocator())),
-   _noEarlyInline(true),
    _returnInfo(TR_VoidReturn),
    _visitCount(0),
    _nodeCount(0),

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -978,9 +978,6 @@ public:
    void setHasMethodHandleInvoke() { _flags.set(HasMethodHandleInvoke); }
    bool getHasMethodHandleInvoke() { return _flags.testAny(HasMethodHandleInvoke); }
 
-   bool supressEarlyInlining() { return _noEarlyInline; }
-   void setSupressEarlyInlining(bool b) { _noEarlyInline = b; }
-
    void setHasColdBlocks()
       {
       _flags.set(HasColdBlocks);
@@ -1233,8 +1230,6 @@ private:
    TR::list<TR::ResolvedMethodSymbol*>      _genILSyms;
 
    TR::SymbolReferenceTable*            _symRefTab;
-
-   bool                               _noEarlyInline;
 
    TR_ReturnInfo                      _returnInfo;
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -226,7 +226,6 @@ int32_t TR_TrivialInliner::perform()
       inliner.performInlining(sym);
       }
 
-   comp()->setSupressEarlyInlining(false);
    return 1; // cost??
    }
 


### PR DESCRIPTION
Not consumed in OMR or any known downstream project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>