### PR TITLE
Remove atoe_gets() since gets() is insecure and deprecated

### DIFF
--- a/util/a2e/atoe.c
+++ b/util/a2e/atoe.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -903,31 +903,6 @@ atoe_fgets(char *buffer, int num, FILE *file)
 	return (char *)0;
 }
 
-
-/**************************************************************************
- * name        - atoe_gets
- * description -
- * parameters  -
- * returns     -
- *************************************************************************/
-char *
-atoe_gets(char *buffer)
-{
-	char *abuf;
-
-	Log(1, "Entry: atoe_gets\n");
-
-	if (gets(buffer)) {
-		int len = strlen(buffer);
-		abuf = e2a(buffer, len);
-		memcpy(buffer, abuf, len);
-
-		free(abuf);
-		return buffer;
-	}
-
-	return (char *)0;
-}
 
 /**************************************************************************
  * name        - atoe_unlink

--- a/util/a2e/headers/old-stdio.h
+++ b/util/a2e/headers/old-stdio.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,6 @@
         size_t     atoe_fread     (void*, size_t, size_t, FILE*);
         FILE *     atoe_freopen   (const char*, char*, FILE*);
         size_t     atoe_fwrite    (const void*, size_t, size_t, FILE*);
-        char *     atoe_gets      (char *);
         void       atoe_perror    (const char*);
         int        atoe_printf    (const char*, ...);
         int        atoe_putchar   (int);
@@ -77,7 +76,6 @@
 		#undef fread
 		#undef freopen
 		#undef fwrite
-		#undef gets
 		#undef perror
 		#undef printf
 		#undef putchar
@@ -94,7 +92,6 @@
 		#define fread           atoe_fread
 		#define freopen         atoe_freopen
 		#define fwrite          atoe_fwrite
-		#define gets            atoe_gets
 		#define perror          atoe_perror
 		#define printf          atoe_printf
 		#define putchar         atoe_putchar

--- a/util/a2e/headers/stdio.h
+++ b/util/a2e/headers/stdio.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,6 @@
         FILE *     atoe_freopen   (const char*, const char*, FILE*);
         size_t     atoe_fwrite    (const void*, size_t, size_t, FILE*);
         char      *atoe_fgets (char *, int, FILE *);
-        char *     atoe_gets      (char *);
         void       atoe_perror    (const char*);
         int        atoe_printf    (const char*, ...);
         int        atoe_putchar   (int);
@@ -80,7 +79,6 @@
 		#undef freopen
 		#undef fwrite
 		#undef fgets
-		#undef gets
 		#undef perror
 		#undef printf
 		#undef putchar
@@ -100,7 +98,6 @@
 		#define freopen         atoe_freopen
 		#define fwrite          atoe_fwrite
 		#define fgets           atoe_fgets
-		#define gets            atoe_gets
 		#define perror          atoe_perror
 		#define printf          atoe_printf
 		#define putchar         atoe_putchar


### PR DESCRIPTION
gets() is deprecated in the C runtime (C99) and subsequently removed
(C11).

@0xdaryl fyi