### PR TITLE
Ignore unreachable paths when merging defined on all paths in GlobalVP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4579,6 +4579,10 @@ TR_BitVector *TR::GlobalValuePropagation::mergeDefinedOnAllPaths(TR_StructureSub
    bool first = true;
    for (auto itr = node->getPredecessors().begin(), end = node->getPredecessors().end(); itr != end; ++itr)
       {
+      EdgeConstraints  *constraints = getEdgeConstraints(*itr);
+      if (isUnreachablePath(constraints))
+         continue;
+      
       TR_BitVector *predDefinedOnAllPaths = (*_definedOnAllPaths)[*itr];
       if (trace())
          {


### PR DESCRIPTION
Ignore unreachable paths when merging defined on all paths in GlobalVP. 

Signed-off-by: Gita Koblents <koblents@ca.ibm.com>

Related:
[1] https://github.com/eclipse/omr/commit/de384893e9c36dff5b7329ed14e23bd23f15733f