### PR TITLE
AArch64: Use negated constant value for add/sub node if it is more concise

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -47,6 +47,24 @@ namespace TR { class RegisterDependencyConditions; }
 namespace TR { class DebugCounterBase; }
 
 /**
+ * @brief Answers if loading negated value is more concise
+ *
+ * @param[in] value : 32bit constant value
+ *
+ * @return true if loading negated value is more concise.
+ */
+extern bool shouldLoadNegatedConstant32(int32_t value);
+
+/**
+ * @brief Answers if loading negated value is more concise
+ *
+ * @param[in] value : 64bit constant value
+ *
+ * @return true if loading negated value is more concise.
+ */
+extern bool shouldLoadNegatedConstant64(int64_t value);
+
+/**
  * @brief Generates instructions for loading 32-bit integer value to a register
  * @param[in] cg : CodeGenerator
  * @param[in] node : node


### PR DESCRIPTION
This commit changes `genericBinaryEvaluator` to use negated value for add/sub
operation if the negated value can be loaded into the register with the fewer
instructions than original value.
Also, `genericBinaryEvaluator` to set a register to the constant node
if the constant cannot be encoded into the instruction and the negated value is not used.
This change prevents instructions to load the constant into the register from
generated multiple times even if the constant node has multiple reference counts.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>