### PR TITLE
Check if current phase concurrent when trying to yield

### DIFF
--- a/example/glue/ScavengerDelegate.hpp
+++ b/example/glue/ScavengerDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,8 +242,6 @@ public:
 	 * Fixup should update slots to point to the forwarded version of the object and/or remove self forwarded bit in the object itself.
 	 */
 	void fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
-	
-	bool shouldYield() { return false; }
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	bool initialize(MM_EnvironmentBase* env) { return true; }

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -765,11 +765,6 @@ public:
 		return concurrent_phase_idle != _concurrentPhase;
 	}
 	
-	/* TODO: remove once downstream projects start using isConcurrentCycleInProgress/isCurrentPhaseConcurrent */
-	bool isConcurrentInProgress() {
-		return concurrent_phase_idle != _concurrentPhase;
-	}
-	
 	bool isMutatorThreadInSyncWithCycle(MM_EnvironmentBase *env) {
 		return (env->_concurrentScavengerSwitchCount == _concurrentScavengerSwitchCount);
 	}


### PR DESCRIPTION
When we consider yielding in Concurrent Scavenger (prematurely
terminating scanning loop, while in concurrent phase, due to external
Exclusive Access Request being raised), we can now rely on explicit flag
that tells us we are really in concurrent phase. Yielding while in STW
phases is meaningless.

Previously we checked if we were not in STW mode by checking that
exclusive access was in 'pending' state, but exclusive VM access
actually can be pending even state is already 'exclusive'. This is true
when exclusive VM access was requested by external thread. In this case,
we could incorrectly conclude we are not in concurrent mode, and never
yield.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>