### PR TITLE
AArch64: Vector mul-div tril test

### DIFF
--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -368,3 +368,261 @@ TEST_F(VectorTest, VDoubleSub) {
     EXPECT_DOUBLE_EQ(inputA[0] - inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary?
     EXPECT_DOUBLE_EQ(inputA[1] - inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary?
 }
+
+TEST_F(VectorTest, VInt8Mul) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "         (aload parm=0)                                         "
+                     "            (vmul                                               "
+                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
+                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(int8_t[],int8_t[],int8_t[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    int8_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    int8_t inputA[] =  {7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, 7};
+    int8_t inputB[] =  {-14, -12, -10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10, 12, -14, 1};
+
+    entry_point(output,inputA,inputB);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_EQ(inputA[i] * inputB[i], output[i]);
+    }
+}
+
+TEST_F(VectorTest, VInt16Mul) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorInt16 offset=0                         "
+                     "         (aload parm=0)                                         "
+                     "            (vmul                                               "
+                     "                 (vloadi type=VectorInt16 (aload parm=1))       "
+                     "                 (vloadi type=VectorInt16 (aload parm=2))))     "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(int16_t[],int16_t[],int16_t[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    int16_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0};
+    int16_t inputA[] =  {60, 45, 30, 0, -3, -2, -1, 2};
+    int16_t inputB[] =  {-5, -10, -1, 13, 15, 10, -7, 5};
+
+    entry_point(output,inputA,inputB);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_EQ(inputA[i] * inputB[i], output[i]);
+    }
+}
+
+TEST_F(VectorTest, VFloatMul) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorFloat offset=0                         "
+                     "         (aload parm=0)                                         "
+                     "            (vmul                                               "
+                     "                 (vloadi type=VectorFloat (aload parm=1))       "
+                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
+    float inputA[] =  {6.0f, 0.0f, -0.1f, 0.6f};
+    float inputB[] =  {-0.5f, 3.5f, -3.0f, 0.7f};
+
+    entry_point(output,inputA,inputB);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_FLOAT_EQ(inputA[i] * inputB[i], output[i]); // Epsilon = 4ULP -- is this necessary?
+    }
+}
+
+TEST_F(VectorTest, VDoubleMul) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorDouble offset=0                        "
+                     "         (aload parm=0)                                         "
+                     "            (vmul                                               "
+                     "                 (vloadi type=VectorDouble (aload parm=1))      "
+                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    double output[] =  {0.0, 0.0};
+    double inputA[] =  {1.0, -1.5};
+    double inputB[] =  {-1.1, -3.0};
+
+    entry_point(output,inputA,inputB);
+    EXPECT_DOUBLE_EQ(inputA[0] * inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary?
+    EXPECT_DOUBLE_EQ(inputA[1] * inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary?
+}
+
+TEST_F(VectorTest, VFloatDiv) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorFloat offset=0                         "
+                     "         (aload parm=0)                                         "
+                     "            (vdiv                                               "
+                     "                 (vloadi type=VectorFloat (aload parm=1))       "
+                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
+    float inputA[] =  {6.0f, 0.0f, -9.0f, 0.6f};
+    float inputB[] =  {-0.5f, 3.5f, -3.0f, 0.7f};
+
+    entry_point(output,inputA,inputB);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_FLOAT_EQ(inputA[i] / inputB[i], output[i]); // Epsilon = 4ULP -- is this necessary?
+    }
+}
+
+TEST_F(VectorTest, VDoubleDiv) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorDouble offset=0                        "
+                     "         (aload parm=0)                                         "
+                     "            (vdiv                                               "
+                     "                 (vloadi type=VectorDouble (aload parm=1))      "
+                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    //
+    // This test is currently disabled on Z platforms because not all Z platforms
+    // have vector support. Determining whether a specific platform has the support
+    // at runtime is currently not possible in tril. So the test is being disabled altogether
+    // on Z for now.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
+    //TODO: What do we query to determine vector width?
+    // -- This test currently assumes 128bit SIMD
+
+    double output[] =  {0.0, 0.0};
+    double inputA[] =  {12.0, -1.5};
+    double inputB[] =  {-4.0, -3.0};
+
+    entry_point(output,inputA,inputB);
+    EXPECT_DOUBLE_EQ(inputA[0] / inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary?
+    EXPECT_DOUBLE_EQ(inputA[1] / inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary?
+}

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -40,11 +40,6 @@ TEST_F(VectorTest, VDoubleAdd) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved. 
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -54,8 +49,7 @@ TEST_F(VectorTest, VDoubleAdd) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
-    //TODO: What do we query to determine vector width?  
-    // -- This test currently assumes 128bit SIMD  
+    // This test currently assumes 128bit SIMD
 
     double output[] =  {0.0, 0.0};
     double inputA[] =  {1.0, 2.0};
@@ -81,11 +75,6 @@ TEST_F(VectorTest, VInt8Add) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -96,8 +85,7 @@ TEST_F(VectorTest, VInt8Add) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int8_t[],int8_t[],int8_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int8_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     int8_t inputA[] =  {7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, 7};
@@ -125,11 +113,6 @@ TEST_F(VectorTest, VInt16Add) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -140,8 +123,7 @@ TEST_F(VectorTest, VInt16Add) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int16_t[],int16_t[],int16_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int16_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0};
     int16_t inputA[] =  {60, 45, 30, 0, -3, -2, -1, 2};
@@ -169,11 +151,6 @@ TEST_F(VectorTest, VFloatAdd) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -183,8 +160,7 @@ TEST_F(VectorTest, VFloatAdd) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
     float inputA[] =  {6.0f, 0.0f, -0.1f, 0.6f};
@@ -212,11 +188,6 @@ TEST_F(VectorTest, VInt8Sub) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -227,8 +198,7 @@ TEST_F(VectorTest, VInt8Sub) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int8_t[],int8_t[],int8_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int8_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     int8_t inputA[] =  {7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, 9};
@@ -256,11 +226,6 @@ TEST_F(VectorTest, VInt16Sub) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -271,8 +236,7 @@ TEST_F(VectorTest, VInt16Sub) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int16_t[],int16_t[],int16_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int16_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0};
     int16_t inputA[] =  {60, 45, 30, 0, -3, -2, -1, 9};
@@ -300,11 +264,6 @@ TEST_F(VectorTest, VFloatSub) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -314,8 +273,7 @@ TEST_F(VectorTest, VFloatSub) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
     float inputA[] =  {6.0f, 0.0f, -0.1f, 2.0f};
@@ -343,11 +301,6 @@ TEST_F(VectorTest, VDoubleSub) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -357,8 +310,7 @@ TEST_F(VectorTest, VDoubleSub) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     double output[] =  {0.0, 0.0};
     double inputA[] =  {1.0, -1.5};
@@ -384,11 +336,6 @@ TEST_F(VectorTest, VInt8Mul) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -401,8 +348,7 @@ TEST_F(VectorTest, VInt8Mul) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int8_t[],int8_t[],int8_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int8_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     int8_t inputA[] =  {7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5, -6, -7, 7};
@@ -430,11 +376,6 @@ TEST_F(VectorTest, VInt16Mul) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -445,8 +386,7 @@ TEST_F(VectorTest, VInt16Mul) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(int16_t[],int16_t[],int16_t[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     int16_t output[] =  {0, 0, 0, 0, 0, 0, 0, 0};
     int16_t inputA[] =  {60, 45, 30, 0, -3, -2, -1, 2};
@@ -474,11 +414,6 @@ TEST_F(VectorTest, VFloatMul) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -488,8 +423,7 @@ TEST_F(VectorTest, VFloatMul) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
     float inputA[] =  {6.0f, 0.0f, -0.1f, 0.6f};
@@ -517,11 +451,6 @@ TEST_F(VectorTest, VDoubleMul) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -531,8 +460,7 @@ TEST_F(VectorTest, VDoubleMul) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     double output[] =  {0.0, 0.0};
     double inputA[] =  {1.0, -1.5};
@@ -558,11 +486,6 @@ TEST_F(VectorTest, VFloatDiv) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -572,8 +495,7 @@ TEST_F(VectorTest, VFloatDiv) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(float[],float[],float[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     float output[] =  {0.0f, 0.0f, 0.0f, 0.0f};
     float inputA[] =  {6.0f, 0.0f, -9.0f, 0.6f};
@@ -601,11 +523,6 @@ TEST_F(VectorTest, VDoubleDiv) {
 
     ASSERT_NOTNULL(trees);
     //TODO: Re-enable this test on S390 after issue #1843 is resolved.
-    //
-    // This test is currently disabled on Z platforms because not all Z platforms
-    // have vector support. Determining whether a specific platform has the support
-    // at runtime is currently not possible in tril. So the test is being disabled altogether
-    // on Z for now.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -615,8 +532,7 @@ TEST_F(VectorTest, VDoubleDiv) {
 
 
     auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
-    //TODO: What do we query to determine vector width?
-    // -- This test currently assumes 128bit SIMD
+    // This test currently assumes 128bit SIMD
 
     double output[] =  {0.0, 0.0};
     double inputA[] =  {12.0, -1.5};


### PR DESCRIPTION
This commit adds test-cases for the vector multiplication & division
tril tests in VectorTest for the following vector data-types-
- VectorInt8
- VectorInt16
- VectorFloat
- VectorDouble