### PR TITLE
Allow 64K page size as a valid option on AIX

### DIFF
--- a/port/aix/omrvmem.c
+++ b/port/aix/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -949,12 +949,14 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 
 	if (0 != validPageSize) {
 		/* For executable pages search through the list of supported page sizes only if
+		 * - request is for 64K pages, or
 		 * - request is for 16M pages, and
 		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
 		 */
 #if defined(OMR_ENV_DATA64)
-		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
-			(SIXTEEN_M == validPageSize))
+		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
+			|| (SIXTY_FOUR_K == validPageSize)
+			|| (SIXTEEN_M == validPageSize)
 #else
 		BOOLEAN codeCacheConsolidationEnabled = FALSE;
 
@@ -967,10 +969,11 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 				codeCacheConsolidationEnabled = TRUE;
 			}
 		}
-		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
-			((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize)))
+		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
+			|| ((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize))
+			|| (SIXTY_FOUR_K == validPageSize)
 #endif /* defined(OMR_ENV_DATA64) */
-		{
+		) {
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(portLibrary);
 			uintptr_t *supportedPageFlags = portLibrary->vmem_supported_page_flags(portLibrary);


### PR DESCRIPTION
xlpCodeCacheTests fails on AIX because the default
code cache large page size 64K is absent in the
list of available code cache large page sizes
output by `-verbose:sizes`.

Include 64K in the list of available code cache
large page sizes for the test to parse as the
expected page size when no `-Xlp` option is
supplied and the default page size is used.

Signed-off-by: Amarpreet Singh amarpreet1997@gmail.com