### PR TITLE
Refactor copy to use template for concurrent GC

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -275,6 +275,7 @@ public:
 	MMINLINE void forwardingSucceeded(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *copyCache, void *newCacheAlloc, uintptr_t oldObjectAge, uintptr_t objectCopySizeInBytes, uintptr_t objectReserveSizeInBytes);
 
 	MMINLINE omrobjectptr_t copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHeader);
+	template <bool variant> omrobjectptr_t copyForVariant(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHeader);
 	
 	/* Flush remaining Copy Scan updates which would otherwise be discarded 
 	 * @param majorFlush last thread to flush updates should perform a major flush (push accumulated updates to history record) 


### PR DESCRIPTION
Copy is now an inline function which calls copyForVariant, which
performs the previous functionality for copy. copyForVariant is a
template function that is told the variant of template that it is to
use, either CS or STW. This dictates if copyForVariant should
exhibit Concurrent Scavenger behaviour or Stop The World behaviour.

The enum CopyVariant is introduced to represent the different variants
of copyForVariant. The two options are STW for IS_CONCURRENT_ENABLED
== false, and CS for IS_CONCURRENT_ENABLED == true.

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>