### PR TITLE
Move definition of PersistentInfo::createCounters to cpp file

### DIFF
--- a/compiler/env/OMRPersistentInfo.cpp
+++ b/compiler/env/OMRPersistentInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,9 +20,17 @@
  *******************************************************************************/
 
 #include "env/PersistentInfo.hpp"
+#include "ras/DebugCounter.hpp"
 
 TR::PersistentInfo *
 OMR::PersistentInfo::self()
    {
    return static_cast<TR::PersistentInfo*>(this);
+   }
+
+void 
+OMR::PersistentInfo::createCounters(TR_PersistentMemory *mem)
+   {
+   _staticCounters  = new (mem) TR::DebugCounterGroup(mem);
+   _dynamicCounters = new (mem) TR::DebugCounterGroup(mem);
    }

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -612,9 +612,3 @@ void TR::DebugCounterGroup::resetAll()
 
    // TODO: Aggregations??
    }
-
-void OMR::PersistentInfo::createCounters(TR_PersistentMemory *mem)
-   {
-   _staticCounters  = new (mem) TR::DebugCounterGroup(mem);
-   _dynamicCounters = new (mem) TR::DebugCounterGroup(mem);
-   }


### PR DESCRIPTION

Signed-off-by: Tao Guan <james_mango@yahoo.com>