### PR TITLE
Add computedStaticCallSymbol

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -291,6 +291,61 @@
    jProfileValueSymbol,
    jProfileValueWithNullCHKSymbol,
 
+   /** \brief
+    * This symbol represents the tempSlot field in j9vmthread. It will provide a mechanism for the compiler
+    * to insert temporary information that the VM can use - such as the number of args when calling
+    * signature-polymorphic methods that are implemented in the VM as internal natives. The VM can use that
+    * information in a number of ways, such as locating items on the stack.
+    *
+    * \code
+    *    istore  <j9VMThreadTempSlotField>
+    *       iconst <number of args for the call to the signature-polymorphic VM internal native method>
+    *    icall <VM internal native method>
+    *       <object the VM needs to locate>
+    *       <parm1>
+    *       <parm2>
+    *       .
+    *       .
+    * \endcode
+    */
+   j9VMThreadTempSlotFieldSymbol,
+
+   /** \brief
+    * This symbol represents a computed static call for methods that have not been compiled yet, but may
+    * get compiled in the future. This provides a mechanism to create a much faster alternate path in the
+    * trees to invoke methods that have been compiled that would otherwise require going down a more
+    * expensive path (such as through invocation of a VM internal native method, for example).
+    *
+    * \code
+    *    ificmpeq goto block_2
+    *       <object field storing the address of the compiled method>
+    *       iconst 0
+    *
+    *block_1:
+    *   icalli <computedStaticCallSymbol>
+    *       <address of compiled method>
+    *       <param1>
+    *       <param2>
+    *       .
+    *       .
+    *   goto block_3
+    *
+    *block_2:
+    *   icall <original call to VM internal native method>
+    *       <param1>
+    *       <param2>
+    *       .
+    *       .
+    *
+    *block_3:
+    *       .
+    *       .
+    *
+    * \endcode
+    *
+    */
+   computedStaticCallSymbol,
+
    OMRlastPrintableCommonNonhelperSymbol = jProfileValueWithNullCHKSymbol,
 
    firstPerCodeCacheHelperSymbol,

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -388,7 +388,43 @@ class SymbolReferenceTable
        */
       j9VMThreadTempSlotFieldSymbol,
 
-      OMRlastPrintableCommonNonhelperSymbol = j9VMThreadTempSlotFieldSymbol,
+      /** \brief
+       * This symbol represents a computed static call for methods that have not been compiled yet, but may
+       * get compiled in the future. This provides a mechanism to create a much faster alternate path in the
+       * trees to invoke methods that have been compiled that would otherwise require going down a more
+       * expensive path (such as through invocation of a VM internal native method, for example).
+       *
+       * \code
+       *    ificmpeq goto block_2
+       *       <object field storing the address of the compiled method>
+       *       iconst 0
+       *
+       *block_1:
+       *   icalli <computedStaticCallSymbol>
+       *       <address of compiled method>
+       *       <param1>
+       *       <param2>
+       *       .
+       *       .
+       *   goto block_3
+       *
+       *block_2:
+       *   icall <original call to VM internal native method>
+       *       <param1>
+       *       <param2>
+       *       .
+       *       .
+       *
+       *block_3:
+       *       .
+       *       .
+       *
+       * \endcode
+       *
+       */
+      computedStaticCallSymbol,
+
+      OMRlastPrintableCommonNonhelperSymbol = computedStaticCallSymbol,
 
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1660,6 +1660,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<osrFearPointHelper>";
          case TR::SymbolReferenceTable::eaEscapeHelperSymbol:
              return "<eaEscapeHelper>";
+         case TR::SymbolReferenceTable::computedStaticCallSymbol:
+             return "<computedStaticCallSymbol>";
          }
       }
 
@@ -2118,7 +2120,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<atomicCompareAndSwapReturnValue>",
    "<jProfileValueSymbol>",
    "<jProfileValueWithNullCHKSymbol>",
-   "<j9VMThreadTempSlotField>"
+   "<j9VMThreadTempSlotField>",
+   "<computedStaticCallSymbol>"
    };
 
 const char *


### PR DESCRIPTION
This symbol is intended to facilitate setting up computed calls
for methods that are yet to be compiled.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>