### PR TITLE
Implement supportsInliningOfIsInstance on POWER

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -910,6 +910,11 @@ bool OMR::Power::CodeGenerator::isSnippetMatched(TR::Snippet *snippet, int32_t s
       }
    }
 
+bool OMR::Power::CodeGenerator::supportsInliningOfIsInstance()
+   {
+   return !self()->comp()->getOption(TR_DisableInlineIsInstance);
+   }
+
 bool OMR::Power::CodeGenerator::hasDataSnippets()
    {
    return (_constantData==NULL)?false:true;

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -207,6 +207,7 @@ public:
    bool canEmitDataForExternallyRelocatableInstructions();
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
+   bool supportsInliningOfIsInstance();
 
    /**
     * Return the proper linkage for this call, especially for the case when the methodSymbol


### PR DESCRIPTION
POWER CG implements instanceOfEvaluator but not `supportsInliningOfIsInstance`. This commit implement it allowing a call node to Class.isInstance() to be changed to an `instanceof` node.

Depends on eclipse-openj9/openj9#12622 which fixes the `ifInstanceOf` evaluator for certain cases.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>