### PR TITLE
Add a new verbose option for JITServer

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4761,6 +4761,7 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "profiling",
    "JITServer",
    "aotcompression",
+   "JITServerConns",
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1072,6 +1072,7 @@ enum TR_VerboseFlags
    TR_VerboseProfiling,
    TR_VerboseJITServer,
    TR_VerboseAOTCompression,
+   TR_VerboseJITServerConns,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };


### PR DESCRIPTION
This commit adds a new verbose option `TR_VerboseJITServerConns`.
The option is used by OpenJ9 JITServer to log connection events
between servers and clients.