### PR TITLE
Generate normal .exp files

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu_exports.exp.in
+++ b/cmake/modules/platform/toolcfg/gnu_exports.exp.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 
 {
 	global :
-	$<JOIN:$<TARGET_PROPERTY:@TARGET_NAME@,EXPORTED_SYMBOLS>,
-	;>;
+		$<JOIN:$<TARGET_PROPERTY:@TARGET_NAME@,EXPORTED_SYMBOLS>,;
+		>;
 	local : *;
 };


### PR DESCRIPTION
Put the semicolons at the end of a line rather than at the beginning of the next line.

Generate this:
```
{
    global :
        a;
        b;
    local : *;
};
```
instead of
```
{
    global :
    a
    ;b
    ;
    local : *;
};
```