### PR TITLE
Update Default Scan Ordering Configuration

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -475,6 +475,8 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 			extensions->splitFreeListSplitAmount = (extensions->gcThreadCount - 1) / 8  +  1;
 			if (MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_NONE == extensions->scavengerScanOrdering) {
 				extensions->scavengerScanOrdering = MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL;
+			} else if (MM_GCExtensionsBase::OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST == extensions->scavengerScanOrdering) {
+				extensions->adaptiveGcCountBetweenHotFieldSort = true;
 			}
 		} else
 #endif /* OMR_GC_MODRON_SCAVENGER */

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1547,7 +1547,7 @@ public:
 		/* Start of options relating to dynamicBreadthFirstScanOrdering */
 		, gcCountBetweenHotFieldSort(1)
 		, gcCountBetweenHotFieldSortMax(6)
-		, adaptiveGcCountBetweenHotFieldSort(true)
+		, adaptiveGcCountBetweenHotFieldSort(false)
 		, depthCopyTwoPaths(true)
 		, depthCopyThreePaths(false)
 		, alwaysDepthCopyFirstOffset(false)


### PR DESCRIPTION
Update scan ordering configuration for more correct configuration of adaptiveGcCountBetweenHotFieldSort.

Related to PR: https://github.com/eclipse-openj9/openj9/pull/12514

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>