### PR TITLE
Unify doRegisterAssignment on all platforms except x86

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -172,12 +172,6 @@ public:
    void endInstructionSelection();
 
    /**
-    * @brief AArch64 local register assignment pass
-    * @param[in] kindsToAssign : mask of register kinds to assign in this pass
-    */
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
-
-   /**
     * @brief AArch64 binary encoding pass
     */
    void doBinaryEncoding();
@@ -322,20 +316,6 @@ public:
     * @param[in] v : IsOutOfLineHotPath flag
     */
    void setIsOutOfLineHotPath(bool v) { _flags.set(IsOutOfLineHotPath, v);}
-
-   /**
-    * @brief Returns the list of registers which is assigned first time in OOL cold path
-    *
-    * @return the list of registers which is assigned first time in OOL cold path
-    */
-   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
-   /**
-    * @brief Sets the list of registers which is assigned first time in OOL cold path
-    *
-    * @param r : the list of registers which is assigned first time in OOL cold path
-    * @return the list of registers
-    */
-   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
 
    /**
     * @brief Picks register

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -348,64 +348,6 @@ void OMR::ARM::CodeGenerator::endInstructionSelection()
       }
    }
 
-void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
-   {
-   TR::Compilation *comp = self()->comp();
-
-   if (comp->getOption(TR_TraceCG))
-      diagnostic("\nPerforming Register Assignment:\n");
-
-   TR::Instruction *instructionCursor = self()->getAppendInstruction();
-   
-   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
-   self()->setSpilledRegisterList(spilledRegisterList);
-   
-   while (instructionCursor)
-      {
-      // TODO Use cross-platform register assignment tracing facility
-      if (comp->getOption(TR_TraceCG))
-         {
-         diagnostic("\nassigning registers for [" POINTER_PRINTF_FORMAT "]:", instructionCursor);
-         self()->getDebug()->print(comp->getOutFile(), instructionCursor);
-         }
-
-      TR::Instruction *prevInstruction = instructionCursor->getPrev();
-      TR::Instruction *nextInstruction = instructionCursor->getNext();
-      instructionCursor->assignRegisters(TR_GPR);
-      // Maintain Internal Control Flow Depth
-      // Track internal control flow on labels
-      if (instructionCursor->isLabel())
-         {
-         TR::ARMLabelInstruction *li = (TR::ARMLabelInstruction *)instructionCursor;
-
-         if (li->getLabelSymbol() != NULL)
-            {
-            if (li->getLabelSymbol()->isStartInternalControlFlow())
-               {
-               self()->decInternalControlFlowNestingDepth();
-               }
-            if (li->getLabelSymbol()->isEndInternalControlFlow())
-               {
-               self()->incInternalControlFlowNestingDepth();
-               }
-            }
-         }
-      self()->freeUnlatchedRegisters();
-      self()->buildGCMapsForInstructionAndSnippet(instructionCursor);
-
-      if (comp->getOption(TR_TraceCG))
-         {
-         diagnostic("\npost-assignment instruction(s):");
-	 TR::Instruction *instr = prevInstruction ? prevInstruction->getNext() : instructionCursor;
-         for (; instr != nextInstruction; instr = instr->getNext())
-            self()->getDebug()->print(comp->getOutFile(), instr);
-         diagnostic("\n");
-         }
-
-      instructionCursor = prevInstruction;
-      }
-   }
-
 void OMR::ARM::CodeGenerator::doBinaryEncoding()
    {
    TR::Compilation *comp = self()->comp();

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -314,49 +314,6 @@ TR::Instruction *OMR::ARM::CodeGenerator::generateSwitchToInterpreterPrePrologue
    return cursor;
    }
 
-static void removeGhostRegistersFromGCMaps(TR::CodeGenerator *cg, TR::Instruction *branchOOL)
-   {
-   // If a virtual is live at the end of the hot path and dead at the beginning it will not be killed immediatey after it's first use in the hot path
-   // if it's also used on the cold path, since RA still needs to be done on the cold path (which is where it's future use count will drop to 0), which
-   // means it will be incorrectly seen as live between it's first use and the top of the hot path.
-   // If there are any GC points between the top of the hot path and the first use the real reg holding the virtual will be included,
-   // so we need to fix this.
-   TR::Instruction *instr = branchOOL->getNext();
-   while (!instr->isLabel() || !((TR::ARMLabelInstruction*)instr)->getLabelSymbol()->isEndOfColdInstructionStream())
-      {
-      if (instr->needsGCMap())
-         {
-         TR_GCStackMap *map = instr->getGCMap();
-         TR_ASSERT( map, "Instruction should have a GC map");
-
-         // This instruction has a GC map, for every register in the register map check if that register is unassigned at the beginning of the hot path.
-         for (uint32_t regNum = TR::RealRegister::FirstGPR; regNum < TR::RealRegister::LastGPR; ++regNum)
-            {
-            uint32_t regMask = cg->registerBitMask(regNum);
-            if (map->getRegisterMap() & regMask)
-               {
-               TR::RealRegister *regInRegMap = cg->machine()->getRealRegister((TR::RealRegister::RegNum)regNum);
-               if (regInRegMap->getState() == TR::RealRegister::Free)
-                  {
-                  // This register is unassigned, check if it was defined before the GC point.
-                  TR::Instruction *prevInstr = instr->getPrev();
-                  while (prevInstr != branchOOL && !prevInstr->defsRealRegister(regInRegMap))
-                     prevInstr = prevInstr->getPrev();
-                  // If it wasn't defined before the GC point it died on the cold path and it's first use on the hot path was after the GC point
-                  // i.e. it shouldn't be in the register map.
-                  if (prevInstr == branchOOL)
-                     {
-                     map->resetRegistersBits(regMask);
-                     }
-                  }
-               }
-            }
-         }
-
-      instr = instr->getNext();
-      }
-   }
-
 void OMR::ARM::CodeGenerator::beginInstructionSelection()
    {
    TR::Compilation *comp = self()->comp();
@@ -431,15 +388,6 @@ void OMR::ARM::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
                {
                self()->incInternalControlFlowNestingDepth();
                }
-            }
-         }
-      else if (instructionCursor->getKind() == TR::Instruction::IsConditionalBranch)
-         {
-         TR::ARMConditionalBranchInstruction *bi = (TR::ARMConditionalBranchInstruction *)instructionCursor;
-
-         if (bi->getLabelSymbol() && bi->getLabelSymbol()->isStartOfColdInstructionStream())
-            {
-            removeGhostRegistersFromGCMaps(self(), bi);
             }
          }
       self()->freeUnlatchedRegisters();

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -124,7 +124,6 @@ public:
 
    void beginInstructionSelection();
    void endInstructionSelection();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
 
    void emitDataSnippets();

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -844,11 +844,14 @@ OMR::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    TR::Instruction *prevInstr = NULL;
    TR::Instruction *currInstr = self()->getAppendInstruction();
 
-   auto *firstTimeLiveOOLRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
-   self()->setFirstTimeLiveOOLRegisterList(firstTimeLiveOOLRegisterList);
+   if (!self()->isOutOfLineColdPath())
+      {
+      auto *firstTimeLiveOOLRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
+      self()->setFirstTimeLiveOOLRegisterList(firstTimeLiveOOLRegisterList);
 
-   auto *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
-   self()->setSpilledRegisterList(spilledRegisterList);
+      auto *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
+      self()->setSpilledRegisterList(spilledRegisterList);
+      }
 
    if (self()->getDebug())
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1085,6 +1085,21 @@ public:
    TR::list<TR_BackingStore*>& getCollectedSpillList() {return _collectedSpillList;}
    TR::list<TR_BackingStore*>& getAllSpillList() {return _allSpillList;}
 
+   /**
+    * @brief Returns the list of registers which is assigned first time in OOL cold path
+    *
+    * @return the list of registers which is assigned first time in OOL cold path
+    */
+   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
+   
+   /**
+    * @brief Sets the list of registers which is assigned first time in OOL cold path
+    *
+    * @param r : the list of registers which is assigned first time in OOL cold path
+    * @return the list of registers
+    */
+   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
+
    TR::list<TR::Register*> *getSpilledRegisterList() {return _spilledRegisterList;}
    TR::list<TR::Register*> *setSpilledRegisterList(TR::list<TR::Register*> *r) {return _spilledRegisterList = r;}
 
@@ -1953,6 +1968,7 @@ public:
 
    int32_t _accumulatorNodeUsage;
 
+   TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
    TR::list<TR::Register*> *_spilledRegisterList;
    TR::list<OMR::RegisterUsage*> *_referencedRegistersList;
    int32_t _currentPathDepth;
@@ -2002,6 +2018,9 @@ public:
    static TR_TreeEvaluatorFunctionPointer _nodeToInstrEvaluators[];
 
    protected:
+
+   /// Determines whether register allocation has been completed
+   bool _afterRA;
 
    bool _disableInternalPointers;
 

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -408,9 +408,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsSynchronizedHandler()                    { _flags.set(_isSynchronizedHandler); }
    bool isSynchronizedHandler()                       { return _flags.testAny(_isSynchronizedHandler); }
 
-   void setHasBeenVisited(bool b = true)              { _flags.set(_hasBeenVisited, b); }
-   bool hasBeenVisited()                              { return _flags.testAny(_hasBeenVisited); }
-
    void setIsPRECandidate(bool b)                     { _flags.set(_isPRECandidate, b); }
    bool isPRECandidate()                              { return _flags.testAny(_isPRECandidate); }
 
@@ -524,7 +521,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _firstBlockInLoop                     = 0x00000020,
       _branchingBackwards                   = 0x00000040,
       _isSynchronizedHandler                = 0x00000100,
-      _hasBeenVisited                       = 0x00000400,
+      // Available                          = 0x00000400,
       _isPRECandidate                       = 0x00000800,
       _isAdded                              = 0x00001000,
       _isOSRInduceBlock                     = 0x00002000,

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -90,14 +90,6 @@ static_assert(TR::NumIlOps ==
  * Local helper functions
  */
 
-static void resetBlockVisitFlags(TR::Compilation *comp)
-   {
-   for (TR::Block *block = comp->getStartBlock(); block != NULL; block = block->getNextBlock())
-      {
-      block->setHasBeenVisited(false);
-      }
-   }
-
 static TR::TreeTop *findNextLegalTreeTop(TR::Compilation *comp, TR::Block *block)
    {
    vcount_t startVisitCount = comp->getStartTree()->getNode()->getVisitCount();
@@ -213,10 +205,6 @@ OMR::Simplifier::postPerformOnBlocks()
    {
    if (trace())
       comp()->dumpMethodTrees("Trees after simplification");
-
-#ifdef DEBUG
-   resetBlockVisitFlags(comp());
-#endif
 
    // Invalidate usedef and value number information if necessary
    //
@@ -342,15 +330,9 @@ OMR::Simplifier::simplifyExtendedBlock(TR::TreeTop * treeTop)
 
       if (b->isOSRCodeBlock() || b->isOSRCatchBlock())
          {
-         b->setHasBeenVisited();
          treeTop = b->getExit();
          continue;
          }
-
-#ifdef DEBUG
-      if (block != b)
-         b->setHasBeenVisited();
-#endif
 
       if (!block && _reassociate &&
           comp()->getFlowGraph()->getStructure() != NULL         // [99391] getStructureOf() only valid if structure isn't invalidated

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -540,62 +540,6 @@ OMR::Power::CodeGenerator::mulDecompositionCostIsJustified(
       }
    }
 
-void OMR::Power::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
-   {
-   TR::Instruction *prevInstruction;
-
-   // gprs, fprs, and ccrs are all assigned in backward direction
-
-   TR::Instruction *instructionCursor = self()->getAppendInstruction();
-
-   TR::Block *currBlock = NULL;
-   TR::Instruction * currBBEndInstr = instructionCursor;
-
-   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
-   self()->setSpilledRegisterList(spilledRegisterList);
-
-   if (self()->getDebug())
-      self()->getDebug()->startTracingRegisterAssignment();
-
-   while (instructionCursor)
-      {
-      prevInstruction = instructionCursor->getPrev();
-
-      self()->tracePreRAInstruction(instructionCursor);
-
-      instructionCursor->assignRegisters(TR_GPR);
-
-      // Maintain Internal Control Flow Depth
-      // Track internal control flow on labels
-      if (instructionCursor->isLabel())
-         {
-         TR::PPCLabelInstruction *li = (TR::PPCLabelInstruction *)instructionCursor;
-
-         if (li->getLabelSymbol() != NULL)
-            {
-            if (li->getLabelSymbol()->isStartInternalControlFlow())
-               {
-               self()->decInternalControlFlowNestingDepth();
-               }
-            if (li->getLabelSymbol()->isEndInternalControlFlow())
-               {
-               self()->incInternalControlFlowNestingDepth();
-               }
-            }
-         }
-
-      self()->freeUnlatchedRegisters();
-      self()->buildGCMapsForInstructionAndSnippet(instructionCursor);
-
-      self()->tracePostRAInstruction(instructionCursor);
-
-      instructionCursor = prevInstruction;
-      }
-
-   if (self()->getDebug())
-      self()->getDebug()->stopTracingRegisterAssignment();
-   }
-
 TR::Instruction *OMR::Power::CodeGenerator::generateNop(TR::Node *n, TR::Instruction *preced, TR_NOPKind nopKind)
    {
    TR::InstOpCode::Mnemonic nop;

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -196,7 +196,6 @@ public:
 
    void beginInstructionSelection();
    void endInstructionSelection();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
    void processRelocations();
    void expandInstructions();

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -155,62 +155,6 @@ OMR::RV::CodeGenerator::endInstructionSelection()
       }
    }
 
-void
-OMR::RV::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
-   {
-   // Registers are assigned in backward direction
-
-   TR::Compilation *comp = self()->comp();
-
-   TR::Instruction *instructionCursor = self()->getAppendInstruction();
-
-   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator()));
-   self()->setSpilledRegisterList(spilledRegisterList);
-
-   if (self()->getDebug())
-      self()->getDebug()->startTracingRegisterAssignment();
-
-   while (instructionCursor)
-      {
-      TR::Instruction *prevInstruction = instructionCursor->getPrev();
-
-      self()->tracePreRAInstruction(instructionCursor);
-
-      instructionCursor->assignRegisters(TR_GPR);
-
-      // Maintain Internal Control Flow Depth
-      // Track internal control flow on labels
-      if (instructionCursor->isLabel())
-         {
-         TR::LabelInstruction *li = (TR::LabelInstruction *)instructionCursor;
-
-         if (li->getLabelSymbol() != NULL)
-            {
-            if (li->getLabelSymbol()->isStartInternalControlFlow())
-               {
-               self()->decInternalControlFlowNestingDepth();
-               }
-            if (li->getLabelSymbol()->isEndInternalControlFlow())
-               {
-               self()->incInternalControlFlowNestingDepth();
-               }
-            }
-         }
-
-      self()->freeUnlatchedRegisters();
-      self()->buildGCMapsForInstructionAndSnippet(instructionCursor);
-
-      self()->tracePostRAInstruction(instructionCursor);
-
-      instructionCursor = prevInstruction;
-      }
-
-   if (self()->getDebug())
-      {
-      self()->getDebug()->stopTracingRegisterAssignment();
-      }
-   }
-
 static void
 expandFarConditionalBranches(TR::CodeGenerator *cg)
    {

--- a/compiler/riscv/codegen/OMRCodeGenerator.hpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.hpp
@@ -97,12 +97,6 @@ public:
    void endInstructionSelection();
 
    /**
-    * @brief AArch64 local register assignment pass
-    * @param[in] kindsToAssign : mask of register kinds to assign in this pass
-    */
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
-
-   /**
     * @brief AArch64 binary encoding pass
     */
    void doBinaryEncoding();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1695,20 +1695,12 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    TR::list<TR::Register*> *firstTimeLiveOOLRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
    self()->setFirstTimeLiveOOLRegisterList(firstTimeLiveOOLRegisterList);
 
-   if (!self()->isOutOfLineColdPath())
-      {
-      TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
-      self()->setSpilledRegisterList(spilledRegisterList);
-      }
+   TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::CFGEdge*>(self()->comp()->allocator()));
+   self()->setSpilledRegisterList(spilledRegisterList);
 
-   if (!self()->isOutOfLineColdPath())
+   if (self()->getDebug())
       {
-      if (self()->getDebug())
-         {
-         TR_RegisterKinds rks = (TR_RegisterKinds)(TR_GPR_Mask | TR_FPR_Mask | TR_VRF_Mask);
-
-         self()->getDebug()->startTracingRegisterAssignment("backward", rks);
-         }
+      self()->getDebug()->startTracingRegisterAssignment();
       }
 
    while (instructionCursor)
@@ -1796,13 +1788,9 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
    _afterRA = true;
 
-   // Done Local RA of GPRs, let make sure we don't have any live registers
-   if (!self()->isOutOfLineColdPath())
+   if (self()->getDebug())
       {
-      if (self()->getDebug())
-         {
-         self()->getDebug()->stopTracingRegisterAssignment();
-         }
+      self()->getDebug()->stopTracingRegisterAssignment();
       }
    }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1707,34 +1707,6 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       {
       TR::Node *treeNode=instructionCursor->getNode();
 
-         /**
-         * Find a free real register for DCB to use during generate binary encoding phase
-         * @see S390DebugCounterBumpInstruction::generateBinaryEncoding()
-         */
-      if(instructionCursor->getOpCodeValue() == TR::InstOpCode::DCB)
-         {
-         TR::S390DebugCounterBumpInstruction *dcbInstr = static_cast<TR::S390DebugCounterBumpInstruction*>(instructionCursor);
-
-         int32_t first = TR::RealRegister::FirstGPR + 1;  // skip GPR0
-         int32_t last  = TR::RealRegister::LastAssignableGPR;
-
-         TR::RealRegister * realReg;
-
-         for (int32_t i=first; i<=last; i++)
-            {
-            realReg = self()->machine()->realRegister(static_cast<TR::RealRegister::RegNum>(i));
-
-            if ( realReg->getState() == TR::RealRegister::Free)
-               {
-               dcbInstr->setAssignableReg(realReg);
-               realReg->setHasBeenAssignedInMethod(true);
-               break;
-               }
-            }
-
-            self()->traceRegisterAssignment("BEST FREE REG for DCB is %R", dcbInstr->getAssignableReg());
-         }
-
       self()->tracePreRAInstruction(instructionCursor);
 
       prevInstruction = instructionCursor->getPrev();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1706,23 +1706,12 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    while (instructionCursor)
       {
       TR::Node *treeNode=instructionCursor->getNode();
-      if(instructionCursor->getOpCodeValue() == TR::InstOpCode::TBEGIN || instructionCursor->getOpCodeValue() == TR::InstOpCode::TBEGINC)
-         {
-         uint16_t immValue = ((TR::S390SILInstruction*)instructionCursor)->getSourceImmediate();
-         uint8_t regMask = 0;
-         for(int8_t i = TR::RealRegister::GPR0; i != TR::RealRegister::GPR15 + 1; i++)
-            {
-            if (self()->machine()->realRegister(static_cast<TR::RealRegister::RegNum>(i))->getState() == TR::RealRegister::Assigned)
-               regMask |= (1 << (7 - ((i - 1) >> 1))); // bit 0 = GPR0/1, GPR0=1, GPR15=16. 'Or' with bit [(i-1)>>1]
-            }
-         immValue = immValue | (regMask<<8);
-         ((TR::S390SILInstruction*)instructionCursor)->setSourceImmediate(immValue);
-         }
+
          /**
          * Find a free real register for DCB to use during generate binary encoding phase
          * @see S390DebugCounterBumpInstruction::generateBinaryEncoding()
          */
-      else if(instructionCursor->getOpCodeValue() == TR::InstOpCode::DCB)
+      if(instructionCursor->getOpCodeValue() == TR::InstOpCode::DCB)
          {
          TR::S390DebugCounterBumpInstruction *dcbInstr = static_cast<TR::S390DebugCounterBumpInstruction*>(instructionCursor);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -142,10 +142,6 @@ namespace TR { class SimpleRegex; }
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
 
-bool compareNodes(TR::Node * node1, TR::Node * node2, TR::CodeGenerator *cg);
-bool isMatchingStoreRestore(TR::Instruction *cursorLoad, TR::Instruction *cursorStore, TR::CodeGenerator *cg);
-void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg);
-
 void
 OMR::Z::CodeGenerator::preLowerTrees()
    {
@@ -1716,8 +1712,6 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
       // Main register assignment procedure
       instructionCursor->assignRegisters(TR_GPR);
-
-      handleLoadWithRegRanges(instructionCursor, self());
 
       // Maintain Internal Control Flow Depth
 
@@ -4699,152 +4693,6 @@ bool OMR::Z::CodeGenerator::IsInMemoryType(TR::DataType type)
 #else
    return false;
 #endif
-   }
-
-uint32_t getRegMaskFromRange(TR::Instruction * inst);
-
-bool isMatchingStoreRestore(TR::Instruction *cursorLoad, TR::Instruction *cursorStore, TR::CodeGenerator *cg)
-   {
-   return false;
-   }
-
-uint32_t getRegMaskFromRange(TR::Instruction * inst)
-   {
-   uint32_t regs = 0;
-
-   TR::Register *lowReg = toS390RSInstruction(inst)->getFirstRegister();
-   TR::Register *highReg = toS390RSInstruction(inst)->getSecondRegister();
-   if (inst->getRegisterOperand(1)->getRegisterPair())
-      highReg = inst->getRegisterOperand(1)->getRegisterPair()->getHighOrder();
-
-   uint32_t lowRegNum = ANYREGINDEX(toRealRegister(lowReg)->getRegisterNumber());
-   uint32_t highRegNum = ANYREGINDEX(toRealRegister(highReg)->getRegisterNumber());
-
-   TR_ASSERT(lowRegNum >= 0 && lowRegNum <= 15 && highRegNum >= 0 && highRegNum <= 15, "Unexpected register number");
-   for (uint32_t i = lowRegNum; ; i = ((i == 15) ? 0 : i+1))  // wrap around to 0 at 15
-      {
-      regs = regs | (0x1 << i);
-      if (i == highRegNum)
-         break;
-      }
-   return regs;
-   }
-
-/**
- * Recursively walk node1 comparing to node2.  This is not a precise function.
- * It is used in a heuristic--many cases are missing and can be added when needed.
- */
-bool compareNodes(TR::Node * node1, TR::Node * node2, TR::CodeGenerator *cg)
-   {
-   if (node1->getOpCodeValue() != node2->getOpCodeValue())
-      return false;
-
-   if (!(node1->getOpCode().isArithmetic() || node1->getOpCode().isConversion() || node1->getOpCode().isTwoChildrenAddress()
-         || ((node1->getOpCode().isLoad() || node1->getOpCode().isLoadAddr()) && node1->getSymbol() == node2->getSymbol())
-         || (node1->getOpCode().isIntegralConst() && node1->get64bitIntegralValue() == node2->get64bitIntegralValue())
-         ))
-      return false;
-
-   // compare children
-   if (node1->getNumChildren() > 0)
-      {
-      if (node1->getNumChildren() != node2->getNumChildren())
-         return false;
-      for (uint32_t i = 0; i < node1->getNumChildren(); i++)
-         {
-         if (!compareNodes(node1->getChild(i), node2->getChild(i), cg))
-            return false;
-         }
-      }
-
-   return true;
-   }
-
-void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg)
-   {
-   TR::Compilation * comp = cg->comp();
-   TR::InstOpCode::Mnemonic opCodeToUse = inst->getOpCodeValue();
-   if (!(opCodeToUse == TR::InstOpCode::LM  || opCodeToUse == TR::InstOpCode::LMG || opCodeToUse == TR::InstOpCode::LMH ||
-         opCodeToUse == TR::InstOpCode::LMY || opCodeToUse == TR::InstOpCode::VLM))
-      return;
-
-   bool isVector = opCodeToUse == TR::InstOpCode::VLM ? true : false;
-   uint32_t numVRFs = TR::RealRegister::LastAssignableVRF - TR::RealRegister::FirstAssignableVRF;
-
-   TR::Register *lowReg  = isVector ? toS390VRSInstruction(inst)->getFirstRegister()  : toS390RSInstruction(inst)->getFirstRegister();
-   TR::Register *highReg = isVector ? toS390VRSInstruction(inst)->getSecondRegister() : toS390RSInstruction(inst)->getSecondRegister();
-
-   if (inst->getRegisterOperand(1)->getRegisterPair())
-      highReg = inst->getRegisterOperand(1)->getRegisterPair()->getHighOrder();
-   uint32_t lowRegNum = ANYREGINDEX(toRealRegister(lowReg)->getRegisterNumber());
-   uint32_t highRegNum = ANYREGINDEX(toRealRegister(highReg)->getRegisterNumber());
-
-   uint32_t regsInRange;
-   if (highRegNum >= lowRegNum)
-      regsInRange = (highRegNum - lowRegNum + 1);
-   else
-      regsInRange = ((isVector ? numVRFs : 16) - lowRegNum) + highRegNum + 1;
-
-   if (regsInRange <= 2)
-      return;   // registers on instruction, nothing more to do.
-
-   // visit all registers in range.  ignore first and last since RA will have taken care of already
-   lowRegNum = lowRegNum == (isVector ? numVRFs - 1 : 15) ? 0 : lowRegNum + 1;
-   // wrap around for loop terminal index to 0 at 15 or 31 for Vector Registers
-
-   uint32_t availForShuffle = cg->machine()->genBitMapOfAssignableGPRs() & ~(getRegMaskFromRange(inst));
-
-   for (uint32_t i  = lowRegNum  ;
-                 i != highRegNum ;
-                 i  = ((i == (isVector ? numVRFs - 1 : 15)) ? 0 : i+1))
-      {
-      TR::RealRegister *reg = cg->machine()->getRealRegister(i + TR::RealRegister::GPR0);
-
-      // Registers that are assigned need to be checked whether they have a matching STM--otherwise we spill.
-      // Since we are called post RA for the LM, we check if assigned registers are last used on the LM so we can
-      // avoid needlessly spilling them. (ex. LM(GPR00F,GPR14P,PSALCCAV->LCCAEMS0); ! PSALCCAV needs a reg and only needed on LM)
-      TR::Register *virtualReg = reg->getAssignedRegister();
-      if (reg->getState() == TR::RealRegister::Assigned && inst != virtualReg->getEndOfRange())
-         {
-         TR::Instruction *cursor = inst->getPrev();
-         bool found = false;
-         while (cursor)
-            {
-            if (cursor->getOpCodeValue() == TR::InstOpCode::FENCE && cursor->getNode()->getOpCodeValue() == TR::BBStart)
-               {
-               TR::Block *block = cursor->getNode()->getBlock();
-               if (!block->isExtensionOfPreviousBlock())
-                  break;
-               }
-            if (cursor->defsRegister(virtualReg))
-               break;
-
-            if (isMatchingStoreRestore(inst, cursor, cg))
-               {
-               cg->traceRegisterAssignment("Skip spilling %R--restored on load", virtualReg);
-               found = true;
-               break; // found matching store--do nothing since load will restore value
-               }
-            cursor = cursor->getPrev();
-            }
-
-         // register is defined before it was stored, spill or shuffle it to a free reg before load clobbers it
-         // start of range will be NULL in some cases, we are cautious and spill (def# 100246)
-         if (!found)
-            {
-            cg->traceRegisterAssignment("trying to free %R for killed reg %R by loadmultiple \n", virtualReg, reg);
-            TR::RealRegister *shuffle = cg->machine()->shuffleOrSpillRegister(inst, virtualReg, availForShuffle);
-            if (shuffle != NULL)
-               {
-               //if the LM instruction uses this reg we just shuffled, it will have the wrong real reg, need to fix this up
-               if (inst->usesRegister(reg))
-                  {
-                  inst->renameRegister(reg, shuffle);
-                  }
-               }
-            }
-         }
-      }
    }
 
 /**

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1711,12 +1711,6 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
          }
       }
 
-   // Set all CFG Blocks unvisited
-   for (currBlock = self()->comp()->getStartBlock(); currBlock != NULL; currBlock = currBlock->getNextBlock())
-     {
-     currBlock->setHasBeenVisited(false);
-     }
-
    while (instructionCursor)
       {
       TR::Node *treeNode=instructionCursor->getNode();

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -523,25 +523,6 @@ public:
 
    bool afterRA() { return _afterRA; }
 
-#ifdef DEBUG
-   void dumpPreGPRegisterAssignment(TR::Instruction *);
-   void dumpPostGPRegisterAssignment(TR::Instruction *, TR::Instruction *);
-
-   // Internal local RA counters for self evaluation
-   void clearTotalSpills()        {_totalColdSpills=0;        _totalHotSpills=0;       }
-   void clearTotalRegisterXfers() {_totalColdRegisterXfers=0; _totalHotRegisterXfers=0;}
-   void clearTotalRegisterMoves() {_totalColdRegisterMoves=0; _totalHotRegisterMoves=0;}
-
-   // current RA block is only valid during register allocation pass and is only used for debug
-   TR::Block * getCurrentRABlock()           { return _curRABlock; }
-   void setCurrentRABlock(TR::Block * block) { _curRABlock = block; }
-
-   void incTotalSpills();
-   void incTotalRegisterXfers();
-   void incTotalRegisterMoves();
-   void printStats(int32_t);
-#endif
-
    TR_S390OutOfLineCodeSection *findS390OutOfLineCodeSectionFromLabel(TR::LabelSymbol *label);
 
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *preced=0, TR_NOPKind nopKind=TR_NOPStandard);
@@ -820,16 +801,6 @@ private:
 
    /** For aggregate type GRA */
    bool considerAggregateSizeForGRA(int32_t size);
-
-#ifdef DEBUG
-   uint32_t _totalColdSpills;
-   uint32_t _totalColdRegisterXfers;
-   uint32_t _totalColdRegisterMoves;
-   uint32_t _totalHotSpills;
-   uint32_t _totalHotRegisterXfers;
-   uint32_t _totalHotRegisterMoves;
-   TR::Block * _curRABlock;
-#endif
 
    bool  TR_LiteralPoolOnDemandOnRun;
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -199,9 +199,6 @@ public:
    TR_BranchPreloadCallData _outlineCall;
    TR_BranchPreloadCallData _outlineArrayCall;
 
-   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
-   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
-
    TR::list<TR_BranchPreloadCallData*> *_callsForPreloadList;
 
    TR::list<TR_BranchPreloadCallData*> * getCallsForPreloadList() { return _callsForPreloadList; }
@@ -282,7 +279,6 @@ public:
    TR::list<TR_OpaqueClassBlock*> * getPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet);
 
    void doInstructionSelection();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
 
    bool loadOrStoreAddressesMatch(TR::Node *node1, TR::Node *node2);
 
@@ -774,8 +770,6 @@ protected:
    TR::list<TR::S390ConstantDataSnippet*>  _constantList;
    TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
 
-   TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
-
 private:
 
    // TODO: These should move into the base class. There also seems to be a little overlap between these and
@@ -816,7 +810,6 @@ private:
 
 protected:
 
-   bool _afterRA;
    flags32_t  _cgFlags;
 
    /** Miscellaneous S390CG boolean flags. */

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -715,33 +715,6 @@ OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //This can be done any time after register assignment
       //If the value is set here, the snippet can be handled in an identical fashion to a normal constantdataSnippet
       }
-
-   // Modify TBEGIN/TBEGINC's General Register Save Mask (GRSM) to only include
-   // live registers.
-   if (self()->getOpCodeValue() == TR::InstOpCode::TBEGIN || self()->getOpCodeValue() == TR::InstOpCode::TBEGINC)
-      {
-      uint8_t linkageBasedSaveMask = 0;
-
-      for (int32_t i = TR::RealRegister::GPR0; i != TR::RealRegister::GPR15 + 1; i++)
-         {
-         if (0 != self()->cg()->getS390Linkage()->getPreserved((TR::RealRegister::RegNum)i))
-            {
-            //linkageBasedSaveMask is 8 bit mask where each bit represents consecutive even/odd regpair to save.
-            linkageBasedSaveMask |= (1 << (7 - ((i - 1) >> 1))); // bit 0 = GPR0/1, GPR0=1, GPR15=16. 'Or' with bit [(i-1)>>1]
-            }
-         }
-
-      // General Register Save Mask (GRSM)
-      uint8_t grsm = (self()->cg()->machine()->genBitVectOfLiveGPRPairs() | linkageBasedSaveMask);
-
-      // GRSM occupies the top 8 bits of the immediate field.  Need to
-      // preserve the lower 8 bits, which has controls for AR, Floating
-      // Point and Program Interruption Filtering.
-      uint16_t originalGRSM = ((TR::S390SILInstruction*)self())->getSourceImmediate();
-      ((TR::S390SILInstruction*)self())->setSourceImmediate((grsm << 8) | (originalGRSM & 0xFF));
-      }
-
-
    }
 
 uint32_t

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -648,6 +648,119 @@ OMR::Z::Instruction::dependencyRefsRegister(TR::Register * reg)
    {
    return false;
    }
+bool isMatchingStoreRestore(TR::Instruction *cursorLoad, TR::Instruction *cursorStore, TR::CodeGenerator *cg)
+   {
+   return false;
+   }
+
+uint32_t getRegMaskFromRange(TR::Instruction * inst)
+   {
+   uint32_t regs = 0;
+
+   TR::Register *lowReg = toS390RSInstruction(inst)->getFirstRegister();
+   TR::Register *highReg = toS390RSInstruction(inst)->getSecondRegister();
+   if (inst->getRegisterOperand(1)->getRegisterPair())
+      highReg = inst->getRegisterOperand(1)->getRegisterPair()->getHighOrder();
+
+   uint32_t lowRegNum = ANYREGINDEX(toRealRegister(lowReg)->getRegisterNumber());
+   uint32_t highRegNum = ANYREGINDEX(toRealRegister(highReg)->getRegisterNumber());
+
+   TR_ASSERT(lowRegNum >= 0 && lowRegNum <= 15 && highRegNum >= 0 && highRegNum <= 15, "Unexpected register number");
+   for (uint32_t i = lowRegNum; ; i = ((i == 15) ? 0 : i+1))  // wrap around to 0 at 15
+      {
+      regs = regs | (0x1 << i);
+      if (i == highRegNum)
+         break;
+      }
+   return regs;
+   }
+   
+static void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg)
+   {
+   TR::Compilation * comp = cg->comp();
+   TR::InstOpCode::Mnemonic opCodeToUse = inst->getOpCodeValue();
+   if (!(opCodeToUse == TR::InstOpCode::LM  || opCodeToUse == TR::InstOpCode::LMG || opCodeToUse == TR::InstOpCode::LMH ||
+         opCodeToUse == TR::InstOpCode::LMY || opCodeToUse == TR::InstOpCode::VLM))
+      return;
+
+   bool isVector = opCodeToUse == TR::InstOpCode::VLM ? true : false;
+   uint32_t numVRFs = TR::RealRegister::LastAssignableVRF - TR::RealRegister::FirstAssignableVRF;
+
+   TR::Register *lowReg  = isVector ? toS390VRSInstruction(inst)->getFirstRegister()  : toS390RSInstruction(inst)->getFirstRegister();
+   TR::Register *highReg = isVector ? toS390VRSInstruction(inst)->getSecondRegister() : toS390RSInstruction(inst)->getSecondRegister();
+
+   if (inst->getRegisterOperand(1)->getRegisterPair())
+      highReg = inst->getRegisterOperand(1)->getRegisterPair()->getHighOrder();
+   uint32_t lowRegNum = ANYREGINDEX(toRealRegister(lowReg)->getRegisterNumber());
+   uint32_t highRegNum = ANYREGINDEX(toRealRegister(highReg)->getRegisterNumber());
+
+   uint32_t regsInRange;
+   if (highRegNum >= lowRegNum)
+      regsInRange = (highRegNum - lowRegNum + 1);
+   else
+      regsInRange = ((isVector ? numVRFs : 16) - lowRegNum) + highRegNum + 1;
+
+   if (regsInRange <= 2)
+      return;   // registers on instruction, nothing more to do.
+
+   // visit all registers in range.  ignore first and last since RA will have taken care of already
+   lowRegNum = lowRegNum == (isVector ? numVRFs - 1 : 15) ? 0 : lowRegNum + 1;
+   // wrap around for loop terminal index to 0 at 15 or 31 for Vector Registers
+
+   uint32_t availForShuffle = cg->machine()->genBitMapOfAssignableGPRs() & ~(getRegMaskFromRange(inst));
+
+   for (uint32_t i  = lowRegNum  ;
+                 i != highRegNum ;
+                 i  = ((i == (isVector ? numVRFs - 1 : 15)) ? 0 : i+1))
+      {
+      TR::RealRegister *reg = cg->machine()->getRealRegister(i + TR::RealRegister::GPR0);
+
+      // Registers that are assigned need to be checked whether they have a matching STM--otherwise we spill.
+      // Since we are called post RA for the LM, we check if assigned registers are last used on the LM so we can
+      // avoid needlessly spilling them. (ex. LM(GPR00F,GPR14P,PSALCCAV->LCCAEMS0); ! PSALCCAV needs a reg and only needed on LM)
+      TR::Register *virtualReg = reg->getAssignedRegister();
+      if (reg->getState() == TR::RealRegister::Assigned && inst != virtualReg->getEndOfRange())
+         {
+         TR::Instruction *cursor = inst->getPrev();
+         bool found = false;
+         while (cursor)
+            {
+            if (cursor->getOpCodeValue() == TR::InstOpCode::FENCE && cursor->getNode()->getOpCodeValue() == TR::BBStart)
+               {
+               TR::Block *block = cursor->getNode()->getBlock();
+               if (!block->isExtensionOfPreviousBlock())
+                  break;
+               }
+            if (cursor->defsRegister(virtualReg))
+               break;
+
+            if (isMatchingStoreRestore(inst, cursor, cg))
+               {
+               cg->traceRegisterAssignment("Skip spilling %R--restored on load", virtualReg);
+               found = true;
+               break; // found matching store--do nothing since load will restore value
+               }
+            cursor = cursor->getPrev();
+            }
+
+         // register is defined before it was stored, spill or shuffle it to a free reg before load clobbers it
+         // start of range will be NULL in some cases, we are cautious and spill (def# 100246)
+         if (!found)
+            {
+            cg->traceRegisterAssignment("trying to free %R for killed reg %R by loadmultiple \n", virtualReg, reg);
+            TR::RealRegister *shuffle = cg->machine()->shuffleOrSpillRegister(inst, virtualReg, availForShuffle);
+            if (shuffle != NULL)
+               {
+               //if the LM instruction uses this reg we just shuffled, it will have the wrong real reg, need to fix this up
+               if (inst->usesRegister(reg))
+                  {
+                  inst->renameRegister(reg, shuffle);
+                  }
+               }
+            }
+         }
+      }
+   }
 
 void
 OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
@@ -715,6 +828,8 @@ OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
       //This can be done any time after register assignment
       //If the value is set here, the snippet can be handled in an identical fashion to a normal constantdataSnippet
       }
+
+   handleLoadWithRegRanges(self(), self()->cg());
    }
 
 uint32_t

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -2745,13 +2745,6 @@ OMR::Z::Machine::reverseSpillState(TR::Instruction      *currentInstruction,
       return NULL;
       }
 
-#ifdef DEBUG
-   if (rk == TR_GPR && (debug("traceMsg90GPR") || debug("traceGPRStats")))
-      {
-      self()->cg()->incTotalSpills();
-      }
-#endif
-
    // no real reg is assigned to targetRegister yet
    if (targetRegister == NULL)
       {

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1028,6 +1028,25 @@ TR::S390PseudoInstruction::estimateBinaryLength(int32_t currentEstimate)
 // TR::S390DebugCounterBumpInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
+void
+TR::S390DebugCounterBumpInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+   {
+   // Find a free real register for DCB to use during binary encoding to avoid spilling scratch registers
+   for (auto i = TR::RealRegister::FirstGPR + 1; i <= TR::RealRegister::LastAssignableGPR; i++)
+      {
+      TR::RealRegister *realReg = cg()->machine()->realRegister(static_cast<TR::RealRegister::RegNum>(i));
+
+      if (realReg->getState() == TR::RealRegister::Free)
+         {
+         _assignableReg = realReg;
+         realReg->setHasBeenAssignedInMethod(true);
+         break;
+         }
+      }
+
+   assignRegistersAndDependencies(kindToBeAssigned);
+   }
+
 /**
  * This instruction is bumps the value at the snippet corresponding to the address of the debug counter count.
  * The valid opcode is TR::InstOpCode::DCB

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -3800,6 +3800,8 @@ class S390SILInstruction : public TR::S390MemInstruction
    uint16_t getSourceImmediate() { return _sourceImmediate; }
    uint16_t setSourceImmediate(uint16_t si) { return _sourceImmediate = si; }
 
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
    virtual uint8_t *generateBinaryEncoding();
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -681,12 +681,6 @@ public:
         _delta(delta){}
 
    /**
-   * A real register must only be assigned for DCB to use if it is guaranteed to be free at the cursor position where DCB is inserted
-   * @param ar Real Register to be assigned
-   */
-   void setAssignableReg(TR::RealRegister * ar){ _assignableReg = ar; }
-
-   /**
    * @return Assigned Real Register
    */
    TR::RealRegister * getAssignableReg(){ return _assignableReg; }
@@ -700,6 +694,8 @@ public:
    * @return The integer amount to increment the counter
    */
    int32_t getDelta(){ return _delta; }
+
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
    virtual uint8_t *generateBinaryEncoding();
    };


### PR DESCRIPTION
See commit messages for details on what was done. Unfortunately on x86 we seem to be doing something completely different from all the other platforms, so in general tackling register allocation on x86 will need to be done separately.

Fixes: #5977