### PR TITLE
Refactor CopyForward to reuse fixupForwardedObject

### DIFF
--- a/example/glue/ObjectModelDelegate.cpp
+++ b/example/glue/ObjectModelDelegate.cpp
@@ -48,10 +48,3 @@ GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, M
 }
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
-void
-GC_ObjectModelDelegate::calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader* forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash)
-{
-	*objectCopySizeInBytes = 0;
-	*objectReserveSizeInBytes = 0;
-	*doesObjectNeedHash = false;
-}

--- a/example/glue/ObjectModelDelegate.hpp
+++ b/example/glue/ObjectModelDelegate.hpp
@@ -286,18 +286,6 @@ public:
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 	/**
-	 * Calculate the actual object size and the size adjusted to object alignment. The calculated object size
-	 * includes any expansion bytes allocated if the object will grow when moved.
-	 *
-	 * @param[in]  env points to the environment for the calling thread
-	 * @param[in]  forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @param[out] objectCopySizeInBytes actual object size
-	 * @param[out] objectReserveSizeInBytes size adjusted to object alignment
-	 * @param[out] doesObjectNeedHash flag that indicates if object needs hashing
-	 */
-	void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader* forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash);
-
-	/**
 	 * Constructor receives a copy of OMR's object flags mask, normalized to low order byte.
 	 */
 	GC_ObjectModelDelegate(fomrobject_t omrHeaderSlotFlagsMask) {}

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -307,22 +307,6 @@ public:
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 	/**
-	 * Calculate the actual object size and the size adjusted to object alignment. The calculated object size
-	 * includes any expansion bytes allocated if the object will grow when moved.
-	 *
-	 * @param[in]  env points to the environment for the calling thread
-	 * @param[in]  forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @param[out] objectCopySizeInBytes actual object size
-	 * @param[out] objectReserveSizeInBytes size adjusted to object alignment
-	 * @param[out] doesObjectNeedHash flag that indicates if object needs hashing
-	 */
-	MMINLINE void
-	calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader* forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, bool *doesObjectNeedHash)
-	{
-		_delegate.calculateObjectDetailsForCopy(env, forwardedHeader, objectCopySizeInBytes, objectReserveSizeInBytes, doesObjectNeedHash);
-	}
-
-	/**
 	 * Set run-time object alignment and shift values in this object model and in the OMR VM struct. These
 	 * values are dependent on OMR_VM::_compressedPointersShift, which must be set before calling this
 	 * method. These values would be const except that they can sometimes be determined only after the


### PR DESCRIPTION
Refactor CopyForward to be more consistent with Scavenger by reusing the existing fixupForwardedObject method from ObjectModel. This allows for the simplification of calculateObjectDetailsForCopy for balanced as `doesObjectNeedHash` argument is no longer needed.

Related to: https://github.com/eclipse-openj9/openj9/pull/12661

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>