### PR TITLE
RISC-V: implement calls without trampolines

### DIFF
--- a/compiler/riscv/codegen/BinaryEvaluator.cpp
+++ b/compiler/riscv/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@
  */
 static void truncate(TR::Node *node, TR::Register *reg, TR::CodeGenerator *cg)
    {
-   int bitwidth = 0;
+   uint32_t bitwidth = 0;
 
    if (node->getDataType().isInt8())
       {
@@ -345,7 +345,7 @@ OMR::RV::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *src1Reg;
    TR::Register *trgReg;
 
-   int width = TR::DataType::getSize(node->getDataType()) * 8;
+   auto width = TR::DataType::getSize(node->getDataType()) * 8;
 
    if (secondChild->getOpCode().isLoadConst())
       {
@@ -449,7 +449,7 @@ OMR::RV::TreeEvaluator::ishrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *src1Reg;
    TR::Register *trgReg;
 
-   int width = TR::DataType::getSize(node->getDataType()) * 8;
+   auto width = TR::DataType::getSize(node->getDataType()) * 8;
 
    if (secondChild->getOpCode().isLoadConst())
       {
@@ -530,7 +530,7 @@ OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Register *src1Reg;
    TR::Register *trgReg;
 
-   int width = TR::DataType::getSize(node->getDataType()) * 8;
+   auto width = TR::DataType::getSize(node->getDataType()) * 8;
 
    if (secondChild->getOpCode().isLoadConst())
       {

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -101,7 +101,7 @@ OMR::RV::CodeGenerator::initialize()
    // Calculate inverse of getGlobalRegister function
    //
    TR_GlobalRegisterNumber grn;
-   int i;
+   uint16_t i;
 
    TR_GlobalRegisterNumber globalRegNumbers[TR::RealRegister::NumRegisters];
    for (i = 0; i < cg->getNumberOfGlobalGPRs(); i++)

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -81,6 +81,11 @@ void TR::RVLinkageProperties::initialize()
             _returnRegisters[_firstFloatReturnRegister + numFloatReturnRegisters++] = regNum;
             }
          }
+
+   // TODO: following is safe default, can probably be lower. Q: how is this number computed?
+   _numberOfDependencyRegisters =   (TR::RealRegister::LastGPR - TR::RealRegister::FirstGPR + 1)
+                                  + (TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR + 1);
+
    }
 
 void OMR::RV::Linkage::mapStack(TR::ResolvedMethodSymbol *method)

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -43,7 +43,7 @@ void TR::RVLinkageProperties::initialize()
    _firstIntegerArgumentRegister = 0;
    _numIntegerArgumentRegisters = 0;
    _firstIntegerReturnRegister = 0;
-   int numIntegerReturnRegisters = 0;
+   uint8_t numIntegerReturnRegisters = 0;
 
    for (auto regNum = TR::RealRegister::FirstGPR; regNum <= TR::RealRegister::LastGPR; regNum++)
       {
@@ -64,7 +64,7 @@ void TR::RVLinkageProperties::initialize()
    _firstFloatArgumentRegister = _firstIntegerArgumentRegister + _numIntegerArgumentRegisters;
    _numFloatArgumentRegisters = 0;
    _firstFloatReturnRegister = _firstIntegerArgumentRegister + numIntegerReturnRegisters;
-   int numFloatReturnRegisters = 0;
+   uint8_t numFloatReturnRegisters = 0;
 
    for (auto regNum = TR::RealRegister::FirstFPR; regNum <= TR::RealRegister::LastFPR; regNum++)
          {
@@ -113,7 +113,7 @@ bool OMR::RV::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    return(false);
    }
 
-TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, int offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg)
+TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, int32_t offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg)
    {
    TR::Machine *machine = cg()->machine();
    const TR::RVLinkageProperties& properties = self()->getProperties();

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -113,12 +113,12 @@ bool OMR::RV::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    return(false);
    }
 
-TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg)
+TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, int offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg)
    {
    TR::Machine *machine = cg()->machine();
    const TR::RVLinkageProperties& properties = self()->getProperties();
 
-   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(argMemReg, 8, cg()); // post-increment
+   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(argMemReg, offset, cg()); // post-increment
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode; // opCode must be post-index form

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -80,28 +80,28 @@ class RVMemoryArgument
 #define RV_Reserved                 0x40
 
 #define FOR_EACH_REGISTER(machine, block)                                        \
-   for (int regNum = TR::RealRegister::FirstGPR; regNum <= TR::RealRegister::LastGPR; regNum++) \
+   for (auto regNum = TR::RealRegister::FirstGPR; regNum <= TR::RealRegister::LastGPR; regNum++) \
       {                                                                          \
       TR::RealRegister *reg                                                      \
-                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
+                   = machine->getRealRegister(regNum);                           \
       { block; }                                                                 \
       }                                                                          \
-   for (int regNum = TR::RealRegister::FirstFPR; regNum <= TR::RealRegister::FirstFPR; regNum++) \
+   for (auto regNum = TR::RealRegister::FirstFPR; regNum <= TR::RealRegister::FirstFPR; regNum++) \
       {                                                                          \
       TR::RealRegister *reg                                                      \
-                   = machine->getRealRegister((TR::RealRegister::RegNum)regNum); \
+                   = machine->getRealRegister(regNum);                           \
       { block; }                                                                 \
       }
 
 #define FOR_EACH_RESERVED_REGISTER(machine, props, block)                        \
    FOR_EACH_REGISTER(machine,                                                    \
-   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] & RV_Reserved)     \
+   if (props._registerFlags[regNum] & RV_Reserved)                               \
       { block; }                                                                 \
    )
 
 #define FOR_EACH_CALLEE_SAVED_REGISTER(machine, props, block)                    \
    FOR_EACH_REGISTER(machine,                                                    \
-   if (props._registerFlags[(TR::RealRegister::RegNum)regNum] == Preserved)      \
+   if (props._registerFlags[regNum] == Preserved)                                \
       { block; }                                                                 \
    )
 
@@ -346,7 +346,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     * @param[out] memArg : struct holding memory argument information
     * @return MemoryReference for the argument
     */
-   virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, int offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg);
+   virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, int32_t offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg);
 
    /**
     * @brief Saves arguments

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -340,12 +340,13 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    /**
     * @brief Returns a MemoryReference for an outgoing argument
     * @param[in] argMemReg : register pointing to address for the outgoing argument
+    * @param[in] offset : offset from argMemReg in bytes
     * @param[in] argReg : register for the argument
     * @param[in] opCode : instruction OpCode for store to memory
     * @param[out] memArg : struct holding memory argument information
     * @return MemoryReference for the argument
     */
-   virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg);
+   virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, int offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg);
 
    /**
     * @brief Saves arguments

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -132,7 +132,7 @@ struct RVLinkageProperties
    TR::RealRegister::RegNum _computedCallTargetRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _j9methodArgumentRegister; // for icallVMprJavaSendStatic
-   uint8_t _numberOfDependencyGPRegisters;
+   uint8_t _numberOfDependencyRegisters;
    int8_t _offsetToFirstLocal;
 
    uint32_t getNumIntArgRegs() const {return _numIntegerArgumentRegisters;}
@@ -291,7 +291,7 @@ struct RVLinkageProperties
 
    int32_t getOffsetToFirstLocal() const {return _offsetToFirstLocal;}
 
-   uint32_t getNumberOfDependencyGPRegisters() const {return _numberOfDependencyGPRegisters;}
+   uint32_t getNumberOfDependencyRegisters() const {return _numberOfDependencyRegisters;}
 
    /**
     * @brief Initialize derived properties from register flags. This *must* be called

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -91,8 +91,8 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
    TR::Instruction *cursor;
    TR::Node *currentNode = currentInstruction->getNode();
    TR_RegisterKinds rk = (virtualRegister == NULL) ? TR_GPR : virtualRegister->getKind();
-   int numCandidates = 0;
-   int first, last;
+   int32_t numCandidates = 0;
+   TR::RealRegister::RegNum first, last;
    int32_t dataSize = 0;
    bool containsCollectedReference;
    TR::InstOpCode::Mnemonic loadOp;
@@ -119,9 +119,9 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
             break;
          }
 
-      for (int i = first; i <= last; i++)
+      for (auto i = first; i <= last; i++)
          {
-         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = self()->getRealRegister(i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             candidates[numCandidates++] = realReg->getAssignedRegister();
@@ -134,7 +134,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
              cursor->getOpCodeValue() != TR::InstOpCode::label &&
              cursor->getOpCodeValue() != TR::InstOpCode::proc)
          {
-         for (int i = 0; i < numCandidates; i++)
+         for (int32_t i = 0; i < numCandidates; i++)
             {
             if (cursor->refsRegister(candidates[i]))
                {

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -465,6 +465,9 @@ static void registerCopy(TR::Instruction *precedingInstruction,
                          TR::RealRegister *sourceReg,
                          TR::CodeGenerator *cg)
    {
+   TR_ASSERT(sourceReg->getKind() == rk, "Source register kind mismatch.");
+   TR_ASSERT(sourceReg->getKind() == targetReg->getKind(), "Source and target register kind mismatch.");
+
    TR::Node *node = precedingInstruction->getNode();
    switch (rk)
       {
@@ -472,7 +475,8 @@ static void registerCopy(TR::Instruction *precedingInstruction,
          generateITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
          break;
       case TR_FPR:
-         TR_ASSERT(false, "Unsupported RegisterKind.");
+         TR_ASSERT(sourceReg->isSinglePrecision() == targetReg->isSinglePrecision(), "Source and target register size mismatch");
+         generateRTYPE(sourceReg->isSinglePrecision() ? TR::InstOpCode::_fsgnj_s : TR::InstOpCode::_fsgnj_d, node, targetReg, sourceReg, sourceReg, cg, precedingInstruction);
          break;
       default:
          TR_ASSERT(false, "Unsupported RegisterKind.");

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -499,9 +499,9 @@ static void registerExchange(TR::Instruction *precedingInstruction,
       }
    else
       {
-      registerCopy(precedingInstruction, rk, targetReg, middleReg, cg);
-      registerCopy(precedingInstruction, rk, sourceReg, targetReg, cg);
-      registerCopy(precedingInstruction, rk, middleReg, sourceReg, cg);
+      registerCopy(precedingInstruction, rk, middleReg, targetReg, cg);
+      registerCopy(precedingInstruction, rk, targetReg, sourceReg, cg);
+      registerCopy(precedingInstruction, rk, sourceReg, middleReg, cg);
       }
    }
 

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -465,8 +465,8 @@ static void registerCopy(TR::Instruction *precedingInstruction,
                          TR::RealRegister *sourceReg,
                          TR::CodeGenerator *cg)
    {
-   TR_ASSERT(sourceReg->getKind() == rk, "Source register kind mismatch.");
-   TR_ASSERT(sourceReg->getKind() == targetReg->getKind(), "Source and target register kind mismatch.");
+   TR_ASSERT_FATAL(sourceReg->getKind() == rk, "Source register kind mismatch.");
+   TR_ASSERT_FATAL(sourceReg->getKind() == targetReg->getKind(), "Source and target register kind mismatch.");
 
    TR::Node *node = precedingInstruction->getNode();
    switch (rk)
@@ -475,11 +475,11 @@ static void registerCopy(TR::Instruction *precedingInstruction,
          generateITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
          break;
       case TR_FPR:
-         TR_ASSERT(sourceReg->isSinglePrecision() == targetReg->isSinglePrecision(), "Source and target register size mismatch");
+         TR_ASSERT_FATAL(sourceReg->isSinglePrecision() == targetReg->isSinglePrecision(), "Source and target register size mismatch");
          generateRTYPE(sourceReg->isSinglePrecision() ? TR::InstOpCode::_fsgnj_s : TR::InstOpCode::_fsgnj_d, node, targetReg, sourceReg, sourceReg, cg, precedingInstruction);
          break;
       default:
-         TR_ASSERT(false, "Unsupported RegisterKind.");
+         TR_ASSERT_FATAL(false, "Unsupported RegisterKind.");
          break;
       }
    }

--- a/compiler/riscv/codegen/OMRRegisterDependency.cpp
+++ b/compiler/riscv/codegen/OMRRegisterDependency.cpp
@@ -207,11 +207,11 @@ bool OMR::RV::RegisterDependencyConditions::usesRegister(TR::Register *r)
 
 void OMR::RV::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::CodeGenerator *cg)
    {
-   for (int i = 0; i < _addCursorForPre; i++)
+   for (uint16_t i = 0; i < _addCursorForPre; i++)
       {
       _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
       }
-   for (int j = 0; j < _addCursorForPost; j++)
+   for (uint16_t j = 0; j < _addCursorForPost; j++)
       {
       _postConditions->getRegisterDependency(j)->getRegister()->incTotalUseCount();
       }

--- a/compiler/riscv/codegen/RVDebug.cpp
+++ b/compiler/riscv/codegen/RVDebug.cpp
@@ -340,7 +340,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::RegisterDependencyConditions *conditions
    {
     if (conditions)
       {
-      int i;
+      uint32_t i;
       trfprintf(pOutFile,"\n PRE: ");
       for (i=0; i<conditions->getAddCursorForPre(); i++)
          {

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -495,15 +495,15 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
          }
       else
          {
-         TR_ASSERT(0, "Non-recursive calls not (yet) supported");
+         offset = (uint8_t*)getSymbolReference()->getMethodAddress() - cursor;
          }
       }
    else
       {
-      uintptr_t destination = (uintptr_t)(getLabelSymbol()->getCodeLocation());
+      uint8_t* destination = (uint8_t*)(getLabelSymbol()->getCodeLocation());
       if (destination != 0)
          {
-         offset = destination - (uintptr_t)cursor;
+         offset = destination - cursor;
          }
       else
          {

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -484,7 +484,7 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
 
    if (getSymbolReference() != nullptr)
       {
-      TR_ASSERT(getLabelSymbol() == nullptr, "Both symbol reference and symbol set in J-type instruction");
+      TR_ASSERT_FATAL(getLabelSymbol() == nullptr, "Both symbol reference and symbol set in J-type instruction");
       TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
       TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
 
@@ -511,7 +511,7 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
          }
       }
 
-   TR_ASSERT(VALID_UJTYPE_IMM(offset), "Jump offset out of range");
+   TR_ASSERT_FATAL(VALID_UJTYPE_IMM(offset), "Jump offset out of range");
    *iPtr = TR_RISCV_UJTYPE (getOpCode().getMnemonic(), getTargetRegister(), offset);
 
    cursor += RISCV_INSTRUCTION_LENGTH;

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -477,9 +477,9 @@ uint8_t *TR::UtypeInstruction::generateBinaryEncoding() {
 // TR::JtypeInstruction:: member functions
 
 uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
-   uint8_t        *instructionStart = cg()->getBinaryBufferCursor();
-   uint8_t        *cursor           = instructionStart;
-   uint32_t *iPtr = (uint32_t*)instructionStart;
+   uint8_t  *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t  *cursor = instructionStart;
+   uint32_t *iPtr = reinterpret_cast<uint32_t*>(instructionStart);
    intptr_t offset = 0;
 
    if (getSymbolReference() != nullptr)
@@ -495,15 +495,15 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding() {
          }
       else
          {
-         offset = (uint8_t*)getSymbolReference()->getMethodAddress() - cursor;
+         offset = reinterpret_cast<intptr_t>(getSymbolReference()->getMethodAddress()) - reinterpret_cast<intptr_t>(cursor);
          }
       }
    else
       {
-      uint8_t* destination = (uint8_t*)(getLabelSymbol()->getCodeLocation());
+      intptr_t destination = reinterpret_cast<intptr_t>(getLabelSymbol()->getCodeLocation());
       if (destination != 0)
          {
-         offset = destination - cursor;
+         offset = destination - reinterpret_cast<intptr_t>(cursor);
          }
       else
          {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -147,7 +147,6 @@ TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
    _vtableIndexArgumentRegister = TR::RealRegister::NoReg;
    _j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
-   _numberOfDependencyRegisters = 32; // To be determined
    _offsetToFirstLocal            = 0; // To be determined
 
    initialize();

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -205,7 +205,7 @@ static void mapSingleParameter(TR::ParameterSymbol *parameter, uint32_t &stackIn
       }
    else
       { // in caller's frame -- always 8-byte aligned
-      TR_ASSERT((stackIndex & 7) == 0, "Unaligned stack index.");
+      TR_ASSERT_FATAL((stackIndex & 7) == 0, "Unaligned stack index.");
       parameter->setParameterOffset(stackIndex);
       stackIndex += 8;
       }
@@ -305,10 +305,10 @@ TR::RVSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
                }
             break;
          case TR::Aggregate:
-            TR_ASSERT(false, "Function parameters of aggregate types are not currently supported on RISC-V.");
+            TR_ASSERT_FATAL(false, "Function parameters of aggregate types are not currently supported on RISC-V.");
             break;
          default:
-            TR_ASSERT(false, "Unknown parameter type.");
+            TR_ASSERT_FATAL(false, "Unknown parameter type.");
          }
       }
 
@@ -355,10 +355,10 @@ TR::RVSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
                }
             break;
          case TR::Aggregate:
-            TR_ASSERT(false, "Function parameters of aggregate types are not currently supported on RISC-V.");
+            TR_ASSERT_FATAL(false, "Function parameters of aggregate types are not currently supported on RISC-V.");
             break;
          default:
-            TR_ASSERT(false, "Unknown parameter type.");
+            TR_ASSERT_FATAL(false, "Unknown parameter type.");
          }
       }
    }
@@ -460,10 +460,10 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
                }
             break;
          case TR::Aggregate:
-            TR_ASSERT(false, "Function parameters of aggregate types are not currently supported on AArch64.");
+            TR_ASSERT_FATAL(false, "Function parameters of aggregate types are not currently supported on RISC-V.");
             break;
          default:
-            TR_ASSERT(false, "Unknown parameter type.");
+            TR_ASSERT_FATAL(false, "Unknown parameter type.");
          }
       }
 
@@ -572,7 +572,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode,
             break;
 
          default:
-            TR_ASSERT(false, "Argument type %s is not supported\n", childType.toString());
+            TR_ASSERT_FATAL(false, "Argument type %s is not supported\n", childType.toString());
          }
       }
 
@@ -891,7 +891,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
          break;
       default:
          retReg = NULL;
-         TR_ASSERT(false, "Unsupported direct call Opcode.");
+         TR_ASSERT_FATAL(false, "Unsupported direct call Opcode.");
       }
 
    callNode->setRegister(retReg);

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -394,7 +394,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
    TR::Node *firstNode = comp()->getStartTree()->getNode();
 
    // allocate stack space
-   uint32_t frameSize = (uint32_t)codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = codeGen->getFrameSizeInBytes();
    if (VALID_ITYPE_IMM(frameSize))
       {
       cursor = generateITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, codeGen, cursor);
@@ -432,7 +432,7 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
             if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
-               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::a0 + nextIntArgReg)), codeGen, cursor);
+               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), codeGen, cursor);
                nextIntArgReg++;
                }
             else
@@ -445,13 +445,13 @@ TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterS
             if (nextFltArgReg < getProperties().getNumFloatArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::_fsd : TR::InstOpCode::_fsw;
-               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::fa0 + nextFltArgReg)), codeGen, cursor);
+               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister(getProperties().getFloatArgumentRegister(nextFltArgReg)), codeGen, cursor);
                nextFltArgReg++;
                }
             else if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
-               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::a0 + nextIntArgReg)), codeGen, cursor);
+               cursor = generateSTORE(op, firstNode, stackSlot, machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), codeGen, cursor);
                nextIntArgReg++;
                }
             else
@@ -844,7 +844,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
           * Note, that here we load the target address into link register (`ra`). It's going to be clobbered
           * anyways and this way we do not need to allocate another one.
           */
-         loadConstant64(cg(), callNode, (int64_t)targetAddr, ra);
+         loadConstant64(cg(), callNode, reinterpret_cast<int64_t>(targetAddr), ra);
          generateITYPE(TR::InstOpCode::_jalr, callNode, ra, ra, 0, dependencies, cg());
          }
       }

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -726,7 +726,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode,
       } // end of for
 
    // NULL deps for unused integer argument registers
-   for (int i = numIntegerArgs + numFloatArgsPassedInGPRs; i < properties.getNumIntArgRegs(); i++)
+   for (auto i = numIntegerArgs + numFloatArgsPassedInGPRs; i < properties.getNumIntArgRegs(); i++)
       {
       if (i == 0 && resType.isAddress())
          {
@@ -749,7 +749,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode,
       }
 
    // NULL deps for unused FP argument registers
-   for (int i = numFloatArgs; i < properties.getNumFloatArgRegs(); i++)
+   for (auto i = numFloatArgs; i < properties.getNumFloatArgRegs(); i++)
       {
       TR::addDependency(dependencies, NULL, properties.getFloatArgumentRegister(i), TR_FPR, cg());
       }

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -147,7 +147,7 @@ TR::RVSystemLinkageProperties::RVSystemLinkageProperties()
    _vtableIndexArgumentRegister = TR::RealRegister::NoReg;
    _j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
-   _numberOfDependencyGPRegisters = 32; // To be determined
+   _numberOfDependencyRegisters = 32; // To be determined
    _offsetToFirstLocal            = 0; // To be determined
 
    initialize();
@@ -752,8 +752,8 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
 
    TR::RegisterDependencyConditions *dependencies =
       new (trHeapMemory()) TR::RegisterDependencyConditions(
-         pp.getNumberOfDependencyGPRegisters(),
-         pp.getNumberOfDependencyGPRegisters(), trMemory());
+         pp.getNumberOfDependencyRegisters(),
+         pp.getNumberOfDependencyRegisters(), trMemory());
 
    int32_t totalSize = buildArgs(callNode, dependencies);
    if (totalSize > 0)

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -634,7 +634,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode,
                   {
                   op = TR::InstOpCode::_sw;
                   }
-               mref = getOutgoingArgumentMemRef(argMemReg, argRegister, op, pushToMemory[argIndex++]);
+               mref = getOutgoingArgumentMemRef(argMemReg, argSize, argRegister, op, pushToMemory[argIndex++]);
                argSize += 8; // always 8-byte aligned
                }
             numIntegerArgs++;
@@ -685,7 +685,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode,
                   {
                   op = TR::InstOpCode::_fsw;
                   }
-               mref = getOutgoingArgumentMemRef(argMemReg, argRegister, op, pushToMemory[argIndex++]);
+               mref = getOutgoingArgumentMemRef(argMemReg, argSize, argRegister, op, pushToMemory[argIndex++]);
                argSize += 8; // always 8-byte aligned
                }
             numFloatArgs++;

--- a/fvtest/compilertriltest/CallTest.cpp
+++ b/fvtest/compilertriltest/CallTest.cpp
@@ -35,7 +35,6 @@ TEST_F(CallTest, icallOracle) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
 
     char inputTrees[200] = {0};
     const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] (iload parm=0)) )  ))";

--- a/fvtest/compilertriltest/CallTest.cpp
+++ b/fvtest/compilertriltest/CallTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,16 @@ class CallTest : public TRTest::JitTest {};
 int32_t oracleBoracle(int32_t x) { return x + 1123; } // Randomish number to avoid accidental test passes.
 
 TEST_F(CallTest, icallOracle) { 
+
+	SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
+    SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
+
     char inputTrees[200] = {0};
     const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] (iload parm=0)) )  ))";
     std::snprintf(inputTrees, 200, format_string, reinterpret_cast<uintmax_t>(&oracleBoracle));
@@ -34,10 +44,6 @@ TEST_F(CallTest, icallOracle) {
 
     ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
 
-    // Execution of this test is disabled on non-X86 platforms, as we 
-    // do not have trampoline support, and so this call may be out of 
-    // range for some architectures. 
-#ifdef TR_TARGET_X86
     Tril::DefaultCompiler compiler(trees);
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
@@ -47,5 +53,4 @@ TEST_F(CallTest, icallOracle) {
     EXPECT_EQ(oracleBoracle(-128), entry_point(-128));
     EXPECT_EQ(oracleBoracle(128), entry_point(128));
     EXPECT_EQ(oracleBoracle(1280), entry_point(1280));
-#endif
 }

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,6 @@ TYPED_TEST(LinkageTest, InvalidLinkageTest) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -119,7 +118,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing1Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     char inputTrees[600] = { 0 };
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -164,7 +162,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing2Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -214,7 +211,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing3Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -268,7 +264,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing4Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -326,7 +321,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing5Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -388,7 +382,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing6Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -454,7 +447,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing7Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -524,7 +516,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing8Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -598,7 +589,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToNativeParameterPassing9Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -706,7 +696,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing2A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -753,7 +742,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing3A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -801,7 +789,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing4A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -850,7 +837,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing5A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -900,7 +886,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing6A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -951,7 +936,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing7A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -1003,7 +987,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing8A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -1056,7 +1039,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToNativeParameterPassing9A
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     char inputTrees[600] = { 0 };
@@ -1398,7 +1380,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing1Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
 
     auto callee_entry_point = getJitCompiledMethodReturning1stArgument<TypeParam>();
     ASSERT_NOTNULL(callee_entry_point) << "Compilation of the callee failed unexpectedly\n";
@@ -1446,7 +1427,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing2Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgument<TypeParam>();
@@ -1499,7 +1479,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing3Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgument<TypeParam>();
@@ -1556,7 +1535,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing4Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgument<TypeParam>();
@@ -1617,7 +1595,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing5Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgument<TypeParam>();
@@ -1682,7 +1659,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing6Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgument<TypeParam>();
@@ -1751,7 +1727,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing7Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgument<TypeParam>();
@@ -1824,7 +1799,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing8Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgument<TypeParam>();
@@ -1901,7 +1875,6 @@ TYPED_TEST(LinkageTest, SystemLinkageJitToJitParameterPassing9Arg) {
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgument<TypeParam>();
@@ -2206,7 +2179,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing2ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning2ndArgumentFromMixedTypes<TypeParam>();
@@ -2256,7 +2228,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing3ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning3rdArgumentFromMixedTypes<TypeParam>();
@@ -2307,7 +2278,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing4ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning4thArgumentFromMixedTypes<TypeParam>();
@@ -2359,7 +2329,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing5ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning5thArgumentFromMixedTypes<TypeParam>();
@@ -2412,7 +2381,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing6ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning6thArgumentFromMixedTypes<TypeParam>();
@@ -2466,7 +2434,6 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing7ArgW
     SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning7thArgumentFromMixedTypes<TypeParam>();
@@ -2517,11 +2484,10 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing8ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
- SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
- SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning8thArgumentFromMixedTypes<TypeParam>();
@@ -2573,11 +2539,10 @@ TYPED_TEST(LinkageWithMixedTypesTest, SystemLinkageJitToJitParameterPassing9ArgW
     SKIP_ON_PPC(MissingImplementation) << "Test is skipped on POWER because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64(MissingImplementation) << "Test is skipped on POWER 64 because calls are not currently supported (see issue #1645)";
     SKIP_ON_PPC64LE(MissingImplementation) << "Test is skipped on POWER 64le because calls are not currently supported (see issue #1645)";
- SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
- SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390_LINUX(MissingImplementation) << "Test is skipped on S390 Linux because calls are not currently supported (see issue #1645)";
+    SKIP_ON_S390X_LINUX(MissingImplementation) << "Test is skipped on S390x Linux because calls are not currently supported (see issue #1645)";
     SKIP_ON_ARM(MissingImplementation) << "Test is skipped on ARM because calls are not currently supported (see issue #1645)";
     SKIP_ON_AARCH64(MissingImplementation) << "Test is skipped on AArch64 because calls are not currently supported (see issue #1645)";
-    SKIP_ON_RISCV(MissingImplementation) << "Test is skipped on RISC-V because calls are not fully supported (see issue #1645)";
     SKIP_ON_WINDOWS(KnownBug) << "The x86_64 code generator crashes (see issue #5324)";
 
     auto callee_entry_point = getJitCompiledMethodReturning9thArgumentFromMixedTypes<TypeParam>();


### PR DESCRIPTION
This PR adds support for calls without trampolines as a temporary solution until #2017 is implemented. 