### PR TITLE
Define isArrayCompTypeValueType method for Value Propagation

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1687,6 +1687,12 @@ TR_YesNoMaybe OMR::ValuePropagation::isCastClassObject(TR::VPClassType *type)
          }
       }
    return TR_maybe;
+   }
+
+
+TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint)
+   {
+   return TR::Compiler->om.areValueTypesEnabled() ? TR_maybe : TR_no;
    }
 
 void OMR::ValuePropagation::checkTypeRelationship(TR::VPConstraint *lhs, TR::VPConstraint *rhs,
@@ -6413,7 +6419,7 @@ void OMR::ValuePropagation::buildBoundCheckComparisonNodes(BlockVersionInfo *blo
 
             temp.add(nextComparisonNode);
 
-            if (arrayIndex->_baseNode && arrayIndex->_instanceOfClass && 
+            if (arrayIndex->_baseNode && arrayIndex->_instanceOfClass &&
                 arrayIndex->_baseNode->getOpCode().getOpCodeValue() == TR::iloadi)
                {
                // InstanceOf check for the object we load the array index from

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -427,6 +427,17 @@ class ValuePropagation : public TR::Optimization
    void invalidateParmConstraintsIfNeeded(TR::Node *node, TR::VPConstraint *constraint);
    void checkTypeRelationship(TR::VPConstraint *lhs, TR::VPConstraint *rhs, int32_t &value, bool isInstanceOf, bool isCheckCast);
    TR_YesNoMaybe isCastClassObject(TR::VPClassType *type);
+
+   /**
+    * Determine whether the component type of an array is, or might be, a value
+    * type.
+    * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
+    * \returns \c TR_yes if the array's component type is definitely a value type;\n
+    *          \c TR_no if it is definitely not a value type; or\n
+    *          \c TR_maybe otherwise.
+    */
+   virtual TR_YesNoMaybe isArrayCompTypeValueType(TR::VPConstraint *arrayConstraint);
+
    TR::VPConstraint *getStoreConstraint(TR::Node *node, TR::Node *relative = NULL);
    void createStoreConstraints(TR::Node *node);
    void setUnreachableStore(StoreRelationship *store);


### PR DESCRIPTION
This change adds a virtual method and base implementation of `isArrayCompTypeValueType` to `OMR::ValuePropagation` that can be used to determine whether the component type of an array is definitely, might be or is definitely not a value type.

The base implementation simply assumes any array's component type might be a value type if value type support is enabled, and that it is definitely not a value type otherwise.