### PR TITLE
AArch64: Enable shifted immediate for add/sub instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1288,13 +1288,13 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
    if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw ||
        op == TR::InstOpCode::addsimmx || op == TR::InstOpCode::addsimmw)
       {
+      done = true;
       TR::Register *r = instr->getTargetRegister();
       if (r && r->getRealRegister()
           && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
          {
          // cmp/cmn alias
          char *mnemonic = NULL;
-         done = true;
          switch (op)
             {
             case TR::InstOpCode::subsimmx:
@@ -1312,6 +1312,30 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
          trfprintf(pOutFile, "%s \t", mnemonic);
          print(pOutFile, instr->getSource1Register(), TR_WordReg);
          trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+         }
+      else
+         {
+         trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+         print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+         print(pOutFile, instr->getSource1Register(), TR_WordReg);
+         trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+         }
+      if (instr->getNbit())
+         {
+         trfprintf(pOutFile, ", LSL #%d", 12);
+         }
+      }
+   else if ((op == TR::InstOpCode::subimmx || op == TR::InstOpCode::subimmw ||
+             op == TR::InstOpCode::addimmx || op == TR::InstOpCode::addimmw))
+      {
+      done = true;
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      if (instr->getNbit())
+         {
+         trfprintf(pOutFile, ", LSL #%d", 12);
          }
       }
    else if (op == TR::InstOpCode::sbfmx || op == TR::InstOpCode::sbfmw)
@@ -1495,6 +1519,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc1ImmInstruction *instr)
       trfprintf(pOutFile, "cmpimm%c \t", (op == TR::InstOpCode::subsimmx) ? 'x' : 'w');
       print(pOutFile, instr->getSource1Register(), TR_WordReg);
       trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      if (instr->getNbit())
+         {
+         trfprintf(pOutFile, ", LSL #%d", 12);
+         }
       }
    else if (op == TR::InstOpCode::addsimmx || op == TR::InstOpCode::addsimmw)
       {
@@ -1503,6 +1531,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ZeroSrc1ImmInstruction *instr)
       trfprintf(pOutFile, "cmnimm%c \t", (op == TR::InstOpCode::addsimmx) ? 'x' : 'w');
       print(pOutFile, instr->getSource1Register(), TR_WordReg);
       trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
+      if (instr->getNbit())
+         {
+         trfprintf(pOutFile, ", LSL #%d", 12);
+         }
       }
    else if (op == TR::InstOpCode::andsimmx || op == TR::InstOpCode::andsimmw)
       {

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -122,6 +122,16 @@ inline bool constantIsUnsignedImm12(uint64_t intValue)
    }
 
 /*
+ * @brief Answers if the unsigned integer value can be encoded in a 12-bit field with 12 bits shift
+ * @param[in] intValue : unsigned integer value
+ * @return true if the value can be encoded in a 12-bit field with 12 bits shift, false otherwise
+ */
+inline bool constantIsUnsignedImm12Shifted(uint64_t intValue)
+   {
+   return ((intValue & (~(static_cast<uint64_t>(0xfff000)))) == 0);
+   }
+
+/*
  * @brief Answers if the signed integer value can be placed in a 16-bit field
  * @param[in] intValue : signed integer value
  * @return true if the value can be placed in 16-bit field, false otherwise

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -95,11 +95,11 @@ genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstO
          value = secondChild->getInt();
          }
       /* When regOp == regOpImm, an immediate version of the instruction does not exist. */
-      if(constantIsUnsignedImm12(value) && regOp != regOpImm)
+      if((constantIsUnsignedImm12(value) || constantIsUnsignedImm12Shifted(value)) && regOp != regOpImm)
          {
          generateTrg1Src1ImmInstruction(cg, regOpImm, node, trgReg, src1Reg, value);
          }
-      else if (constantIsUnsignedImm12(-value) &&
+      else if ((constantIsUnsignedImm12(-value) || constantIsUnsignedImm12Shifted(-value))  &&
                (regOpImm == TR::InstOpCode::addimmw || regOpImm == TR::InstOpCode::addimmx ||
                 regOpImm == TR::InstOpCode::subimmw || regOpImm == TR::InstOpCode::subimmx))
          {

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -179,12 +179,8 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
    if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL)
       {
       int64_t value = is64bit ? secondChild->getLongInt() : secondChild->getInt();
-      if (constantIsUnsignedImm12(value))
-         {
-         generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
-         useRegCompare = false;
-         }
-      else if (constantIsUnsignedImm12(-value))
+      if (constantIsUnsignedImm12(value) || constantIsUnsignedImm12(-value) ||
+          constantIsUnsignedImm12Shifted(value) || constantIsUnsignedImm12Shifted(-value))
          {
          generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
          useRegCompare = false;
@@ -379,12 +375,8 @@ static TR::Register *icmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
    if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL)
       {
       int64_t value = is64bit ? secondChild->getLongInt() : secondChild->getInt();
-      if (constantIsUnsignedImm12(value))
-         {
-         generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
-         useRegCompare = false;
-         }
-      else if (constantIsUnsignedImm12(-value))
+      if (constantIsUnsignedImm12(value) || constantIsUnsignedImm12(-value) ||
+          constantIsUnsignedImm12Shifted(value) || constantIsUnsignedImm12Shifted(-value))
          {
          generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
          useRegCompare = false;


### PR DESCRIPTION
This commit enables use of shifted immediate value for
`add` and `sub` instructions and their variants.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>