### PR TITLE
Move `_start/_endTime` in `ScavengerStats` to `Collector`

### DIFF
--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -75,7 +75,7 @@ private:
 	uintptr_t _tiltedAverageBytesFlippedDelta;
 
 	double _averageScavengeTimeRatio;
-	uint64_t _lastScavengeEndTime;
+	uint64_t _lastGCEndTime;
 
 	double _desiredSurvivorSpaceRatio;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
@@ -187,7 +187,7 @@ public:
 		,_tiltedAverageBytesFlipped(0)
 		,_tiltedAverageBytesFlippedDelta(0)
 		,_averageScavengeTimeRatio(0.0)
-		,_lastScavengeEndTime(0)
+		,_lastGCEndTime(0)
 		,_desiredSurvivorSpaceRatio(0.0)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)		
 		,_bytesAllocatedDuringConcurrent(0)

--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -162,6 +162,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
 		<data type="void*" name="subSpace" description="the subspace which was collected" />
 		<data type="bool" name="cycleEnd" description="true, if last GC increment in a cycle" />
+		<data type="uint64_t" name="incrementStartTime" description="start time of cycle increment" />
+		<data type="uint64_t" name="incrementEndTime" description="end time of cycle increment" />
 	</event>
 
 	<event>

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -70,6 +70,15 @@ class MM_Scavenger : public MM_Collector
 	/*
 	 * Data members
 	 */
+public:
+	struct {
+		/* The following start/end times record total cycle and cycle increment durations, done only by main thread. */
+		uint64_t cycleStart;
+		uint64_t cycleEnd;
+		uint64_t incrementStart;
+		uint64_t incrementEnd;
+	} _cycleTimes;
+
 private:
 	MM_ScavengerDelegate _delegate;
 
@@ -899,6 +908,7 @@ public:
 
 	MM_Scavenger(MM_EnvironmentBase *env, MM_HeapRegionManager *regionManager) :
 		MM_Collector()
+		, _cycleTimes()
 		, _delegate(env)
 		, _objectAlignmentInBytes(env->getObjectAlignmentInBytes())
 		, _isRememberedSetInOverflowAtTheBeginning(false)

--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -127,6 +127,8 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uintptr_t" name="tenureLOATotalBytes" description="total number of bytes in the LOA" />
 		<data type="uintptr_t" name="tenureAge" description="the age at which objects currently get tenured" />
 		<data type="uintptr_t" name="totalMemorySize" description="the total size of all memory spaces" />
+		<data type="uint64_t" name="incrementStartTime" description="start time of increment" />
+		<data type="uint64_t" name="incrementEndTime" description="end time of increment" />
 	</event>
 
 	<event>

--- a/gc/stats/ConcurrentMarkPhaseStats.hpp
+++ b/gc/stats/ConcurrentMarkPhaseStats.hpp
@@ -40,8 +40,6 @@ class MM_ConcurrentMarkPhaseStats : public MM_ConcurrentPhaseStatsBase
 private:
 protected:
 public:
-	uint64_t _startTime;
-	uint64_t _endTime;
 	MM_ConcurrentCardTableStats *_cardTableStats;
 	MM_ConcurrentGCStats *_collectionStats;
 
@@ -51,16 +49,12 @@ protected:
 public:
 	virtual void clear() {
 		MM_ConcurrentPhaseStatsBase::clear();
-		_startTime = 0;
-		_endTime = 0;
 		_cardTableStats = NULL;
 		_collectionStats = NULL;
 	}
 
 	MM_ConcurrentMarkPhaseStats()
 		: MM_ConcurrentPhaseStatsBase(OMR_GC_CYCLE_TYPE_GLOBAL)
-		, _startTime(0)
-		, _endTime(0)
 		, _cardTableStats(NULL)
 		, _collectionStats(NULL)
 		{}

--- a/gc/stats/ConcurrentPhaseStatsBase.hpp
+++ b/gc/stats/ConcurrentPhaseStatsBase.hpp
@@ -42,6 +42,8 @@ class MM_ConcurrentPhaseStatsBase : public MM_Base
 private:
 protected:
 public:
+	uint64_t _startTime;
+	uint64_t _endTime;
 	uintptr_t _cycleID;	/**< The "_id" of the corresponding cycle */
 	uintptr_t _scanTargetInBytes;	/**< The number of bytes a given concurrent task was expected to scan before terminating */
 	uintptr_t _bytesScanned;	/**< The number of bytes a given concurrent task did scan before it terminated (can be lower than _scanTargetInBytes if the termination was asynchronously requested) */
@@ -53,7 +55,6 @@ public:
 		terminationRequest_External
 	};
 	TerminationRequestType _terminationRequestType; /**< Reason for concurrent task termination, asynchronous external event or itself GC (work or survivor space exhausted etc). */
-
 	/* Member Functions */
 private:
 protected:
@@ -67,6 +68,8 @@ public:
 	}
 	
 	virtual void clear() {
+		_startTime = 0;
+		_endTime = 0;
 		_cycleID = 0;
 		_scanTargetInBytes = 0;
 		_bytesScanned = 0;
@@ -76,6 +79,8 @@ public:
 	 
 	MM_ConcurrentPhaseStatsBase(uintptr_t concurrentCycleType = OMR_GC_CYCLE_TYPE_DEFAULT)
 		: MM_Base()
+		, _startTime(0)
+		, _endTime(0)
 		, _cycleID(0)
 		, _scanTargetInBytes(0)
 		, _bytesScanned(0)

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -44,8 +44,6 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_failedFlipCount(0)
 	,_failedFlipBytes(0)
 	,_tenureAge(0)
-	,_startTime(0)
-	,_endTime(0)
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	,_releaseScanListCount(0)
 	,_acquireFreeListCount(0)
@@ -66,8 +64,8 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_depthDeepestStructure(0)
 	,_copyScanUpdates(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-	,_workerScavengeStartTime(0)
-	,_workerScavengeEndTime(0)
+	,_startTime(0)
+	,_endTime(0)
 	,_notifyStallTime(0)
 	,_adjustedSyncStallTime(0)
 	,_avgInitialFree(0)
@@ -201,8 +199,8 @@ MM_ScavengerStats::clear(bool firstIncrement)
 
 	_adjustedSyncStallTime = 0;
 	_notifyStallTime = 0;
-	_workerScavengeEndTime = 0;
-	_workerScavengeStartTime = 0;
+	_startTime = 0;
+	_endTime = 0;
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	_readObjectBarrierCopy = 0;

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -75,9 +75,6 @@ public:
 	uintptr_t _failedFlipCount;
 	uintptr_t _failedFlipBytes;
 	uintptr_t _tenureAge;
-	/* The following start/end times are not used as thread local, but to record total cycle duration, done only by main thread. Ideally, these should be moved to the collector. */
-	uint64_t _startTime;
-	uint64_t _endTime;
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	uintptr_t _releaseScanListCount;
 	uintptr_t _acquireFreeListCount;
@@ -100,8 +97,8 @@ public:
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
 	/* Stats Used Specifically for Adaptive Threading */
-	uint64_t _workerScavengeStartTime; /**< Timestamp taken when worker starts the scavenge task */
-	uint64_t _workerScavengeEndTime; /**< Timestamp taken when worker completes the scavenge task */
+	uint64_t _startTime; /**< Timestamp taken when worker starts the scavenge task */
+	uint64_t _endTime; /**< Timestamp taken when worker completes the scavenge task */
 
 	/* The time, in hi-res ticks, the thread spent stalled notifying other
 	 * threads during scavenge. Note: this is not all inclusive, it records notify

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -405,7 +405,7 @@ MM_VerboseHandlerOutputStandard::handleScavengeEndNoLock(J9HookInterface** hook,
 	MM_ScavengerStats *cycleScavengerStats = &extensions->scavengerStats;
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	uint64_t duration = 0;
-	bool deltaTimeSuccess = getTimeDeltaInMicroSeconds(&duration, scavengerStats->_startTime, scavengerStats->_endTime);
+	bool deltaTimeSuccess = getTimeDeltaInMicroSeconds(&duration, event->incrementStartTime, event->incrementEndTime);
 
 	handleGCOPOuterStanzaStart(env, "scavenge", env->_cycleState->_verboseContextID, duration, deltaTimeSuccess);
 
@@ -478,6 +478,8 @@ MM_VerboseHandlerOutputStandard::handleConcurrentEndInternal(J9HookInterface** h
 		scavengeEndEvent.eventid = event->eventid;
 		scavengeEndEvent.subSpace = NULL; //unknown info
 		scavengeEndEvent.cycleEnd = false;
+		scavengeEndEvent.incrementStartTime = stats->_startTime;
+		scavengeEndEvent.incrementEndTime = stats->_endTime;
 
 		handleScavengeEndNoLock(hook, J9HOOK_MM_PRIVATE_SCAVENGE_END, &scavengeEndEvent);
 	}


### PR DESCRIPTION
Issue reported in https://github.com/eclipse/omr/pull/5830#discussion_r584834266

Move `_start/_endTime` from `MM_ScavengerStats`
to `MM_Scavenger` and rename to `_cycleStart/End`.

Rename `MM_MemorySubSpaceSemiSpace::_lastScavengeEndTime`
to `_lastGCEndTime`

Rename `MM_ScavengerStats::_workerScavengeStart/EndTime`
to `_start/endTime`

Add `incrementStart/EndTime` to `MM_LocalGCEndEvent`
