### PR TITLE
Limit Incremental Card Alignment under 64 bit system

### DIFF
--- a/gc/base/MemoryPoolAddressOrderedList.hpp
+++ b/gc/base/MemoryPoolAddressOrderedList.hpp
@@ -39,7 +39,8 @@ class MM_AllocateDescription;
 class MM_ConcurrentSweepScheme;
 #endif /* OMR_GC_CONCURRENT_SWEEP */
 
-#define FREE_ENTRY_END ((MM_HeapLinkedFreeHeader *) UDATA_MAX)
+#define FREE_ENTRY_END ((MM_HeapLinkedFreeHeader *)OMRPORT_VMEM_MAX_ADDRESS)
+
 /**
  * @todo Provide class documentation
  * @ingroup GC_Base_Core
@@ -85,7 +86,11 @@ private:
 
 	MMINLINE bool doesNeedAlignment(MM_EnvironmentBase *env, MM_HeapLinkedFreeHeader *freeEntry)
 	{
+#if defined(OMR_ENV_DATA64)
 		return (freeEntry >= _firstUnalignedFreeEntry);
+#else
+		return false;
+#endif /* OMR_ENV_DATA64 */
 	}
 
 	/**


### PR DESCRIPTION
Incremental Card Alignment is designed only for 64bit system,
the code should never run on 32/31 bit system, use OMR_ENV_DATA64
 precompile define to avoiding the side affection on 32/31 bit system.

fix:  acceptance build issue on Z/OS

Signed-off-by: Lin Hu <linhu@ca.ibm.com>