### PR TITLE
Deprecate findOrCreateLiteral codegen API

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -5780,13 +5780,6 @@ OMR::Z::CodeGenerator::isCompressedClassPointerOfObjectHeader(TR::Node * node)
             node->getSymbolReference() == self()->getSymRefTab()->findVftSymbolRef()));
    }
 
-size_t
-OMR::Z::CodeGenerator::findOrCreateLiteral(void *value, size_t len)
-   {
-   TR_ASSERT(0, "findOrCreateLiteral unimplemented\n");
-   return 0;
-   }
-
 bool
 OMR::Z::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddress, intptr_t sourceAddress)
    {

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -354,15 +354,6 @@ public:
 
    bool isCompressedClassPointerOfObjectHeader(TR::Node * node);
 
-   /**
-    * @brief Create a literal pool entry for the given value.
-    *
-    * @details
-    *    This function must be implemented and will assert if called.
-    *    See issue eclipse/omr#2180 for details.
-    */
-   size_t findOrCreateLiteral(void *value, size_t len);
-
    bool usesImplicit64BitGPRs(TR::Node *node);
    bool nodeMayCauseException(TR::Node *node);
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -16667,48 +16667,9 @@ OMR::Z::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
          if (valueNode->getOpCode().isLoadConst())
             {
-            TR::Register *litReg = getLitPoolBaseReg(valueNode, cg);
-            size_t offset = 0;
-
-            if (size == 1)
-               {
-               uint8_t value = valueNode->getIntegerNodeValue<uint8_t>();
-               offset = cg->findOrCreateLiteral(&value, size);
-               }
-            else if (size == 2)
-               {
-               uint16_t value = valueNode->getIntegerNodeValue<uint16_t>();
-               offset = cg->findOrCreateLiteral(&value, size);
-               }
-            else if (size == 4)
-               {
-               if (valueNode->getOpCode().isFloat())
-                  {
-                  float value = valueNode->getFloat();
-                  offset = cg->findOrCreateLiteral(&value, size);
-                  }
-               else
-                  {
-                  uint32_t value = valueNode->getIntegerNodeValue<uint32_t>();
-                  offset = cg->findOrCreateLiteral(&value, size);
-                  }
-               }
-            else if (size == 8)
-               {
-               if (valueNode->getOpCode().isDouble())
-                  {
-                  double value = valueNode->getDouble();
-                  offset = cg->findOrCreateLiteral(&value, size);
-                  }
-               else
-                  {
-                  uint64_t value = valueNode->getIntegerNodeValue<uint64_t>();
-                  offset = cg->findOrCreateLiteral(&value, size);
-                  }
-               }
-
-            memRef = new (cg->trHeapMemory()) TR::MemoryReference(litReg, offset, cg);
-            cg->stopUsingRegister(litReg);
+            // This path used to contain a call to an API which would have returned a garbage result. Rather than 100% of the
+            // time generating an invalid sequence here which is guaranteed to crash if executed, we fail the compilation.
+            cg->comp()->failCompilation<TR::CompilationException>("Existing code relied on an unimplemented API and is thus not safe. See eclipse/omr#5937.");
             }
          else
             memRef = TR::MemoryReference::create(cg, valueNode);


### PR DESCRIPTION
This API is unimplemented and calling it and using the result will
likely produce a crash. This API is used in dead code paths:

1. DFP
2. arraycmpWithPad
3. pdneg
4. vsetlem

under certain circumstances. Please see the self review in the PR which
is associated to this commit for explicit reasons as to why failing the
compilation in each case is safe and warranted.

Closes: #5937
Closes: #2180