### PR TITLE
Add default constructor for SymbolReference

### DIFF
--- a/compiler/il/SymbolReference.hpp
+++ b/compiler/il/SymbolReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@ class OMR_EXTENSIBLE SymbolReference : public OMR::SymbolReferenceConnector
    {
 
 public:
+   SymbolReference() : OMR::SymbolReferenceConnector() {}
 
    SymbolReference(TR::SymbolReferenceTable * symRefTab) :
       OMR::SymbolReferenceConnector(symRefTab) {}


### PR DESCRIPTION
Match underlying OMR::SymbolReference constructors and enable it for extension.

Signed-off-by: Tao Guan <james_mango@yahoo.com>