### PR TITLE
Define __EXTABI__ for Port library compilation on AIX64

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -393,6 +393,10 @@ target_include_directories(omrport_obj PRIVATE
 # This flag indicates that we are compiling the port library
 target_compile_definitions(omrport_obj PRIVATE -DOMRPORT_LIBRARY_DEFINE)
 
+if(OMR_OS_AIX AND OMR_ENV_DATA64)
+	target_compile_definitions(omrport_obj PRIVATE -D__EXTABI__)
+endif()
+
 omr_add_exports(omrport_obj
 	omrport_allocate_library
 	omrport_create_library


### PR DESCRIPTION
With enabling vector code generation for Project Panama, AIX systems
need to define `__EXTABI__` for full Vector ABI support. This is
required for the signal handling code in the port library.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>