### PR TITLE
AArch64: Implement arraycopyEvaluator() for primitive arraycopy

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -535,6 +535,12 @@ public:
    bool supportsSinglePrecisionSQRT() { return true; }
 
    /**
+    * @brief Answers whether Unsafe.copyMemory transformation is supported or not
+    * @return true if supported, false otherwise
+    */
+   bool canTransformUnsafeCopyToArrayCopy() { return true; }
+
+   /**
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter


### PR DESCRIPTION
This commit implements arraycopyEvaluator() and related functions
for primitive arraycopy for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>