### PR TITLE
Add command line option to make inliner more aggressive

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -627,6 +627,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"dumpIprofilerMethodNamesAndCounts",  "O\tDebug Printing of Method Names and Persisted Counts.", SET_OPTION_BIT(TR_DumpPersistedIProfilerMethodNamesAndCounts), "F"},
    {"dynamicThreadPriority",              "M\tenable dynamic changing of compilation thread priority", SET_OPTION_BIT(TR_DynamicThreadPriority), "F", NOT_IN_SUBSET},
    {"earlyLPQ",                           "M\tAllow compilations from low priority queue to happen early, during startup", SET_OPTION_BIT(TR_EarlyLPQ), "F", NOT_IN_SUBSET },
+   {"enableAggressiveInlining",           "I\tSet additional options that makes inlining more aggressive ", SET_OPTION_BIT(TR_AggressiveInlining), "F", NOT_IN_SUBSET},
    {"enableAggressiveLiveness",           "I\tenable globalLiveVariablesForGC below warm", SET_OPTION_BIT(TR_EnableAggressiveLiveness), "F"},
    {"enableAggressiveLoopVersioning", "O\tOptions and thresholds that result in loop versioning occurring in more cases", SET_OPTION_BIT(TR_EnableAggressiveLoopVersioning), "F" },
    {"enableAllocationOfScratchBTL",       "M\tAllow the allocation scratch memory below the line (zOS 31-bit)", RESET_OPTION_BIT(TR_DontAllocateScratchBTL), "F", NOT_IN_SUBSET },
@@ -3691,7 +3692,11 @@ OMR::Options::jitPostProcess()
       self()->setOption(TR_EnableCodeCacheConsolidation, false);
       }
 #endif
-
+   if (self()->getOption(TR_AggressiveInlining))
+      {
+      // Note: this could override some of the inlining options set by the user
+      self()->setMoreAggressiveInlining();
+      }
    return true;
    }
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -97,7 +97,7 @@ enum TR_CompilationOptions
    TR_StrictFPCompares           = 0x00000800,
    TR_RegisterMaps               = 0x00001000,
    TR_CreatePCMaps               = 0x00002000,
-   // Available                  = 0x00004000,
+   TR_AggressiveInlining         = 0x00004000,
    TR_MimicInterpreterFrameShape = 0x00008000,
 
    TR_TraceBC                    = 0x00010000,


### PR DESCRIPTION
Added `enableAggressiveInlining` command line option which, under the covers,
will enable other options or set threshold values such that the Inliner is
more aggressive in inlining callees. This is done in the `jitPostProcess()`
phase, so it may override other inliner specific options, also present on
the command line.
The new option is directed at experimentation and not geared towards
production use. Moreover, the new option cannot be applied in a subset,
but only globally, to all the methods.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>