### PR TITLE
AArch64: Add query for supported feature of CPU

### DIFF
--- a/compiler/aarch64/env/OMRCPU.cpp
+++ b/compiler/aarch64/env/OMRCPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,9 @@
  *******************************************************************************/
 
 #include "env/CPU.hpp"
+#include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
+#include "omrport.h"
 
 bool
 OMR::ARM64::CPU::isTargetWithinUnconditionalBranchImmediateRange(intptr_t targetAddress, intptr_t sourceAddress)
@@ -28,4 +30,16 @@ OMR::ARM64::CPU::isTargetWithinUnconditionalBranchImmediateRange(intptr_t target
    intptr_t range = targetAddress - sourceAddress;
    return range <= self()->maxUnconditionalBranchImmediateForwardOffset() &&
           range >= self()->maxUnconditionalBranchImmediateBackwardOffset();
+   }
+
+bool
+OMR::ARM64::CPU::supportsFeature(uint32_t feature)
+   {
+   if (TR::Compiler->omrPortLib == NULL)
+      {
+      return false;
+      }
+
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+   return (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
    }

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,12 @@ class OMR_EXTENSIBLE CPU : public OMR::CPU
    {
 protected:
 
-   CPU() : OMR::CPU() {}
+   CPU() : OMR::CPU()
+      {
+      _processorDescription.processor = OMR_PROCESSOR_ARM64_V8_A;
+      _processorDescription.physicalProcessor = OMR_PROCESSOR_ARM64_V8_A;
+      memset(_processorDescription.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
+      }
    CPU(const OMRProcessorDesc& processorDescription) : OMR::CPU(processorDescription) {}
 
 public:
@@ -111,6 +116,13 @@ public:
     */
    bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
 
+   /**
+    * @brief Answers if the specified feature is supported by this cpu
+    *
+    * @param[in] feature: feature bit
+    * @returns true if feature is supported
+    */
+   bool supportsFeature(uint32_t feature);
    };
 
 }


### PR DESCRIPTION
This commit adds `supportsFeature` method to `OMRCPU` class for aarch64.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>