### PR TITLE
Simplify the logic for identifying minimum free size for sweeping

### DIFF
--- a/gc/base/ParallelSweepChunk.hpp
+++ b/gc/base/ParallelSweepChunk.hpp
@@ -84,6 +84,8 @@ public:
 	uintptr_t _accumulatedFreeSize;
 	uintptr_t _accumulatedFreeHoles;
 
+	uintptr_t _minFreeSize;
+
 	/**
 	 * clear the Chunk object.
 	 */	
@@ -109,6 +111,16 @@ public:
 			_previousLargestFreeEntry = previousLargestFreeEntryCandidate;
 			_largestFreeEntry = largestFreeEntrySizeCandidate;
  		}
+	}
+
+	MMINLINE bool isFreeSizeEligibleForRecycling(uintptr_t size)
+	{
+		return size >= _minFreeSize;
+	}
+
+	MMINLINE bool isTrailingFreeCandidateEligibleForRecycling()
+	{
+		return trailingFreeCandidateSize >= _minFreeSize;
 	}
 
 	/**
@@ -147,7 +159,8 @@ public:
 		_splitCandidate(NULL),
 		_splitCandidatePreviousEntry(NULL),
 		_accumulatedFreeSize(0),
-		_accumulatedFreeHoles(0)
+		_accumulatedFreeHoles(0),
+		_minFreeSize(0)
 	{
 		_typeId = __FUNCTION__;
 	};

--- a/gc/base/SweepPoolManager.hpp
+++ b/gc/base/SweepPoolManager.hpp
@@ -52,6 +52,7 @@ private:
 protected:
 
 	MM_GCExtensionsBase *_extensions;
+	uintptr_t _minFreeSize;
 
 	virtual void tearDown(MM_EnvironmentBase *env);
 	virtual bool initialize(MM_EnvironmentBase *env);
@@ -106,11 +107,14 @@ public:
 	 */
 	virtual MM_SweepPoolState *getPoolState(MM_MemoryPool *memoryPool) = 0;
 
+	MMINLINE uintptr_t getMinimumFreeSize() { return _minFreeSize; }
+
 	/**
 	 * Create a SweepPoolManager object.
 	 */
 	MM_SweepPoolManager(MM_EnvironmentBase *env)
 		: _extensions(env->getExtensions())
+		, _minFreeSize(_extensions->getMinimumFreeEntrySize())
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/SweepPoolManagerAddressOrderedListBase.hpp
+++ b/gc/base/SweepPoolManagerAddressOrderedListBase.hpp
@@ -47,16 +47,14 @@ class MM_HeapLinkedFreeHeader;
 class MM_SweepPoolManagerAddressOrderedListBase : public MM_SweepPoolManager
 {
 private:
-
 protected:
+public:
 
+private:
+protected:
 	MMINLINE void calculateTrailingDetails(MM_ParallelSweepChunk *sweepChunk, uintptr_t *trailingCandidate, uintptr_t trailingCandidateSlotCount);
 	MMINLINE virtual void connectChunkPostProcess(MM_ParallelSweepChunk *chunk, MM_SweepPoolState *sweepState, MM_HeapLinkedFreeHeader* splitCandidate, MM_HeapLinkedFreeHeader* splitCandidatePreviousEntry){}
 	MMINLINE virtual void addFreeMemoryPostProcess(MM_EnvironmentBase *env, MM_MemoryPoolAddressOrderedListBase *memoryPool, void *addrBase, void *addrTop, bool needSync, void *oldAddrTop = NULL) {}
-	MMINLINE virtual bool isEligibleForFreeMemory(MM_EnvironmentBase *env, MM_MemoryPoolAddressOrderedListBase *memoryPool, void* address, uintptr_t size)
-	{
-		return memoryPool->canMemoryBeConnectedToPool(env, address, size);
-	}
 
 	MMINLINE void updateLargestFreeEntryInChunk(MM_ParallelSweepChunk *chunk, MM_SweepPoolState *sweepState, MM_HeapLinkedFreeHeader* previousFreeEntry)
 	{


### PR DESCRIPTION
New variable _minFreeSize in MM_ParallelSweepChunk for keeping minimum
free entry size for sweeping related memory pool.
Avoid callback check and retrieve minimum free entry size from
memorypool every time.

for Default case:
minimum free entry size = memorypool.minimumFreeEntrySize

Signed-off-by: Lin Hu <linhu@ca.ibm.com>