### PR TITLE
Update CEL4RO31 control block function descriptor member

### DIFF
--- a/port/zos390/omrcel4ro31.h
+++ b/port/zos390/omrcel4ro31.h
@@ -59,8 +59,7 @@ typedef struct OMR_CEL4RO31_controlBlock {
 	uint32_t functionOffset;        /**< (Input) Offset to RO31_function section from start of RO31_CB. Req'd for dll query flag. */
 	uint32_t argumentsOffset;       /**< (Input) Offset to outgoing arguments section from start of RO31_CB. Req'd for function execution flag. */
 	uint32_t dllHandle;             /**< DLL handle of target program (Input) DLL handle if dll query flag. (Output) DLL handle if dll load flag. */
-	uint32_t functionEnv;           /**< Environment of target Program (Input) Environment if function execution flag. (Output) Environment if dll query flag. */
-	uint32_t functionEntryPoint;    /**< Entry point of target program (Input) Entry point if function execution flag. (Output) Entry point if dll query flag. */
+	uint32_t functionDescriptor;    /**< Function descriptor of target function (Input) Func Desc if function execution flag. (Output) Func Desc if dll query flag. */
 	uint32_t gpr15ReturnValue;      /**< (Output) Return GPR buffer containing 32-bit GPR15 value when target program returned after execution. */
 	uint32_t gpr0ReturnValue;       /**< (Output) Return GPR buffer containing 32-bit GPR0 value when target program returned after execution. */
 	uint32_t gpr1ReturnValue;       /**< (Output) Return GPR buffer containing 32-bit GPR1 value when target program returned after execution. */

--- a/port/zos390/omrsl.c
+++ b/port/zos390/omrsl.c
@@ -274,12 +274,11 @@ omrsl_lookup_name(struct OMRPortLibrary *portLibrary, uintptr_t descriptor, char
 			ro31ControlBlock->dllHandle = (uint32_t)handle;
 			omr_cel4ro31_call(ro31InfoBlock);
 			if (OMR_CEL4RO31_RETCODE_OK == ro31ControlBlock->retcode) {
-				/* CEL4RO31 returns the function descriptor (FDCB) in the functionEntryPoint member */
-				address = (void *)ro31ControlBlock->functionEntryPoint;
+				address = (void *)ro31ControlBlock->functionDescriptor;
 				address = (void *)(OMRPORT_SL_ZOS_31BIT_TARGET_HIGHTAG | (uintptr_t)address);
 			}
 			omr_cel4ro31_deinit(ro31InfoBlock);
-			DMESSAGE(("omrsl_lookup_name: Attempted to 31-bit DLL function [%s] from DLL handle: %p - return code: [%d] Function Pointer: [%p]\n", name, handle, ro31InfoBlock->ro31ControlBlock.retcode, address))
+			DMESSAGE(("omrsl_lookup_name: Attempted to query 31-bit DLL function [%s] from DLL handle: %p - return code: [%d] Function Pointer: [%p]\n", name, handle, ro31InfoBlock->ro31ControlBlock.retcode, address))
 		}
 	} else
 #endif /* defined(J9ZOS39064) */


### PR DESCRIPTION
The latest specification of the CEL4RO31 control block
consolidates the environment and entry point members into
a single function descriptor member.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>