### PR TITLE
Fix Peephole optimization for iushr,ishr

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1587,8 +1587,7 @@ bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
              firstOp == TR::iushr) &&
              firstChild->getSecondChild()->getOpCodeValue() == TR::iconst  &&
             firstChild->getSecondChild()->getInt() > 0 &&
-            (firstOp == TR::iushr ||
-             leadingZeroes(secondChild->getInt()) >=
+            (leadingZeroes(secondChild->getInt()) >=
               firstChild->getSecondChild()->getInt())))))
       return true;
    else


### PR DESCRIPTION
In POWER the peephole optimization for iushr, ishr uses rlwinm.
However, the rlwinm does not take into consideration of sign
extension that is required by iushr/ishr. This commit fix the case
for ishr so that the optimization is only possible for correct case.

Signed-off-by: Mohammad Nazmul Alam <mohammad.nazmul.alam@ibm.com>