### PR TITLE
Disable x87 floating point for 32-bit code generation

### DIFF
--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -93,7 +93,7 @@ public:
       }
    bool isGenuineIntel();
    bool isAuthenticAMD();
-   
+
    bool requiresLFence();
    bool supportsFCOMIInstructions();
    bool supportsMFence();
@@ -101,8 +101,16 @@ public:
    bool supportsSFence();
    bool prefersMultiByteNOP();
    bool supportsAVX();
-   bool testOSForSSESupport() { return false; }
-   
+
+   /**
+    * It is generally safe to assume that all modern operating systems
+    * support preserving the SSE state.  However, to be strictly
+    * correct, this support should be verified.
+    *
+    * See issue #5964.
+    */
+   bool testOSForSSESupport() { return true; }
+
    /**
     * @brief Determines whether 32bit integer rotate is available
     *


### PR DESCRIPTION
The minimum target processor level for OMR code generation is Pentium 4,
which has support for SSE2.  All modern operating systems are assumed
to support preserving the SSE state.  Disable x87 code generation in
preparation for removal.

Issue: #946

Signed-off-by: Daryl Maier <maier@ca.ibm.com>