### PR TITLE
Add omrsl cel4ro31 testcase

### DIFF
--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -136,6 +136,38 @@ if(OMR_OS_AIX)
 	)
 endif()
 
+if (OMR_OS_ZOS AND OMR_ENV_DATA64)
+	omr_add_library(sltestlib31 SHARED
+		sltestlib31/sltest.cpp
+	)
+
+	# Force 31-bit NON-XPLINK. These options appended at the end overrides
+	# the default 64-bit options from CMAKE_C_FLAGS.
+	target_compile_options(sltestlib31
+		PRIVATE
+			"-Wc,ILP32"    # Force AMODE31 generation
+			"-Wc,noxplink" # Force OS Linkage
+	)
+
+	# Force AMODE31/OS linkage for linking as well. Unfortunately,
+	# there are no -Wl,ILP32 -Wl,noxplink linker options and using LINK_FLAGS
+	# does not append the options at the very end. However, specifying
+	# -Wc,ILP32 and -Wc,noxplink, along with the *.o being AMODE31
+	# will result in the binder to build an AMODE31 shared library.
+	# This requires xlc/xlc++ to work. If we are able to use CMake 3.13
+	# or newer on z/OS one day, we should directly update target_link_options
+	# instead.
+	set_target_properties(sltestlib31
+		PROPERTIES
+			LINK_FLAGS "-Wc,ILP32 -Wc,noxplink"  # Force AMODE31/OS Linkage
+			FOLDER fvtest
+	)
+
+	omr_add_exports(sltestlib31
+		sl_testOpen31bitDLLviaCEL4RO31_function
+	)
+endif()
+
 if (NOT (OMR_OS_AIX OR OMR_OS_ZOS OR CMAKE_CROSSCOMPILING))
 	omr_add_test(
 		NAME porttest

--- a/fvtest/porttest/sltestlib31/sltest.cpp
+++ b/fvtest/porttest/sltestlib31/sltest.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * Test function for CEL4RO31 sl tests.
+ */
+void
+sl_testOpen31bitDLLviaCEL4RO31_function(void)
+{
+}

--- a/fvtest/porttest/sltestlib31/sltestlib31.exportlist
+++ b/fvtest/porttest/sltestlib31/sltestlib31.exportlist
@@ -1,0 +1,21 @@
+###############################################################################
+# Copyright (c) 2021, 2021 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+sl_testOpen31bitDLLviaCEL4RO31_function


### PR DESCRIPTION
Add an omrport shared library test to load 31-bit libraries
from 64-bit and query a function via the CEL4RO31 interface on zOS.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>