### PR TITLE
Remove Signed-off-by requirement for OMR commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,23 +263,21 @@ This patch eliminates the race condition in issue #1234.
 Closes: #1234
 ```
 
-Sign off on your commit in the footer. By doing this, you assert original
-authorship of the commit and that you are permitted to contribute it. This can
-be automatically added to your commit by passing `-s` to `git commit`, or by
-hand adding the following line to the footer of the commit.
+### Commit Authorship
 
-```
-Signed-off-by: Full Name <email>
-```
+Be sure to author commits with the same email address that you used to
+sign the Eclipse Contributor Agreement.
 
-Remember, if a blank line is found anywhere after the `Signed-off-by` line, the
-`Signed-off-by:` will be considered outside of the footer, and will fail the
-automated Signed-off-by validation.
+If there are multiple authors of a commit they should all be credited
+with a `Co-authored-by: Full Name <email address>` line at the footer
+of each commit.  Each co-author must sign the ECA.
 
-It is important that you read and understand the legal considerations found
-below when signing off or contributing any commit.
+Each time a commit is pushed, a GitHub CI check will be run
+automatically that verifies that the commit author(s) has signed the
+Eclipse Contributor Agreement.  If not, the check will fail and the
+result will be visible in the pull request.
 
-### Example commits
+### Example Commits
 
 Here is an example of a *good* commit:
 
@@ -298,15 +296,13 @@ The guidelines are changed to:
   message.
 
 Issue: #124
-Signed-off-by: Robert Young <rwy0717@gmail.com>
 ```
 
 The first line is meaningful and imperative. The body contains enough
 information that the reader understands the why and how of the commit, and its
-relation to any issues. The issue is properly tagged and the commit is signed
-off.
+relation to any issues. The issue is properly tagged.
 
-The following is a *bad* commit:
+The following is an example of a *bad* commit:
 
 ```
 FIX #124: Changing a couple random things in CONTRIBUTING.md.
@@ -315,8 +311,8 @@ Also, there are some bug fixes in the thread library.
 
 The commit rolls unrelated changes together in a very bad way. There is not
 enough information for the commit message to be useful. The first line is not
-meaningful or imperative. The message is not formatted correctly, the issue is
-improperly referenced, and the commit is not signed off by the author.
+meaningful or imperative. The message is not formatted correctly and the issue is
+improperly referenced.
 
 ### Other resources for writing good commits
 
@@ -352,14 +348,13 @@ Here is the checklist for contributions to be _acceptable_:
 1. [Create an account at Eclipse](https://dev.eclipse.org/site_login/createaccount.php).
 2. Add your GitHub user name in your account settings.
 3. [Log into the project's portal](https://projects.eclipse.org/) and sign the ["Eclipse ECA"](https://projects.eclipse.org/user/sign/cla).
-4. Ensure that you [_sign-off_](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit) your Git commits.
-5. Ensure that you use the _same_ email address as your Eclipse account in commits.
-6. Include the appropriate copyright notice and license at the top of each file.
+4. Ensure that you author the commit using the _same_ email address as your Eclipse account.
+5. Include the appropriate copyright notice and license at the top of each file.
 
 Your signing of the ECA will be verified by a webservice called 'ip-validation'
-that checks the email address that signed-off on your commits has signed the
+that checks the email address(es) that authored your commits has signed the
 ECA. **Note**: This service is case-sensitive, so ensure the email that signed
-the ECA and that signed-off on your commits is the same, down to the case.
+the ECA and that authored your commits is the same, down to the case.
 
 ### Copyright Notice and Licensing Requirements
 

--- a/doc/GitCrashCourse.md
+++ b/doc/GitCrashCourse.md
@@ -83,8 +83,8 @@ wizard.
 Before you can make any code contributions to the Eclipse OMR GitHub repository
 you must sign the Eclipse Contributor Agreement (ECA).  This is a simple process
 outlined in the [Contribution Guidelines](../CONTRIBUTING.md#legal-considerations).
-This step is important because each of your commits must be signed off by the
-same email you used to sign the ECA.
+This step is important because the email of the author of each commit 
+must match the email you used to sign the ECA.
 
 ---
 
@@ -107,7 +107,7 @@ simply go into the project directory and enter any of the above commands
 with the project-specific name/email to use and excluding the `--global`
 argument.
 
-Please note that the email associated with the commits you make in OMR must
+Please note that the email associated with the author of the commits you make in OMR must
 be the email you used for signing the
 [ECA - Eclipse Foundation Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
 Therefore, you must either configure the global `user.email` or the OMR
@@ -346,7 +346,6 @@ The guidelines are changed to:
   message.
 
 Issue: #124
-Signed-off-by: Robert Young <rwy0717@gmail.com>
 ```
 
 The first line in the commit message is the commit heading, and should
@@ -354,16 +353,11 @@ summarize what this commit is doing. After a blank line comes the body of
 the commit message containing more details about what this commit is
 about. You can be as descriptive of the changes as you wish.
 
-Next, you may include the Issue in OMR that this commit addresses,
-followed by signing off the commit.
+Next, you may include the Issue in OMR that this commit addresses.
 
 Tips: `git commit -a` combines the 2 commands:
 1. `git add -u`
 2. `git commit`
-
-You can also generate the `Signed-off-by:` information in your commit message
-from your `user.name` and `user.email` settings using the `-s` flag in your
-`git commit` command.
 
 ### Push branch to your fork
 

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,29 +1,29 @@
 #!/usr/bin/env ruby
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#           
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-# 
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
-#                       
+#
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
 # This script is intended to be used under omr_repo_dir/.git/hooks to check
 # each git commit message against OMR contributing guidelines. The script
-# needs to be executable and it will be invoked when a 'git commit' command 
+# needs to be executable and it will be invoked when a 'git commit' command
 # is issued. OMR contributing guidelines can be found at:
 # https://github.com/eclipse/omr/blob/master/CONTRIBUTING.md#commit-guidelines
 
@@ -36,8 +36,8 @@ message.each_line do |line|
   if (line.match(/^(?!#).*$/))
     commit.concat(line)
   elsif (line.match(/^# ------------------------ >8 -.*$/))
-     # Stop processing after seeing the snip marker. 
-     break  
+     # Stop processing after seeing the snip marker.
+     break
   end
 end
 
@@ -87,16 +87,12 @@ if (state == "success")
   end
 end
 
-# check signed-off line
 if (state == "success")
   lines = body.split(/\n+/)
   if (lines.empty?)
     state = "failure"
-    description = "Commit requires a message body and a sign-off footer."
-  elsif (!lines.last.match(/^Signed-off-by/))
-    state = "failure"
-    description = "Commit requires a sign-off footer."
-  elsif (lines.count < 3)
+    description = "Commit requires a message body."
+  elsif (lines.count < 2)
     state = "failure"
     description = "Commit requires a message body explaining your changes."
   else
@@ -106,7 +102,7 @@ end
 
 # display results
 if (state == "failure")
-  puts "FAILED: #{description}" 
+  puts "FAILED: #{description}"
   puts "Please see guidelines: https://github.com/eclipse/omr/blob/master/CONTRIBUTING.md#commit-guidelines\n"
   exit 1
 end


### PR DESCRIPTION
The Eclipse Foundation no longer requires commits to be signed.  Modify
documentation and tooling to reflect that.  Also, clean up some of the
related wording in the CONTRIBUTING.md guide.

See https://www.eclipse.org/lists/eclipse.org-committers/msg01291.html