### PR TITLE
Add j9VMThreadFloatTemp1Symbol

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -346,7 +346,26 @@
     */
    computedStaticCallSymbol,
 
-   OMRlastPrintableCommonNonhelperSymbol = jProfileValueWithNullCHKSymbol,
+   /** \brief
+    * This symbol represents the floatTemp1 field in j9vmthread. It will provide another mechanism for the
+    * compiler to insert temporary information at run-time that the VM can use, similar to how tempSlot is
+    * used. While the name suggests this field would contain floats, other data types could also be stored.
+    *
+    * \code
+    *    istore  <j9VMThreadTempSlotFieldSymbol>
+    *       iconst <value1>
+    *    istore  <j9VMThreadFloatTemp1Symbol>
+    *       dconst <value2>
+    *    icall <VM internal native method>
+    *       <parm1>
+    *       <parm2>
+    *       .
+    *       .
+    * \endcode
+    */
+   j9VMThreadFloatTemp1Symbol,
+
+   OMRlastPrintableCommonNonhelperSymbol = j9VMThreadFloatTemp1Symbol,
 
    firstPerCodeCacheHelperSymbol,
    lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -424,7 +424,26 @@ class SymbolReferenceTable
        */
       computedStaticCallSymbol,
 
-      OMRlastPrintableCommonNonhelperSymbol = computedStaticCallSymbol,
+      /** \brief
+       * This symbol represents the floatTemp1 field in j9vmthread. It will provide another mechanism for the
+       * compiler to insert temporary information at run-time that the VM can use, similar to how tempSlot is
+       * used. While the name suggests this field would contain floats, other data types could also be stored.
+       *
+       * \code
+       *    istore  <j9VMThreadTempSlotFieldSymbol>
+       *       iconst <value1>
+       *    istore  <j9VMThreadFloatTemp1Symbol>
+       *       dconst <value2>
+       *    icall <VM internal native method>
+       *       <parm1>
+       *       <parm2>
+       *       .
+       *       .
+       * \endcode
+       */
+      j9VMThreadFloatTemp1Symbol,
+
+      OMRlastPrintableCommonNonhelperSymbol = j9VMThreadFloatTemp1Symbol,
 
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1660,8 +1660,12 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<osrFearPointHelper>";
          case TR::SymbolReferenceTable::eaEscapeHelperSymbol:
              return "<eaEscapeHelper>";
+         case TR::SymbolReferenceTable::j9VMThreadTempSlotFieldSymbol:
+             return "<j9VMThreadTempSlotFieldSymbol>";
          case TR::SymbolReferenceTable::computedStaticCallSymbol:
              return "<computedStaticCallSymbol>";
+         case TR::SymbolReferenceTable::j9VMThreadFloatTemp1Symbol:
+             return "<j9VMThreadFloatTemp1Symbol>";
          case TR::SymbolReferenceTable::objectEqualityComparisonSymbol:
              return "<objectEqualityComparison>";
          }
@@ -2123,7 +2127,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<jProfileValueSymbol>",
    "<jProfileValueWithNullCHKSymbol>",
    "<j9VMThreadTempSlotField>",
-   "<computedStaticCallSymbol>"
+   "<computedStaticCallSymbol>",
+   "<j9VMThreadFloatTemp1>"
    };
 
 const char *


### PR DESCRIPTION
This symbol represents the floatTemp1 field in j9vmthread.
It will provide another mechanism for the compiler to insert
temporary information at run-time that the VM can use, similar
to how tempSlot is used. While the name suggests this field
would contain floats, other data types could also be stored.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>