### PR TITLE
Initialize TR_X86ProcessorInfo once

### DIFF
--- a/compiler/env/JitConfig.hpp
+++ b/compiler/env/JitConfig.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,9 +46,6 @@ class JitConfig
       TR::FILE    * vLogFile;
       uint64_t      verboseFlags;
       } options;
-
-   void *getProcessorInfo() { return _processorInfo; }
-   void setProcessorInfo(void *buf) { _processorInfo = buf; }
 
    void setInterpreterTOC(size_t interpreterTOC) { _interpreterTOC = interpreterTOC; }
    size_t getInterpreterTOC()                    { return _interpreterTOC; }

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -114,6 +114,11 @@ public:
     */
    static TR::CPU detectRelocatable(OMRPortLibrary * const omrPortLib);
 
+   /**
+    * @brief API to initialize platform specific target processor info if it exists
+    */
+   static void initializeTargetProcessorInfo() {}
+
    TR_Processor setProcessor(TR_Processor p) { return(_processor = p); }
 
    // Processor identity and generation comparisons

--- a/compiler/env/OMRCompilerEnv.cpp
+++ b/compiler/env/OMRCompilerEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -124,6 +124,7 @@ OMR::CompilerEnv::initializeTargetEnvironment()
    // Initialize the target CPU by querying the host processor
    //
    target.cpu = TR::CPU::detect(TR::Compiler->omrPortLib);
+   TR::CPU::initializeTargetProcessorInfo();
 
    // Target major operating system
    //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,20 +109,20 @@ namespace TR { class RegisterDependencyConditions; }
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
-void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
+void TR_X86ProcessorInfo::initialize()
    {
    if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))
       return;
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
    //
-   _featureFlags.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags());
-   _featureFlags2.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags2());
-   _featureFlags8.set(cg->comp()->target().cpu.getX86ProcessorFeatureFlags8());
+   _featureFlags.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags());
+   _featureFlags2.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags2());
+   _featureFlags8.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags8());
 
    // Determine the processor vendor.
    //
-   const char *vendor = cg->comp()->target().cpu.getX86ProcessorVendorId();
+   const char *vendor = TR::Compiler->target.cpu.getX86ProcessorVendorId();
    if (!strncmp(vendor, "GenuineIntel", 12))
       _vendorFlags.set(TR_GenuineIntel);
    else if (!strncmp(vendor, "AuthenticAMD", 12))
@@ -139,7 +139,7 @@ void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
 
    // set up the processor family and cache description
 
-   uint32_t _processorSignature = cg->comp()->target().cpu.getX86ProcessorSignature();
+   uint32_t _processorSignature = TR::Compiler->target.cpu.getX86ProcessorSignature();
 
    if (isGenuineIntel())
       {
@@ -206,9 +206,7 @@ void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
 void
 OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
    {
-
    bool supportsSSE2 = false;
-   _targetProcessorInfo.initialize(self());
 
    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.isGenuineIntel() == _targetProcessorInfo.isGenuineIntel(), "isGenuineIntel() failed\n");
    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->target().cpu.isAuthenticAMD() == _targetProcessorInfo.isAuthenticAMD(), "isAuthenticAMD() failed\n");

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -223,7 +223,7 @@ private:
 
    friend class OMR::X86::CodeGenerator;
 
-   void initialize(TR::CodeGenerator *cg);
+   void initialize();
 
    /**
     * @brief testFlag Ensures that the feature being tested for exists in the mask
@@ -343,6 +343,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
 
    static TR_X86ProcessorInfo &getX86ProcessorInfo() {return _targetProcessorInfo;}
+   static void initializeX86TargetProcessorInfo() { _targetProcessorInfo.initialize(); }
 
    typedef enum
       {

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,8 @@ protected:
 public:
 
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
+
+   static void initializeTargetProcessorInfo();
 
    TR_X86CPUIDBuffer *queryX86TargetCPUID();
    const char *getX86ProcessorVendorId();


### PR DESCRIPTION
`TR_X86ProcessorInfo` is currently used in OMR because the compiler does not yet have access to the portlib. Therefore, it has to determine the processor features itself. In order to not initialize `TR_X86ProcessorInfo` multiple times a flag is set. However, it is
a race possible if there are multiple compilations, as is the case in Eclipse OpenJ9. Because the processor feature flags were copied from the target `TR::Environment` set in `TR::Compilation` object, if two racing compilations had different target environments, the feature flags could become inconsistent.

This PR initializes the processor info just once in `OMR::CompilerEnv::initializeTargetEnvironment()`.

This change is based on https://github.com/eclipse/omr/pull/5561 and fixes https://github.com/eclipse/openj9/issues/12334 (not adding the keyword since the OpenJ9 issue should probably only be closed when it accepts the OMR change into `openj9-omr`).