### PR TITLE
Fix compiler errors when DEBUG is defined

### DIFF
--- a/gc/base/standard/CompactScheme.cpp
+++ b/gc/base/standard/CompactScheme.cpp
@@ -1272,8 +1272,7 @@ MM_CompactScheme::doCompact(MM_EnvironmentStandard *env, MM_MemorySubSpace *memo
 			setFreeChunkSize(deadObject, deadObjectSize);
 #if defined(DEBUG)
 		if (deadObjectSize > 2*sizeof(uintptr_t)) {
-			uintptr_t junk = _extensions->objectModel.getSizeInBytesMultiSlotDeadObject(deadObject);
-			assume0(junk == deadObjectSize);
+			assume0(_extensions->objectModel.getSizeInBytesMultiSlotDeadObject(deadObject) == deadObjectSize);
 		}
 #endif /* DEBUG */
 		}

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -398,7 +398,7 @@ HookGen::createFile(char *path, const char *fileName)
 
 	FILE *file = fopen(buff, "wb");
 #if defined(DEBUG)
-	fprintf(stderr, "Opening %s for writing\n", temp);
+	fprintf(stderr, "Opening %s for writing\n", buff);
 #endif /* DEBUG */
 
 	free(buff);


### PR DESCRIPTION
This PR fixes compiler errors in the OpenJ9 build when the compile time flag `DEBUG` is defined.