### PR TITLE
Version HCR guards even if they are loop transfer candidates

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4102,8 +4102,6 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          TR::TreeTop *tt = search.currentTreeTop();
          TR::Node *ttNode = tt->getNode();
          culprit = ttNode;
-         if (removedNodes.contains(ttNode))
-            continue;
 
          if (ttNode->isHCRGuard())
             {
@@ -4111,6 +4109,9 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
             removedNodes.add(ttNode); // Don't search the taken side.
             continue;
             }
+
+         if (removedNodes.contains(ttNode))
+            continue;
 
          // There is no need to identify the call nodes corresponding to HCR
          // guards. Typically none will be found by this search, but even if


### PR DESCRIPTION
Once versioner has decided to use loop transfer for a guard, there is a guarantee that the guard, if it is still present in the hot loop, will exit the loop if taken. The guard can still be versioned (and removed entirely from the loop), in which case there will no longer be any possibility that it could be taken at all. So the taken edge of the guard can always be disregarded when searching the loop for operations that will remain in the hot loop after versioning. To make such searches more precise, loop transfer candidates are automatically included in `_definitelyRemovableNodes` and `_optimisticallyRemovableNodes`.

One such search of the loop determines whether or not HCR guards can be versioned, and also finds the HCR guards to be versioned (if possible). By ignoring removable nodes before checking whether they are HCR guards, this search has been failing to find HCR guards that are also loop transfer candidates (in the current loop). As a result, versioner has been failing to version those HCR guards even when the analysis concludes that it is safe to do so (and even though versioning is preferable to loop transfer).

With this commit, the HCR guard search will now check for an HCR guard before skipping the node (in case it is removable). This way, HCR guards will be identified and (if possible) versioned regardless of whether they are also loop transfer candidates.

Note that this change only affects HCR guards that are loop transfer candidates in the *current* loop. It's possible to have guards that appear within the current loop, and which are also loop transfer candidates, but which are only considered for loop transfer in an outer loop because they target blocks that are already outside of the current loop. Such guards are not included in `_definitelyRemovableNodes` and `_optimisticallyRemovableNodes` (and because their targets are outside of the current loop, including them wouldn't be helpful), so they would be found and versioned appropriately even before this commit.