### PR TITLE
Enable warnings as errors in compiler component on OSX

### DIFF
--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -283,8 +283,14 @@ function(create_omr_compiler_library)
 	omr_inject_object_modification_targets(COMPILER_OBJECTS ${COMPILER_NAME} ${COMPILER_OBJECTS})
 
 	# warnings as errors and enhanced warnings currently don't work
-	set(OMR_WARNINGS_AS_ERRORS OFF)
-	set(OMR_ENHANCED_WARNINGS OFF)
+	if(OMR_OS_OSX AND OMR_ARCH_X86)
+		set(OMR_WARNINGS_AS_ERRORS ON)
+		set(OMR_ENHANCED_WARNINGS OFF)
+	else()
+		set(OMR_WARNINGS_AS_ERRORS OFF)
+		set(OMR_ENHANCED_WARNINGS OFF)
+	endif()
+	
 	set(output_name_args "")
 	if(COMPILER_OUTPUT_NAME)
 		set(output_name_args "OUTPUT_NAME" "${COMPILER_OUTPUT_NAME}")

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -162,7 +162,7 @@ enum ProfilingMode
    void addDebug(const char * string);
 #else
    #define diagnostic(msg, ...) ((void)0)
-   #define debug(option)      0
+   #define debug(option)      NULL
    #define addDebug(string)   ((void)0)
 #endif
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2073,8 +2073,8 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          _queueWeightThresholdForStarvation = TR::Compiler->target.numberOfProcessors() <= 2 ? 1600 : 3200;
 
       // enable by default rampup improvements
-      if (! (TR::Options::getCmdLineOptions()    && TR::Options::getCmdLineOptions()->getOption(TR_DisableRampupImprovements) ||
-             TR::Options::getAOTCmdLineOptions() && TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableRampupImprovements)))
+      if (! ((TR::Options::getCmdLineOptions()    && TR::Options::getCmdLineOptions()->getOption(TR_DisableRampupImprovements)) ||
+             (TR::Options::getAOTCmdLineOptions() && TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableRampupImprovements))))
          {
          self()->setOption(TR_EnableDowngradeOnHugeQSZ);
          self()->setOption(TR_EnableMultipleGCRPeriods);

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -95,6 +95,8 @@ char *feGetEnv(const char *s)
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
 
 TR::OptionTable OMR::Options::_feOptions[] =
    {
@@ -114,6 +116,7 @@ TR::OptionTable OMR::Options::_feOptions[] =
    {0}
    };
 
+#pragma clang diagnostic pop
 
 #include "control/Recompilation.hpp"
 

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1176,8 +1176,8 @@ static TR::SymbolReference * createSymRefForNode(TR::Compilation *comp, TR::Reso
                // 2. Itself is a pointer to array object.
                TR::SymbolReference *valueChildSymRef = valueChild->getSymbolReference();
                if (valueChildSymRef != NULL &&
-                  (valueChild->getOpCode().isLoadVarDirect() && valueChildSymRef->getSymbol()->isAuto()) ||
-                  (valueChild->getOpCode().isLoadReg() && valueChildSymRef->getSymbol()->castToAutoSymbol()->isInternalPointer()))
+                  ((valueChild->getOpCode().isLoadVarDirect() && valueChildSymRef->getSymbol()->isAuto()) ||
+                  (valueChild->getOpCode().isLoadReg() && valueChildSymRef->getSymbol()->castToAutoSymbol()->isInternalPointer())))
                   {
                   if (valueChildSymRef->getSymbol()->castToAutoSymbol()->isInternalPointer())
                      {

--- a/compiler/infra/BitVector.cpp
+++ b/compiler/infra/BitVector.cpp
@@ -187,23 +187,6 @@ void TR_BitVector::setChunkSize(int32_t chunkSize)
 #endif
    }
 
-// produce a hexadecimal string for this bitvector, high bits first, low last
-const char *TR_BitVector::getHexString()
-   {
-   int32_t chunk_hexlen = (BITS_IN_CHUNK/4);
-   char *buf = _region ? (char *)_region->allocate(_numChunks*chunk_hexlen + 1) : (char*)TR_Memory::jitPersistentAlloc(_numChunks*chunk_hexlen + 1);
-   char *pos = buf;
-   #ifdef TRACK_TRBITVECTOR_MEMORY
-   _memoryUsed += _numChunks*chunk_hexlen + 1;
-   #endif
-   for (int32_t i = _numChunks-1; i >= 0; i--)
-      {
-      sprintf(pos, "%0*lX", chunk_hexlen, _chunks[i]);
-      pos += chunk_hexlen;
-      }
-   return buf;
-   }
-
 void TR_BitVector::print(TR::Compilation *comp, TR::FILE *file)
    {
    if (comp->getDebug())

--- a/compiler/infra/BitVector.hpp
+++ b/compiler/infra/BitVector.hpp
@@ -831,9 +831,6 @@ class TR_BitVector
       setChunkSize(numUsedChunks());
       }
 
-   // produce a hexadecimal "name" for this bitvector
-   const char *getHexString();
-
    // Print the bit vector to the log file
    //
    void print(TR::Compilation *comp, TR::FILE *file = NULL);

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -234,7 +234,7 @@ void TR_DebuggingCounters::report()
          int32_t deviation = ((counterInfo->delta + 1)*counterInfo->bucketSize);
 
          if (deviation != INT_MAX)
-            fprintf(output, "Name: [%31s (%5d)] dynamic : (%5.2lf ) static : (%5.2lf ) [%lu]\n",
+            fprintf(output, "Name: [%31s (%5d)] dynamic : (%5.2lf ) static : (%5.2lf ) [%" OMR_PRIu64 "]\n",
 	   	             counterInfo->counterName,
                    ((counterInfo->delta + 1)*counterInfo->bucketSize),
                    //(uint32_t) counterInfo->totalCount,
@@ -254,7 +254,7 @@ void TR_DebuggingCounters::report()
 	       }
       }
 
-   fprintf(output, "Compilation sum %d Dynamic sum %lu \n", (int32_t) compilationSum, dynamicSum);
+   fprintf(output, "Compilation sum %d Dynamic sum %" OMR_PRIu64 " \n", (int32_t) compilationSum, dynamicSum);
    fprintf(output, "\n");
 
    if (output != stdout)

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -9170,7 +9170,7 @@ bool TR_LoopVersioner::guardOkForExpr(TR::Node *node, bool onlySearching)
  * While it is not necessarily incorrect for \p node for to be unrepresentable,
  * it is unexpected and likely to cause a performance problem. So in case
  * \p node \em is unrepresentable, this method increments a static debug
- * counter matching <tt>{loopVersioner.unrepresentable/*}</tt>, and optionally
+ * counter matching <tt>{loopVersioner.unrepresentable*}</tt>, and optionally
  * fails an assertion when enabled using \c ASSERT_REPRESENTABLE_IN_VERSIONER
  * or \c TR_assertRepresentableInVersioner.
  *

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -8095,8 +8095,8 @@ bool TR_LoopVersioner::depsForLoopEntryPrep(
       //
       TR::Node *divisor = node->getSecondChild();
       bool divisorIsNonzeroConstant =
-         divisor->getOpCodeValue() == TR::lconst && divisor->getLongInt() != 0
-         || divisor->getOpCodeValue() == TR::iconst && divisor->getInt() != 0;
+         (divisor->getOpCodeValue() == TR::lconst && divisor->getLongInt() != 0)
+         || (divisor->getOpCodeValue() == TR::iconst && divisor->getInt() != 0);
 
       if (!divisorIsNonzeroConstant)
          {

--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -257,7 +257,7 @@ struct LoopTemps : public TR_Link<LoopTemps>
  *   kind and test type (see guardOkForExpr())
  *
  * Privatization-related debug counters:
- * - \c staticDebugCounters={loopVersioner.unrepresentable/*}
+ * - \c staticDebugCounters={loopVersioner.unrepresentable*}
  *
  * \see LoopImprovement
  * \see LoopEntryPrep
@@ -320,7 +320,7 @@ class TR_LoopVersioner : public TR_LoopTransformer
     *
     * Furthermore, to help detect cases where optimization is inhibited because
     * of an unrepresentable expression, static debug counters are available:
-    * <tt>staticDebugCounters={loopVersioner.unrepresentable/*}</tt>.
+    * <tt>staticDebugCounters={loopVersioner.unrepresentable*}</tt>.
     *
     * For an overview of privatization and the deferral of transformations see
     * TR_LoopVersioner.

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -2636,7 +2636,7 @@ bool TR_BlockStructure::changeContinueLoopsToNestedLoops(TR_RegionStructure *roo
 
 bool TR_RegionStructure::changeContinueLoopsToNestedLoops(TR_RegionStructure *root)
    {
-   static bool traceMyself=(debug("TR_traceChangeContinues") != 0);
+   static bool traceMyself=(debug("TR_traceChangeContinues") != NULL);
 
    bool changed = false;
    TR_RegionStructure::Cursor si(*this);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12232,8 +12232,8 @@ static TR_YesNoMaybe isArrayCompTypeValueType(OMR::ValuePropagation *vp, TR::VPC
          int32_t len;
          const char *sig = arrayConstraint->getClassSignature(len);
 
-         if (!sig || !arrayConstraint->isFixedClass() && sig[0] == '[' && len == 19
-                     && !strncmp(sig, "[Ljava/lang/Object;", 19))
+         if (!sig || (!arrayConstraint->isFixedClass() && sig[0] == '[' && len == 19
+                     && !strncmp(sig, "[Ljava/lang/Object;", 19)))
             {
             isValueType = TR_maybe;
             }


### PR DESCRIPTION
The commits have addressed all warnings on an OSX build, so to prevent
new warnings from being introduced we enable warnings as errors only on
this platform. Future platforms will follow. See each commit for an
explanation of what warning was triggered and fixed.

Issue: #1640