### PR TITLE
Introduce New Default Scan Ordering 'None'

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -473,6 +473,9 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		if (extensions->scavengerEnabled) {
 			extensions->splitFreeListSplitAmount = (extensions->gcThreadCount - 1) / 8  +  1;
+			if (MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_NONE == extensions->scavengerScanOrdering) {
+				extensions->scavengerScanOrdering = MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL;
+			}
 		} else
 #endif /* OMR_GC_MODRON_SCAVENGER */
 		{

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -444,7 +444,8 @@ public:
 
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	enum ScavengerScanOrdering {
-		OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST = 0,
+		OMR_GC_SCAVENGER_SCANORDERING_NONE = 0,
+		OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST,
 		OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST,
 		OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL,
 	};
@@ -1542,7 +1543,7 @@ public:
 		, gcThreadCountForced(false)
 		, dispatcherHybridNotifyThreadBound(16)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
-		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
+		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_NONE)
 		/* Start of options relating to dynamicBreadthFirstScanOrdering */
 		, gcCountBetweenHotFieldSort(1)
 		, gcCountBetweenHotFieldSortMax(6)


### PR DESCRIPTION
Introduce a new default scan ordering type 'none'. In gencon configuration, scan ordering will be set to hierarchical if it has not already been overridden by an option. In balanced, scan ordering will be set to dynamic BF if it has not already been overridden by an option.

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>