### PR TITLE
Handle both AddressOrdered and BumpPointer regionType in setMarkMapValid

### DIFF
--- a/gc/base/HeapRegionDescriptor.hpp
+++ b/gc/base/HeapRegionDescriptor.hpp
@@ -330,10 +330,23 @@ public:
 	 * Sets a ADDRESS_ORDERED region to ADDRESS_ORDERED_MARKED.  Asserts if called on any other region type.
 	 * This can be extended to other region types which have a "marked" variant as they are needed.
 	 */
+/*
 	void setMarkMapValid()
 	{
 		Assert_MM_true(ADDRESS_ORDERED == getRegionType());
 		setRegionType(ADDRESS_ORDERED_MARKED);
+	}
+*/
+/* temporary change for breaking cross dependency */
+	void setMarkMapValid()
+	{
+		Assert_MM_true((ADDRESS_ORDERED == getRegionType()) || (BUMP_ALLOCATED == getRegionType()));
+		if (ADDRESS_ORDERED == getRegionType()) {
+			setRegionType(ADDRESS_ORDERED_MARKED);
+		} else {
+			setRegionType(BUMP_ALLOCATED_MARKED);
+		}
+
 	}
 	
 	/**

--- a/gc/base/ObjectHeapBufferedIterator.cpp
+++ b/gc/base/ObjectHeapBufferedIterator.cpp
@@ -90,14 +90,20 @@ GC_ObjectHeapBufferedIterator::getPopulator()
 	case MM_HeapRegionDescriptor::RESERVED:
 	case MM_HeapRegionDescriptor::FREE:
 	case MM_HeapRegionDescriptor::ADDRESS_ORDERED_IDLE:
+	case MM_HeapRegionDescriptor::BUMP_ALLOCATED_IDLE: /* remove it after completing transition from bumpPointer to AddressOrdered */
 		/* (for all intents and purposes, an IDLE region is the same as a FREE region) */
 	case MM_HeapRegionDescriptor::ARRAYLET_LEAF:
 		populator = &_emptyListPopulator;
+		break;
+	/* remove it after completing transition from bumpPointer to AddressOrdered */
+	case MM_HeapRegionDescriptor::BUMP_ALLOCATED:
+		populator = &_bumpAllocatedListPopulator;
 		break;
 	case MM_HeapRegionDescriptor::ADDRESS_ORDERED:
 		populator = &_addressOrderedListPopulator;
 		break;
 	case MM_HeapRegionDescriptor::ADDRESS_ORDERED_MARKED:
+	case MM_HeapRegionDescriptor::BUMP_ALLOCATED_MARKED: /* remove it after completing transition from bumpPointer to AddressOrdered */
 		populator = &_markedObjectPopulator;
 		break;
 #if defined(OMR_GC_SEGREGATED_HEAP)

--- a/gc/base/ObjectHeapBufferedIterator.hpp
+++ b/gc/base/ObjectHeapBufferedIterator.hpp
@@ -25,6 +25,7 @@
 #define OBJECTHEAPBUFFEREDITERATOR_HPP_
 
 #include "AddressOrderedListPopulator.hpp"
+#include "BumpAllocatedListPopulator.hpp" /* remove it after completing transition from bumpPointer to AddressOrdered */
 #include "EmptyListPopulator.hpp"
 #include "MarkedObjectPopulator.hpp"
 #include "ObjectHeapBufferedIteratorPopulator.hpp"
@@ -51,6 +52,7 @@ class GC_ObjectHeapBufferedIterator
 /* Data Members */
 private:
 	MM_AddressOrderedListPopulator _addressOrderedListPopulator;
+	MM_BumpAllocatedListPopulator _bumpAllocatedListPopulator; /* remove it after completing transition from bumpPointer to AddressOrdered */
 	MM_EmptyListPopulator _emptyListPopulator;
 	MM_MarkedObjectPopulator _markedObjectPopulator;
 #if defined(OMR_GC_SEGREGATED_HEAP)


### PR DESCRIPTION
	In order to smooth transition for replacing MemoryPoolBumpPointer
	with MemoryPoolAddressOrderedList, update setMarkMapValid() to handle
	both AddressOrdered and BumpPointer regionType.
       Rollback the changes in ObjectHeapBufferedIterator.
it is a fix for omr acceptance build failures, which is caused by https://github.com/eclipse/omr/pull/5783 

Signed-off-by: Lin Hu <linhu@ca.ibm.com>