### PR TITLE
Remove TR_OrderedCompiles

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -992,7 +992,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"optLevel=scorching", "O\tcompile all methods at scorching level", TR::Options::set32BitValue, offsetof(OMR::Options, _optLevel), scorching, "P"},
    {"optLevel=veryHot",   "O\tcompile all methods at veryHot level",   TR::Options::set32BitValue, offsetof(OMR::Options, _optLevel), veryHot, "P"},
    {"optLevel=warm",      "O\tcompile all methods at warm level",      TR::Options::set32BitValue, offsetof(OMR::Options, _optLevel), warm, "P"},
-   {"orderCompiles",      "C\tcompile methods in limitfile order", SET_OPTION_BIT(TR_OrderCompiles), "P" , NOT_IN_SUBSET},
    {"packedTest=",        "D{regex}\tforce particular code paths to test Java Packed Object",
         TR::Options::setRegex, offsetof(OMR::Options, _packedTest), 0, "P"},
    {"paintAllocatedFrameSlotsDead",   "C\tpaint all slots allocated in method prologue with deadf00d",    SET_OPTION_BIT(TR_PaintAllocatedFrameSlotsDead), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1223,13 +1223,6 @@ public:
 
    int32_t getOptionSet()       {return _optionSet;}
    int32_t getTickCount()       {return _optionSet;}
-   int32_t getSampleCount()     {return _sampleInfo;}
-   int32_t getSampleLevel()     {return _sampleInfo;}
-
-   char  getSampleProfiled()  {return _sampleProfiled;}
-   void  setSampleCount(int32_t n)   {_sampleInfo = (int16_t)n;}
-   void  setSampleLevel(int32_t n)   {_sampleInfo = (int16_t)n;}
-   void  setSampleProfiled(char p) {_sampleProfiled = p;}
 
    char *getName()            {return _name;}
    void setName(char *n, int32_t l) {_name = n; _nameLen = l;}
@@ -1274,14 +1267,6 @@ public:
    // For filter position in a limit file
    int32_t _lineNumber;
 
-   // For sampling point, the new invocation count or compilation level
-   //
-   int16_t _sampleInfo;
-
-   // For sampling point, whether the compilation is to be profiled
-   //
-   char _sampleProfiled;
-
    uint32_t _nameLen;
 
    // The filter type - see definitions above
@@ -1312,10 +1297,6 @@ public:
    // Linked list for regular expressions.
    //
    TR_FilterBST  *filterRegexList;
-
-   // Linked list for sampling point information
-   //
-   TR_FilterBST  *samplingPoints;
 
    // Special filter representing excluded methods
    //

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -428,7 +428,7 @@ enum TR_CompilationOptions
    // Available                               = 0x00000200 + 11,
    // Available                               = 0x00000400 + 11,
    // Available                               = 0x00000800 + 11,
-   TR_OrderCompiles                           = 0x00001000 + 11,
+   // Available                               = 0x00001000 + 11,
    TR_VerboseOptTransformations               = 0x00002000 + 11,
    TR_DisableEnhancedClobberEval              = 0x00004000 + 11,
    TR_Enable39064Epilogue                     = 0x00008000 + 11,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -465,12 +465,10 @@ public:
    virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, TR::CompilationFilters *);
    virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, bool loadLimit);
    virtual TR_FilterBST *  addExcludedMethodFilter(bool loadLimit);
-   virtual bool            addSamplingPoint(char *, TR_FilterBST * &, bool loadLimit);
    virtual int32_t         scanFilterName(char *, TR_FilterBST *);
    virtual void            printFilters(TR::CompilationFilters *);
    virtual void            printFilters();
    virtual void            print(TR_FilterBST * filter);
-   virtual void            printSamplingPoints();
    virtual void         printHeader();
    virtual void         printMethodHotness();
    virtual void         printInstrDumpHeader(const char * title);

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -533,8 +533,7 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
    if (limitFile)
       {
       TR::CompilationFilters * filters = findOrCreateFilters(loadLimit);
-      if (!cmdLineOptions->getOption(TR_OrderCompiles))
-         filters->setDefaultExclude(true);
+      filters->setDefaultExclude(true);
 
       char          limitReadBuffer[1024];
       bool          limitFileError = false;
@@ -679,13 +678,6 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
                       isNegative = true;
                   }
                }
-            }
-         else if (limitReadBuffer[0] == '(' && cmdLineOptions->getOption(TR_OrderCompiles))
-            {
-            // Recognize new sampling point
-            //
-            static TR_FilterBST *lastSamplingPoint = NULL;
-            addSamplingPoint(limitReadBuffer, lastSamplingPoint, loadLimit);
             }
          }
       if (limitFileError)

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -623,10 +623,10 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
 
             bool isNegative = false;
             if (*(p) == '-')
-              {
-	      p++;
-	      isNegative = true;
-	      }
+               {
+               p++;
+               isNegative = true;
+               }
 
             int32_t randNum;
             while (isdigit(p[0]))
@@ -636,21 +636,23 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
                   ++p;
 
                if (isNegative)
- 		  randNum = -1*randNum;
+                  randNum = -1*randNum;
 
                if ((curPseudoRandomListElem == NULL) ||
                    (curIndex == PSEUDO_RANDOM_NUMBERS_SIZE))
-		  {
-		  int32_t sz = sizeof(TR_PseudoRandomNumbersListElement);
-		  TR_PseudoRandomNumbersListElement *newPseudoRandomListElem = (TR_PseudoRandomNumbersListElement *)(TR::Compiler->regionAllocator.allocate(sz));
+                  {
+                  int32_t sz = sizeof(TR_PseudoRandomNumbersListElement);
+                  TR_PseudoRandomNumbersListElement *newPseudoRandomListElem = (TR_PseudoRandomNumbersListElement *)(TR::Compiler->regionAllocator.allocate(sz));
                   newPseudoRandomListElem->_next = NULL;
                   curIndex = 0;
+
                   if (curPseudoRandomListElem == NULL)
-		     *pseudoRandomListHeadPtr = newPseudoRandomListElem;
+                     *pseudoRandomListHeadPtr = newPseudoRandomListElem;
                   else
                      curPseudoRandomListElem->_next =  newPseudoRandomListElem;
+
                   curPseudoRandomListElem =  newPseudoRandomListElem;
-		  }
+                  }
 
                if (curPseudoRandomListElem == NULL)
                   {
@@ -662,7 +664,7 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
                curPseudoRandomListElem->_curIndex = curIndex;
 
                if (*p == PSEUDO_RANDOM_SUFFIX)
-		  break;
+                  break;
 
                if (*(p++) != ' ')
                   {
@@ -672,11 +674,11 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
 
                isNegative = false;
                if (*(p) == '-')
-		  {
-		  p++;
-	          isNegative = true;
-		  }
-	       }
+                  {
+                  p++;
+                      isNegative = true;
+                  }
+               }
             }
          else if (limitReadBuffer[0] == '(' && cmdLineOptions->getOption(TR_OrderCompiles))
             {


### PR DESCRIPTION
Deleting generally unused code guarded by TR_OrderedCompiles as per https://github.com/eclipse-openj9/openj9/issues/12500

Should not be merged before https://github.com/eclipse-openj9/openj9/pull/12809

Closes https://github.com/eclipse-openj9/openj9/issues/12500