### PR TITLE
Remove wrapper method createJittedMethodSymbol in Compilation

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -384,11 +384,8 @@ OMR::Compilation::Compilation(
    //_methodSymbol must be done after symRefTab, but before codegen
    // _methodSymbol must be initialized here because creating a jitted method symbol
    //   actually inspects TR::comp()->_methodSymbol (to compare against the new object)
-   _methodSymbol = NULL;
-      {
-      _methodSymbol = TR::ResolvedMethodSymbol::createJittedMethodSymbol(self()->trHeapMemory(), compilee, self());
-      }
-
+   _methodSymbol = TR::ResolvedMethodSymbol::createJittedMethodSymbol(self()->trHeapMemory(), compilee, self());
+   
    // initPersistentCPUField and createOpCode must be done after method symbol creation
 
    if (self()->getOption(TR_EnableNodeGC))
@@ -554,13 +551,6 @@ OMR::Compilation::getHotnessName()
    {
    return TR::Compilation::getHotnessName(self()->getMethodHotness());
    }
-
-
-TR::ResolvedMethodSymbol * OMR::Compilation::createJittedMethodSymbol(TR_ResolvedMethod *resolvedMethod)
-   {
-   return TR::ResolvedMethodSymbol::createJittedMethodSymbol(self()->trHeapMemory(), resolvedMethod, self());
-   }
-
 
 bool OMR::Compilation::canAffordOSRControlFlow()
    {

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1003,8 +1003,6 @@ public:
       return _flags.testAny(GenerateReadOnlyCode);
       }
 
-   TR::ResolvedMethodSymbol *createJittedMethodSymbol(TR_ResolvedMethod *resolvedMethod);
-
    bool isGPUCompilation() { return _flags.testAny(IsGPUCompilation);}
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -540,7 +540,7 @@ TR_ResolvedMethod::_genMethodILForPeeking(TR::ResolvedMethodSymbol *, TR::Compil
 
 TR::ResolvedMethodSymbol* TR_ResolvedMethod::findOrCreateJittedMethodSymbol(TR::Compilation *comp)
    {
-   return comp->createJittedMethodSymbol(this);
+   return TR::ResolvedMethodSymbol::createJittedMethodSymbol(comp->trHeapMemory(), this, comp);
    }
 
 void TR_ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)


### PR DESCRIPTION
using TR::ResolvedMethodSymbol::createJittedMethodSymbol directly 

Signed-off-by: Tao Guan <james_mango@yahoo.com>