### PR TITLE
AArch64: Improve code generation for i2l-lshl sequence

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1110,6 +1110,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(pOutFile, instr->getSource1Register(), TR_WordReg); 
             }
          }
+      if (!done)
+         {
+         done = true;
+         trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+         print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+         print(pOutFile, instr->getSource1Register(), TR_WordReg);
+         trfprintf(pOutFile, ", %d, %d", immr, imms);
+         }
       }
    else if (op == TR::InstOpCode::ubfmx || op == TR::InstOpCode::ubfmw)
       {
@@ -1165,6 +1173,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
             print(pOutFile, instr->getSource1Register(), TR_WordReg);
             }
+         }
+      if (!done)
+         {
+         done = true;
+         trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+         print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+         print(pOutFile, instr->getSource1Register(), TR_WordReg);
+         trfprintf(pOutFile, ", %d, %d", immr, imms);
          }
       }
    else if (op == TR::InstOpCode::andimmx || op == TR::InstOpCode::andimmw ||

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -675,6 +675,28 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
 TR::Register *
 OMR::ARM64::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   if (node->getOpCodeValue() == TR::lshl)
+      {
+      TR::Node *firstChild = node->getFirstChild();
+      TR::Node *secondChild = node->getSecondChild();
+      if (firstChild->getOpCodeValue() == TR::i2l &&
+          firstChild->getRegister() == NULL &&
+          secondChild->getOpCodeValue() == TR::iconst)
+         {
+         // Typical IL sequence in array access (sign-extend index value and shift it to left)
+         TR::Node *indexChild = firstChild->getFirstChild();
+         TR::Register *srcReg = cg->evaluate(indexChild);
+         TR::Register *trgReg = (indexChild->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+         int32_t bitsToShift = secondChild->getInt();
+         int32_t imm = ((64 - bitsToShift) << 6) | 31; // immr = 64 - bitsToShift, imms = 31
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, node, trgReg, srcReg, imm);
+         node->setRegister(trgReg);
+         cg->recursivelyDecReferenceCount(firstChild);
+         cg->decReferenceCount(secondChild);
+         return trgReg;
+         }
+      }
+
    return shiftHelper(node, TR::SH_LSL, cg);
    }
 


### PR DESCRIPTION
This commit improves code generation for the IL sequence i2l-lshl that
often appears in offset calculation for array access, by using `sbfm`
instruction.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>