### PR TITLE
Update getProcessorName routines

### DIFF
--- a/compiler/aarch64/env/OMRCPU.cpp
+++ b/compiler/aarch64/env/OMRCPU.cpp
@@ -43,3 +43,22 @@ OMR::ARM64::CPU::supportsFeature(uint32_t feature)
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
    return (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
    }
+
+const char*
+OMR::ARM64::CPU::getProcessorName()
+   {
+   const char* returnString = "";
+   switch(_processorDescription.processor)
+      {
+      case OMR_PROCESSOR_ARM64_UNKNOWN:
+         returnString = "Unknown ARM64 processor";
+         break;
+      case OMR_PROCESSOR_ARM64_V8_A:
+         returnString = "ARMv8-A processor";
+         break;
+      default:
+         returnString = "Unknown ARM64 processor";
+         break;
+      }
+   return returnString;
+   }

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -123,6 +123,12 @@ public:
     * @returns true if feature is supported
     */
    bool supportsFeature(uint32_t feature);
+
+   /**
+    * @brief Returns name of the current processor
+    * @returns const char* string representing the name of the current processor
+    */
+   const char* getProcessorName();
    };
 
 }

--- a/compiler/arm/env/OMRCPU.hpp
+++ b/compiler/arm/env/OMRCPU.hpp
@@ -104,6 +104,12 @@ public:
     * @param requireRotateToLeft if true, returns true if rotate to left operation is available.
     */
    bool getSupportsHardware64bitRotate(bool requireRotateToLeft=false) { return !requireRotateToLeft; } // only rotate to right is available
+
+   /**
+    * @brief Returns name of the current processor
+    * @returns const char* string representing the name of the current processor
+    */
+   const char* getProcessorName() { return "Unknown Arm Processor"; }
    };
 
 }

--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -212,6 +212,12 @@ public:
     */
    bool supportsFeature(uint32_t feature);
 
+   /**
+    * @brief Returns name of the current processor
+    * @returns const char* string representing the name of the current processor
+    */
+   const char* getProcessorName() { return "Unknown Processor"; }
+
 protected:
    OMRProcessorDesc _processorDescription;
 

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -192,3 +192,84 @@ OMR::Power::CPU::getOldProcessorTypeFromNewProcessorType(OMRProcessorArchitectur
    return TR_FirstPPCProcessor;
    }
 
+const char*
+OMR::Power::CPU::getProcessorName()
+   {
+   const char* returnString = "";
+   switch(_processorDescription.processor)
+      {
+      case OMR_PROCESSOR_PPC_PWR604:
+         returnString = "PPCPWR604";
+         break;
+
+      case OMR_PROCESSOR_PPC_PWR630:
+         returnString = "PPCpwr630 ";
+         break;
+
+      case OMR_PROCESSOR_PPC_GP:
+         returnString = "PPCgp";
+         break;
+
+      case OMR_PROCESSOR_PPC_GR:
+         returnString = "PPCgr";
+         break;
+
+      case OMR_PROCESSOR_PPC_P6:
+         returnString = "PPCp6";
+         break;
+
+      case OMR_PROCESSOR_PPC_P7:
+         returnString = "PPCp7";
+         break;
+
+      case OMR_PROCESSOR_PPC_P8:
+         returnString = "PPCp8";
+         break;
+
+      case OMR_PROCESSOR_PPC_P9:
+         returnString = "PPCp9";
+         break;
+
+      case OMR_PROCESSOR_PPC_P10:
+         returnString = "PPCp10";
+         break;
+
+      case OMR_PROCESSOR_PPC_PULSAR:
+         returnString = "PPCpulsar";
+         break;
+
+      case OMR_PROCESSOR_PPC_NSTAR:
+         returnString = "PPCnstar";
+         break;
+
+      case OMR_PROCESSOR_PPC_PWR403:
+         returnString = "PPCPWR403";
+         break;
+
+      case OMR_PROCESSOR_PPC_PWR601:
+         returnString = "PPCPWR601";
+         break;
+
+      case OMR_PROCESSOR_PPC_PWR603:
+         returnString = "PPCPWR603";
+         break;
+
+      case OMR_PROCESSOR_PPC_82XX:
+         returnString = "PPCP82xx";
+         break;
+
+      case OMR_PROCESSOR_PPC_7XX:
+         returnString = "PPC7xx";
+         break;
+
+      case OMR_PROCESSOR_PPC_PWR440:
+         returnString = "PPCPWR440";
+         break;
+
+      default:
+         returnString = "Unknown PPC processor";
+         break;
+      }
+   return returnString;
+   }
+

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -131,6 +131,12 @@ public:
    bool isAtLeast(OMRProcessorArchitecture p);
    bool isAtMost(OMRProcessorArchitecture p);
 
+   /**
+    * @brief Returns name of the current processor
+    * @returns const char* string representing the name of the current processor
+    */
+   const char* getProcessorName();
+
 private:
    
    TR_Processor getOldProcessorTypeFromNewProcessorType(OMRProcessorArchitecture p);

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -573,3 +573,83 @@ OMR::X86::CPU::supports_feature_old_api(uint32_t feature)
    return supported;
    }
 
+const char*
+OMR::X86::CPU::getProcessorName()
+   {
+   const char* returnString = "";
+   switch(_processorDescription.processor)
+      {
+      case OMR_PROCESSOR_X86_INTELPENTIUM:
+         returnString = "X86 Intel Pentium";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELP6:
+         returnString = "X86 Intel P6";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELPENTIUM4:
+         returnString = "X86 Intel Netburst Microarchitecture";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELCORE2:
+         returnString = "X86 Intel Core2 Microarchitecture";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELTULSA:
+         returnString = "X86 Intel Tulsa";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELNEHALEM:
+         returnString = "X86 Intel Nehalem";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELWESTMERE:
+         returnString = "X86 Intel Westmere";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELSANDYBRIDGE:
+         returnString = "X86 Intel Sandy Bridge";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELIVYBRIDGE:
+         returnString = "X86 Intel Ivy Bridge";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELHASWELL:
+         returnString = "X86 Intel Haswell";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELBROADWELL:
+         returnString = "X86 Intel Broadwell";
+         break;
+
+      case OMR_PROCESSOR_X86_INTELSKYLAKE:
+         returnString = "X86 Intel Skylake";
+         break;
+
+      case OMR_PROCESSOR_X86_AMDK5:
+         returnString = "X86 AMDK5";
+         break;
+
+      case OMR_PROCESSOR_X86_AMDK6:
+         returnString = "X86 AMDK6";
+         break;
+
+      case OMR_PROCESSOR_X86_AMDATHLONDURON:
+         returnString = "X86 AMD Athlon-Duron";
+         break;
+
+      case OMR_PROCESSOR_X86_AMDOPTERON:
+         returnString = "X86 AMD Opteron";
+         break;
+
+      case OMR_PROCESSOR_X86_AMDFAMILY15H:
+         returnString = "X86 AMD Family 15h";
+         break;
+
+      default:
+         returnString = "Unknown X86 Processor";
+         break;
+      }
+   return returnString;
+   }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -140,6 +140,12 @@ public:
    bool supportsFeature(uint32_t feature);
    bool supports_feature_old_api(uint32_t feature);
    bool supports_feature_test(uint32_t feature);
+
+   /**
+    * @brief Returns name of the current processor
+    * @returns const char* string representing the name of the current processor
+    */
+   const char* getProcessorName();
    };
 }
 

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -86,7 +86,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize();
    }
@@ -96,7 +96,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.isAtLeast(_opcode.getMinimumALS()), "Processor detected (%s) does not support instruction %s\n", cg->comp()->target().cpu.getProcessorName(), _opcode.getMnemonicName());
 
    self()->initialize(precedingInstruction, true);
    }

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -197,58 +197,11 @@ OMR::Z::CPU::supportsFeatureOldAPI(uint32_t feature)
    }
 
 const char*
-OMR::Z::CPU::getProcessorName(Architecture arch)
-   {
-   const char* result = "";
-   switch (arch)
-      {
-      case Unknown:
-         result = "Unknown";
-         break;
-      case z900:
-         result = "z900";
-         break;
-      case z990:
-         result = "z990";
-         break;
-      case z9:
-         result = "z9";
-         break;
-      case z10:
-         result = "z10";
-         break;
-      case z196:
-         result = "z196";
-         break;
-      case zEC12:
-         result = "zEC12";
-         break;
-      case z13:
-         result = "z13";
-         break;
-      case z14:
-         result = "z14";
-         break;
-      case z15:
-         result = "z15";
-         break;
-      case zNext:
-         result = "zNext";
-         break;
-      default:
-         TR_ASSERT(false, "Invalid Archiecture Type: %d", arch);
-         result = "Invalid Architecture type!";
-         break;
-      }
-   return result;
-   }
-
-const char*
-OMR::Z::CPU::getProcessorName(OMRProcessorArchitecture arch)
+OMR::Z::CPU::getProcessorName()
    {
    const char* result = "";
 
-   switch(arch)
+   switch(_processorDescription.processor)
       {
       case OMR_PROCESSOR_S390_UNKNOWN:
          result = "Unknown";
@@ -284,89 +237,9 @@ OMR::Z::CPU::getProcessorName(OMRProcessorArchitecture arch)
          result = "zNext";
          break;
       default:
-         TR_ASSERT(false, "Invalid Archiecture Type: %d", arch);
          result = "Invalid Architecture type!";
          break;
       }
-   return result;
-   }
-
-const char*
-OMR::Z::CPU::getProcessorName(int32_t machineId)
-   {
-   const char* result = "";
-
-   switch (machineId)
-      {
-      case 1090:
-      case 1091:
-         result = "zPDT";
-      break;
-
-      case 2066:
-         result = "z800";
-      break;
-
-      case 2084:
-         result = "z990";
-      break;
-
-      case 2086:
-         result = "z890";
-      break;
-
-      case 2064:
-         result = "z900";
-      break;
-
-      case 2094:
-      case 2096:
-         result = "z9";
-      break;
-
-      case 2097:
-      case 2098:
-         result = "z10";
-      break;
-
-      case 2817:
-         result = "z196";
-      break;
-      
-      case 2818:
-         result = "z114";
-      break;
-
-      case 2827:
-      case 2828:
-         result = "zEC12";
-      break;
-
-      case 2964:
-      case 2965:
-         result = "z13";
-      break;
-
-      case 3906:
-      case 3907:
-         result = "z14";
-      break;
-
-      case 8561:
-      case 8562:
-         result = "z15";
-      break;
-
-      case 9998:
-      case 9999:
-         result = "zNext";
-      break;
-
-      default:
-         result = "Unknown";
-      break;
-      }
-
    return result;
    }
 

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -65,19 +65,9 @@ public:
       };
 
    /** \brief
-    *     Gets the name of the processor given the four digit machine id.
+    *     Gets the name of the processor that _processorDescription described.
     */
-   static const char* getProcessorName(int32_t machineId);
-
-   /** \brief
-    *     Gets the name of the processor given the four TR::CPU::Architecture enum type.
-    */
-   static const char* getProcessorName(Architecture arch);
-
-   /** \brief
-    *     Gets the name of the processor given the OMRProcessorArchitecture enum type.
-    */
-   static const char* getProcessorName(OMRProcessorArchitecture arch);
+   const char* getProcessorName();
 
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -64,9 +64,10 @@ public:
       zNext,
       };
 
-   /** \brief
-    *     Gets the name of the processor that _processorDescription described.
-    */
+   /**
+     * @brief Returns name of the current processor
+     * @returns const char* string representing the name of the current processor
+     */
    const char* getProcessorName();
 
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);


### PR DESCRIPTION
This commit cleans up and simplifies usage of the getProcessorName routines in z/codegen's implementation of OMRCPU.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>