### PR TITLE
AArch64: Vector Splat Implementation

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -756,6 +756,12 @@ static const char *opCodeToNameMap[] =
    "vfneg4s",
    "vfneg2d",
    "vnot16b",
+   "vdup16b",
+   "vdup8h",
+   "vdup4s",
+   "vdup2d",
+   "vfdup4s",
+   "vfdup2d",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -735,6 +735,12 @@
 		vfneg4s,                                                  	/* 0x6EA0F800	FNEG      	 */
 		vfneg2d,                                                  	/* 0x6EE0F800	FNEG      	 */
 		vnot16b,                                                  	/* 0x6E205800	NOT      	 */
+		vdup16b,                                               		/* 0x4E010C00	DUP      	 */
+		vdup8h,                                                  	/* 0x4E020C00	DUP      	 */
+		vdup4s,                                               		/* 0x4E040C00	DUP      	 */
+		vdup2d,                                               		/* 0x4E080C00	DUP      	 */
+		vfdup4s,                                                  	/* 0x4E040400	DUP      	 */
+		vfdup2d,                                                  	/* 0x4E080400	DUP      	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -741,6 +741,13 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6EA0F800,	/* FNEG      	vfneg4s	 */
 		0x6EE0F800,	/* FNEG      	vfneg2d	 */
 		0x6E205800,	/* NOT      	vnot16b	 */
+		0x4E010C00,	/* DUP      	vdup16b  */
+		0x4E020C00,	/* DUP      	vdup8h   */
+		0x4E040C00,	/* DUP      	vdup4s   */
+		0x4E080C00,	/* DUP      	vdup2d   */
+		0x4E040400,	/* DUP      	vfdup4s  */
+		0x4E080400,	/* DUP      	vfdup2d  */
+
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };


### PR DESCRIPTION
This commit accommodates the implementation of the vector splat
operation and respective opcodes for the data types-
- VectorInt8
- VectorInt16
- VectorInt32
- VectorInt64
- VectorFloat
- VectorDouble

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>