### PR TITLE
Don't use once read symbol heuristics in UseDef at warm

### DIFF
--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -152,9 +152,10 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
    TR::SymbolReferenceTable *symRefTab = comp()->getSymRefTab();
    int32_t numSymRefs = comp()->getSymRefCount();
 
+
    if (_hasLoadsAsDefs &&
        !cannotOmitTrivialDefs &&
-       (comp()->getMethodHotness() < hot))
+       (comp()->getMethodHotness() < warm))
       {
       for (int32_t j = 0; j < numSymRefs; j++)
          {


### PR DESCRIPTION
Don't use once read symbol heuristics in UseDef at warm

    - Use onceReadSymbolsIndices at < warm since it helps performance
      without considerably increasing compile time