### PR TITLE
AArch64: Use the immediate offset of ldr/str instructions

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -98,6 +98,8 @@ OMR::ARM64::CodeGenerator::initialize()
 
    cg->setSupportsByteswap();
 
+   cg->setSupportsAlignedAccessOnly();
+
    if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
       {
       _numberBytesReadInaccessible = 4096;


### PR DESCRIPTION
This commit changes populateMemoryReference() so that the compiler
generates ldr/str instructions with constant immediate offsets in
accessing arrays with constant indexes.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>