### PR TITLE
Enable OSR for profiling compilations with JProfiling

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -442,7 +442,7 @@ OMR::Compilation::Compilation(
       self()->setOption(TR_EnableOSR); // OSR must be enabled for NextGenHCR
       }
 
-   if (self()->isDLT() || (((self()->getMethodHotness() < warm) || self()->compileRelocatableCode() || self()->isProfilingCompilation()) && !enableOSRAtAllOptLevels && !_options->getOption(TR_FullSpeedDebug)))
+   if (self()->isDLT() || (((self()->getMethodHotness() < warm) || self()->compileRelocatableCode() || (self()->isProfilingCompilation() && self()->getProfilingMode() != JProfiling)) && !enableOSRAtAllOptLevels && !_options->getOption(TR_FullSpeedDebug)))
       {
       self()->setOption(TR_DisableOSR);
       _options->setOption(TR_EnableOSR, false);
@@ -2505,7 +2505,7 @@ OMR::Compilation::getHCRMode()
    {
    if (!self()->getOption(TR_EnableHCR))
       return TR::none;
-   if (self()->isDLT() || self()->isProfilingCompilation() || self()->getOptLevel() <= cold)
+   if (self()->isDLT() || (self()->isProfilingCompilation() && self()->getProfilingMode() != JProfiling) || self()->getOptLevel() <= cold)
       return TR::traditional;
    return self()->getOption(TR_EnableOSR) && !self()->getOption(TR_DisableNextGenHCR) ? TR::osr : TR::traditional;
    }


### PR DESCRIPTION
In the profiling compilations that was using JIT Profiler, we had to
disable the OSR in profiling compilations as we had to duplicate the
method and size would become an issue and profiling compilations are
very short-lived. With JProfiler we do not need to duplicate the method
body and counters to collect profiling data are inserted in the code.
This commits enables OSR and sets HCR mode to osr from traditional for
profiling compilations when JProfiler is used which would allow us to
collect accurate profile of the method to be used in subsequent
compilations which by default has OSR enabled.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>