### PR TITLE
Use a human readable name for the object comparison non-helper

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1662,6 +1662,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<eaEscapeHelper>";
          case TR::SymbolReferenceTable::computedStaticCallSymbol:
              return "<computedStaticCallSymbol>";
+         case TR::SymbolReferenceTable::objectEqualityComparisonSymbol:
+             return "<objectEqualityComparison>";
          }
       }
 


### PR DESCRIPTION
The object comparison non-helper is not recognized by `TR_Debug::getName`, so it's shown in tree listings as `unknown[#337  helper Method]`.  This change has its name reported as `<objectEqualityComparison>`.