### PR TITLE
Share common logic in SweepHeapSectioning base class

### DIFF
--- a/gc/base/SweepHeapSectioning.hpp
+++ b/gc/base/SweepHeapSectioning.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,7 @@
 
 class MM_ParallelSweepChunk;
 class MM_ParallelSweepChunkArray;
+class MM_HeapRegionDescriptor;
 
 /**
  * Support for sectioning the heap into chunks useable by sweep (and compact).
@@ -50,8 +51,9 @@ protected:
 	virtual bool initialize(MM_EnvironmentBase* env);
 	void tearDown(MM_EnvironmentBase* env);
 
-	virtual uintptr_t estimateTotalChunkCount(MM_EnvironmentBase* env) = 0;
+	virtual uintptr_t estimateTotalChunkCount(MM_EnvironmentBase* env);
 	virtual uintptr_t calculateActualChunkNumbers() const = 0;
+	virtual bool isReadyToSweep(MM_EnvironmentBase* env, MM_HeapRegionDescriptor* region) { return false; }
 
 	bool initArrays(uintptr_t);
 
@@ -61,7 +63,7 @@ public:
 	virtual void kill(MM_EnvironmentBase* env);
 
 	bool update(MM_EnvironmentBase* env);
-	virtual uintptr_t reassignChunks(MM_EnvironmentBase* env) = 0;
+	virtual uintptr_t reassignChunks(MM_EnvironmentBase* env);
 
 	void* getBackingStoreAddress();
 	uintptr_t getBackingStoreSize();

--- a/gc/base/standard/SweepHeapSectioningSegmented.cpp
+++ b/gc/base/standard/SweepHeapSectioningSegmented.cpp
@@ -29,7 +29,6 @@
 #include "EnvironmentBase.hpp"
 #include "Heap.hpp"
 #include "HeapRegionIterator.hpp"
-#include "HeapRegionDescriptor.hpp"
 #include "NonVirtualMemory.hpp"
 #include "MemoryPool.hpp"
 #include "MemorySubSpace.hpp"
@@ -48,19 +47,7 @@
 uintptr_t
 MM_SweepHeapSectioningSegmented::estimateTotalChunkCount(MM_EnvironmentBase *env)
 {
-	uintptr_t totalChunkCountEstimate;
-
-	if(0 == _extensions->parSweepChunkSize) {
-		/* -Xgc:sweepchunksize= has NOT been specified, so we set it heuristically.
-		 *
-		 *                  maxheapsize
-		 * chunksize =   ----------------   (rounded up to the nearest 256k)
-		 *               threadcount * 32
-		 */
-		_extensions->parSweepChunkSize = MM_Math::roundToCeiling(256*1024, _extensions->heap->getMaximumMemorySize() / (_extensions->dispatcher->threadCountMaximum() * 32));
-	}
-
-	totalChunkCountEstimate = MM_Math::roundToCeiling(_extensions->parSweepChunkSize, _extensions->heap->getMaximumMemorySize()) / _extensions->parSweepChunkSize;
+	uintptr_t totalChunkCountEstimate = MM_SweepHeapSectioning::estimateTotalChunkCount(env);
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/* Because object memory segments have not been allocated yet, we cannot get the real numbers.
@@ -104,101 +91,6 @@ MM_SweepHeapSectioningSegmented::calculateActualChunkNumbers() const
 			/* Add extra chunks if more than one memory pool */
 			totalChunkCount += (poolCount - 1);
 		}
-	}
-
-	return totalChunkCount;
-}
-
-/**
- * Reset and reassign each chunk to a range of heap memory.
- * Given the current updated listed of chunks and the corresponding heap memory, walk the chunk
- * list reassigning each chunk to an appropriate range of memory.  This will clear each chunk
- * structure and then assign its basic values that connect it to a range of memory (base/top,
- * pool, segment, etc).
- * @return the total number of chunks in the system.
- */
-uintptr_t
-MM_SweepHeapSectioningSegmented::reassignChunks(MM_EnvironmentBase *env)
-{
-	MM_ParallelSweepChunk *chunk; /* Sweep table chunk (global) */
-	MM_ParallelSweepChunk *previousChunk;
-	uintptr_t totalChunkCount;  /* Total chunks in system */
-
-	MM_SweepHeapSectioningIterator sectioningIterator(this);
-
-	totalChunkCount = 0;
-	previousChunk = NULL;
-
-	MM_HeapRegionManager *regionManager = _extensions->getHeap()->getHeapRegionManager();
-	GC_HeapRegionIterator regionIterator(regionManager);
-	MM_HeapRegionDescriptor *region = NULL;
-
-	while (NULL != (region = regionIterator.nextRegion())) {
-		if (region->isCommitted()) {
-			/* TODO:  this must be rethought for Tarok since it treats all regions identically but some might require different sweep logic */
-			uintptr_t *heapChunkBase = (uintptr_t *)region->getLowAddress();  /* Heap chunk base pointer */
-			uintptr_t *regionHighAddress = (uintptr_t *)region->getHighAddress();
-
-			while (heapChunkBase < regionHighAddress) {
-				void *poolHighAddr;
-				uintptr_t *heapChunkTop;
-				MM_MemoryPool *pool;
-
-				chunk = sectioningIterator.nextChunk();
-				Assert_MM_true(chunk != NULL);  /* Should never return NULL */
-				totalChunkCount += 1;
-
-				/* Clear all data in the chunk (including sweep implementation specific information) */
-				chunk->clear();
-
-				if(((uintptr_t)regionHighAddress - (uintptr_t)heapChunkBase) < _extensions->parSweepChunkSize) {
-					/* corner case - we will wrap our address range */
-					heapChunkTop = regionHighAddress;
-				} else {
-					/* normal case - just increment by the chunk size */
-					heapChunkTop = (uintptr_t *)((uintptr_t)heapChunkBase + _extensions->parSweepChunkSize);
-				}
-
-				/* Find out if the range of memory we are considering spans 2 different pools.  If it does,
-				 * the current chunk can only be attributed to one, so we limit the upper range of the chunk
-				 * to the first pool and will continue the assignment at the upper address range.
-				 */
-				pool = region->getSubSpace()->getMemoryPool(env, heapChunkBase, heapChunkTop, poolHighAddr);
-				if (NULL == poolHighAddr) {
-					heapChunkTop = (heapChunkTop > regionHighAddress ? regionHighAddress : heapChunkTop);
-				} else {
-					/* Yes ..so adjust chunk boundaries */
-					assume0(poolHighAddr > heapChunkBase && poolHighAddr < heapChunkTop);
-					heapChunkTop = (uintptr_t *) poolHighAddr;
-				}
-
-				/* All values for the chunk have been calculated - assign them */
-				chunk->chunkBase = (void *)heapChunkBase;
-				chunk->chunkTop = (void *)heapChunkTop;
-				chunk->memoryPool = pool;
-				Assert_MM_true(NULL != pool);
-				/* Some memory pools, like the one in LOA, may have larger min free size then in the rest of the heap being swept */
-				chunk->_minFreeSize = OMR_MAX(pool->getMinimumFreeEntrySize(), pool->getSweepPoolManager()->getMinimumFreeSize());
-
-				chunk->_coalesceCandidate = (heapChunkBase != region->getLowAddress());
-				chunk->_previous= previousChunk;
-				if(NULL != previousChunk) {
-					previousChunk->_next = chunk;
-				}
-
-				/* Move to the next chunk */
-				heapChunkBase = heapChunkTop;
-
-				/* and remember address of previous chunk */
-				previousChunk = chunk;
-
-				assume0((uintptr_t)heapChunkBase == MM_Math::roundToCeiling(_extensions->heapAlignment,(uintptr_t)heapChunkBase));
-			}
-		}
-	}
-
-	if(NULL != previousChunk) {
-		previousChunk->_next = NULL;
 	}
 
 	return totalChunkCount;

--- a/gc/base/standard/SweepHeapSectioningSegmented.hpp
+++ b/gc/base/standard/SweepHeapSectioningSegmented.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 #define SWEEPSCHEMESECTIONINGSEGMENTED_HPP_
 
 #include "SweepHeapSectioning.hpp"
+#include "HeapRegionDescriptor.hpp"
 
 class MM_ParallelSweepChunkArray;
 class MM_EnvironmentBase;
@@ -39,11 +40,13 @@ private:
 protected:
 	virtual uintptr_t estimateTotalChunkCount(MM_EnvironmentBase *env);
 	virtual uintptr_t calculateActualChunkNumbers() const;
+	virtual bool isReadyToSweep(MM_EnvironmentBase* env, MM_HeapRegionDescriptor* region)
+	{
+		return region->isCommitted();
+	}
 
 public:
 	static MM_SweepHeapSectioningSegmented *newInstance(MM_EnvironmentBase *env);
-
-	virtual uintptr_t reassignChunks(MM_EnvironmentBase *env);
 
 	MM_SweepHeapSectioningSegmented(MM_EnvironmentBase *env)
 		: MM_SweepHeapSectioning(env)


### PR DESCRIPTION
Avoid logic duplication between SweepHeapSectioning subclasses

Signed-off-by: Lin Hu <linhu@ca.ibm.com>