### PR TITLE
Make _ialoadUnneeded protected

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -770,6 +770,7 @@ public:
 protected:
    TR::list<TR::S390ConstantDataSnippet*>  _constantList;
    TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
+   List<TR_Pair<TR::Node, int32_t> > _ialoadUnneeded;
 
 private:
 
@@ -782,8 +783,6 @@ private:
 
    TR::list<TR::S390WritableDataSnippet*>  _writableList;
    TR::list<TR_S390OutOfLineCodeSection*> _outOfLineCodeSectionList;
-
-   List<TR_Pair<TR::Node, int32_t> > _ialoadUnneeded; 
 
    CS2::HashTable<TR::Register *, TR::RealRegister::RegNum, TR::Allocator> _previouslyAssignedTo;
 


### PR DESCRIPTION
For use in downstream projects. OpenJ9 is a consumer.