### PR TITLE
Map OMRPORT_RESOURCE_ADDRESS_SPACE to RLIMIT_MEMLIMIT for z/OS 64 bit

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -3505,7 +3505,11 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 
 		switch (resourceRequested) {
 		case OMRPORT_RESOURCE_ADDRESS_SPACE:
+#if defined(J9ZOS39064)
+			resource = RLIMIT_MEMLIMIT;
+#else /* defined(J9ZOS39064) */
 			resource = RLIMIT_AS;
+#endif /* defined(J9ZOS39064) */
 			break;
 		case OMRPORT_RESOURCE_CORE_FILE:
 			resource = RLIMIT_CORE;
@@ -3571,7 +3575,11 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 
 		switch (resourceRequested) {
 		case OMRPORT_RESOURCE_ADDRESS_SPACE:
+#if defined(J9ZOS39064)
+			resource = RLIMIT_MEMLIMIT;
+#else /* defined(J9ZOS39064) */
 			resource = RLIMIT_AS;
+#endif /* defined(J9ZOS39064) */
 			break;
 		case OMRPORT_RESOURCE_CORE_FILE:
 			resource = RLIMIT_CORE;


### PR DESCRIPTION
`z/OS` application using `IARV64`/`__moservices` can only allocate memory at `memory above bar` which is specified by `RLIMIT_MEMLIMIT`, not `RLIMIT_AS`.

related https://github.com/eclipse/omr/issues/5881

Signed-off-by: Jason Feng <fengj@ca.ibm.com>