### PR TITLE
New static method initializeFreeMemoryProfileMaxSizeClasses

### DIFF
--- a/gc/stats/FreeEntrySizeClassStats.hpp
+++ b/gc/stats/FreeEntrySizeClassStats.hpp
@@ -87,6 +87,7 @@ public:
 	/* return the 'average' number of pages which can be freed */
 	uintptr_t getPageAlignedFreeMemory(const uintptr_t sizeClassSizes[], uintptr_t pageSize);
 
+	uintptr_t getMaxSizeClasses() { return _maxSizeClasses; }
 	/**< @param factorVeryLargeEntryPool : multiple factor for _maxVeryLargeEntrySizes, default = 1, double for splitFreeList case 
 	 *   @param simulation : if true, generate _fractionFrequentAllocation array for cumulating fraction of frequentAllocation during estimating fragmentation, default = false
 	 */

--- a/gc/stats/LargeObjectAllocateStats.hpp
+++ b/gc/stats/LargeObjectAllocateStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corp. and others
+ * Copyright (c) 2012, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -166,6 +166,8 @@ public:
 	
 
 	static MM_LargeObjectAllocateStats *newInstance(MM_EnvironmentBase *env, uint16_t maxAllocateSizes, uintptr_t largeObjectThreshold, uintptr_t veryLargeObjectThreshold, float sizeClassRatio, uintptr_t maxHeapSize, uintptr_t tlhMaximumSize, uintptr_t tlhMinimumSize, uintptr_t factorVeryLargeEntryPool=1);
+	static void	initializeFreeMemoryProfileMaxSizeClasses(MM_EnvironmentBase *env, uintptr_t veryLargeObjectThreshold, float sizeClassRatio, uintptr_t maxHeapSize);
+
 	void kill(MM_EnvironmentBase *env);
 
 	bool initialize(MM_EnvironmentBase *env, uint16_t maxAllocateSizes, uintptr_t largeObjectThreshold, uintptr_t veryLargeObjectThreshold, float sizeClassRatio, uintptr_t maxHeapSize, uintptr_t tlhMaximumSize, uintptr_t tlhMinimumSize, uintptr_t factorVeryLargeEntryPool=1);


### PR DESCRIPTION
global variables largeObjectAllocationProfilingVeryLargeObjectThreshold,
largeObjectAllocationProfilingVeryLargeObjectSizeClass and
freeMemoryProfileMaxSizeClasses are initialized during
MM_LargeObjectAllocateStats construction, new static method
initializeFreeMemoryProfileMaxSizeClasses is created for avoiding the
 case, which the global variables has been used before initialized.


Signed-off-by: Lin Hu <linhu@ca.ibm.com>