### PR TITLE
AArch64: Code cleanup

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -47,7 +47,7 @@ void TR::ARM64LabelInstruction::assignRegistersForOutOfLineCodeSection(TR_Regist
       // Switch to the outlined instruction stream and assign registers.
       //
       TR_ARM64OutOfLineCodeSection *oi = cg()->findARM64OutOfLineCodeSectionFromLabel(getLabelSymbol());
-      TR_ASSERT(oi, "Could not find ARM64OutOfLineCodeSection stream from label.  instr=%p, label=%p\n", this, getLabelSymbol());
+      TR_ASSERT(oi, "Could not find ARM64OutOfLineCodeSection stream from label.  instr=%p, label=%p", this, getLabelSymbol());
       if (!oi->hasBeenRegisterAssigned())
          oi->assignRegisters(kindToBeAssigned);
       }
@@ -65,7 +65,7 @@ void TR::ARM64LabelInstruction::assignRegistersForOutOfLineCodeSection(TR_Regist
          // in the OOL section can jump to the end of section and then only one branch (the
          // last instruction of an OOL section) jumps to the merge-point. In other words, OOL
          // section must contain exactly one exit point.
-         TR_ASSERT(cg()->getAppendInstruction() == this, "OOL section must have only one branch to the merge point\n");
+         TR_ASSERT(cg()->getAppendInstruction() == this, "OOL section must have only one branch to the merge point");
          // Start RA for OOL cold path, restore register state from snap shot
          TR::Machine *machine = cg()->machine();
          if (comp->getOption(TR_TraceRA))

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -264,8 +264,8 @@ inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnem
    lhsReg = cg->evaluate(firstChild);
    rhsReg = cg->evaluate(secondChild);
 
-   TR_ASSERT(lhsReg->getKind() == TR_VRF, "unexpected Register kind\n");
-   TR_ASSERT(rhsReg->getKind() == TR_VRF, "unexpected Register kind\n");
+   TR_ASSERT(lhsReg->getKind() == TR_VRF, "unexpected Register kind");
+   TR_ASSERT(rhsReg->getKind() == TR_VRF, "unexpected Register kind");
 
    TR::Register *resReg = cg->allocateRegister(TR_VRF);
 
@@ -302,7 +302,7 @@ OMR::ARM64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          addOp = TR::InstOpCode::vfadd2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, addOp);
@@ -333,7 +333,7 @@ OMR::ARM64::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          subOp = TR::InstOpCode::vfsub2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, subOp);
@@ -361,7 +361,7 @@ OMR::ARM64::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          mulOp = TR::InstOpCode::vfmul2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, mulOp);
@@ -380,7 +380,7 @@ OMR::ARM64::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          divOp = TR::InstOpCode::vfdiv2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, divOp);
@@ -396,7 +396,7 @@ OMR::ARM64::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          andOp = TR::InstOpCode::vand16b;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, andOp);
@@ -412,7 +412,7 @@ OMR::ARM64::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          orrOp = TR::InstOpCode::vorr16b;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, orrOp);
@@ -428,7 +428,7 @@ OMR::ARM64::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          xorOp = TR::InstOpCode::veor16b;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorBinaryOp(node, cg, xorOp);

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -312,7 +312,7 @@ TR::Linkage *OMR::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
          break;
       default:
-         TR_ASSERT(false, "using system linkage for unrecognized convention %d\n", lc);
+         TR_ASSERT(false, "using system linkage for unrecognized convention %d", lc);
          linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
       }
    self()->setLinkage(lc, linkage);

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -454,7 +454,7 @@ void OMR::ARM64::RegisterDependencyGroup::assignRegisters(
                   opCode = TR::InstOpCode::vldrimmq;
                   break;
                default:
-                  TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");
+                  TR_ASSERT(0, "\nRegister kind not supported in OOL spill");
                   break;
                }
 

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64HelperCallSnippet.hpp"
+#include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64ShiftCode.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
@@ -1184,32 +1184,32 @@ OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *c
    switch (node->getDataType())
       {
       case TR::VectorInt8:
-         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup16b;
          break;
       case TR::VectorInt16:
-         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup8h;
          break;
       case TR::VectorInt32:
-         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup4s;
          break;
       case TR::VectorInt64:
-         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup2d;
          break;
       case TR::VectorFloat:
-         TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
          op = TR::InstOpCode::vfdup4s;
          break;
       case TR::VectorDouble:
-         TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind\n");
+         TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
          op = TR::InstOpCode::vfdup2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
-	      return NULL;
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
+         return NULL;
       }
 
    TR::Register *resReg = cg->allocateRegister(TR_VRF);
@@ -2490,7 +2490,7 @@ loadAddressConstant(TR::CodeGenerator *cg, TR::Node *node, intptr_t value, TR::R
 TR::Register *
 OMR::ARM64::TreeEvaluator::unImpOpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 	{
-	TR_ASSERT_FATAL(false, "Opcode %s is not implemented\n", node->getOpCode().getName());
+	TR_ASSERT_FATAL(false, "Opcode %s is not implemented", node->getOpCode().getName());
 	return NULL;
 	}
 

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -147,7 +147,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
          negOp = TR::InstOpCode::vfneg2d;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorUnaryOp(node, cg, negOp);
@@ -163,7 +163,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeG
          notOp = TR::InstOpCode::vnot16b;
          break;
       default:
-         TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString());
+         TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
          return NULL;
       }
    return inlineVectorUnaryOp(node, cg, notOp);


### PR DESCRIPTION
This commit contains the following changes:

- Remove unnecessary end-of-line characters from TR_ASSERT() messages
- Include header files in alphabetical order in OMRTreeEvaluator.cpp
- Change the indentation of a line in OMRTreeEvaluator.cpp

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>