### PR TITLE
AArch64: Fix i2l-lshl optimization

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -773,6 +773,7 @@ OMR::ARM64::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       TR::Node *secondChild = node->getSecondChild();
       if (firstChild->getOpCodeValue() == TR::i2l &&
           firstChild->getRegister() == NULL &&
+          firstChild->getReferenceCount() == 1 &&
           secondChild->getOpCodeValue() == TR::iconst &&
           secondChild->getInt() < 32)
          {


### PR DESCRIPTION
This commit fixes an issue introduced by #6011.

The i2l-lshl optimization skips assigning a register to the i2l node.
When the i2l node has two or more references, the i2l node is evaluated
later again, and it leads to unexpected results.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>