### PR TITLE
AArch64: Add register related virtual method to ARM64MemInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -358,12 +358,12 @@ void TR::ARM64Trg1Src3Instruction::assignRegisters(TR_RegisterKinds kindToBeAssi
 
 bool TR::ARM64MemSrc1Instruction::refsRegister(TR::Register *reg)
    {
-   return (getMemoryReference()->refsRegister(reg) || reg == getSource1Register());
+   return (TR::ARM64MemInstruction::refsRegister(reg) || reg == getSource1Register());
    }
 
 bool TR::ARM64MemSrc1Instruction::usesRegister(TR::Register *reg)
    {
-   return (getMemoryReference()->refsRegister(reg) || reg == getSource1Register());
+   return (TR::ARM64MemInstruction::usesRegister(reg) || reg == getSource1Register());
    }
 
 bool TR::ARM64MemSrc1Instruction::defsRegister(TR::Register *reg)
@@ -534,6 +534,40 @@ TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op,
    {
    mr->bookKeepingRegisterUses(self(), cg);
    TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
+   }
+
+bool TR::ARM64MemInstruction::refsRegister(TR::Register *reg)
+   {
+   return getMemoryReference()->refsRegister(reg);
+   }
+
+bool TR::ARM64MemInstruction::usesRegister(TR::Register *reg)
+   {
+   return getMemoryReference()->refsRegister(reg);
+   }
+
+bool TR::ARM64MemInstruction::defsRegister(TR::Register *reg)
+   {
+   return false;
+   }
+
+bool TR::ARM64MemInstruction::defsRealRegister(TR::Register *reg)
+   {
+   return false;
+   }
+
+void TR::ARM64MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+   {
+   TR::Machine *machine = cg()->machine();
+   TR::MemoryReference *mref = getMemoryReference();
+
+   if (getDependencyConditions())
+      getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
+
+   mref->assignRegisters(this, cg());
+
+   if (getDependencyConditions())
+      getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
    }
 
 // TR::ARM64Trg1MemSrc1Instruction:: member functions

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -3012,7 +3012,35 @@ class ARM64MemInstruction : public TR::Instruction
     * @return offset
     */
    virtual int32_t getOffset() {return getMemoryReference()->getOffset();}
-
+   /**
+    * @brief Answers whether this instruction references the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction references the virtual register
+    */
+   virtual bool refsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction uses the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction uses the virtual register
+    */
+   virtual bool usesRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction defines the virtual register
+    */
+   virtual bool defsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given real register
+    * @param[in] reg : real register
+    * @return true when the instruction defines the real register
+    */
+   virtual bool defsRealRegister(TR::Register *reg);
+   /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
    /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor


### PR DESCRIPTION
Add refsRegister/usesRegister/defsRegister/defsRealRegister/assignRegister
to ARM64MemInstruction class and change child classes to call those methods.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>