### PR TITLE
Deprecate TR_DisableOOL option

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -323,9 +323,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
    switch (rk)
       {
       case TR_GPR:
-         if (!comp->getOption(TR_DisableOOL) &&
-            (cg->isOutOfLineColdPath() || cg->isOutOfLineHotPath()) &&
-            registerToSpill->getBackingStorage())
+         if ((cg->isOutOfLineColdPath() || cg->isOutOfLineHotPath()) && registerToSpill->getBackingStorage())
             {
             // reuse the spill slot
             if (debugObj)
@@ -348,9 +346,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
          break;
       case TR_FPR:
       case TR_VRF:
-         if (!comp->getOption(TR_DisableOOL) &&
-            (cg->isOutOfLineColdPath() || cg->isOutOfLineHotPath()) &&
-            registerToSpill->getBackingStorage())
+         if ((cg->isOutOfLineColdPath() || cg->isOutOfLineHotPath()) && registerToSpill->getBackingStorage())
             {
             // reuse the spill slot
             if (debugObj)
@@ -373,45 +369,42 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
 
    tmemref = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), cg);
 
-   if (!comp->getOption(TR_DisableOOL))
+   if (!cg->isOutOfLineColdPath())
       {
-      if (!cg->isOutOfLineColdPath())
-         {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL cold path, post dependencies will be generated using this list
-         cg->getSpilledRegisterList()->push_front(registerToSpill);
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL cold path, post dependencies will be generated using this list
+      cg->getSpilledRegisterList()->push_front(registerToSpill);
 
-         // OOL cold path: depth = 3, hot path: depth = 2,  main line: depth = 1
-         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-         // if we reverse spill this register inside the OOL cold/hot path
-         if (!cg->isOutOfLineHotPath())
-            {// main line
-            location->setMaxSpillDepth(1);
-            }
-         else
-            {
-            // hot path
-            // do not overwrite main line spill depth
-            if (location->getMaxSpillDepth() != 1)
-               {
-               location->setMaxSpillDepth(2);
-               }
-            }
-         if (debugObj)
-            cg->traceRegisterAssignment("OOL: adding %R to the spilledRegisterList, maxSpillDepth = %d ",
-                                          registerToSpill, location->getMaxSpillDepth());
+      // OOL cold path: depth = 3, hot path: depth = 2,  main line: depth = 1
+      // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+      // if we reverse spill this register inside the OOL cold/hot path
+      if (!cg->isOutOfLineHotPath())
+         {// main line
+         location->setMaxSpillDepth(1);
          }
       else
          {
-         // do not overwrite mainline and hot path spill depth
-         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-         // because the post condition at OOL entry does not expect this register to be spilled
-         if (location->getMaxSpillDepth() != 1 &&
-             location->getMaxSpillDepth() != 2 )
+         // hot path
+         // do not overwrite main line spill depth
+         if (location->getMaxSpillDepth() != 1)
             {
-            location->setMaxSpillDepth(3);
-            cg->traceRegisterAssignment("OOL: In OOL cold path, spilling %R not adding to spilledRegisterList", registerToSpill);
+            location->setMaxSpillDepth(2);
             }
+         }
+      if (debugObj)
+         cg->traceRegisterAssignment("OOL: adding %R to the spilledRegisterList, maxSpillDepth = %d ",
+                                       registerToSpill, location->getMaxSpillDepth());
+      }
+   else
+      {
+      // do not overwrite mainline and hot path spill depth
+      // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+      // because the post condition at OOL entry does not expect this register to be spilled
+      if (location->getMaxSpillDepth() != 1 &&
+            location->getMaxSpillDepth() != 2 )
+         {
+         location->setMaxSpillDepth(3);
+         cg->traceRegisterAssignment("OOL: In OOL cold path, spilling %R not adding to spilledRegisterList", registerToSpill);
          }
       }
 
@@ -493,123 +486,51 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
 
    tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
 
-   if (comp->getOption(TR_DisableOOL))
+   switch (rk)
       {
-      switch (rk)
-         {
-         case TR_GPR:
-            dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            storeOp = TR::InstOpCode::strimmx;
-            break;
-         case TR_FPR:
-            dataSize = 8;
-            storeOp = TR::InstOpCode::vstrimmd;
-            break;
-         case TR_VRF:
-            dataSize = 16;
-            storeOp = TR::InstOpCode::vstrimmq;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
-         }
-         self()->cg()->freeSpill(location, dataSize, 0);
-         generateMemSrc1Instruction(self()->cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
+      case TR_GPR:
+         dataSize = TR::Compiler->om.sizeofReferenceAddress();
+         break;
+      case TR_FPR:
+         dataSize = 8;
+         break;
+      case TR_VRF:
+         dataSize = 16;
+         break;
+      default:
+         TR_ASSERT(false, "Unsupported RegisterKind.");
+         break;
       }
-   else
+   if (self()->cg()->isOutOfLineColdPath())
       {
-      switch (rk)
+      bool isOOLentryReverseSpill = false;
+      if (currentInstruction->isLabel())
          {
-         case TR_GPR:
-            dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            break;
-         case TR_FPR:
-            dataSize = 8;
-            break;
-         case TR_VRF:
-            dataSize = 16;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
-         }
-      if (self()->cg()->isOutOfLineColdPath())
-         {
-         bool isOOLentryReverseSpill = false;
-         if (currentInstruction->isLabel())
+         if (((TR::ARM64LabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
             {
-            if (((TR::ARM64LabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
-               {
-               // indicates that we are at OOL entry point post conditions. Since
-               // we are now exiting the OOL cold path (going reverse order)
-               // and we called reverseSpillState(), the main line path
-               // expects the Virt reg to be assigned to a real register
-               // we can now safely unlock the protected backing storage
-               // This prevents locking backing storage for future OOL blocks
-               isOOLentryReverseSpill = true;
-               }
-            }
-         // OOL: only free the spill slot if the register was spilled in the same or less dominant path
-         // ex: spilled in cold path, reverse spill in hot path or main line
-         // we have to spill this register again when we reach OOL entry point due to post
-         // conditions. We want to guarantee that the same spill slot will be protected and reused.
-         // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
-         // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
-         // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
-         if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
-            {
-            if (location->getMaxSpillDepth() != 0)
-               location->setMaxSpillDepth(0);
-            else if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
-
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+            // indicates that we are at OOL entry point post conditions. Since
+            // we are now exiting the OOL cold path (going reverse order)
+            // and we called reverseSpillState(), the main line path
+            // expects the Virt reg to be assigned to a real register
+            // we can now safely unlock the protected backing storage
+            // This prevents locking backing storage for future OOL blocks
+            isOOLentryReverseSpill = true;
             }
          }
-      else if (self()->cg()->isOutOfLineHotPath())
+      // OOL: only free the spill slot if the register was spilled in the same or less dominant path
+      // ex: spilled in cold path, reverse spill in hot path or main line
+      // we have to spill this register again when we reach OOL entry point due to post
+      // conditions. We want to guarantee that the same spill slot will be protected and reused.
+      // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
+      // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
+      // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
+      if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
          {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
-         // Any registers reverse spilled before entering OOL should be removed from the spilled list
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-
-         // Reset maxSpillDepth here so that in the cold path we know to free the spill
-         // and so that the spill is not included in future GC points in the hot path while it is protected
-         location->setMaxSpillDepth(0);
-         if (location->getMaxSpillDepth() == 2)
-            {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            }
-         }
-      else // main line
-         {
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-         location->setMaxSpillDepth(0);
+         if (location->getMaxSpillDepth() != 0)
+            location->setMaxSpillDepth(0);
+         else if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          self()->cg()->freeSpill(location, dataSize, 0);
 
          if (!self()->cg()->isFreeSpillListLocked())
@@ -617,23 +538,70 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             spilledRegister->setBackingStorage(NULL);
             }
          }
-      switch (rk)
+      else
          {
-         case TR_GPR:
-            storeOp = TR::InstOpCode::strimmx;
-            break;
-         case TR_FPR:
-            storeOp = TR::InstOpCode::vstrimmd;
-            break;
-         case TR_VRF:
-            storeOp = TR::InstOpCode::vstrimmq;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          }
-         generateMemSrc1Instruction(self()->cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
       }
+   else if (self()->cg()->isOutOfLineHotPath())
+      {
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL path (in backwards RA). Post dependencies will be generated using this list.
+      // Any registers reverse spilled before entering OOL should be removed from the spilled list
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+
+      // Reset maxSpillDepth here so that in the cold path we know to free the spill
+      // and so that the spill is not included in future GC points in the hot path while it is protected
+      location->setMaxSpillDepth(0);
+      if (location->getMaxSpillDepth() == 2)
+         {
+         self()->cg()->freeSpill(location, dataSize, 0);
+         if (!self()->cg()->isFreeSpillListLocked())
+            {
+            spilledRegister->setBackingStorage(NULL);
+            }
+         }
+      else
+         {
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+         }
+      }
+   else // main line
+      {
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      location->setMaxSpillDepth(0);
+      self()->cg()->freeSpill(location, dataSize, 0);
+
+      if (!self()->cg()->isFreeSpillListLocked())
+         {
+         spilledRegister->setBackingStorage(NULL);
+         }
+      }
+   switch (rk)
+      {
+      case TR_GPR:
+         storeOp = TR::InstOpCode::strimmx;
+         break;
+      case TR_FPR:
+         storeOp = TR::InstOpCode::vstrimmd;
+         break;
+      case TR_VRF:
+         storeOp = TR::InstOpCode::vstrimmq;
+         break;
+      default:
+         TR_ASSERT(false, "Unsupported RegisterKind.");
+         break;
+      }
+   generateMemSrc1Instruction(self()->cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
+      
    return targetRegister;
    }
 
@@ -663,7 +631,7 @@ TR::RealRegister *OMR::ARM64::Machine::assignOneRegister(TR::Instruction *curren
             cg->setRegisterAssignmentFlag(TR_RegisterSpilled);
             assignedRegister = self()->freeBestRegister(currentInstruction, virtualRegister, NULL);
             }
-         if (!comp->getOption(TR_DisableOOL) && cg->isOutOfLineColdPath())
+         if (cg->isOutOfLineColdPath())
             {
             cg->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
             }
@@ -781,7 +749,7 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
             }
          else
             {
-            if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+            if (self()->cg()->isOutOfLineColdPath())
                {
                self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                }
@@ -846,7 +814,7 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
                }
             else
                {
-               if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+               if (self()->cg()->isOutOfLineColdPath())
                   {
                   self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                   }
@@ -910,7 +878,7 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
                }
             else
                {
-               if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+               if (self()->cg()->isOutOfLineColdPath())
                   {
                   self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                   }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -348,73 +348,70 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
    uint32_t i, j;
    bool changed;
 
-   if (!comp->getOption(TR_DisableOOL))
+   for (i = 0; i< numberOfRegisters; i++)
       {
-      for (i = 0; i< numberOfRegisters; i++)
+      virtReg = _dependencies[i].getRegister();
+      if (_dependencies[i].isSpilledReg())
          {
-         virtReg = _dependencies[i].getRegister();
-         if (_dependencies[i].isSpilledReg())
+         TR_ASSERT(virtReg->getBackingStorage(), "should have a backing store if SpilledReg");
+         if (virtReg->getAssignedRealRegister())
             {
-            TR_ASSERT(virtReg->getBackingStorage(), "should have a backing store if SpilledReg");
-            if (virtReg->getAssignedRealRegister())
-               {
-               // this happens when the register was first spilled in main line path then was reverse spilled
-               // and assigned to a real register in OOL path. We protected the backing store when doing
-               // the reverse spill so we could re-spill to the same slot now
-               traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
-               TR::Node *currentNode = currentInstruction->getNode();
-               TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-               TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), cg);
-               TR_RegisterKinds rk = virtReg->getKind();
-               TR::InstOpCode::Mnemonic opCode;
-               switch (rk)
-                  {
-                  case TR_GPR:
-                     opCode = TR::InstOpCode::ldrimmx;
-                     break;
-                  case TR_FPR:
-                     opCode = TR::InstOpCode::vldrimmd;
-                     break;
-                  case TR_VRF:
-                     opCode = TR::InstOpCode::vldrimmq;
-                     break;
-                  default:
-                     TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");
-                     break;
-                  }
-
-               TR::Instruction *inst = generateTrg1MemInstruction(cg, opCode, currentNode, assignedReg, tempMR, currentInstruction);
-
-               assignedReg->setAssignedRegister(NULL);
-               virtReg->setAssignedRegister(NULL);
-               assignedReg->setState(TR::RealRegister::Free);
-
-               if (comp->getDebug())
-                  cg->traceRegisterAssignment("Generate reload of virt %s due to spillRegIndex dep at inst %p\n", cg->comp()->getDebug()->getName(virtReg), currentInstruction);
-               cg->traceRAInstruction(inst);
-               }
-
-            if (!(std::find(cg->getSpilledRegisterList()->begin(), cg->getSpilledRegisterList()->end(), virtReg) != cg->getSpilledRegisterList()->end()))
-               cg->getSpilledRegisterList()->push_front(virtReg);
-            }
-         // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
-         else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
-            {
-            TR::ARM64LabelInstruction *labelInstr = (TR::ARM64LabelInstruction *)currentInstruction;
-            TR_BackingStore *location = virtReg->getBackingStorage();
+            // this happens when the register was first spilled in main line path then was reverse spilled
+            // and assigned to a real register in OOL path. We protected the backing store when doing
+            // the reverse spill so we could re-spill to the same slot now
+            traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
+            TR::Node *currentNode = currentInstruction->getNode();
+            TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
+            TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), cg);
             TR_RegisterKinds rk = virtReg->getKind();
-            int32_t dataSize;
-            if (labelInstr->getLabelSymbol()->isStartOfColdInstructionStream() && location)
+            TR::InstOpCode::Mnemonic opCode;
+            switch (rk)
                {
-               traceMsg (comp,"\nOOL: Releasing backing storage (%p)\n", location);
-               if (rk == TR_GPR)
-                  dataSize = TR::Compiler->om.sizeofReferenceAddress();
-               else
-                  dataSize = 8;
-               location->setMaxSpillDepth(0);
-               cg->freeSpill(location, dataSize, 0);
-               virtReg->setBackingStorage(NULL);
+               case TR_GPR:
+                  opCode = TR::InstOpCode::ldrimmx;
+                  break;
+               case TR_FPR:
+                  opCode = TR::InstOpCode::vldrimmd;
+                  break;
+               case TR_VRF:
+                  opCode = TR::InstOpCode::vldrimmq;
+                  break;
+               default:
+                  TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");
+                  break;
                }
+
+            TR::Instruction *inst = generateTrg1MemInstruction(cg, opCode, currentNode, assignedReg, tempMR, currentInstruction);
+
+            assignedReg->setAssignedRegister(NULL);
+            virtReg->setAssignedRegister(NULL);
+            assignedReg->setState(TR::RealRegister::Free);
+
+            if (comp->getDebug())
+               cg->traceRegisterAssignment("Generate reload of virt %s due to spillRegIndex dep at inst %p\n", cg->comp()->getDebug()->getName(virtReg), currentInstruction);
+            cg->traceRAInstruction(inst);
+            }
+
+         if (!(std::find(cg->getSpilledRegisterList()->begin(), cg->getSpilledRegisterList()->end(), virtReg) != cg->getSpilledRegisterList()->end()))
+            cg->getSpilledRegisterList()->push_front(virtReg);
+         }
+      // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
+      else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
+         {
+         TR::ARM64LabelInstruction *labelInstr = (TR::ARM64LabelInstruction *)currentInstruction;
+         TR_BackingStore *location = virtReg->getBackingStorage();
+         TR_RegisterKinds rk = virtReg->getKind();
+         int32_t dataSize;
+         if (labelInstr->getLabelSymbol()->isStartOfColdInstructionStream() && location)
+            {
+            traceMsg (comp,"\nOOL: Releasing backing storage (%p)\n", location);
+            if (rk == TR_GPR)
+               dataSize = TR::Compiler->om.sizeofReferenceAddress();
+            else
+               dataSize = 8;
+            location->setMaxSpillDepth(0);
+            cg->freeSpill(location, dataSize, 0);
+            virtReg->setBackingStorage(NULL);
             }
          }
       }

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -544,7 +544,7 @@ static TR::Register *compareLongsForOrder(TR_ARMConditionCode branchOp, TR::Node
    // For now we just generate pessimistic code.
    static bool disableOOLForLongCompares = (feGetEnv("TR_DisableOOLForLongCompares") != NULL);
    TR::Register *src2Reg = cg->evaluate(secondChild);
-   if (cg->comp()->getOption(TR_DisableOOL) || disableOOLForLongCompares)
+   if (disableOOLForLongCompares)
       {
       TR::ARMControlFlowInstruction *cfop = generateControlFlowInstruction(cg, ARMOp_iflong, node, deps);
       cfop->addSourceRegister(src1Reg->getHighOrder());

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -399,11 +399,10 @@ void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
       diagnostic("\nPerforming Register Assignment:\n");
 
    TR::Instruction *instructionCursor = self()->getAppendInstruction();
-   if (!comp->getOption(TR_DisableOOL))
-      {
-      TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
-      self()->setSpilledRegisterList(spilledRegisterList);
-      }
+   
+   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
+   self()->setSpilledRegisterList(spilledRegisterList);
+   
    while (instructionCursor)
       {
       // TODO Use cross-platform register assignment tracing facility

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -237,44 +237,42 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
    candidates[0]->setBackingStorage(location);
 
    tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), self()->cg());
-   if (!comp->getOption(TR_DisableOOL))
-      {
-      if (!self()->cg()->isOutOfLineColdPath())
-         {
-         TR_Debug   *debugObj = self()->cg()->getDebug();
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL cold path, post dependencies will be generated using this list
-         self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
 
-         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-         // if we reverse spill this register inside the OOL cold/hot path
-         if (!self()->cg()->isOutOfLineHotPath())
-            {// main line
-            location->setMaxSpillDepth(1);
-            }
-         else
-            {
-            // hot path
-            // do not overwrite main line spill depth
-            if (location->getMaxSpillDepth() != 1)
-               location->setMaxSpillDepth(2);
-            }
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
-                                          debugObj->getName(candidates[0]), location->getMaxSpillDepth());
+   if (!self()->cg()->isOutOfLineColdPath())
+      {
+      TR_Debug   *debugObj = self()->cg()->getDebug();
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL cold path, post dependencies will be generated using this list
+      self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
+
+      // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+      // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+      // if we reverse spill this register inside the OOL cold/hot path
+      if (!self()->cg()->isOutOfLineHotPath())
+         {// main line
+         location->setMaxSpillDepth(1);
          }
       else
          {
-         // do not overwrite mainline and hot path spill depth
-         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-         // because the post condition at OOL entry does not expect this register to be spilled
-         if (location->getMaxSpillDepth() != 1 &&
-             location->getMaxSpillDepth() != 2 )
-            {
-            location->setMaxSpillDepth(3);
-            self()->cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList", (candidates[0])->getRegisterName(self()->cg()->comp()));
-            }
+         // hot path
+         // do not overwrite main line spill depth
+         if (location->getMaxSpillDepth() != 1)
+            location->setMaxSpillDepth(2);
+         }
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
+                                       debugObj->getName(candidates[0]), location->getMaxSpillDepth());
+      }
+   else
+      {
+      // do not overwrite mainline and hot path spill depth
+      // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+      // because the post condition at OOL entry does not expect this register to be spilled
+      if (location->getMaxSpillDepth() != 1 &&
+            location->getMaxSpillDepth() != 2 )
+         {
+         location->setMaxSpillDepth(3);
+         self()->cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList", (candidates[0])->getRegisterName(self()->cg()->comp()));
          }
       }
 
@@ -348,124 +346,106 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction      *cur
 
    tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), self()->cg());
 
-   if (self()->cg()->comp()->getOption(TR_DisableOOL))
+   int32_t dataSize = 0; // GARY OOL
+   switch (rk)
       {
-      switch (rk)
-         {
-         case TR_GPR:
-            self()->cg()->freeSpill(location, TR::Compiler->om.sizeofReferenceAddress(), 0);
-            generateMemSrc1Instruction(self()->cg(), ARMOp_str, currentNode, tmemref, targetRegister, currentInstruction);
-            break;
-         case TR_FPR:
-            self()->cg()->freeSpill(location, 8, 0); // TODO: use 4 when floatSpill is implemented
-            //if targetRegister is FS0-FS15, using ARMOp_fsts.
-            generateMemSrc1Instruction(self()->cg(), (isSinglePrecision ? ARMOp_fsts : ARMOp_fstd), currentNode, tmemref, targetRegister, currentInstruction);
-            break;
-         }
+      case TR_GPR:
+         dataSize = TR::Compiler->om.sizeofReferenceAddress();
+         break;
+      case TR_FPR:
+         dataSize = 8; // TODO: use 4 when floatSpill is implemented
+         break;
       }
-   else
+   if (self()->cg()->isOutOfLineColdPath())
       {
-      int32_t dataSize = 0; // GARY OOL
-      switch (rk)
+      bool isOOLentryReverseSpill = false;
+      if (currentInstruction->isLabel())
          {
-         case TR_GPR:
-            dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            break;
-         case TR_FPR:
-            dataSize = 8; // TODO: use 4 when floatSpill is implemented
-            break;
-         }
-      if (self()->cg()->isOutOfLineColdPath())
-         {
-         bool isOOLentryReverseSpill = false;
-         if (currentInstruction->isLabel())
+         if (((TR::ARMLabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
             {
-            if (((TR::ARMLabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
-               {
-               // indicates that we are at OOL entry point post conditions. Since
-               // we are now exiting the OOL cold path (going reverse order)
-               // and we called reverseSpillState(), the main line path
-               // expects the Virt reg to be assigned to a real register
-               // we can now safely unlock the protected backing storage
-               // This prevents locking backing storage for future OOL blocks
-               isOOLentryReverseSpill = true;
-               }
-            }
-         // OOL: only free the spill slot if the register was spilled in the same or less dominant path
-         // ex: spilled in cold path, reverse spill in hot path or main line
-         // we have to spill this register again when we reach OOL entry point due to post
-         // conditions. We want to guarantee that the same spill slot will be protected and reused.
-         // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
-         // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
-         // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
-         if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
-            {
-            if (location->getMaxSpillDepth() != 0)
-               location->setMaxSpillDepth(0);
-            else if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+            // indicates that we are at OOL entry point post conditions. Since
+            // we are now exiting the OOL cold path (going reverse order)
+            // and we called reverseSpillState(), the main line path
+            // expects the Virt reg to be assigned to a real register
+            // we can now safely unlock the protected backing storage
+            // This prevents locking backing storage for future OOL blocks
+            isOOLentryReverseSpill = true;
             }
          }
-      else if (self()->cg()->isOutOfLineHotPath())
+      // OOL: only free the spill slot if the register was spilled in the same or less dominant path
+      // ex: spilled in cold path, reverse spill in hot path or main line
+      // we have to spill this register again when we reach OOL entry point due to post
+      // conditions. We want to guarantee that the same spill slot will be protected and reused.
+      // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
+      // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
+      // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
+      if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
          {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
-         // Any registers reverse spilled before entering OOL should be removed from the spilled list
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-         // Reset maxSpillDepth here so that in the cold path we know to free the spill
-         // and so that the spill is not included in future GC points in the hot path while it is protected
-         location->setMaxSpillDepth(0);
-         if (location->getMaxSpillDepth() == 2)
-            {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            }
-         }
-      else // main line
-         {
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-         location->setMaxSpillDepth(0);
+         if (location->getMaxSpillDepth() != 0)
+            location->setMaxSpillDepth(0);
+         else if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          self()->cg()->freeSpill(location, dataSize, 0);
          if (!self()->cg()->isFreeSpillListLocked())
             {
             spilledRegister->setBackingStorage(NULL);
             }
          }
-      switch (rk)
+      else
          {
-         case TR_GPR:
-            generateMemSrc1Instruction(self()->cg(), ARMOp_str, currentNode, tmemref, targetRegister, currentInstruction);
-            break;
-         case TR_FPR:
-             //if targetRegister is FS0-FS15, using ARMOp_fsts.
-             generateMemSrc1Instruction(self()->cg(), (isSinglePrecision ? ARMOp_fsts : ARMOp_fstd), currentNode, tmemref, targetRegister, currentInstruction);
-            break;
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          }
+      }
+   else if (self()->cg()->isOutOfLineHotPath())
+      {
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL path (in backwards RA). Post dependencies will be generated using this list.
+      // Any registers reverse spilled before entering OOL should be removed from the spilled list
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      // Reset maxSpillDepth here so that in the cold path we know to free the spill
+      // and so that the spill is not included in future GC points in the hot path while it is protected
+      location->setMaxSpillDepth(0);
+      if (location->getMaxSpillDepth() == 2)
+         {
+         self()->cg()->freeSpill(location, dataSize, 0);
+         if (!self()->cg()->isFreeSpillListLocked())
+            {
+            spilledRegister->setBackingStorage(NULL);
+            }
+         }
+      else
+         {
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+         }
+      }
+   else // main line
+      {
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      location->setMaxSpillDepth(0);
+      self()->cg()->freeSpill(location, dataSize, 0);
+      if (!self()->cg()->isFreeSpillListLocked())
+         {
+         spilledRegister->setBackingStorage(NULL);
+         }
+      }
+   switch (rk)
+      {
+      case TR_GPR:
+         generateMemSrc1Instruction(self()->cg(), ARMOp_str, currentNode, tmemref, targetRegister, currentInstruction);
+         break;
+      case TR_FPR:
+            //if targetRegister is FS0-FS15, using ARMOp_fsts.
+            generateMemSrc1Instruction(self()->cg(), (isSinglePrecision ? ARMOp_fsts : ARMOp_fstd), currentNode, tmemref, targetRegister, currentInstruction);
+         break;
       }
    return targetRegister;
    }

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -458,7 +458,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableNoServerDuringStartup",       "M\tDo not use NoServer during startup",  SET_OPTION_BIT(TR_DisableNoServerDuringStartup), "F"},
    {"disableNoVMAccess",                  "O\tdisable compilation without holding VM access",  SET_OPTION_BIT(TR_DisableNoVMAccess), "F"},
    {"disableOnDemandLiteralPoolRegister", "O\tdisable on demand literal pool register",        SET_OPTION_BIT(TR_DisableOnDemandLiteralPoolRegister), "F"},
-   {"disableOOL",                         "O\tdisable out of line instruction selection",      SET_OPTION_BIT(TR_DisableOOL), "F"},
    {"disableOpts=",                       "O{regex}\tlist of optimizations to disable",
                                           TR::Options::setRegex, offsetof(OMR::Options, _disabledOpts), 0, "P"},
    {"disableOptTransformations=",         "O{regex}\tlist of optimizer transformations to disable",
@@ -2360,11 +2359,6 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
       {
          self()->setOption(TR_ReservingLocks, false);
       }
-#if defined(TR_HOST_S390)
-   // Lock reservation without OOL has not implemented on Z
-   if (self()->getOption(TR_DisableOOL))
-      self()->setOption(TR_ReservingLocks,false);
-#endif
 
    return true;
    }

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -375,7 +375,7 @@ enum TR_CompilationOptions
    // Available                           = 0x00010000 + 9,
    TR_DisableIntegerCompareSimplification = 0x00020000 + 9,
    TR_DisableAutoSIMD                      = 0x00040000 + 9,
-   TR_DisableOOL                          = 0x00080000 + 9,
+   // Available                           = 0x00080000 + 9,
    TR_DisableWriteBarriersRangeCheck      = 0x00100000 + 9,
    TR_Randomize                           = 0x00200000 + 9,
    TR_BreakOnWriteBarrier                 = 0x00400000 + 9,

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -164,11 +164,8 @@ OMR::RV::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
    TR::Instruction *instructionCursor = self()->getAppendInstruction();
 
-   if (!comp->getOption(TR_DisableOOL))
-      {
-      TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
-      self()->setSpilledRegisterList(spilledRegisterList);
-      }
+   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
+   self()->setSpilledRegisterList(spilledRegisterList);
 
    if (self()->getDebug())
       self()->getDebug()->startTracingRegisterAssignment();

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,46 +187,43 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
 
    tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
 
-   if (!comp->getOption(TR_DisableOOL))
+   if (!self()->cg()->isOutOfLineColdPath())
       {
-      if (!self()->cg()->isOutOfLineColdPath())
-         {
-         TR_Debug *debugObj = self()->cg()->getDebug();
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL cold path, post dependencies will be generated using this list
-         self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
+      TR_Debug *debugObj = self()->cg()->getDebug();
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL cold path, post dependencies will be generated using this list
+      self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
 
-         // OOL cold path: depth = 3, hot path: depth = 2,  main line: depth = 1
-         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-         // if we reverse spill this register inside the OOL cold/hot path
-         if (!self()->cg()->isOutOfLineHotPath())
-            {// main line
-            location->setMaxSpillDepth(1);
-            }
-         else
-            {
-            // hot path
-            // do not overwrite main line spill depth
-            if (location->getMaxSpillDepth() != 1)
-               {
-               location->setMaxSpillDepth(2);
-               }
-            }
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
-                                          debugObj->getName(candidates[0]), location->getMaxSpillDepth());
+      // OOL cold path: depth = 3, hot path: depth = 2,  main line: depth = 1
+      // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+      // if we reverse spill this register inside the OOL cold/hot path
+      if (!self()->cg()->isOutOfLineHotPath())
+         {// main line
+         location->setMaxSpillDepth(1);
          }
       else
          {
-         // do not overwrite mainline and hot path spill depth
-         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-         // because the post condition at OOL entry does not expect this register to be spilled
-         if (location->getMaxSpillDepth() != 1 &&
-             location->getMaxSpillDepth() != 2 )
+         // hot path
+         // do not overwrite main line spill depth
+         if (location->getMaxSpillDepth() != 1)
             {
-            location->setMaxSpillDepth(3);
-            self()->cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList", (candidates[0])->getRegisterName(self()->cg()->comp()));
+            location->setMaxSpillDepth(2);
             }
+         }
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
+                                       debugObj->getName(candidates[0]), location->getMaxSpillDepth());
+      }
+   else
+      {
+      // do not overwrite mainline and hot path spill depth
+      // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+      // because the post condition at OOL entry does not expect this register to be spilled
+      if (location->getMaxSpillDepth() != 1 &&
+            location->getMaxSpillDepth() != 2 )
+         {
+         location->setMaxSpillDepth(3);
+         self()->cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList", (candidates[0])->getRegisterName(self()->cg()->comp()));
          }
       }
 
@@ -305,116 +302,48 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
 
    tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
 
-   if (comp->getOption(TR_DisableOOL))
+   switch (rk)
       {
-      switch (rk)
-         {
-         case TR_GPR:
-            dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            storeOp = TR::InstOpCode::_sd;
-            break;
-         case TR_FPR:
-            dataSize = 8;
-            storeOp = TR::InstOpCode::_fsd;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
-         }
-         self()->cg()->freeSpill(location, dataSize, 0);
-         generateSTORE(storeOp, currentNode, tmemref, targetRegister, self()->cg(), currentInstruction);
+      case TR_GPR:
+         dataSize = TR::Compiler->om.sizeofReferenceAddress();
+         break;
+      case TR_FPR:
+         dataSize = 8;
+         break;
+      default:
+         TR_ASSERT(false, "Unsupported RegisterKind.");
+         break;
       }
-   else
+   if (self()->cg()->isOutOfLineColdPath())
       {
-      switch (rk)
+      bool isOOLentryReverseSpill = false;
+      if (currentInstruction->isLabel())
          {
-         case TR_GPR:
-            dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            break;
-         case TR_FPR:
-            dataSize = 8;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
-         }
-      if (self()->cg()->isOutOfLineColdPath())
-         {
-         bool isOOLentryReverseSpill = false;
-         if (currentInstruction->isLabel())
+         if (((TR::LabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
             {
-            if (((TR::LabelInstruction*)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
-               {
-               // indicates that we are at OOL entry point post conditions. Since
-               // we are now exiting the OOL cold path (going reverse order)
-               // and we called reverseSpillState(), the main line path
-               // expects the Virt reg to be assigned to a real register
-               // we can now safely unlock the protected backing storage
-               // This prevents locking backing storage for future OOL blocks
-               isOOLentryReverseSpill = true;
-               }
-            }
-         // OOL: only free the spill slot if the register was spilled in the same or less dominant path
-         // ex: spilled in cold path, reverse spill in hot path or main line
-         // we have to spill this register again when we reach OOL entry point due to post
-         // conditions. We want to guarantee that the same spill slot will be protected and reused.
-         // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
-         // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
-         // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
-         if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
-            {
-            if (location->getMaxSpillDepth() != 0)
-               location->setMaxSpillDepth(0);
-            else if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
-
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+            // indicates that we are at OOL entry point post conditions. Since
+            // we are now exiting the OOL cold path (going reverse order)
+            // and we called reverseSpillState(), the main line path
+            // expects the Virt reg to be assigned to a real register
+            // we can now safely unlock the protected backing storage
+            // This prevents locking backing storage for future OOL blocks
+            isOOLentryReverseSpill = true;
             }
          }
-      else if (self()->cg()->isOutOfLineHotPath())
+      // OOL: only free the spill slot if the register was spilled in the same or less dominant path
+      // ex: spilled in cold path, reverse spill in hot path or main line
+      // we have to spill this register again when we reach OOL entry point due to post
+      // conditions. We want to guarantee that the same spill slot will be protected and reused.
+      // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
+      // Also free the spill if maxSpillDepth==0, which will be the case if the reverse spill also occured on the hot path.
+      // If the reverse spill occured on both paths then this is the last chance we have to free the spill slot.
+      if (location->getMaxSpillDepth() == 3 || location->getMaxSpillDepth() == 0 || isOOLentryReverseSpill)
          {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
-         // Any registers reverse spilled before entering OOL should be removed from the spilled list
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-
-         // Reset maxSpillDepth here so that in the cold path we know to free the spill
-         // and so that the spill is not included in future GC points in the hot path while it is protected
-         location->setMaxSpillDepth(0);
-         if (location->getMaxSpillDepth() == 2)
-            {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked())
-               {
-               spilledRegister->setBackingStorage(NULL);
-               }
-            }
-         else
-            {
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
-                                             debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            }
-         }
-      else // main line
-         {
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-         location->setMaxSpillDepth(0);
+         if (location->getMaxSpillDepth() != 0)
+            location->setMaxSpillDepth(0);
+         else if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse spill on both paths indicated, free spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          self()->cg()->freeSpill(location, dataSize, 0);
 
          if (!self()->cg()->isFreeSpillListLocked())
@@ -422,20 +351,68 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             spilledRegister->setBackingStorage(NULL);
             }
          }
-      switch (rk)
+      else
          {
-         case TR_GPR:
-            storeOp = TR::InstOpCode::_sd;
-            break;
-         case TR_FPR:
-            storeOp = TR::InstOpCode::_fsd;
-            break;
-         default:
-            TR_ASSERT(false, "Unsupported RegisterKind.");
-            break;
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
          }
-         generateSTORE(storeOp, currentNode, tmemref, targetRegister, self()->cg(), currentInstruction);
       }
+   else if (self()->cg()->isOutOfLineHotPath())
+      {
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL path (in backwards RA). Post dependencies will be generated using this list.
+      // Any registers reverse spilled before entering OOL should be removed from the spilled list
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+
+      // Reset maxSpillDepth here so that in the cold path we know to free the spill
+      // and so that the spill is not included in future GC points in the hot path while it is protected
+      location->setMaxSpillDepth(0);
+      if (location->getMaxSpillDepth() == 2)
+         {
+         self()->cg()->freeSpill(location, dataSize, 0);
+         if (!self()->cg()->isFreeSpillListLocked())
+            {
+            spilledRegister->setBackingStorage(NULL);
+            }
+         }
+      else
+         {
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+         }
+      }
+   else // main line
+      {
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      location->setMaxSpillDepth(0);
+      self()->cg()->freeSpill(location, dataSize, 0);
+
+      if (!self()->cg()->isFreeSpillListLocked())
+         {
+         spilledRegister->setBackingStorage(NULL);
+         }
+      }
+   switch (rk)
+      {
+      case TR_GPR:
+         storeOp = TR::InstOpCode::_sd;
+         break;
+      case TR_FPR:
+         storeOp = TR::InstOpCode::_fsd;
+         break;
+      default:
+         TR_ASSERT(false, "Unsupported RegisterKind.");
+         break;
+      }
+      
+   generateSTORE(storeOp, currentNode, tmemref, targetRegister, self()->cg(), currentInstruction);
+      
    return targetRegister;
    }
 

--- a/compiler/riscv/codegen/OMRRegisterDependency.cpp
+++ b/compiler/riscv/codegen/OMRRegisterDependency.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -164,70 +164,67 @@ void TR_RVRegisterDependencyGroup::assignRegisters(
    uint32_t i, j;
    bool changed;
 
-   if (!comp->getOption(TR_DisableOOL))
+   for (i = 0; i< numberOfRegisters; i++)
       {
-      for (i = 0; i< numberOfRegisters; i++)
+      virtReg = _dependencies[i].getRegister();
+      if (_dependencies[i].isSpilledReg())
          {
-         virtReg = _dependencies[i].getRegister();
-         if (_dependencies[i].isSpilledReg())
+         TR_ASSERT(virtReg->getBackingStorage(), "should have a backing store if SpilledReg");
+         if (virtReg->getAssignedRealRegister())
             {
-            TR_ASSERT(virtReg->getBackingStorage(), "should have a backing store if SpilledReg");
-            if (virtReg->getAssignedRealRegister())
-               {
-               // this happens when the register was first spilled in main line path then was reverse spilled
-               // and assigned to a real register in OOL path. We protected the backing store when doing
-               // the reverse spill so we could re-spill to the same slot now
-               traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
-               TR::Node *currentNode = currentInstruction->getNode();
-               TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-               TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t), cg);
-               TR_RegisterKinds rk = virtReg->getKind();
-               TR::InstOpCode::Mnemonic opCode;
-               switch (rk)
-                  {
-                  case TR_GPR:
-                     opCode = TR::InstOpCode::_ld;
-                     break;
-                  case TR_FPR:
-                     opCode = TR::InstOpCode::_fld;
-                     break;
-                  default:
-                     TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");
-                     break;
-                  }
-
-               TR::Instruction *inst = generateLOAD(opCode, currentNode, assignedReg, tempMR, cg, currentInstruction);
-
-               assignedReg->setAssignedRegister(NULL);
-               virtReg->setAssignedRegister(NULL);
-               assignedReg->setState(TR::RealRegister::Free);
-
-               if (comp->getDebug())
-                  cg->traceRegisterAssignment("Generate reload of virt %s due to spillRegIndex dep at inst %p\n", cg->comp()->getDebug()->getName(virtReg), currentInstruction);
-               cg->traceRAInstruction(inst);
-               }
-
-            if (!(std::find(cg->getSpilledRegisterList()->begin(), cg->getSpilledRegisterList()->end(), virtReg) != cg->getSpilledRegisterList()->end()))
-               cg->getSpilledRegisterList()->push_front(virtReg);
-            }
-         // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
-         else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
-            {
-            TR::LabelInstruction *labelInstr = (TR::LabelInstruction *)currentInstruction;
-            TR_BackingStore *location = virtReg->getBackingStorage();
+            // this happens when the register was first spilled in main line path then was reverse spilled
+            // and assigned to a real register in OOL path. We protected the backing store when doing
+            // the reverse spill so we could re-spill to the same slot now
+            traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
+            TR::Node *currentNode = currentInstruction->getNode();
+            TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
+            TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t), cg);
             TR_RegisterKinds rk = virtReg->getKind();
-            int32_t dataSize;
-            if (labelInstr->getLabelSymbol()->isStartOfColdInstructionStream() && location)
+            TR::InstOpCode::Mnemonic opCode;
+            switch (rk)
                {
-               traceMsg (comp,"\nOOL: Releasing backing storage (%p)\n", location);
-               if (rk == TR_GPR)
-                  dataSize = TR::Compiler->om.sizeofReferenceAddress();
-               else
-                  dataSize = 8;
-               location->setMaxSpillDepth(0);
-               cg->freeSpill(location, dataSize, 0);
-               virtReg->setBackingStorage(NULL);
+               case TR_GPR:
+                  opCode = TR::InstOpCode::_ld;
+                  break;
+               case TR_FPR:
+                  opCode = TR::InstOpCode::_fld;
+                  break;
+               default:
+                  TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");
+                  break;
                }
+
+            TR::Instruction *inst = generateLOAD(opCode, currentNode, assignedReg, tempMR, cg, currentInstruction);
+
+            assignedReg->setAssignedRegister(NULL);
+            virtReg->setAssignedRegister(NULL);
+            assignedReg->setState(TR::RealRegister::Free);
+
+            if (comp->getDebug())
+               cg->traceRegisterAssignment("Generate reload of virt %s due to spillRegIndex dep at inst %p\n", cg->comp()->getDebug()->getName(virtReg), currentInstruction);
+            cg->traceRAInstruction(inst);
+            }
+
+         if (!(std::find(cg->getSpilledRegisterList()->begin(), cg->getSpilledRegisterList()->end(), virtReg) != cg->getSpilledRegisterList()->end()))
+            cg->getSpilledRegisterList()->push_front(virtReg);
+         }
+      // we also need to free up all locked backing storage if we are exiting the OOL during backwards RA assignment
+      else if (currentInstruction->isLabel() && virtReg->getAssignedRealRegister())
+         {
+         TR::LabelInstruction *labelInstr = (TR::LabelInstruction *)currentInstruction;
+         TR_BackingStore *location = virtReg->getBackingStorage();
+         TR_RegisterKinds rk = virtReg->getKind();
+         int32_t dataSize;
+         if (labelInstr->getLabelSymbol()->isStartOfColdInstructionStream() && location)
+            {
+            traceMsg (comp,"\nOOL: Releasing backing storage (%p)\n", location);
+            if (rk == TR_GPR)
+               dataSize = TR::Compiler->om.sizeofReferenceAddress();
+            else
+               dataSize = 8;
+            location->setMaxSpillDepth(0);
+            cg->freeSpill(location, dataSize, 0);
+            virtReg->setBackingStorage(NULL);
             }
          }
       }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1721,16 +1721,13 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    TR::Block *currBlock = NULL;
    TR::Instruction * currBBEndInstr = instructionCursor;
 
-   if (!self()->comp()->getOption(TR_DisableOOL))
-      {
-      TR::list<TR::Register*> *firstTimeLiveOOLRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
-      self()->setFirstTimeLiveOOLRegisterList(firstTimeLiveOOLRegisterList);
+   TR::list<TR::Register*> *firstTimeLiveOOLRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
+   self()->setFirstTimeLiveOOLRegisterList(firstTimeLiveOOLRegisterList);
 
-      if (!self()->isOutOfLineColdPath())
-         {
-         TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
-         self()->setSpilledRegisterList(spilledRegisterList);
-         }
+   if (!self()->isOutOfLineColdPath())
+      {
+      TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
+      self()->setSpilledRegisterList(spilledRegisterList);
       }
 
    if (!self()->isOutOfLineColdPath())
@@ -2351,29 +2348,26 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
 
    // Create exception table entries for outlined instructions.
    //
-   if (!self()->comp()->getOption(TR_DisableOOL))
+   auto oiIterator = self()->getS390OutOfLineCodeSectionList().begin();
+   while (oiIterator != self()->getS390OutOfLineCodeSectionList().end())
       {
-      auto oiIterator = self()->getS390OutOfLineCodeSectionList().begin();
-      while (oiIterator != self()->getS390OutOfLineCodeSectionList().end())
-         {
-       TR::Block * block = (*oiIterator)->getBlock();
-         TR::Node *firstNode = (*oiIterator)->getFirstInstruction()->getNode();
+      TR::Block * block = (*oiIterator)->getBlock();
+      TR::Node *firstNode = (*oiIterator)->getFirstInstruction()->getNode();
 
-         // Create Exception Table Entries for Nodes that can cause GC's.
-         bool needsETE = (firstNode->getOpCode().hasSymbolReference())? firstNode->getSymbolReference()->canCauseGC() : false;
+      // Create Exception Table Entries for Nodes that can cause GC's.
+      bool needsETE = (firstNode->getOpCode().hasSymbolReference())? firstNode->getSymbolReference()->canCauseGC() : false;
 #ifdef J9_PROJECT_SPECIFIC
-         if (firstNode->getOpCodeValue() == TR::BCDCHK || firstNode->getType().isBCD()) needsETE = true;
+      if (firstNode->getOpCodeValue() == TR::BCDCHK || firstNode->getType().isBCD()) needsETE = true;
 #endif
-         if (needsETE && block && !block->getExceptionSuccessors().empty())
-            {
-            uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
-            uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
+      if (needsETE && block && !block->getExceptionSuccessors().empty())
+         {
+         uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
+         uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
 
-            block->addExceptionRangeForSnippet(startOffset, endOffset);
-            }
-
-         ++oiIterator;
+         block->addExceptionRangeForSnippet(startOffset, endOffset);
          }
+
+      ++oiIterator;
       }
 
    self()->getLinkage()->performPostBinaryEncoding();

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1622,41 +1622,38 @@ OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister ** firstReg, TR::RealRe
 
       bestVirtCandidateLow->setAssignedRegister(NULL);
 
-      if (!comp->getOption(TR_DisableOOL))
+      if (!self()->cg()->isOutOfLineColdPath())
          {
-         if (!self()->cg()->isOutOfLineColdPath())
-            {
-            // the spilledRegisterList contains all registers that are spilled before entering
-            // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
+         // the spilledRegisterList contains all registers that are spilled before entering
+         // the OOL cold path, post dependencies will be generated using this list
+         self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
 
-            // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-            // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-            // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath())
-               {// main line
-               locationLow->setMaxSpillDepth(1);
-               }
-            else
-               {
-               // hot path
-               // do not overwrite main line spill depth
-               if (locationLow->getMaxSpillDepth() != 1)
-                  locationLow->setMaxSpillDepth(2);
-               }
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
-                                             debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
+         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+         // if we reverse spill this register inside the OOL cold/hot path
+         if (!self()->cg()->isOutOfLineHotPath())
+            {// main line
+            locationLow->setMaxSpillDepth(1);
             }
          else
             {
-            // do not overwrite mainline and hot path spill depth
-            // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-            // because the post condition at OOL entry does not expect this register to be spilled
-            if (locationLow->getMaxSpillDepth() != 1 &&
-                locationLow->getMaxSpillDepth() != 2 )
-               locationLow->setMaxSpillDepth(3);
+            // hot path
+            // do not overwrite main line spill depth
+            if (locationLow->getMaxSpillDepth() != 1)
+               locationLow->setMaxSpillDepth(2);
             }
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
+                                          debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
+         }
+      else
+         {
+         // do not overwrite mainline and hot path spill depth
+         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+         // because the post condition at OOL entry does not expect this register to be spilled
+         if (locationLow->getMaxSpillDepth() != 1 &&
+               locationLow->getMaxSpillDepth() != 2 )
+            locationLow->setMaxSpillDepth(3);
          }
       } // if (bestVirtCandidateLow != NULL)
 
@@ -1677,41 +1674,38 @@ OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister ** firstReg, TR::RealRe
 
       bestVirtCandidateHigh->setAssignedRegister(NULL);
 
-      if (!comp->getOption(TR_DisableOOL))
+      if (!self()->cg()->isOutOfLineColdPath())
          {
-         if (!self()->cg()->isOutOfLineColdPath())
-            {
-            // the spilledRegisterList contains all registers that are spilled before entering
-            // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
+         // the spilledRegisterList contains all registers that are spilled before entering
+         // the OOL cold path, post dependencies will be generated using this list
+         self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
 
-            // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-            // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-            // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath())
-               {// main line
-               locationHigh->setMaxSpillDepth(1);
-               }
-            else
-               {
-               // hot path
-               // do not overwrite main line spill depth
-               if (locationHigh->getMaxSpillDepth() != 1)
-                  locationHigh->setMaxSpillDepth(2);
-               }
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
-                                             debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
+         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+         // if we reverse spill this register inside the OOL cold/hot path
+         if (!self()->cg()->isOutOfLineHotPath())
+            {// main line
+            locationHigh->setMaxSpillDepth(1);
             }
          else
             {
-            // do not overwrite mainline and hot path spill depth
-            // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-            // because the post condition at OOL entry does not expect this register to be spilled
-            if (locationHigh->getMaxSpillDepth() != 1 &&
-                locationHigh->getMaxSpillDepth() != 2 )
-               locationHigh->setMaxSpillDepth(3);
+            // hot path
+            // do not overwrite main line spill depth
+            if (locationHigh->getMaxSpillDepth() != 1)
+               locationHigh->setMaxSpillDepth(2);
             }
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
+                                          debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
+         }
+      else
+         {
+         // do not overwrite mainline and hot path spill depth
+         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+         // because the post condition at OOL entry does not expect this register to be spilled
+         if (locationHigh->getMaxSpillDepth() != 1 &&
+               locationHigh->getMaxSpillDepth() != 2 )
+            locationHigh->setMaxSpillDepth(3);
          }
       } //if (bestVirtCandidateHigh != NULL)
 
@@ -1848,41 +1842,38 @@ OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister ** firstReg, TR::RealRegi
 
       bestVirtCandidateLow->setAssignedRegister(NULL);
 
-      if (!comp->getOption(TR_DisableOOL))
+      if (!self()->cg()->isOutOfLineColdPath())
          {
-         if (!self()->cg()->isOutOfLineColdPath())
-            {
-            // the spilledRegisterList contains all registers that are spilled before entering
-            // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
+         // the spilledRegisterList contains all registers that are spilled before entering
+         // the OOL cold path, post dependencies will be generated using this list
+         self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
 
-            // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-            // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-            // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath())
-               {// main line
-               locationLow->setMaxSpillDepth(1);
-               }
-            else
-               {
-               // hot path
-               // do not overwrite main line spill depth
-               if (locationLow->getMaxSpillDepth() != 1)
-                  locationLow->setMaxSpillDepth(2);
-               }
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
-                                             debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
+         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+         // if we reverse spill this register inside the OOL cold/hot path
+         if (!self()->cg()->isOutOfLineHotPath())
+            {// main line
+            locationLow->setMaxSpillDepth(1);
             }
          else
             {
-            // do not overwrite mainline and hot path spill depth
-            // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-            // because the post condition at OOL entry does not expect this register to be spilled
-            if (locationLow->getMaxSpillDepth() != 1 &&
-                  locationLow->getMaxSpillDepth() != 2 )
-               locationLow->setMaxSpillDepth(3);
+            // hot path
+            // do not overwrite main line spill depth
+            if (locationLow->getMaxSpillDepth() != 1)
+               locationLow->setMaxSpillDepth(2);
             }
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
+                                          debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
+         }
+      else
+         {
+         // do not overwrite mainline and hot path spill depth
+         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+         // because the post condition at OOL entry does not expect this register to be spilled
+         if (locationLow->getMaxSpillDepth() != 1 &&
+               locationLow->getMaxSpillDepth() != 2 )
+            locationLow->setMaxSpillDepth(3);
          }
       }
 
@@ -1932,41 +1923,38 @@ OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister ** firstReg, TR::RealRegi
 
       bestVirtCandidateHigh->setAssignedRegister(NULL);
 
-      if (!comp->getOption(TR_DisableOOL))
+      if (!self()->cg()->isOutOfLineColdPath())
          {
-         if (!self()->cg()->isOutOfLineColdPath())
-            {
-            // the spilledRegisterList contains all registers that are spilled before entering
-            // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
+         // the spilledRegisterList contains all registers that are spilled before entering
+         // the OOL cold path, post dependencies will be generated using this list
+         self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
 
-            // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-            // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-            // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath())
-               {// main line
-               locationHigh->setMaxSpillDepth(1);
-               }
-            else
-               {
-               // hot path
-               // do not overwrite main line spill depth
-               if (locationHigh->getMaxSpillDepth() != 1)
-                  locationHigh->setMaxSpillDepth(2);
-               }
-            if (debugObj)
-               self()->cg()->traceRegisterAssignment("OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
-                                             debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
+         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+         // if we reverse spill this register inside the OOL cold/hot path
+         if (!self()->cg()->isOutOfLineHotPath())
+            {// main line
+            locationHigh->setMaxSpillDepth(1);
             }
          else
             {
-            // do not overwrite mainline and hot path spill depth
-            // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-            // because the post condition at OOL entry does not expect this register to be spilled
-            if (locationHigh->getMaxSpillDepth() != 1 &&
-                  locationHigh->getMaxSpillDepth() != 2 )
-               locationHigh->setMaxSpillDepth(3);
+            // hot path
+            // do not overwrite main line spill depth
+            if (locationHigh->getMaxSpillDepth() != 1)
+               locationHigh->setMaxSpillDepth(2);
             }
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
+                                          debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
+         }
+      else
+         {
+         // do not overwrite mainline and hot path spill depth
+         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+         // because the post condition at OOL entry does not expect this register to be spilled
+         if (locationHigh->getMaxSpillDepth() != 1 &&
+               locationHigh->getMaxSpillDepth() != 2 )
+            locationHigh->setMaxSpillDepth(3);
          }
       }
 
@@ -2612,9 +2600,7 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
    switch (rk)
      {
      case TR_GPR:
-       if (!comp->getOption(TR_DisableOOL) &&
-           (self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath()) &&
-           virtReg->getBackingStorage())
+       if ((self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage())
          {
          // reuse the spill slot
          if (debugObj)
@@ -2643,9 +2629,7 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
 
        break;
      case TR_FPR:
-       if (!comp->getOption(TR_DisableOOL) &&
-           (self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath()) &&
-           virtReg->getBackingStorage())
+       if ((self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage())
          {
          // reuse the spill slot
          if (debugObj)
@@ -2691,42 +2675,40 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
       cursor->assignBestSpillRegister();
       }
 
-   if (!comp->getOption(TR_DisableOOL) && location != NULL)
+   if (!self()->cg()->isOutOfLineColdPath())
       {
-      if (!self()->cg()->isOutOfLineColdPath())
-         {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL cold path, post dependencies will be generated using this list
-         self()->cg()->getSpilledRegisterList()->push_front(virtReg);
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL cold path, post dependencies will be generated using this list
+      self()->cg()->getSpilledRegisterList()->push_front(virtReg);
 
-         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
-         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
-         // if we reverse spill this register inside the OOL cold/hot path
-         if (!self()->cg()->isOutOfLineHotPath())
-            {// main line
-            location->setMaxSpillDepth(1);
-            }
-         else
-            {
-            // hot path
-            // do not overwrite main line spill depth
-            if (location->getMaxSpillDepth() != 1)
-               location->setMaxSpillDepth(2);
-            }
-         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
-                                          debugObj->getName(virtReg), location->getMaxSpillDepth());
+      // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
+      // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
+      // if we reverse spill this register inside the OOL cold/hot path
+      if (!self()->cg()->isOutOfLineHotPath())
+         {// main line
+         location->setMaxSpillDepth(1);
          }
       else
          {
-         // do not overwrite mainline and hot path spill depth
-         // if this spill is inside OOL cold path, we do not need to protecting the spill slot
-         // because the post condition at OOL entry does not expect this register to be spilled
-         if (location->getMaxSpillDepth() != 1 &&
-             location->getMaxSpillDepth() != 2 )
-            location->setMaxSpillDepth(3);
+         // hot path
+         // do not overwrite main line spill depth
+         if (location->getMaxSpillDepth() != 1)
+            location->setMaxSpillDepth(2);
          }
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
+                                       debugObj->getName(virtReg), location->getMaxSpillDepth());
       }
+   else
+      {
+      // do not overwrite mainline and hot path spill depth
+      // if this spill is inside OOL cold path, we do not need to protecting the spill slot
+      // because the post condition at OOL entry does not expect this register to be spilled
+      if (location->getMaxSpillDepth() != 1 &&
+            location->getMaxSpillDepth() != 2 )
+         location->setMaxSpillDepth(3);
+      }
+      
    best->setAssignedRegister(NULL);
    best->setState(TR::RealRegister::Free);
 
@@ -2852,82 +2834,72 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
          break;
       }
 
-   if(true) // Check to see if we should free spill location
-     {
-     if (comp->getOption(TR_DisableOOL))
-       {
-       self()->cg()->freeSpill(location, dataSize, 0);
-       }
-     else
-       {
-       if (self()->cg()->isOutOfLineColdPath())
+   if (self()->cg()->isOutOfLineColdPath())
+      {
+      bool isOOLentryReverseSpill = false;
+      if (currentInstruction->isLabel())
          {
-         bool isOOLentryReverseSpill = false;
-         if (currentInstruction->isLabel())
-           {
-           if (toS390LabelInstruction(currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
-             {
-             // indicates that we are at OOL entry point post conditions. Since
-             // we are now exiting the OOL cold path (going reverse order)
-             // and we called reverseSpillState(), the main line path
-             // expects the Virt reg to be assigned to a real register
-             // we can now safely unlock the protected backing storage
-             // This prevents locking backing storage for future OOL blocks
-             isOOLentryReverseSpill = true;
-             }
-           }
+         if (toS390LabelInstruction(currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream())
+            {
+            // indicates that we are at OOL entry point post conditions. Since
+            // we are now exiting the OOL cold path (going reverse order)
+            // and we called reverseSpillState(), the main line path
+            // expects the Virt reg to be assigned to a real register
+            // we can now safely unlock the protected backing storage
+            // This prevents locking backing storage for future OOL blocks
+            isOOLentryReverseSpill = true;
+            }
+         }
 
-         // OOL: only free the spill slot if the register was spilled in the same or less dominant path
-         // ex: spilled in cold path, reverse spill in hot path or main line
-         // we have to spill this register again when we reach OOL entry point due to post
-         // conditions. We want to guarantee that the same spill slot will be protected and reused.
-         // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
-         if (location->getMaxSpillDepth() == 0 || location->getMaxSpillDepth() == 3 || isOOLentryReverseSpill)
-           {
-           location->setMaxSpillDepth(0);
-           self()->cg()->freeSpill(location, dataSize, 0);
-           spilledRegister->setBackingStorage(NULL);
-           }
-         else
-           {
-           if (debugObj)
-             self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
-                                           debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-           }
-         }
-       else if (self()->cg()->isOutOfLineHotPath())
+      // OOL: only free the spill slot if the register was spilled in the same or less dominant path
+      // ex: spilled in cold path, reverse spill in hot path or main line
+      // we have to spill this register again when we reach OOL entry point due to post
+      // conditions. We want to guarantee that the same spill slot will be protected and reused.
+      // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
+      if (location->getMaxSpillDepth() == 0 || location->getMaxSpillDepth() == 3 || isOOLentryReverseSpill)
          {
-         // the spilledRegisterList contains all registers that are spilled before entering
-         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
-         // Any registers reverse spilled before entering OOL should be removed from the spilled list
-         if (debugObj)
-           self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
-         if (location->getMaxSpillDepth() == 2)
-           {
-           location->setMaxSpillDepth(0);
-           self()->cg()->freeSpill(location, dataSize, 0);
-           spilledRegister->setBackingStorage(NULL);
-           }
-         else
-           {
-           if (debugObj)
-             self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
-                                           debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-           location->setMaxSpillDepth(0);
-           }
-         }
-       else // main line
-         {
-         if (debugObj)
-           self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
          location->setMaxSpillDepth(0);
          self()->cg()->freeSpill(location, dataSize, 0);
          spilledRegister->setBackingStorage(NULL);
          }
-       }
-     } // Need to free the spill location
+      else
+         {
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+         }
+      }
+   else if (self()->cg()->isOutOfLineHotPath())
+      {
+      // the spilledRegisterList contains all registers that are spilled before entering
+      // the OOL path (in backwards RA). Post dependencies will be generated using this list.
+      // Any registers reverse spilled before entering OOL should be removed from the spilled list
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      if (location->getMaxSpillDepth() == 2)
+         {
+         location->setMaxSpillDepth(0);
+         self()->cg()->freeSpill(location, dataSize, 0);
+         spilledRegister->setBackingStorage(NULL);
+         }
+      else
+         {
+         if (debugObj)
+            self()->cg()->traceRegisterAssignment("\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
+                                          debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
+         location->setMaxSpillDepth(0);
+         }
+      }
+   else // main line
+      {
+      if (debugObj)
+         self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n", debugObj->getName(spilledRegister));
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      location->setMaxSpillDepth(0);
+      self()->cg()->freeSpill(location, dataSize, 0);
+      spilledRegister->setBackingStorage(NULL);
+      }
 
    if (opCode == TR::InstOpCode::VST)
       cursor = generateVRXInstruction(self()->cg(), opCode, currentNode, targetRegister, tempMR, 0, currentInstruction);
@@ -3044,7 +3016,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
             }
          else
             {
-            if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+            if (self()->cg()->isOutOfLineColdPath())
                {
                self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                }
@@ -3142,7 +3114,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
             }
          else
             {
-            if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+            if (self()->cg()->isOutOfLineColdPath())
                {
                self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                }
@@ -3349,7 +3321,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
                }
             else
                {
-               if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+               if (self()->cg()->isOutOfLineColdPath())
                   {
                   self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                   }
@@ -3389,7 +3361,7 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
             }
          else
             {
-            if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+            if (self()->cg()->isOutOfLineColdPath())
                {
                self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                }


### PR DESCRIPTION
This option is inconsistently used throughout the codebase. It was
originally introduced when OOL code sequences were first implemented as
a fallback path due to register allocation issues.

We have been using OOL sequences for almost a decade now and in some
places we don't even have a guard or fallback path against using OOL,
so enabling this option is not safe. Because of these reasons it is
best to just remove it.

Closes: #5968