### PR TITLE
AArch64: Add TR_ARM64jitCollapseJNIReferenceFrame to getRuntimeHelperName

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4217,6 +4217,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          case TR_ARM64revertToInterpreterGlue:                     return "_revertToInterpreterGlue";
          case TR_ARM64doubleRemainder:                             return "doubleRemainder";
          case TR_ARM64floatRemainder:                              return "floatRemainder";
+         case TR_ARM64jitCollapseJNIReferenceFrame:                return "jitCollapseJNIReferenceFrame";
          }
       }
 #endif


### PR DESCRIPTION
This commit changes `TR_Debug::getRuntimeHelperName` to return valid name
for `TR_ARM64jitCollapseJNIReferenceFrame`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>