### PR TITLE
Add DummyResolvedMethod flag to OMR Symbol

### DIFF
--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -438,6 +438,9 @@ public:
    void setIsPendingPush() { _flags2.set(PendingPush); }
    bool isPendingPush()    { return _flags2.testAny(PendingPush); }
 
+   inline void setDummyResolvedMethod();
+   inline bool isDummyResolvedMethod();
+
    /**
     * Enum values for _flags field.
     */
@@ -566,6 +569,14 @@ public:
       NonSpecificConstObject    = 0x00002000, // Constant object not specific to a type
       BlockFrequency            = 0x00004000,
       RecompQueuedFlag          = 0x00008000,
+      /**
+       * This flag is used to identify symbols corresponding to dummy TR_ResolvedMethod
+       * that are not really resolved, but treated as such as the resolution mechanism
+       * involves resolving the arguments instead. An example of that is linkToStatic,
+       * which is a VM internal native call that is created for unresolved invokedynamic
+       * and invokehandle bytecodes.
+       */
+      DummyResolvedMethod       = 0x00010000,
       };
 
 protected:

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -731,6 +731,18 @@ OMR::Symbol::isSyncVolatile()
    return self()->isVolatile();
    }
 
+void
+OMR::Symbol::setDummyResolvedMethod()
+   {
+   _flags2.set(DummyResolvedMethod);
+   }
+
+bool
+OMR::Symbol::isDummyResolvedMethod()
+   {
+   return _flags2.testAny(DummyResolvedMethod);
+   }
+
 TR::RegisterMappedSymbol *
 OMR::Symbol::getRegisterMappedSymbol()
    {


### PR DESCRIPTION
Includes getter/setter functions. This flag is used to identify
symbols corresponding to dummy TR_ResolvedMethod that are not
really resolved, but treated as such as the resolution mechanism
involves resolving the arguments instead. An example of that is
linkToStatic, which is a VM internal native call that is created
for unresolved invokedynamic and invokehandle bytecodes.

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>