### PR TITLE
Enable warnings as errors in compiler component on S390

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -287,7 +287,9 @@ def SPECS = [
         'label' : 'compile:zos',
         'reference' : '',
         'environment' : [
-            "LIBPATH+EXTRA=/openzdk/jenkins/workspace/${workspaceName}/build"
+            "LIBPATH+EXTRA=/openzdk/jenkins/workspace/${workspaceName}/build",
+            "_C89_ACCEPTABLE_RC=0",
+            "_CXX_ACCEPTABLE_RC=0"
         ],
         'ccache' : false,
         'buildSystem' : 'cmake',

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -21,8 +21,6 @@
 
 include(OmrCompilerSupport)
 
-set(OMR_WARNINGS_AS_ERRORS OFF)
-
 set(COMPILERTEST_FILES
 	compile/ResolvedMethod.cpp
 	control/TestJit.cpp
@@ -55,7 +53,7 @@ elseif(OMR_ARCH_S390)
 	)
 endif()
 
-if(OMR_ARCH_X86)
+if(OMR_ARCH_X86 OR OMR_ARCH_S390)
 	set(OMR_WARNINGS_AS_ERRORS ON)
 	set(OMR_ENHANCED_WARNINGS OFF)
 else()

--- a/fvtest/tril/test/ASTTest.cpp
+++ b/fvtest/tril/test/ASTTest.cpp
@@ -23,10 +23,6 @@
 #include <gtest/gtest.h>
 #include "ast.hpp"
 
-#if defined(AIXPPC) || defined(J9ZOS390)
-#pragma report(disable, "CCN8924")
-#endif
-
 TEST(ASTValueTest, CreateInt64ASTValue) {
    auto baseValue = 3UL;
 
@@ -620,7 +616,3 @@ TEST(ASTNodeTest, GetSecondNamedArgumentTest) {
    argList = argList->next->next;
    ASSERT_EQ(*argList, *arg);
 }
-
-#if defined(AIXPPC) || defined(J9ZOS390)
-#pragma report(enable, "CCN8924")
-#endif

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -92,7 +92,7 @@ set(omrgc_sources
 	base/HeapRegionManagerTarok.cpp
 	base/HeapVirtualMemory.cpp
 	base/LightweightNonReentrantLock.cpp
-	base/LightweightNonReentrantReaderWriterLock.cpp
+	base/LightweightNonReentrantRWLock.cpp
 	base/MarkedObjectPopulator.cpp
 	base/MarkingScheme.cpp
 	base/MarkMap.cpp

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gc/base/HeapRegionManager.hpp
+++ b/gc/base/HeapRegionManager.hpp
@@ -28,7 +28,7 @@
 
 #include "BaseVirtual.hpp"
 #include "HeapRegionDescriptor.hpp"
-#include "LightweightNonReentrantReaderWriterLock.hpp"
+#include "LightweightNonReentrantRWLock.hpp"
 #include "ModronAssertions.h"
 
 class MM_EnvironmentBase;
@@ -67,7 +67,7 @@ class MM_HeapRegionManager : public MM_BaseVirtual {
 public:
 protected:
 	friend class MM_InterRegionRememberedSet;
-	MM_LightweightNonReentrantReaderWriterLock _heapRegionListMonitor; /**< monitor that controls modification of the heap region linked list */
+	MM_LightweightNonReentrantRWLock _heapRegionListMonitor; /**< monitor that controls modification of the heap region linked list */
 	MM_HeapRegionDescriptor* _auxRegionDescriptorList; /**< address ordered doubly linked list for auxiliary heap regions */
 	uintptr_t _auxRegionCount; /**< number of heap regions on the auxiliary list */
 

--- a/gc/base/HeapRegionManager.hpp
+++ b/gc/base/HeapRegionManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gc/base/LightweightNonReentrantRWLock.cpp
+++ b/gc/base/LightweightNonReentrantRWLock.cpp
@@ -23,10 +23,10 @@
 #include <assert.h>
 
 #include "AtomicOperations.hpp"
-#include "LightweightNonReentrantReaderWriterLock.hpp"
+#include "LightweightNonReentrantRWLock.hpp"
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::initialize(uintptr_t spinCount)
+MM_LightweightNonReentrantRWLock::initialize(uintptr_t spinCount)
 {
 	intptr_t ret = LWRW_OK;
 	_spinCount = spinCount;
@@ -35,7 +35,7 @@ MM_LightweightNonReentrantReaderWriterLock::initialize(uintptr_t spinCount)
 	_status = LWRW_READER_MODE;
 	MM_AtomicOperations::writeBarrier();
 #else /* defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK) */
-	if (J9THREAD_RWMUTEX_OK != omrthread_rwmutex_init( &_rwmutex, 0, "MM_LightweightNonReentrantReaderWriterLock::_rwmutex" )) {
+	if (J9THREAD_RWMUTEX_OK != omrthread_rwmutex_init( &_rwmutex, 0, "MM_LightweightNonReentrantRWLock::_rwmutex" )) {
 		ret = LWRW_FAILED_INIT;
 	}
 #endif /* defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK) */
@@ -43,7 +43,7 @@ MM_LightweightNonReentrantReaderWriterLock::initialize(uintptr_t spinCount)
 }
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::tearDown()
+MM_LightweightNonReentrantRWLock::tearDown()
 {
 	intptr_t ret = LWRW_OK;
 #if !defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)
@@ -53,7 +53,7 @@ MM_LightweightNonReentrantReaderWriterLock::tearDown()
 }
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::enterRead()
+MM_LightweightNonReentrantRWLock::enterRead()
 {
 	intptr_t ret = LWRW_OK;
 #if defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)
@@ -96,7 +96,7 @@ MM_LightweightNonReentrantReaderWriterLock::enterRead()
 }
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::exitRead()
+MM_LightweightNonReentrantRWLock::exitRead()
 {
 	intptr_t ret = LWRW_OK;
 #if defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)
@@ -119,7 +119,7 @@ MM_LightweightNonReentrantReaderWriterLock::exitRead()
 }
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::enterWrite()
+MM_LightweightNonReentrantRWLock::enterWrite()
 {
 	intptr_t ret = LWRW_OK;
 #if defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)
@@ -171,7 +171,7 @@ MM_LightweightNonReentrantReaderWriterLock::enterWrite()
 }
 
 intptr_t
-MM_LightweightNonReentrantReaderWriterLock::exitWrite()
+MM_LightweightNonReentrantRWLock::exitWrite()
 {
 	intptr_t ret = LWRW_OK;
 #if defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)

--- a/gc/base/LightweightNonReentrantRWLock.cpp
+++ b/gc/base/LightweightNonReentrantRWLock.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gc/base/LightweightNonReentrantRWLock.hpp
+++ b/gc/base/LightweightNonReentrantRWLock.hpp
@@ -47,7 +47,7 @@
  * The lock is not re-entrant, can be extended to support re-entrant in future
  * it would not provide realtime locking.
  */
-class MM_LightweightNonReentrantReaderWriterLock : public MM_BaseNonVirtual {
+class MM_LightweightNonReentrantRWLock : public MM_BaseNonVirtual {
 private:
 	uintptr_t _spinCount;
 
@@ -58,7 +58,7 @@ private:
 #endif /* defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK) */
 protected:
 public:
-	MM_LightweightNonReentrantReaderWriterLock() :
+	MM_LightweightNonReentrantRWLock() :
 		MM_BaseNonVirtual()
 		,_spinCount(1)
 #if defined(J9MODRON_USE_CUSTOM_READERWRITERLOCK)

--- a/gc/base/LightweightNonReentrantRWLock.hpp
+++ b/gc/base/LightweightNonReentrantRWLock.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -24,8 +24,6 @@ include(OmrCompilerSupport)
 
 find_package(PythonInterp REQUIRED)
 
-set(OMR_WARNINGS_AS_ERRORS OFF)
-
 # JitBuilder Files
 set(JITBUILDER_OBJECTS
 	env/FrontEnd.cpp
@@ -108,7 +106,7 @@ list(APPEND JITBUILDER_OBJECTS
 	${JITBUILDER_API_SOURCES}
 )
 
-if(OMR_ARCH_X86)
+if(OMR_ARCH_X86 OR OMR_ARCH_S390)
 	set(OMR_WARNINGS_AS_ERRORS ON)
 	set(OMR_ENHANCED_WARNINGS OFF)
 else()

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/common/omrfilestream.c
+++ b/port/common/omrfilestream.c
@@ -43,7 +43,9 @@
 
 #if defined(J9ZOS390)
 /* Needed for a translation table from ascii -> ebcdic */
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 
 /*
  * a2e overrides many functions to use ASCII strings.

--- a/port/common/omrfilestream.c
+++ b/port/common/omrfilestream.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/common/omrfilestreamtext.c
+++ b/port/common/omrfilestreamtext.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/common/omrfilestreamtext.c
+++ b/port/common/omrfilestreamtext.c
@@ -41,7 +41,9 @@
 
 #if defined(J9ZOS390)
 /* Needed for a translation table from ascii -> ebcdic */
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 
 /* a2e overrides many functions to use ASCII strings.
  * We need the native EBCDIC string

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -51,7 +51,9 @@
 
 /* a2e overrides nl_langinfo to return ASCII strings. We need the native EBCDIC string */
 #if defined(J9ZOS390)
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #if defined (nl_langinfo)
 #undef nl_langinfo
 #endif

--- a/port/unix/omrsharedhelper.c
+++ b/port/unix/omrsharedhelper.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/unix/omrsharedhelper.c
+++ b/port/unix/omrsharedhelper.c
@@ -36,7 +36,9 @@
 #include <fcntl.h>
 
 #if defined(J9ZOS390)
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include "spawn.h"
 #include "sys/wait.h"
 #endif

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -176,7 +176,9 @@
 #if defined(J9ZOS390)
 #include <sys/ps.h>
 #include <sys/types.h>
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 
 #if !defined(PATH_MAX)
 /* This is a somewhat arbitrarily selected fixed buffer size. */

--- a/port/unix_include/omriconvhelpers.h
+++ b/port/unix_include/omriconvhelpers.h
@@ -35,7 +35,9 @@
 
 #if defined(J9ZOS390)
 #define J9VM_CACHE_ICONV_DESC
+#if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #endif
 #include <iconv.h>
 #define J9VM_INVALID_ICONV_DESCRIPTOR ((iconv_t)(-1))

--- a/port/unix_include/omriconvhelpers.h
+++ b/port/unix_include/omriconvhelpers.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrgetjobname.c
+++ b/port/zos390/omrgetjobname.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrgetjobname.c
+++ b/port/zos390/omrgetjobname.c
@@ -29,7 +29,9 @@
 #include <string.h>
 #include "omrport.h"
 #include "omrgetjobname.h"
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 
 #define J9_MAX_JOBNAME 16
 

--- a/port/zos390/omrgetstfle64.s
+++ b/port/zos390/omrgetstfle64.s
@@ -51,3 +51,4 @@ Z_GSTFLE      AMODE 64
   DC X'b2b02000'
   lgr   r3,r0
   b  RETURNOFFSET(CRA)
+  END

--- a/port/zos390/omrgetstfle64.s
+++ b/port/zos390/omrgetstfle64.s
@@ -1,5 +1,5 @@
 ***********************************************************************
-* Copyright (c) 2013, 2016 IBM Corp. and others
+* Copyright (c) 2013, 2021 IBM Corp. and others
 * 
 * This program and the accompanying materials are made available 
 * under the terms of the Eclipse Public License 2.0 which accompanies 
@@ -34,6 +34,9 @@
 * it in as such so that we can compile on any platform.
 
         TITLE 'omrgetstfle64.s'
+Z_GSTFLE      CSECT
+Z_GSTFLE      AMODE 64
+Z_GSTFLE      RMODE ANY
 
 CARG1 EQU 1
 CRA EQU 7
@@ -41,11 +44,9 @@ RETURNOFFSET EQU 2
 r0 EQU 0
 r3 EQU 3
 
-Z_GSTFLE  DS 0D
      ENTRY Z_GSTFLE
 Z_GSTFLE  ALIAS C'getstfle'
 Z_GSTFLE  XATTR SCOPE(X),LINKAGE(XPLINK)
-Z_GSTFLE      AMODE 64
 
   lgr   r0,CARG1
   DC X'b2b02000'

--- a/port/zos390/omrgetuserid.c
+++ b/port/zos390/omrgetuserid.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrgetuserid.c
+++ b/port/zos390/omrgetuserid.c
@@ -27,7 +27,9 @@
  */
 #include <stdlib.h>
 #include <string.h>
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include "omrgetuserid.h"
 
 #define J9_MAX_USERID 16

--- a/port/zos390/omrjobname.s
+++ b/port/zos390/omrjobname.s
@@ -1,5 +1,5 @@
 ***********************************************************************
-* Copyright (c) 1991, 2014 IBM Corp. and others
+* Copyright (c) 1991, 2021 IBM Corp. and others
 * 
 * This program and the accompanying materials are made available 
 * under the terms of the Eclipse Public License 2.0 which accompanies 

--- a/port/zos390/omrjobname.s
+++ b/port/zos390/omrjobname.s
@@ -53,4 +53,3 @@ _JOBNAME CELQPRLG BASEREG=8
          IKJTCB
 *
          END
-

--- a/port/zos390/omrosdump.c
+++ b/port/zos390/omrosdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrosdump.c
+++ b/port/zos390/omrosdump.c
@@ -38,7 +38,9 @@
 #include <pwd.h>
 #include <ctest.h>
 #include "omrport.h"
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include "portnls.h"
 
 static void convertToUpper(struct OMRPortLibrary *portLibrary, char *toConvert, uintptr_t len);

--- a/port/zos390/omrsysinfo_helpers.c
+++ b/port/zos390/omrsysinfo_helpers.c
@@ -29,7 +29,9 @@
 #include <errno.h>
 #include <sys/__wlm.h>
 
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include "omrport.h"
 #include "omrsimap.h"
 #include "omrzfs.h"

--- a/port/zos390/omrsysinfo_helpers.c
+++ b/port/zos390/omrsysinfo_helpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrsyslog.c
+++ b/port/zos390/omrsyslog.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrsyslog.c
+++ b/port/zos390/omrsyslog.c
@@ -105,7 +105,7 @@ writeToZOSLog(const char *message)
 		return FALSE;
 	}
 #else
-   ebcdicbuf = message;
+	ebcdicbuf = (char *)message;
 #endif /* !defined(OMR_EBCDIC) */
 
 	/* Re-implemented using _console2() instead of WTO, to provided proper multi-line messages. See

--- a/port/zos390/omrsyslog.c
+++ b/port/zos390/omrsyslog.c
@@ -26,7 +26,9 @@
  * @brief System logging support
  */
 #include "omrportpriv.h"
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include <string.h>
 #include <sys/__messag.h>
 

--- a/port/zos390/omruserid.s
+++ b/port/zos390/omruserid.s
@@ -53,4 +53,3 @@ _USERID CELQPRLG BASEREG=8
          IKJTCB
 *
          END
-

--- a/port/zos390/omruserid.s
+++ b/port/zos390/omruserid.s
@@ -1,5 +1,5 @@
 ***********************************************************************
-* Copyright (c) 1991, 2014 IBM Corp. and others
+* Copyright (c) 1991, 2021 IBM Corp. and others
 * 
 * This program and the accompanying materials are made available 
 * under the terms of the Eclipse Public License 2.0 which accompanies 

--- a/port/zos390/omrzfs.c
+++ b/port/zos390/omrzfs.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/zos390/omrzfs.c
+++ b/port/zos390/omrzfs.c
@@ -30,7 +30,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
+#endif
 #include "omrport.h"
 #include "omrzfs.h"
 #include "omrsysinfo_helpers.h"

--- a/third_party/gtest-1.8.0/include/gtest/internal/gtest-internal.h
+++ b/third_party/gtest-1.8.0/include/gtest/internal/gtest-internal.h
@@ -888,8 +888,14 @@ class ImplicitlyConvertible {
   // possible loss of data, so we need to temporarily disable the
   // warning.
   GTEST_DISABLE_MSC_WARNINGS_PUSH_(4244)
+#if defined(J9ZOS390) || defined(AIXPPC)
+#pragma report(disable, "CCN8924")
+#endif
   static const bool value =
       sizeof(Helper(ImplicitlyConvertible::MakeFrom())) == 1;
+#if defined(J9ZOS390) || defined(AIXPPC)
+#pragma report(enable, "CCN8924")
+#endif
   GTEST_DISABLE_MSC_WARNINGS_POP_()
 #endif  // __BORLANDC__
 };

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -217,7 +217,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 		unsigned char *output_buffer = (unsigned char *) &threadData;
 		uint32_t output_size = sizeof(struct j9pg_thread_data);
 		uint32_t input_size = sizeof(struct pgtha);
-		int32_t ret_val = 0;
+		uint32_t ret_val = 0;
 		uint32_t ret_code = 0;
 		uint32_t reason_code = 0;
 		uint32_t data_offset = 0;
@@ -749,7 +749,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 		unsigned char *output_buffer = (unsigned char *) &threadData;
 		uint32_t output_size = sizeof(struct j9pg_thread_data);
 		struct pgthc *pgthc = NULL;
-		int32_t ret_val = 0;
+		uint32_t ret_val = 0;
 		uint32_t ret_code = 0;
 		uint32_t reason_code = 0;
 		uint32_t data_offset = 0;

--- a/util/omrutil/gettimebase.c
+++ b/util/omrutil/gettimebase.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corp. and others
+ * Copyright (c) 2014, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/util/omrutil/gettimebase.c
+++ b/util/omrutil/gettimebase.c
@@ -80,7 +80,7 @@ getTimebase(void)
 #elif defined(LINUX) && defined(S390)
 	asm("stck %0" : "=m" (tsc));
 #elif defined(J9ZOS390)
-	__stck(&tsc);
+	__stck((unsigned long long*)&tsc);
 #elif defined(LINUX) && (defined(OMR_ARCH_ARM) || defined(OMR_ARCH_RISCV) || defined(RISCV64))
 	/* For now, use the system nano clock */
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)

--- a/util/omrutil/unix/zos/omrgetdsa.s
+++ b/util/omrutil/unix/zos/omrgetdsa.s
@@ -68,4 +68,4 @@ GETDSA   CELQPRLG DSASIZE=0,BASEREG=NONE
          LGR   R3,R4 move DSA into return code
          CELQEPLG
 .JMP2    ANOP
-
+         END

--- a/util/omrutil/unix/zos/omrgetdsa.s
+++ b/util/omrutil/unix/zos/omrgetdsa.s
@@ -1,5 +1,5 @@
 ***********************************************************************
-* Copyright (c) 1991, 2010 IBM Corp. and others
+* Copyright (c) 1991, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made available 
 *  under the terms of the Eclipse Public License 2.0 which 


### PR DESCRIPTION
Address the last warning on z/OS and enable warnings as errors on all S390 platforms.