### PR TITLE
Add disableForceInlineAnnotations JIT command line option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -329,6 +329,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {DisableFastStringIndexOfString,       "O\tdisable fast String.indexOf",                    SET_OPTION_BIT(TR_DisableFastStringIndexOf), "F"},
    {"disableFieldPrivatization",          "O\tdisable field privatization",                    TR::Options::disableOptimization, fieldPrivatization, 0, "P"},
    {"disableForcedEXInlining",            "O\tdisable forced EX inlining",                     SET_OPTION_BIT(TR_DisableForcedEXInlining), "F"},
+   {"disableForceInlineAnnotations",      "M\tdisable recognition of @ForceInline",            SET_OPTION_BIT(TR_DisableForceInlineAnnotations), "F"},
    {"disableFPCodeGen",                   "O\tdisable floating point code generation",               SET_OPTION_BIT(TR_DisableFPCodeGen), "F"},
    {"disableFPE",                         "C\tdisable FPE",                                    SET_OPTION_BIT(TR_DisableFPE), "F"},
    {"disableGCRPatching",                 "R\tdisable patching of the GCR guard",              RESET_OPTION_BIT(TR_EnableGCRPatching), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -379,7 +379,7 @@ enum TR_CompilationOptions
    TR_Randomize                           = 0x00200000 + 9,
    TR_BreakOnWriteBarrier                 = 0x00400000 + 9,
    BreakOnWriteBarrierSnippet             = 0x00800000 + 9,
-   // Available                           = 0x01000000 + 9,
+   TR_DisableForceInlineAnnotations       = 0x01000000 + 9,
    TR_CountWriteBarriersRT                = 0x02000000 + 9,
    TR_DisableNoServerDuringStartup        = 0x04000000 + 9,  // set TR_NoOptServer during startup and insert GCR trees
    TR_BreakOnNew                          = 0x08000000 + 9,


### PR DESCRIPTION
This option will be used to disable recognition of
the ForceInline annotation by the Inliner