### PR TITLE
Correct condition used to setting unneeded aloadi

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -220,7 +220,10 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
 
    if (node->isUnneededIALoad())
       {
-      if (parent->getOpCodeValue() == TR::ifacmpne || parent->getOpCodeValue() == TR::ificmpeq || parent->getOpCodeValue() == TR::ificmpne || parent->getOpCodeValue() == TR::ifacmpeq)
+      if (parent->getOpCodeValue() == TR::ifacmpne
+         || parent->getOpCodeValue() == TR::ificmpeq
+         || parent->getOpCodeValue() == TR::ificmpne
+         || parent->getOpCodeValue() == TR::ifacmpeq)
          {
          if (!parent->isNopableInlineGuard() || !self()->getSupportsVirtualGuardNOPing())
             {
@@ -228,10 +231,10 @@ OMR::Z::CodeGenerator::checkIsUnneededIALoad(TR::Node *parent, TR::Node *node, T
             }
          else
             {
-            TR_VirtualGuard * virtualGuard = self()->comp()->findVirtualGuardInfo(parent);
-            if (!parent->isHCRGuard() && !parent->isOSRGuard() && !self()->comp()->performVirtualGuardNOPing() &&
-                self()->comp()->isVirtualGuardNOPingRequired(virtualGuard) &&
-                virtualGuard->canBeRemoved())
+            TR_VirtualGuard *virtualGuard = self()->comp()->findVirtualGuardInfo(parent);
+            if (!((self()->comp()->performVirtualGuardNOPing() || parent->isHCRGuard() || parent->isOSRGuard())
+                     && self()->comp()->isVirtualGuardNOPingRequired(virtualGuard))
+               && virtualGuard->canBeRemoved())
                {
                node->setUnneededIALoad(false);
                }


### PR DESCRIPTION
On Z, during trees lowering phase, it checks if the encountered aloadi
node while walking trees appears under nopable inline guards. Conditions
used to check if we are going to generate NOP for such parent Virtual
Guard node (In which case, aloadi would not be evaluated) while marking
aloadi unneeded was incorrect and in some cases, it would mark such
aloadi unneeded even though it will generate the inline test which
eventually can cause incorrect functional behaviour.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>