### PR TITLE
Improvements to detecting whether array component type is a value type in Value Propagation

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1715,6 +1715,10 @@ TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *
          {
          isValueType = TR_yes;
          }
+      else if (TR::Compiler->cls.isClassArray(comp(), arrayComponentClass))
+         {
+         isValueType = TR_no;
+         }
       else if (!TR::Compiler->cls.isConcreteClass(comp(), arrayComponentClass))
          {
          isValueType = TR_maybe;

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1715,7 +1715,7 @@ TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *
          {
          isValueType = TR_yes;
          }
-      else if (TR::Compiler->cls.isAbstractClass(comp(), arrayComponentClass))
+      else if (!TR::Compiler->cls.isConcreteClass(comp(), arrayComponentClass))
          {
          isValueType = TR_maybe;
          }

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1687,6 +1687,56 @@ TR_YesNoMaybe OMR::ValuePropagation::isCastClassObject(TR::VPClassType *type)
          }
       }
    return TR_maybe;
+   }
+
+
+TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint)
+   {
+   TR_YesNoMaybe isValueType = TR_maybe;
+
+   if (!TR::Compiler->om.areValueTypesEnabled())
+      {
+      isValueType = TR_no;
+      }
+   else if (!(arrayConstraint && arrayConstraint->getClass()
+              && arrayConstraint->getClassType()->isArray() == TR_yes))
+      {
+      isValueType = TR_maybe;
+      }
+   else
+      {
+      TR_OpaqueClassBlock *arrayComponentClass = fe()->getComponentClassFromArrayClass(arrayConstraint->getClass());
+
+      if (!arrayComponentClass)
+         {
+         isValueType = TR_maybe;
+         }
+      else if (TR::Compiler->cls.isValueTypeClass(arrayComponentClass))
+         {
+         isValueType = TR_yes;
+         }
+      else if (TR::Compiler->cls.isAbstractClass(comp(), arrayComponentClass))
+         {
+         isValueType = TR_maybe;
+         }
+      else
+         {
+         int32_t len;
+         const char *sig = arrayConstraint->getClassSignature(len);
+
+         if (!sig || !arrayConstraint->isFixedClass() && sig[0] == '[' && len == 19
+                     && !strncmp(sig, "[Ljava/lang/Object;", 19))
+            {
+            isValueType = TR_maybe;
+            }
+         else
+            {
+            isValueType = TR_no;
+            }
+         }
+      }
+
+   return isValueType;
    }
 
 void OMR::ValuePropagation::checkTypeRelationship(TR::VPConstraint *lhs, TR::VPConstraint *rhs,
@@ -6413,7 +6463,7 @@ void OMR::ValuePropagation::buildBoundCheckComparisonNodes(BlockVersionInfo *blo
 
             temp.add(nextComparisonNode);
 
-            if (arrayIndex->_baseNode && arrayIndex->_instanceOfClass && 
+            if (arrayIndex->_baseNode && arrayIndex->_instanceOfClass &&
                 arrayIndex->_baseNode->getOpCode().getOpCodeValue() == TR::iloadi)
                {
                // InstanceOf check for the object we load the array index from

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -436,7 +436,7 @@ class ValuePropagation : public TR::Optimization
     *          \c TR_no if it is definitely not a value type; or\n
     *          \c TR_maybe otherwise.
     */
-   TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
+   virtual TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
 
    TR::VPConstraint *getStoreConstraint(TR::Node *node, TR::Node *relative = NULL);
    void createStoreConstraints(TR::Node *node);

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -427,6 +427,17 @@ class ValuePropagation : public TR::Optimization
    void invalidateParmConstraintsIfNeeded(TR::Node *node, TR::VPConstraint *constraint);
    void checkTypeRelationship(TR::VPConstraint *lhs, TR::VPConstraint *rhs, int32_t &value, bool isInstanceOf, bool isCheckCast);
    TR_YesNoMaybe isCastClassObject(TR::VPClassType *type);
+
+   /**
+    * Determine whether the component type of an array is, or might be, a value
+    * type.
+    * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
+    * \returns \c TR_yes if the array's component type is definitely a value type;\n
+    *          \c TR_no if it is definitely not a value type; or\n
+    *          \c TR_maybe otherwise.
+    */
+   TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
+
    TR::VPConstraint *getStoreConstraint(TR::Node *node, TR::Node *relative = NULL);
    void createStoreConstraints(TR::Node *node);
    void setUnreachableStore(StoreRelationship *store);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -12189,64 +12189,6 @@ TR::Node *constrainArrayCopyBndChk(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-/**
- * Determine whether the component type of an array is, or might be, a value
- * type.
- * \param vp The \ref OMR::ValuePropagation object
- * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
- * \returns \c TR_yes if the array's component type is definitely a value type;\n
- *          \c TR_no if it is definitely not a value type; or\n
- *          \c TR_maybe otherwise.
- */
-static TR_YesNoMaybe isArrayCompTypeValueType(OMR::ValuePropagation *vp, TR::VPConstraint *arrayConstraint)
-   {
-   TR_YesNoMaybe isValueType = TR_maybe;
-
-   if (!TR::Compiler->om.areValueTypesEnabled())
-      {
-      isValueType = TR_no;
-      }
-   else if (!(arrayConstraint && arrayConstraint->getClass()
-              && arrayConstraint->getClassType()->isArray() == TR_yes))
-      {
-      isValueType = TR_maybe;
-      }
-   else
-      {
-      TR_OpaqueClassBlock *arrayComponentClass = vp->fe()->getComponentClassFromArrayClass(arrayConstraint->getClass());
-
-      if (!arrayComponentClass)
-         {
-         isValueType = TR_maybe;
-         }
-      else if (TR::Compiler->cls.isValueTypeClass(arrayComponentClass))
-         {
-         isValueType = TR_yes;
-         }
-      else if (TR::Compiler->cls.isAbstractClass(vp->comp(), arrayComponentClass))
-         {
-         isValueType = TR_maybe;
-         }
-      else
-         {
-         int32_t len;
-         const char *sig = arrayConstraint->getClassSignature(len);
-
-         if (!sig || !arrayConstraint->isFixedClass() && sig[0] == '[' && len == 19
-                     && !strncmp(sig, "[Ljava/lang/Object;", 19))
-            {
-            isValueType = TR_maybe;
-            }
-         else
-            {
-            isValueType = TR_no;
-            }
-         }
-      }
-
-   return isValueType;
-   }
-
 TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
    {
    constrainChildren(vp, node);
@@ -12282,7 +12224,7 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPConstraint *object = vp->getConstraint(objectRef, isGlobal);
       TR::VPConstraint *array  = vp->getConstraint(arrayRef, isGlobal);
 
-      TR_YesNoMaybe arrayCompIsValueType = isArrayCompTypeValueType(vp, array);
+      TR_YesNoMaybe arrayCompIsValueType = vp->isArrayCompTypeValueType(array);
 
       // If the object reference is null we can remove this check, if the
       // array's element type is not a value type


### PR DESCRIPTION
These changes make some improvements to Value Propagation's checks of whether the component type of an array is, or might be, a value type.  It moves the method `isArrayCompTypeValueType` from being a static method in `VPHandlers.cpp` to being a method in `OMR::ValuePropagation::isArrayCompTypeValueType` - that will allow downstream projects to call it.  It also detects some additional cases that were not being considered:  arrays of arrays, and arrays of interfaces.
