### PR TITLE
Skip some tests in compilertriltest on AArch64

### DIFF
--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,8 @@ TEST_P(UInt32Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support iudiv/iurem (see issue #3673)";
+    SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support iudiv/iurem (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -202,6 +204,8 @@ TEST_P(UInt32Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support iudiv/iurem (see issue #3673)";
+    SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support iudiv/iurem (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -231,6 +235,8 @@ TEST_P(UInt32Arithmetic, UsingLoadParamAndLoadConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support iudiv/iurem (see issue #3673)";
+    SKIP_IF((param.opcode == "iudiv" || param.opcode == "iurem") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support iudiv/iurem (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -341,6 +347,8 @@ TEST_P(UInt64Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "ludiv" && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support ludiv (see issue #2227)";
+    SKIP_IF(param.opcode == "ludiv" && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support ludiv (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -374,6 +382,8 @@ TEST_P(UInt64Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "ludiv" && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support ludiv (see issue #2227)";
+    SKIP_IF(param.opcode == "ludiv" && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support ludiv (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -403,6 +413,8 @@ TEST_P(UInt64Arithmetic, UsingLoadParamAndLoadConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "ludiv" && (OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), MissingImplementation)
         << "The Power codegen does not yet support ludiv (see issue #2227)";
+    SKIP_IF(param.opcode == "ludiv" && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support ludiv (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -429,6 +441,8 @@ TEST_P(UInt64Arithmetic, UsingLoadParamAndLoadConst) {
 
 TEST_P(Int16Arithmetic, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sadd/ssub/smul (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -457,8 +471,9 @@ TEST_P(Int16Arithmetic, UsingConst) {
 }
 
 TEST_P(Int16Arithmetic, UsingLoadParam) {
-
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sadd/ssub/smul (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -485,6 +500,8 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
 TEST_P(Int16Arithmetic, UsingLoadParamAndLoadConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sadd/ssub/smul (see issue #5891)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
       "(method return=Int16 args=[Int16]"
@@ -510,6 +527,8 @@ TEST_P(Int16Arithmetic, UsingLoadParamAndLoadConst) {
 
 TEST_P(Int8Arithmetic, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support badd/bsub/bmul (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -540,6 +559,8 @@ TEST_P(Int8Arithmetic, UsingConst) {
 TEST_P(Int8Arithmetic, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support badd/bsub/bmul (see issue #5891)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
       "(method return=Int8 args=[Int8, Int8]"
@@ -564,6 +585,8 @@ TEST_P(Int8Arithmetic, UsingLoadParam) {
 
 TEST_P(Int8Arithmetic, UsingLoadParamAndLoadConst) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support badd/bsub/bmul (see issue #5891)";
 
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -898,6 +898,10 @@ TEST_P(FloatCompare, UsingConst) {
         SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "fcmpl" || param.opcode == "fcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support fcmpl/fcmpg (see issue #5895)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, 1024,
        "(method return=Int32 "
@@ -929,6 +933,10 @@ TEST_P(FloatCompare, UsingRhsConst) {
         SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "fcmpl" || param.opcode == "fcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support fcmpl/fcmpg (see issue #5895)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, 1024,
        "(method return=Int32 args=[Float] "
@@ -954,6 +962,10 @@ TEST_P(FloatCompare, UsingRhsConst) {
 
 TEST_P(FloatCompare, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "fcmpl" || param.opcode == "fcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support fcmpl/fcmpg (see issue #5895)";
 
     char inputTrees[160] = {0};
     std::snprintf(inputTrees, 160,
@@ -1056,6 +1068,10 @@ TEST_P(DoubleCompare, UsingConst) {
         SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "dcmpl" || param.opcode == "dcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support dcmpl/dcmpg (see issue #5895)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, 1024,
        "(method return=Int32 "
@@ -1087,6 +1103,10 @@ TEST_P(DoubleCompare, UsingRhsConst) {
         SKIP_ON_WINDOWS(KnownBug) << "TRIL parser cannot handle NaN values on Windows (see issue #5324)";
     }
 
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "dcmpl" || param.opcode == "dcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support dcmpl/dcmpg (see issue #5895)";
+
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, 1024,
        "(method return=Int32 args=[Double] "
@@ -1112,6 +1132,10 @@ TEST_P(DoubleCompare, UsingRhsConst) {
 
 TEST_P(DoubleCompare, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.opcode == "dcmpl" || param.opcode == "dcmpg") && OMRPORT_ARCH_AARCH64 == arch, MissingImplementation)
+        << "The AArch64 codegen does not yet support dcmpl/dcmpg (see issue #5895)";
 
     char inputTrees[160] = {0};
     std::snprintf(inputTrees, 160,

--- a/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
+++ b/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,6 +92,7 @@ class Int8ReductionTest : public IfxcmpgeReductionTest<int8_t> {};
 
 TEST_P(Int8ReductionTest, Reduction)
    {
+   SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support ifbcmpge (see issue #5893)";
    SKIP_ON_RISCV(MissingImplementation);
 
    auto param = to_struct(GetParam());
@@ -138,6 +139,7 @@ class UInt8ReductionTest : public IfxcmpgeReductionTest<uint8_t> {};
 
 TEST_P(UInt8ReductionTest, Reduction)
    {
+   SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support ifbucmpge (see issue #5893)";
    SKIP_ON_RISCV(MissingImplementation);
 
    auto param = to_struct(GetParam());
@@ -184,6 +186,7 @@ class Int16ReductionTest : public IfxcmpgeReductionTest<int16_t> {};
 
 TEST_P(Int16ReductionTest, Reduction)
    {
+   SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support ifscmpge (see issue #5893)";
    SKIP_ON_RISCV(MissingImplementation);
 
    auto param = to_struct(GetParam());
@@ -230,6 +233,7 @@ class UInt16ReductionTest : public IfxcmpgeReductionTest<uint16_t> {};
 
 TEST_P(UInt16ReductionTest, Reduction)
    {
+   SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support ifsucmpge (see issue #5893)";
    SKIP_ON_RISCV(MissingImplementation);
 
    auto param = to_struct(GetParam());

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -199,6 +199,7 @@ class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
 TEST_P(FloatMaxMin, UsingConst) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support fmax/fmin (see issue #5894)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -234,6 +235,7 @@ TEST_P(FloatMaxMin, UsingConst) {
 TEST_P(FloatMaxMin, UsingLoadParam) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support fmax/fmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support fmax/fmin (see issue #4276)";
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support fmax/fmin (see issue #5894)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -277,6 +279,7 @@ class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
 TEST_P(DoubleMaxMin, UsingConst) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support dmax/dmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support dmax/dmin (see issue #4276)";
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support dmax/dmin (see issue #5894)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -312,6 +315,7 @@ TEST_P(DoubleMaxMin, UsingConst) {
 TEST_P(DoubleMaxMin, UsingLoadParam) {
     SKIP_ON_X86(KnownBug) << "The X86 code generator currently doesn't support dmax/dmin (see issue #4276)";
     SKIP_ON_HAMMER(KnownBug) << "The AMD64 code generator currently doesn't support dmax/dmin (see issue #4276)";
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support dmax/dmin (see issue #5894)";
 
     auto param = TRTest::to_struct(GetParam());
 

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -299,6 +299,8 @@ class Int8ShiftAndRotate : public ShiftAndRotateArithmetic<int8_t> {};
 TEST_P(Int8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8"
@@ -326,6 +328,8 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -352,6 +356,8 @@ TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
 TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -377,6 +383,8 @@ TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -411,6 +419,8 @@ class Int16ShiftAndRotate : public ShiftAndRotateArithmetic<int16_t> {};
 TEST_P(Int16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16"
@@ -438,6 +448,8 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -464,6 +476,8 @@ TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
 TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int32]"
@@ -489,6 +503,8 @@ TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -737,6 +753,8 @@ class UInt8ShiftAndRotate : public ShiftAndRotateArithmetic<uint8_t> {};
 TEST_P(UInt8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8"
@@ -764,6 +782,8 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -790,6 +810,8 @@ TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
 TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -815,6 +837,8 @@ TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -848,6 +872,8 @@ class UInt16ShiftAndRotate : public ShiftAndRotateArithmetic<uint16_t> {};
 TEST_P(UInt16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16"
@@ -875,6 +901,8 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -901,6 +929,8 @@ TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
 TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int32]"
@@ -926,6 +956,8 @@ TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1272,6 +1304,8 @@ class UInt16MaskThenShift : public MaskThenShiftArithmetic<uint16_t> {};
 TEST_P(UInt16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -1307,6 +1341,8 @@ class Int16MaskThenShift : public MaskThenShiftArithmetic<int16_t> {};
 
 TEST_P(Int16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1344,6 +1380,8 @@ class UInt8MaskThenShift : public MaskThenShiftArithmetic<uint8_t> {};
 TEST_P(UInt8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
+
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -1379,6 +1417,8 @@ class Int8MaskThenShift : public MaskThenShiftArithmetic<int8_t> {};
 
 TEST_P(Int8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
+
+    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),


### PR DESCRIPTION
This commit adds SKIP_ON_AARCH64() and SKIP_IF() to the tests of opcodes
that are not supported yet on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>