### PR TITLE
AArch64: Implement atomic add and swap codegen support

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -812,3 +812,22 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
    srm.reclaimScratchRegister(counterReg);
    return cursor;
    }
+
+bool
+OMR::ARM64::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+   {
+   bool result = false;
+
+   switch (symbol)
+      {
+      case TR::SymbolReferenceTable::atomicAddSymbol:
+      case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
+      case TR::SymbolReferenceTable::atomicSwapSymbol:
+         {
+         result = true;
+         break;
+         }
+      }
+
+   return result;
+   }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -505,6 +505,24 @@ public:
    static uint32_t registerBitMask(int32_t reg);
 
    /**
+    * @brief Generates an inlined instruction sequence instead of a direct call
+    *
+    * @param[in]          node: node
+    * @param[inout]  resultReg: resultReg
+    *
+    * @return true if an inlined instruction sequence is generated
+    */
+   bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
+
+   /**
+    * @brief Answers if intrinsics for the symbol is supported
+    *
+    * @param[in] symbol: symbol
+    * @return true if intrinsics for the symbol is supported
+    */
+   bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
+
+   /**
     * @brief Answers whether bit operations are supported or not
     * @return true if supported, false otherwise
     */

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -793,7 +793,9 @@ static bool isImm7OffsetGPRInstruction(uint32_t enc)
 static bool isExclusiveMemAccessInstruction(TR::InstOpCode::Mnemonic op)
    {
    return (op == TR::InstOpCode::ldxrx || op == TR::InstOpCode::ldxrw ||
-           op == TR::InstOpCode::stxrx || op == TR::InstOpCode::stxrw);
+           op == TR::InstOpCode::ldaxrx || op == TR::InstOpCode::ldaxrw ||
+           op == TR::InstOpCode::stxrx || op == TR::InstOpCode::stxrw ||
+           op == TR::InstOpCode::stlxrx || op == TR::InstOpCode::stlxrw);
    }
 
 


### PR DESCRIPTION
Add support for inlining the atomic intrinsics on aarch64.
- atomicAddSymbol
- atomicFetchAndAddSymbol
- atomicSwapSymbol

Issue: https://github.com/eclipse/omr/issues/2958

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>