### PR TITLE
CMake: fix ddr macro processing on z/OS

### DIFF
--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -150,6 +150,10 @@ function(process_source_files src_files)
 			# Adding this option to the command alleviates this issue.
 			list(APPEND pp_command "-xc++")
 		endif()
+		if("@OMR_OS_ZOS@" and "@OMR_ENV_DATA64@")
+			# we need to set 64 bit code generation to ensure that limits.h macros are set correctly.
+			list(APPEND pp_command "-Wc,lp64")
+		endif()
 		list(APPEND pp_command ${BASE_ARGS} "-E" "${stub_file}")
 		add_custom_command(
 			OUTPUT "${annt_file}"


### PR DESCRIPTION
Ensure that macros from limits.h have correct values on 64bit builds.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>