### PR TITLE
CMake: fix typo in DDRSetStub.cmake.in

### DIFF
--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -150,7 +150,7 @@ function(process_source_files src_files)
 			# Adding this option to the command alleviates this issue.
 			list(APPEND pp_command "-xc++")
 		endif()
-		if("@OMR_OS_ZOS@" and "@OMR_ENV_DATA64@")
+		if("@OMR_OS_ZOS@" AND "@OMR_ENV_DATA64@")
 			# we need to set 64 bit code generation to ensure that limits.h macros are set correctly.
 			list(APPEND pp_command "-Wc,lp64")
 		endif()


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>