### PR TITLE
Allow inliner policy to decide whether to remove differing targets

### DIFF
--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -615,6 +615,7 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
       bool aggressiveSmallAppOpts() { return comp()->getOption(TR_AggressiveOpts); }
       virtual bool willBeInlinedInCodeGen(TR::RecognizedMethod method);
       virtual bool canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method);
+      virtual bool shouldRemoveDifferingTargets(TR::Node *callNode);
 
       /** \brief
        *     Determines whether to skip generation of HCR guards for a particular callee during inlining.


### PR DESCRIPTION
Previously, for direct calls, targets that appear to be a different method from the one specified by the call node's symbol reference would always be removed.

This behaviour is still the default, but the new query allows downstream projects to customize the conditions under which those targets are removed, e.g. by exempting certain methods.