### PR TITLE
AArch64: Enable byteswap

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -97,6 +97,7 @@ OMR::ARM64::CodeGenerator::initialize()
 
    cg->setSupportsSelect();
 
+   cg->setSupportsByteswap();
 
    if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
       {


### PR DESCRIPTION
This commit enables byteswap on AArch64.
Evaluators for sbyteswap/ibyteswap/lbyteswap are already implemented.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>