### PR TITLE
Remove unused global memoryAllocMonitor definition

### DIFF
--- a/compiler/env/TRPersistentMemory.cpp
+++ b/compiler/env/TRPersistentMemory.cpp
@@ -40,7 +40,6 @@
 namespace TR { class Compilation; }
 namespace TR { class PersistentInfo; }
 
-extern TR::Monitor *memoryAllocMonitor;
 extern const char * objectName[];
 
 namespace TR

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,6 @@
 #include "infra/MonitorTable.hpp"
 
 TR::MonitorTable *OMR::MonitorTable::_instance = 0;
-
-TR::Monitor *memoryAllocMonitor = NULL;
 
 void *
 OMR::Monitor::operator new(size_t size)

--- a/compiler/infra/OMRMonitorTable.hpp
+++ b/compiler/infra/OMRMonitorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,6 @@ class OMR_EXTENSIBLE MonitorTable
    void free() { TR_UNIMPLEMENTED(); }
    void removeAndDestroy(TR::Monitor *monitor) { TR_UNIMPLEMENTED(); }
 
-   TR::Monitor *getMemoryAllocMonitor() { return _memoryAllocMonitor; }
    TR::Monitor *getScratchMemoryPoolMonitor() { return _scratchMemoryPoolMonitor; }
 
    protected:
@@ -54,10 +53,6 @@ class OMR_EXTENSIBLE MonitorTable
    TR::MonitorTable *self();
 
    static TR::MonitorTable *_instance;
-
-   // Used by TR_PersistentMemory
-   //
-   TR::Monitor *_memoryAllocMonitor;
 
    // Used by SCRATCH segments allocations
    // A copy of this goes into TR_PersistentMemory as well


### PR DESCRIPTION
The global `memoryAllocMonitor` is no longer used by the persistent allocator in OpenJ9 - it was removed in https://github.com/eclipse/openj9/pull/12443. This PR removes its definition from OMR.