### PR TITLE
Relocatable Compilation support for Method Handles in Eclipse OpenJ9

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -490,6 +490,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_InlinedAbstractMethod (106)",
    "TR_Breakpoint (107)",
    "TR_InlinedMethodPointer (108)",
+   "TR_VMINLMethod (109)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,7 +157,7 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
    //
    if ((_methodIndex > JITTED_METHOD_INDEX && !_resolvedMethod->isSameMethod(comp->getJittedMethodSymbol()->getResolvedMethod()))
        || comp->isDLT()
-       || (comp->getOption(TR_UseSymbolValidationManager) && comp->compileRelocatableCode()))
+       || comp->compileRelocatableCode())
       {
       if (_resolvedMethod->isInterpreted())
          {
@@ -165,7 +165,9 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
          self()->setMethodAddress(_resolvedMethod->resolvedMethodAddress());
          }
       else
+         {
          self()->setMethodAddress(_resolvedMethod->startAddressForJittedMethod());
+         }
       }
 
    if (!_resolvedMethod->isJNINative())

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -334,7 +334,8 @@ typedef enum
    TR_InlinedAbstractMethod               = 106,
    TR_Breakpoint                          = 107,
    TR_InlinedMethodPointer                = 108,
-   TR_NumExternalRelocationKinds          = 109,
+   TR_VMINLMethod                         = 109,
+   TR_NumExternalRelocationKinds          = 110,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 


### PR DESCRIPTION
This PR contains changes necessary to support the Method Handle feature in Eclipse OpenJ9 (https://github.com/eclipse/openj9/issues/4850), namely:

- Adding a new relo type, which is used to relocate special methods known to the VM.
- Ensuring consistency between the isInterpreted flag between the resolved method and resolved method symbol.