### PR TITLE
AArch64: Vector Int32 & Int64 Support

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -743,6 +743,7 @@ static const char *opCodeToNameMap[] =
    "vfsub2d",
    "vmul16b",
    "vmul8h",
+   "vmul4s",
    "vfmul4s",
    "vfmul2d",
    "vfdiv4s",

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -731,6 +731,8 @@ static const char *opCodeToNameMap[] =
    "vorr2d",
    "vadd16b",
    "vadd8h",
+   "vadd4s",
+   "vadd2d",
    "vfadd4s",
    "vfadd2d",
    "vsub16b",

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -737,6 +737,8 @@ static const char *opCodeToNameMap[] =
    "vfadd2d",
    "vsub16b",
    "vsub8h",
+   "vsub4s",
+   "vsub2d",
    "vfsub4s",
    "vfsub2d",
    "vmul16b",

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -289,6 +289,12 @@ OMR::ARM64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt16:
          addOp = TR::InstOpCode::vadd8h;
          break;
+      case TR::VectorInt32:
+         addOp = TR::InstOpCode::vadd4s;
+         break;
+      case TR::VectorInt64:
+         addOp = TR::InstOpCode::vadd2d;
+         break;
       case TR::VectorFloat:
          addOp = TR::InstOpCode::vfadd4s;
          break;

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -351,6 +351,9 @@ OMR::ARM64::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt16:
          mulOp = TR::InstOpCode::vmul8h;
          break;
+      case TR::VectorInt32:
+         mulOp = TR::InstOpCode::vmul4s;
+         break;
       case TR::VectorFloat:
          mulOp = TR::InstOpCode::vfmul4s;
          break;

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -320,6 +320,12 @@ OMR::ARM64::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       case TR::VectorInt16:
          subOp = TR::InstOpCode::vsub8h;
          break;
+      case TR::VectorInt32:
+         subOp = TR::InstOpCode::vsub4s;
+         break;
+      case TR::VectorInt64:
+         subOp = TR::InstOpCode::vsub2d;
+         break;
       case TR::VectorFloat:
          subOp = TR::InstOpCode::vfsub4s;
          break;

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -709,6 +709,8 @@
 		vorr2d,                                                  	/* 0x4EA01C00   ORR       	 */
 		vadd16b,                                                  	/* 0x4E208400	ADD      	 */
 		vadd8h,                                                  	/* 0x4E608400	ADD      	 */
+		vadd4s,                                                  	/* 0x4EA08400	ADD      	 */
+		vadd2d,                                                  	/* 0x4EE08400	ADD      	 */
 		vfadd4s,                                                  	/* 0x4E20D400	FADD      	 */
 		vfadd2d,                                                  	/* 0x4E60D400	FADD      	 */
 		vsub16b,                                                  	/* 0x6E208400	SUB      	 */

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -721,6 +721,7 @@
 		vfsub2d,                                                  	/* 0x4EE0D400	FSUB      	 */
 		vmul16b,                                                  	/* 0x4E209C00	MUL      	 */
 		vmul8h,                                                  	/* 0x4E609C00	MUL      	 */
+		vmul4s,                                                  	/* 0x4EA09C00	MUL      	 */
 		vfmul4s,                                                  	/* 0x6E20DC00	FMUL      	 */
 		vfmul2d,                                                  	/* 0x6E60DC00	FMUL      	 */
 		vfdiv4s,                                                  	/* 0x6E20FC00	FDIV      	 */

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -715,6 +715,8 @@
 		vfadd2d,                                                  	/* 0x4E60D400	FADD      	 */
 		vsub16b,                                                  	/* 0x6E208400	SUB      	 */
 		vsub8h,                                                  	/* 0x6E608400	SUB      	 */
+		vsub4s,                                                  	/* 0x6EA08400	SUB      	 */
+		vsub2d,                                                  	/* 0x6EE08400	SUB      	 */
 		vfsub4s,                                                  	/* 0x4EA0D400	FSUB      	 */
 		vfsub2d,                                                  	/* 0x4EE0D400	FSUB      	 */
 		vmul16b,                                                  	/* 0x4E209C00	MUL      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -727,6 +727,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4EE0D400,	/* FSUB      	vfsub2d	 */
 		0x4E209C00,	/* MUL      	vmul16b	 */
 		0x4E609C00,	/* MUL      	vmul8h	 */
+		0x4EA09C00,	/* MUL      	vmul4s	 */
 		0x6E20DC00,	/* FMUL      	vfmul4s	 */
 		0x6E60DC00,	/* FMUL      	vfmul2d	 */
 		0x6E20FC00,	/* FDIV      	vfdiv4s	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -721,6 +721,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E60D400,	/* FADD      	vfadd2d	 */
 		0x6E208400,	/* SUB      	vsub16b	 */
 		0x6E608400,	/* SUB      	vsub8h	 */
+		0x6EA08400,	/* SUB      	vsub4s	 */
+		0x6EE08400,	/* SUB      	vsub2d	 */
 		0x4EA0D400,	/* FSUB      	vfsub4s	 */
 		0x4EE0D400,	/* FSUB      	vfsub2d	 */
 		0x4E209C00,	/* MUL      	vmul16b	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -715,6 +715,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4EA01C00,	/* ORR      	vorr2d	 */
 		0x4E208400,	/* ADD      	vadd16b	 */
 		0x4E608400,	/* ADD      	vadd8h	 */
+		0x4EA08400,	/* ADD      	vadd4s	 */
+		0x4EE08400,	/* ADD      	vadd2d	 */
 		0x4E20D400,	/* FADD      	vfadd4s	 */
 		0x4E60D400,	/* FADD      	vfadd2d	 */
 		0x6E208400,	/* SUB      	vsub16b	 */


### PR DESCRIPTION
This commit accommodates the changes needed to support Int32 and Int64
data types for Vector arithmetic operations. The following operations
are covered-
- Vector Add (VectorInt32, VectorInt64)
- Vector Subtract (VectorInt32, VectorInt64)
- Vector Multiplication  (VectorInt32)