### PR TITLE
Suspend convlit around inline assembly on z/OS

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -75,7 +75,9 @@
 #elif defined(__GNUC__) && (defined(J9X86) || defined(J9HAMMER))
 		inline void __yield() { __asm volatile ("pause"); }
 #elif defined(J9ZOS390)
+#pragma convlit(suspend)
 		inline void __yield() { __asm__ volatile (" nop 0"); }
+#pragma convlit(resume)
 #else
 		inline void __yield() { __asm volatile ("# AtomicOperations::__yield"); }
 #endif /* __GNUC__ && (J9X86 || J9HAMMER) */
@@ -91,7 +93,9 @@
 		 */
 		inline void __nop() { __asm__ volatile ("nop 0"); }
 #elif defined(J9ZOS390)
+#pragma convlit(suspend)
 		inline void __nop() { __asm__ volatile (" nop 0"); }
+#pragma convlit(resume)
 #else /* GCC && XL */
 		inline void __nop() { __asm__ volatile ("nop"); }
 #endif


### PR DESCRIPTION
If we are building with `-Wc,"convlit(ISO8859-1)"` xlC option then we
want to avoid doing literal conversion of inline assembly statements
because HLASM expects them to be in EBCDIC. Failing to do this results
in compilation errors with HLASM as it tries to interpret ASCII
characters of the inline assembly string.

This pragma is used elsewhere in the codebase so it is not something
new.