### PR TITLE
PPC: Exclude tril tests

### DIFF
--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -89,6 +89,7 @@ TEST_F(VectorTest, VInt8Add) {
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
 
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
@@ -132,6 +133,7 @@ TEST_F(VectorTest, VInt16Add) {
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
 
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;


### PR DESCRIPTION
This commit excludes tril tests for VectorInt8 & VectorInt16 for PPC
platform as it does not have support for these data types.

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>