### PR TITLE
Include omriarv64.h only for ZOS 64bit

### DIFF
--- a/port/zos390/omrvmem.c
+++ b/port/zos390/omrvmem.c
@@ -32,7 +32,10 @@
 #include "ut_omrport.h"
 #include "omrportasserts.h"
 #include "omrvmem.h"
+#if defined(J9ZOS39064)
 #include "omriarv64.h"
+#endif /* defined(J9ZOS39064) */
+
 #include "omrsimap.h"
 
 #include <errno.h>


### PR DESCRIPTION
`omriarv64.h` is for `zOS 64bit`, and should not be included for `zOS 31bit`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>