### PR TITLE
zOS: Exploit CEEPCB_3164 indicator bit + propagate CEL4RO31 lookup return code

### DIFF
--- a/fvtest/porttest/omrslTest.cpp
+++ b/fvtest/porttest/omrslTest.cpp
@@ -39,12 +39,12 @@
 
 #if defined(J9ZOS39064)
 /* We replicate the function pointer definitions from omrcel4ro31 here to avoid unnecessarily
- * having to expose omr_cel4ro31_is_supported() in omrport.h. These are static definitions
- * off fast vector from CCA control block that are not subject to change. Final offset is
- * updated to +8 to test for routine address.
+ * having to expose omr_cel4ro31_is_supported() in omrport.h.  These are static defintions
+ * not subject to change.
  */
-#define CEL4RO31_FNPTR (*(uintptr_t *)((char *)(*(int *)(((char *)__gtca())+1096))+8))
-#define CELQGIPB_FNPTR (*(uintptr_t *)((char *)(*(int *)(((char *)__gtca())+1096))+96))
+#define CEEPCBFLAG6_VALUE *((char *)(*(long *)(((char *)__gtca())+912))+344)
+#define CEEPCB_3164_MASK 0x4
+
 #endif /* defined(J9ZOS39064) */
 
 /**
@@ -298,7 +298,7 @@ TEST(PortSlTest, sl_testOpen31bitDLLviaCEL4RO31)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-	if ((NULL != CEL4RO31_FNPTR) && (NULL != CELQGIPB_FNPTR)) {
+	if (OMR_ARE_ANY_BITS_SET(CEEPCBFLAG6_VALUE, CEEPCB_3164_MASK)) {
 		/* Only attempt the test if the underlying LE support is available. */
 		rc = omrsl_open_shared_library(sharedLibName, &dllHandle, OMRPORT_SLOPEN_DECORATE | OMRPORT_SLOPEN_ATTEMPT_31BIT_OPEN);
 		if (0 != rc) {

--- a/fvtest/porttest/sltestlib31/sltest.cpp
+++ b/fvtest/porttest/sltestlib31/sltest.cpp
@@ -22,7 +22,7 @@
 /**
  * Test function for CEL4RO31 sl tests.
  */
-void
+extern "C" void
 sl_testOpen31bitDLLviaCEL4RO31_function(void)
 {
 }

--- a/port/zos390/omrcel4ro31.c
+++ b/port/zos390/omrcel4ro31.c
@@ -35,6 +35,16 @@ typedef void cel4ro31_cwi_func(void *);
 typedef void celqgipb_cwi_func(uint32_t *, OMR_CEL4RO31_infoBlock **, uint32_t *);
 #define CELQGIPB_FNPTR ((celqgipb_cwi_func *)((char *)(*(int *)(((char *)__gtca())+1096))+96))
 
+/* CEEPCB_3164 indicator is the 6th bit of PCB's CEEPCBFLAG6 field (byte 344).
+ * CEECAAPCB field is byte 912 of CAA.
+ *
+ * References for AMODE64:
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=mappings-language-environment-process-control-block
+ * https://www.ibm.com/docs/en/zos/2.4.0?topic=mappings-language-environment-common-anchor-area
+ */
+#define CEEPCBFLAG6_VALUE *((char *)(*(long *)(((char *)__gtca())+912))+344)
+#define CEEPCB_3164_MASK 0x4
+
 OMR_CEL4RO31_infoBlock *
 omr_cel4ro31_init(uint32_t flags, const char *moduleName, const char *functionName, uint32_t argsLength)
 {
@@ -165,7 +175,7 @@ omr_cel4ro31_call(OMR_CEL4RO31_infoBlock *infoBlock)
 BOOLEAN
 omr_cel4ro31_is_supported(void)
 {
-	return (NULL != CEL4RO31_FNPTR) && (NULL != CELQGIPB_FNPTR);
+	return OMR_ARE_ANY_BITS_SET(CEEPCBFLAG6_VALUE, CEEPCB_3164_MASK);
 }
 
 const char*


### PR DESCRIPTION
A few miscellaneous updates and fixes related to CEL4RO31:

- LE added a new CEEPCB_3164 bit on CEEPCBFLAG6 flag within Process
Control Block (PCB) to indicate support for CEL4RO31/64.  Update
omr_cel4ro31_isSupported() and sl_testOpen31bitDLLviaCEL4RO31
to use this new bit.
- Add extern "C" to sltestlib31's function to ensure name is
not C++ mangled.
- Capture the CEL4RO31 return code for function lookup
to the Trc_PRT_sl_lookup_name_Exit2 when function is
not found.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>