### PR TITLE
WIP: JitBuilder2 initial commit

### DIFF
--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -41,29 +41,16 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
                                       int32_t bcLength)
    : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary()),
    _fallThroughBuilder(0),
-   _bcIndex(bcIndex),
    _name(name),
    _bcLength(bcLength),
    _initialVMState(0),
    _vmState(0)
    {
+   _bcIndex = bcIndex;
    _successorBuilders = new (PERSISTENT_NEW) List<TR::BytecodeBuilder>(_types->trMemory());
    initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
               methodBuilder->fe(), methodBuilder->symRefTab());
    initSequence();
-   }
-
-/**
- * Call this function at the top of your bytecode iteration loop so that all services called
- * while this bytecode builder is being translated will mark their IL nodes as having this
- * BytecodeBuilder's _bcIndex (very handy when looking at compiler logs).
- * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
- *       BytecodeBuilder's SetCurrentIlGenerator() is called.
- */
-void
-OMR::BytecodeBuilder::SetCurrentIlGenerator()
-   {
-   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
    }
 
 void

--- a/compiler/ilgen/OMRBytecodeBuilder.hpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.hpp
@@ -40,15 +40,6 @@ public:
 
    virtual bool isBytecodeBuilder() { return true; }
 
-   /**
-    * @brief bytecode index for this builder object
-    */
-   int32_t bcIndex() { return _bcIndex; }
-   virtual int32_t currentByteCodeIndex() { return _bcIndex; } // override from IlGenerator
-
-   /* @brief after calling this, all IL nodes created will have this BytecodeBuilder's _bcIndex */
-   void SetCurrentIlGenerator();
-
    /* The name for this BytecodeBuilder. This can be very helpful for debug output */
    char *name() { return _name; }
 
@@ -125,7 +116,6 @@ public:
 protected:
    TR::BytecodeBuilder       * _fallThroughBuilder;
    List<TR::BytecodeBuilder> * _successorBuilders;
-   int32_t                     _bcIndex;
    char                      * _name;
    int32_t                     _bcLength;
    TR::VirtualMachineState   * _initialVMState;

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -551,11 +551,12 @@ OMR::IlBuilder::AppendBuilder(TR::IlBuilder *builder)
 
    builder->_partOfSequence = true;
    _sequenceAppender->add(builderEntry(builder));
-   if (_currentBlock != NULL)
+   if (_currentBlock != NULL && comesBack())
       {
       cfg()->addEdge(_currentBlock, builder->getEntry());
       _currentBlock = NULL;
       }
+   setComesBack();
 
    TraceIL("IlBuilder[ %p ]::AppendBuilder %p\n", this, builder);
 

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -207,6 +207,25 @@ OMR::IlBuilder::printBlock(TR::Block *block)
    comp()->getDebug()->print(comp()->getOutFile(), tt);
    }
 
+TR::IlBuilder *
+OMR::IlBuilder::setBCIndex(int32_t bcIndex)
+   {
+   _bcIndex = bcIndex;
+   return static_cast<TR::IlBuilder *>(this);
+   }
+/**
+ * Call this function before calling services on this builder so they will
+ * mark their IL nodes as having this builder's _bcIndex (very handy when
+ * looking at compiler logs and ultimate used to track program locations).
+ * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
+ *       builder's SetCurrentIlGenerator() is called.
+ */
+void
+OMR::IlBuilder::SetCurrentIlGenerator()
+   {
+   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
+   }
+
 TR::SymbolReference *
 OMR::IlBuilder::lookupSymbol(const char *name)
    {
@@ -427,7 +446,10 @@ OMR::IlBuilder::connectTrees()
 
       // also add exit block to blocks array and add an edge from last block to EXIT if the builder comes back (i.e. doesn't return or branch off somewhere)
       if (comesBack())
+         {
+         TraceIL("[ %p ] Adding edge from last block [entry %p node %p] to EXIT block [entry %p node %p]\n", blocks[currentBlock-1]->getEntry()->getNode(), blocks[currentBlock-1], _exitBlock->getEntry()->getNode(), _exitBlock);
          cfg()->addEdge(blocks[currentBlock-1], getExit());
+         }
 
       blocks[currentBlock++] = _exitBlock;
       TraceIL("[ %p ] exit block %d is %p (%p -> %p)\n", this, _exitBlock->getNumber(), _exitBlock->getEntry(), _exitBlock->getExit());

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -204,6 +204,16 @@ public:
 
    //char *getName();
 
+   /**
+    * @brief bytecode index for this builder object
+    */
+   int32_t bcIndex() { return _bcIndex; }
+   TR::IlBuilder * setBCIndex(int32_t bcIndex);
+   virtual int32_t currentByteCodeIndex() { return _bcIndex; } // override from IlGenerator
+
+   /* @brief after calling this, all IL nodes created will have this object's _bcIndex */
+   void SetCurrentIlGenerator();
+
    void print(const char *title, bool recurse=false);
    void printBlock(TR::Block *block);
 
@@ -724,6 +734,8 @@ protected:
     * @brief returns true if this IlBuilder object is a handler for an exception edge
     */
    bool                          _isHandler;
+
+   int32_t                       _bcIndex;
 
    virtual bool buildIL()
       {

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -510,7 +510,13 @@ OMR::MethodBuilder::DefineName(const char *name)
 void
 OMR::MethodBuilder::DefineLocal(const char *name, TR::IlType *dt)
    {
-   TR_ASSERT_FATAL(_symbolTypes.find(name) == _symbolTypes.end(), "Symbol '%s' already defined", name);
+   auto sym = _symbolTypes.find(name);
+   if (sym != _symbolTypes.end())
+      {
+      assert(strcmp(name, sym->first) == 0);
+      assert(dt == sym->second);
+      return; // duplicate symbol definition, just ignore
+      }
    _symbolTypes.insert(std::make_pair(name, dt));
    }
 

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -222,7 +222,7 @@ OMR::StructType::AddField(const char *name, TR::IlType *typeInfo, size_t offset)
    if (_closed)
       return;
 
-   TR_ASSERT_FATAL(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
+   //TR_ASSERT_FATAL(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
 
    OMR::FieldInfo *fieldInfo = new (PERSISTENT_NEW) OMR::FieldInfo(name, offset, typeInfo);
    if (0 != _lastField)
@@ -230,7 +230,8 @@ OMR::StructType::AddField(const char *name, TR::IlType *typeInfo, size_t offset)
    else
       _firstField = fieldInfo;
    _lastField = fieldInfo;
-   _size = offset + typeInfo->getSize();
+   if (_size < offset + typeInfo->getSize())
+      _size = offset + typeInfo->getSize();
    }
 
 void

--- a/jitbuilder/jbil/Action.cpp
+++ b/jitbuilder/jbil/Action.cpp
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <map>
 #include "Action.hpp"
 
 namespace OMR
@@ -26,9 +27,8 @@ namespace OMR
 namespace JitBuilder
 {
 
-std::string actionName[] =
-   {
-     "None"
+static std::string builtinActionNames[] =
+   { "None"
    , "ConstInt8"
    , "ConstInt16"
    , "ConstInt32"
@@ -71,9 +71,33 @@ std::string actionName[] =
    // } END
    // New action names, order must correspond to Action enum order in Action.hpp
 
+   , "DynamicOperationPlaceholderShouldNotAppear"
    };
 
-static_assert(sizeof(actionName)/sizeof(*actionName) == NumActions, "Missing/extra action name");
+static_assert(sizeof(builtinActionNames)/sizeof(*builtinActionNames) == NumStaticActions+1, "Missing/extra action name");
+
+static std::map<Action,std::string> dynamicActionNames;
+
+
+uint32_t NumActions = NumStaticActions;
+
+void
+registerDynamicActionName(Action a, std::string name)
+   {
+   assert(a >= aFirstDynamicOperation && a < NumActions);
+   dynamicActionNames.insert({a, name});
+   }
+
+std::string
+actionName(Action a)
+   {
+   if (a < NumStaticActions)
+      return builtinActionNames[a];
+   auto it = dynamicActionNames.find(a);
+   if (it != dynamicActionNames.end())
+      return it->second;
+   return std::string("Unknown:") + std::to_string(a);
+   }
 
 } // namespace JitBuilder
 } // namespace OMR

--- a/jitbuilder/jbil/Action.cpp
+++ b/jitbuilder/jbil/Action.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Action.hpp"
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+std::string actionName[] =
+   {
+     "None"
+   , "ConstInt8"
+   , "ConstInt16"
+   , "ConstInt32"
+   , "ConstInt64"
+   , "ConstFloat"
+   , "ConstDouble"
+   , "ConstAddress"
+   , "CoercePointer"
+   , "Add"
+   , "Sub"
+   , "Mul"
+   , "Load"
+   , "LoadAt"
+   , "LoadField"
+   , "LoadIndirect"
+   , "Store"
+   , "StoreAt"
+   , "StoreField"
+   , "StoreIndirect"
+   , "IndexAt"
+   , "AppendBuilder"
+   , "Call"
+   , "Goto"
+   , "Return"
+   , "IfCmpGreaterThan"
+   , "IfCmpLessThan"
+   , "IfCmpGreaterOrEqual"
+   , "IfCmpLessOrEqual"
+   , "IfThenElse"
+   , "Switch"
+   , "ForLoop"
+   , "CreateLocalArray"
+   , "CreateLocalStruct"
+
+   // New action names, order must correspond to Action enum order in Action.hpp
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New action names, order must correspond to Action enum order in Action.hpp
+
+   };
+
+static_assert(sizeof(actionName)/sizeof(*actionName) == NumActions, "Missing/extra action name");
+
+} // namespace JitBuilder
+} // namespace OMR

--- a/jitbuilder/jbil/Action.hpp
+++ b/jitbuilder/jbil/Action.hpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ACTION_INCL
+#define ACTION_INCL
+
+#include <string>
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+enum Action
+   {
+   aNone=0,
+   aConstInt8,             // create an 8 bit integer constant
+   aConstInt16,            // create a 16 bit integer constant
+   aConstInt32,            // create a 32 bit integer constant
+   aConstInt64,            // create a 64 bit integer constant
+   aConstFloat,            // create a 32 bit floating point constant
+   aConstDouble,           // create a 64 bit floating point constant
+   aConstAddress,          // create an address (void *) constant
+   aCoercePointer,         // coerce one pointer address to a new pointer type
+   aAdd,                   // create a value that is the sum of two values
+   aSub,                   // create a value that is the first value minus the second value
+   aMul,                   // create a value that is the product of two values
+   aLoad,                  // create value by loading a named local variable
+   aLoadAt,                // create a value by loading through a pointer value
+   aLoadField,             // create a value by loading from a field of a struct/union
+   aLoadIndirect,          // create a value by loading from a field of a pointer to struct/union
+   aStore,                 // store a value to a named local variable
+   aStoreAt,               // store a value through a pointer value with the same base type
+   aStoreField,            // store a value into a field of a struct/union
+   aStoreIndirect,         // store a value into a field through a pointer value to a struct/union
+   aIndexAt,               // create a pointer value by indexing a pointer value (using base type for element size)
+   aAppendBuilder,         // append the given builder into this builder
+   aCall,                  // call a function, passing arguments
+   aGoto,                  // branch unconditionally to the beginning of another builder object
+   aReturn,                // return a value or just return if function returns NoType
+   aIfCmpGreaterThan,      // if the first value is greater than the second value, branch to the builder
+   aIfCmpLessThan,         // if the first value is less than the second value, branch to the builder
+   aIfCmpGreaterOrEqual,   // if the first value is greater than or equal to the second value, branch to the builder
+   aIfCmpLessOrEqual,      // if the first value is less than or equal to the second value, branch to the builder
+   aIfThenElse,            // if the value is non-zero, branch to the first builder, otherwise branch to the second builder
+   aSwitch,                // the first value must be an integer, used to select from the cases provided to branch to a particular builder
+   aForLoop,               // build a for loop around the body loop that iterates from initial to end by bump, possibly providing a break builder and a continue builder to use as destinations inside the loop
+   aCreateLocalArray,      // allocate stack space for an array of elements, evaluates to the address of the stack space
+   aCreateLocalStruct,     // allocate stack space for a struct, evalualtes to the address of the stack space
+
+   // New actions
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New actions
+
+   LastActionSentinel
+   };
+
+const int32_t NumActions = LastActionSentinel;
+
+extern std::string actionName[];
+
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // defined(ACTION_INCL)

--- a/jitbuilder/jbil/Action.hpp
+++ b/jitbuilder/jbil/Action.hpp
@@ -29,7 +29,7 @@ namespace OMR
 namespace JitBuilder
 {
 
-enum Action
+enum ActionEnum
    {
    aNone=0,
    aConstInt8,             // create an 8 bit integer constant
@@ -74,12 +74,18 @@ enum Action
    // } END
    // New actions
 
+   aFirstDynamicOperation, // placeholder for first dynamically defined operation
+
    LastActionSentinel
    };
 
-const int32_t NumActions = LastActionSentinel;
+typedef uint32_t Action;
 
-extern std::string actionName[];
+const uint32_t NumStaticActions = aFirstDynamicOperation;
+extern uint32_t NumActions;
+
+extern void registerDynamicActionName(Action a, std::string name);
+extern std::string actionName(Action a);
 
 } // namespace JitBuilder
 } // namespace OMR

--- a/jitbuilder/jbil/AppendBuilderInliner.hpp
+++ b/jitbuilder/jbil/AppendBuilderInliner.hpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JitBuilder.hpp"
+#include "Transformer.hpp"
+
+using namespace OMR::JitBuilder;
+
+class AppendBuilderInliner : public Transformer
+   {
+public:
+   AppendBuilderInliner(FunctionBuilder *fb)
+      : Transformer(fb)
+      {
+      }
+
+protected:
+   virtual Builder * transformOperation(Operation * op)
+      {
+      if (op->action() != aAppendBuilder || op->builder(0)->isTarget())
+         // ignore anything but AppendBuilder and AppendBuilders that are targets of branches
+         return NULL;
+
+      // replace AppendBuilder operation with the operations from the appended builder
+      return op->builder(0);
+      }
+   };

--- a/jitbuilder/jbil/Builder.cpp
+++ b/jitbuilder/jbil/Builder.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string>
+#include <vector>
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "TypeDictionary.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+Builder::Builder(Builder * parent, FunctionBuilder * fb, TypeDictionary *types)
+   : BuilderBase(parent, fb, types)
+
+   // New initialization (must be duplicated for all constructors)
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New initialization
+
+   {
+   // New constructor (must be duplicated for all constructors)
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New constructor code
+   }
+
+Builder::Builder(Builder * parent, TypeDictionary *types)
+   : BuilderBase(parent, types)
+
+   // New initialization (must be duplicated for all constructors)
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New initialization
+
+   {
+   // New constructor (must be duplicated for all constructors)
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New constructor code
+   }
+
+Builder *
+Builder::OrphanBuilder()
+   {
+   Builder * orphan = new Builder(_fb, _fb->dict());
+   _fb->registerObject(orphan);
+   orphan->setLocation(location());
+   return orphan;
+   }
+
+// Add new Builder class code below
+// BEGIN {
+//
+
+//
+// } END
+// Add new Builder class code below

--- a/jitbuilder/jbil/Builder.hpp
+++ b/jitbuilder/jbil/Builder.hpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef BUILDER_INCL
+#define BUILDER_INCL
+
+#include "BuilderBase.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder : public BuilderBase
+   {
+   public:
+   Builder * OrphanBuilder();
+
+   // new public API
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // new public API
+
+   protected:
+   Builder(Builder * parent, FunctionBuilder * fb, TypeDictionary *types);
+   Builder(Builder * parent, TypeDictionary *types);
+
+   // new protected API
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // new protected API
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(BUILDER_INCL)

--- a/jitbuilder/jbil/BuilderBase.cpp
+++ b/jitbuilder/jbil/BuilderBase.cpp
@@ -1,0 +1,852 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string>
+#include <vector>
+#include "Action.hpp"
+#include "Operation.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "Location.hpp"
+#include "OperationCloner.hpp"
+#include "TextWriter.hpp"
+#include "Value.hpp"
+#include "Transformer.hpp"
+#include "TypeDictionary.hpp"
+
+using namespace OMR::JitBuilder;
+
+int64_t BuilderBase::globalIndex = 0;
+
+BuilderBase::BuilderBase(Builder * parent, FunctionBuilder * fb, TypeDictionary *types)
+   : Object(fb)
+   , _id(globalIndex++)
+   , _name("")
+   , _parent(parent)
+   , _successor(0)
+   , _currentLocation(parent->location())
+   , _boundToOperation(NULL)
+   , _isTarget(false)
+   , _isBound(false)
+   , _boundness(May)
+   , NoType(types->NoType)
+   , Int8(types->Int8)
+   , Int16(types->Int16)
+   , Int32(types->Int32)
+   , Int64(types->Int64)
+   , Float(types->Float)
+   , Double(types->Double)
+   , Address(types->Address)
+   {
+   if (parent != this) // FunctionBuilders have parent==this, so don't add itself as child
+      parent->addChild(self());
+   }
+
+BuilderBase::BuilderBase(Builder * parent, TypeDictionary *types)
+   : Object(parent->fb())
+   , _id(globalIndex++)
+   , _name("")
+   , _parent(parent)
+   , _successor(0)
+   , _currentLocation(NULL)
+   , _boundToOperation(NULL)
+   , _isTarget(false)
+   , _isBound(false)
+   , _boundness(May)
+   , NoType(types->NoType)
+   , Int8(types->Int8)
+   , Int16(types->Int16)
+   , Int32(types->Int32)
+   , Int64(types->Int64)
+   , Float(types->Float)
+   , Double(types->Double)
+   , Address(types->Address)
+   {
+   if (parent != this) // FunctionBuilders have parent==this, so don't add itself as child
+      parent->addChild(self());
+   }
+
+Builder *
+BuilderBase::self()
+   {
+   return static_cast<Builder *>(this);
+   }
+
+TypeDictionary *
+BuilderBase::dict() const
+   {
+   return _fb->dict();
+   }
+
+void
+BuilderBase::creationError(Action a, std::string msg)
+   {
+   std::cerr << "Error creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << msg << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string sName, std::string s)
+   {
+   std::cerr << "Unknown name creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << sName << " : " << s << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string vName, Value * v)
+   {
+   std::cerr << "Incorrect operand type creatign operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder b" << _id << ")\n";
+   std::cerr << "\t" << vName << " : " << v << " has type " << v->type() << " (" << v->type()->name() << ")\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string tName, Type * t, std::string vName, Value * v)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder b" << _id << ")\n";
+   std::cerr << "\t" << tName << " : " << t << "\n";
+   std::cerr << "\t" << vName << " : " << v << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string t1Name, Type * t1, std::string t2Name, Type * t2)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << t1Name << " : " << t1 << "\n";
+   std::cerr << "\t" << t2Name << " : " << t2 << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string oneName, Value * one,
+                       std::string twoName, Value * two, std::string threeName, Value * three)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << oneName   << " : " << one   << "\n";
+   std::cerr << "\t" << twoName   << " : " << two   << "\n";
+   std::cerr << "\t" << threeName << " : " << three << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string lName, Value * left, std::string rName, Value * right)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << lName << " : " << left  << "\n";
+   std::cerr << "\t" << rName << " : " << right << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string tName, Type * t, std::string firstName, Value * first, std::string secondName, Value * second)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << tName      << " : " << t << "\n";
+   std::cerr << "\t" << firstName  << " : " << first  << "\n";
+   std::cerr << "\t" << secondName << " : " << second << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << sName      << " : " << sValue << "\n";
+   std::cerr << "\t" << fName      << " : " << fValue << "\n";
+   std::cerr << "\t" << bName      << " : " << bValue << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue, std::string vName, Value *vValue)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << sName      << " : " << sValue << "\n";
+   std::cerr << "\t" << fName      << " : " << fValue << "\n";
+   std::cerr << "\t" << bName      << " : " << bValue << "\n";
+   std::cerr << "\t" << vName      << " : " << vValue << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string fName, Value *function, int32_t numArgs, va_list args)
+   {
+   Value ** argsArray = new Value *[numArgs];
+   for (int a=0;a < numArgs;a++)
+      argsArray[a] = va_arg(args, Value *);
+   creationError(a, fName, function, numArgs, argsArray);
+   }
+
+void
+BuilderBase::creationError(Action a, std::string fName, Value *function, int32_t numArgs, Value **args)
+   {
+   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "\t(builder " << this << ")\n";
+   std::cerr << "\t" << fName      << " : " << function << "\n";
+   std::cerr << "\t" << "numArgs"  << " : " << numArgs  << "\n";
+   for (int a=0;a < numArgs;a++)
+      std::cerr << "\t" << a          << " : " << args[a] << "\n";
+   assert(0);
+   }
+
+void
+BuilderBase::setParent(Builder *parent)
+   {
+   _parent = parent;
+   _parent->addChild(self());
+   }
+
+void
+BuilderBase::addChild(Builder *child)
+   {
+   // shouldn't ever be duplicates, but let's make absolutely sure (assert instead?)
+   for (int32_t c=0;c < _children.size();c++)
+      if (_children[c] == child)
+         return;
+   _children.push_back(child);
+   }
+
+Builder *
+BuilderBase::setBoundness(MustMayCant v)
+   {
+   assert(v != Must || _isBound == true);
+   assert(v != Cant || _isBound == false);
+   _boundness = v;
+   return self();
+   }
+
+void
+BuilderBase::checkBoundness(bool v) const
+   {
+   if (_boundness == May)
+         return;
+
+   if (v)
+      assert(_boundness == Must);
+      else
+      assert(_boundness == Cant);
+   }
+
+Builder *
+BuilderBase::setBound(bool v, Operation * boundToOp)
+   {
+   checkBoundness(v);
+   _isBound = v;
+   _boundToOperation = boundToOp;
+   return self();
+   }
+
+Builder *
+BuilderBase::setBound(Operation * boundToOp)
+   {
+   checkBoundness(true);
+   _isBound = true;
+   _boundToOperation = boundToOp;
+   return self();
+   }
+
+Builder *
+BuilderBase::setTarget(bool v)
+   {
+   _isTarget = v;
+   return self();
+   }
+
+Operation *
+BuilderBase::appendClone(Operation *op, OperationCloner *cloner)
+   {
+   Operation *clonedOp = op->clone(self(), cloner);
+   add(clonedOp);
+   return clonedOp;
+   }
+
+Value *
+BuilderBase::ConstInt8 (int8_t v)
+   {
+   Value * result = Value::create(self(), Int8);
+   add(OMR::JitBuilder::ConstInt8::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstInt16 (int16_t v)
+   {
+   Value * result = Value::create(self(), Int16);
+   add(OMR::JitBuilder::ConstInt16::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstInt32 (int32_t v)
+   {
+   Value * result = Value::create(self(), Int32);
+   add(OMR::JitBuilder::ConstInt32::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstInt64 (int64_t v)
+   {
+   Value * result = Value::create(self(), Int64);
+   add(OMR::JitBuilder::ConstInt64::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstFloat (float v)
+   {
+   Value * result = Value::create(self(), Float);
+   add(OMR::JitBuilder::ConstFloat::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstDouble (double v)
+   {
+   Value * result = Value::create(self(), Double);
+   add(OMR::JitBuilder::ConstDouble::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::ConstAddress (void *v)
+   {
+   Value * result = Value::create(self(), Address);
+   add(OMR::JitBuilder::ConstAddress::create(self(), result, v));
+   return result;
+   }
+
+Value *
+BuilderBase::CoercePointer(Type * t, Value * v)
+   {
+   if (!(v->type()->isPointer() || v->type() == Address) || !t->isPointer())
+      creationError(aCoercePointer, "type", t, "value", v);
+
+   Value * result = Value::create(self(), t);
+   add(OMR::JitBuilder::CoercePointer::create(self(), result, t, v));
+   return result;
+   }
+
+Value *
+BuilderBase::Add (Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aAdd, left, right);
+   if (!returnType)
+      creationError(aAdd, "left", left, "right", right);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::Add::create(self(), result, left, right));
+   return result;
+   }
+
+Value *
+BuilderBase::Sub (Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aSub, left, right);
+   if (!returnType)
+      creationError(aSub, "left", left, "right", right);
+
+   Value * result = Value::create(self(), returnType);
+
+   add(OMR::JitBuilder::Sub::create(self(), result, left, right));
+   return result;
+   }
+
+Value *
+BuilderBase::Mul (Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aMul, left, right);
+   if (!returnType)
+      creationError(aMul, "left", left, "right", right);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::Mul::create(self(), result, left, right));
+   return result;
+   }
+
+Value *
+BuilderBase::IndexAt (Type * type, Value * base, Value * index)
+   {
+   Type *returnType = dict()->producedType(aIndexAt, base, index);
+   if (!returnType)
+      creationError(aIndexAt, "type", type, "base", base, "index", index);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::IndexAt::create(self(), result, type, base, index));
+   return result;
+   }
+
+Value *
+BuilderBase::Load(Symbol *local)
+   {
+   Type *returnType = local->type();
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::Load::create(self(), result, local));
+   return result;
+   }
+
+Value *
+BuilderBase::Load (std::string name)
+   {
+   Symbol *local = _fb->getSymbol(name);
+   if (!local)
+      creationError(aLoad, "localName", name);
+   return Load(local);
+   }
+
+Value *
+BuilderBase::LoadAt (Type * type, Value * address)
+   {
+   Type *returnType = dict()->producedType(aLoadAt, address);
+   if (!returnType)
+      creationError(aLoadAt, "type", type, "address", address);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::LoadAt::create(self(), result, type, address));
+   return result;
+   }
+
+Value *
+BuilderBase::LoadField (std::string structName, std::string fieldName, Value * structBase)
+   {
+   StructType *structType = dict()->LookupStruct(structName);
+   FieldType *fieldType = structType->LookupField(fieldName);
+   assert(fieldType);
+   return LoadField(fieldType, structBase);
+   }
+
+Value *
+BuilderBase::LoadField (FieldType *fieldType, Value *structBase)
+   {
+   StructType *structType = fieldType->owningStruct();
+   Type *returnType = dict()->producedType(aLoadField, fieldType, structBase);
+   if (!returnType)
+      creationError(aLoadField, "struct", structType->name(), "field", fieldType->name(), "base", structBase);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::LoadField::create(self(), result, fieldType, structBase));
+   return result;
+   }
+
+Value *
+BuilderBase::LoadIndirect (std::string structName, std::string fieldName, Value * pStructBase)
+   {
+   StructType *structType = dict()->LookupStruct(structName);
+   FieldType *fieldType = structType->LookupField(fieldName);
+   assert(fieldType);
+   return LoadIndirect(fieldType, pStructBase);
+   }
+
+Value *
+BuilderBase::LoadIndirect (FieldType *fieldType, Value *pStructBase)
+   {
+   StructType *structType = fieldType->owningStruct();
+   Type *returnType = dict()->producedType(aLoadIndirect, fieldType, pStructBase);
+   if (!returnType)
+      creationError(aLoadIndirect, "struct", structType->name(), "field", fieldType->name(), "basePtr", pStructBase);
+
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::LoadIndirect::create(self(), result, fieldType, pStructBase));
+   return result;
+   }
+
+void
+BuilderBase::Store(Symbol * local, Value * value)
+   {
+   add(OMR::JitBuilder::Store::create(self(), local, value));
+   }
+   
+void
+BuilderBase::Store (std::string name, Value * value)
+   {
+   Symbol *local = fb()->getSymbol(name);
+   if (local == NULL)
+      {
+      fb()->DefineLocal(name, value->type());
+      local = fb()->getSymbol(name);
+      }
+   add(OMR::JitBuilder::Store::create(self(), local, value));
+   }
+
+void
+BuilderBase::StoreAt (Value * address, Value * value)
+   {
+   Type *returnType = dict()->producedType(aStoreAt, address, value);
+   if (returnType != NoType)
+      creationError(aStoreAt, "address", address, "value", value);
+
+   add(OMR::JitBuilder::StoreAt::create(self(), address, value));
+   }
+
+void
+BuilderBase::StoreField (std::string structName, std::string fieldName, Value * structBase, Value *value)
+   {
+   StructType *structType = dict()->LookupStruct(structName);
+   FieldType *fieldType = structType->LookupField(fieldName);
+   assert(fieldType);
+   return StoreField(fieldType, structBase, value);
+   }
+
+void
+BuilderBase::StoreField (FieldType *fieldType, Value *structBase, Value *value)
+   {
+   StructType *structType = fieldType->owningStruct();
+   Type *returnType = dict()->producedType(aStoreField, fieldType, structBase, value);
+   if (structType != fieldType->owningStruct() || returnType != NoType)
+      creationError(aStoreField, "struct", structType->name(), "field", fieldType->name(), "base", structBase, "value", value);
+
+   add(OMR::JitBuilder::StoreField::create(self(), fieldType, structBase, value));
+   }
+
+void
+BuilderBase::StoreIndirect (std::string structName, std::string fieldName, Value * pStructBase, Value *value)
+   {
+   StructType *structType = dict()->LookupStruct(structName);
+   FieldType *fieldType = structType->LookupField(fieldName);
+   assert(fieldType);
+   return StoreIndirect(fieldType, pStructBase, value);
+   }
+
+void
+BuilderBase::StoreIndirect (FieldType *fieldType, Value *pStructBase, Value *value)
+   {
+   StructType *structType = fieldType->owningStruct();
+   Type *returnType = dict()->producedType(aStoreIndirect, fieldType, pStructBase, value);
+   if (structType != fieldType->owningStruct() || returnType != NoType)
+      creationError(aStoreIndirect, "struct", structType->name(), "field", fieldType->name(), "basePtr", pStructBase, "value", value);
+
+   add(OMR::JitBuilder::StoreIndirect::create(self(), fieldType, pStructBase, value));
+   }
+
+void
+BuilderBase::AppendBuilder(Builder * b)
+   {
+   Operation * appendBuilderOp = OMR::JitBuilder::AppendBuilder::create(self(), b);
+   add(appendBuilderOp);
+   b->setBoundness(May)
+    ->setBound(appendBuilderOp)
+    ->setBoundness(Must);
+   _controlReachesEnd = true; // AppendBuilder establishes a label so control can now reach the end of this builder even if earlier it could not
+   }
+
+Value *
+BuilderBase::Call(Value *func, int32_t numArgs, ...)
+   {
+   assert(func->type()->isFunction());
+
+   va_list args ;
+   va_start(args, numArgs);
+   FunctionType *function = static_cast<FunctionType *>(func->type());
+   Type *returnType = dict()->producedType(function, numArgs, args);
+   if (returnType == NULL)
+      creationError(aCall, "functionType", func, numArgs, args);
+   va_end(args);
+
+   Value * result = NULL;
+   if (returnType != NoType)
+      result = Value::create(self(), returnType);
+   va_list args2 ;
+   va_start(args2, numArgs);
+   Operation * callOp = OMR::JitBuilder::Call::create(self(), result, func, numArgs, args2);
+   add(callOp);
+   va_end(args2);
+   return result;
+   }
+
+Value *
+BuilderBase::Call(Value *func, int32_t numArgs, Value **args)
+   {
+   assert(func->type()->isFunction());
+   FunctionType *function = static_cast<FunctionType *>(func->type());
+   Type *returnType = dict()->producedType(function, numArgs, args);
+   if (returnType == NULL)
+      creationError(aCall, "functionType", func, numArgs, args);
+
+   Value * result = NULL;
+   if (returnType != NoType)
+      result = Value::create(self(), returnType);
+   Operation * callOp = OMR::JitBuilder::Call::create(self(), result, func, numArgs, args);
+   add(callOp);
+   return result;
+   }
+
+void
+BuilderBase::Goto(Builder * b)
+   {
+   Operation * gotoOp = OMR::JitBuilder::Goto::create(self(), b);
+   add(gotoOp);
+   _controlReachesEnd = false; // Goto definitely leaves this builder object
+   }
+
+void
+BuilderBase::IfCmpGreaterThan(Builder * gtBuilder, Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aIfCmpGreaterThan, left, right);
+   if (!returnType || returnType != NoType)
+      creationError(aIfCmpGreaterThan, "left", left, "right", right);
+   add(OMR::JitBuilder::IfCmpGreaterThan::create(self(), gtBuilder, left, right));
+   gtBuilder->setTarget()
+            ->setBoundness(Cant);
+   }
+
+void
+BuilderBase::IfCmpLessThan(Builder * ltBuilder, Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aIfCmpLessThan, left, right);
+   if (!returnType || returnType != NoType)
+      creationError(aIfCmpLessThan, "left", left, "right", right);
+   add(OMR::JitBuilder::IfCmpLessThan::create(self(), ltBuilder, left, right));
+   ltBuilder->setTarget()
+            ->setBoundness(Cant);
+   }
+
+void
+BuilderBase::IfCmpGreaterOrEqual(Builder * goeBuilder, Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aIfCmpGreaterOrEqual, left, right);
+   if (!returnType || returnType != NoType)
+      creationError(aIfCmpGreaterOrEqual, "left", left, "right", right);
+   add(OMR::JitBuilder::IfCmpGreaterOrEqual::create(self(), goeBuilder, left, right));
+   goeBuilder->setTarget()
+             ->setBoundness(Cant);
+   }
+
+void
+BuilderBase::IfCmpLessOrEqual(Builder * loeBuilder, Value * left, Value * right)
+   {
+   Type *returnType = dict()->producedType(aIfCmpLessOrEqual, left, right);
+   if (!returnType || returnType != NoType)
+      creationError(aIfCmpLessOrEqual, "left", left, "right", right);
+   add(OMR::JitBuilder::IfCmpLessOrEqual::create(self(), loeBuilder, left, right));
+   loeBuilder->setTarget()
+             ->setBoundness(Cant);
+   }
+
+void
+BuilderBase::IfThenElse(Builder * thenB, Builder * elseB, Value * cond)
+   {
+   if (thenB && thenB->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because thenB builder cannot be bound");
+   if (elseB && elseB->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because elseB builder cannot be bound");
+
+   Operation *ifThenElseOp = OMR::JitBuilder::IfThenElse::create(self(), thenB, elseB, cond);
+   add(ifThenElseOp);
+   if (thenB)
+      thenB->setTarget()
+           ->setBoundness(May)
+           ->setBound(ifThenElseOp)
+           ->setBoundness(Must);
+   if (elseB)
+      elseB->setTarget()
+           ->setBoundness(May)
+           ->setBound(ifThenElseOp)
+           ->setBoundness(Must);
+   }
+
+void
+BuilderBase::ForLoopUp(std::string loopVar, Builder * body, Value * initial, Value * end, Value * bump)
+   {
+   LocalSymbol *loopSym = NULL;
+   Symbol *sym = fb()->getSymbol(loopVar);
+   if (sym && sym->isLocal())
+      loopSym = static_cast<LocalSymbol *>(sym);
+   else
+      loopSym = fb()->DefineLocal(loopVar, initial->type());
+   ForLoopUp(loopSym, body, initial, end, bump);
+   }
+
+void
+BuilderBase::ForLoopUp(LocalSymbol *loopSym, Builder * body, Value * initial, Value * end, Value * bump)
+   {
+   Type *returnType = dict()->producedType(aForLoop, initial, end, bump);
+   if (!returnType || returnType != NoType)
+      creationError(aForLoop, "initial", initial, "end", end, "bump", bump);
+   if (body->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because body builder cannot be bound");
+
+   Operation * forLoopOp = OMR::JitBuilder::ForLoop::create(self(), true, loopSym, body, initial, end, bump);
+   add(forLoopOp);
+   }
+
+void
+BuilderBase::ForLoop(bool countsUp, std::string loopVar, Builder * loopBody, Builder * loopContinue, Builder * loopBreak, Value * initial, Value * end, Value * bump)
+   {
+   LocalSymbol *loopSym = NULL;
+   Symbol *sym = fb()->getSymbol(loopVar);
+   if (sym && sym->isLocal())
+      loopSym = static_cast<LocalSymbol *>(sym);
+   else
+      loopSym = fb()->DefineLocal(loopVar, initial->type());
+   ForLoop(countsUp, loopSym, loopBody, loopContinue, loopBreak, initial, end, bump);
+   }
+
+void
+BuilderBase::ForLoop(bool countsUp, LocalSymbol *loopSym, Builder * loopBody, Builder * loopContinue, Builder * loopBreak, Value * initial, Value * end, Value * bump)
+   {
+   Type *returnType = dict()->producedType(aForLoop, initial, end, bump);
+   if (!returnType || returnType != NoType)
+      creationError(aForLoop, "initial", initial, "end", end, "bump", bump);
+   if (loopBody->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because loopBody builder cannot be bound");
+   if (loopContinue && loopContinue->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because loopContinue builder cannot be bound");
+   if (loopBreak && loopBreak->boundness() == Cant)
+      creationError(aIfThenElse, "Operation invalid because loopBreak builder cannot be bound");
+
+   Operation * forLoopOp = (OMR::JitBuilder::ForLoop::create(self(), countsUp, loopSym, loopBody, loopContinue, loopBreak, initial, end, bump));
+   add(forLoopOp);
+   loopBody->setTarget()
+           ->setBoundness(May)
+           ->setBound(forLoopOp)
+           ->setBoundness(Must);
+   if (loopContinue)
+      loopContinue->setBoundness(May)
+                  ->setBound(forLoopOp)
+                  ->setBoundness(Must);
+   if (loopBreak)
+      loopBreak->setBoundness(May)
+               ->setBound(forLoopOp)
+               ->setBoundness(Must);
+   }
+
+void
+BuilderBase::Switch(Value * selector, Builder * defaultBuilder, int numCases, Case ** cases)
+   {
+   Type *returnType = dict()->producedType(aSwitch, selector);
+   if (!returnType || returnType != NoType)
+      creationError(aSwitch, "selector", selector);
+   Operation *switchOp = OMR::JitBuilder::Switch::create(self(), selector, defaultBuilder, numCases, cases);
+   add(switchOp);
+   if (defaultBuilder)
+      defaultBuilder->setTarget()
+                    ->setBoundness(May)
+                    ->setBound(switchOp)
+                    ->setBoundness(Must);
+   for (auto c=0;c < numCases;c++)
+      {
+      Case *thisCase = cases[c];
+      Builder *b = thisCase->builder();
+      b->setTarget()
+       ->setBoundness(May)
+       ->setBound(switchOp)
+       ->setBoundness(Must);
+      }
+   }
+
+void
+BuilderBase::Return()
+   {
+   if (_fb->getReturnType() != NoType)
+      creationError(aReturn, "expected type", _fb->getReturnType(), "returned type", NoType);
+
+   add(OMR::JitBuilder::Return::create(self()));
+   if (boundness() == Must)
+      creationError(aReturn, "Operation invalid because target builder is bound");
+   setBoundness(Cant);
+   }
+
+void
+BuilderBase::Return(Value *v)
+   {
+   Type *returnType = dict()->producedType(aReturn, v);
+   if (v->type() != _fb->getReturnType() || !returnType || returnType != NoType)
+      creationError(aReturn, "expected type", _fb->getReturnType(), "returned type", v->type());
+
+   add(OMR::JitBuilder::Return::create(self(), v));
+   if (boundness() == Must)
+      creationError(aReturn, "Operation invalid because target builder is bound");
+   setBoundness(Cant);
+   }
+
+Value *
+BuilderBase::CreateLocalArray(int32_t numElements, Type *elementType)
+   {
+   Type *returnType = dict()->PointerTo(elementType);
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::CreateLocalArray::create(self(), result, numElements, elementType));
+   return result;
+   }
+
+Value *
+BuilderBase::CreateLocalStruct(Type *structType)
+   {
+   Type *returnType = dict()->PointerTo(structType);
+   Value * result = Value::create(self(), returnType);
+   add(OMR::JitBuilder::CreateLocalStruct::create(self(), result, structType));
+   return result;
+   }
+
+Location *
+BuilderBase::SourceLocation()
+   {
+   Location *loc = OMR::JitBuilder::Location::create(_fb);
+   _fb->addLocation(loc);
+   setLocation(loc);
+   return loc;
+   }
+
+Location *
+BuilderBase::SourceLocation(std::string lineNumber)
+   {
+   Location *loc = OMR::JitBuilder::Location::create(_fb, lineNumber);
+   _fb->addLocation(loc);
+   setLocation(loc);
+   return loc;
+   }
+
+Location *
+BuilderBase::SourceLocation(std::string lineNumber, int32_t bcIndex)
+   {
+   Location *loc = OMR::JitBuilder::Location::create(_fb, lineNumber, bcIndex);
+   _fb->addLocation(loc);
+   setLocation(loc);
+   return loc;
+   }
+
+Builder *
+BuilderBase::add(Operation * op)
+   {
+   _fb->registerObject(op);
+   op->setLocation(_currentLocation);
+   TextWriter *log = _fb->logger();
+   if (_fb->config()->traceBuildIL() && log)
+      {
+      log->indent() << self() << " : create ";
+      log->print(op);
+      }
+
+   _operations.push_back(op);
+   return self();
+   }

--- a/jitbuilder/jbil/BuilderBase.cpp
+++ b/jitbuilder/jbil/BuilderBase.cpp
@@ -26,6 +26,7 @@
 #include "Builder.hpp"
 #include "FunctionBuilder.hpp"
 #include "Location.hpp"
+#include "DynamicOperation.hpp"
 #include "OperationCloner.hpp"
 #include "TextWriter.hpp"
 #include "Value.hpp"
@@ -99,7 +100,7 @@ BuilderBase::dict() const
 void
 BuilderBase::creationError(Action a, std::string msg)
    {
-   std::cerr << "Error creating operation " << actionName[a] << "\n";
+   std::cerr << "Error creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << msg << "\n";
    assert(0);
@@ -108,7 +109,7 @@ BuilderBase::creationError(Action a, std::string msg)
 void
 BuilderBase::creationError(Action a, std::string sName, std::string s)
    {
-   std::cerr << "Unknown name creating operation " << actionName[a] << "\n";
+   std::cerr << "Unknown name creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << sName << " : " << s << "\n";
    assert(0);
@@ -117,7 +118,7 @@ BuilderBase::creationError(Action a, std::string sName, std::string s)
 void
 BuilderBase::creationError(Action a, std::string vName, Value * v)
    {
-   std::cerr << "Incorrect operand type creatign operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand type creatign operation " << actionName(a) << "\n";
    std::cerr << "\t(builder b" << _id << ")\n";
    std::cerr << "\t" << vName << " : " << v << " has type " << v->type() << " (" << v->type()->name() << ")\n";
    assert(0);
@@ -126,7 +127,7 @@ BuilderBase::creationError(Action a, std::string vName, Value * v)
 void
 BuilderBase::creationError(Action a, std::string tName, Type * t, std::string vName, Value * v)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder b" << _id << ")\n";
    std::cerr << "\t" << tName << " : " << t << "\n";
    std::cerr << "\t" << vName << " : " << v << "\n";
@@ -136,7 +137,7 @@ BuilderBase::creationError(Action a, std::string tName, Type * t, std::string vN
 void
 BuilderBase::creationError(Action a, std::string t1Name, Type * t1, std::string t2Name, Type * t2)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << t1Name << " : " << t1 << "\n";
    std::cerr << "\t" << t2Name << " : " << t2 << "\n";
@@ -147,7 +148,7 @@ void
 BuilderBase::creationError(Action a, std::string oneName, Value * one,
                        std::string twoName, Value * two, std::string threeName, Value * three)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << oneName   << " : " << one   << "\n";
    std::cerr << "\t" << twoName   << " : " << two   << "\n";
@@ -158,7 +159,7 @@ BuilderBase::creationError(Action a, std::string oneName, Value * one,
 void
 BuilderBase::creationError(Action a, std::string lName, Value * left, std::string rName, Value * right)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << lName << " : " << left  << "\n";
    std::cerr << "\t" << rName << " : " << right << "\n";
@@ -168,7 +169,7 @@ BuilderBase::creationError(Action a, std::string lName, Value * left, std::strin
 void
 BuilderBase::creationError(Action a, std::string tName, Type * t, std::string firstName, Value * first, std::string secondName, Value * second)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << tName      << " : " << t << "\n";
    std::cerr << "\t" << firstName  << " : " << first  << "\n";
@@ -179,7 +180,7 @@ BuilderBase::creationError(Action a, std::string tName, Type * t, std::string fi
 void
 BuilderBase::creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << sName      << " : " << sValue << "\n";
    std::cerr << "\t" << fName      << " : " << fValue << "\n";
@@ -190,7 +191,7 @@ BuilderBase::creationError(Action a, std::string sName, std::string sValue, std:
 void
 BuilderBase::creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue, std::string vName, Value *vValue)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << sName      << " : " << sValue << "\n";
    std::cerr << "\t" << fName      << " : " << fValue << "\n";
@@ -211,7 +212,7 @@ BuilderBase::creationError(Action a, std::string fName, Value *function, int32_t
 void
 BuilderBase::creationError(Action a, std::string fName, Value *function, int32_t numArgs, Value **args)
    {
-   std::cerr << "Incorrect operand types creating operation " << actionName[a] << "\n";
+   std::cerr << "Incorrect operand types creating operation " << actionName(a) << "\n";
    std::cerr << "\t(builder " << this << ")\n";
    std::cerr << "\t" << fName      << " : " << function << "\n";
    std::cerr << "\t" << "numArgs"  << " : " << numArgs  << "\n";
@@ -833,6 +834,64 @@ BuilderBase::SourceLocation(std::string lineNumber, int32_t bcIndex)
    _fb->addLocation(loc);
    setLocation(loc);
    return loc;
+   }
+
+Operation *
+BuilderBase::Append(OperationBuilder *opBuilder)
+   {
+   // ideally do some type checking for the operation to be created
+
+   for (auto i=0;i < opBuilder->numResults();i++)
+      opBuilder->addResult(Value::create(self(), opBuilder->resultType(i)));
+
+   Operation *newOp = opBuilder->createOperation(self());
+   return newOp;
+   }
+
+Value *
+BuilderBase::Append(OperationBuilder *opBuilder, LiteralValue *l)
+   {
+   // ideally do some type checking for the operation to be created
+
+   assert(opBuilder->numResults() == 1);
+   Value *returnValue = Value::create(self(), opBuilder->resultType());
+   opBuilder->addResult(returnValue);
+   opBuilder->addLiteral(l);
+
+   Operation *newOp = opBuilder->createOperation(self());
+   add(newOp);
+   return returnValue;
+   }
+
+Value *
+BuilderBase::Append(OperationBuilder *opBuilder, Value *v)
+   {
+   // ideally do some type checking for the operation to be created
+
+   assert(opBuilder->numResults() == 1);
+   Value *returnValue = Value::create(self(), opBuilder->resultType());
+   opBuilder->addResult(returnValue);
+   opBuilder->addOperand(v);
+
+   Operation *newOp = opBuilder->createOperation(self());
+   add(newOp);
+   return returnValue;
+   }
+
+Value *
+BuilderBase::Append(OperationBuilder *opBuilder, Value *left, Value *right)
+   {
+   // ideally do some type checking for the operation to be created
+
+   assert(opBuilder->numResults() == 1);
+   Value *returnValue = Value::create(self(), opBuilder->resultType());
+   opBuilder->addResult(returnValue);
+   opBuilder->addOperand(left);
+   opBuilder->addOperand(right);
+
+   Operation *newOp = opBuilder->createOperation(self());
+   add(newOp);
+   return returnValue;
    }
 
 Builder *

--- a/jitbuilder/jbil/BuilderBase.hpp
+++ b/jitbuilder/jbil/BuilderBase.hpp
@@ -55,6 +55,7 @@ class Case;
 class FunctionBuilder;
 class Location;
 class Operation;
+class OperationBuilder;
 class OperationCloner;
 class Type;
 class Value;
@@ -69,11 +70,17 @@ enum MustMayCant {
 class BuilderBase : public Object
    {
    friend class Transformer;
+   friend class OperationBuilder;
 
 public:
 
    Operation * appendClone(Operation *op);
    Operation * appendClone(Operation *op, OperationCloner *cloner);
+
+   Operation * Append(OperationBuilder *opBuilder);
+   Value * Append(OperationBuilder *opBuilder, LiteralValue *l);
+   Value * Append(OperationBuilder *opBuilder, Value *v);
+   Value * Append(OperationBuilder *opBuilder, Value *left, Value *right);
 
    Value * ConstInt8(int8_t v);
    Value * ConstInt16(int16_t v);

--- a/jitbuilder/jbil/BuilderBase.hpp
+++ b/jitbuilder/jbil/BuilderBase.hpp
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef BUILDERBASE_INCL
+#define BUILDERBASE_INCL
+
+#include <vector>
+
+namespace OMR
+{
+namespace JitBuilder
+{ 
+
+class Operation;
+typedef std::vector<Operation *> OperationVector;
+typedef OperationVector::iterator OperationIterator;
+
+} // namespace JitBuilder
+} // namespace OMR
+
+
+#include <stdint.h>
+#include <vector>
+
+#include "Object.hpp"
+#include "TypeDictionary.hpp"
+
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class FunctionBuilder;
+class Location;
+class Operation;
+class OperationCloner;
+class Type;
+class Value;
+class Transformer;
+
+enum MustMayCant {
+   Must=0,
+   May=1,
+   Cant=2
+};
+
+class BuilderBase : public Object
+   {
+   friend class Transformer;
+
+public:
+
+   Operation * appendClone(Operation *op);
+   Operation * appendClone(Operation *op, OperationCloner *cloner);
+
+   Value * ConstInt8(int8_t v);
+   Value * ConstInt16(int16_t v);
+   Value * ConstInt32(int32_t v);
+   Value * ConstInt64(int64_t v);
+   Value * ConstFloat(float v);
+   Value * ConstDouble(double v);
+   Value * ConstAddress(void *v);
+
+   Value * CoercePointer(Type * t, Value * v);
+
+   Value * Add(Value * left, Value * right);
+   Value * Sub(Value * left, Value * right);
+   Value * Mul(Value * left, Value * right);
+
+   Value * IndexAt(Type * type, Value * base, Value * index);
+   Value * Load(std::string name);
+   Value * Load(Symbol *local);
+   Value * LoadAt(Type * type, Value * address);
+   Value * LoadField(std::string structName, std::string fieldName, Value * structBase);
+   Value * LoadField(FieldType *fieldType, Value * structBase);
+   Value * LoadIndirect(std::string structName, std::string fieldName, Value * pStructBase);
+   Value * LoadIndirect(FieldType *fieldType, Value * pStructBase);
+   void Store(std::string name, Value * value);
+   void Store(Symbol * local, Value * value);
+   void StoreAt(Value * address, Value * value);
+   void StoreField(std::string structName, std::string fieldName, Value * structBase, Value *value);
+   void StoreField(FieldType *fieldType, Value * structBase, Value *value);
+   void StoreIndirect(std::string structName, std::string fieldName, Value * pStructBase, Value *value);
+   void StoreIndirect(FieldType *fieldType, Value * pStructBase, Value *value);
+
+   void AppendBuilder(Builder * b);
+   Value * Call(Value *function, int32_t numArgs, ...);
+   Value * Call(Value *function, int32_t numArgs, Value **args);
+   void Goto(Builder * b);
+   void IfCmpGreaterThan(Builder * gtBuilder, Value * left, Value * right);
+   void IfCmpLessThan(Builder * ltBuilder, Value * left, Value * right);
+   void IfCmpGreaterOrEqual(Builder * goeBuilder, Value * left, Value * right);
+   void IfCmpLessOrEqual(Builder * loeBuilder, Value * left, Value * right);
+   void IfThenElse(Builder * thenB, Value * cond);
+   void IfThenElse(Builder * thenB, Builder * elseB, Value * cond);
+   void ForLoopUp(std::string loopVar, Builder * body, Value * initial, Value * end, Value * bump);
+   void ForLoopUp(LocalSymbol *loopSym, Builder * body, Value * initial, Value * end, Value * bump);
+   void ForLoop(bool countsUp, std::string loopVar, Builder * body, Builder * loopContinue, Builder * loopBreak, Value * initial, Value * end, Value * bump);
+   void ForLoop(bool countsUp, LocalSymbol *loopSym, Builder * body, Builder * loopContinue, Builder * loopBreak, Value * initial, Value * end, Value * bump);
+   void Switch(Value * selector, Builder * defaultBuilder, int numCases, Case ** cases);
+   void Return();
+   void Return(Value *v);
+
+   Value * CreateLocalArray(int32_t numElements, Type *elementType);
+   Value * CreateLocalStruct(Type *elementType);
+
+   Location * SourceLocation();
+   Location * SourceLocation(std::string lineNumber);
+   Location * SourceLocation(std::string lineNumber, int32_t bcIndex);
+
+   Type * NoType;
+   Type * Int8;
+   Type * Int16;
+   Type * Int32;
+   Type * Int64;
+   Type * Float;
+   Type * Double;
+   Type * Address;
+
+   int64_t id() const                          { return _id; }
+   std::string name() const                    { return _name; }
+   virtual size_t size() const                 { return sizeof(BuilderBase); }
+
+   TypeDictionary * dict() const;
+   Builder * parent() const                    { return _parent; }
+
+   int32_t numChildren() const                 { return _children.size(); }
+   BuilderIterator ChildrenBegin()             { return BuilderIterator(_children); }
+   BuilderIterator ChildrenEnd()               { return BuilderIterator(); }
+
+   int32_t numOperations() const               { return _operations.size(); }
+   OperationVector & operations()              { return _operations; }
+   OperationIterator OperationsBegin()         { return _operations.begin(); }
+   OperationIterator OperationsEnd()           { return _operations.end(); }
+
+   MustMayCant boundness() const               { return _boundness; }
+   Builder * setBoundness(MustMayCant v);
+   void checkBoundness(bool v) const;
+
+   bool isBound() const                        { return _isBound; }
+   Builder * setBound(bool v, Operation * boundToOp=NULL);
+   Builder * setBound(Operation * boundToOp);
+   Operation * boundToOperation()              { assert(_isBound); return _boundToOperation; }
+
+   bool isTarget() const                       { return _isTarget; }
+   Builder * setTarget(bool v=true);
+
+   bool controlReachesEnd() const              { return _controlReachesEnd; }
+
+   static int64_t maxIndex()                   { return globalIndex; }
+
+
+   protected:
+   BuilderBase(Builder * parent, FunctionBuilder * fb, TypeDictionary *types);
+   BuilderBase(Builder * parent, TypeDictionary *types);
+
+   Builder *self();
+
+   void creationError(Action a, std::string msg);
+   void creationError(Action a, std::string sName, std::string s);
+   void creationError(Action a, std::string vName, Value * v);
+   void creationError(Action a, std::string tName, Type * t, std::string vName, Value * v);
+   void creationError(Action a, std::string t1Name, Type * t1, std::string t2Name, Type * t2);
+   void creationError(Action a, std::string lName, Value * left, std::string rName, Value * right);
+   void creationError(Action a, std::string oneName, Value * one, std::string twoName, Value * two, std::string threeName, Value * three);
+   void creationError(Action a, std::string tName, Type * t, std::string firstName, Value * first, std::string secondName, Value * second);
+   void creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue);
+   void creationError(Action a, std::string sName, std::string sValue, std::string fName, std::string fValue, std::string bName, Value *bValue, std::string vName, Value *vValue);
+   void creationError(Action a, std::string fName, Value *function, int32_t numArgs, va_list args);
+   void creationError(Action a, std::string fName, Value *function, int32_t numArgs, Value **args);
+
+   void setParent(Builder *parent);
+   void addChild(Builder *child);
+   Builder * add(Operation * op);
+   Location *location() const
+      {
+      return _currentLocation;
+      }
+   void setLocation(Location * loc)
+      {
+      _currentLocation = loc;
+      }
+
+   int64_t                    _id;
+   std::string                _name;
+   Builder                  * _parent;
+   std::vector<Builder *>     _children;
+   Builder                  * _successor;
+   OperationVector            _operations;
+   Location                 * _currentLocation;
+   Operation                * _boundToOperation;
+   bool                       _isTarget;
+   bool                       _isBound;
+   bool                       _controlReachesEnd;
+   MustMayCant                _boundness;
+   static int64_t             globalIndex;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(BUILDERBASE_INCL)

--- a/jitbuilder/jbil/Case.cpp
+++ b/jitbuilder/jbil/Case.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Builder.hpp"
+#include "Case.hpp"
+#include "FunctionBuilder.hpp"
+
+int64_t OMR::JitBuilder::Case::globalIndex = 0;
+
+OMR::JitBuilder::Case::Case(int64_t v, Builder * b, bool ft)
+   : Object(b->fb())
+   , _id(globalIndex++)
+   , _value(v)
+   , _builder(b)
+   , _fallsThrough(ft)
+   { }
+
+OMR::JitBuilder::Case *
+OMR::JitBuilder::Case::create(int64_t v, Builder * b, bool ft)
+   {
+   Case *c = new Case(v, b, ft);
+   b->fb()->registerObject(c);
+   return c;
+   }

--- a/jitbuilder/jbil/Case.hpp
+++ b/jitbuilder/jbil/Case.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CASE_INCL
+#define CASE_INCL
+
+#include <stdint.h>
+#include <vector>
+#include <iostream>
+#include "Object.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class FunctionBuilder;
+
+class Case : public Object
+   {
+public:
+   static Case * create(int64_t v, Builder * b, bool ft);
+
+   int64_t id() const          { return _id; }
+   int64_t value() const       { return _value; }
+   Builder * builder() const   { return _builder; }
+   bool fallsThrough() const   { return _fallsThrough; }
+   virtual size_t size() const { return sizeof(Case); }
+
+protected:
+   Case(int64_t v, Builder * b, bool ft);
+
+   int64_t _id;
+   int64_t _value;
+   Builder * _builder;
+   bool _fallsThrough;
+
+   static int64_t globalIndex;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(CASE_INCL)

--- a/jitbuilder/jbil/CodeGenerator.cpp
+++ b/jitbuilder/jbil/CodeGenerator.cpp
@@ -1,0 +1,576 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "CodeGenerator.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "Location.hpp"
+#include "Operation.hpp"
+#include "TextWriter.hpp"
+#include "Type.hpp"
+#include "Value.hpp"
+
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/IlType.hpp"
+#include "ilgen/IlValue.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "env/FrontEnd.hpp"
+#include "env/TRMemory.hpp"
+
+using namespace OMR::JitBuilder;
+
+CodeGenerator::CodeGenerator(FunctionBuilder * fb, TR::MethodBuilder * mb)
+   : Transformer(fb)
+   , _mb(mb)
+   {
+   setTraceEnabled(fb->config()->traceCodeGenerator());
+   }
+
+TR::IlBuilder *
+CodeGenerator::mapBuilder(Builder * b)
+   {
+   if (b == NULL)
+      return NULL;
+   if (_builders.find(b->id()) == _builders.end())
+      storeBuilder(b, mapBuilder(b->parent())->OrphanBuilder());
+   return _builders[b->id()];
+   }
+
+void
+CodeGenerator::storeBuilder(Builder * b, TR::IlBuilder *omr_b)
+   {
+   _builders[b->id()] = omr_b;
+   }
+
+TR::IlType *
+CodeGenerator::mapType(Type * t)
+   {
+   return _types[t->id()];
+   }
+
+TR::IlType *
+CodeGenerator::mapPointerType(TR::TypeDictionary * types, PointerType * t)
+   {
+   if (_types.find(t->id()) != _types.end())
+      return mapType(t);
+
+   Type * baseType = t->BaseType();
+   TR::IlType *baseIlType;
+   if (baseType->isPointer())
+      baseIlType = mapPointerType(types, (PointerType *)baseType);
+   else
+      baseIlType = mapType(baseType);
+
+   TR::IlType *ptrIlType;
+   if (baseIlType)
+      ptrIlType = types->PointerTo(baseIlType);
+
+   return ptrIlType;
+   }
+
+// mapStructFields is designed to iterate (recursively) through the fields of a struct/union,
+// defining the fields of that struct in the `types` dictionary. If a field has a struct or
+// union type, then the fields of that struct/union are also walked and added directly to
+// *this* structure. That means "inner" structs/unions are inlined into the current struct.
+//
+// structName/fieldName are the names for the entire structure (field names are assembled to
+//     include containing struct/union names)
+// sType/fType are the struct and field types for this specific struct
+// As mapStructFields recursively visits inner types, structName/fieldName will stay the same,
+//     but sType/fType will reflect each inner type in succession
+TR::IlType *
+CodeGenerator::mapStructFields(TR::TypeDictionary * types, StructType * sType, char *structName, std::string fNamePrefix, size_t baseOffset)
+   {
+   for (auto fIt = sType->FieldsBegin(); fIt != sType->FieldsEnd(); fIt++)
+      {
+      FieldType *fType = fIt->second;
+      std::string fieldName = fNamePrefix + fType->name();
+      const char *fieldString = findOrCreateString(fieldName);
+      size_t fieldOffset = baseOffset + fType->offset();
+
+      if (fType->isStruct() || fType->isUnion())
+         {
+         // define a "dummy" field corresponding to the struct field itself, so we can ask for its address easily
+         // in case this field's struct needs to be passed to anything
+         _mb->typeDictionary()->DefineField(structName, fieldString, types->NoType, fieldOffset/8);
+         StructType *innerStructType = static_cast<StructType *>(fType->type());
+         mapStructFields(types, innerStructType, structName, fieldName + ".", fieldOffset);
+         }
+      else
+         _mb->typeDictionary()->DefineField(structName, fieldString, mapType(fType->type()), fieldOffset/8); // JB1 uses bytes offsets
+      }
+   return mapType(sType);
+   }
+
+void
+CodeGenerator::storeType(Type * t, TR::IlType *omr_t)
+   {
+   _types[t->id()] = omr_t;
+   }
+
+TR::IlValue *
+CodeGenerator::mapValue(Value * v)
+   {
+   return _values[v->id()];
+   }
+
+void
+CodeGenerator::storeValue(Value * v, TR::IlValue *omr_v)
+   {
+   _values[v->id()] = omr_v;
+   }
+
+#define MAP_CASE(omr_b,c) (reinterpret_cast<TR::IlBuilder::JBCase *>(mapCase((omr_b),(c))))
+
+void *
+CodeGenerator::mapCase(TR::IlBuilder *omr_b, Case *c)
+   {
+   if (_cases.find(c->id()) == _cases.end())
+      {
+      TR::IlBuilder *omr_target = mapBuilder(c->builder());
+      TR::IlBuilder::JBCase *jbCase = omr_b->MakeCase(c->value(), &omr_target, c->fallsThrough());
+      _cases[c->id()] = jbCase;
+      return jbCase;
+      }
+   return _cases[c->id()];
+   }
+
+char *
+CodeGenerator::findOrCreateString(std::string str)
+   {
+   if (_strings.find(str) != _strings.end())
+      return _strings[str];
+
+   char *s = new char[str.length()+1];
+   strcpy(s, str.c_str());
+   _strings[str] = s;
+   return s;
+   }
+
+void
+OMR::JitBuilder::CodeGenerator::printAllMaps()
+   {
+   TextWriter * pLog = _fb->logger(traceEnabled());
+   if (pLog)
+      {
+      TextWriter & log = *pLog;
+
+      log << "[ printAllMaps" << log.endl();
+      log.indentIn();
+
+      log.indent() << "[ Builders" << log.endl();
+      log.indentIn();
+      for (auto builderIt = _builders.cbegin(); builderIt != _builders.cend(); builderIt++)
+         {
+         log.indent() << "[ builder " << builderIt->first << " -> TR::IlBuilder " << (int64_t *)(void *) builderIt->second << " ]" << log.endl();
+         }
+      log.indentOut();
+      log.indent() << "]" << log.endl();
+
+      log.indent() << "[ Values" << log.endl();
+      log.indentIn();
+      for (auto valueIt = _values.cbegin(); valueIt != _values.cend(); valueIt++)
+         {
+         log.indent() << "[ value " << valueIt->first << " -> TR::IlValue " << (int64_t *)(void *) valueIt->second << " ]" << log.endl();
+         }
+      log.indentOut();
+      log.indent() << "]" << log.endl();
+
+      log.indent() << "[ Types" << log.endl();
+      log.indentIn();
+      for (auto typeIt = _types.cbegin(); typeIt != _types.cend(); typeIt++)
+         {
+         log.indent() << "[ type " << typeIt->first << " -> TR::IlType " << (int64_t *)(void *) typeIt->second << " ]" << log.endl();
+         }
+      log.indentOut();
+      log.indent() << "]" << log.endl();
+
+      log.indentOut();
+      log.indent() << "]" << log.endl();
+      }
+   }
+
+void
+OMR::JitBuilder::CodeGenerator::generateFunctionAPI(FunctionBuilder *fb)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->indent() << "CodeGenerator::generateFunctionAPI F" << fb->id() << log->endl();
+
+   TypeDictionary *types = fb->dict();
+   TR::TypeDictionary * typesJB1 = _mb->typeDictionary();
+   _typeDictionaries[types->id()] = typesJB1;
+
+   // First, make sure all base types have mapped TR::IlType's
+   //    in this pass, we skip Pointer types and only define Structs and Unions (without iterating their fields)
+   //    Note that unions are converted to Structs in JitBuilder1 (doesn't use JB1's DefineUnion/UnionField services)
+   storeType(types->NoType,  typesJB1->NoType );
+   storeType(types->Int8,    typesJB1->Int8   );
+   storeType(types->Int16,   typesJB1->Int16  );
+   storeType(types->Int32,   typesJB1->Int32  );
+   storeType(types->Int64,   typesJB1->Int64  );
+   storeType(types->Float,   typesJB1->Float  );
+   storeType(types->Double,  typesJB1->Double );
+   storeType(types->Address, typesJB1->Address);
+   storeType(types->Word,    typesJB1->Word   );
+
+   if (log) log->indent() << "First pass:" << log->endl();
+   for (TypeIterator typeIt = types->TypesBegin(); typeIt != types->TypesEnd(); typeIt++)
+      {
+      Type * type = *typeIt;
+      if (log) log->writeType(type);
+      if (type->isStruct() || type->isUnion())
+         {
+         char *name = findOrCreateString(type->name());
+         storeType(type, _mb->typeDictionary()->DefineStruct(name));
+         }
+      else if (type->isFunction())
+         {
+         // function types all map to Address in JitBuilder 1.0
+         storeType(type, _mb->typeDictionary()->Address);
+         }
+      else if (type->isPointer() || type->isField())
+         {
+         // skip function and pointer types in this pass
+         }
+      else
+         {
+         // should be a primitive type; verify that the type has been mapped already
+         //assert(mapType(type));
+         }
+      }
+
+   // Second pass: map all Pointer types now that anything a Pointer can point to has been mapped
+   for (TypeIterator typeIt = types->TypesBegin(); typeIt != types->TypesEnd(); typeIt++)
+      {
+      Type * type = *typeIt;
+      if (type->isPointer())
+         {
+         TR::IlType *ptrIlType = mapPointerType(typesJB1, static_cast<PointerType *>(type));
+         storeType(type, ptrIlType);
+         }
+      }
+
+   // all basic types should have mappings now. what remains is to define the fields of
+   // structs and unions to JB1 so that fields will be mapped to appropriate offsets
+   // in this process, any inner structs/unions are inlined into containing struct
+
+   // Third pass: revisit all Structs and Unions to iterate over field types to map them
+   for (TypeIterator typeIt = types->TypesBegin(); typeIt != types->TypesEnd(); typeIt++)
+      {
+      Type * type = *typeIt;
+      if (type->isStruct())
+         {
+         StructType *sType = static_cast<StructType *>(type);
+         char * structName = findOrCreateString(sType->name());
+         mapStructFields(typesJB1, sType, structName, std::string(""), 0);
+         _mb->typeDictionary()->CloseStruct(structName, sType->size()/8);
+         }
+      else if (type->isUnion())
+         {
+         UnionType *uType = static_cast<UnionType *>(type);
+         char * structName = findOrCreateString(uType->name());
+         mapStructFields(typesJB1, uType, structName, std::string(""), 0);
+         _mb->typeDictionary()->CloseStruct(structName, uType->size()/8);
+         }
+      }
+
+   // All types should be represented in the JB1 layer now, and mapTypes should be set up for every
+   // type in TypeDictionary
+   for (TypeIterator typeIt = types->TypesBegin(); typeIt != types->TypesEnd(); typeIt++)
+      {
+      Type * type = *typeIt;
+      assert(type->isField() || mapType(type) != NULL);
+      }
+
+   _methodBuilders[fb->id()] = _mb;
+   storeBuilder(fb, _mb);
+
+   _mb->DefineName(findOrCreateString(fb->name()));
+   _mb->DefineFile(findOrCreateString(fb->fileName()));
+   _mb->DefineLine(findOrCreateString(fb->lineNumber()));
+   _mb->DefineReturnType(mapType(fb->getReturnType()));
+
+   for (ParameterSymbolIterator paramIt = fb->ParametersBegin();paramIt != fb->ParametersEnd(); paramIt++)
+      {
+      const ParameterSymbol *parameter = *paramIt;
+      char *paramName = findOrCreateString(parameter->name());
+      _mb->DefineParameter(paramName, mapType(parameter->type()));
+      }
+   for (LocalSymbolIterator localIt = fb->LocalsBegin();localIt != fb->LocalsEnd();localIt++)
+      {
+      const LocalSymbol *symbol = *localIt;
+      char *localName = findOrCreateString(symbol->name());
+      _mb->DefineLocal(localName, mapType(symbol->type()));
+      }
+   for (FunctionSymbolIterator fnIt = fb->FunctionsBegin();fnIt != fb->FunctionsEnd();fnIt++)
+      {
+      const FunctionSymbol *symbol = *fnIt;
+      const FunctionSymbol *fSym = static_cast<const FunctionSymbol *>(symbol);
+      const FunctionType *fType = fSym->functionType();
+      TR::IlType *parmTypes[fType->numParms()];
+      for (int32_t p=0;p < fType->numParms();p++)
+         parmTypes[p] = mapType(fType->parmType(p));
+      _mb->DefineFunction(findOrCreateString(fType->name()),
+                          findOrCreateString(fSym->fileName()),
+                          findOrCreateString(fSym->lineNumber()),
+                          fSym->entryPoint(),
+                          mapType(fType->returnType()),
+                          fType->numParms(),
+                          parmTypes);
+       }
+   }
+
+FunctionBuilder *
+CodeGenerator::transformFunctionBuilder(FunctionBuilder *fb)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->indent() << "CodeGenerator transformFunctionBuilder F" << fb->id() << log->endl();
+   if (log) log->indentIn();
+   return NULL;
+   }
+
+Builder *
+CodeGenerator::transformOperation(Operation * op)
+   {
+   Builder * b = op->parent();
+   TR::IlBuilder *omr_b = mapBuilder(b);
+   omr_b->setBCIndex(op->location()->bcIndex())->SetCurrentIlGenerator();
+   switch (op->action())
+      {
+      case aConstInt8 :
+         storeValue(op->result(), omr_b->ConstInt8(op->literal()->getInt8()));
+         break;
+
+      case aConstInt16 :
+         storeValue(op->result(), omr_b->ConstInt16(op->literal()->getInt16()));
+         break;
+
+      case aConstInt32 :
+         storeValue(op->result(), omr_b->ConstInt32(op->literal()->getInt32()));
+         break;
+
+      case aConstInt64 :
+         storeValue(op->result(), omr_b->ConstInt64(op->literal()->getInt64()));
+         break;
+
+      case aConstFloat :
+         storeValue(op->result(), omr_b->ConstFloat(op->literal()->getFloat()));
+         break;
+
+      case aConstDouble :
+         storeValue(op->result(), omr_b->ConstDouble(op->literal()->getDouble()));
+         break;
+
+      case aConstAddress :
+         {
+         TR::IlValue *rv = omr_b->ConstAddress(op->literal()->getAddress());
+         storeValue(op->result(),rv);
+         }
+         break;
+
+      case aCoercePointer :
+         {
+         TR::IlValue *object = mapValue(op->operand());
+         storeValue(op->result(), mapValue(op->operand()));
+         }
+         break;
+
+      case aAdd :
+         storeValue(op->result(), omr_b->Add(mapValue(op->operand(0)), mapValue(op->operand(1))));
+         break;
+
+      case aSub :
+         storeValue(op->result(), omr_b->Sub(mapValue(op->operand(0)), mapValue(op->operand(1))));
+         break;
+
+      case aMul :
+         storeValue(op->result(), omr_b->Mul(mapValue(op->operand(0)), mapValue(op->operand(1))));
+         break;
+
+      case aLoad :
+         {
+         Symbol *sym = op->symbol();
+         if (sym->isFunction())
+            {
+            FunctionSymbol *fnSym = static_cast<FunctionSymbol *>(sym);
+            storeValue(op->result(), omr_b->ConstAddress(reinterpret_cast<void *>(fnSym->entryPoint())));
+            }
+         else
+            storeValue(op->result(), omr_b->Load(findOrCreateString(sym->name())));
+         }
+         break;
+
+      case aLoadAt :
+         {
+         Value *v = op->operand();
+         TR::IlValue *jb_v = mapValue(v);
+         Type *t = op->type();
+         TR::IlType *jb_t = mapType(op->type());
+         Value *r = op->result();
+         storeValue(r, omr_b->LoadAt(jb_t, jb_v));
+         }
+         break;
+
+      case aLoadIndirect :
+         {
+         LoadIndirect *liOp = static_cast<LoadIndirect *>(op);
+         FieldType *fieldType = liOp->getFieldType();
+         const char *structName = findOrCreateString(fieldType->owningStruct()->name());
+         const char *fieldName = findOrCreateString(fieldType->name());
+         TR::IlValue *object = mapValue(op->operand());
+         assert(object);
+         storeValue(op->result(), omr_b->LoadIndirect(structName, fieldName, mapValue(op->operand())));
+         }
+         break;
+
+      case aStore :
+         omr_b->Store(findOrCreateString(op->symbol()->name()), mapValue(op->operand()));
+         break;
+
+      case aStoreAt :
+         omr_b->StoreAt(mapValue(op->operand(0)), mapValue(op->operand(1)));
+         break;
+
+      case aStoreIndirect :
+         {
+         StoreIndirect *siOp = static_cast<StoreIndirect *>(op);
+         FieldType *fieldType = siOp->getFieldType();
+         const char *structName = findOrCreateString(fieldType->owningStruct()->name());
+         const char *fieldName = findOrCreateString(fieldType->name());
+         TR::IlValue *object = mapValue(op->operand(0));
+         assert(object);
+         TR::IlValue *value = mapValue(op->operand(1));
+         assert(value);
+         omr_b->StoreIndirect(structName, fieldName, object, value);
+         }
+         break;
+
+      case aIndexAt :
+         storeValue(op->result(), omr_b->IndexAt(mapType(op->type()), mapValue(op->operand(0)), mapValue(op->operand(1))));
+         break;
+
+      case aCall :
+         {
+         Call *callOp = static_cast<Call *>(op);
+         FunctionType *fType = static_cast<FunctionType *>(callOp->function()->type());
+         TR::IlValue *args[op->numOperands()];
+         args[0] = mapValue(callOp->function());
+         for (int32_t a=1;a < op->numOperands();a++)
+            args[a] = mapValue(callOp->operand(a));
+
+         if (op->result() != NULL)
+            storeValue(op->result(), omr_b->ComputedCall(fType->name().c_str(), callOp->numOperands(), args));
+         else
+            omr_b->ComputedCall(fType->name().c_str(), callOp->numOperands(), args);
+         }
+         break;
+
+      case aAppendBuilder :
+         omr_b->AppendBuilder(mapBuilder(op->builder()));
+         break;
+
+      case aGoto :
+         omr_b->Goto(mapBuilder(op->builder()));
+         break;
+
+      case aReturn :
+         if (op->numOperands() > 0)
+            omr_b->Return(mapValue(op->operand()));
+         else
+            omr_b->Return();
+         break;
+
+      case aIfCmpGreaterThan :
+         omr_b->IfCmpGreaterThan(mapBuilder(op->builder()), mapValue(op->operand(0)), mapValue(op->operand(1)));
+         break;
+
+      case aIfCmpLessThan :
+         omr_b->IfCmpLessThan(mapBuilder(op->builder()), mapValue(op->operand(0)), mapValue(op->operand(1)));
+         break;
+
+      case aIfCmpGreaterOrEqual :
+         omr_b->IfCmpGreaterOrEqual(mapBuilder(op->builder()), mapValue(op->operand(0)), mapValue(op->operand(1)));
+         break;
+
+      case aIfCmpLessOrEqual :
+         omr_b->IfCmpLessOrEqual(mapBuilder(op->builder()), mapValue(op->operand(0)), mapValue(op->operand(1)));
+         break;
+
+      case aIfThenElse :
+         {
+         TR::IlBuilder *omr_thenB = mapBuilder(op->builder(0));
+         TR::IlBuilder *omr_elseB = mapBuilder(op->builder(1));
+         omr_b->IfThenElse(&omr_thenB, &omr_elseB, mapValue(op->operand()));
+         break;
+         }
+
+      case aForLoop :
+         {
+         TR::IlBuilder *omr_body = mapBuilder(op->builder(0));
+         TR::IlBuilder *omr_break = mapBuilder(op->builder(1));
+         TR::IlBuilder *omr_continue = mapBuilder(op->builder(2));
+         omr_b->ForLoop(static_cast<bool>(op->literal()->getInt8()),
+                        findOrCreateString(op->symbol()->name()),
+                        &omr_body,
+                        &omr_break,
+                        &omr_continue,
+                        mapValue(op->operand(0)),
+                        mapValue(op->operand(1)),
+                        mapValue(op->operand(2)));
+         break;
+         }
+
+      case aSwitch :
+         {
+         TR::IlBuilder::JBCase *cases[op->numCases()];
+         int32_t cNum = 0;
+         for (auto cIt = op->CasesBegin(); cIt != op->CasesEnd(); cIt++)
+            cases[cNum++] = MAP_CASE(omr_b, *cIt);
+         TR::IlBuilder *omr_defaultTarget = mapBuilder(op->builder());
+         omr_b->Switch(mapValue(op->operand()), &omr_defaultTarget, op->numCases(), cases);
+         break;
+         }
+
+      case aCreateLocalArray :
+         storeValue(op->result(), omr_b->CreateLocalArray(op->literal(0)->getInt32(), mapType(op->type())));
+         break;
+
+      case aCreateLocalStruct :
+         storeValue(op->result(), omr_b->CreateLocalStruct(mapType(op->type())));
+         break;
+
+      default :
+         assert(0); // unhandled action!!
+         break;
+      }
+
+   return NULL;
+   }
+
+FunctionBuilder *
+OMR::JitBuilder::CodeGenerator::transformFunctionBuilderAtEnd(FunctionBuilder * fb)
+   {
+   TextWriter *log = fb->logger(traceEnabled());
+   if (log) log->indentOut();
+   printAllMaps();
+   return NULL;
+   }

--- a/jitbuilder/jbil/CodeGenerator.hpp
+++ b/jitbuilder/jbil/CodeGenerator.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CODEGENERATOR_INCL
+#define CODEGENERATOR_INCL
+
+#include <map>
+#include <string>
+#include "Transformer.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+namespace TR { class MethodBuilder; }
+namespace TR { class TypeDictionary; }
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class FunctionBuilder;
+class Operation;
+class PointerType;
+class StructType;
+class Type;
+class Value;
+
+class CodeGenerator : public Transformer
+   {
+public:
+   CodeGenerator(FunctionBuilder * fb, TR::MethodBuilder * mb);
+
+   TR::MethodBuilder *mb()    { return _mb; }
+   void * entryPoint() const  { return _entryPoint; }
+   int32_t returnCode() const { return _compileReturnCode; }
+
+   void generateFunctionAPI(FunctionBuilder *fb);
+
+protected:
+   virtual FunctionBuilder * transformFunctionBuilder(FunctionBuilder * fb);
+   virtual Builder * transformOperation(Operation *op);
+   virtual FunctionBuilder * transformFunctionBuilderAtEnd(FunctionBuilder * fb);
+
+   TR::IlBuilder *mapBuilder(Builder * b);
+   void storeBuilder(Builder * b, TR::IlBuilder *omr_b);
+   TR::IlType *mapPointerType(TR::TypeDictionary * types, PointerType * t);
+   TR::IlType *mapStructFields(TR::TypeDictionary * types, StructType * sType, char * structName, std::string fNamePrefix, size_t baseOffset);
+   TR::IlType *mapType(Type * t);
+   void storeType(Type * t, TR::IlType *omr_t);
+   TR::IlValue *mapValue(Value * v);
+   void storeValue(Value * v, TR::IlValue *omr_v);
+   void *mapCase(TR::IlBuilder *omr_b, Case * c); // void * so we don't have to include IlBuilder.hpp in this header
+
+   char * findOrCreateString(std::string str);
+
+   void printAllMaps();
+
+   std::map<uint64_t,TR::IlBuilder *> _builders;
+   std::map<uint64_t,void *> _cases; // void * so we don't need to include IlBuilder.hpp in this header
+   std::map<uint64_t,TR::IlType *> _types;
+   std::map<uint64_t,TR::IlValue *> _values;
+   std::map<uint64_t,TR::MethodBuilder *> _methodBuilders;
+   std::map<uint64_t,TR::TypeDictionary *> _typeDictionaries;
+   std::map<std::string,char *> _strings;
+
+   TR::MethodBuilder *_mb;
+   void *  _entryPoint;
+   int32_t _compileReturnCode;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(CODEGENERATOR_INCL)

--- a/jitbuilder/jbil/ComplexMatMult.cpp
+++ b/jitbuilder/jbil/ComplexMatMult.cpp
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string>
+#include "complex.hpp"
+
+#include "JitBuilder.hpp"
+#include "ComplexMatMult.hpp"
+#include "ComplexSupport.hpp"
+
+using namespace OMR::JitBuilder;
+
+ComplexMatMult::ComplexMatMult(TypeDictionary * types)
+   : FunctionBuilder(types)
+   , pComplex(types->PointerTo(Complex))
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("complexmatmult");
+
+   // C = A * B, all NxN matrices
+   DefineParameter("C", pComplex);
+   DefineParameter("A", pComplex);
+   DefineParameter("B", pComplex);
+   DefineParameter("N", Int64);
+
+   DefineReturnType(NoType);
+
+   DefineLocal("sum", Complex);
+   }
+
+
+void
+ComplexMatMult::Store2D(Builder *bldr,
+                        Value *base,
+                        Value *first,
+                        Value *second,
+                        Value *N,
+                        Value *value)
+   {
+   bldr->StoreAt(
+   bldr->   IndexAt(pComplex,
+               base,
+   bldr->      Add(
+   bldr->         Mul(
+                    first,
+                    N),
+                 second)),
+            value);
+   }
+
+Value *
+ComplexMatMult::Load2D(Builder *bldr,
+                       Value *base,
+                       Value *first,
+                       Value *second,
+                       Value *N)
+   {
+   return
+      bldr->LoadAt(pComplex,
+      bldr->   IndexAt(pComplex,
+                  base,
+      bldr->      Add(
+      bldr->         Mul(
+                       first,
+                       N),
+                     second)));
+   }
+
+bool
+ComplexMatMult::buildIL()
+   {
+   Value *A = Load("A");
+   Value *B = Load("B");
+   Value *C = Load("C");
+   Value *N = Load("N");
+   Value *zero = ConstInt64(0);
+   Value *one = ConstInt64(1);
+
+   Builder *iloop=OrphanBuilder();
+   ForLoopUp("i", iloop, zero, N, one);
+      {
+      Value *i = iloop->Load("i");
+
+      Builder *jloop = iloop->OrphanBuilder();
+      iloop->ForLoopUp("j", jloop, zero, N, one);
+         {
+         Value *j = jloop->Load("j");
+
+         complex<double> complexZero(0.0, 0.0);
+         jloop->Store("sum",
+         jloop->   Append(ConstComplexBuilder, LiteralValue::create(dict(), Complex, &complexZero)));
+
+         Builder *kloop = jloop->OrphanBuilder();
+         jloop->ForLoopUp("k", kloop, zero, N, one);
+            {
+            Value *k = kloop->Load("k");
+
+            Value *A_ik = Load2D(kloop, A, i, k, N);
+            Value *B_kj = Load2D(kloop, B, k, j, N);
+            kloop->Store("sum",
+            kloop->   Add(
+            kloop->      Load("sum"),
+            kloop->      Mul(A_ik, B_kj)));
+            }
+
+         Store2D(jloop, C, i, j, N, jloop->Load("sum"));
+         }
+      }
+
+   Return();
+
+   return true;
+   }
+
+
+void
+printMatrix(complex<double> *M, int64_t N, const char *name)
+   {
+   printf("%s = [\n", name);
+   for (int64_t i=0;i < N;i++)
+      {
+      printf("      [ (%lf,%lf)", M[i*N].real, M[i*N].imag);
+      for (int64_t j=1;j < N;j++)
+          printf(", (%lf,%lf)", M[i * N + j].real, M[i * N + j].imag);
+      printf(" ],\n");
+      }
+   printf("    ]\n\n");
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define matrices\n");
+   const int64_t N=4;
+   complex<double> A[N*N];
+   complex<double> B[N*N];
+   complex<double> C[N*N];
+   complex<double> D[N*N];
+   for (int64_t i=0;i < N;i++)
+      {
+      for (int64_t j=0;j < N;j++)
+         {
+         A[i*N+j] = complex<double>(1.0,0.0);
+         B[i*N+j] = complex<double>((double)i,(double)j);
+         C[i*N+j] = complex<double>(0.0,0.0);
+         D[i*N+j] = complex<double>(0.0,0.0);
+         }
+      }
+   printMatrix(A, N, "A");
+   printMatrix(B, N, "B");
+
+   printf("Step 3: define type dictionaries\n");
+   TypeDictionary types("ComplexMatMultTypes");
+   initializeComplexSupport(&types);
+   assert(Complex != NULL);
+   assert(ConstComplexBuilder != NULL);
+
+   printf("Step 4: construct MatMult method builder\n");
+   ComplexMatMult method(&types);
+
+   Transformer *typeReplacer = (new TypeReplacer(&method))
+                           //->setTraceEnabled()
+                           ->explode(Complex);
+
+   std::cerr.setf(std::ios_base::skipws);
+   TextWriter printer(&method, std::cout, std::string("    "));
+   method.setLogger(&printer);
+   method.config()//->setReportMemory()
+                  //->setTraceBuildIL()
+                  //->setTraceReducer()
+                  //->setTraceCodeGenerator()
+                  ->setTypeReplacer(typeReplacer);
+
+   bool success = constructFunctionBuilder(&method);
+   if (!success)
+      {
+      fprintf(stderr,"FAIL: construction error\n");
+      exit(-2);
+      }
+   fprintf(stderr, "Builder successfully constructed!\n");
+
+   printer.print();
+
+   int32_t rc=0;
+#if 1
+   ComplexMatMultFunctionType *dbgTest = method.DebugEntry<ComplexMatMultFunctionType>(&rc);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: debug entry construction error: %d\n", rc);
+      exit(-2);
+      }
+   dbgTest(C, A, B, N);
+   printf("Matrix Multiply operands:\n");
+   printMatrix(A, N, "A");
+   printMatrix(B, N, "B");
+   printf("Result after debugging is:\n");
+   printMatrix(C, N, "C");
+   exit(0);
+#endif
+
+#if 0
+   printf("Print function builder before reduction to jbil_ll dialect\n");
+   printer.print();
+
+   printf("Step 5: reduce method builder to jbil_ll dialect\n");
+   //typeReplacer.transform();
+
+   printf("Print function builder after reduction to jbil_ll dialect\n");
+   printer.print();
+
+   printf("Step 6: inline AppendBuilders\n");
+   AppendBuilderInliner inliner(&method);
+   inliner.transform();
+
+   printf("After inlining orphan AppendBuilder\n");
+   printer.print();
+#endif
+
+   printf("Step n: explode Complex type\n");
+
+   printer.print();
+   typeReplacer->transform();
+   printer.print();
+
+   printf("Step 7: compile MatMult jbil\n");
+   void *entry = NULL;
+   rc = compileFunctionBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation failed %d\n", rc);
+      exit(rc);
+      }
+
+   printf("Step 8: invoke MatMult compiled code\n");
+   ComplexMatMultFunctionType *test = (ComplexMatMultFunctionType *)entry;
+   test(C, A, B, N);
+
+   printMatrix(A, N, "A");
+   printMatrix(B, N, "B");
+   printMatrix(C, N, "C");
+
+   printf ("Step 9: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/jbil/ComplexMatMult.hpp
+++ b/jitbuilder/jbil/ComplexMatMult.hpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef COMPLEXMATMULT_INCL
+#define COMPLEXMATMULT_INCL
+
+#include "complex.hpp"
+#include "JitBuilder.hpp"
+
+typedef void (ComplexMatMultFunctionType)(complex<double> *, complex<double> *, complex<double> *, int64_t);
+
+class ComplexMatMult : public OMR::JitBuilder::FunctionBuilder
+   {
+   private:
+   OMR::JitBuilder::Type *pComplex;
+
+   void Store2D(OMR::JitBuilder::Builder *bldr,
+                OMR::JitBuilder::Value *base,
+                OMR::JitBuilder::Value *first,
+                OMR::JitBuilder::Value *second,
+                OMR::JitBuilder::Value *N,
+                OMR::JitBuilder::Value *value);
+   OMR::JitBuilder::Value *Load2D(OMR::JitBuilder::Builder *bldr,
+                                  OMR::JitBuilder::Value *base,
+                                  OMR::JitBuilder::Value *first,
+                                  OMR::JitBuilder::Value *second,
+                                  OMR::JitBuilder::Value *N);
+
+   public:
+   ComplexMatMult(OMR::JitBuilder::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(COMPLEXMATMULT_INCL)

--- a/jitbuilder/jbil/ComplexSupport.cpp
+++ b/jitbuilder/jbil/ComplexSupport.cpp
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <assert.h>
+#include "complex.hpp"
+#include "ComplexSupport.hpp"
+#include "DynamicType.hpp"
+#include "DynamicOperation.hpp"
+#include "LiteralValue.hpp"
+#include "Mapper.hpp"
+#include "Operation.hpp"
+#include "OperationReplacer.hpp"
+#include "TextWriter.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+#include "TypeReplacer.hpp"
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+DynamicType *Complex = NULL;
+OperationBuilder *ConstComplexBuilder = NULL;
+OperationBuilder *ConjugateBuilder = NULL;
+
+static void
+ComplexPrinter(TextWriter *w, const Type *t, void *p)
+   {
+   assert(t == Complex);
+   complex<double> *pd = reinterpret_cast<complex<double> *>(p);
+   (*w) << pd->real << "+i" << pd->imag;
+   }
+
+static LiteralMapper *
+ComplexTypeExploder(TypeDictionary *dict, LiteralValue *value, LiteralMapper *m)
+   {
+   assert(value->kind() == T_dynamic && value->type() == Complex);
+   complex<double> lv = *(reinterpret_cast<complex<double> *>(value->getDynamicTypeValue()));
+
+   if (!m)
+      m = new LiteralMapper;
+   // if m was passed in, assume it was already cleared
+
+   m->add(LiteralValue::create(dict, lv.real));
+   m->add(LiteralValue::create(dict, lv.imag));
+ 
+   return m; // ownership of memory, if allocated here, passes to caller
+   }
+
+static bool
+ComplexTypeReplacer(OperationReplacer *replacer)
+   {
+   Operation *op = replacer->operation();
+   if (op->action() == aMul)
+      {
+      Value *left = op->operand(0);
+      Value *right = op->operand(1);
+      if (left->type() == Complex && right->type() == Complex)
+         {
+         Builder *b = replacer->builder();
+         ValueMapper *leftMapper = replacer->operandMapper(0);
+         ValueMapper *rightMapper = replacer->operandMapper(1);
+
+         // cross multiply the elements and add corresponding real, imag parts
+         Value * l_imag = leftMapper->next();
+         Value * l_real = leftMapper->next();
+         Value * r_imag = rightMapper->next();
+         Value * r_real = rightMapper->next();
+
+         Value *res_real = b->Sub( b->Mul(l_real, r_real), b->Mul(l_imag, r_imag) );
+         Value *res_imag = b->Add( b->Mul(l_real, r_imag), b->Mul(l_imag, r_real) );
+
+         ValueMapper *resultMapper = replacer->resultMapper();
+         resultMapper->add(res_imag);
+         resultMapper->add(res_real);
+
+         return true;
+         }
+      }
+
+   return false;
+   }
+
+static void
+ComplexTypeRegistrar(DynamicType *Complex, TypeDictionary *dict, TypeGraph *graph)
+   {
+   Type *NoType = dict->NoType;
+   Type *Double = dict->Double;
+
+   graph->registerValidOperation(Complex, aAdd, Complex, Complex);
+   graph->registerValidOperation(Complex, aAdd, Complex, Double);
+   graph->registerValidOperation(Complex, aAdd, Double, Complex);
+   graph->registerValidOperation(Complex, aSub, Complex, Complex);
+   graph->registerValidOperation(Complex, aSub, Double, Complex);
+   graph->registerValidOperation(Complex, aSub, Complex, Double);
+   graph->registerValidOperation(Complex, aMul, Complex, Complex);
+   graph->registerValidOperation(Complex, aMul, Double, Complex);
+   graph->registerValidOperation(Complex, aMul, Complex, Double);
+   #if 0 // not needed in ComplexMatMult, haven't been tested
+   // probably need a Sqrt operation before we can implement some of these
+   graph->registerValidOperation(NoType, aIfCmpGreaterThan,    Complex, Complex);
+   graph->registerValidOperation(NoType, aIfCmpLessThan,       Complex, Complex  );
+   graph->registerValidOperation(NoType, aIfCmpGreaterOrEqual, Complex, Complex  );
+   graph->registerValidOperation(NoType, aIfCmpLessOrEqual,    Complex, Complex  );
+   graph->registerValidOperation(NoType, aForLoop, Complex, Complex, Complex);
+   graph->registerValidOperation(NoType, aReturn, Complex);
+   #endif
+   }
+
+static bool
+ConstComplexExpander(OperationReplacer *replacer)
+   {
+   assert(ConstComplexBuilder);
+   Operation *op = replacer->operation();
+   assert(op->action() == ConstComplexBuilder->action());
+   Builder *b = replacer->builder();
+   LiteralMapper *lm = replacer->literalMapper();
+   ValueMapper *resultMapper = replacer->resultMapper();
+
+   if (lm->current()->type() == b->fb()->dict()->Double)
+      {
+      resultMapper->add( b->ConstDouble(lm->next()->getDouble()) );
+      resultMapper->add( b->ConstDouble(lm->next()->getDouble()) );
+      return true;
+      }
+
+   return false;
+   }
+
+static void
+ConstComplexPrinter(TextWriter *w, Operation *op)
+   {
+   assert(ConstComplexBuilder);
+   assert(op->action() == ConstComplexBuilder->action());
+   (*w) << op->result() << " = ConstComplex " << op->literal() << w->endl();
+   }
+
+static bool
+ConjugateExpander(OperationReplacer *replacer)
+   {
+   assert(ConjugateBuilder);
+   Operation *op = replacer->operation();
+   assert(op->action() == ConjugateBuilder->action());
+   auto explodedTypes = replacer->explodedTypes();
+   if (explodedTypes->find(Complex) != explodedTypes->end())
+      {
+      Builder *b = replacer->builder();
+      ValueMapper *m = replacer->operandMapper();
+      ValueMapper *resultMapper = replacer->resultMapper();
+
+      Value *v_imag = m->next();
+      Value *v_real = m->next();
+
+      resultMapper->add(b->Sub(b->ConstDouble(0.0), v_imag));
+      resultMapper->add(v_real);
+
+      return true;
+      }
+
+   return false;
+   }
+
+static void
+ConjugatePrinter(TextWriter *w, Operation *op)
+   {
+   assert(ConjugateBuilder);
+   assert(op->action() == ConjugateBuilder->action());
+   (*w) << op->result() << " = Conjugate " << op->operand();
+   }
+
+static void
+ConjugateRegistrar(TypeDictionary *dict, TypeGraph *graph)
+   {
+   graph->registerValidOperation(Complex, ConjugateBuilder->action(), Complex);
+   }
+
+void initializeComplexSupport(TypeDictionary *dict)
+   {
+   const size_t size = sizeof(complex<double>) * 8;
+   StructType *layout = dict->DefineStruct("Complex::layout", size);
+   LiteralValue *realName = LiteralValue::create(dict, std::string("real"));
+   dict->DefineField(layout, realName, dict->Double, 8*offsetof(complex<double>, real));
+   LiteralValue *imagName = LiteralValue::create(dict, std::string("imag"));
+   dict->DefineField(layout, imagName, dict->Double, 8*offsetof(complex<double>, imag));
+   dict->CloseStruct(layout);
+   Complex = DynamicType::create(dict, "Complex", size, ComplexPrinter, layout, ComplexTypeExploder, ComplexTypeReplacer, ComplexTypeRegistrar);
+
+   assert(ConstComplexBuilder == NULL);
+   ConstComplexBuilder = new OperationBuilder();
+   ConstComplexBuilder->newAction("ConstComplex")
+                      ->setNumResults(1)
+                      ->addResultType(Complex)
+                      ->setNumLiterals(1)
+                      ->setExpander(ConstComplexExpander)
+                      ->setPrinter(ConstComplexPrinter);
+                      // no registrar needed, though LiteralValues should really be considered...
+
+   assert(ConjugateBuilder == NULL);
+   ConjugateBuilder = new OperationBuilder();
+   ConjugateBuilder->newAction("Conjugate")
+                   ->setNumResults(1)
+                   ->addResultType(Complex)
+                   ->setNumOperands(1)
+                   ->setExpander(ConjugateExpander)
+                   ->setPrinter(ConjugatePrinter)
+                   ->setRegistrar(ConjugateRegistrar);
+   }
+
+} // namespace JitBuilder
+
+} // namespace OMR

--- a/jitbuilder/jbil/ComplexSupport.hpp
+++ b/jitbuilder/jbil/ComplexSupport.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef COMPLEXSUPPORT_INCL
+#define COMPLEXSUPPORT_INCL
+
+
+#include "complex.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class DynamicType;
+class LiteralValue;
+class OperationBuilder;
+class TypeDictionary;
+
+extern DynamicType *Complex;
+extern OperationBuilder *ConstComplexBuilder;
+extern OperationBuilder *ConjugateBuilder;
+
+extern void initializeComplexSupport(TypeDictionary *dict);
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // !defined(COMPLEXSUPPORT_INCL)

--- a/jitbuilder/jbil/Config.hpp
+++ b/jitbuilder/jbil/Config.hpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CONFIG_INCL
+#define CONFIG_INCL
+
+#include <string>
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+class Transformer;
+
+class Config
+   {
+   public:
+   Config()
+      : _reportMemory(false)
+      , _traceBuildIL(false)
+      , _traceCodeGenerator(false)
+      , _traceReducer(false)
+      , _lastTransformationIndex(-1) // no limit
+      , _logRegex("")
+      , _reducer(NULL)
+      { }
+
+   // when true, FunctionBuilder will report memory usage and check everything was freed
+   bool reportMemory() const                      { return _reportMemory; }
+   Config * setReportMemory(bool v=true)          { _reportMemory = v; return this; }
+
+   // when true, turn logging on when buildIL() is called
+   bool traceBuildIL() const                      { return _traceBuildIL; }
+   Config * setTraceBuildIL(bool v=true)          { _traceBuildIL = v; return this; }
+
+   // when true, turn logging on when CodeGenerator runs
+   bool traceCodeGenerator() const                { return _traceCodeGenerator; }
+   Config * setTraceCodeGenerator(bool v=true)    { _traceCodeGenerator = v; return this; }
+
+   // when true, turn logging on when CodeGenerator runs
+   bool traceTypeReplacer() const                 { return _traceTypeReplacer; }
+   Config * setTraceTypeReplacer(bool v=true)     { _traceTypeReplacer = v; return this; }
+
+   // when true, turn logging on when DialectReducer runs
+   bool traceReducer() const                      { return _traceReducer; }
+   Config * setTraceReducer(bool v=true)          { _traceReducer = v; return this; }
+
+   // if >= 0, identifies the last transformation to apply
+   bool limitLastTransformationIndex() const      { return _lastTransformationIndex >= 0; }
+   int64_t lastTransformationIndex() const        { return _lastTransformationIndex; }
+   Config * setLastTransformationIndex(int64_t v) { _lastTransformationIndex = v; return this; }
+
+   // when true, logging should be enabled
+   bool logFunctionBuilder(FunctionBuilder * fb) const { return false; } // TODO: match fb->name against _logRegex
+   Config * setMethodLogRegex(std::string regex)  { _logRegex = regex; return this; }
+
+   // if set, the reducer will be applied automatically before code generation
+   // should really be handled as part of an optimization sequence
+   bool hasReducer() const { return _reducer != NULL; }
+   Transformer *reducer() const { return _reducer; }
+   Config * setTypeReplacer(Transformer *r) { _reducer = r; return this; }
+
+   protected:
+   bool _reportMemory;
+   bool _traceBuildIL;
+   bool _traceCodeGenerator;
+   bool _traceReducer;
+   bool _traceTypeReplacer;
+
+   int64_t _lastTransformationIndex;
+
+   std::string _logRegex;
+
+   Transformer * _reducer;
+   };
+
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // defined(CONFIG_INCL)

--- a/jitbuilder/jbil/Debugger.cpp
+++ b/jitbuilder/jbil/Debugger.cpp
@@ -1,0 +1,1523 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <cstring>
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
+#include "FunctionBuilder.hpp"
+#include "Debugger.hpp"
+#include "OperationCloner.hpp"
+#include "Symbol.hpp"
+#include "Type.hpp"
+#include "TypeReplacer.hpp"
+#include "Value.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+
+// Support for debugging at JBIL level
+
+// DebugValue is used to record concrete values and locals computed by the debugged functions
+// The possible values that can be stored here are determined at runtime per FunctionBuilder based
+// on the variety of Types that are manipulated by the FunctionBuilder. This type as defined is just
+// a prefix for the actual type: the payload of the type is determined dynamically per FunctionBuilder.
+// Allocating and indexing into arrays of debug values will use the size of the DebugDictionary's
+// _DebugValue type which takes into account all these Types. Because it's a union, the address of
+// the _firstValueData field is used as the offset where any debug value is stored, regardless of its
+// Type.
+class DebugValue
+   {
+public:
+   Type *_type;
+   // conceptually followed by:
+   // union {
+   //   one field per type defined in the FunctionBuilder's dictionary
+   // };
+
+   // dummy field: not used by anything
+   uintptr_t _firstValueData;
+   // to allocate space for a DebugValue, you have to ask a specific FunctionBuilder's DebugDictionary for the size of its _DebugValue type
+   // Note that different FunctionBuilders have different corresponding _DebugValue types.
+   };
+
+class FunctionDebugInfo;
+
+// This structure represents the Debugger state for each activation on a thread stack.
+// Because the generated code accesses fields of this struct, we consciously use a
+// 'struct' rather than a class and it should never contain any virtual functions or
+// be subclassed..
+struct DebuggerFrame
+   {
+   FunctionDebugInfo * _info;
+   Debugger *_debugger;
+   DebugValue *_locals; // array of values, but size of each determined by _DebugValue->size()
+   DebugValue *_values; // array of values, but size of each determined by _DebugValue->size()
+   DebugValue *_returnValues; // array of values, but size of each determined by _DebugValule->size()
+   Builder * _fromBuilder;
+   bool      _returning;
+   Builder * _builderToDebug;
+
+   std::map<uint64_t, OperationIterator> _builderReentryPoints;
+   std::list<struct Breakpoint *> _breakpoints;
+
+   DebugValue *getValueInArray(uint8_t *p, uint64_t idx);
+   DebugValue *getValue(uint64_t idx);
+   DebugValue *getLocal(uint64_t idx);
+   };
+
+class DebugDictionary : public TypeDictionary
+   {
+   public:
+   DebugDictionary(FunctionBuilder *fbToDebug);
+   DebugDictionary(FunctionBuilder *fbToDebug, DebugDictionary *baseDict);
+
+   StructType *_DebugValue;
+   PointerType *_pDebugValue;
+   FieldType *_DebugValue_type;
+   std::map<Type *, FieldType *> _DebugValue_fields;
+
+   StructType *_DebugFrame;
+   PointerType *_pDebugFrame;
+   FieldType *_DebugFrame_info;
+   FieldType *_DebugFrame_debugger;
+   FieldType *_DebugFrame_locals;
+   FieldType *_DebugFrame_values;
+   FieldType *_DebugFrame_returnValues;
+   FieldType *_DebugFrame_fromBuilder;
+   FieldType *_DebugFrame_returning;
+   FieldType *_DebugFrame_builderToDebug;
+
+   protected:
+   void createTypes(FunctionBuilder *fbToDbug);
+   void initTypes(DebugDictionary *baseDict);
+   };
+
+class DebuggerFunctionBuilder : public FunctionBuilder
+   {
+   public:
+
+   DebuggerFunctionBuilder(Debugger *dbgr, FunctionBuilder *fbToDebug);
+   DebuggerFunctionBuilder(Debugger *dbgr, FunctionBuilder *fbToDebug, DebugDictionary *types);
+
+   protected:
+   DebugDictionary *dbgDict() { return static_cast<DebugDictionary *>(_types); }
+
+   void initialize(DebugDictionary *types);
+
+   void storeValue(Builder *b, Symbol *local, Value *value);
+   void storeValue(Builder *b, Value *debugvalue, Value *value);
+   void storeReturnValue(Builder *b, int32_t resultIdx, Value *value);
+   Value *loadValue(Builder *b, Symbol *local);
+   Value *loadValue(Builder *b, Value *value);
+   void storeToDebugValue(Builder *b, Value *debugValue, Value *value);
+   Value *loadFromDebugValue(Builder *b, Value *debugValue, Type *type);
+
+   FieldType *lookupTypeField(Type *type);
+
+   void transferToBoundBuilder(Builder *b, Builder *bound);
+   void transferToUnboundBuilder(Builder *b, Builder *target);
+
+   Debugger *_debugger;
+   StructType *_DebugValue;
+   PointerType *_pDebugValue;
+   FieldType *_DebugValue_type;
+   std::map<Type *, FieldType *> *_DebugValue_fields;
+
+   StructType *_DebugFrame;
+   PointerType *_pDebugFrame;
+   FieldType *_DebugFrame_info;
+   FieldType *_DebugFrame_debugger;
+   FieldType *_DebugFrame_locals;
+   FieldType *_DebugFrame_values;
+   FieldType *_DebugFrame_returnValues;
+   FieldType *_DebugFrame_fromBuilder;
+   FieldType *_DebugFrame_returning;
+   FieldType *_DebugFrame_builderToDebug;
+   };
+
+DebuggerFunctionBuilder::DebuggerFunctionBuilder(Debugger *dbgr, FunctionBuilder *fbToDebug)
+   : FunctionBuilder(new DebugDictionary(fbToDebug, dbgr->getDictionary(fbToDebug)))
+   , _debugger(dbgr)
+   {
+   initialize(dbgDict());
+   _config = *(fbToDebug->config());
+   }
+
+DebuggerFunctionBuilder::DebuggerFunctionBuilder(Debugger *dbgr, FunctionBuilder *fbToDebug, DebugDictionary *types)
+   : FunctionBuilder(types)
+   , _debugger(dbgr)
+   {
+   initialize(types);
+   _config = *fbToDebug->config();
+   }
+
+void
+DebuggerFunctionBuilder::initialize(DebugDictionary *types)
+   {
+   _DebugValue = types->_DebugValue;
+   _pDebugValue = types->_pDebugValue;
+   _DebugValue_type = types->_DebugValue_type;
+   _DebugValue_fields = &types->_DebugValue_fields;
+
+   _DebugFrame = types->_DebugFrame;
+   _pDebugFrame = types->_pDebugFrame;
+   _DebugFrame_info = types->_DebugFrame_info;
+   _DebugFrame_debugger = types->_DebugFrame_debugger;
+   _DebugFrame_locals = types->_DebugFrame_locals;
+   _DebugFrame_values = types->_DebugFrame_values;
+   _DebugFrame_returnValues = types->_DebugFrame_returnValues;
+   _DebugFrame_fromBuilder = types->_DebugFrame_fromBuilder;
+   _DebugFrame_returning = types->_DebugFrame_returning;
+   _DebugFrame_builderToDebug = types->_DebugFrame_builderToDebug;
+   }
+
+void
+DebuggerFunctionBuilder::storeValue(Builder *b, Symbol *local, Value *value)
+   {
+   storeToDebugValue(b, b->IndexAt(_pDebugValue, b->Load("locals"), b->ConstInt64(_debugger->index(local))), value);
+   }
+
+void
+DebuggerFunctionBuilder::storeValue(Builder *b, Value *destValue, Value *value)
+   {
+   storeToDebugValue(b, b->IndexAt(_pDebugValue, b->Load("values"), b->ConstInt64(_debugger->index(destValue))), value);
+   }
+
+void
+DebuggerFunctionBuilder::storeReturnValue(Builder *b, int32_t resultIdx, Value *value)
+   {
+   storeToDebugValue(b, b->IndexAt(_pDebugValue, b->LoadIndirect(_DebugFrame_returnValues, b->Load("frame")), b->ConstInt64(resultIdx)), value);
+   }
+
+Value *
+DebuggerFunctionBuilder::loadValue(Builder *b, Symbol *local)
+   {
+   return loadFromDebugValue(b, b->IndexAt(_pDebugValue, b->Load("locals"), b->ConstInt64(_debugger->index(local))), local->type());
+   }
+
+Value *
+DebuggerFunctionBuilder::loadValue(Builder *b, Value *value)
+   {
+   return loadFromDebugValue(b, b->IndexAt(_pDebugValue, b->Load("values"), b->ConstInt64(_debugger->index(value))), value->type());
+   }
+
+FieldType *
+DebuggerFunctionBuilder::lookupTypeField(Type *type)
+   {
+   auto it = _DebugValue_fields->find(type);
+   assert(it != _DebugValue_fields->end());
+   FieldType *typeField = it->second;
+   return typeField;
+   }
+
+void
+DebuggerFunctionBuilder::storeToDebugValue(Builder *b, Value *debugValue, Value *value)
+   {
+   Type *type = value->type();
+   b->StoreIndirect(_DebugValue_type, debugValue, b->ConstInt64((int64_t)type));
+   b->StoreIndirect(lookupTypeField(type), debugValue, value);
+   }
+
+Value *
+DebuggerFunctionBuilder::loadFromDebugValue(Builder *b, Value *debugValueBase, Type *type)
+   {
+   assert(debugValueBase->type() == _pDebugValue);
+   return b->LoadIndirect(lookupTypeField(type), debugValueBase);
+   }
+
+DebugDictionary::DebugDictionary(FunctionBuilder *fbToDebug)
+   : TypeDictionary(fbToDebug->dict()->name() + "_DBG", fbToDebug->dict())
+   {
+   createTypes(fbToDebug);
+   }
+
+DebugDictionary::DebugDictionary(FunctionBuilder *fbToDebug, DebugDictionary *baseDict)
+   : TypeDictionary(fbToDebug->dict()->name() + "_DBG", baseDict)
+   {
+   //createTypes(fbToDebug);
+   initTypes(baseDict);
+   }
+
+void
+DebugDictionary::createTypes(FunctionBuilder *fbToDebug)
+   {
+   TypeDictionary *tdToDebug = fbToDebug->dict();
+   size_t sizeDebugValue = 0;
+   for (auto typeIt = tdToDebug->TypesBegin(); typeIt != tdToDebug->TypesEnd(); typeIt++)
+      {
+      Type *type = *typeIt;
+      size_t size = type->size();
+      if (sizeDebugValue < size)
+         sizeDebugValue = size;
+      }
+   sizeDebugValue = sizeof(DebugValue) - sizeof(uintptr_t) + sizeDebugValue / 8;
+
+   _DebugValue = DefineStruct("DebugValue", sizeDebugValue);
+   _DebugValue_type = DefineField(_DebugValue, LiteralValue::create(this, "_type"),  Int64, 8*offsetof(DebugValue, _type));
+   for (auto typeIt = tdToDebug->TypesBegin(); typeIt != tdToDebug->TypesEnd(); typeIt++)
+      {
+      Type *type = *typeIt;
+      if (type->size() > 0 && !type->isField())
+         {
+         Type *myType = LookupType(type->id());
+         // special typeString Literal will be handled correctly by TypeReplacer
+         // otherwise user defined types may not be handled properly
+         LiteralValue *typeName = LiteralValue::create(this, myType);
+         _DebugValue_fields.insert({type, DefineField(_DebugValue, typeName, myType, 8*offsetof(DebugValue, _firstValueData))});
+         }
+      }
+   CloseStruct(_DebugValue);
+   _pDebugValue = PointerTo(_DebugValue);
+
+   _DebugFrame = DefineStruct("DebugFrame", 8*sizeof(struct DebuggerFrame));
+   _DebugFrame_info = DefineField(_DebugFrame, "_info", Address, 8*offsetof(DebuggerFrame, _info));
+   _DebugFrame_debugger = DefineField(_DebugFrame, "_debugger", Address, 8*offsetof(DebuggerFrame, _debugger));
+   _DebugFrame_locals = DefineField(_DebugFrame, "_locals", _pDebugValue, 8*offsetof(DebuggerFrame, _locals));
+   _DebugFrame_values = DefineField(_DebugFrame, "_values", _pDebugValue, 8*offsetof(DebuggerFrame, _values));
+   _DebugFrame_returnValues = DefineField(_DebugFrame, "_returnValues", _pDebugValue, 8*offsetof(DebuggerFrame, _returnValues));
+   _DebugFrame_fromBuilder = DefineField(_DebugFrame, "_fromBuilder", Address, 8*offsetof(DebuggerFrame, _fromBuilder));
+   _DebugFrame_returning = DefineField(_DebugFrame, "_returning", Address, 8*offsetof(DebuggerFrame, _returning));
+   _DebugFrame_builderToDebug = DefineField(_DebugFrame, "_builderToDebug", Address, 8*offsetof(DebuggerFrame, _builderToDebug));
+   CloseStruct(_DebugFrame);
+   _pDebugFrame = PointerTo(_DebugFrame);
+   }
+
+void
+DebugDictionary::initTypes(DebugDictionary *baseDict)
+   {
+   _DebugValue =                baseDict->_DebugValue;
+   _DebugValue_type =           baseDict->_DebugValue_type;
+   _DebugValue_fields =         baseDict->_DebugValue_fields;
+   _pDebugValue =               baseDict->_pDebugValue;
+   _DebugFrame =                baseDict->_DebugFrame;
+   _DebugFrame_info =           baseDict->_DebugFrame_info;
+   _DebugFrame_debugger =       baseDict->_DebugFrame_debugger;
+   _DebugFrame_locals =         baseDict->_DebugFrame_locals;
+   _DebugFrame_values =         baseDict->_DebugFrame_values;
+   _DebugFrame_returnValues =   baseDict->_DebugFrame_returnValues;
+   _DebugFrame_fromBuilder =    baseDict->_DebugFrame_fromBuilder;
+   _DebugFrame_returning =      baseDict->_DebugFrame_returning;
+   _DebugFrame_builderToDebug = baseDict->_DebugFrame_builderToDebug;
+   _pDebugFrame =               baseDict->_pDebugFrame;
+   }
+
+typedef bool (OperationDebuggerFunc)(DebuggerFrame *, int64_t);
+class OperationDebugger : public DebuggerFunctionBuilder
+   {
+   public:
+   OperationDebugger(Debugger *dbgr, Operation *op);
+
+   virtual bool buildIL();
+   virtual bool debug(DebuggerFrame *frame, Operation *op);
+
+   protected:
+   virtual Operation *cloneOperationForDebug(Builder *b, OperationCloner *cloner);
+   void setDebuggerBuilderTarget(Builder *b, Builder *targetBuilder);
+   std::string valueName(Value *v);
+   void handleLocalsAndValuesIncoming(Builder *b);
+   void handleLocalsOutgoing(Builder *b);
+
+   void copyResult(DebugValue *dest, DebugValue *src);
+
+   Operation  *_op;
+   std::string _frameName;
+   std::string _dbgrName;
+   std::string _localsName;
+   std::string _valuesName;
+   std::string _fromBuilderID;
+   };
+
+// FunctionDebugInfo holds debugger information corresponding to a FunctionBuilder
+// (information that can be shared across multiple DebuggerFrames). Since there
+// are read/write fields in this class, synchronization will be required if
+// multiple threads access one of these objects. Alternatively, debuggers for all
+// Operations in a FunctionBuilder could be generated ahead of time, at which point
+// this structure would become read-only.
+class FunctionDebugInfo
+   {
+public:
+   FunctionDebugInfo(FunctionBuilder *fb)
+      : _fb(fb)
+      , _dbgDict(fb)
+      , _valueSizeInBytes(_dbgDict._DebugValue->size()/8)
+      { }
+   FunctionBuilder * _fb;
+   DebugDictionary _dbgDict;
+   size_t _valueSizeInBytes;
+   std::map<int64_t, OperationDebugger *> _operationDebugBuilders;
+   std::map<int64_t, OperationDebuggerFunc *> _operationDebuggers;
+   std::map<int64_t, bool> _debugOperations;
+   };
+
+
+// new code below
+OperationDebugger::OperationDebugger(Debugger *dbgr, Operation *op)
+   : DebuggerFunctionBuilder(dbgr, op->fb())
+   , _frameName("frame")
+   , _dbgrName("debugger")
+   , _localsName("locals")
+   , _valuesName("values")
+   , _fromBuilderID("fromBuilderID")
+   , _op(op)
+   {
+   DefineName(op->fb()->name() + std::string(".op") + std::to_string(op->id()));
+   DefineFile("OpDbgr");
+   DefineLine(actionName[op->action()]);
+   DefineParameter(_frameName, dbgDict()->_pDebugFrame);
+   DefineParameter(_fromBuilderID, Int32);
+   DefineReturnType(Int8);
+   }
+
+bool
+OperationDebugger::debug(DebuggerFrame *frame, Operation *op)
+   {
+   return frame->_info->_operationDebuggers[op->id()](frame, frame->_fromBuilder->id());
+   }
+
+Operation *
+OperationDebugger::cloneOperationForDebug(Builder *b, OperationCloner *cloner)
+   {
+   // clone the original operation, replacing operands and builder objects as
+   // created above
+   return b->appendClone(_op, cloner);
+   }
+
+void
+OperationDebugger::setDebuggerBuilderTarget(Builder *b, Builder *targetBuilder)
+   {
+
+   }
+
+void
+OperationDebugger::copyResult(DebugValue *dest, DebugValue *src)
+   {
+   memcpy(dest, src, dbgDict()->_DebugValue->size());
+   }
+
+std::string
+OperationDebugger::valueName(Value *v)
+   {
+   return std::string("#_v") + std::to_string(v->id());
+   }
+
+// locals are stored in DebugValues in the debugger frame, but operations that access
+// locals will do so by their name encoded in Symbol (Local, Parameter, Function).
+// At entry, copy the debug values for any string typed LiteralValues that match the
+// names of symbols into actual locals for this function with the string name. That way,
+// any operation that accesses the local value will be able to load it directly.
+// Similarly, values (operands) are stored ni DebugValues in debugger frame. To ensure
+// that any code path can access those values safely, we load these into local variables
+// at the beginning of the function, That way, whereever the operands are used in the
+// generated code for the operation, the operands can be loaded safely from these locals.
+// Otherwise, there can be cases where the operand values are actually loaded only on
+// some paths (like the entry path) but e.g. not when control is coming back from some
+// bound builder.
+void
+OperationDebugger::handleLocalsAndValuesIncoming(Builder *b)
+   {
+   for (auto sIt = _op->SymbolsBegin(); sIt != _op->SymbolsEnd(); sIt++)
+      {
+      Symbol *sym = *sIt;
+      b->Store(sym->name(), loadValue(b, sym));
+      }
+   }
+
+// locals are stored directly in the frame, but other operations will need to access
+// their values as DebugValues from the debugger frame. On any outgoing path, then,
+// we store the values for any locals into their corresponding DebugValue in the frame.
+// Must be called on any outgoing path from the operation, to ensure the local value is
+// available to other operation debuggers.
+void
+OperationDebugger::handleLocalsOutgoing(Builder *b)
+   {
+   for (auto sIt = _op->SymbolsBegin(); sIt != _op->SymbolsEnd(); sIt++)
+      {
+      Symbol *sym = *sIt;
+      storeValue(b, sym, b->Load(sym->name()));
+      }
+   }
+
+bool
+OperationDebugger::buildIL()
+   {
+   Value *frame = Load(_frameName);
+   Store(_dbgrName, LoadIndirect(_DebugFrame_debugger, frame));
+   Store(_localsName, LoadIndirect(_DebugFrame_locals, frame));
+   Store(_valuesName, LoadIndirect(_DebugFrame_values, frame));
+
+   handleLocalsAndValuesIncoming(this);
+
+   OperationCloner cloner(_op);
+
+   // convert operands v of this operation to load their values from the DebugValues in the frame
+   // operands *must* be loaded here so they reach all paths
+   if (_op->numOperands() > 0)
+      {
+      int32_t opNum=0;
+      for (auto opIt = _op->OperandsBegin(); opIt != _op->OperandsEnd(); opIt++)
+         {
+         Value *origOperand = *opIt;
+         cloner.changeOperand(loadValue(this, origOperand), opNum++);
+         //cloner.changeOperand(firstEntry->Load(valueName(origOperand)), opNum++);
+         }
+      }
+
+
+   // generate switch based on incoming builder id
+   //    each case jumps to the END of the corresponding builder used in the operation (builder B for each builder operand)
+   // generate the operation Op_dbg, but the builder operands:
+   //    contain two builders, A and B
+   //        A contains the code to redirect the debugger control to the builder operand of the actual operation being debugged (passed as a parameter)
+   //        B is just a label builder that is appended to the end of A. It is used to transfer control back from the corresponding builder of the
+   //            operation being debugged via the switch above
+   // Operation class must be able to generate Op_dbg via a virtual call
+   //   createActionDebugger()
+
+   // allocate builder objects to handle debugger transition to each of the
+   //  the builders referenced by this operation
+   // Each builder writes the target builder (from the original operation) into the
+   //  debugger object and then returns true to the debugger, indicating that this handler
+   //  has been "suspended" so that control can flow to debugger->_builderToDebug
+
+   Builder *orphanTargets = NULL;
+   int32_t numBoundBuilders = 0;
+   if (_op->numBuilders() > 0)
+      {
+      orphanTargets = OrphanBuilder();
+      for (int32_t bIdx = 0; bIdx < _op->numBuilders(); bIdx++)
+         {
+         Builder *op_b = _op->builder(bIdx);
+         Builder *b = OrphanBuilder();
+         cloner.changeBuilder(b, bIdx);
+         handleLocalsOutgoing(b);
+         b->StoreIndirect(_DebugFrame_builderToDebug, b->Load(_frameName), b->ConstAddress(op_b));
+         b->Return(b->ConstInt8(1));
+         
+
+         if (op_b->isBound() && _op == op_b->boundToOperation())
+            numBoundBuilders++;
+         else
+            orphanTargets->AppendBuilder(b);
+         }
+      }
+
+   // no need to change Types or LiteralValues because the action debugger borrowed Types from original's
+   // TypeDictionary and LiteralValues don't require translation
+
+   // need to change Symbols from those in the original FunctionBuiilder to those in this OperationDebugger
+   if (_op->numSymbols() > 0)
+      {
+      for (auto s=0;s < _op->numSymbols();s++)
+         {
+         Symbol *origSymbol = _op->symbol(s);
+         Symbol *debugOpSymbol = _fb->getSymbol(origSymbol->name());
+         cloner.changeSymbol(debugOpSymbol, s);
+         }
+      }
+
+   // For each bound builder, this action debugger could also be called for
+   //  the control flow path that comes from that builder. We set up an initial switch
+   //  to direct control flow to the appropriate incoming control flow path in the
+   //  operation. If control is flowing into this operation for the first time,
+   //  control will flow to the cloned operation (see below). But if control is
+   //  flowing from one of the bound/targeted builders, we set up a switch statement
+   //  to direct control to the appropriate path in the cloned operation. We create
+   //  a new builder object and append it to each corresponding builder handler after
+   //  the Return. Control will flow from this new builder object to where ever the
+   //  operation dictates. One could consider the Return in the builder handler to be
+   //  "saving" the state of this operation, and the Switch is used to "restart" this
+   //  operation at the point it left.
+   Builder **caseBuilders = NULL;
+   Case **cases = NULL;
+   int32_t numCases = numBoundBuilders;
+   if (numBoundBuilders > 0)
+      {
+      caseBuilders = new Builder *[numCases];
+      cases = new Case *[numCases];
+      int32_t caseIdx = 0;
+
+      for (int32_t bIdx=0;bIdx < _op->numBuilders();bIdx++)
+         {
+         Builder *builder = _op->builder(bIdx);
+         if (builder->isBound() && _op == builder->boundToOperation())
+            {
+            Builder *restartTarget = OrphanBuilder();
+            cloner.builder(bIdx)->AppendBuilder(restartTarget);
+   
+            caseBuilders[caseIdx] = OrphanBuilder();
+            caseBuilders[caseIdx]->Goto(restartTarget);
+            cases[caseIdx] = Case::create(builder->id(), caseBuilders[caseIdx], false);
+            caseIdx++;
+            }
+         }
+         assert(caseIdx == numCases);
+      }
+
+   Builder *firstEntry = OrphanBuilder();
+   if (numCases > 0)
+      {
+      // safer would be to add parent builder ID to the set of cases and have a
+      // default case that throws some kind of debug error; for now default is firstEntry
+      Switch(Load(_fromBuilderID), firstEntry, numCases, cases);
+      }
+   else
+      AppendBuilder(firstEntry);
+
+   if (_op->action() == aReturn)
+      {
+      // for Return, just copy any operands to the frame's return values
+      for (int32_t oIdx=0;oIdx < _op->numOperands();oIdx++)
+         {
+         storeReturnValue(firstEntry, oIdx, cloner.operand(oIdx));
+         }
+      }
+   else
+      {
+      Operation *cloneOp = cloneOperationForDebug(firstEntry, &cloner);
+
+      // store any results produced by the cloned operation to the appropriate DebugValues
+      // (the result values produced by the original operation)
+      assert(cloneOp->numResults() == _op->numResults());
+      auto cloneIt = cloneOp->ResultsBegin();
+      for (auto rIt = _op->ResultsBegin(); rIt != _op->ResultsEnd(); rIt++, cloneIt++)
+         {
+         Value *result = *rIt;
+         Value *cloneResult = *cloneIt;
+         storeValue(firstEntry, result, cloneResult);
+         }
+
+      handleLocalsOutgoing(this);
+      }
+
+   if (orphanTargets)
+      {
+      // have to put orphan builders some place
+      Builder *merge = OrphanBuilder();
+      Goto(merge);
+      AppendBuilder(orphanTargets);
+      AppendBuilder(merge);
+      }
+
+   Return(ConstInt8(0));
+
+   return true;
+   }
+
+
+
+Debugger::Debugger(FunctionBuilder *fb)
+   : Object(fb)
+   , _writer(new TextWriter(fb, std::cout, "  "))
+   , _time(0)
+   , _frame(NULL)
+   , _firstEntry(false)
+   {
+   FunctionDebugInfo *info = _functionDebugInfos[fb->id()];
+   if (!info)
+      _functionDebugInfos[fb->id()] = info = new FunctionDebugInfo(fb);
+
+   // transform types now because everything else will need them (do it here so only need to do once)
+   if (fb->config()->hasReducer())
+      static_cast<TypeReplacer *>(fb->config()->reducer())->transformTypes(&info->_dbgDict);
+   }
+
+void
+Debugger::recordReentryPoint(Builder *b, OperationIterator & opIt)
+   {
+   _frame->_builderReentryPoints.insert({b->id(), opIt});
+   }
+
+OperationIterator *
+Debugger::fetchReentryPoint(Builder *b)
+  {
+   auto reentryPointIt = _frame->_builderReentryPoints.find(b->id());
+   if (reentryPointIt == _frame->_builderReentryPoints.end())
+      return NULL;
+   return &(reentryPointIt->second);
+   }
+void
+Debugger::removeReentryPoint(Builder *b)
+   {
+   _frame->_builderReentryPoints.erase(b->id());
+   }
+
+void
+Debugger::printDebugValue(DebugValue *val)
+   {
+   if (val->_type)
+      val->_type->printValue(_writer, &(val->_firstValueData));
+   else
+      {
+      TextWriter &w = (*_writer);
+      w << "Undefined";
+      }
+   }
+
+DebugValue *
+DebuggerFrame::getValueInArray(uint8_t *base, uint64_t idx)
+   {
+   uint8_t *valueBase = base + idx * _info->_valueSizeInBytes;
+   return reinterpret_cast<DebugValue *>(valueBase);
+   }
+
+DebugValue *
+DebuggerFrame::getValue(uint64_t idx)
+   {
+   uint8_t *p = reinterpret_cast<uint8_t *>(reinterpret_cast<uintptr_t>(_values));
+   return getValueInArray(p, idx);
+   }
+
+DebugValue *
+DebuggerFrame::getLocal(uint64_t idx)
+   {
+   uint8_t *p = reinterpret_cast<uint8_t *>(reinterpret_cast<uintptr_t>(_locals));
+   return getValueInArray(p, idx);
+   }
+
+void
+Debugger::printValue(uint64_t idx)
+   {
+   TextWriter &w = (*_writer);
+   DebugValue *val = _frame->getValue(idx);
+   w << "v" << idx << ": ";
+   printDebugValue(val);
+   w << " ]" << w.endl();
+   }
+
+void
+Debugger::printTypeName(Type *type)
+   {
+   TextWriter &w = (*_writer);
+   w << "t" << type->id() << " : [ " << type->name() << " ]";
+   }
+
+void
+Debugger::printType(Type * type)
+   {
+   TextWriter &w = (*_writer);
+   printTypeName(type);
+   w << w.endl();
+   }
+
+void
+Debugger::printSymbol(std::string name)
+   {
+   TextWriter &w = (*_writer);
+   Symbol *sym = _fb->getSymbol(name);
+   DebugValue *val = _frame->getLocal(index(sym));
+   w << sym->name() << " : ";
+   printDebugValue(val);
+   w << w.endl();
+   }
+
+struct Breakpoint
+   {
+   Breakpoint()
+      : _id(globalID++)
+      , _enabled(true)
+      , _silent(false)
+      , _count(0)
+      { }
+   virtual bool breakBefore(Operation *op) { return false; }
+   virtual bool breakBefore(Builder *b)    { return false; }
+   virtual bool breakAfter(Operation *op)  { return false; }
+   virtual bool breakAfter(Builder *b)     { return false; }
+   virtual bool breakAt(uint64_t time)     { return false; }
+   virtual void print(TextWriter *writer);
+   virtual bool fire()
+      {
+      if (_count > 0)
+         _count--;
+      if (_count == 0)
+         _enabled = true;
+      return _enabled;
+      }
+   bool removeAfterFiring()                                 { return _removeAfterFiring; }
+   bool silent()                                            { return _silent; }
+
+   Breakpoint * setRemoveAfterFiring(bool r=true)           { _removeAfterFiring = r; return this;}
+   Breakpoint * setIgnoreCount(int64_t c)                   { if (c >= 0) _count = c; return this;}
+   Breakpoint * setEnabled(bool e=true)                     { _enabled = e; return this; }
+   Breakpoint * setSilent(bool s=true  )                    { _silent = s; return this; }
+   
+   uint64_t _id;
+   bool _enabled;
+   bool _removeAfterFiring;
+   bool _silent;
+   int64_t _count;
+   static uint64_t globalID;
+   };
+
+uint64_t Breakpoint::globalID = 1;
+
+struct InternalBreakpoint : public Breakpoint
+   {
+   InternalBreakpoint() : Breakpoint() { }
+   virtual void print(TextWriter *w) { }
+   };
+
+void
+Breakpoint::print(TextWriter *writer)
+   {
+   *writer << "Breakpoint " << _id;
+   if (_enabled)
+      *writer << " (enabled): ";
+   else
+      *writer << " (disabled, ignore count " << _count << "): ";
+   }
+
+struct BreakpointAtTime : public Breakpoint
+   {
+   BreakpointAtTime(uint64_t t)
+      : Breakpoint()
+      , _time(t)
+      { }
+   virtual bool breakAt(uint64_t time)
+      {
+      return time == _time && fire();
+      }
+   virtual void print(TextWriter *writer)
+      {
+      Breakpoint::print(writer);
+      *writer << "Stop at time " << _time << writer->endl();
+      }
+
+   uint64_t _time;
+   };
+
+struct BreakpointStepInto : public BreakpointAtTime
+   {
+   BreakpointStepInto(uint64_t t)
+      : BreakpointAtTime(t)
+      { }
+
+   virtual void print(TextWriter *writer) { }
+   };
+
+struct BreakpointAfterOperation : public Breakpoint
+   {
+   BreakpointAfterOperation(uint64_t id)
+      : Breakpoint()
+      , _opID(id)
+      { }
+   virtual bool breakAfter(Operation *op)
+      {
+      return (op->id() == _opID) && fire();
+      }
+   virtual void print(TextWriter *writer)
+      {
+      Breakpoint::print(writer);
+      *writer << "Stop after op" << _opID << writer->endl();
+      }
+   uint64_t _opID;
+   };
+
+struct BreakpointBeforeOperation : public Breakpoint
+   {
+   BreakpointBeforeOperation(uint64_t id)
+      : Breakpoint()
+      , _opID(id)
+      { }
+   virtual bool breakBefore(Operation *op)
+      {
+      return (op->id() == _opID) && fire();
+      }
+   virtual void print(TextWriter *writer)
+      {
+      Breakpoint::print(writer);
+      *writer << "Stop before op" << _opID << writer->endl();
+      }
+   uint64_t _opID;
+   };
+
+struct BreakpointStepOver : public InternalBreakpoint
+   {
+   // This one is complicated :( .
+   // From the current operation, control could flow:
+   //     1) to an unbound builder
+   //     2) to a potentially empty builder bound to the current operation
+   //     3) to a potentially empty builder bound to some other operation
+   //     4) to the next operation in the current builder
+   //     5) to the end of of the current bound builder and returning to the parent operation which can then act like any of 1 through 5
+   //     6) out of the current function (if current operation is Return)
+   //
+   // StepOver means to stop at the next executed operation BUT skip any operations executed by a builder object bound to this operation
+   // Here is how each scenario is handled:
+   //     1) add target builder's first operation to _stopOp list
+   //     2) add target builder's bound operation (which is also the current operation) to the _stopOp list
+   //     3) add target builder's bound operation to the _stopOp list
+   //     4) add next operation to the _stopOp list
+   //     5) add this operation's parent builder's bound operation to the _stopOp list
+   //     6) do nothing
+   // Whichever of the operations 1-5 is encountered first, that will fire this breakpoint (typically also remove the breakpoint)
+   //
+   BreakpointStepOver(Operation *op, Operation *nextOp)
+      : InternalBreakpoint()
+      {
+      if (nextOp)
+         _stopOps.push_back(nextOp->id());
+      else if (op->parent() != op->fb() && op->parent()->controlReachesEnd())
+         {
+         assert(op->parent()->isBound());
+         _stopOps.push_back(op->parent()->boundToOperation()->id());
+         }
+
+      for (BuilderIterator bIt = op->BuildersBegin(); bIt != op->BuildersEnd(); bIt++)
+         {
+         Builder *bTgt = *bIt;
+         if (bTgt->isBound())
+            _stopOps.push_back(bTgt->boundToOperation()->id()); // may be op itself!
+         else
+            _stopOps.push_back(bTgt->operations()[0]->id());
+         }
+      }
+
+   virtual bool breakBefore(Operation *op)
+      {
+      uint64_t opID = op->id();
+      for (auto opIt = _stopOps.begin(); opIt != _stopOps.end(); opIt++)
+         {
+         uint64_t stopID = *opIt;
+         if (opID == stopID)
+            return fire();
+         }
+      return false;
+      }
+
+   std::vector<uint64_t> _stopOps;
+   };
+
+struct BreakpointBeforeBuilder : public Breakpoint
+   {
+   BreakpointBeforeBuilder(uint64_t id)
+      : Breakpoint()
+      , _bID(id)
+      { }
+   virtual bool breakBefore(Builder *b)
+      {
+      return (b->id() == _bID) && fire();
+      }
+   virtual void print(TextWriter *writer)
+      {
+      Breakpoint::print(writer);
+      *writer << "Stop before B" << _bID << writer->endl();
+      }
+   uint64_t _bID;
+   };
+
+void
+Debugger::printHelp()
+   {
+   TextWriter &w = *_writer;
+   w << "JBDB Command reference" << w.endl();
+   w << "   h,  help          display this help summary" << w.endl();
+   w << "   l,  list          print the current methodbuilder IL" << w.endl();
+   w << "   s,  step          step into the next operation, including operations in bound builders" << w.endl();
+   w << "   n,  next          step over the next operation, not including operations in bound builders" << w.endl();
+   w << "   c,  cont          continue until the next breakpoint" << w.endl();
+   w << "   pv, printvalue    print a value (v#)" << w.endl();
+   w << "   pt, printtype     print a type (t#)" << w.endl();
+   w << "   p,  print         print a symbol (name)" << w.endl();
+   w << "   bl, breaklist     print list of active breakpoints" << w.endl();
+   w << "   bb, breakbefore   break before an operation (o#) or builder (B#)" << w.endl();
+   w << "   ba, breakafter    break after an operation (o#)" << w.endl();
+   w << "   b @#              break at time #" << w.endl();
+   w << "   d, debug          debug opcode handler for an operation (o#)" << w.endl();
+   w << w.endl();
+   }
+
+// accept input on what to do next
+// op is the operation currently being debugged; it can be NULL e.g. at a breakpoint *after* an operation
+// nextOp is the next operation that would sequentially follow this operation in the current builder object;
+//     it can be NULL e.g. if the current operation is the last one in the current builder object
+void
+Debugger::acceptCommands(Operation *op, Operation *nextOp)
+   {
+   bool done = false;
+   while (!done)
+      {
+
+      fprintf(stderr, "[T=%llu] (jbdb) ", _time);
+   
+      char line[1024];
+      if (fgets(line, sizeof(line), stdin))
+         {
+         if (line[0] == '\n')
+            if (_commandHistory.size() > 0) // repeat last
+               strcpy(line, _commandHistory.back().c_str());
+            else
+               continue;
+         else
+            {
+            std::string current(line);
+            _commandHistory.push_back(current);
+            }
+
+         char *command = strtok(line, " \r\n");
+         if (strcmp(command, "h") == 0 || strcmp(command, "help") == 0)
+            {
+            printHelp();
+            }
+         if (strcmp(command, "n") == 0 || strcmp(command, "next") == 0)
+            {
+            Breakpoint *brkpt = (new BreakpointStepOver(op, nextOp))->setRemoveAfterFiring();
+            _frame->_breakpoints.push_front(brkpt); // put it at the beginning so it will be found quickly and quick to remove
+            done = true;
+            break;
+            }
+         if (strcmp(command, "s") == 0 || strcmp(command, "step") == 0)
+            {
+            Breakpoint *brkpt = (new BreakpointStepInto(_time+1))->setRemoveAfterFiring();
+            _frame->_breakpoints.push_front(brkpt); // put it at the beginning so it will be found quickly and quick to remove
+            done = true;
+            break;
+            }
+         else if (strcmp(command, "c") == 0 || strcmp(command, "cont") == 0 || strcmp(command, "continue") == 0)
+            {
+            done = true;
+            break;
+            }
+         else if (strcmp(command, "pt") == 0 || strcmp(command, "printtype") == 0)
+            {
+            char *expr = strtok(NULL, " \r\n");
+            uint64_t id = strtoul(expr, NULL, 10);
+            if (expr[0] == 't')
+               id = strtoul(expr+1, NULL, 10);
+         
+            if (id < Type::maxID())
+               printType(_fb->dict()->LookupType(id));
+            else
+               *(_writer) << "Unrecognized type: should be t# (max id:" << Type::maxID() << ")" << _writer->endl();
+            }
+         else if (strcmp(command, "pv") == 0 || strcmp(command, "printvalue") == 0)
+            {
+            char *expr = strtok(NULL, " \r\n");
+            uint64_t id = strtoul(expr, NULL, 10);
+            if (expr[0] == 'v')
+               id = strtoul(expr+1, NULL, 10);
+
+            if (id < Value::maxID())
+               printValue(id);
+            else
+               *(_writer) << "Unrecognized value: should be v# (max id:" << Value::maxID() << ")" << _writer->endl();
+            }
+         else if (strcmp(command, "p") == 0 || strcmp(command, "print") == 0)
+            {
+            char *expr = strtok(NULL, " \r\n");
+            if (expr && _fb->getSymbol(expr))
+               {
+               printSymbol(expr);
+               }
+            else
+               fprintf(stderr, "Unrecognized symbol name\n");
+            }
+         else if (strcmp(command, "l") == 0 || strcmp(command, "list") == 0)
+            {
+            _writer->print();
+            }
+         else if (strcmp(command, "bb") == 0 || strcmp(command, "breakbefore") == 0)
+            {
+            char *bp = strtok(NULL, " \r\n");
+            if (strncmp(bp, "o", 1) == 0)
+               {
+               uint64_t id = strtoul(bp+1, NULL, 10);
+               Breakpoint *brkpt = new BreakpointBeforeOperation(id);
+               _frame->_breakpoints.push_back(brkpt);
+               *_writer << "Breakpoint " << brkpt->_id << " will stop before operation o" << id << _writer->endl();
+               }
+            else if (bp[0] == 'B')
+               {
+               uint64_t id = strtoul(bp+1, NULL, 10);
+               Breakpoint *brkpt = new BreakpointBeforeBuilder(id);
+               _frame->_breakpoints.push_back(brkpt);
+               *_writer << "Breakpoint " << brkpt->_id << " will stop before builder b" << id << _writer->endl();
+               }
+            }
+         else if (strcmp(command, "ba") == 0 || strcmp(command, "breakafter") == 0)
+            {
+            char *bp = strtok(NULL, " \r\n");
+            if (strncmp(bp, "o", 1) == 0)
+               {
+               uint64_t id = strtoul(bp+1, NULL, 10);
+               Breakpoint *brkpt = new BreakpointAfterOperation(id);
+               _frame->_breakpoints.push_back(brkpt);
+               *_writer << "Breakpoint " << brkpt->_id << " will stop after operation o" << id << _writer->endl();
+               }
+            }
+         else if (strcmp(command, "bl") == 0 || strcmp(command, "breaklist") == 0)
+            {
+            for (auto it=_frame->_breakpoints.begin(); it != _frame->_breakpoints.end(); it++)
+               {
+               Breakpoint *bp = *it;
+               bp->print(_writer);
+               }
+            }
+         else if (strcmp(command, "b") == 0)
+            {
+            char *bp = strtok(NULL, " \r\n");
+            if (bp[0] == '@')
+               {
+               uint64_t time = strtoul(bp+1, NULL, 10);
+               Breakpoint *brkpt = new BreakpointAtTime(time);
+               _frame->_breakpoints.push_back(brkpt);
+               *_writer << "Breakpoint " << brkpt->_id << " will stop at time " << time << _writer->endl();
+               }
+            }
+         else if (strcmp(command, "d") == 0 || strcmp(command,"debug") == 0)
+            {
+            char *opStr = strtok(NULL, " \r\n");
+            if (strncmp(opStr, "o", 1) == 0)
+               {
+               uint64_t id = strtoul(opStr+1, NULL, 10);
+               _frame->_info->_debugOperations.insert({id, true});
+               *_writer << "Will debug into operation handler for o" << id << _writer->endl();
+               }
+            }
+         }
+      }
+   }
+
+void
+Debugger::showOp(Operation *op, std::string msg)
+   {
+   TextWriter &w = *_writer;
+   w << msg;
+   w.writeOperation(op);
+   }
+
+bool
+Debugger::breakBefore(Operation *op)
+   {
+   for (auto it=_frame->_breakpoints.begin(); it != _frame->_breakpoints.end(); it++)
+      {
+      Breakpoint *bp=*it;
+      if (bp->breakBefore(op) || bp->breakAt(_time))
+         {
+         bp->print(_writer);
+         if (bp->removeAfterFiring())
+            _frame->_breakpoints.erase(it);
+         return true;
+         }
+      }
+   return false;
+   }
+
+bool
+Debugger::breakAfter(Operation *op)
+   {
+   for (auto it=_frame->_breakpoints.begin(); it != _frame->_breakpoints.end(); it++)
+      {
+      Breakpoint *bp=*it;
+      if (bp->breakAfter(op))
+         {
+         bp->print(_writer);
+         if (bp->removeAfterFiring())
+            _frame->_breakpoints.erase(it);
+         return true;
+         }
+      }
+   return false;
+   }
+
+bool
+Debugger::breakBefore(Builder *b)
+   {
+   for (auto it=_frame->_breakpoints.begin(); it != _frame->_breakpoints.end(); it++)
+      {
+      Breakpoint *bp=*it;
+      if (bp->breakBefore(b))
+         {
+         if (bp->removeAfterFiring())
+            _frame->_breakpoints.erase(it);
+
+         if (bp->silent())
+            {
+            OperationIterator allIter = b->OperationsBegin();
+            OperationIterator * pIter = &allIter;
+            auto entryPoint = _frame->_builderReentryPoints.find(b->id());
+            if (entryPoint != _frame->_builderReentryPoints.end())
+               pIter = &(entryPoint->second);
+               
+            OperationIterator &opIt = *pIter;
+            Operation *op = *opIt;
+            Breakpoint *newBP = new BreakpointBeforeOperation(op->id());
+            newBP->setSilent();
+            _frame->_breakpoints.push_front(newBP);
+
+            return false;
+            }
+
+         bp->print(_writer);
+
+         return true;
+         }
+      }
+   return false;
+   }
+
+void
+Debugger::beforeOp(Operation *op, Operation *nextOp)
+   {
+   if (breakBefore(op))
+      {
+      showOp(op, "Stopped before ");
+      acceptCommands(op, nextOp);
+      }
+   }
+
+void
+Debugger::afterOp(Operation *op, Operation *nextOp)
+   {
+   if (breakAfter(op))
+      {
+      showOp(op, "Stopped after ");
+      acceptCommands(op, nextOp);
+      }
+   }
+
+DebugDictionary *
+Debugger::getDictionary(FunctionBuilder *fb)
+   {
+   FunctionDebugInfo *info = _functionDebugInfos[fb->id()];
+   assert(info);
+   return &info->_dbgDict;
+   }
+
+void
+Debugger::debug(FunctionBuilder *fb, DebugValue *returnValues, DebugValue *locals)
+   {
+   FunctionBuilder *savedFB = _fb;
+   DebuggerFrame *savedFrame = _frame;
+
+   DebuggerFrame frame;
+   frame._debugger = this;
+   frame._info = _functionDebugInfos[fb->id()];
+   size_t valueSizeInBytes = frame._info->_valueSizeInBytes;
+   frame._returnValues = returnValues;
+   frame._locals = locals;
+   frame._values = reinterpret_cast<DebugValue *>(new uint8_t[fb->numValues() * valueSizeInBytes]);
+   frame._fromBuilder = fb;
+   frame._returning = false;
+   frame._builderToDebug = fb;
+   _frame = &frame;
+   _fb = fb;
+
+   if (_firstEntry)
+      {
+      TextWriter &w = (*_writer);
+      w << "JitBuilder Debugger (JBDB)" << w.endl();
+      w << "Happy debugging!" << w.endl() << w.endl();
+      w << "Type h or help for a list of jbdb commands" << w.endl() << w.endl();
+      w << "Entering function " << fb->name() << " with arguments:" << w.endl();
+      for (auto pIt = fb->ParametersBegin(); pIt != fb->ParametersEnd(); pIt++)
+         {
+         const ParameterSymbol *param = *pIt;
+         w << "    ";
+         printSymbol(param->name());
+         }
+      w << w.endl();
+      _firstEntry = false;
+      }
+
+   Breakpoint *brkpt = new BreakpointBeforeBuilder(fb->id());
+   brkpt->setSilent()
+        ->setRemoveAfterFiring();
+   _frame->_breakpoints.push_front(brkpt);
+ 
+   _frame->_builderToDebug = _fb;
+   while (_frame->_builderToDebug)
+      {
+      Builder *b = _frame->_builderToDebug;
+      //_frame->_builderToDebug = NULL;
+      debug(b);
+      }
+
+   _fb = savedFB;
+   _frame = savedFrame;
+
+   //if (savedFB != fb)
+   //   (*_writer) << "Returning from FB" << fb->id() << _writer->endl();
+   }
+
+void
+Debugger::ensureOperationDebugger(Operation * op)
+   {
+   FunctionDebugInfo *info = _frame->_info;
+
+   auto opDbgrs = info->_operationDebuggers;
+   auto debugger = opDbgrs.find(op->id());
+   if (debugger != opDbgrs.end())
+      return;
+
+   OperationDebugger *opDebugFB = new OperationDebugger(this, op);
+   int32_t rc = opDebugFB->Construct();
+
+//#define TRACE_OPDEBUGGERS
+#ifdef TRACE_OPDEBUGGERS
+   std::cout.setf(std::ios_base::skipws);
+   OMR::JitBuilder::TextWriter printer(opDebugFB, std::cout, std::string("    "));
+   opDebugFB->setLogger(&printer);
+   opDebugFB->config()
+                   ->setTraceBuildIL()
+                   //->setTraceReducer()
+                   //->setTraceCodeGenerator()
+                   ;
+   std::cerr << "Operation Debugger for " << op << std::endl;
+   printer.print();
+#endif
+
+   // debug entry doesn't work yet due to Type name conflicts (DebugFrame, DebugValue)
+   bool useDebugEntry = (info->_debugOperations.find(op->id()) != info->_debugOperations.end());
+   auto dbgFunc = useDebugEntry ? opDebugFB->DebugEntry<OperationDebuggerFunc>(&rc) : opDebugFB->CompiledEntry<OperationDebuggerFunc>(&rc);
+   info->_operationDebuggers[op->id()] = dbgFunc;
+   }
+
+void
+Debugger::debug(Builder *b)
+   {
+   auto allIter = b->OperationsBegin();
+   OperationIterator * iter = &allIter;
+   bool usingReentryPoint = false;
+
+   auto entryPoint = _frame->_builderReentryPoints.find(b->id());
+   if (entryPoint != _frame->_builderReentryPoints.end())
+      {
+      iter = &(entryPoint->second);
+      usingReentryPoint = true;
+      }
+   else if (_frame->_fromBuilder->isBound() && _frame->_returning)
+      {
+      // this scenario is exemplified by an AppendBuilder operation referencing a bound Builder object to which control has just been directed
+      // When that builder object completes executing, it comes "back" to its parent but the parent was never entered
+      // note that it is possible for any Goto to direct to *any* bound builder object of an operation
+      bool foundFromBuilder = false;
+      while (allIter != b->OperationsEnd())
+         {
+         Operation *possibleOwnerOp = *allIter;
+         foundFromBuilder = false;
+         for (BuilderIterator bIt = possibleOwnerOp->BuildersBegin(); bIt != possibleOwnerOp->BuildersEnd(); bIt++)
+            {
+            Builder *bTgt = *bIt;
+            if (bTgt == _frame->_fromBuilder)
+               {
+               foundFromBuilder = true;
+               break;
+               }
+            }
+
+         if (foundFromBuilder)
+            break;
+
+         allIter++;
+         }
+
+      // something wrong if we didn't find the fromBuilderTarget
+      if (!foundFromBuilder)
+         {
+         TextWriter &w = (*_writer);
+         uint64_t fromBuilderID = _frame->_fromBuilder->id();
+
+         w << "Internal debugger error:" << w.endl();
+         w << "    Control arrived at B" << b->id() << w.endl();
+         w << "    From B" << fromBuilderID << w.endl();
+         w << "    but no operation has B" << fromBuilderID << " as a bound builder" << w.endl();
+         w << "Aborting frame with no way to recover" << w.endl();
+
+         _frame->_fromBuilder = NULL;
+         _frame->_builderToDebug = NULL;
+         assert(foundFromBuilder);
+         return;
+         }
+      }
+   else
+      // first time this builder has been entered
+      _frame->_fromBuilder = b;
+
+   OperationIterator &opIt = *iter;
+   if (breakBefore(b))
+      {
+      _writer->print(b);
+      Operation *op = NULL;
+      if (opIt != b->OperationsEnd())
+         op = *opIt;
+      acceptCommands(NULL, op);
+      }
+
+   _frame->_builderToDebug = NULL;
+   _frame->_returning = false;
+   while(opIt != b->OperationsEnd())
+      {
+      Operation *op = *opIt;
+      auto nextIt = std::next(opIt);
+      Operation *nextOp = (nextIt == b->OperationsEnd()) ? NULL : (*nextIt);
+
+      beforeOp(op, nextOp);
+      bool suspend = debug(op);
+      afterOp(op, nextOp);
+
+      if (suspend)
+         {
+         if (_frame->_builderToDebug->isBound() && _frame->_builderToDebug->boundToOperation() == op && !usingReentryPoint)
+            _frame->_builderReentryPoints.insert({b->id(), opIt});
+
+         return;
+         }
+
+      opIt++; // must do after the above suspension code so bound builders return to the same operation, not the following operation
+      //op = nextOp;
+      }
+
+   // done with iterator now, so if we got it from the reentry points we can erase it
+   if (usingReentryPoint)
+      _frame->_builderReentryPoints.erase(b->id());
+
+   if (b->isBound())
+      {
+      _frame->_fromBuilder = b;
+      _frame->_builderToDebug = b->boundToOperation()->parent();
+      _frame->_returning = true;
+      //(*_writer) << "Returning from B" << b->id() << " to B" << _builderToDebug->id() << _writer->endl();
+      return;
+      }
+
+   // shouldn't fall off end of an unbound builder unless it's the end of the function!
+   assert(_frame->_builderToDebug == NULL);
+   }
+
+bool
+Debugger::debug(Operation *op)
+   {
+   ensureOperationDebugger(op);
+   showOp(op, "Executing: ");
+   bool suspendBuilder = _frame->_info->_operationDebuggers[op->id()](_frame, _frame->_fromBuilder->id());
+   _time++;
+   return suspendBuilder;
+   }
+
+extern "C"
+{
+#define DEBUGFUNCTION_LINENUMBER LINETOSTR(__LINE__)
+void
+Debugger::debugFunction(Debugger *dbgr, FunctionBuilder *fb, DebugValue *returnValues, DebugValue *locals)
+   {
+   dbgr->debug(fb, returnValues, locals);
+   }
+}
+
+
+class DebuggerThunk : public DebuggerFunctionBuilder
+   {
+   public:
+   DebuggerThunk(Debugger *dbgr, FunctionBuilder *debugFB)
+      : DebuggerFunctionBuilder(dbgr, debugFB) //, dbgr->getDictionary(debugFB))
+      , _debugger(dbgr)
+      , _debugFB(debugFB)
+      {
+      DefineName(std::string("jbdb_") + debugFB->name());
+      DefineFile(debugFB->fileName());
+      DefineLine(debugFB->lineNumber());
+
+      for (auto pIt = debugFB->ParametersBegin(); pIt != debugFB->ParametersEnd(); pIt++)
+         {
+         const ParameterSymbol *param = *pIt;
+         DefineParameter(param->name(), param->type());
+         }
+      DefineReturnType(debugFB->getReturnType());
+
+      DefineFunction("debugFunction()", __FILE__, DEBUGFUNCTION_LINENUMBER, reinterpret_cast<void *>(&Debugger::debugFunction),
+                     NoType, 4, Address, Address, _pDebugValue, _pDebugValue);
+      }
+
+   virtual bool buildIL()
+      {
+      const char *returnValues = "returnValues";
+      int32_t numReturnValues = _debugFB->numReturnValues();
+      Value *rvPtr = NULL;
+      if (numReturnValues > 0)
+         rvPtr = CreateLocalArray(numReturnValues, dbgDict()->_DebugValue);
+      else
+         rvPtr = ConstAddress(0);
+      Store(returnValues, CoercePointer(_pDebugValue, rvPtr));
+
+      const char *locals = "locals";
+      int32_t numLocals = _debugFB->numLocals();
+      Value *lPtr = NULL;
+      if (numLocals > 0)
+         lPtr = CreateLocalArray(numLocals, dbgDict()->_DebugValue);
+      else
+         lPtr = ConstAddress(0);
+      Store(locals, CoercePointer(_pDebugValue, lPtr));
+
+      for (auto pIt = _debugFB->ParametersBegin(); pIt != _debugFB->ParametersEnd(); pIt++)
+         {
+         ParameterSymbol *parm = *pIt;
+         storeValue(this, parm, Load(parm->name()));
+         }
+      Call(Load("debugFunction()"), 4, ConstAddress(_debugger), ConstAddress(_debugFB), Load(returnValues), Load(locals));
+      if (numReturnValues > 0)
+         {
+         assert(numReturnValues == 1); // only supporting one return value ffor now
+         Return(loadFromDebugValue(this, Load(returnValues), _debugFB->getReturnType()));
+         }
+      else
+         Return();
+
+      return true;
+      }
+
+   protected:
+   Debugger *_debugger;
+   FunctionBuilder *_debugFB;
+   };
+
+
+void *
+Debugger::createDebugger(int32_t *returnCode)
+   {
+   DebuggerThunk *thunk = new DebuggerThunk(this, _fb);
+   thunk->Construct();
+
+//#define TRACE_DEBUGTHUNK
+#ifdef TRACE_DEBUGTHUNK
+   std::cout.setf(std::ios_base::skipws);
+   OMR::JitBuilder::TextWriter printer(thunk, std::cout, std::string("    "));
+   thunk->setLogger(&printer);
+   thunk->config()
+                   //->setTraceBuildIL()
+                   //->setTraceReducer()
+                   ->setTraceCodeGenerator();
+   std::cerr << "Debug Entry Thunk:" << std::endl;
+   printer.print();
+#endif
+
+   return thunk->CompiledEntry<void *>(returnCode);
+   }
+
+} // namespace JitBuilder
+} // namespace OMR

--- a/jitbuilder/jbil/Debugger.cpp
+++ b/jitbuilder/jbil/Debugger.cpp
@@ -388,7 +388,7 @@ OperationDebugger::OperationDebugger(Debugger *dbgr, Operation *op)
    {
    DefineName(op->fb()->name() + std::string(".op") + std::to_string(op->id()));
    DefineFile("OpDbgr");
-   DefineLine(actionName[op->action()]);
+   DefineLine(actionName(op->action()));
    DefineParameter(_frameName, dbgDict()->_pDebugFrame);
    DefineParameter(_fromBuilderID, Int32);
    DefineReturnType(Int8);

--- a/jitbuilder/jbil/Debugger.hpp
+++ b/jitbuilder/jbil/Debugger.hpp
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef DEBUGGER_INCL
+#define DEBUGGER_INCL
+
+#include <list>
+#include "Action.hpp"
+#include "FunctionBuilder.hpp"
+#include "Object.hpp"
+#include "TextWriter.hpp"
+#include "TypeDictionary.hpp"
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+class Operation;
+class Type;
+class TypeDictionary;
+class Value;
+
+class Debugger;
+class DebuggerFrame;
+class DebuggerThunk;
+class DebugValue;
+class FunctionDebugInfo;
+
+class Debugger : public Object
+   {
+   friend class DebuggerThunk;
+
+   public:
+   Debugger(FunctionBuilder *fb);
+   void * createDebugger(int32_t *returnCode);
+
+   uint64_t index(const Symbol *symbol) const { return symbol->id(); };
+   uint64_t index(const Value *value) const   { return value->id(); }
+
+   void ensureOperationDebugger(Operation * op);
+
+   // These functions are static so they can be called by generated DebuggerThunk
+   static void debugFunction(Debugger *dbgr, FunctionBuilder *b, DebugValue *returnValues, DebugValue *locals);
+
+   uint64_t time() { return _time; }
+
+   // public because needs to be called by the DebuggerActionHandler objects
+   void switchTo(Builder *b); // { _frame->switchTo(b); }
+   Builder * switchedFromBuilder(); // { return _frame->_builderFrom; }
+
+   DebugDictionary *getDictionary(FunctionBuilder *fb);
+
+   protected:
+
+   virtual void debug(FunctionBuilder *fb, DebugValue *returnValues, DebugValue *locals);
+   virtual void debug(Builder *b);
+   virtual bool debug(Operation *op);
+
+   virtual void printDebugValue(DebugValue *val);
+   virtual void printTypeName(Type *type);
+   virtual void printType(Type *type);
+   virtual void printValue(uint64_t idx);
+   virtual void printSymbol(std::string name);
+   virtual void printHelp();
+   virtual void acceptCommands(Operation *op, Operation *nextOp=NULL);
+   virtual void showOp(Operation *op, std::string msg);
+
+   virtual void beforeOp(Operation *op, Operation *nextOp);
+   virtual void afterOp(Operation *op, Operation *nextOp);
+
+   virtual bool breakBefore(Builder *b);
+   virtual bool breakBefore(Operation *op);
+   virtual bool breakAfter(Operation *op);
+
+   void setup();
+
+   void recordReentryPoint(Builder *b, OperationIterator & opIt);
+   OperationIterator * fetchReentryPoint(Builder *b);
+   void removeReentryPoint(Builder *b);
+
+   TextWriter *_writer;
+   std::list<std::string> _commandHistory;
+   uint64_t _time;
+   DebuggerFrame *_frame;
+   std::map<int64_t, FunctionDebugInfo *> _functionDebugInfos; // maps from fb->id() to FDI
+   bool _firstEntry;
+   };
+
+} // namespace JitBuilder
+} // namespace OMR
+
+#endif // defined(DEBUGGER_INCL)

--- a/jitbuilder/jbil/Dialect.hpp
+++ b/jitbuilder/jbil/Dialect.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef DIALECT_INCL
+#define DIALECT_INCL
+
+#include <stdint.h>
+
+typedef int64_t Dialect;
+
+#define DIALECT(name) Dialect_##name
+
+const int64_t DIALECT(native) = 1;
+#define DefineDialect(name,builton) \
+	const int64_t DIALECT(name)=2*DIALECT(builton); \
+	static_assert((DIALECT(builton) != ((uint64_t)1) << 63), "ran out of dialect identifiers")
+
+// Let's define some dialects (doesn't mean much yet)
+
+// native == native code
+
+// codegen == instructions
+DefineDialect(codegen, native);
+
+// tril == compiler IL
+DefineDialect(tril, codegen);
+
+// jbil_ll == low level JitBuilder: only low level control flow operations like IfCmp* and Switch
+DefineDialect(jbil_ll, tril);
+
+// jbil == current JitBuilder API, including higher level operations like ForLoop, IfThenElse
+DefineDialect(jbil, jbil_ll);
+
+//
+// Add any User Dialect definitions here:
+// BEGIN {
+
+// e.g. DefineDialect(UserDialect, jbil)
+
+// } END
+// Stop User Dialect definitions here
+//
+
+#endif // !defined(DIALECT_INCL)

--- a/jitbuilder/jbil/DialectReducer.cpp
+++ b/jitbuilder/jbil/DialectReducer.cpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "DialectReducer.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "Operation.hpp"
+#include "Type.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+
+DialectReducer::DialectReducer(FunctionBuilder * fb, Dialect target)
+   : Transformer(fb)
+   , _target(target)
+   {
+   setTraceEnabled(fb->config()->traceReducer());
+   }
+
+Builder *
+DialectReducer::transformOperation(Operation * op)
+   {
+   switch (op->action())
+      {
+      case aForLoop :
+         {
+         // ForLoop is dialect jbil so nothing to do unless target is lower than jbil
+         if (_target >= DIALECT(jbil))
+            return NULL;
+
+         bool countsUp = (bool) op->literal(0)->getInt8();
+         std::string indVar = op->literal(1)->getString();
+         Builder *loopCode = op->builder(0);
+         Builder *providedLoopContinue = op->builder(1);
+         Builder *breakBuilder = op->builder(2);
+         Value *initial = op->operand(0);
+         assert(initial);
+         Value *end = op->operand(1);
+         assert(end);
+         Value *increment = op->operand(2);
+         assert(increment);
+
+         // ForLoop sets isTarget to true, so clear it now and the reduction should
+         //  cause it to be appropriate set (or left) depending on the final structure
+         loopCode->setTarget(false);
+
+         // Also make loopCode unbound, since it will no longer be bound by a for loop operation
+         loopCode->setBoundness(May)->setBound(false);
+         if (providedLoopContinue)
+            providedLoopContinue->setBoundness(May)->setBound(false);
+         if (breakBuilder)
+            breakBuilder->setBoundness(May)->setBound(false);
+
+         Builder * parent = op->parent();
+         Builder * b = parent->OrphanBuilder();
+         Builder * loopBody = b->OrphanBuilder();
+         Builder * loopContinue = (providedLoopContinue != NULL) ? providedLoopContinue : b->OrphanBuilder();
+         Builder * loopExit = b->OrphanBuilder();
+
+         b->Store(indVar, initial);
+
+         if (countsUp)
+            b->IfCmpGreaterOrEqual(loopExit, b->Load(indVar), end);
+         else
+            b->IfCmpLessOrEqual(loopExit, b->Load(indVar), end);
+
+         if (countsUp)
+            {
+            loopContinue->Store(indVar,
+            loopContinue->   Add(
+            loopContinue->      Load(indVar),
+                                increment));
+            loopContinue->IfCmpLessThan(loopBody, 
+            loopContinue->   Load(indVar),
+                             end);
+            }
+         else
+            {
+            loopContinue->Store(indVar,
+            loopContinue->   Sub(
+            loopContinue->      Load(indVar),
+                                increment));
+            loopContinue->IfCmpGreaterThan(loopBody, 
+            loopContinue->   Load(indVar),
+                             end);
+            }
+
+         appendOrInline(loopBody, loopCode);
+         appendOrInline(loopBody, loopContinue);
+
+         b->AppendBuilder(loopBody);
+
+         if (breakBuilder)
+            appendOrInline(b, breakBuilder);
+
+         b->AppendBuilder(loopExit);
+
+         return b;
+         }
+
+      default :
+         break;
+      }
+
+   return NULL;
+   }

--- a/jitbuilder/jbil/DialectReducer.hpp
+++ b/jitbuilder/jbil/DialectReducer.hpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef DIALECTREDUCER_INCL
+#define DIALECTREDUCER_INCL
+
+
+#include "Dialect.hpp"
+#include "Transformer.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class FunctionBuilder;
+class Operation;
+
+class DialectReducer : public Transformer
+   {
+public:
+   DialectReducer(FunctionBuilder * fb, Dialect target);
+
+protected:
+   Builder * transformOperation(Operation * op);
+
+   Dialect _target;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(DIALECTREDUCER_INCL)

--- a/jitbuilder/jbil/DynamicOperation.cpp
+++ b/jitbuilder/jbil/DynamicOperation.cpp
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+#include "Builder.hpp"
+#include "Case.hpp"
+#include "DynamicOperation.hpp"
+#include "FunctionBuilder.hpp"
+#include "LiteralValue.hpp"
+#include "Location.hpp"
+#include "Operation.hpp"
+#include "OperationCloner.hpp"
+#include "TypeDictionary.hpp"
+#include "TypeGraph.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+uint32_t OperationBuilder::nextDynamicAction = NumStaticActions;
+
+DynamicOperation *
+OperationBuilder::createOperation(Builder *parent)
+   {
+   DynamicOperation *newOp = new DynamicOperation(_action, parent,
+                                                  _numResults, _results,
+                                                  _numBuilders, _builders,
+                                                  _numCases, _cases,
+                                                  _numLiterals, _literals,
+                                                  _numOperands, _operands,
+                                                  _numSymbols, _symbols,
+                                                  _numTypes, _types,
+                                                  _expander,
+                                                  _printer);
+
+   // prepare for next Operation to build
+   this->setNumResults(_numResults)
+       ->setNumBuilders(_numBuilders)
+       ->setNumCases(_numCases)
+       ->setNumLiterals(_numLiterals)
+       ->setNumOperands(_numOperands)
+       ->setNumSymbols(_numSymbols)
+       ->setNumTypes(_numTypes);
+
+   return newOp;
+   }
+
+Operation *
+DynamicOperation::clone(Builder *b, Value **results) const
+   {
+   DynamicOperation *newOp = new DynamicOperation(_action, b,
+                                                  _numResults, results,
+                                                  _numBuilders, _builders,
+                                                  _numCases, _cases,
+                                                  _numLiterals, _literals,
+                                                  _numOperands, _operands,
+                                                  _numSymbols, _symbols,
+                                                  _numTypes, _types,
+                                                  _expander,
+                                                  _printer);
+   return newOp;
+   }
+
+Operation *
+DynamicOperation::clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+   {
+   DynamicOperation *newOp = new DynamicOperation(_action, b,
+                                                  _numResults, results,
+                                                  _numBuilders, builders,
+                                                  _numCases, _cases,
+                                                  _numLiterals, _literals,
+                                                  _numOperands, operands,
+                                                  _numSymbols, _symbols,
+                                                  _numTypes, _types,
+                                                  _expander,
+                                                  _printer);
+   return newOp;
+   }
+
+void
+DynamicOperation::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   OperationBuilder bldr;
+   bldr.setAction(_action)
+       ->setNumResults(_numResults)
+       ->setNumBuilders(_numBuilders)
+       ->setNumCases(_numCases)
+       ->setNumLiterals(_numLiterals)
+       ->setNumOperands(_numOperands)
+       ->setNumSymbols(_numSymbols)
+       ->setNumTypes(_numTypes)
+       ->setExpander(_expander)
+       ->setPrinter(_printer);
+
+   for (auto i=0;i < _numResults;i++)
+      bldr.addResultType(result(i)->type());
+   for (auto i=0;i < _numBuilders;i++)
+      bldr.addBuilder(builderMappers[i]->next());
+   for (auto i=0;i < _numCases;i++)
+      bldr.addCase(_cases[i]);
+   for (auto i=0;i < _numLiterals;i++)
+      bldr.addLiteral(literalMappers[i]->next());
+   for (auto i=0;i < _numOperands;i++)
+      bldr.addOperand(operandMappers[i]->next());
+   for (auto i=0;i < _numSymbols;i++)
+      bldr.addSymbol(symbolMappers[i]->next());
+   for (auto i=0;i < _numTypes;i++)
+      bldr.addType(typeMappers[i]->next());
+
+   Operation *newOp = b->Append(&bldr);
+
+   for (auto i=0;i < _numResults;i++)
+      resultMappers[i]->add(newOp->result(i));
+   }
+
+Operation *
+DynamicOperation::clone(Builder *b, OperationCloner *cloner) const
+   {
+   OperationBuilder bldr;
+   bldr.setAction(_action)
+       ->setNumResults(_numResults)
+       ->setNumBuilders(_numBuilders)
+       ->setNumCases(_numCases)
+       ->setNumLiterals(_numLiterals)
+       ->setNumOperands(_numOperands)
+       ->setNumSymbols(_numSymbols)
+       ->setNumTypes(_numTypes)
+       ->setExpander(_expander)
+       ->setPrinter(_printer);
+
+   for (auto i=0;i < _numResults;i++)
+      bldr.addResultType(result(i)->type());
+   for (auto i=0;i < _numBuilders;i++)
+      bldr.addBuilder(cloner->builder(i));
+   for (auto i=0;i < _numCases;i++)
+      bldr.addCase(_cases[i]);
+   for (auto i=0;i < _numLiterals;i++)
+      bldr.addLiteral(cloner->literal(i));
+   for (auto i=0;i < _numOperands;i++)
+      bldr.addOperand(operand(i));
+   for (auto i=0;i < _numSymbols;i++)
+      bldr.addSymbol(symbol(i));
+   for (auto i=0;i < _numTypes;i++)
+      bldr.addType(type(i));
+
+   Operation *newOp = b->Append(&bldr);
+
+   for (auto i=0;i < _numResults;i++)
+      cloner->changeResult(newOp->result(i), i);
+
+   return newOp;
+   }
+
+} // namespace JitBuilder
+
+} // namespace OMR

--- a/jitbuilder/jbil/DynamicOperation.hpp
+++ b/jitbuilder/jbil/DynamicOperation.hpp
@@ -1,0 +1,440 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef DYNAMICOPERATION_INCL
+#define DYNAMICOPERATION_INCL
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "Action.hpp"
+#include "Iterator.hpp"
+#include "Operation.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class LiteralValue;
+class OperationBuilder;
+class OperationReplacer;
+class Symbol;
+class Type;
+class TypeDictionary;
+class TypeGraph;
+class Value;
+
+typedef bool (OperationExpander)(OperationReplacer *replacer);
+
+typedef void (OperationPrinter)(TextWriter *w, Operation *op);
+
+typedef void (OperationRegistrar)(TypeDictionary *dict, TypeGraph *graph);
+
+// DynamicOperation defines a class of operations that can be configured dynamically at run timie. 
+// DynamicOperation objects are not created directly: they are created via an OperationBuilder object (see below).
+// A DynamicOperation has an OperationExpander, which is a function that converts the operation to
+// a Builder object containing Operations that implement the DynamicOperation. Before Code Generation,
+// all DynamicOperations will be replaced by the contents of the Builder object returned by its OperationExpander.
+
+class DynamicOperation : public Operation
+   {
+   friend class OperationBuilder;
+
+   public:
+
+   virtual size_t size() const { return sizeof(DynamicOperation); }
+
+   virtual bool isDynamic() const { return true; }
+
+   virtual LiteralIterator LiteralsBegin()             { return LiteralIterator(_literals, _numLiterals); }
+           LiteralIterator &LiteralsEnd()              { return literalEndIterator; }
+   virtual int32_t numLiterals() const                 { return _numLiterals; }
+   virtual LiteralValue * literal(int i=0) const       { assert(i >= 0 && i < _numLiterals); return _literals[i]; }
+
+   virtual SymbolIterator SymbolsBegin()               { return SymbolIterator(_symbols, _numSymbols); }
+           SymbolIterator &SymbolsEnd()                { return symbolEndIterator; }
+   virtual int32_t numSymbols() const                  { return _numSymbols; }
+   virtual Symbol *symbol(int i=0) const               { assert(i >=0 && i < _numSymbols); return _symbols[i]; }
+
+   virtual ValueIterator OperandsBegin()               { return ValueIterator(_operands, _numOperands); }
+           ValueIterator &OperandsEnd()                { return valueEndIterator; }
+   virtual int32_t numOperands() const                 { return _numOperands; }
+   virtual Value * operand(int i=0) const              { assert(i >= 0 && i < _numOperands); return _operands[i]; }
+
+   virtual ValueIterator ResultsBegin()                { return ValueIterator(_results, _numResults); }
+           ValueIterator &ResultsEnd()                 { return valueEndIterator; }
+   virtual int32_t numResults() const                  { return _numResults; }
+   virtual Value * result(int i=0) const               { assert(i >= 0 && i < _numResults); return _results[i]; }
+ 
+   virtual BuilderIterator BuildersBegin()             { return BuilderIterator(_builders, _numBuilders); }
+           BuilderIterator &BuildersEnd()              { return builderEndIterator; }
+   virtual int32_t numBuilders() const                 { return _numBuilders; }
+   virtual Builder *builder(int i=0) const             { assert(i >= 0 && i < _numBuilders); return _builders[i]; }
+
+   virtual CaseIterator CasesBegin()                   { return CaseIterator(_cases, _numCases); }
+   virtual CaseIterator CasesEnd()                     { return CaseIterator(); }
+   virtual int32_t numCases() const                    { return _numCases; }
+   virtual Case * getCase(int i=0) const               { assert(i >= 0 && i < _numCases); return _cases[i]; }
+
+   virtual TypeIterator TypesBegin()                   { return TypeIterator(_types, _numTypes); }
+           TypeIterator &TypesEnd()                    { return typeEndIterator; }
+   virtual int32_t numTypes() const                    { return _numTypes; }
+   virtual Type * type(int i=0) const                  { assert(i >= 0 && i < _numTypes); return _types[i]; }
+
+   virtual Operation * clone(Builder *b, Value **results) const;
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const;
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   void print(TextWriter *w)
+      {
+      assert(_printer);
+      _printer(w, this);
+      }
+
+   bool hasExpander() const { return _expander != NULL; }
+   bool expand(OperationReplacer *replacer) const
+      {
+      assert(_expander);
+      return _expander(replacer);
+      }
+
+   //
+   // New public API
+   // BEGIN {
+
+   // } END
+   // New public API
+   //
+
+protected:
+   DynamicOperation(uint32_t action, Builder *parent,
+                    uint32_t numReturnValues, Value **returnValues,
+                    uint32_t numBuilders, Builder **builders,
+                    uint32_t numCases, Case **cases,
+                    uint32_t numLiterals, LiteralValue **literals,
+                    uint32_t numOperands, Value **operands,
+                    uint32_t numSymbols, Symbol **symbols,
+                    uint32_t numTypes, Type **types,
+                    OperationExpander *expander,
+                    OperationPrinter *printer)
+      : Operation(action, parent)
+      , _numResults(numReturnValues)
+      , _results(returnValues)
+      , _numBuilders(numBuilders)
+      , _builders(builders)
+      , _numCases(numCases)
+      , _cases(cases)
+      , _numLiterals(numLiterals)
+      , _literals(literals)
+      , _numOperands(numOperands)
+      , _operands(operands)
+      , _numSymbols(numSymbols)
+      , _symbols(symbols)
+      , _numTypes(numTypes)
+      , _types(types)
+      , _expander(expander)
+      , _printer(printer)
+      { }
+
+   //
+   // New protected API
+   // BEGIN {
+
+   // } END
+   // New protected API
+   //
+
+   uint32_t            _numResults;
+   Value            ** _results;
+   uint32_t            _numBuilders;
+   Builder          ** _builders;
+   uint32_t            _numCases;
+   Case             ** _cases;
+   uint32_t            _numLiterals;
+   LiteralValue     ** _literals;
+   uint32_t            _numOperands;
+   Value            ** _operands;
+   uint32_t            _numSymbols;
+   Symbol           ** _symbols;
+   uint32_t            _numTypes;
+   Type             ** _types;
+   OperationExpander * _expander;
+   OperationPrinter  * _printer;
+   };
+
+class OperationBuilder
+   {
+   public:
+   OperationBuilder()
+      : _action(aNone)
+      , _numResults(0)
+      , _currentResultTypeIndex(0)
+      , _resultTypes(NULL)
+      , _currentResultIndex(0)
+      , _results(NULL)
+      , _numBuilders(0)
+      , _currentBuilderIndex(0)
+      , _builders(NULL)
+      , _numCases(0)
+      , _currentCaseIndex(0)
+      , _cases(NULL)
+      , _numLiterals(0)
+      , _currentLiteralIndex(0)
+      , _literals(NULL)
+      , _numOperands(0)
+      , _currentOperandIndex(0)
+      , _operands(NULL)
+      , _numSymbols(0)
+      , _currentSymbolIndex(0)
+      , _symbols(NULL)
+      , _numTypes(0)
+      , _currentTypeIndex(0)
+      , _types(NULL)
+      , _expander(NULL)
+      , _printer(NULL)
+      , _registrar(NULL)
+      { }
+
+   DynamicOperation *createOperation(Builder *parent);
+   DynamicOperation *create(Builder *parent, Value *result, Value *v)
+      {
+      return addResult(result)
+             ->addOperand(v)
+             ->createOperation(parent);
+      }
+   DynamicOperation *create(Builder *parent, Value *result, Value *left, Value *right)
+      {
+      return addResult(result)
+             ->addOperand(left)
+             ->addOperand(right)
+             ->createOperation(parent);
+      }
+
+   void initializeTypeProductions(TypeDictionary *dict, TypeGraph *graph)
+      {
+      if (_registrar)
+         _registrar(dict, graph);
+      }
+
+   OperationBuilder *newAction(std::string name)
+      {
+      _action = NumActions++;
+      registerDynamicActionName(_action, name);
+      return this;
+      }
+   OperationBuilder *setAction(Action a)
+      {
+      _action = a;
+      return this;
+      }
+
+   Action action()
+      {
+      return _action;
+      }
+
+   uint32_t numResults() { return _numResults; }
+   OperationBuilder *setNumResults(uint32_t n)
+      {
+      _numResults = n;
+      _resultTypes = new Type *[n];
+      for (auto i = 0;i < n;i++)
+         _resultTypes[i] = NULL;
+      _currentResultTypeIndex = 0;
+      _results = new Value *[n];
+      for (auto i = 0;i < n;i++)
+         _results[i] = NULL;
+      _currentResultIndex = 0;
+      return this;
+      }
+   OperationBuilder *addResultType(Type *t)
+      {
+      assert(_currentResultTypeIndex < _numResults);
+      _resultTypes[_currentResultTypeIndex] = t;
+      return this;
+      }
+   OperationBuilder *addResult(Value *v)
+      {
+      assert(_currentResultIndex < _numResults);
+      _results[_currentResultIndex] = v;
+      return this;
+      }
+   Type *resultType(uint32_t i=0) { assert(i < _numResults); return _resultTypes[i]; }
+
+   uint32_t numBuilders() { return _numBuilders; }
+   OperationBuilder *setNumBuilders(uint32_t n)
+      {
+      _numBuilders = n;
+      _builders = new Builder *[n];
+      for (auto i = 0;i < n;i++)
+         _builders[i] = NULL;
+      _currentBuilderIndex = 0;
+      return this;
+      }
+   OperationBuilder *addBuilder(Builder *b)
+      {
+      assert(_currentBuilderIndex < _numBuilders);
+      _builders[_currentBuilderIndex] = b;
+      return this;
+      }
+
+   uint32_t numCases() { return _numCases; }
+   OperationBuilder *setNumCases(uint32_t n)
+      {
+      _numCases = n;
+      _cases = new Case *[n];
+      for (auto i = 0;i < n;i++)
+         _cases[i] = NULL;
+      _currentCaseIndex = 0;
+      return this;
+      }
+   OperationBuilder *addCase(Case *c)
+      {
+      assert(_currentCaseIndex < _numCases);
+      _cases[_currentCaseIndex] = c;
+      return this;
+      }
+
+   uint32_t numLiterals() { return _numLiterals; }
+   OperationBuilder *setNumLiterals(uint32_t n)
+      {
+      _numLiterals = n;
+      _literals = new LiteralValue *[n];
+      for (auto i = 0;i < n;i++)
+         _literals[i] = NULL;
+      _currentLiteralIndex = 0;
+      return this;
+      }
+   OperationBuilder *addLiteral(LiteralValue *l)
+      {
+      assert(_currentLiteralIndex < _numLiterals);
+      _literals[_currentLiteralIndex] = l;
+      return this;
+      }
+
+   uint32_t numOperands() { return _numOperands; }
+   OperationBuilder *setNumOperands(uint32_t n)
+      {
+      _numOperands = n;
+      _operands = new Value *[n];
+      for (auto i = 0;i < n;i++)
+         _operands[i] = NULL;
+      _currentOperandIndex = 0;
+      return this;
+      }
+   OperationBuilder *addOperand(Value *v)
+      {
+      assert(_currentOperandIndex < _numOperands);
+      _operands[_currentOperandIndex] = v;
+      return this;
+      }
+
+   uint32_t numSymbols() { return _numSymbols; }
+   OperationBuilder *setNumSymbols(uint32_t n)
+      {
+      _numSymbols = n;
+      _symbols = new Symbol *[n];
+      for (auto i = 0;i < n;i++)
+         _symbols[i] = NULL;
+      _currentSymbolIndex = 0;
+      return this;
+      }
+   OperationBuilder *addSymbol(Symbol *s)
+      {
+      assert(_currentSymbolIndex < _numSymbols);
+      _symbols[_currentSymbolIndex] = s;
+      return this;
+      }
+
+   uint32_t numTypes() { return _numTypes; }
+   OperationBuilder *setNumTypes(uint32_t n)
+      {
+      _numTypes = n;
+      _types = new Type *[n];
+      for (auto i = 0;i < n;i++)
+         _types[i] = NULL;
+      return this;
+      }
+   OperationBuilder *addType(Type *t)
+      {
+      assert(_currentTypeIndex < _numTypes);
+      _types[_currentTypeIndex] = t;
+      return this;
+      }
+
+   OperationBuilder *setExpander(OperationExpander *expander) { _expander = expander; return this; }
+
+   OperationBuilder *setPrinter(OperationPrinter *printer) { _printer = printer; return this; }
+
+   OperationBuilder *setRegistrar(OperationRegistrar *registrar) { _registrar = registrar; return this; }
+
+   protected:
+
+   Action _action;
+
+   uint32_t _numResults;
+   uint32_t _currentResultTypeIndex;
+   Type **_resultTypes;
+   uint32_t _currentResultIndex;
+   Value **_results;
+
+   uint32_t _numBuilders;
+   uint32_t _currentBuilderIndex;
+   Builder **_builders;
+
+   uint32_t _numCases;
+   uint32_t _currentCaseIndex;
+   Case **_cases;
+
+   uint32_t _numLiterals;
+   uint32_t _currentLiteralIndex;
+   LiteralValue **_literals;
+
+   uint32_t _numOperands;
+   uint32_t _currentOperandIndex;
+   Value **_operands;
+
+   uint32_t _numSymbols;
+   uint32_t _currentSymbolIndex;
+   Symbol **_symbols;
+
+   uint32_t _numTypes;
+   uint32_t _currentTypeIndex;
+   Type **_types;
+
+   OperationExpander *_expander;
+   OperationPrinter *_printer;
+   OperationRegistrar *_registrar;
+
+   static uint32_t nextDynamicAction;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // !defined(DYNAMICOPERATION_INCL)

--- a/jitbuilder/jbil/DynamicType.cpp
+++ b/jitbuilder/jbil/DynamicType.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2020, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,40 +19,41 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef JITBUILDER_INCL
-#define JITBUILDER_INCL
-
-#define TOSTR(x)     #x
-#define LINETOSTR(x) TOSTR(x)
-
-#include "Builder.hpp"
 #include "DynamicOperation.hpp"
 #include "DynamicType.hpp"
-#include "FunctionBuilder.hpp"
-#include "Operation.hpp"
-#include "Symbol.hpp"
-#include "Transformer.hpp"
-#include "TextWriter.hpp"
-#include "Type.hpp"
 #include "TypeDictionary.hpp"
-#include "Value.hpp"
 
-bool initializeJit();
-bool constructFunctionBuilder(OMR::JitBuilder::FunctionBuilder * fb);
-int32_t compileFunctionBuilder(OMR::JitBuilder::FunctionBuilder * fb, void ** entry);
-void shutdownJit();
+namespace OMR
+{
 
-// Legacy definitions: may need to make IlBuilder a class....
-//#define IlBuilder Builder
-//#define MethodBuilder FunctionBuilder
-//#define compileMethodBuilder(fb,e) compileFunctionBuilder(fb, e)
+namespace JitBuilder
+{
 
-// Global user definitions
-// BEGIN {
-//
+DynamicType::DynamicType(TypeDictionary *dict, std::string name, size_t size, ValuePrinter *printer, StructType *layout, LiteralExploder *exploder, OperationExpander *expander, TypeRegistrar *registrar)
+   : Type(dict, name, size, printer)
+   , _layout(layout)
+   , _exploder(exploder)
+   , _expander(expander)
+   , _registrar(registrar)
+   {
+   dict->registerDynamicType(this);
+   }
 
-//
-// } END
-// Global user definitions
+bool
+DynamicType::expand(OperationReplacer *replacer) const
+   {
+   if (_expander)
+      return _expander(replacer);
+   return false;
+   }
 
-#endif // defined(JITBUILDER_INCL)
+void
+DynamicType::initializeTypeProductions(TypeDictionary *dict, TypeGraph *graph)
+   {
+   if (_registrar)
+      _registrar(this, dict, graph);
+   }
+
+} // namespace JitBuilder
+
+} // namespace OMR

--- a/jitbuilder/jbil/DynamicType.hpp
+++ b/jitbuilder/jbil/DynamicType.hpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef DYNAMICTYPE_INCL
+#define DYNAMICTYPE_INCL
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+
+#include "DynamicOperation.hpp"
+#include "Type.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class TextWriter;
+class TypeDictionary;
+class TypeGraph;
+
+typedef LiteralMapper *(LiteralExploder)(TypeDictionary *dict, LiteralValue *value, LiteralMapper *m);
+
+typedef void (TypeRegistrar)(DynamicType *type, TypeDictionary *dict, TypeGraph *graph);
+
+class DynamicType : public Type
+   {
+public:
+   static DynamicType * create(TypeDictionary *dict, std::string name, size_t size, ValuePrinter *printer, StructType *layout, LiteralExploder *exploder, OperationExpander *expander, TypeRegistrar *registrar)
+      {
+      return new DynamicType(dict, name, size, printer, layout, exploder, expander, registrar);
+      }
+
+   virtual bool isDynamic() const { return true; }
+
+   virtual StructType *layout() const { return _layout; }
+   virtual LiteralMapper *explode(LiteralValue *value, LiteralMapper *m=NULL) const { return _exploder(_dict, value, m); }
+   virtual bool expand(OperationReplacer *replacer) const;
+   virtual void initializeTypeProductions(TypeDictionary *dict, TypeGraph *graph);
+
+protected:
+   DynamicType(TypeDictionary *dict, std::string name, size_t size, ValuePrinter *printer, StructType *layout, LiteralExploder *exploder, OperationExpander *expander, TypeRegistrar *registrar);
+
+   StructType        * _layout;
+   LiteralExploder   * _exploder;
+   OperationExpander * _expander;
+   TypeRegistrar     * _registrar;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(DYNAMICTYPE_INCL)

--- a/jitbuilder/jbil/FunctionBuilder.cpp
+++ b/jitbuilder/jbil/FunctionBuilder.cpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string>
+#include <vector>
+#include "FunctionBuilder.hpp"
+#include "Debugger.hpp"
+#include "JitBuilder.hpp"
+#include "Operation.hpp"
+#include "TextWriter.hpp"
+
+
+using namespace OMR::JitBuilder;
+
+
+FunctionBuilder::~FunctionBuilder()
+   {
+   if (config()->reportMemory() && logger())
+      logger()->indent() << "FunctionBuilder " << this << " : memory allocated is " << _memoryAllocated << " bytes" << logger()->endl();
+
+   // do accounting for objects that will be freed to see if anything left
+   for (auto objIt = _objects.begin(); objIt != _objects.end(); objIt++)
+      {
+      Object *obj = *objIt;
+      _memoryAllocated -= obj->size();
+      delete obj;
+      }
+
+   if (_memoryAllocated != 0 && config()->reportMemory() && logger())
+      logger()->indent() << "Error: unaccounted memory: " << _memoryAllocated << logger()->endl();
+   }
+
+void
+FunctionBuilder::registerObject(Object *obj)
+   {
+   if (obj != this)
+      {
+      _memoryAllocated += obj->size();
+      _objects.push_back(obj);
+      }
+   }
+
+int32_t
+FunctionBuilder::numValues() const
+   {
+   return Value::maxID();
+   }
+
+int32_t
+FunctionBuilder::numLocals() const
+   {
+   return _locals.size() + _parameters.size();
+   }
+
+void
+FunctionBuilder::DefineName(std::string name)
+   {
+   _givenName = name;
+   }
+
+void
+FunctionBuilder::DefineFile(std::string file)
+   {
+   _fileName = file;
+   }
+
+void
+FunctionBuilder::DefineLine(std::string line)
+   {
+   _lineNumber = line;
+   }
+
+void
+FunctionBuilder::DefineParameter(std::string name, Type * type)
+   {
+   ParameterSymbol *parm = ParameterSymbol::create(name, type, _parameters.size());
+   _parameters.push_back(parm);
+   }
+
+void
+FunctionBuilder::DefineReturnType(Type * type)
+   {
+   _returnType = type;
+   _types->registerReturnType(type);
+   }
+
+LocalSymbol *
+FunctionBuilder::DefineLocal(std::string name, Type * type)
+   {
+   Symbol *sym = getSymbol(name);
+   if (sym && sym->isLocal())
+      return static_cast<LocalSymbol *>(sym);
+
+   LocalSymbol *local = LocalSymbol::create(name, type);
+   _locals.push_back(local);
+   return local;
+   }
+
+void
+OMR::JitBuilder::FunctionBuilder::DefineFunction(std::string name,
+                                                 std::string fileName,
+                                                 std::string lineNumber,
+                                                 void *entryPoint,
+                                                 Type *returnType,
+                                                 int32_t numParms,
+                                                 ...)
+   {
+   Type **parmTypes = new Type*[numParms];
+   va_list parms;
+   va_start(parms, numParms);
+   
+   for (int32_t p=0;p < numParms;p++)
+      parmTypes[p] = (Type *) va_arg(parms, Type *);
+   va_end(parms);
+
+   internalDefineFunction(name, fileName, lineNumber, entryPoint, returnType, numParms, parmTypes);
+   }
+
+void
+OMR::JitBuilder::FunctionBuilder::DefineFunction(std::string name,
+                                                 std::string fileName,
+                                                 std::string lineNumber,
+                                                 void *entryPoint,
+                                                 Type *returnType,
+                                                 int32_t numParms,
+                                                 Type **parmTypes)
+   {
+   // copy parameter types so don't have to force caller to keep the parmTypes array alive
+   Type **copiedParmTypes = new Type*[numParms];
+   for (int32_t p=0;p < numParms;p++)
+      copiedParmTypes[p] = parmTypes[p];
+
+   internalDefineFunction(name, fileName, lineNumber, entryPoint, returnType, numParms, copiedParmTypes);
+   }
+
+void
+OMR::JitBuilder::FunctionBuilder::internalDefineFunction(std::string name,
+                                                         std::string fileName,
+                                                         std::string lineNumber,
+                                                         void *entryPoint,
+                                                         Type *returnType,
+                                                         int32_t numParms,
+                                                         Type **parmTypes)
+   {
+   FunctionType *type = _types->DefineFunctionType(name, returnType, numParms, parmTypes);
+   FunctionSymbol *sym = FunctionSymbol::create(type, name, fileName, lineNumber, entryPoint);
+
+   // TODO: Why? _locals.push_back(sym);
+   _functions.push_back(sym);
+   }
+
+Symbol *
+FunctionBuilder::getSymbol(std::string name)
+   {
+   for (LocalSymbolIterator lIt = LocalsBegin(); lIt != LocalsEnd(); lIt++)
+      {
+      LocalSymbol * local = *lIt;
+      if (local->name() == name)
+         return local;
+      }
+
+   for (ParameterSymbolIterator pIt = ParametersBegin(); pIt != ParametersEnd(); pIt++)
+      {
+      ParameterSymbol * parameter = *pIt;
+      if (parameter->name() == name)
+         return parameter;
+      }
+
+   for (FunctionSymbolIterator fIt = FunctionsBegin(); fIt != FunctionsEnd(); fIt++)
+      {
+      FunctionSymbol * function = *fIt;
+      if (function->name() == name)
+         return function;
+      }
+
+   return NULL;
+   }
+
+bool
+OMR::JitBuilder::FunctionBuilder::Construct()
+   {
+   return constructFunctionBuilder(this);
+   }
+
+void *
+OMR::JitBuilder::FunctionBuilder::internalCompile(int32_t *returnCode)
+   {
+   _entryPoint = NULL;
+   *returnCode = compileFunctionBuilder(this, &_entryPoint);
+   return _entryPoint;
+   }
+
+void *
+OMR::JitBuilder::FunctionBuilder::internalDebugger(int32_t *returnCode)
+   {
+   _debuggerObject = new OMR::JitBuilder::Debugger(this);
+   _debugEntryPoint = _debuggerObject->createDebugger(returnCode);
+   return _debugEntryPoint;
+   }

--- a/jitbuilder/jbil/FunctionBuilder.hpp
+++ b/jitbuilder/jbil/FunctionBuilder.hpp
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef FUNCTIONBUILDER_INCL
+#define FUNCTIONBUILDER_INCL
+
+
+#include <string>
+#include <vector>
+
+#include "Builder.hpp"
+#include "Config.hpp"
+#include "Iterator.hpp"
+#include "Operation.hpp"
+#include "Symbol.hpp"
+#include "Type.hpp"
+
+#define TOSTR(x) #x
+#define LINETOSTR(x) TOSTR(x)
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class FunctionBuilder;
+class Operation;
+class Debugger;
+class TextWriter;
+class TypeDictionary;
+
+class FunctionBuilder : public Builder
+   {
+   friend class Builder;
+   friend class Type;
+public:
+   virtual ~FunctionBuilder();
+
+   void DefineName(std::string name);
+   void DefineFile(std::string file);
+   void DefineLine(std::string line);
+   void DefineParameter(std::string name, Type * type);
+   void DefineReturnType(Type * type);
+   LocalSymbol * DefineLocal(std::string name, Type * type);
+   void DefineFunction(std::string name, std::string fileName, std::string lineNumber, void *entryPoint, Type *returnType, int32_t numParms, ...);
+   void DefineFunction(std::string name, std::string fileName, std::string lineNumber, void *entryPoint, Type *returnType, int32_t numParms, Type **parmTypes);
+
+   std::string name() const                        { return _givenName; }
+   std::string fileName() const                    { return _fileName; }
+   std::string lineNumber() const                  { return _lineNumber; }
+
+   ParameterSymbolIterator ParametersBegin()       { return _parameters.begin(); }
+   ParameterSymbolIterator ParametersEnd()         { return _parameters.end(); }
+   ParameterSymbolVector ResetParameters()
+      {
+      ParameterSymbolVector prev = _parameters;
+      _parameters.clear();
+      return prev;
+      }
+   LocalSymbolIterator LocalsBegin()               { return _locals.begin(); }
+   LocalSymbolIterator LocalsEnd()                 { return _locals.end(); }
+   LocalSymbolVector ResetLocals()
+      {
+      LocalSymbolVector prev = _locals;
+      _locals.clear();
+      return prev;
+      }
+
+   FunctionSymbolIterator FunctionsBegin()         { return _functions.begin(); }
+   FunctionSymbolIterator FunctionsEnd()           { return _functions.end(); }
+   FunctionSymbolVector ResetFunctions()
+      {
+      FunctionSymbolVector prev = _functions;
+      _functions.clear();
+      return prev;
+      }
+
+   FunctionSymbol *LookupFunction(std::string name)
+      {
+      Symbol *sym = getSymbol(name);
+      if (!sym->isFunction())
+         return NULL;
+      return static_cast<FunctionSymbol *>(sym);
+      }
+
+   int32_t numValues() const;
+   int32_t numLocals() const;
+   int32_t numReturnValues() const                 { return (_returnType == NoType) ? 0 : 1; /* for now */ }
+
+   Type * getReturnType() const                    { return _returnType; }
+   TypeDictionary * dict() const                   { return _types; }
+   Config * config()                               { return &_config; }
+   virtual size_t size() const                     { return sizeof(FunctionBuilder); }
+
+   bool constructIL()
+      {
+      bool rc = buildIL();
+      _ilBuilt = true;
+      return rc;
+      }
+
+   virtual bool buildIL()
+      {
+      return false;
+      }
+
+   bool Construct();
+
+   template<typename T> T *CompiledEntry(int32_t *returnCode) { return reinterpret_cast<T *>(internalCompile(returnCode)); }
+   template<typename T> T *entryPoint()                       { assert(_entryPoint != NULL); return reinterpret_cast<T *>(_entryPoint); }
+
+   template<typename T> T *DebugEntry(int32_t *returnCode)    { return reinterpret_cast<T *>(internalDebugger(returnCode)); }
+   template<typename T> T *debugEntryPoint()                  { assert(_debugEntryPoint != NULL); return reinterpret_cast<T *>(_debugEntryPoint); }
+
+   bool ilBuilt() const                                       { return _ilBuilt; }
+
+   Symbol * getSymbol(std::string name);
+
+   int32_t incrementLocations()                               { return _numLocations++; }
+   void addLocation(Location *loc )                           { _locations.push_back(loc); }
+
+   int64_t incrementTransformation()                          { return _numTransformations++; }
+
+   void setLogger(TextWriter * logger)                        { _logger = logger; }
+   TextWriter * logger(bool enabled=false) const              { return enabled ? _logger : NULL; }
+
+   virtual size_t size()                                      { return sizeof(FunctionBuilder); }
+   void registerObject(Object *obj);
+
+   protected:
+   FunctionBuilder(TypeDictionary * types)
+      : Builder(this, this, types)
+      , _types(types)
+      , _returnType(NoType)
+      , _entryPoint(NULL)
+      , _debugEntryPoint(NULL)
+      , _ilBuilt(false)
+      , _numLocations(0)
+      , _memoryAllocated(0)
+      , _numTransformations(0)
+      , _logger(NULL)
+      {
+      SourceLocation(); // make sure everything has a location; by default BCIndex is 0
+      }
+
+   void internalDefineFunction(std::string name, std::string fileName, std::string lineNumber, void *entryPoint, Type *returnType, int32_t numParms, Type **parmTypes);
+   void *internalCompile(int32_t *returnCode);
+   void *internalDebugger(int32_t *returnCode);
+
+   TypeDictionary         * _types;
+   Config                   _config;
+   std::string              _givenName;
+   std::string              _fileName;
+   std::string              _lineNumber;
+   ParameterSymbolVector    _parameters;
+   LocalSymbolVector        _locals;
+   FunctionSymbolVector     _functions;
+   Type                   * _returnType;
+
+   void                   * _entryPoint;
+
+   Debugger               * _debuggerObject;
+   void                   * _debugEntryPoint;
+
+   int64_t                  _numLocations;
+   std::vector<Location *>  _locations;
+   bool                     _ilBuilt;
+   uint64_t                 _memoryAllocated;
+   std::vector<Object *>    _objects;
+   int64_t                  _numTransformations;
+   TextWriter             * _logger;
+
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(FUNCTIONBUILDER_INCL)

--- a/jitbuilder/jbil/Increment.cpp
+++ b/jitbuilder/jbil/Increment.cpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string>
+
+#include "JitBuilder.hpp"
+
+using namespace OMR::JitBuilder;
+
+class Increment : public FunctionBuilder
+   {
+public:
+   Increment(TypeDictionary * types)
+      : FunctionBuilder(types)
+      {
+      DefineName("Increment");
+      DefineLine(LINETOSTR(__LINE__));
+      DefineFile(__FILE__);
+      DefineParameter("value", Int32);
+      DefineReturnType(Int32);
+      }
+
+   virtual bool buildIL()
+      {
+      Return(Add(Load("value"), ConstInt32(1)));
+
+      #if 0
+         Builder *b = OrphanBuilder();
+         AppendBuilder(b);
+      #endif
+
+      return true;
+      }
+   };
+
+typedef int32_t (IncrementFunc)(int32_t);
+
+int
+main(int argc, char *argv[])
+   {
+   bool success = initializeJit();
+   if (!success)
+      {
+      printf("initializeJit failure\n");
+      exit(-1);
+      }
+
+   TypeDictionary types("Increment_Types");
+   Increment method(&types);
+   success = method.Construct();
+   if (!success)
+      {
+      printf("construction failure\n");
+      exit(-2);
+      }
+
+
+   std::cerr.setf(std::ios_base::skipws);
+   std::cerr << "Method to debug:" << std::endl;
+   OMR::JitBuilder::TextWriter printer(&method, std::cout, std::string("    "));
+   method.setLogger(&printer);
+   printer.print();
+
+   int32_t rc=0;
+   IncrementFunc *func = method.DebugEntry<IncrementFunc>(&rc);
+   if (rc != 0)
+      {
+      printf("Simulation request returned error code %d\n", rc);
+      exit(rc);
+      }
+
+   int32_t mlae = func(41);
+ 
+   printf("rv is %d\n", mlae);
+
+   shutdownJit();
+
+   exit(0);
+   }

--- a/jitbuilder/jbil/Iterator.hpp
+++ b/jitbuilder/jbil/Iterator.hpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ITERATOR_INCL
+#define ITERATOR_INCL
+
+#include <cstdarg>
+#include <vector>
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class LiteralValue;
+class Symbol;
+class Type;
+class Value;
+
+template <class T>
+class Iterator
+   {
+   public:
+   Iterator<T>() // used to create an "end" iterator, _index must be -1 to match end of iteration
+      : _index(-1)
+      { }
+   Iterator<T>(const Iterator<T> & other)
+      : _index(other._index)
+      {
+      _items = other._items;
+      }
+   Iterator<T>(T * one)
+      : _index(0)
+      , _items(1)
+      {
+      _items[0] = one;
+      }
+
+   Iterator<T>(T * one, T * two)
+      : _index(1)
+      , _items(2)
+      {
+      _items[0] = one;
+      _items[1] = two;
+      }
+   Iterator<T>(T * one, T * two, T * three)
+      : _index(2)
+      , _items(3)
+      {
+      _items[0] = one;
+      _items[1] = two;
+      _items[2] = three;
+      }
+   Iterator<T>(int numArgs, ...)
+      : _index(numArgs-1)
+      , _items(numArgs)
+      {
+      va_list(args);
+      va_start(args, numArgs);
+      for (int a=0;a < numArgs;a++)
+         _items[a] = va_arg(args, T *);
+      va_end(args);
+      }
+   Iterator<T>(T **array, int arraySize)
+      : _index(arraySize-1)
+      {
+      _items.assign(array, array+arraySize);
+      }
+   Iterator<T>(std::vector<T *> v)
+      : _index(v.size()-1)
+      , _items(v)
+      {
+      }
+   void prepend(Iterator<T> toPrepend)
+      {
+      std::vector<T *> v = toPrepend._items;
+      _items.reserve(_items.size() + v.size());
+      _items.insert(_items.begin(), v.begin(), v.end());
+      _index = _items.size() - 1;
+      }
+   T * operator*()
+      {
+      return _items[_items.size()-1-_index];
+      }
+
+   T * operator++(int)
+      {
+      if (_index >= 0)
+         {
+         T * elem = _items[_items.size()-1-_index];
+         _index--;
+         return elem;
+         }
+      // at end, _index == -1
+      return NULL;
+      }
+   bool operator!=(const Iterator<T> & other)
+      {
+      return !(*this == other);
+      }
+   bool operator==(const Iterator<T> & other)
+      {
+      return _index == other._index;
+      }
+   protected:
+   std::vector<T *> _items;
+   int              _index;
+   };
+
+typedef Iterator<Builder> BuilderIterator;
+typedef std::vector<Case *>::iterator CaseIterator;
+typedef Iterator<LiteralValue> LiteralIterator;
+typedef Iterator<Symbol> SymbolIterator;
+typedef Iterator<Type> TypeIterator;
+typedef Iterator<Value> ValueIterator;
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(ITERATOR_INCL)

--- a/jitbuilder/jbil/Iterator.hpp
+++ b/jitbuilder/jbil/Iterator.hpp
@@ -129,7 +129,7 @@ class Iterator
    };
 
 typedef Iterator<Builder> BuilderIterator;
-typedef std::vector<Case *>::iterator CaseIterator;
+typedef Iterator<Case> CaseIterator; //std::vector<Case *>::iterator CaseIterator;
 typedef Iterator<LiteralValue> LiteralIterator;
 typedef Iterator<Symbol> SymbolIterator;
 typedef Iterator<Type> TypeIterator;

--- a/jitbuilder/jbil/JitBuilder.cpp
+++ b/jitbuilder/jbil/JitBuilder.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JitBuilder.hpp"
+#include "CodeGenerator.hpp"
+#include "TextWriter.hpp"
+
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+bool internal_initializeJit();
+int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
+void internal_shutdownJit();
+
+bool
+initializeJit()
+   {
+   internal_initializeJit();
+   return true;
+   }
+
+bool
+constructFunctionBuilder(OMR::JitBuilder::FunctionBuilder * fb)
+   {
+   OMR::JitBuilder::TextWriter * logger = fb->logger();
+   if (logger)
+      {
+      (*logger) << "Logging constructFunctionBuilder:\n";
+      (*logger) << fb << " : call buildIL()\n";
+      }
+   return fb->constructIL();
+   }
+
+class CompileMethodBuilder : public TR::MethodBuilder
+   {
+   public:
+   CompileMethodBuilder(OMR::JitBuilder::FunctionBuilder *fb, TR::TypeDictionary *types)
+      : TR::MethodBuilder(types)
+      , _fb(fb)
+      , _cg(fb, this)
+      , _ilBuilt(false)
+      {
+      bool success = _fb->ilBuilt();
+      if (!success)
+         success = _fb->buildIL();
+
+      if (_fb->config()->hasReducer())
+         _fb->config()->reducer()->transform(_fb);
+
+      _cg.generateFunctionAPI(fb);
+
+      _ilBuilt = success;
+      }
+
+   virtual bool buildIL()
+      {
+      if (_ilBuilt)
+         _cg.transform();
+
+      return _ilBuilt;
+      }
+
+   protected:
+   OMR::JitBuilder::FunctionBuilder * _fb;
+   OMR::JitBuilder::CodeGenerator _cg;
+   bool _ilBuilt;
+   };
+
+int32_t
+compileFunctionBuilder(OMR::JitBuilder::FunctionBuilder *fb, void **entry)
+   {
+   TR::TypeDictionary types;
+   CompileMethodBuilder cmb(fb, &types);
+   return internal_compileMethodBuilder(&cmb, entry);
+   }
+
+void
+shutdownJit()
+   {
+   internal_shutdownJit();
+   }

--- a/jitbuilder/jbil/JitBuilder.hpp
+++ b/jitbuilder/jbil/JitBuilder.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef JITBUILDER_INCL
+#define JITBUILDER_INCL
+
+#define TOSTR(x)     #x
+#define LINETOSTR(x) TOSTR(x)
+
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "Operation.hpp"
+#include "Symbol.hpp"
+#include "Transformer.hpp"
+#include "TextWriter.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+#include "Value.hpp"
+
+bool initializeJit();
+bool constructFunctionBuilder(OMR::JitBuilder::FunctionBuilder * fb);
+int32_t compileFunctionBuilder(OMR::JitBuilder::FunctionBuilder * fb, void ** entry);
+void shutdownJit();
+
+// Legacy definitions: may need to make IlBuilder a class....
+//#define IlBuilder Builder
+//#define MethodBuilder FunctionBuilder
+//#define compileMethodBuilder(fb,e) compileFunctionBuilder(fb, e)
+
+// Global user definitions
+// BEGIN {
+//
+
+//
+// } END
+// Global user definitions
+
+#endif // defined(JITBUILDER_INCL)

--- a/jitbuilder/jbil/LiteralValue.cpp
+++ b/jitbuilder/jbil/LiteralValue.cpp
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "LiteralValue.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+
+using namespace OMR::JitBuilder;
+
+LiteralValue::~LiteralValue()
+   {
+   if (_kind == T_string)
+      delete v_string;
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, int8_t v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, int16_t v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, int32_t v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, int64_t v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, float v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, double v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, void *v)
+   {
+   return new LiteralValue(dict, v);
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, std::string v)
+   {
+   return new LiteralValue(dict, new std::string(v));
+   }
+
+LiteralValue *
+LiteralValue::create(TypeDictionary *dict, Type *t)
+   {
+   return new LiteralValue(dict, t);
+   }
+
+int8_t
+LiteralValue::getInt8()
+   {
+   assert(_kind == T_int8);
+   return v_Int8;
+   }
+
+int16_t
+LiteralValue::getInt16()
+   {
+   assert(_kind == T_int16);
+   return v_Int16;
+   }
+
+int32_t
+LiteralValue::getInt32()
+   {
+   assert(_kind == T_int32);
+   return v_Int32;
+   }
+
+int64_t
+LiteralValue::getInt64()
+   {
+   assert(_kind == T_int64);
+   return v_Int64;
+   }
+
+float
+LiteralValue::getFloat()
+   {
+   assert(_kind == T_float);
+   return v_Float;
+   }
+
+double
+LiteralValue::getDouble()
+   {
+   assert(_kind == T_double);
+   return v_Double;
+   }
+
+void *
+LiteralValue::getAddress()
+   {
+   assert(_kind == T_address);
+   return v_Address;
+   }
+
+std::string
+LiteralValue::getString()
+   {
+   if (_kind == T_string)
+      return *v_string;
+   if (_kind == T_typename)
+      return v_type->name();
+   assert(0);
+   }
+
+Type *
+LiteralValue::getType()
+   {
+   assert(_kind == T_typename);
+   return v_type;
+   }
+
+std::string
+LiteralValue::getTypeString()
+   {
+   assert(_kind == T_typename);
+   return v_type->name();
+   }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, int8_t v)
+   : _dict(dict)
+   , _kind(T_int8)
+   , _type(dict->Int8)
+   , v_Int8(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, int16_t v)
+   : _dict(dict)
+   , _kind(T_int16)
+   , _type(dict->Int16)
+   , v_Int16(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, int32_t v)
+   : _dict(dict)
+   , _kind(T_int32)
+   , _type(dict->Int32)
+   , v_Int32(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, int64_t v)
+   : _dict(dict)
+   , _kind(T_int64)
+   , _type(dict->Int64)
+   , v_Int64(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, float v)
+   : _dict(dict)
+   , _kind(T_float)
+   , _type(dict->Float)
+   , v_Float(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, double v)
+   : _dict(dict)
+   , _kind(T_double)
+   , _type(dict->Double)
+   , v_Double(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, void *v)
+   : _dict(dict)
+   , _kind(T_address)
+   , _type(dict->Address)
+   , v_Address(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, std::string *v)
+   : _dict(dict)
+   , _kind(T_string)
+   , _type(dict->Address) // until string becomes a recognized type
+   , v_string(v)
+   { }
+
+LiteralValue::LiteralValue(TypeDictionary *dict, Type *v)
+   : _dict(dict)
+   , _kind(T_typename)
+   , _type(dict->Address)
+   , v_type(v)
+   { }
+
+
+// New user code
+// BEGIN {
+//
+
+//
+// } END
+// New user code

--- a/jitbuilder/jbil/LiteralValue.hpp
+++ b/jitbuilder/jbil/LiteralValue.hpp
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LITERALVALUE_INCL
+#define LITERALVALUE_INCL
+
+#include <map>
+#include <vector>
+
+#include "Object.hpp"
+
+// New includes
+// BEGIN {
+//
+
+//
+// } END
+// New includes
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Type;
+class TypeDictionary;
+
+enum LiteralKind
+   {
+     T_none=-1
+   , T_int8
+   , T_int16
+   , T_int32
+   , T_int64
+   , T_float
+   , T_double
+   , T_address
+   , T_string
+   , T_typename
+   , T_aggregate
+
+   // new literal base types
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // new literal base types
+   };
+
+class LiteralValue //: public Object
+   {
+   public:
+   ~LiteralValue();
+
+   static LiteralValue *create(TypeDictionary *dict, int8_t v);
+   static LiteralValue *create(TypeDictionary *dict, int16_t v);
+   static LiteralValue *create(TypeDictionary *dict, int32_t v);
+   static LiteralValue *create(TypeDictionary *dict, int64_t v);
+   static LiteralValue *create(TypeDictionary *dict, float v);
+   static LiteralValue *create(TypeDictionary *dict, double v);
+   static LiteralValue *create(TypeDictionary *dict, void *v);
+   static LiteralValue *create(TypeDictionary *dict, std::string v);
+   static LiteralValue *create(TypeDictionary *dict, Type *t);
+
+   enum LiteralKind kind() const { return _kind; }
+   Type *type() const { return _type; }
+
+   int8_t getInt8();
+   int16_t getInt16();
+   int32_t getInt32();
+   int64_t getInt64();
+   float getFloat();
+   double getDouble();
+   void *getAddress();
+   std::string getString();
+   Type * getType();
+   std::string getTypeString();
+
+   // New public API
+   // BEGIN {
+   //
+   
+   //
+   // } END
+   // New public API
+
+   protected:
+   LiteralValue(TypeDictionary *dict, int8_t v);
+   LiteralValue(TypeDictionary *dict, int16_t v);
+   LiteralValue(TypeDictionary *dict, int32_t v);
+   LiteralValue(TypeDictionary *dict, int64_t v);
+   LiteralValue(TypeDictionary *dict, float v);
+   LiteralValue(TypeDictionary *dict, double v);
+   LiteralValue(TypeDictionary *dict, void *v);
+   LiteralValue(TypeDictionary *dict, std::string *v);
+   LiteralValue(TypeDictionary *dict, Type *t);
+
+   // New protected API
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // New protected API
+
+   TypeDictionary *_dict;
+   LiteralKind _kind;
+   Type *_type;
+   union
+      {
+      int8_t v_Int8; // also bool
+      int16_t v_Int16;
+      int32_t v_Int32;
+      int64_t v_Int64;
+      float v_Float;
+      double v_Double;
+      void *v_Address;
+      std::string *v_string;
+      Type *v_type;
+      std::map<std::string, LiteralValue *> *v_aggregate;
+
+      // New literal values
+      // BEGIN {
+      //
+
+      //
+      // } END
+      // New literal values
+ 
+      };
+   };
+
+typedef std::vector<LiteralValue *> LiteralValueVector;
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(LITERALVALUE_INCL)

--- a/jitbuilder/jbil/LiteralValue.hpp
+++ b/jitbuilder/jbil/LiteralValue.hpp
@@ -41,6 +41,8 @@ namespace OMR
 namespace JitBuilder
 {
 
+class DynamicType;
+class TextWriter;
 class Type;
 class TypeDictionary;
 
@@ -57,6 +59,7 @@ enum LiteralKind
    , T_string
    , T_typename
    , T_aggregate
+   , T_dynamic
 
    // new literal base types
    // BEGIN {
@@ -81,6 +84,7 @@ class LiteralValue //: public Object
    static LiteralValue *create(TypeDictionary *dict, void *v);
    static LiteralValue *create(TypeDictionary *dict, std::string v);
    static LiteralValue *create(TypeDictionary *dict, Type *t);
+   static LiteralValue *create(TypeDictionary *dict, DynamicType *t, void *v);
 
    enum LiteralKind kind() const { return _kind; }
    Type *type() const { return _type; }
@@ -95,6 +99,9 @@ class LiteralValue //: public Object
    std::string getString();
    Type * getType();
    std::string getTypeString();
+   void *getDynamicTypeValue();
+
+   void print(TextWriter *w);
 
    // New public API
    // BEGIN {
@@ -114,6 +121,7 @@ class LiteralValue //: public Object
    LiteralValue(TypeDictionary *dict, void *v);
    LiteralValue(TypeDictionary *dict, std::string *v);
    LiteralValue(TypeDictionary *dict, Type *t);
+   LiteralValue(TypeDictionary *dict, DynamicType *t, void *v);
 
    // New protected API
    // BEGIN {
@@ -138,6 +146,7 @@ class LiteralValue //: public Object
       std::string *v_string;
       Type *v_type;
       std::map<std::string, LiteralValue *> *v_aggregate;
+      size_t v_startDynamicTypeValue;
 
       // New literal values
       // BEGIN {
@@ -149,6 +158,8 @@ class LiteralValue //: public Object
  
       };
    };
+
+#define LARGEST_STATIC_TYPE   size_t   // largest type in LiteralValue's union of static types
 
 typedef std::vector<LiteralValue *> LiteralValueVector;
 

--- a/jitbuilder/jbil/Location.cpp
+++ b/jitbuilder/jbil/Location.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "FunctionBuilder.hpp"
+#include "Location.hpp"
+
+int64_t OMR::JitBuilder::Location::globalIndex = 0;
+
+OMR::JitBuilder::Location::Location(FunctionBuilder * fb)
+   : Object(fb)
+   , _id(globalIndex++)
+   , _fb(fb)
+   , _bcIndex(fb->incrementLocations())
+   , _fileName(fb->fileName())
+   , _lineNumber(fb->lineNumber())
+   { }
+
+OMR::JitBuilder::Location::Location(FunctionBuilder * fb, std::string lineNumber)
+   : Object(fb)
+   , _id(globalIndex++)
+   , _fb(fb)
+   , _bcIndex(fb->incrementLocations())
+   , _fileName(fb->fileName())
+   , _lineNumber(lineNumber)
+   { }
+
+OMR::JitBuilder::Location::Location(FunctionBuilder * fb, std::string lineNumber, int32_t bcIndex)
+   : Object(fb)
+   , _id(globalIndex++)
+   , _fb(fb)
+   , _bcIndex(bcIndex)
+   , _fileName(fb->fileName())
+   , _lineNumber(lineNumber)
+   { }
+

--- a/jitbuilder/jbil/Location.hpp
+++ b/jitbuilder/jbil/Location.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef LOCATION_INCL
+#define LOCATION_INCL
+
+#include "stdint.h"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class FunctionBuilder;
+
+class Location : Object
+   {
+public:
+   static Location * create(FunctionBuilder * fb)
+      {
+      return new Location(fb);
+      }
+   static Location * create(FunctionBuilder * fb, std::string lineNumber)
+      {
+      return new Location(fb, lineNumber);
+      }
+   static Location * create(FunctionBuilder * fb, std::string lineNumber, int32_t bcIndex)
+      {
+      return new Location(fb, lineNumber, bcIndex);
+      }
+
+   virtual size_t size()          { return sizeof(Location); }
+   uint64_t id() const            { return _id; }
+   int32_t bcIndex() const        { return _bcIndex; }
+   std::string fileName() const   { return _fileName; }
+   std::string lineNumber() const { return _lineNumber; }
+
+protected:
+   Location(FunctionBuilder * fb);
+   Location(FunctionBuilder * fb, std::string lineNumber);
+   Location(FunctionBuilder * fb, std::string lineNumber, int32_t bcIndex);
+
+   int64_t           _id;
+   FunctionBuilder * _fb;
+   int32_t           _bcIndex;
+   std::string       _fileName;
+   std::string       _lineNumber;
+
+   static int64_t globalIndex;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(LOCATION_INCL)

--- a/jitbuilder/jbil/Makefile
+++ b/jitbuilder/jbil/Makefile
@@ -20,6 +20,9 @@ min: Min.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
 matmult: MatMult.o JitBuilder.hpp $(LIBJITB2)
 	g++ -g -o matmult $(LINK_OPTIONS) MatMult.o
 
+complexmatmult: ComplexMatMult.o JitBuilder.hpp ComplexSupport.o $(LIBJITB2)
+	g++ -g -o complexmatmult $(LINK_OPTIONS) ComplexMatMult.o ComplexSupport.o
+
 returns: Returns.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
 	g++ -g -o returns $(LINK_OPTIONS) Returns.o
 
@@ -76,6 +79,7 @@ TypeDictionary.o: TypeDictionary.cpp TypeDictionary.hpp
 TypeGraph.o: TypeGraph.cpp TypeGraph.hpp TextWriter.hpp
 Value.o: Value.cpp Value.hpp
 Visitor.o: Visitor.cpp Visitor.hpp
+ComplexSupport.o: ComplexSupport.cpp ComplexSupport.hpp
 
 JitBuilder.o: JitBuilder.cpp JitBuilder.hpp TextWriter.hpp
 	g++ $(CXXFLAGS) -c -I. -I${OMRDIR}/jitbuilder/x/amd64 -I${OMRDIR}/jitbuilder/x -I${OMRDIR}/jitbuilder -I${OMRDIR}/compiler/x/amd64 -I${OMRDIR}/compiler/x -I${OMRDIR}/compiler -I${OMRDIR}/ -I${OMRDIR}/include_core -I${OMRBUILDDIR} $<

--- a/jitbuilder/jbil/Makefile
+++ b/jitbuilder/jbil/Makefile
@@ -7,7 +7,7 @@ LIBJITBDIR=$(OMRBUILDDIR)/jitbuilder
 JITB2=jitbuilder2
 LIBJITB2=lib$(JITB2).a
 
-all: min increment matmult returns testTypeGraph
+all: min increment matmult returns testTypeGraph complexmatmult
 
 LINK_OPTIONS=-L. -l$(JITB2) -L$(LIBJITBDIR) -l$(JITB)
 
@@ -17,7 +17,7 @@ increment: Increment.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
 min: Min.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
 	g++ -g -o min $(LINK_OPTIONS) Min.o
 
-matmult: MatMult.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
+matmult: MatMult.o JitBuilder.hpp $(LIBJITB2)
 	g++ -g -o matmult $(LINK_OPTIONS) MatMult.o
 
 returns: Returns.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
@@ -26,7 +26,7 @@ returns: Returns.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
 testTypeGraph: testTypeGraph.o
 	g++ -g -o testTypeGraph $(LINK_OPTIONS) testTypeGraph.o
 
-$(LIBJITB2): Action.o Builder.o BuilderBase.o Case.o CodeGenerator.o Debugger.o DialectReducer.o FunctionBuilder.o LiteralValue.o Location.o Object.o Operation.o OperationBase.o OperationCloner.o Symbol.o TextWriter.o Transformer.o Type.o TypeDictionary.o TypeGraph.o TypeReplacer.o Value.o Visitor.o JitBuilder.o
+$(LIBJITB2): Action.o Builder.o BuilderBase.o Case.o CodeGenerator.o Debugger.o DialectReducer.o DynamicOperation.o DynamicType.o FunctionBuilder.o LiteralValue.o Location.o Object.o Operation.o OperationBase.o OperationCloner.o OperationReplacer.o Symbol.o TextWriter.o Transformer.o Type.o TypeDictionary.o TypeGraph.o TypeReplacer.o Value.o Visitor.o JitBuilder.o
 	ar -cr $(LIBJITB2) \
 		Action.o \
 		Builder.o \
@@ -35,6 +35,8 @@ $(LIBJITB2): Action.o Builder.o BuilderBase.o Case.o CodeGenerator.o Debugger.o 
 		CodeGenerator.o \
 		Debugger.o \
 		DialectReducer.o \
+		DynamicOperation.o \
+		DynamicType.o \
 		FunctionBuilder.o \
 		LiteralValue.o \
 		Location.o \
@@ -42,6 +44,7 @@ $(LIBJITB2): Action.o Builder.o BuilderBase.o Case.o CodeGenerator.o Debugger.o 
 		Operation.o \
 		OperationBase.o \
 		OperationCloner.o \
+		OperationReplacer.o \
 		Symbol.o \
 		TextWriter.o \
 		Transformer.o \

--- a/jitbuilder/jbil/Makefile
+++ b/jitbuilder/jbil/Makefile
@@ -1,0 +1,90 @@
+OMRDIR=../..
+JITB=jitbuilder
+LIBJITB=lib$(JITB).a
+OMRBUILDDIR=$(OMRDIR)/build
+LIBJITBDIR=$(OMRBUILDDIR)/jitbuilder
+
+JITB2=jitbuilder2
+LIBJITB2=lib$(JITB2).a
+
+all: min increment matmult returns testTypeGraph
+
+LINK_OPTIONS=-L. -l$(JITB2) -L$(LIBJITBDIR) -l$(JITB)
+
+increment: Increment.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
+	g++ -g -o increment $(LINK_OPTIONS) Increment.o
+
+min: Min.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
+	g++ -g -o min $(LINK_OPTIONS) Min.o
+
+matmult: MatMult.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
+	g++ -g -o matmult $(LINK_OPTIONS) MatMult.o
+
+returns: Returns.o JitBuilder.hpp TextWriter.hpp $(LIBJITB2)
+	g++ -g -o returns $(LINK_OPTIONS) Returns.o
+
+testTypeGraph: testTypeGraph.o
+	g++ -g -o testTypeGraph $(LINK_OPTIONS) testTypeGraph.o
+
+$(LIBJITB2): Action.o Builder.o BuilderBase.o Case.o CodeGenerator.o Debugger.o DialectReducer.o FunctionBuilder.o LiteralValue.o Location.o Object.o Operation.o OperationBase.o OperationCloner.o Symbol.o TextWriter.o Transformer.o Type.o TypeDictionary.o TypeGraph.o TypeReplacer.o Value.o Visitor.o JitBuilder.o
+	ar -cr $(LIBJITB2) \
+		Action.o \
+		Builder.o \
+		BuilderBase.o \
+		Case.o \
+		CodeGenerator.o \
+		Debugger.o \
+		DialectReducer.o \
+		FunctionBuilder.o \
+		LiteralValue.o \
+		Location.o \
+		Object.o \
+		Operation.o \
+		OperationBase.o \
+		OperationCloner.o \
+		Symbol.o \
+		TextWriter.o \
+		Transformer.o \
+		Type.o \
+		TypeDictionary.o \
+		TypeGraph.o \
+		TypeReplacer.o \
+		Value.o \
+		Visitor.o \
+		JitBuilder.o
+
+#CXXFLAGS=-O3 -g -std=c++0x -fno-rtti -fPIC -Wwritable-strings
+CXXFLAGS=-O0 -g -std=c++0x -fno-rtti -fPIC -Wno-writable-strings -D_XOPEN_SOURCE=0
+
+.cpp.o:
+	g++ $(CXXFLAGS) -c $<
+
+Action.o: Action.cpp Action.hpp
+Builder.o: Builder.cpp Builder.hpp Operation.hpp Type.hpp Value.hpp
+DialectReducer.o: DialectReducer.cpp DialectReducer.hpp
+FunctionBuilder.o: FunctionBuilder.cpp FunctionBuilder.hpp
+Location.o: Location.cpp Location.hpp
+Operation.o: Operation.cpp Operation.hpp
+Simulator.o: Simulator.cpp Simulator.hpp Builder.hpp FunctionBuilder.hpp Operation.hpp
+Symbol.o: Symbol.cpp Symbol.hpp
+TextWriter.o: TextWriter.cpp TextWriter.hpp Builder.hpp
+Type.o: Type.cpp Type.hpp
+TypeDictionary.o: TypeDictionary.cpp TypeDictionary.hpp
+TypeGraph.o: TypeGraph.cpp TypeGraph.hpp TextWriter.hpp
+Value.o: Value.cpp Value.hpp
+Visitor.o: Visitor.cpp Visitor.hpp
+
+JitBuilder.o: JitBuilder.cpp JitBuilder.hpp TextWriter.hpp
+	g++ $(CXXFLAGS) -c -I. -I${OMRDIR}/jitbuilder/x/amd64 -I${OMRDIR}/jitbuilder/x -I${OMRDIR}/jitbuilder -I${OMRDIR}/compiler/x/amd64 -I${OMRDIR}/compiler/x -I${OMRDIR}/compiler -I${OMRDIR}/ -I${OMRDIR}/include_core -I${OMRBUILDDIR} $<
+
+CodeGenerator.o: CodeGenerator.cpp CodeGenerator.hpp
+	g++ $(CXXFLAGS) -c -I. -I${OMRDIR}/jitbuilder/x/amd64 -I${OMRDIR}/jitbuilder/x -I${OMRDIR}/jitbuilder -I${OMRDIR}/compiler/x/amd64 -I${OMRDIR}/compiler/x -I${OMRDIR}/compiler -I${OMRDIR}/ -I${OMRDIR}/include_core -I${OMRBUILDDIR} $<
+
+testTypeGraph.o: testTypeGraph.cpp Action.hpp TypeDictionary.hpp TypeGraph.hpp
+
+Increment.o: Increment.cpp
+
+Min.o: Min.cpp
+
+clean:
+	rm -f matmult return3 *.o $(LIBJITB2)

--- a/jitbuilder/jbil/Mapper.hpp
+++ b/jitbuilder/jbil/Mapper.hpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef MAPPER_INCL
+#define MAPPER_INCL
+
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+template <typename T>
+class Mapper
+   {
+   private:
+
+   struct Element
+      {
+      Element(T *t, std::string name="", size_t offset=0)
+         : _item(t)
+         , _name(name)
+         , _offset(offset)
+         , _next(NULL)
+         { }
+
+      T *_item;
+      std::string _name;
+      size_t _offset;
+      Element *_next;
+      };
+
+   public:
+   Mapper() : _head(NULL), _tail(NULL), _current(NULL), _size(0) { }
+   Mapper(T *t, std::string name="", size_t offset=0)
+      : _head(NULL)
+      , _tail(NULL)
+      , _current(NULL)
+      , _size(0)
+      {
+      add(t, name, offset);
+      }
+
+   size_t size()  { return _size; }
+   void start()   { _current = _head; }
+   void add(T *t, std::string name="", size_t offset=0)
+      {
+      Element *elem = new Element(t, name, offset);
+      if (_head == NULL)
+         {
+         _head = elem;
+         _current = _head;
+         }
+      if (_tail)
+         _tail->_next = elem;
+      _tail = elem;
+      elem->_next = _head;
+      _size++;
+      }
+   void clear()
+      {
+      if (_head == NULL) return;
+      while (_head != _tail)
+         {
+         Element *next = _head->_next;
+         delete _head;
+         _head = next;
+         }
+      delete _head;
+      _head = _tail = _current = NULL;
+      _size = 0;
+      }
+
+   // add() adds a new element to the mapper
+   // next() returns the next value from _current
+   // start() should be called to ensure next() starts from the first element
+   // clear() can be used to empty out the mapper
+
+   // The list always wraps around so next() will always return an element once something
+   // has been added to the Mapper.
+   // Expected common scenarios:
+   //   1) _items has several item; TypeReplacer calls next() as many times as size()
+   //   2) _items has one item and TypeReplacer will call next() many times to reuse that item
+   //          with different items returned by another Mapper (like "scalar" expansion)
+   T *next()
+      {
+      if (!_current) return NULL;
+      T *item = _current->_item;
+      _current = _current->_next;
+      return item;
+      }
+   T *current()
+      {
+      return _current->_item;
+      }
+   std::string name() // must be called *before* next() to get correct name
+      {
+      if (!_current) return std::string("");
+      return _current->_name;
+      }
+   size_t offset() // must be called *before* next() to geet correct offset
+      {
+      if (!_current) return 0;
+      return _current->_offset;
+      }
+
+   private:
+   Element *_head;
+   Element *_tail;
+   Element *_current;
+   size_t   _size;
+   };
+
+class Builder;
+typedef Mapper<Builder> BuilderMapper;
+
+class LiteralValue;
+typedef Mapper<LiteralValue> LiteralMapper;
+
+class Symbol;
+typedef Mapper<Symbol> SymbolMapper;
+
+class Type;
+typedef Mapper<Type> TypeMapper;
+
+class Value;
+typedef Mapper<Value> ValueMapper;
+
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(MAPPER_INCL)

--- a/jitbuilder/jbil/MatMult.cpp
+++ b/jitbuilder/jbil/MatMult.cpp
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string>
+
+#include "MatMult.hpp"
+#include "AppendBuilderInliner.hpp"
+#include "CodeGenerator.hpp"
+#include "DialectReducer.hpp"
+#include "TextWriter.hpp"
+
+
+MatMult::MatMult(OMR::JitBuilder::TypeDictionary * types)
+   : OMR::JitBuilder::FunctionBuilder(types)
+   , pDouble(types->PointerTo(Double))
+
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("matmult");
+
+   // C = A * B, all NxN matrices
+   DefineParameter("C", pDouble);
+   DefineParameter("A", pDouble);
+   DefineParameter("B", pDouble);
+   DefineParameter("N", Int32);
+
+   DefineReturnType(NoType);
+
+   DefineLocal("sum", Double);
+   }
+
+
+void
+MatMult::Store2D(OMR::JitBuilder::Builder *bldr,
+                 OMR::JitBuilder::Value *base,
+                 OMR::JitBuilder::Value *first,
+                 OMR::JitBuilder::Value *second,
+                 OMR::JitBuilder::Value *N,
+                 OMR::JitBuilder::Value *value)
+   {
+   bldr->StoreAt(
+   bldr->   IndexAt(pDouble,
+               base,
+   bldr->      Add(
+   bldr->         Mul(
+                    first,
+                    N),
+                  second)),
+            value);
+   }
+
+OMR::JitBuilder::Value *
+MatMult::Load2D(OMR::JitBuilder::Builder *bldr,
+                OMR::JitBuilder::Value *base,
+                OMR::JitBuilder::Value *first,
+                OMR::JitBuilder::Value *second,
+                OMR::JitBuilder::Value *N)
+   {
+   return
+      bldr->LoadAt(pDouble,
+      bldr->   IndexAt(pDouble,
+                  base,
+      bldr->      Add(
+      bldr->         Mul(
+                       first,
+                       N),
+                     second)));
+   }
+
+bool
+MatMult::buildIL()
+   {
+   // marking all locals as defined allows remaining locals to be temps
+   // which enables further optimization opportunities particularly for
+   //    floating point types
+   //AllLocalsHaveBeenDefined();
+
+   SourceLocation();
+   OMR::JitBuilder::Value *A = Load("A");
+   OMR::JitBuilder::Value *B = Load("B");
+   OMR::JitBuilder::Value *C = Load("C");
+   OMR::JitBuilder::Value *N = Load("N");
+   OMR::JitBuilder::Value *zero = ConstInt32(0);
+   OMR::JitBuilder::Value *one = ConstInt32(1);
+
+   OMR::JitBuilder::Builder *iloop=OrphanBuilder();
+   ForLoopUp("i", iloop, zero, N, one);
+      {
+      OMR::JitBuilder::Value *i = iloop->Load("i");
+
+      OMR::JitBuilder::Builder *jloop = iloop->OrphanBuilder();
+      iloop->ForLoopUp("j", jloop, zero, N, one);
+         {
+         OMR::JitBuilder::Value *j = jloop->Load("j");
+
+         OMR::JitBuilder::Builder *kloop = jloop->OrphanBuilder();
+         jloop->Store("sum", jloop->ConstDouble(0.0));
+         jloop->ForLoopUp("k", kloop, zero, N, one);
+            {
+            OMR::JitBuilder::Value *k = kloop->Load("k");
+
+            OMR::JitBuilder::Value *A_ik = Load2D(kloop, A, i, k, N);
+            OMR::JitBuilder::Value *B_kj = Load2D(kloop, B, k, j, N);
+            kloop->Store("sum",
+            kloop->   Add(
+            kloop->      Load("sum"),
+            kloop->      Mul(A_ik, B_kj)));
+            }
+
+         Store2D(jloop, C, i, j, N, jloop->Load("sum"));
+         }
+      }
+
+   Return();
+
+   return true;
+   }
+
+
+void
+printMatrix(double *M, int32_t N, const char *name)
+   {
+   printf("%s = [\n", name);
+   for (int32_t i=0;i < N;i++)
+      {
+      printf("      [ %lf", M[i*N]);
+      for (int32_t j=1;j < N;j++)
+          printf(", %lf", M[i * N + j]);
+      printf(" ],\n");
+      }
+   printf("    ]\n\n");
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define matrices\n");
+   const int32_t N=4;
+   double A[N*N];
+   double B[N*N];
+   double C[N*N];
+   double D[N*N];
+   for (int32_t i=0;i < N;i++)
+      {
+      for (int32_t j=0;j < N;j++)
+         {
+         A[i*N+j] = 1.0;
+         B[i*N+j] = (double)i+(double)j;
+         C[i*N+j] = 0.0;
+         D[i*N+j] = 0.0;
+         }
+      }
+
+   printf("Step 3: define type dictionaries\n");
+   OMR::JitBuilder::TypeDictionary types("MatMultTypes");
+
+   printf("Step 4: construct MatMult method builder\n");
+   MatMult method(&types);
+
+   std::cerr.setf(std::ios_base::skipws);
+   //OMR::JitBuilder::TextWriter printer(&method, std::cout, std::string("    "));
+   //method.setLogger(&printer);
+   method.config()->setReportMemory();
+                  //->setTraceBuildIL()
+                  //->setTraceReducer()
+                  //->setTraceCodeGenerator();
+
+   bool success = constructFunctionBuilder(&method);
+   if (!success)
+      {
+      fprintf(stderr,"FAIL: construction error\n");
+      exit(-2);
+      }
+   printf("Builder successfully constructed!\n");
+
+#if 0
+   printf("Print method builder before reduction to jbil_ll dialect\n");
+   printer.print();
+
+   printf("Step 5: reduce method builder to jbil_ll dialect\n");
+   OMR::JitBuilder::DialectReducer reducer(&method, DIALECT(jbil_ll));
+   reducer.transform();
+
+   printf("Print method builder after reduction to jbil_ll dialect\n");
+   printer.print();
+
+   printf("Step 6: inline AppendBuilders\n");
+   AppendBuilderInliner inliner(&method);
+   inliner.transform();
+
+   printf("After inlining orphan AppendBuilder\n");
+   printer.print();
+#endif
+
+   printf("Step 7: compile MatMult jbil\n");
+   int32_t rc;
+   MatMultFunctionType *test = method.DebugEntry<MatMultFunctionType>(&rc);
+   //void *entry = NULL;
+   //int32_t rc = compileFunctionBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation failed %d\n", rc);
+      exit(rc);
+      }
+
+   printf("Step 8: invoke MatMult compiled code\n");
+   //MatMultFunctionType *test = (MatMultFunctionType *)entry;
+   test(C, A, B, N);
+
+   printMatrix(A, N, "A");
+   printMatrix(B, N, "B");
+   printMatrix(C, N, "C");
+
+   printf ("Step 9: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/jbil/MatMult.hpp
+++ b/jitbuilder/jbil/MatMult.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef MATMULT_INCL
+#define MATMULT_INCL
+
+#include "JitBuilder.hpp"
+
+typedef void (MatMultFunctionType)(double *, double *, double *, int32_t);
+
+class MatMult : public OMR::JitBuilder::FunctionBuilder
+   {
+   public:
+   MatMult(OMR::JitBuilder::TypeDictionary *);
+   virtual bool buildIL();
+
+   protected:
+   OMR::JitBuilder::Type *pDouble;
+
+   void Store2D(OMR::JitBuilder::Builder *bldr,
+                OMR::JitBuilder::Value *base,
+                OMR::JitBuilder::Value *first,
+                OMR::JitBuilder::Value *second,
+                OMR::JitBuilder::Value *N,
+                OMR::JitBuilder::Value *value);
+   OMR::JitBuilder::Value *Load2D(OMR::JitBuilder::Builder *bldr,
+                                  OMR::JitBuilder::Value *base,
+                                  OMR::JitBuilder::Value *first,
+                                  OMR::JitBuilder::Value *second,
+                                  OMR::JitBuilder::Value *N);
+   };
+
+#endif // !defined(MATMULT_INCL)

--- a/jitbuilder/jbil/Min.cpp
+++ b/jitbuilder/jbil/Min.cpp
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string>
+
+#include "JitBuilder.hpp"
+
+using namespace OMR::JitBuilder;
+
+class Min : public FunctionBuilder
+   {
+public:
+   Min(TypeDictionary * types)
+      : FunctionBuilder(types)
+      {
+      DefineName("min");
+      DefineLine(LINETOSTR(__LINE__));
+      DefineFile(__FILE__);
+      DefineParameter("x", Int32);
+      DefineParameter("y", Int32);
+      DefineReturnType(Int32);
+      }
+
+   virtual bool buildIL()
+      {
+      Store("m", Load("x"));
+      Builder *ymin = OrphanBuilder();
+      Builder *merge = OrphanBuilder();
+      IfCmpLessThan(ymin, Load("y"), Load("x"));
+         {
+         ymin->Store("m", ymin->Load("y"));
+         ymin->Goto(merge);
+         }
+      AppendBuilder(merge);
+      Return(Load("m"));
+      return true;
+      }
+   };
+
+typedef int32_t (MinFunc)(int32_t, int32_t);
+
+int
+main(int argc, char *argv[])
+   {
+   bool success = initializeJit();
+   if (!success)
+      {
+      printf("initializeJit failure\n");
+      exit(-1);
+      }
+
+   TypeDictionary types("Min_Types");
+   Min method(&types);
+   success = method.Construct();
+   if (!success)
+      {
+      printf("construction failure\n");
+      exit(-2);
+      }
+
+
+   std::cerr.setf(std::ios_base::skipws);
+   std::cerr << "Method to debug:" << std::endl;
+   OMR::JitBuilder::TextWriter printer(&method, std::cout, std::string("    "));
+   method.setLogger(&printer);
+   printer.print();
+
+   int32_t rc=0;
+   MinFunc *minfunc = method.DebugEntry<MinFunc>(&rc);
+   if (rc != 0)
+      {
+      printf("Simulation request returned error code %d\n", rc);
+      exit(rc);
+      }
+
+   int32_t mlae = minfunc(42, 45);
+   printf("rv is %d\n", mlae);
+
+   mlae = minfunc(45, 42);
+   printf("rv is %d\n", mlae);
+
+   shutdownJit();
+
+   exit(0);
+   }

--- a/jitbuilder/jbil/Object.cpp
+++ b/jitbuilder/jbil/Object.cpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Object.hpp"
+#include "FunctionBuilder.hpp"
+#include "TextWriter.hpp"
+
+OMR::JitBuilder::Object::Object(FunctionBuilder *fb)
+   : _fb(fb)
+   {
+   if (this != fb)
+      {
+      //if (_fb->logger())
+      //   _fb->logger()->indent() << "Allocated " << (uint64_t)(uintptr_t)(this) << _fb->logger()->endl();
+      //_fb->registerObject(this);
+      }
+   }

--- a/jitbuilder/jbil/Object.hpp
+++ b/jitbuilder/jbil/Object.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OBJECT_INCL
+#define OBJECT_INCL
+
+#include <stdint.h>
+#include <vector>
+#include <iostream>
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class FunctionBuilder;
+
+class Object
+   {
+public:
+   Object(FunctionBuilder *fb);
+   virtual ~Object() { }
+
+   virtual size_t size() const { return sizeof(Object); }
+
+   FunctionBuilder *fb() const { return _fb; }
+
+protected:
+   FunctionBuilder * _fb;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(OBJECT_INCL)

--- a/jitbuilder/jbil/Operation.cpp
+++ b/jitbuilder/jbil/Operation.cpp
@@ -1,0 +1,946 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+#include "Builder.hpp"
+#include "Case.hpp"
+#include "FunctionBuilder.hpp"
+#include "LiteralValue.hpp"
+#include "Location.hpp"
+#include "Operation.hpp"
+#include "OperationCloner.hpp"
+#include "TypeDictionary.hpp"
+#include "TypeGraph.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+namespace OMR
+{
+namespace JitBuilder
+{
+
+Operation::Operation(Action a, Builder * parent)
+   : OperationBase(a, parent)
+   {
+   }
+
+
+ConstInt8::ConstInt8(Builder * parent, Value * result, int8_t value)
+   : OperationR1L1(aConstInt8, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstInt8::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstInt8(literalMappers[0]->next()->getInt8()) );
+   }
+
+Operation *
+ConstInt8::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getInt8());
+   }
+
+ConstInt16::ConstInt16(Builder * parent, Value * result, int16_t value)
+   : OperationR1L1(aConstInt16, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstInt16::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstInt16(literalMappers[0]->next()->getInt16()) );
+   }
+
+Operation *
+ConstInt16::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getInt16());
+   }
+
+ConstInt32::ConstInt32(Builder * parent, Value * result, int32_t value)
+   : OperationR1L1(aConstInt32, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstInt32::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstInt32(literalMappers[0]->next()->getInt32()) );
+   }
+
+Operation *
+ConstInt32::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getInt32());
+   }
+
+ConstInt64::ConstInt64(Builder * parent, Value * result, int64_t value)
+   : OperationR1L1(aConstInt64, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstInt64::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstInt64(literalMappers[0]->next()->getInt64()) );
+   }
+
+Operation *
+ConstInt64::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getInt64());
+   }
+
+ConstFloat::ConstFloat(Builder * parent, Value * result, float value)
+   : OperationR1L1(aConstFloat, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstFloat::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstFloat(literalMappers[0]->next()->getFloat()) );
+   }
+
+Operation *
+ConstFloat::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getFloat());
+   }
+
+ConstDouble::ConstDouble(Builder * parent, Value * result, double value)
+   : OperationR1L1(aConstDouble, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstDouble::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstDouble(literalMappers[0]->next()->getDouble()) );
+   }
+
+Operation *
+ConstDouble::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getDouble());
+   }
+
+ConstAddress::ConstAddress(Builder * parent, Value * result, void * value)
+   : OperationR1L1(aConstAddress, parent, result, LiteralValue::create(parent->fb()->dict(), value))
+   {
+   }
+
+void
+ConstAddress::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->ConstAddress(literalMappers[0]->next()->getAddress()) );
+   }
+
+Operation *
+ConstAddress::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getAddress());
+   }
+
+CoercePointer::CoercePointer(Builder * parent, Value * result, Type * t, Value * v)
+   : OperationR1V1T1(aCoercePointer, parent, result, t, v)
+   {
+   assert(t->isPointer() && v->type()->isPointer());
+   }
+
+void
+CoercePointer::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->CoercePointer(typeMappers[0]->next(), operandMappers[0]->next()) );
+   }
+
+Operation *
+CoercePointer::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->type(), cloner->operand());
+   }
+
+void
+CoercePointer::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->Address, aCoercePointer, types->Address);
+   }
+
+Add::Add(Builder * parent, Value * result, Value * left, Value * right)
+   : OperationR1V2(aAdd, parent, result, left, right)
+   {
+   }
+
+void
+Add::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->Add(operandMappers[0]->next(), operandMappers[1]->next()) );
+   }
+
+Operation *
+Add::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+Add::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->Int8,    aAdd, types->Int8,    types->Int8 );
+   graph->registerValidOperation(types->Int16,   aAdd, types->Int16,   types->Int16);
+   graph->registerValidOperation(types->Int32,   aAdd, types->Int32,   types->Int32);
+   graph->registerValidOperation(types->Int64,   aAdd, types->Int64,   types->Int64);
+   graph->registerValidOperation(types->Float,   aAdd, types->Float,   types->Float);
+   graph->registerValidOperation(types->Double,  aAdd, types->Double,  types->Double);
+   graph->registerValidOperation(types->Address, aAdd, types->Address, types->Word);
+   }
+
+
+Sub::Sub(Builder * parent, Value * result, Value * left, Value * right)
+   : OperationR1V2(aSub, parent, result, left, right)
+   {
+   }
+
+void
+Sub::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->Sub(operandMappers[0]->next(), operandMappers[1]->next()) );
+   }
+
+Operation *
+Sub::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+Sub::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->Int8,    aSub, types->Int8,    types->Int8 );
+   graph->registerValidOperation(types->Int16,   aSub, types->Int16,   types->Int16);
+   graph->registerValidOperation(types->Int32,   aSub, types->Int32,   types->Int32);
+   graph->registerValidOperation(types->Int64,   aSub, types->Int64,   types->Int64);
+   graph->registerValidOperation(types->Float,   aSub, types->Float,   types->Float);
+   graph->registerValidOperation(types->Double,  aSub, types->Double,  types->Double);
+   graph->registerValidOperation(types->Address, aSub, types->Address, types->Word);
+   }
+
+
+Mul::Mul(Builder * parent, Value * result, Value * left, Value * right)
+   : OperationR1V2(aMul, parent, result, left, right)
+   {
+   }
+
+void
+Mul::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->Mul(operandMappers[0]->next(), operandMappers[1]->next()) );
+   }
+
+Operation *
+Mul::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+Mul::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->Int8,    aMul, types->Int8,    types->Int8 );
+   graph->registerValidOperation(types->Int16,   aMul, types->Int16,   types->Int16);
+   graph->registerValidOperation(types->Int32,   aMul, types->Int32,   types->Int32);
+   graph->registerValidOperation(types->Int64,   aMul, types->Int64,   types->Int64);
+   graph->registerValidOperation(types->Float,   aMul, types->Float,   types->Float);
+   graph->registerValidOperation(types->Double,  aMul, types->Double,  types->Double);
+   graph->registerValidOperation(types->Address, aMul, types->Address, types->Word);
+   }
+
+
+IndexAt::IndexAt(Builder * parent, Value * result, Type * pointerType, Value * base, Value * index)
+   : OperationR1V2T1(aIndexAt, parent, result, pointerType, base, index)
+   {
+   }
+
+void
+IndexAt::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->IndexAt(typeMappers[0]->next(), operandMappers[0]->next(), operandMappers[1]->next()) );
+   }
+
+Operation *
+IndexAt::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->type(), cloner->operand(0), cloner->operand(1));
+   }
+
+Load::Load(Builder * parent, Value * result, std::string localName)
+   : OperationR1S1(aLoad, parent, result, parent->fb()->getSymbol(localName))
+   {
+   }
+
+void
+Load::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Symbol *sym = symbolMappers[0]->next();
+   resultMappers[0]->add( b->Load(sym) );
+   }
+
+Operation *
+Load::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->symbol());
+   }
+
+LoadAt::LoadAt(Builder * parent, Value * result, Type * pointerType, Value * address)
+   : OperationR1V1T1(aLoadAt, parent, result, pointerType, address)
+   {
+   }
+
+void
+LoadAt::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->LoadAt(typeMappers[0]->next(), operandMappers[0]->next()) );
+   }
+
+Operation *
+LoadAt::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->type(), cloner->operand());
+   }
+
+void
+LoadField::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Type *t = typeMappers[0]->next();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   resultMappers[0]->add( b->LoadField(fieldType, operandMappers[0]->next()) );
+   }
+
+Operation *
+LoadField::clone(Builder *b, OperationCloner *cloner) const
+   {
+   Type *t = cloner->type();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   return create(b, cloner->result(), fieldType, cloner->operand());
+   }
+
+void
+LoadIndirect::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Type *t = typeMappers[0]->next();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   resultMappers[0]->add( b->LoadIndirect(fieldType, operandMappers[0]->next()) );
+   }
+
+Operation *
+LoadIndirect::clone(Builder *b, OperationCloner *cloner) const
+   {
+   Type *t = cloner->type();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   return create(b, cloner->result(), fieldType, cloner->operand());
+   }
+
+Store::Store(Builder * parent, std::string name, Value * value)
+   : OperationR0S1V1(aStore, parent, parent->fb()->getSymbol(name), value)
+      { }
+
+void
+Store::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->Store(symbolMappers[0]->next(), operandMappers[0]->next());
+   }
+
+Operation *
+Store::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->symbol(), cloner->operand());
+   }
+
+StoreAt::StoreAt(Builder * parent, Value * address, Value * value)
+   : OperationR0V2(aStoreAt, parent, address, value)
+   {
+   }
+
+void
+StoreAt::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->StoreAt(operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+StoreAt::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->operand(0), cloner->operand(1));
+   }
+
+void
+StoreField::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Type *t = typeMappers[0]->next();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   b->StoreField(fieldType, operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+StoreField::clone(Builder *b, OperationCloner *cloner) const
+   {
+   Type *t = cloner->type();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   return create(b, fieldType, cloner->operand(0), cloner->operand(1));
+   }
+
+void
+StoreIndirect::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Type *t = typeMappers[0]->next();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   b->StoreIndirect(fieldType, operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+StoreIndirect::clone(Builder *b, OperationCloner *cloner) const
+   {
+   Type *t = cloner->type();
+   assert(t->isField());
+   FieldType *fieldType = static_cast<FieldType *>(t);
+   return create(b, fieldType, cloner->operand(0), cloner->operand(1));
+   }
+
+AppendBuilder::AppendBuilder(Builder * parent, Builder * b)
+   : OperationB1(aAppendBuilder, parent, b)
+   {
+   }
+
+void
+AppendBuilder::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->AppendBuilder(builderMappers[0]->next());
+   }
+
+Operation *
+AppendBuilder::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder());
+   }
+
+Call::Call(Builder * parent, Value *result, Value *function, int32_t numArgs, va_list args)
+   : Operation(aCall, parent)
+   , _result(result)
+   , _function(function)
+   , _numArgs(numArgs)
+   {
+   _args = new Value *[numArgs];
+   for (int32_t a=0;a < _numArgs;a++)
+      {
+      Value *arg = va_arg(args,Value *);
+      _args[a] = arg;
+      }
+   }
+
+Call::Call(Builder * parent, Value *result, Value *function, int32_t numArgs, Value **args)
+   : Operation(aCall, parent)
+   , _result(result)
+   , _function(function)
+   , _numArgs(numArgs)
+   , _args(args)
+   {
+   }
+
+void
+Call::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   Value **arguments = new Value *[_numArgs];
+   Value *function = operandMappers[0]->next();
+   for (int a=0;a < _numArgs;a++)
+      arguments[a] = operandMappers[a+1]->next();
+   Value *result = b->Call(function, _numArgs, arguments);
+   if (NULL != result)
+      resultMappers[0]->add( result );
+   }
+
+Operation *
+Call::clone(Builder *b, OperationCloner *cloner) const
+   {
+   Value **arguments = new Value *[_numArgs];
+   Value *function = cloner->operand(0);
+   for (int a=0;a < _numArgs;a++)
+      arguments[a] = cloner->operand(a+1);
+   return create(b, function, cloner->result(), _numArgs, arguments);
+   }
+
+Goto::Goto(Builder * parent, Builder * b)
+   : OperationB1(aGoto, parent, b)
+   {
+   }
+
+void
+Goto::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->Goto(builderMappers[0]->next());
+   }
+
+Operation *
+Goto::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder());
+   }
+
+ForLoop::ForLoop(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                                  Builder * loopBody, Builder * loopBreak, Builder * loopContinue,
+                                  Value * initial, Value * end, Value * bump)
+   : Operation(aForLoop, parent)
+   , _countsUp(LiteralValue::create(parent->fb()->dict(), (int8_t)countsUp))
+   , _loopSym(loopSym)
+   , _loopBody(loopBody)
+   , _loopBreak(loopBreak)
+   , _loopContinue(loopContinue)
+   , _initial(initial)
+   , _end(end)
+   , _bump(bump)
+   { }
+
+ForLoop::ForLoop(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                                  Builder * loopBody, Builder * loopBreak,
+                                  Value * initial, Value * end, Value * bump)
+   : Operation(aForLoop, parent)
+   , _countsUp(LiteralValue::create(parent->fb()->dict(), (int8_t)countsUp))
+   , _loopSym(loopSym)
+   , _loopBody(loopBody)
+   , _loopBreak(loopBreak)
+   , _loopContinue(NULL)
+   , _initial(initial)
+   , _end(end)
+   , _bump(bump)
+   { }
+
+ForLoop::ForLoop(Builder * parent, bool countsUp, LocalSymbol *loopSym,
+                                  Builder * loopBody,
+                                  Value * initial, Value * end, Value * bump)
+   : Operation(aForLoop, parent)
+   , _countsUp(LiteralValue::create(parent->fb()->dict(), (int8_t)countsUp))
+   , _loopSym(loopSym)
+   , _loopBody(loopBody)
+   , _loopBreak(NULL)
+   , _loopContinue(NULL)
+   , _initial(initial)
+   , _end(end)
+   , _bump(bump)
+   { }
+
+void
+ForLoop::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->ForLoop(literalMappers[0]->next()->getInt8(), static_cast<LocalSymbol *>(symbolMappers[0]->next()),
+              builderMappers[0]->next(),
+              _loopBreak ? builderMappers[1]->next() : NULL,
+              _loopContinue ? builderMappers[2]->next() : NULL,
+              operandMappers[0]->next(), operandMappers[1]->next(), operandMappers[2]->next());
+   }
+
+Operation *
+ForLoop::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->literal(0)->getInt8(), static_cast<LocalSymbol *>(cloner->symbol()),
+               cloner->builder(0),
+               _loopBreak ? cloner->builder(1) : NULL,
+               _loopContinue ? cloner->builder(2) : NULL,
+               cloner->operand(0), cloner->operand(1), cloner->operand(2));
+   }
+
+ForLoop *
+ForLoop::create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Builder * loopBreak, Builder * loopContinue,
+                           Value * initial, Value * end, Value * bump)
+   {
+   ForLoop * forLoopOp = new ForLoop(parent, countsUp, loopSym,
+                                                      loopBody, loopBreak, loopContinue,
+                                                      initial, end, bump);
+   loopBody->setTarget()
+           ->setBoundness(May)
+           ->setBound(forLoopOp)
+           ->setBoundness(Must);
+   if (loopBreak)
+      loopBreak->setTarget()
+               ->setBoundness(May)
+               ->setBound(forLoopOp)
+               ->setBoundness(Must);
+   if (loopContinue)
+      loopContinue->setTarget()
+                  ->setBoundness(May)
+                  ->setBound(forLoopOp)
+                  ->setBoundness(Must);
+   return forLoopOp;
+   }
+
+ForLoop *
+ForLoop::create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Builder * loopBreak,
+                           Value * initial, Value * end, Value * bump)
+   {
+   ForLoop * forLoopOp = new ForLoop(parent, countsUp, loopSym, loopBody, loopBreak,
+                                                      initial, end, bump);
+   loopBody->setTarget()
+           ->setBoundness(May)
+           ->setBound(forLoopOp)
+           ->setBoundness(Must);
+   if (loopBreak)
+      loopBreak->setTarget()
+               ->setBoundness(May)
+               ->setBound(forLoopOp)
+               ->setBoundness(Must);
+   return forLoopOp;
+   }
+
+ForLoop *
+ForLoop::create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Value * initial, Value * end, Value * bump)
+   {
+   ForLoop * forLoopOp = new ForLoop(parent, countsUp, loopSym, loopBody, initial, end, bump);
+   loopBody->setTarget()
+           ->setBoundness(May)
+           ->setBound(forLoopOp)
+           ->setBoundness(Must);
+   return forLoopOp;
+   }
+
+void
+ForLoop::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aForLoop, types->Int8  , types->Int8  , types->Int8 );
+   graph->registerValidOperation(types->NoType, aForLoop, types->Int16 , types->Int16 , types->Int16);
+   graph->registerValidOperation(types->NoType, aForLoop, types->Int32 , types->Int32 , types->Int32);
+   graph->registerValidOperation(types->NoType, aForLoop, types->Int64 , types->Int64 , types->Int64);
+   graph->registerValidOperation(types->NoType, aForLoop, types->Float , types->Float , types->Float);
+   graph->registerValidOperation(types->NoType, aForLoop, types->Double, types->Double, types->Double);
+   }
+
+IfCmpGreaterThan::IfCmpGreaterThan(Builder * parent, Builder * tgt, Value * left, Value * right)
+   : OperationR0V2B1(aIfCmpGreaterThan, parent, tgt, left, right)
+   {
+   }
+
+void
+IfCmpGreaterThan::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->IfCmpGreaterThan(builderMappers[0]->next(), operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+IfCmpGreaterThan::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+IfCmpGreaterThan::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Int8  , types->Int8  );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Int16 , types->Int16 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Int32 , types->Int32 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Int64 , types->Int64 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Float , types->Float );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterThan, types->Double, types->Double);
+   }
+
+IfCmpLessThan::IfCmpLessThan(Builder * parent, Builder * tgt, Value * left, Value * right)
+   : OperationR0V2B1(aIfCmpLessThan, parent, tgt, left, right)
+   {
+   }
+
+void
+IfCmpLessThan::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->IfCmpLessThan(builderMappers[0]->next(), operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+IfCmpLessThan::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+IfCmpLessThan::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Int8  , types->Int8  );
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Int16 , types->Int16 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Int32 , types->Int32 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Int64 , types->Int64 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Float , types->Float );
+   graph->registerValidOperation(types->NoType, aIfCmpLessThan, types->Double, types->Double);
+   }
+
+IfCmpGreaterOrEqual::IfCmpGreaterOrEqual(Builder * parent, Builder * tgt, Value * left, Value * right)
+   : OperationR0V2B1(aIfCmpGreaterOrEqual, parent, tgt, left, right)
+   {
+   }
+
+void
+IfCmpGreaterOrEqual::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->IfCmpGreaterOrEqual(builderMappers[0]->next(), operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+IfCmpGreaterOrEqual::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+IfCmpGreaterOrEqual::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Int8  , types->Int8  );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Int16 , types->Int16 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Int32 , types->Int32 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Int64 , types->Int64 );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Float , types->Float );
+   graph->registerValidOperation(types->NoType, aIfCmpGreaterOrEqual, types->Double, types->Double);
+   }
+
+IfCmpLessOrEqual::IfCmpLessOrEqual(Builder * parent, Builder * tgt, Value * left, Value * right)
+   : OperationR0V2B1(aIfCmpLessOrEqual, parent, tgt, left, right)
+   {
+   }
+
+void
+IfCmpLessOrEqual::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->IfCmpLessOrEqual(builderMappers[0]->next(), operandMappers[0]->next(), operandMappers[1]->next());
+   }
+
+Operation *
+IfCmpLessOrEqual::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder(), cloner->operand(0), cloner->operand(1));
+   }
+
+void
+IfCmpLessOrEqual::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Int8  , types->Int8  );
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Int16 , types->Int16 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Int32 , types->Int32 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Int64 , types->Int64 );
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Float , types->Float );
+   graph->registerValidOperation(types->NoType, aIfCmpLessOrEqual, types->Double, types->Double);
+   }
+
+IfThenElse::IfThenElse(Builder * parent, Builder * thenB, Builder * elseB, Value * cond)
+   : OperationR0V1B1(aIfThenElse, parent, thenB, cond)
+   , _elseBuilder(elseB)
+   {
+   }
+
+IfThenElse::IfThenElse(Builder * parent, Builder * thenB, Value * cond)
+   : OperationR0V1B1(aIfThenElse, parent, thenB, cond)
+   , _elseBuilder(NULL)
+   {
+   }
+
+void
+IfThenElse::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->IfThenElse(builderMappers[0]->next(), _elseBuilder ? builderMappers[1]->next() : NULL, operandMappers[0]->next());
+   }
+
+Operation *
+IfThenElse::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->builder(0), _elseBuilder ? cloner->builder(1) : NULL, cloner->operand(0));
+   }
+
+IfThenElse *
+IfThenElse::create(Builder * parent, Builder * thenB, Builder * elseB, Value * cond)
+   {
+   IfThenElse * ifThenElseOp = new IfThenElse(parent, thenB, elseB, cond);
+   thenB->setTarget()
+        ->setBoundness(May)
+        ->setBound(ifThenElseOp)
+        ->setBoundness(Must);
+   elseB->setTarget()
+        ->setBoundness(May)
+        ->setBound(ifThenElseOp)
+        ->setBoundness(Must);
+   return ifThenElseOp;
+   }
+
+IfThenElse *
+IfThenElse::create(Builder * parent, Builder * thenB, Value * cond)
+   {
+   IfThenElse * ifThenOp = new IfThenElse(parent, thenB, cond);
+   thenB->setTarget()
+        ->setBoundness(May)
+        ->setBound(ifThenOp)
+        ->setBoundness(Must);
+   return ifThenOp;
+   }
+
+void
+IfThenElse::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aIfThenElse, types->Int8);
+   graph->registerValidOperation(types->NoType, aIfThenElse, types->Int16);
+   graph->registerValidOperation(types->NoType, aIfThenElse, types->Int32);
+   graph->registerValidOperation(types->NoType, aIfThenElse, types->Int64);
+   }
+
+Return::Return(Builder * parent)
+   : Operation(aReturn, parent), _value(NULL)
+   {
+   }
+
+Return::Return(Builder * parent, Value * v)
+   : Operation(aReturn, parent), _value(v)
+   {
+   }
+
+void
+Return::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   if (NULL != _value)
+      b->Return(operandMappers[0]->next());
+   else
+      b->Return();
+   }
+
+Operation *
+Return::clone(Builder *b, OperationCloner *cloner) const
+   {
+   if (NULL != _value)
+      return create(b, cloner->operand());
+   else
+      return create(b);
+   }
+
+void
+Return::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aReturn, types->Int8);
+   graph->registerValidOperation(types->NoType, aReturn, types->Int16);
+   graph->registerValidOperation(types->NoType, aReturn, types->Int32);
+   graph->registerValidOperation(types->NoType, aReturn, types->Int64);
+   graph->registerValidOperation(types->NoType, aReturn, types->Float);
+   graph->registerValidOperation(types->NoType, aReturn, types->Double);
+   graph->registerValidOperation(types->NoType, aReturn, types->Address);
+   }
+
+Switch::Switch(Builder * parent, Value * selector, Builder *defaultTarget, int numCases, Case ** cases)
+   : OperationR0V1(aSwitch, parent, selector)
+   , _defaultTarget(defaultTarget)
+   , _cases(numCases)
+   {
+   for (int c=0;c < numCases;c++)
+      _cases[c] = cases[c];
+   }
+
+Operation *
+Switch::clone(Builder *b, Value **results) const
+   {
+   assert(NULL == results);
+   Case **clonedCases = new Case *[numCases()];
+   for (int32_t c=0;c < numCases(); c++)
+      clonedCases[c] = Case::create(_cases[c]->value(), _cases[c]->builder(), _cases[c]->fallsThrough());
+   return new Switch(b, operand(), builder(), numCases(), clonedCases);
+   }
+
+Operation *
+Switch::clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+   {
+   assert(NULL == results && operands && builders);
+   Case **clonedCases = new Case *[numCases()];
+   for (int32_t c=0;c < numCases(); c++)
+      clonedCases[c] = Case::create(_cases[c]->value(), builders[c+1], _cases[c]->fallsThrough());
+   return new Switch(b, operands[0], builders[0], numCases(), clonedCases);
+   }
+
+void
+Switch::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   b->Switch(operandMappers[0]->next(), builderMappers[0]->next(), numCases(), (Case **)_cases.data());
+   }
+
+Operation *
+Switch::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->operand(), cloner->builder(), numCases(), (Case **)_cases.data());
+   }
+
+void
+Switch::initializeTypeProductions(TypeDictionary * types, TypeGraph * graph)
+   {
+   graph->registerValidOperation(types->NoType, aSwitch, types->Int32);
+   }
+
+CreateLocalArray::CreateLocalArray(Builder * parent, Value * result, int32_t numElements, Type * elementType)
+   : OperationR1L1T1(aCreateLocalArray, parent, result, LiteralValue::create(parent->fb()->dict(), numElements), elementType)
+   {
+   }
+
+void
+CreateLocalArray::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->CreateLocalArray(literalMappers[0]->next()->getInt32(), typeMappers[0]->next()) );
+   }
+
+Operation *
+CreateLocalArray::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->literal()->getInt32(), cloner->type());
+   }
+
+CreateLocalStruct::CreateLocalStruct(Builder * parent, Value * result, Type * structType)
+   : OperationR1T1(aCreateLocalStruct, parent, result, structType)
+   {
+   }
+
+void
+CreateLocalStruct::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const
+   {
+   resultMappers[0]->add( b->CreateLocalStruct(typeMappers[0]->next()) );
+   }
+
+Operation *
+CreateLocalStruct::clone(Builder *b, OperationCloner *cloner) const
+   {
+   return create(b, cloner->result(), cloner->type());
+   }
+
+// New operation code
+// BEGIN {
+//
+
+//
+// } END
+// New operation code
+
+} // namespace JitBuilder
+} // namespace OMR

--- a/jitbuilder/jbil/Operation.hpp
+++ b/jitbuilder/jbil/Operation.hpp
@@ -828,6 +828,9 @@ class LoadAt : public OperationR1V1T1
 
    virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
 
+   virtual bool hasExpander() const { return true; }
+   virtual bool expand(OperationReplacer *r) const;
+
    protected:
    LoadAt(Builder * parent, Value * result, Type * pointerType, Value * address);
    };
@@ -937,6 +940,9 @@ class StoreAt : public OperationR0V2
    virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
 
    virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   virtual bool hasExpander() const { return true; }
+   virtual bool expand(OperationReplacer *r) const;
 
    protected:
    StoreAt(Builder * parent, Value * address, Value * value);
@@ -1492,8 +1498,7 @@ class Switch : public OperationR0V1
       }
 
    virtual int32_t numCases() const  { return _cases.size(); }
-   virtual CaseIterator CasesBegin() { return _cases.begin(); }
-   virtual CaseIterator CasesEnd()   { return _cases.end(); }
+   virtual CaseIterator CasesBegin() { return CaseIterator(_cases); }
 
    static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
 

--- a/jitbuilder/jbil/Operation.hpp
+++ b/jitbuilder/jbil/Operation.hpp
@@ -1,0 +1,1573 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OPERATION_INCL
+#define OPERATION_INCL
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "Action.hpp"
+#include "Case.hpp"
+#include "Iterator.hpp"
+#include "LiteralValue.hpp"
+#include "OperationBase.hpp"
+#include "TypeReplacer.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class Location;
+class OperationCloner;
+class Type;
+class TypeDictionary;
+class TypeGraph;
+class Value;
+
+// Operation defines an interface to all kinds of operations, it cannot itself be instantiated
+// Operation classes corresponding to specific Actions (which can be instantiated) follow
+
+class Operation : public OperationBase
+   {
+   public:
+   virtual size_t size() const { return sizeof(Operation); }
+
+   // define any new public API here
+
+protected:
+   Operation(Action a, Builder * parent);
+
+   // define any new constructors here
+
+   // define any new protected API here
+
+   };
+
+// Following are "structural" classes that are used to hold results(R), literals(L),
+// operand values (V), struct/field names (F), and builders (B) for different kinds
+// of Operations. The name signifies the structure using the designator letters
+// listed above. So the structural Operation class with one result and two operand
+// values is called OperationR1V2. Operation sub classes then derive from these
+// structural classes and can add some semantically relevant services.
+class OperationR1 : public Operation
+   {
+   public:
+   virtual size_t size() const                { return sizeof(OperationR1); }
+   virtual ValueIterator ResultsBegin()       { return ValueIterator(_result); }
+   virtual int32_t numResults() const         { return 1; }
+   virtual Value * result(int i=0) const
+      {
+      if (i == 0) return _result;
+      return NULL;
+      }
+
+   protected:
+   OperationR1(Action a, Builder * parent, Value * result)
+      : Operation(a, parent)
+      , _result(result)
+      { }
+
+   Value * _result;
+   };
+
+class OperationR1L1 : public OperationR1
+   {
+   public:
+   virtual int32_t numLiterals() const { return 1; }
+   virtual LiteralValue *literal(int i=0) const
+      {
+      if (i == 0) return _v;
+      return NULL;
+      }
+   virtual LiteralIterator LiteralsBegin()       { return LiteralIterator(_v); }
+
+   protected:
+   OperationR1L1(Action a, Builder * parent, Value * result, LiteralValue *value)
+      : OperationR1(a, parent, result)
+      , _v(value)
+      { }
+
+   LiteralValue *_v;
+   };
+
+class OperationR1L1T1 : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const      { return sizeof(OperationR1L1T1); }
+   virtual int32_t numTypes() const { return 1; }
+   virtual Type * type(int i=0) const
+      {
+      if (i == 0) return _elementType;
+      return NULL;
+      }
+   virtual TypeIterator TypesBegin() { return TypeIterator(_elementType); }
+
+   protected:
+   OperationR1L1T1(Action a, Builder * parent, Value * result, LiteralValue *numElements, Type *elementType)
+      : OperationR1L1(a, parent, result, numElements)
+      , _elementType(elementType)
+      { }
+
+   Type *_elementType;
+   };
+
+class OperationR1S1 : public OperationR1
+   {
+   public:
+   virtual int32_t numSymbols() const { return 1; }
+   virtual Symbol *symbol(int i=0) const
+      {
+      if (i == 0) return _symbol;
+      return NULL;
+      }
+   virtual SymbolIterator SymbolsBegin() { return SymbolIterator(_symbol); }
+
+   protected:
+   OperationR1S1(Action a, Builder * parent, Value * result, Symbol *symbol)
+      : OperationR1(a, parent, result)
+      , _symbol(symbol)
+      { }
+
+   Symbol *_symbol;
+   };
+
+class OperationR0V1 : public Operation
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR0V1); }
+   virtual int32_t numOperands() const { return 1; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _value;
+      return NULL;
+      }
+
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_value); }
+
+   protected:
+   OperationR0V1(Action a, Builder * parent, Value * value)
+      : Operation(a, parent)
+      , _value(value)
+      { }
+
+   Value * _value;
+   };
+
+class OperationR1V1 : public OperationR1
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR1V1); }
+   virtual int32_t numOperands() const { return 1; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _value;
+      return NULL;
+      }
+
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_value); }
+
+   protected:
+   OperationR1V1(Action a, Builder * parent, Value * result, Value * value)
+      : OperationR1(a, parent, result)
+      , _value(value)
+      { }
+
+   Value * _value;
+   };
+
+class OperationR1V1T1 : public OperationR1V1
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR1V1T1); }
+   virtual int32_t numTypes() const { return 1; }
+   virtual Type * type(int i=0) const
+      {
+      if (i == 0) return _type;
+      return NULL;
+      }
+
+   virtual TypeIterator TypesBegin()       { return TypeIterator(_type); }
+
+   protected:
+   OperationR1V1T1(Action a, Builder * parent, Value * result, Type * t, Value * v)
+      : OperationR1V1(a, parent, result, v)
+      , _type(t)
+      { }
+
+   Type * _type;
+   };
+
+class OperationR0V2 : public Operation
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR0V2); }
+   virtual int32_t numOperands() const { return 2; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _left;
+      if (i == 1) return _right;
+      return NULL;
+      }
+   virtual Value * getLeft() const  { return _left; }
+   virtual Value * getRight() const { return _right; }
+
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_left, _right); }
+
+   protected:
+   OperationR0V2(Action a, Builder * parent, Value * left, Value * right)
+      : Operation(a, parent)
+      , _left(left)
+      , _right(right)
+      { }
+
+   Value * _left;
+   Value * _right;
+   };
+
+class OperationR1V2 : public OperationR1
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR1V2); }
+   virtual int32_t numOperands() const { return 2; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _left;
+      if (i == 1) return _right;
+      return NULL;
+      }
+   virtual Value * getLeft() const  { return _left; }
+   virtual Value * getRight() const { return _right; }
+
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_left, _right); }
+
+   protected:
+   OperationR1V2(Action a, Builder * parent, Value * result, Value * left, Value * right)
+      : OperationR1(a, parent, result)
+      , _left(left)
+      , _right(right)
+      { }
+
+   Value * _left;
+   Value * _right;
+   };
+
+class OperationR1V2T1 : public OperationR1V2
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR1V2T1); }
+   virtual int32_t numTypes() const { return 1; }
+   virtual Type * type(int i=0) const
+      {
+      if (i == 0) return _type;
+      return NULL;
+      }
+   virtual TypeIterator TypesBegin()       { return TypeIterator(_type); }
+
+   virtual int32_t numOperands() const { return 2; }
+   virtual Value *operand(int i=0) const
+      {
+      if (i == 0) return _left;
+      if (i == 1) return _right;
+      return NULL;
+      }
+   virtual Value * getAddress() const  { return _left; }
+   virtual Value * getValue() const    { return _right; }
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_left, _right); }
+
+
+   protected:
+   OperationR1V2T1(Action a, Builder * parent, Value * result, Type * t, Value * addr, Value * v)
+      : OperationR1V2(a, parent, result, addr, v)
+      , _type(t)
+      { }
+
+   Type * _type;
+   };
+
+class OperationR1T1 : public OperationR1
+   {
+   public:
+   virtual size_t size() const         { return sizeof(OperationR1V2T1); }
+   virtual int32_t numTypes() const { return 1; }
+   virtual Type * type(int i=0) const
+      {
+      if (i == 0) return _type;
+      return NULL;
+      }
+   virtual TypeIterator TypesBegin()       { return TypeIterator(_type); }
+
+   protected:
+   OperationR1T1(Action a, Builder * parent, Value * result, Type * t)
+      : OperationR1(a, parent, result)
+      , _type(t)
+      { }
+
+   Type * _type;
+   };
+
+class OperationR0S1V1 : public Operation
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationR0S1V1); }
+
+   virtual int32_t numSymbols() const { return 1; }
+   virtual Symbol *symbol(int i=0) const
+      {
+      if (i == 0) return _symbol;
+      return NULL;
+      }
+   virtual SymbolIterator SymbolsBegin() { return SymbolIterator(_symbol); }
+
+   virtual int32_t numOperands() const { return 1; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _value;
+      return NULL;
+      }
+   virtual ValueIterator OperandsBegin() { return ValueIterator(_value); }
+
+   protected:
+   OperationR0S1V1(Action a, Builder * parent, Symbol *symbol, Value * value)
+      : Operation(a, parent)
+      , _symbol(symbol)
+      , _value(value)
+      { }
+
+   Symbol *_symbol;
+   Value * _value;
+   };
+
+class OperationR0T1 : public Operation
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationR0T1); }
+
+   virtual int32_t numTypes() const { return 1; }
+   virtual Type *type(int i=0) const
+      {
+      if (i == 0) return _type;
+      return NULL;
+      }
+   virtual TypeIterator TypesBegin()       { return TypeIterator(_type); }
+
+   protected:
+   OperationR0T1(Action a, Builder *parent, Type *type)
+      : Operation(a, parent)
+      , _type(type)
+      { }
+
+   Type *_type;
+   };
+
+class OperationR0V2T1 : public OperationR0T1
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationR0V2T1); }
+   virtual int32_t numOperands() const   { return 2; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _structBase;
+      if (i == 1) return _value;
+      return NULL;
+      }
+   virtual ValueIterator OperandsBegin()       { return ValueIterator(_structBase, _value); }
+
+   protected:
+   OperationR0V2T1(Action a, Builder *parent, FieldType *fieldType, Value * structBase, Value * value)
+      : OperationR0T1(a, parent, fieldType)
+      , _structBase(structBase)
+      , _value(value)
+      { }
+
+   Value *_structBase;
+   Value *_value;
+   };
+
+class OperationB1 : public Operation
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationB1); }
+   virtual int32_t numBuilders() const { return 1; }
+   virtual Builder * builder(int i=0) const
+      {
+      if (i == 0) return _builder;
+      return NULL;
+      }
+
+   virtual BuilderIterator BuildersBegin()       { return BuilderIterator(_builder); }
+
+   protected:
+   OperationB1(Action a, Builder * parent, Builder * b)
+      : Operation(a, parent)
+      , _builder(b)
+      { }
+
+   Builder * _builder;
+   };
+
+class OperationR0V2B1 : public OperationR0V2
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationR0V2B1); }
+   virtual int32_t numBuilders() const { return 1; }
+   virtual Builder * builder(int i=0) const
+      {
+      if (i == 0) return _builder;
+      return NULL;
+      }
+   virtual BuilderIterator BuildersBegin()       { return BuilderIterator(_builder); }
+
+   protected:
+   OperationR0V2B1(Action a, Builder * parent, Builder * b, Value * left, Value * right)
+      : OperationR0V2(a, parent, left, right)
+      , _builder(b)
+      { }
+
+   Builder * _builder;
+   };
+
+class OperationR0V1B1 : public OperationR0V1
+   {
+   public:
+   virtual size_t size() const { return sizeof(OperationR0V1B1); }
+   virtual int32_t numBuilders() const { return 1; }
+   virtual Builder * builder(int i=0) const
+      {
+      if (i == 0) return _builder;
+      return NULL;
+      }
+   virtual BuilderIterator BuildersBegin()       { return BuilderIterator(_builder); }
+
+   protected:
+   OperationR0V1B1(Action a, Builder * parent, Builder * b, Value * value)
+      : OperationR0V1(a, parent, value)
+      , _builder(b)
+      { }
+
+   Builder * _builder;
+   };
+
+
+
+//
+// classes for specific operations that can be directly instantiated
+// These classes are manipulated primarily by Builder
+//
+
+class ConstInt8 : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstInt8); }
+   static ConstInt8 * create(Builder * parent, Value * result, int8_t value)
+      { return new ConstInt8(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getInt8());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getInt8());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstInt8(Builder * parent, Value * result, int8_t value);
+   };
+
+class ConstInt16 : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstInt16); }
+   static ConstInt16 * create(Builder * parent, Value * result, int16_t value)
+      { return new ConstInt16(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getInt16());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getInt16());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstInt16(Builder * parent, Value * result, int16_t value);
+   };
+
+class ConstInt32 : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstInt32); }
+   static ConstInt32 * create(Builder * parent, Value * result, int32_t value)
+      { return new ConstInt32(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getInt32());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getInt32());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstInt32(Builder * parent, Value * result, int32_t value);
+   };
+
+class ConstInt64 : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstInt64); }
+   static ConstInt64 * create(Builder * parent, Value * result, int64_t value)
+      { return new ConstInt64(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getInt64());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getInt64());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstInt64(Builder * parent, Value * result, int64_t value);
+   };
+
+class ConstFloat : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstFloat); }
+   static ConstFloat * create(Builder * parent, Value * result, float value)
+      { return new ConstFloat(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getFloat());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getFloat());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstFloat(Builder * parent, Value * result, float value);
+   };
+
+class ConstDouble : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstDouble); }
+   static ConstDouble * create(Builder * parent, Value * result, double value)
+      { return new ConstDouble(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getDouble());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getDouble());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstDouble(Builder * parent, Value * result, double value);
+   };
+
+class ConstAddress : public OperationR1L1
+   {
+   public:
+   virtual size_t size() const { return sizeof(ConstAddress); }
+   static ConstAddress * create(Builder * parent, Value * result, void * value)
+      { return new ConstAddress(parent, result, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal()->getAddress());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal()->getAddress());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ConstAddress(Builder * parent, Value * result, void * value);
+   };
+
+class CoercePointer : public OperationR1V1T1
+   {
+   public:
+   static CoercePointer * create(Builder * parent, Value * result, Type * type, Value * value)
+      { return new CoercePointer(parent, result, type, value); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], type(0), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], type(0), operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   protected:
+   CoercePointer(Builder * parent, Value * result, Type * t, Value * v);
+   };
+
+class Add : public OperationR1V2
+   {
+   public:
+   static Add * create(Builder * parent, Value * result, Value * left, Value * right)
+      { return new Add(parent, result, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Add(Builder * parent, Value * result, Value * left, Value * right);
+   };
+
+class Sub : public OperationR1V2
+   {
+   public:
+   static Sub * create(Builder * parent, Value * result, Value * left, Value * right)
+      { return new Sub(parent, result, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Sub(Builder * parent, Value * result, Value * left, Value * right);
+   };
+
+class Mul : public OperationR1V2
+   {
+   public:
+   static Mul * create(Builder * parent, Value * result, Value * left, Value * right)
+      { return new Mul(parent, result, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == builders);
+      return create(b, results[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Mul(Builder * parent, Value * result, Value * left, Value * right);
+   };
+
+class IndexAt : public OperationR1V2T1
+   {
+   public:
+   static IndexAt * create(Builder * parent, Value * result, Type * pointerType, Value * address, Value * value)
+      { return new IndexAt(parent, result, pointerType, address, value); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], type(0), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], type(0), operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IndexAt(Builder * parent, Value * result, Type * pointerType, Value * address, Value * value);
+   };
+
+class Load : public OperationR1S1
+   {
+   public:
+   static Load * create(Builder * parent, Value * result, Symbol *local)
+      { return new Load(parent, result, local); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], symbol());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], symbol());
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Load(Builder * parent, Value * result, std::string name);
+   Load(Builder * parent, Value * result, Symbol *s)
+      : OperationR1S1(aLoad, parent, result, s)
+      { }
+   };
+
+class LoadAt : public OperationR1V1T1
+   {
+   public:
+   static LoadAt * create(Builder * parent, Value * result, Type * pointerType, Value * address)
+      { return new LoadAt(parent, result, pointerType, address); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], type(0), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], type(0), operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   LoadAt(Builder * parent, Value * result, Type * pointerType, Value * address);
+   };
+
+class LoadField : public OperationR1V1T1
+   {
+   public:
+   static LoadField * create(Builder * parent, Value * result, FieldType *fieldType, Value *structBase)
+      { return new LoadField(parent, result, fieldType, structBase); }
+
+   FieldType *getFieldType() const { return static_cast<FieldType *>(_type); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], getFieldType(), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], getFieldType(), operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   LoadField(Builder * parent, Value * result, FieldType *fieldType, Value * structBase)
+      : OperationR1V1T1(aLoadField, parent, result, fieldType, structBase)
+      { }
+   };
+
+class LoadIndirect : public OperationR1V1T1
+   {
+   public:
+   static LoadIndirect * create(Builder * parent, Value * result, FieldType *fieldType, Value *structBase)
+      { return new LoadIndirect(parent, result, fieldType, structBase); }
+
+   FieldType *getFieldType() const { return static_cast<FieldType *>(_type); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], getFieldType(), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && operands && NULL == builders);
+      return create(b, results[0], getFieldType(), operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   LoadIndirect(Builder * parent, Value * result, FieldType *fieldType, Value * structBase)
+      : OperationR1V1T1(aLoadIndirect, parent, result, fieldType, structBase)
+      { }
+   };
+
+class Store : public OperationR0S1V1
+   {
+   public:
+   static Store * create(Builder * parent, Symbol *local, Value * value)
+      { return new Store(parent, local, value); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, symbol(), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && NULL == builders);
+      return create(b, symbol(), operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Store(Builder * parent, std::string name, Value * value);
+   Store(Builder * parent, Symbol *s, Value * value)
+      : OperationR0S1V1(aStore, parent, s, value)
+      { }
+   };
+
+class StoreAt : public OperationR0V2
+   {
+   public:
+   static StoreAt * create(Builder * parent, Value * address, Value * value)
+      { return new StoreAt(parent, address, value); }
+   
+   virtual Value * getAddress() const { return _left; }
+   virtual Value * getValue() const   { return _right; }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, getAddress(), getValue());
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && NULL == builders);
+      return create(b, operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   StoreAt(Builder * parent, Value * address, Value * value);
+   };
+
+class StoreField : public OperationR0V2T1
+   {
+   public:
+   static StoreField * create(Builder * parent, FieldType *fieldType, Value *structBase, Value *value)
+      { return new StoreField(parent, fieldType, structBase, value); }
+
+   FieldType *getFieldType() const { return static_cast<FieldType *>(_type); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, getFieldType(), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && NULL == builders);
+      return create(b, getFieldType(), operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   StoreField(Builder * parent, FieldType *fieldType, Value * structBase, Value *value)
+      : OperationR0V2T1(aStoreField, parent, fieldType, structBase, value)
+      { }
+   };
+
+class StoreIndirect : public OperationR0V2T1
+   {
+   public:
+   static StoreIndirect * create(Builder * parent, FieldType *fieldType, Value *structBase, Value *value)
+      { return new StoreIndirect(parent, fieldType, structBase, value); }
+
+   FieldType *getFieldType() const { return static_cast<FieldType *>(_type); }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, getFieldType(), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && NULL == builders);
+      return create(b, getFieldType(), operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   StoreIndirect(Builder * parent, FieldType *fieldType, Value * structBase, Value *value)
+      : OperationR0V2T1(aStoreIndirect, parent, fieldType, structBase, value)
+      { }
+   };
+
+class AppendBuilder : public OperationB1
+   {
+   public:
+   static AppendBuilder * create(Builder * parent, Builder * b)
+      { return new AppendBuilder(parent, b); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && NULL == operands && builders);
+      return create(b, builders[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   AppendBuilder(Builder * parent, Builder * b);
+   };
+
+class Call : public Operation
+   {
+   public:
+   static Call * create(Builder * parent, Value *function, int32_t numArgs, va_list args)
+      {
+      Call *call = new Call(parent, function, NULL, numArgs, args);
+      return call;
+      }
+   static Call * create(Builder * parent, Value *function, Value *result, int32_t numArgs, va_list args)
+      {
+      Call *call = new Call(parent, function, result, numArgs, args);
+      return call;
+      }
+   static Call * create(Builder * parent, Value *function, int32_t numArgs, Value **args)
+      {
+      Call *call = new Call(parent, function, NULL, numArgs, args);
+      return call;
+      }
+   static Call * create(Builder * parent, Value *function, Value *result, int32_t numArgs, Value **args)
+      {
+      Call *call = new Call(parent, function, result, numArgs, args);
+      return call;
+      }
+
+   virtual size_t size() const { return sizeof(Call); }
+   
+   Value *function() const  { return _function; }
+   int32_t numArguments() const { return _numArgs; }
+   Value *argument(int32_t a) const
+      {
+      if (a < _numArgs)
+         return _args[a];
+      return NULL;
+      }
+
+   virtual int32_t numOperands() const   { return _numArgs+1; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0)
+         return _function;
+      else if (i >= 1 && i <= _numArgs)
+         return _args[i-1];
+      return NULL;
+      }
+   virtual ValueIterator OperandsBegin()
+      {
+      ValueIterator it1(_function);
+      ValueIterator it2(_args, _numArgs);
+      it2.prepend(it1);
+      return it2;
+      }
+
+   virtual int32_t numResults() const          { return (_result != NULL) ? 1 : 0; }
+   virtual Value * result(int i=0) const
+      {
+      if (i == 0) return _result; // may return NULL if there is no result
+      return NULL;
+      }
+   virtual ValueIterator ResultsBegin()
+      {
+      if (_result)
+         return ValueIterator(_result);
+      return ResultsEnd();
+      }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      Value **cloneArgs = new Value *[_numArgs];
+      for (int32_t a=0;a < _numArgs;a++)
+         cloneArgs[a] = _args[a];
+      if (_result)
+         {
+         assert(results);
+         return new Call(b, operand(0), results[0], _numArgs, cloneArgs);
+         }
+      else
+         {
+         assert(NULL == results);
+         return new Call(b, operand(0), NULL, _numArgs, cloneArgs);
+         }
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      if (_result)
+         {
+         assert(results && operands && NULL == builders);
+         return new Call(b, operands[0], results[0], _numArgs-1, operands+1);
+         }
+      else
+         {
+         assert(NULL == results && operands && NULL == builders);
+         return new Call(b, operands[0], NULL, _numArgs-1, operands+1);
+         }
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Call(Builder * parent, Value *result, Value *function, int32_t numArgs, va_list args);
+   Call(Builder * parent, Value *result, Value *function, int32_t numArgs, Value **args);
+
+   Value *_function;
+   Value *_result;
+   int32_t _numArgs;
+   Value **_args;
+   };
+
+class Goto : public OperationB1
+   {
+   public:
+   static Goto * create(Builder * parent, Builder * b)
+      { return new Goto(parent, b); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && NULL == operands && builders);
+      return create(b, builders[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Goto(Builder * parent, Builder * b);
+   };
+
+class ForLoop : public Operation
+   {
+   public:
+   virtual size_t size() const { return sizeof(ForLoop); }
+   static ForLoop * create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Builder * loopBreak, Builder * loopContinue,
+                           Value * initial, Value * end, Value * bump);
+   static ForLoop * create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Builder * loopBreak,
+                           Value * initial, Value * end, Value * bump);
+   static ForLoop * create(Builder * parent, bool countsUp, LocalSymbol * loopSym,
+                           Builder * loopBody, Value * initial, Value * end, Value * bump);
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual bool countsUp() const                       { return (bool)(_countsUp->getInt8()); }
+   virtual LocalSymbol *getLoopSymbol() const          { return _loopSym; }
+
+   virtual Value * getInitial() const                  { return _initial; }
+   virtual Value * getEnd() const                      { return _end; }
+   virtual Value * getBump() const                     { return _bump; }
+
+   virtual int32_t numLiterals() const                 { return 1; }
+   virtual LiteralValue *literal(int i=0) const
+      {
+      if (i == 0) return _countsUp;
+      return NULL;
+      }
+   virtual LiteralIterator LiteralsBegin()             { return LiteralIterator(_countsUp); }
+
+   virtual int32_t numSymbols() const                  { return 1; }
+   virtual Symbol *symbol(int i=0) const
+      {
+      if (i == 0) return _loopSym;
+      return NULL;
+      }
+   virtual SymbolIterator SymbolsBegin()               { return SymbolIterator(_loopSym); }
+
+   virtual int32_t numOperands() const                 { return 3; }
+   virtual Value * operand(int i=0) const
+      {
+      if (i == 0) return _initial;
+      if (i == 1) return _end;
+      if (i == 2) return _bump;
+      return NULL;
+      }
+   virtual ValueIterator OperandsBegin()               { return ValueIterator(_initial, _end, _bump); }
+
+   virtual Builder * getBody() const                   { return _loopBody; }
+   virtual Builder * getBreak() const                  { return _loopBreak; }
+   virtual Builder * getContinue() const               { return _loopContinue; }
+   virtual int32_t numBuilders() const                 { return 1 + (_loopBreak ? 1 : 0) + (_loopContinue ? 1 : 0); }
+
+   virtual Builder * builder(int i=0) const
+      {
+      if (i == 0) return _loopBody;
+      if (i == 1) return _loopBreak;
+      if (i == 2) return _loopContinue;
+      return NULL;
+      }
+
+   virtual BuilderIterator BuildersBegin()
+      {
+      if (_loopContinue) return BuilderIterator(_loopBody, _loopBreak, _loopContinue);
+      if (_loopBreak)    return BuilderIterator(_loopBody, _loopBreak);
+      return BuilderIterator(_loopBody);
+      }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, literal(0)->getInt8(), _loopSym, builder(0), builder(1), builder(2), operand(0), operand(1), operand(2));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, literal(0)->getInt8(), _loopSym, builders[0], _loopBreak ? builders[1] : NULL, _loopContinue ? builders[2] : NULL, operands[0], operands[1], operands[2]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   ForLoop(Builder * parent, bool countsUp, LocalSymbol *loopSym,
+           Builder * loopBody, Builder * loopBreak, Builder * loopContinue,
+           Value * initial, Value * end, Value * bump);
+   ForLoop(Builder * parent, bool countsUp, LocalSymbol *loopSym,
+           Builder * loopBody, Builder * loopBreak,
+           Value * initial, Value * end, Value * bump);
+   ForLoop(Builder * parent, bool countsUp, LocalSymbol *loopSym,
+           Builder * loopBody,
+           Value * initial, Value * end, Value * bump);
+
+   LiteralValue *_countsUp;
+   LocalSymbol *_loopSym;
+
+   Builder * _loopBody;
+   Builder * _loopBreak;
+   Builder * _loopContinue;
+
+   Value * _initial;
+   Value * _end;
+   Value * _bump;
+   };
+
+class IfCmpGreaterThan : public OperationR0V2B1
+   {
+   public:
+   static IfCmpGreaterThan * create(Builder * parent, Builder * tgt, Value * left, Value * right)
+      { return new IfCmpGreaterThan(parent, tgt, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, builders[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IfCmpGreaterThan(Builder * parent, Builder * tgt, Value * left, Value * right);
+   };
+
+class IfCmpLessThan : public OperationR0V2B1
+   {
+   public:
+   static IfCmpLessThan * create(Builder * parent, Builder * tgt, Value * left, Value * right)
+      { return new IfCmpLessThan(parent, tgt, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, builders[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IfCmpLessThan(Builder * parent, Builder * tgt, Value * left, Value * right);
+   };
+
+class IfCmpGreaterOrEqual : public OperationR0V2B1
+   {
+   public:
+   static IfCmpGreaterOrEqual * create(Builder * parent, Builder * tgt, Value * left, Value * right)
+      { return new IfCmpGreaterOrEqual(parent, tgt, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, builders[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IfCmpGreaterOrEqual(Builder * parent, Builder * tgt, Value * left, Value * right);
+   };
+
+class IfCmpLessOrEqual : public OperationR0V2B1
+   {
+   public:
+   static IfCmpLessOrEqual * create(Builder * parent, Builder * tgt, Value * left, Value * right)
+      { return new IfCmpLessOrEqual(parent, tgt, left, right); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0), operand(0), operand(1));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, builders[0], operands[0], operands[1]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IfCmpLessOrEqual(Builder * parent, Builder * tgt, Value * left, Value * right);
+   };
+
+class IfThenElse : public OperationR0V1B1
+   {
+   public:
+   virtual size_t size() const { return sizeof(IfThenElse); }
+   static IfThenElse * create(Builder * parent, Builder * thenB, Builder * elseB, Value * cond);
+   static IfThenElse * create(Builder * parent, Builder * thenB, Value * cond);
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Builder * getThenBuilder() const { return _builder; }
+   virtual Builder * getElseBuilder() const { return _elseBuilder; }
+
+   virtual int32_t numBuilders() const { return _elseBuilder ? 2 : 1; }
+   virtual Builder * builder(int i=0) const
+      {
+      if (i == 0)
+         return _builder;
+      else if (i == 1 && _elseBuilder)
+         return _elseBuilder;
+      return NULL;
+      }
+   virtual BuilderIterator BuildersBegin()
+      {
+      if (_elseBuilder)
+         return BuilderIterator(_builder, _elseBuilder);
+      return BuilderIterator(_builder);
+      }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      return create(b, builder(0), builder(1), operand(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && operands && builders);
+      return create(b, builders[0], _elseBuilder ? builders[1] : NULL, operands[0]);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   IfThenElse(Builder * parent, Builder * thenB, Builder * elseB, Value * cond);
+   IfThenElse(Builder * parent, Builder * thenB, Value * cond);
+
+   Builder * _elseBuilder;
+   };
+
+class Return : public Operation
+   {
+   public:
+   virtual size_t size() const { return sizeof(Return); }
+   static Return * create(Builder * parent)
+      { return new Return(parent); }
+   static Return * create(Builder * parent, Value * v)
+      { return new Return(parent, v); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual int32_t numOperands() const { return _value ? 1 : 0; }
+   virtual Value * operand(int32_t i=0) const
+      {
+      if (i == 0 && _value)
+         return _value;
+      return NULL;
+      }
+
+   virtual ValueIterator OperandsBegin()
+      {
+      if (_value)
+         return ValueIterator(_value);
+      else
+         return OperandsEnd();
+      }
+
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(NULL == results);
+      if (numOperands() > 0)
+         return create(b, operand(0));
+      return create(b);
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(NULL == results && NULL == builders);
+      if (numOperands() > 0)
+         return create(b, operands[0]);
+      return create(b);
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Return(Builder * parent);
+   Return(Builder * parent, Value * v);
+
+   Value * _value;
+   };
+
+class Switch : public OperationR0V1
+   {
+   public:
+   virtual size_t size() const { return sizeof(Switch); }
+   static Switch * create(Builder * parent, Value *selector, Builder *defaultTarget, int numCases, Case ** cases)
+      { return new Switch(parent, selector, defaultTarget, numCases, cases); }
+
+   virtual Value * getSelector() const { return _value; }
+
+   virtual int32_t numBuilders() const { return 1 + _cases.size(); }
+   virtual Builder *builder(int32_t i=0) const
+      {
+      if (i == 0)
+         return _defaultTarget;
+      else if (i-1 < _cases.size())
+         return _cases[i-1]->builder();
+      return NULL;
+      }
+   virtual BuilderIterator BuildersBegin()
+      {
+      std::vector<Builder *> it;
+      it.push_back(_defaultTarget);
+      for (auto cIt = CasesBegin(); cIt != CasesEnd(); cIt++)
+         it.push_back((*cIt)->builder());
+      return BuilderIterator(it);
+      }
+
+   virtual int32_t numCases() const  { return _cases.size(); }
+   virtual CaseIterator CasesBegin() { return _cases.begin(); }
+   virtual CaseIterator CasesEnd()   { return _cases.end(); }
+
+   static void initializeTypeProductions(TypeDictionary * types, TypeGraph * graph);
+
+   virtual Operation * clone(Builder *b, Value **results) const;
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const;
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   Switch(Builder * parent, Value *selector, Builder *defaultCase, int numCases, Case ** cases);
+
+   Builder *_defaultTarget;
+   std::vector<Case *> _cases;
+   };
+
+class CreateLocalArray : public OperationR1L1T1
+   {
+   public:
+   static CreateLocalArray * create(Builder * parent, Value * result, int32_t numElements, Type * elementType)
+      { return new CreateLocalArray(parent, result, numElements, elementType); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], literal(0)->getInt32(), type(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], literal(0)->getInt32(), type(0));
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   CreateLocalArray(Builder * parent, Value * result, int32_t numElements, Type * elementType);
+   };
+
+class CreateLocalStruct : public OperationR1T1
+   {
+   public:
+   static CreateLocalStruct * create(Builder * parent, Value * result, Type * structType)
+      { return new CreateLocalStruct(parent, result, structType); }
+   
+   virtual Operation * clone(Builder *b, Value **results) const
+      {
+      assert(results);
+      return create(b, results[0], type(0));
+      }
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const
+      {
+      assert(results && NULL == operands && NULL == builders);
+      return create(b, results[0], type(0));
+      }
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const;
+
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const;
+
+   protected:
+   CreateLocalStruct(Builder * parent, Value * result, Type * structType);
+   };
+
+// Add any new operation classes here
+// BEGIN {
+//
+
+//
+// } END
+// Add any new operation classes here
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(OPERATION_INCL)

--- a/jitbuilder/jbil/OperationBase.cpp
+++ b/jitbuilder/jbil/OperationBase.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdint.h>
+#include "Builder.hpp"
+#include "Operation.hpp"
+
+int64_t OMR::JitBuilder::OperationBase::globalIndex = 0;
+OMR::JitBuilder::BuilderIterator OMR::JitBuilder::OperationBase::builderEndIterator;
+OMR::JitBuilder::SymbolIterator OMR::JitBuilder::OperationBase::symbolEndIterator;
+OMR::JitBuilder::TypeIterator OMR::JitBuilder::OperationBase::typeEndIterator;
+OMR::JitBuilder::ValueIterator OMR::JitBuilder::OperationBase::valueEndIterator;
+OMR::JitBuilder::LiteralIterator OMR::JitBuilder::OperationBase::literalEndIterator;
+
+OMR::JitBuilder::OperationBase::OperationBase(Action a, Builder * parent)
+   : Object(parent->fb())
+   , _index(globalIndex++)
+   , _parent(parent)
+   , _action(a)
+   , _location(NULL)
+   {
+   } 
+
+OMR::JitBuilder::Operation *
+OMR::JitBuilder::OperationBase::setParent(Builder * newParent)
+   {
+   _parent = newParent;
+   return static_cast<OMR::JitBuilder::Operation *>(this);
+   }
+
+OMR::JitBuilder::Operation *
+OMR::JitBuilder::OperationBase::setLocation(Location *location)
+   {
+   _location = location;
+   return static_cast<OMR::JitBuilder::Operation *>(this);
+   }

--- a/jitbuilder/jbil/OperationBase.cpp
+++ b/jitbuilder/jbil/OperationBase.cpp
@@ -26,10 +26,11 @@
 
 int64_t OMR::JitBuilder::OperationBase::globalIndex = 0;
 OMR::JitBuilder::BuilderIterator OMR::JitBuilder::OperationBase::builderEndIterator;
+OMR::JitBuilder::CaseIterator OMR::JitBuilder::OperationBase::caseEndIterator;
+OMR::JitBuilder::LiteralIterator OMR::JitBuilder::OperationBase::literalEndIterator;
 OMR::JitBuilder::SymbolIterator OMR::JitBuilder::OperationBase::symbolEndIterator;
 OMR::JitBuilder::TypeIterator OMR::JitBuilder::OperationBase::typeEndIterator;
 OMR::JitBuilder::ValueIterator OMR::JitBuilder::OperationBase::valueEndIterator;
-OMR::JitBuilder::LiteralIterator OMR::JitBuilder::OperationBase::literalEndIterator;
 
 OMR::JitBuilder::OperationBase::OperationBase(Action a, Builder * parent)
    : Object(parent->fb())

--- a/jitbuilder/jbil/OperationBase.hpp
+++ b/jitbuilder/jbil/OperationBase.hpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OPERATIONBASE_INCL
+#define OPERATIONBASE_INCL
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "Action.hpp"
+#include "Iterator.hpp"
+#include "Object.hpp"
+#include "Symbol.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class Case;
+class LiteralValue;
+class Location;
+class Operation;
+class OperationCloner;
+class Type;
+class TypeDictionary;
+class TypeGraph;
+class Value;
+
+
+class OperationBase : public Object
+   {
+   friend class Builder;
+   friend class BuilderBase;
+   friend class Transformer;
+
+   public:
+   int64_t id() const                                  { return _index; }
+   Action action() const                               { return _action; }
+   Builder * parent() const                            { return _parent; }
+   Location * location() const                         { return _location; }
+
+   virtual LiteralIterator LiteralsBegin()             { return LiteralIterator(); }
+           LiteralIterator &LiteralsEnd()              { return literalEndIterator; }
+   virtual int32_t numLiterals() const                 { return 0; }
+   virtual LiteralValue * literal(int i=0) const       { assert(0); return 0; }
+
+   virtual SymbolIterator SymbolsBegin()               { return SymbolIterator(); }
+           SymbolIterator &SymbolsEnd()                { return symbolEndIterator; }
+   virtual int32_t numSymbols() const                  { return 0; }
+   virtual Symbol *symbol(int i=0) const               { assert(0); return 0; }
+
+   virtual ValueIterator OperandsBegin()               { return ValueIterator(); }
+           ValueIterator &OperandsEnd()                { return valueEndIterator; }
+   virtual int32_t numOperands() const                 { return 0; }
+   virtual Value * operand(int i=0) const              { return NULL; }
+
+   virtual ValueIterator ResultsBegin()                { return ValueIterator(); }
+           ValueIterator &ResultsEnd()                 { return valueEndIterator; }
+   virtual int32_t numResults() const                  { return 0; }
+   virtual Value * result(int i=0) const               { return NULL; }
+ 
+   virtual SymbolIterator ReadSymbolsBegin()           { return SymbolIterator(); }
+           SymbolIterator ReadSymbolsEnd()             { return symbolEndIterator; }
+   virtual int32_t numReadSymbols() const              { return 0; }
+   virtual Symbol * readSymbol(int i=0) const          { return NULL; }
+
+   virtual SymbolIterator WrittenSymbolsBegin()        { return SymbolIterator(); }
+           SymbolIterator WrittenSymbolsEnd()          { return symbolEndIterator; }
+   virtual int32_t numWrittenSymbols() const           { return 0; }
+   virtual Symbol * writtenSymbol(int i=0) const       { return NULL; }
+
+   virtual BuilderIterator BuildersBegin()             { return BuilderIterator(); }
+           BuilderIterator &BuildersEnd()              { return builderEndIterator; }
+   virtual int32_t numBuilders() const                 { return 0; }
+   virtual Builder *builder(int i=0) const             { return NULL; }
+
+   virtual CaseIterator CasesBegin()                   { return CaseIterator(); }
+   virtual CaseIterator CasesEnd()                     { return CaseIterator(); }
+   virtual int32_t numCases() const                    { return 0; }
+   virtual Case * getCase(int i=0) const               { return NULL; }
+
+   virtual TypeIterator TypesBegin()                   { return TypeIterator(); }
+           TypeIterator &TypesEnd()                    { return typeEndIterator; }
+   virtual int32_t numTypes() const                    { return 0; }
+   virtual Type * type(int i=0) const                  { return NULL; }
+
+   // deprecated
+   virtual Operation * clone(Builder *b, Value **results) const = 0;
+   virtual Operation * clone(Builder *b, Value **results, Value **operands, Builder **builders) const = 0;
+   virtual void cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers) const = 0;
+
+   // the new clone API
+   virtual Operation * clone(Builder *b, OperationCloner *cloner) const = 0;
+
+protected:
+   OperationBase(Action a, Builder * parent);
+
+   Operation * setParent(Builder * newParent);
+   Operation * setLocation(Location *location);
+
+   int64_t                  _index;
+   Builder                * _parent;
+   Action                   _action;
+   Location               * _location;
+
+   static int64_t globalIndex;
+   static BuilderIterator builderEndIterator;
+   static LiteralIterator literalEndIterator;
+   static SymbolIterator symbolEndIterator;
+   static TypeIterator typeEndIterator;
+   static ValueIterator valueEndIterator;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(OPERATIONBASE_INCL)

--- a/jitbuilder/jbil/OperationBase.hpp
+++ b/jitbuilder/jbil/OperationBase.hpp
@@ -42,6 +42,7 @@ class LiteralValue;
 class Location;
 class Operation;
 class OperationCloner;
+class OperationReplacer;
 class Type;
 class TypeDictionary;
 class TypeGraph;
@@ -59,6 +60,8 @@ class OperationBase : public Object
    Action action() const                               { return _action; }
    Builder * parent() const                            { return _parent; }
    Location * location() const                         { return _location; }
+
+   virtual bool isDynamic() const                      { return false; }
 
    virtual LiteralIterator LiteralsBegin()             { return LiteralIterator(); }
            LiteralIterator &LiteralsEnd()              { return literalEndIterator; }
@@ -96,7 +99,7 @@ class OperationBase : public Object
    virtual Builder *builder(int i=0) const             { return NULL; }
 
    virtual CaseIterator CasesBegin()                   { return CaseIterator(); }
-   virtual CaseIterator CasesEnd()                     { return CaseIterator(); }
+   virtual CaseIterator CasesEnd()                     { return caseEndIterator; }
    virtual int32_t numCases() const                    { return 0; }
    virtual Case * getCase(int i=0) const               { return NULL; }
 
@@ -113,6 +116,9 @@ class OperationBase : public Object
    // the new clone API
    virtual Operation * clone(Builder *b, OperationCloner *cloner) const = 0;
 
+   virtual bool hasExpander() const                       { return false; }
+   virtual bool expand(OperationReplacer *replacer) const { return false; }
+
 protected:
    OperationBase(Action a, Builder * parent);
 
@@ -126,6 +132,7 @@ protected:
 
    static int64_t globalIndex;
    static BuilderIterator builderEndIterator;
+   static CaseIterator caseEndIterator;
    static LiteralIterator literalEndIterator;
    static SymbolIterator symbolEndIterator;
    static TypeIterator typeEndIterator;

--- a/jitbuilder/jbil/OperationCloner.cpp
+++ b/jitbuilder/jbil/OperationCloner.cpp
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "OperationCloner.hpp"
+#include "Operation.hpp"
+#include "Value.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+OperationCloner::OperationCloner(Operation *op)
+   : _op(op)
+   , _numResults(op->numResults())
+   , _results(NULL)
+   , _numOperands(op->numOperands())
+   , _operands(NULL)
+   , _numTypes(op->numTypes())
+   , _types(NULL)
+   , _numLiterals(op->numLiterals())
+   , _literals(NULL)
+   , _numSymbols(op->numSymbols())
+   , _symbols(NULL)
+   , _numBuilders(op->numBuilders())
+   , _builders(NULL)
+   {
+   init();
+   reset();
+   }
+
+OperationCloner::~OperationCloner()
+   {
+   if (_results)
+      delete[] _results;
+
+   if (_operands)
+      delete[] _operands;
+
+   if (_types)
+      delete[] _types;
+
+   if (_literals)
+      delete[] _literals;
+
+   if (_symbols)
+      delete[] _symbols;
+
+   if (_builders)
+      delete[] _builders;
+   }
+
+void
+OperationCloner::init()
+   {
+   if (_numResults > 0)
+      _results = new Value *[_numResults];
+
+   if (_numOperands > 0)
+      _operands = new Value *[_numOperands];
+
+   if (_numTypes > 0)
+      _types = new Type *[_numTypes];
+
+   if (_numLiterals > 0)
+      _literals = new LiteralValue *[_numLiterals];
+
+   if (_numSymbols > 0)
+      _symbols = new Symbol *[_numSymbols];
+
+   if (_numBuilders > 0)
+      _builders = new Builder *[_numBuilders];
+   }
+
+void
+OperationCloner::reset()
+   {
+   for (int i=0;i < _numResults;i++)
+      _results[i] = _op->result(i);
+   for (int i=0;i < _numOperands;i++)
+      _operands[i] = _op->operand(i);
+   for (int i=0;i < _numTypes;i++)
+      _types[i] = _op->type(i);
+   for (int i=0;i < _numLiterals;i++)
+      _literals[i] = _op->literal(i);
+   for (int i=0;i < _numSymbols;i++)
+      _symbols[i] = _op->symbol(i);
+   for (int i=0;i < _numBuilders;i++)
+      _builders[i] = _op->builder(i);
+   }
+
+void
+OperationCloner::createResult(Builder *b, uint32_t i)
+   {
+   changeResult( Value::create(b, _op->result(i)->type()) );
+   }
+
+Operation *
+OperationCloner::clone(Builder *b)
+   {
+   return _op->clone(b, this);
+   }
+
+Operation *
+OperationCloner::cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMappers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers)
+   {
+   for (uint32_t i=0;i < _numOperands;i++)
+      changeOperand(operandMappers[i]->next(), i);
+   for (uint32_t i=0;i < _numTypes;i++)
+      changeType(typeMappers[i]->next(), i);
+   for (uint32_t i=0;i < _numLiterals;i++)
+      changeLiteral(literalMappers[i]->next(), i);
+   for (uint32_t i=0;i < _numSymbols;i++)
+      changeSymbol(symbolMappers[i]->next(), i);
+   for (uint32_t i=0;i < _numBuilders;i++)
+      changeBuilder(builderMappers[i]->next(), i);
+
+   Operation *clonedOp = clone(b);
+
+   for (uint32_t i=0;i < _numResults;i++)
+      resultMappers[i]->add( result(i) );
+
+   return clonedOp;
+   }
+ 
+} // namespace JitBuilder
+
+} // namespace OMR

--- a/jitbuilder/jbil/OperationCloner.hpp
+++ b/jitbuilder/jbil/OperationCloner.hpp
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OPERATIONCLONER_INCL
+#define OPERATIONCLONER_INCL
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include "Mapper.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class LiteralValue;
+class Operation;
+class Symbol;
+class Type;
+class Value;
+
+class OperationCloner
+   {
+   public:
+   OperationCloner(Operation *op);
+   ~OperationCloner();
+
+   void init();
+   void reset();
+
+   OperationCloner *changeOperand(Value *v, uint32_t i=0)
+      {
+      if (i < _numOperands)
+         _operands[i] = v;
+      return this;
+      }
+
+   OperationCloner *changeType(Type *t, uint32_t i=0)
+      {
+      if (i < _numTypes)
+         _types[i] = t;
+      return this;
+      }
+
+   OperationCloner *changeLiteral(LiteralValue *v, uint32_t i=0)
+      {
+      if (i < _numLiterals)
+         _literals[i] = v;
+      return this;
+      }
+
+   OperationCloner *changeSymbol(Symbol *s, uint32_t i=0)
+      {
+      if (i < _numSymbols)
+         _symbols[i] = s;
+      return this;
+      }
+
+   OperationCloner *changeBuilder(Builder *b, uint32_t i=0)
+      {
+      if (i < _numBuilders)
+         _builders[i] = b;
+      return this;
+      }
+
+   Operation *clone(Builder *b);
+   Operation *cloneTo(Builder *b, ValueMapper **resultMappers, ValueMapper **operandMappers, TypeMapper **typeMappers, LiteralMapper **literalMapppers, SymbolMapper **symbolMappers, BuilderMapper **builderMappers);
+
+   uint32_t numResults() const
+      {
+      return _numResults;
+      }
+   Value *result(uint32_t i=0) const
+      {
+      if (i < _numResults) return _results[i];
+      return NULL;
+      }
+   void changeResult(Value *v, uint32_t i=0)
+      {
+      if (i < _numResults) _results[i] = v;
+      }
+   void createResult(Builder *b, uint32_t i=0);
+
+   uint32_t numOperands() const
+      {
+      return _numOperands;
+      }
+   Value *operand(uint32_t i=0) const
+      {
+      if (i < _numOperands) return _operands[i];
+      return NULL;
+      }
+
+   uint32_t numTypes() const
+      {
+      return _numTypes;
+      }
+   Type *type(uint32_t i=0) const
+      {
+      if (i < _numTypes) return _types[i];
+      return NULL;
+      }
+
+   uint32_t numLiterals() const
+      {
+      return _numLiterals;
+      }
+   LiteralValue *literal(uint32_t i=0) const
+      {
+      if (i < _numLiterals) return _literals[i];
+      return NULL;
+      }
+
+   uint32_t numSymbols() const
+      {
+      return _numSymbols;
+      }
+   Symbol *symbol(uint32_t i=0) const
+      {
+      if (i < _numSymbols) return _symbols[i];
+      return NULL;
+      }
+
+   uint32_t numBuilders() const
+      {
+      return _numBuilders;
+      }
+   Builder *builder(uint32_t i=0) const
+      {
+      if (i < _numBuilders) return _builders[i];
+      return NULL;
+      }
+
+   private:
+
+   Operation *_op;
+
+   int32_t _numResults;
+   Value **_results;
+
+   int32_t _numOperands;
+   Value **_operands;
+
+   int32_t _numTypes;
+   Type **_types;
+
+   int32_t _numLiterals;
+   LiteralValue **_literals;
+
+   int32_t _numSymbols;
+   Symbol **_symbols;
+
+   int32_t _numBuilders;
+   Builder **_builders;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(OPERATIONCLONER_INCL)

--- a/jitbuilder/jbil/OperationReplacer.cpp
+++ b/jitbuilder/jbil/OperationReplacer.cpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Operation.hpp"
+#include "OperationReplacer.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+OperationReplacer::OperationReplacer(Operation *op)
+   : _builder(NULL)
+   , _op(op)
+   , _numResults(0)
+   , _resultMappers(NULL)
+   , _numOperands(0)
+   , _operandMappers(NULL)
+   , _numBuilders(0)
+   , _builderMappers(NULL)
+   , _numLiterals(0)
+   , _literalMappers(NULL)
+   , _numSymbols(0)
+   , _symbolMappers(NULL)
+   , _numTypes(0)
+   , _typeMappers(NULL)
+   {
+   _numResults = op->numResults();
+   if (_numResults > 0)
+      {
+      _resultMappers = new ValueMapper *[_numResults];
+      for (auto i=0;i < _numResults;i++)
+         _resultMappers[i] = NULL;
+      }
+
+   _numOperands = op->numOperands();
+   if (_numOperands > 0)
+      {
+      _operandMappers = new ValueMapper *[_numOperands];
+      for (auto i=0;i < _numOperands;i++)
+         _operandMappers[i] = NULL;
+      }
+
+   _numBuilders = op->numBuilders();
+   if (_numBuilders > 0)
+      {
+      _builderMappers = new BuilderMapper *[_numBuilders];
+      for (auto i=0;i < _numBuilders;i++)
+         _builderMappers[i] = NULL;
+      }
+
+   _numLiterals = op->numLiterals();
+   if (_numLiterals > 0)
+      {
+      _literalMappers = new LiteralMapper *[_numLiterals];
+      for (auto i=0;i < _numLiterals;i++)
+         _literalMappers[i] = NULL;
+      }
+
+   _numSymbols = op->numSymbols();
+   if (_numSymbols > 0)
+      {
+      _symbolMappers = new SymbolMapper *[_numSymbols];
+      for (auto i=0;i < _numSymbols;i++)
+         _symbolMappers[i] = NULL;
+      }
+
+   _numTypes = op->numTypes();
+   if (_numTypes > 0)
+      {
+      _typeMappers = new TypeMapper *[_numTypes];
+      for (auto i=0;i < _numTypes;i++)
+         _typeMappers[i] = NULL;
+      }
+   }
+
+OperationReplacer::~OperationReplacer()
+   {
+   if (_resultMappers)
+      delete[] _resultMappers;
+   if (_operandMappers)
+      delete[] _operandMappers;
+   if (_builderMappers)
+      delete[] _builderMappers;
+   if (_literalMappers)
+      delete[] _literalMappers;
+   if (_symbolMappers)
+      delete[] _symbolMappers;
+   if (_typeMappers)
+      delete[] _typeMappers;
+   }
+
+} // namespace JitBuilder
+
+} // namespace OMR

--- a/jitbuilder/jbil/OperationReplacer.hpp
+++ b/jitbuilder/jbil/OperationReplacer.hpp
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OPERATIONREPLACER_INCL
+#define OPERATIONREPLACER_INCL
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include "Mapper.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class LiteralValue;
+class Operation;
+class Symbol;
+class Type;
+class Value;
+
+class OperationReplacer
+   {
+   public:
+   OperationReplacer(Operation *op);
+   ~OperationReplacer();
+
+   void setBuilder(Builder *b)
+      {
+      _builder = b;
+      }
+
+   void setResultMapper(ValueMapper *m, uint32_t i=0)
+      {
+      if (i < _numResults)
+         _resultMappers[i] = m;
+      }
+
+   void setOperandMapper(ValueMapper *m, uint32_t i=0)
+      {
+      if (i < _numOperands)
+         _operandMappers[i] = m;
+      }
+
+   void setBuilderMapper(BuilderMapper *m, uint32_t i=0)
+      {
+      if (i < _numBuilders)
+         _builderMappers[i] = m;
+      }
+
+   void setLiteralMapper(LiteralMapper *m, uint32_t i=0)
+      {
+      if (i < _numLiterals)
+         _literalMappers[i] = m;
+      }
+
+   void setSymbolMapper(SymbolMapper *m, uint32_t i=0)
+      {
+      if (i < _numSymbols)
+         _symbolMappers[i] = m;
+      }
+
+   void setTypeMapper(TypeMapper *m, uint32_t i=0)
+      {
+      if (i < _numTypes)
+         _typeMappers[i] = m;
+      }
+
+   void setExplodedTypes(std::set<Type *> *explodedTypes)
+      {
+      _explodedTypes = explodedTypes;
+      }
+
+   Builder *builder() const     { return _builder; }
+   Operation *operation() const { return _op; }
+   uint32_t numResults() const  { return _numResults; }
+   ValueMapper *resultMapper(uint32_t i=0) const
+      {
+      if (i < _numResults) return _resultMappers[i];
+      return NULL;
+      }
+   uint32_t numOperands() const  { return _numOperands; }
+   ValueMapper *operandMapper(uint32_t i=0) const
+      {
+      if (i < _numOperands) return _operandMappers[i];
+      return NULL;
+      }
+   uint32_t numBuilders() const  { return _numBuilders; }
+   BuilderMapper *builderMapper(uint32_t i=0) const
+      {
+      if (i < _numBuilders) return _builderMappers[i];
+      return NULL;
+      }
+   uint32_t numLiterals() const  { return _numLiterals; }
+   LiteralMapper *literalMapper(uint32_t i=0) const
+      {
+      if (i < _numLiterals) return _literalMappers[i];
+      return NULL;
+      }
+   uint32_t numSymbols() const  { return _numSymbols; }
+   SymbolMapper *symbolMapper(uint32_t i=0) const
+      {
+      if (i < _numSymbols) return _symbolMappers[i];
+      return NULL;
+      }
+   uint32_t numTypes() const  { return _numTypes; }
+   TypeMapper *typeMapper(uint32_t i=0) const
+      {
+      if (i < _numTypes) return _typeMappers[i];
+      return NULL;
+      }
+   const std::set<Type *> * explodedTypes() const { return _explodedTypes; }
+
+   private:
+
+   Builder          * _builder;
+   Operation        * _op;
+
+   uint32_t           _numResults;
+   ValueMapper     ** _resultMappers;
+
+   uint32_t           _numOperands;
+   ValueMapper     ** _operandMappers;
+
+   uint32_t           _numBuilders;
+   BuilderMapper   ** _builderMappers;
+
+   uint32_t           _numLiterals;
+   LiteralMapper   ** _literalMappers;
+
+   uint32_t           _numSymbols;
+   SymbolMapper    ** _symbolMappers;
+
+   uint32_t           _numTypes;
+   TypeMapper      ** _typeMappers;
+
+   std::set<Type *> * _explodedTypes;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(OPERATIONREPLACER_INCL)

--- a/jitbuilder/jbil/Returns.cpp
+++ b/jitbuilder/jbil/Returns.cpp
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string>
+
+#include "JitBuilder.hpp"
+
+using namespace OMR::JitBuilder;
+
+class Return3 : public FunctionBuilder
+   {
+public:
+   Return3(TypeDictionary * types)
+      : FunctionBuilder(types)
+      {
+      DefineName("Return3");
+      DefineLine(LINETOSTR(__LINE__));
+      DefineFile(__FILE__);
+      DefineParameter("pi8", types->PointerTo(Int8));
+      DefineParameter("pi16", types->PointerTo(Int16));
+      DefineParameter("pi32", types->PointerTo(Int32));
+      DefineParameter("pi64", types->PointerTo(Int64));
+      DefineParameter("pf32", types->PointerTo(Float));
+      DefineParameter("pf64", types->PointerTo(Double));
+      DefineParameter("pa", types->PointerTo(Address));
+      DefineReturnType(Address);
+      DefineParameter("ptr", types->PointerTo(Int32));
+      }
+
+   virtual bool buildIL()
+      {
+      Builder *b = OrphanBuilder();
+
+      Value *vi8 = b->Mul(b->ConstInt8(2), b->LoadAt(_types->PointerTo(Int8), b->Load("pi8")));
+      b->StoreAt(b->Load("pi8"), vi8);
+      Value *vi16 = b->Mul(b->ConstInt16(2), b->LoadAt(_types->PointerTo(Int16), b->Load("pi16")));
+      b->StoreAt(b->Load("pi16"), vi16);
+      Value *vi32 = b->Mul(b->ConstInt32(2), b->LoadAt(_types->PointerTo(Int32), b->Load("pi32")));
+      b->StoreAt(b->Load("pi32"), vi32);
+      Value *vi64 = b->Mul(b->ConstInt64(2), b->LoadAt(_types->PointerTo(Int64), b->Load("pi64")));
+      b->StoreAt(b->Load("pi64"), vi64);
+      Value *vf32 = b->Mul(b->ConstFloat(2.0), b->LoadAt(_types->PointerTo(Float), b->Load("pf32")));
+      b->StoreAt(b->Load("pf32"), vf32);
+      Value *vf64 = b->Mul(b->ConstDouble(2.0), b->LoadAt(_types->PointerTo(Double), b->Load("pf64")));
+      b->StoreAt(b->Load("pf64"), vf64);
+      Value *zero = b->ConstInt64(0);
+      Value *va64 = b->Add(b->LoadAt(_types->PointerTo(Address), b->IndexAt(_types->PointerTo(Address), b->Load("pa"), zero)), b->ConstInt64(8) );
+      AppendBuilder(b);
+      Return(va64);
+      //Return(CoercePointer(_types->PointerTo(Int8), Load("ptr")));
+      return true;
+      }
+   };
+
+typedef void * (Return3Func)(int8_t*, int16_t*, int32_t*, int64_t*, float*, double*, void **);
+
+int
+main(int argc, char *argv[])
+   {
+   bool success = initializeJit();
+   if (!success)
+      {
+      printf("initializeJit failure\n");
+      exit(-1);
+      }
+
+   TypeDictionary types("Return3Types");
+   Return3 method(&types);
+   success = method.Construct();
+   if (!success)
+      {
+      printf("construction failure\n");
+      exit(-2);
+      }
+
+
+   std::cerr.setf(std::ios_base::skipws);
+   std::cerr << "Method to debug:" << std::endl;
+   OMR::JitBuilder::TextWriter printer(&method, std::cout, std::string("    "));
+   method.setLogger(&printer);
+   printer.print();
+
+   int32_t rc=0;
+   Return3Func *func = method.DebugEntry<Return3Func>(&rc);
+   if (rc != 0)
+      {
+      printf("Simulation request returned error code %d\n", rc);
+      exit(rc);
+      }
+
+   int array[10];
+   int8_t i8=1; int16_t i16=2; int32_t i32=4; int64_t i64=8; float f32=16.0; double f64=32.0; void *ptr = array; 
+   void *rv = func(&i8, &i16, &i32, &i64, &f32, &f64, &ptr);
+ 
+   printf("rv is %p\n", rv);
+   printf("i8  is %d\n", i8);
+   printf("i16 is %d\n", i16);
+   printf("i32 is %d\n", i32);
+   printf("i64 is %lld\n", i64);
+   printf("f32 is %f\n", f32);
+   printf("f64 is %lf\n", f64);
+   printf("ptr is %p (array is %p)\n", ptr, array);
+
+   shutdownJit();
+
+   exit(0);
+   }

--- a/jitbuilder/jbil/Symbol.cpp
+++ b/jitbuilder/jbil/Symbol.cpp
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Symbol.hpp"
+
+
+int64_t OMR::JitBuilder::Symbol::globalIndex = 0;

--- a/jitbuilder/jbil/Symbol.hpp
+++ b/jitbuilder/jbil/Symbol.hpp
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef SYMBOL_INCL
+#define SYMBOL_INCL
+
+#include <string>
+#include <vector>
+#include "Type.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Symbol
+   {
+   public:
+   static Symbol *create(std::string name, Type * type) { return new Symbol(name, type); }
+
+   std::string name() const { return _name; }
+   Type * type() const      { return _type; }
+   uint64_t id()   const    { return _id; }
+
+   virtual bool isLocal() const     { return false; }
+   virtual bool isParameter() const { return false; }
+   virtual bool isField() const     { return false; }
+   virtual bool isFunction() const  { return false; }
+
+   static uint64_t maxID() { return globalIndex; }
+
+   protected:
+   Symbol(std::string name, Type * type)
+      : _name(name)
+      , _type(type)
+      , _id(globalIndex++)
+      { }
+   std::string _name;
+   Type      * _type;
+   uint64_t    _id;
+
+   static int64_t globalIndex;
+   };
+
+class LocalSymbol : public Symbol
+   {
+   public:
+   static LocalSymbol *create(std::string name, Type * type) { return new LocalSymbol(name, type); }
+
+   virtual bool isLocal() const { return true; }
+
+   protected:
+   LocalSymbol(std::string name, Type * type)
+      : Symbol(name, type)
+      { }
+   };
+
+class ParameterSymbol : public LocalSymbol
+   {
+   public:
+   static ParameterSymbol *create(std::string name, Type * type, int index) { return new ParameterSymbol(name, type, index); }
+
+   int index() const { return _index; }
+
+   virtual bool isParameter() const { return true; }
+
+   protected:
+   ParameterSymbol(std::string name, Type * type, int index)
+      : LocalSymbol(name, type)
+      , _index(index)
+      { }
+
+   int _index;
+   };
+
+class FunctionSymbol : public Symbol
+   {
+   public:
+   static FunctionSymbol *create(FunctionType *type, std::string name, std::string fileName, std::string lineNumber, void *entryPoint)
+      {
+      return new FunctionSymbol(type, name, fileName, lineNumber, entryPoint);
+      }
+
+   FunctionType *functionType() const { return static_cast<FunctionType *>(_type); }
+   std::string fileName() const       { return _fileName; }
+   std::string lineNumber() const     { return _lineNumber; }
+   void *entryPoint() const           { return _entryPoint; }
+
+   virtual bool isFunction() const { return true; }
+
+   protected:
+   FunctionSymbol(FunctionType *type, std::string name, std::string fileName, std::string lineNumber, void *entryPoint)
+      : Symbol(name, type)
+      , _fileName(fileName)
+      , _lineNumber(lineNumber)
+      , _entryPoint(entryPoint)
+      { }
+
+   std::string _fileName;
+   std::string _lineNumber;
+   void *_entryPoint;
+   };
+
+class FieldSymbol : public Symbol
+   {
+   public:
+   static FieldSymbol *create(std::string name, StructType *structType, FieldType *fieldType)
+      {
+      return new FieldSymbol(name, structType, fieldType);
+      }
+
+   StructType *structType() const { return _structType; }
+   FieldType *fieldType() const   { return _fieldType; }
+
+   virtual bool isLocal() const   { return false; }
+   virtual bool isField() const   { return false; }
+
+   protected:
+   FieldSymbol(std::string name, StructType *structType, FieldType *fieldType)
+      : Symbol(name, fieldType->type())
+      , _structType(structType)
+      , _fieldType(fieldType)
+      { }
+   StructType *_structType;
+   FieldType *_fieldType;
+   };
+   
+
+typedef std::vector<Symbol *>                    SymbolVector;
+
+typedef std::vector<LocalSymbol *>               LocalSymbolVector;
+typedef std::vector<LocalSymbol *>::iterator     LocalSymbolIterator;
+
+typedef std::vector<ParameterSymbol *>           ParameterSymbolVector;
+typedef std::vector<ParameterSymbol *>::iterator ParameterSymbolIterator;
+
+typedef std::vector<FunctionSymbol *>            FunctionSymbolVector;
+typedef std::vector<FunctionSymbol *>::iterator  FunctionSymbolIterator;
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(SYMBOL_INCL)

--- a/jitbuilder/jbil/TextWriter.cpp
+++ b/jitbuilder/jbil/TextWriter.cpp
@@ -1,0 +1,473 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "TextWriter.hpp"
+#include "Builder.hpp"
+#include "Case.hpp"
+#include "FunctionBuilder.hpp"
+#include "Operation.hpp"
+#include "Type.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+void
+OMR::JitBuilder::TextWriter::writeDictionary(TypeDictionary *types)
+   {
+   TextWriter &w = *this;
+   w << "[ TypeDictionary " << types << " " << types->name() << w.endl();
+   w.indentIn();
+   if (types->hasLinkedDictionary())
+      w.indent() << "[ linkedDictionary " << types->linkedDictionary() << " ]" << w.endl();
+   for (TypeIterator typeIt = types->TypesBegin();typeIt != types->TypesEnd();typeIt++)
+      {
+      Type *type = *typeIt;
+      writeType(type);
+      }
+   w.indentOut();
+   w.indent() << "]" << w.endl();
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitFunctionBuilderPreOps(FunctionBuilder * fb)
+   {
+   TextWriter &w = *this;
+
+   TypeDictionary *types = fb->dict();
+   writeDictionary(types);
+
+   w << "[ FunctionBuilder F" << fb->id() << " \"" << fb->name() << "\"" << w.endl();
+   w.indentIn();
+   w.indent() << "[ types " << fb->dict() << " ]" << w.endl();
+   w.indent() << "[ origin " << fb->fileName() + "::" + fb->lineNumber() << " ]" << w.endl();
+   w.indent() << "[ returnType " << fb->getReturnType() << "]" << w.endl();
+   for (ParameterSymbolIterator paramIt = fb->ParametersBegin();paramIt != fb->ParametersEnd(); paramIt++)
+      {
+      const ParameterSymbol *parameter = *paramIt;
+      w.indent() << "[ parameter " << parameter << " ]" << w.endl();
+      }
+   for (LocalSymbolIterator localIt = fb->LocalsBegin();localIt != fb->LocalsEnd();localIt++)
+      {
+      const LocalSymbol *local = *localIt;
+      w.indent() << "[ local " << local << " ]" << w.endl();
+      }
+   for (FunctionSymbolIterator functionIt = fb->FunctionsBegin();functionIt != fb->FunctionsEnd();functionIt++)
+      {
+      const FunctionSymbol *function = *functionIt;
+      w.indent() << "[ function " << function << " ]" << w.endl();
+      }
+   w.indent() << "[ operations" << w.endl();
+   w.indentIn();
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitFunctionBuilderPostOps(FunctionBuilder * fb)
+   {
+   TextWriter &w = *this;
+
+   w.indentOut();
+   w.indent() << "]" << w.endl();
+   //w.indentOut();
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitBuilderPreOps(Builder * b)
+   {
+   // empty (Label) builders aren't printed independently
+   if (b->numOperations() > 0)
+      {
+      TextWriter &w = *this;
+
+      w.indent() << "[ Builder " << b << w.endl();;
+      w.indentIn();
+
+      w.indent() << "[ parent " << b->parent() << " ]" << w.endl();
+
+      if (b->numChildren() > 0)
+         {
+         w.indent() << "[ children" << w.endl();
+         w.indentIn();
+         for (BuilderIterator bIt = b->ChildrenBegin(); bIt != b->ChildrenEnd(); bIt++)
+            {
+            Builder *child = *bIt;
+            w.indent() << "[ " << child << " ]" << w.endl();
+            }
+         w.indentOut();
+         w.indent() << "]" << w.endl();
+         }
+
+      if (b->isBound())
+         w.indent() << "[ bound " << b->boundToOperation() << " ]" << w.endl();
+      //else
+      //   w.indent() << "[ unbound ]" << w.endl();
+
+      if (b->isTarget())
+         w.indent() << "[ isTarget ]" << w.endl();
+      //else
+      //   w.indent() << "[ notTarget ]" << w.endl();
+
+      w.indent() << "[ operations" << w.endl();
+      w.indentIn();
+      }
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitBuilderPostOps(Builder * b)
+   {
+   if (b->numOperations() > 0)
+      {
+      TextWriter &w = *this;
+
+      w.indentOut();
+      w.indent() << "]" << w.endl();
+      w.indentOut();
+      w.indent() << "]" << w.endl();
+      }
+   }
+
+void
+OMR::JitBuilder::TextWriter::printTypePrefix(Type * type, bool indent)
+   {
+   TextWriter &w = *this;
+   if (indent)
+      w.indent();
+   w << "[ " << ((void*)type) << " type " << type << " " << type->size() << " " << type->name() << " ";
+   }
+
+void
+OMR::JitBuilder::TextWriter::writeType(Type *type, bool indent)
+   {
+   TextWriter &w = *this;
+   printTypePrefix(type, indent);
+   if (type->isPointer())
+      {
+      PointerType *pType = static_cast<PointerType *>(type);
+      w << "pointerType t" << pType->BaseType()->id() << " ]" << w.endl();
+      }
+   else if (type->isStruct())
+      {
+      StructType *sType = static_cast<StructType *>(type);
+      w << "structType";
+      for (auto fIt = sType->FieldsBegin(); fIt != sType->FieldsEnd(); fIt++)
+         {
+         FieldType *fType = fIt->second;
+         w << " t" << fType->id() << "@" << fType->offset();
+         }
+      w << " ]" << w.endl();
+      }
+   else if (type->isUnion())
+      {
+      UnionType *uType = static_cast<UnionType *>(type);
+      w << "unionType ";
+      for (auto fIt = uType->FieldsBegin(); fIt != uType->FieldsEnd(); fIt++)
+         {
+         FieldType *fType = fIt->second;
+         w << " t" << fType->id();
+         }
+      w << " ]" << w.endl();
+      }
+   else if (type->isField())
+      {
+      const FieldType *fType = static_cast<FieldType *>(type);
+      w << "fieldType struct t" << fType->owningStruct()->id() << " field t" << fType->type()->id() << " " << fType->name() << " offset " << fType->offset() << " ]" << w.endl();
+      }
+   else if (type->isFunction())
+      {
+      FunctionType *fType = static_cast<FunctionType *>(type);
+      w << "functionType t" << fType->returnType()->id() << " " << fType->numParms();
+      for (int32_t p=0;p < fType->numParms();p++)
+         w << " t" << fType->parmType(p)->id();
+      w << " ]" << w.endl();
+      }
+   else
+      {
+      w << "primitiveType";
+      Type *layout = type->layout();
+      if (layout)
+         w << " layout " << layout;
+      w << "]" << w.endl();
+
+      }
+   }
+
+void
+OMR::JitBuilder::TextWriter::printOperationPrefix(Operation * op)
+   {
+   TextWriter &w = *this;
+   w.indent() << op->fb()->name() << "!" << op->parent() << "!o" << op->id() << " : ";
+   }
+
+void
+OMR::JitBuilder::TextWriter::writeOperation(Operation * op)
+   {
+   TextWriter &w = *this;
+   printOperationPrefix(op);
+   switch (op->action())
+      {
+      case aNone :
+         break;
+
+      case aConstInt8 :
+         w << op->result() << " = ConstInt8 " << (int32_t) op->literal()->getInt8() << w.endl();
+         break;
+
+      case aConstInt16 :
+         w << op->result() << " = ConstInt16 " << (int32_t) op->literal()->getInt16() << w.endl();
+         break;
+
+      case aConstInt32 :
+         w << op->result() << " = ConstInt32 " << op->literal()->getInt32() << w.endl();
+         break;
+
+      case aConstInt64 :
+         w << op->result() << " = ConstInt64 " << op->literal()->getInt64() << w.endl();
+         break;
+
+      case aConstFloat :
+         w << op->result() << " = ConstFloat " << op->literal()->getFloat() << w.endl();
+         break;
+
+      case aConstDouble :
+         w << op->result() << " = ConstDouble " << op->literal()->getDouble() << w.endl();
+         break;
+
+      case aConstAddress :
+         w << op->result() << " = ConstAddress " << op->literal()->getAddress() << w.endl();
+         break;
+
+      case aCoercePointer :
+         w << op->result() << " = CoercePointer " << op->type() << " " << op->operand() << w.endl();
+         break;
+
+      case aAdd :
+         w << op->result() << " = Add " << op->operand(0) << " " << op->operand(1) << w.endl();
+         break;
+
+      case aSub :
+         w << op->result() << " = Sub " << op->operand(0) << " " << op->operand(1) << w.endl();
+         break;
+
+      case aMul :
+         w << op->result() << " = Mul " << op->operand(0) << " " << op->operand(1) << w.endl();
+         break;
+
+      case aLoad :
+         w << op->result() << " = Load " << op->symbol() << w.endl();
+         break;
+
+      case aLoadAt :
+         w << op->result() << " = LoadAt " << op->type() << " " << op->operand() << w.endl();
+         break;
+
+      case aLoadField :
+         {
+         LoadField *lfOp = static_cast<LoadField *>(op);
+         FieldType *fieldType = lfOp->getFieldType();
+         StructType *structType = fieldType->owningStruct();
+         w << lfOp->result() << " = LoadField " << fieldType << " ( " << structType->name() << " . " << fieldType->name() << " ) " << lfOp->operand() << w.endl();
+         }
+         break;
+
+      case aLoadIndirect :
+         {
+         LoadIndirect *liOp = static_cast<LoadIndirect *>(op);
+         FieldType *fieldType = liOp->getFieldType();
+         StructType *structType = fieldType->owningStruct();
+         w << liOp->result() << " = LoadIndirect " << fieldType << " ( " << structType->name() << " -> " << fieldType->name() << " ) " << liOp->operand() << w.endl();
+         }
+         break;
+
+      case aStore :
+         w << "Store " << op->symbol() << " " << op->operand() << w.endl();
+         break;
+
+      case aStoreField :
+         {
+         StoreField *sfOp = static_cast<StoreField *>(op);
+         FieldType *fieldType = sfOp->getFieldType();
+         StructType *structType = fieldType->owningStruct();
+         w << "StoreField " << fieldType << " ( " << structType->name() << " . " << fieldType->name() << " ) " << sfOp->operand(0) << " " << sfOp->operand(1) << w.endl();
+         }
+         break;
+
+      case aStoreIndirect :
+         {
+         StoreIndirect *siOp = static_cast<StoreIndirect *>(op);
+         FieldType *fieldType = siOp->getFieldType();
+         StructType *structType = fieldType->owningStruct();
+         w << "StoreIndirect " << fieldType << " ( " << structType->name() << " -> " << fieldType->name() << " ) " << siOp->operand(0) << " " << siOp->operand(1) << w.endl();
+         }
+         break;
+
+      case aStoreAt :
+         w << "StoreAt " << op->operand(0) << " " << op->operand(1) << w.endl();
+         break;
+
+      case aIndexAt :
+         w << op->result() << " = IndexAt " << op->type() << " " << op->operand(0) << " " << op->operand(1) << w.endl();
+         break;
+
+      case aCall :
+         {
+         Call *callOp = static_cast<Call *>(op);
+         if (callOp->result())
+            w << callOp->result() << " = ";
+         w << "Call " << callOp->function() << " " << callOp->numOperands();
+         for (int32_t a=0;a < callOp->numArguments(); a++)
+            w << " " << callOp->argument(a);
+         w << w.endl();
+         }
+         break;
+
+      case aAppendBuilder :
+         {
+         Builder * b = op->builder();
+         if (b->numOperations() == 0)
+            w << "AppendBuilder " << b << " (Label)" << w.endl();
+         else
+            {
+            w << "AppendBuilder " << b << w.endl();
+            if (_visitAppendedBuilders)
+               {
+               w.indentIn();
+               start(b);
+               w.indentOut();
+               }
+            }
+         }
+         break;
+
+      case aGoto :
+         {
+         Builder * b = op->builder();
+         if (b->numOperations() == 0)
+            w << "Goto " << b << " (Label)" << w.endl();
+         else
+            w << "Goto " << b << w.endl();
+         }
+         break;
+
+      case aReturn :
+         w << "Return";
+         if (op->numOperands() > 0)
+            {
+            for (ValueIterator vIt = op->OperandsBegin(); vIt != op->OperandsEnd(); vIt++)
+               {
+               Value * v = *vIt;
+               w << " " << v;
+               }
+            }
+         else
+            {
+            w << " nil";
+            }
+         w << w.endl();
+         break;
+
+      case aIfCmpGreaterThan :
+         w << "IfCmpGreaterThan " << op->operand(0) << " " << op->operand(1);
+         w << " then " << op->builder() << w.endl();;
+         break;
+
+      case aIfCmpLessThan :
+         w << "IfCmpLessThan " << op->operand(0) << " " << op->operand(1);
+         w << " then " << op->builder() << w.endl();
+         break;
+
+      case aIfCmpGreaterOrEqual :
+         w << "IfCmpGreaterOrEqual " << op->operand(0) << " " << op->operand(1);
+         w << " then " << op->builder() << w.endl();;
+         break;
+
+      case aIfCmpLessOrEqual :
+         w << "IfCmpLessOrEqual " << op->operand(0) << " " << op->operand(1);
+         w << " then " << op->builder() << w.endl();
+         break;
+
+      case aIfThenElse :
+         w << "IfThenElse " << op->operand() << " then " << op->builder() << " else ";
+         w << " else ";
+         if (op->numBuilders() == 2)
+            w << op->builder(1);
+         else
+            w << "nil";
+         w << w.endl();
+         break;
+
+      case aSwitch :
+         w << "Switch " << op->operand(0);
+         for (CaseIterator cIt = op->CasesBegin(); cIt != op->CasesEnd(); cIt++)
+            {
+            Case * c = *cIt;
+            w << " " << c;
+            }
+         w << " else " << op->builder(0) << w.endl();
+         break;
+
+      case aForLoop :
+         if ((bool)op->literal()->getInt8())
+            w << "ForLoopUp ";
+         else
+            w << "ForLoopDn ";
+         w << op->symbol() << " : " << op->operand(0) << " to " << op->operand(1) << " by " << op->operand(2);
+         w << " body " << op->builder(0);
+         if (op->builder(1) != NULL)
+            w << " continue " << op->builder(1);
+         if (op->builder(2) != NULL)
+            w << " break " << op->builder(2);
+         w << w.endl();
+         break;
+
+      case aCreateLocalArray :
+         w << op->result() << " = CreateLocalArray " << op->literal()->getInt32() << " " << op->type() << w.endl();
+         break;
+
+      case aCreateLocalStruct :
+         w << op->result() << " = CreateLocalStruct " << op->type() << w.endl();
+         break;
+
+      // New operations
+      // BEGIN {
+      //
+
+      //
+      // } END
+      // New operations
+
+      default :
+         assert(0);
+         break;
+      }
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitOperation(Operation *op)
+   {
+   writeOperation(op);
+   }
+
+void
+OMR::JitBuilder::TextWriter::visitEnd()
+   {
+   TextWriter & w = *this;
+   w.indentOut();
+   w.indent() << "]" << w.endl();
+   }

--- a/jitbuilder/jbil/TextWriter.hpp
+++ b/jitbuilder/jbil/TextWriter.hpp
@@ -112,6 +112,11 @@ public:
       w._os << v;
       return w;
       }
+   friend TextWriter &operator<<(TextWriter &w, LiteralValue *lv)
+      {
+      lv->print(&w);
+      return w;
+      }
    //
    // User type handlng
    // BEGIN {

--- a/jitbuilder/jbil/TextWriter.hpp
+++ b/jitbuilder/jbil/TextWriter.hpp
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TEXTWRITER_INCL
+#define TEXTWRITER_INCL
+
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <deque>
+#include "Visitor.hpp"
+#include "Builder.hpp"
+#include "Case.hpp"
+#include "FunctionBuilder.hpp"
+#include "Operation.hpp"
+#include "Symbol.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+#include "TypeGraph.hpp"
+#include "Value.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class TextWriter : public Visitor
+   {
+public:
+   TextWriter(FunctionBuilder * fb, std::ostream & os, std::string perIndent)
+      : Visitor(fb)
+      , _os(os)
+      , _perIndent(perIndent)
+      , _indent(0)
+      {
+      os << std::showbase // show the 0x prefix
+            << std::internal
+            << std::setfill('0'); // fill pointers with 0s
+      }
+
+   void print()               { start(); }
+   void print(Builder * b)    { start(b); }
+   void print(Operation * op) { start(op); }
+
+   friend TextWriter &operator<<(TextWriter &w, const bool v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const int8_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const int16_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const int32_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const int64_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const uint64_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const size_t v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const void * v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const float v)
+      {
+      w._os << v;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const double v)
+      {
+      w._os << v;
+      return w;
+      }
+   //
+   // User type handlng
+   // BEGIN {
+
+   // } END
+   // User type handling
+   //
+
+   friend TextWriter &operator<<(TextWriter &w, const std::string s)
+      {
+      w._os << s;
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const char *s)
+      {
+      w._os << s;
+      return w;
+      }
+   friend TextWriter & operator<<(TextWriter &w, const Builder *b)
+      {
+      w << "B" << b->id();
+      if (b->name().length() > 0)
+         w << " \""" \"" << b->name() << "\"";
+      return w;
+      }
+   friend TextWriter &operator<<(TextWriter &w, const Case *c)
+      {
+      w << c->value() << " : " << c->builder();
+      if (c->fallsThrough())
+         w << " fallthrough ";
+      return w;
+      }
+   friend TextWriter & operator<< (TextWriter &w, FunctionBuilder *fb)
+      {
+      return w << "F" << fb->id();
+      }
+   friend TextWriter & operator<< (TextWriter &w, Operation *op)
+      {
+      return w << "o" << op->id();
+      }
+   friend TextWriter & operator<< (TextWriter &w, const ParameterSymbol *param)
+      {
+      return w << "p" << param->index() << "_" << param->type() << " \"" << param->name() << "\"";
+      }
+   friend TextWriter & operator<< (TextWriter &w, const Symbol *s)
+      {
+      return w << "s" << s->id() << "_" << s->type() << " \"" << s->name() << "\"";
+      }
+   friend TextWriter &operator<<(TextWriter &w, const Type *t)
+      {
+      return w << "t" << t->id();
+      }
+   friend TextWriter & operator<<(TextWriter &w, const TypeDictionary *dict)
+      {
+      return w << "D" << dict->id();
+      }
+   friend TextWriter & operator<<(TextWriter &w, const TypeGraph *graph)
+      {
+      return w << "G" << graph->id();
+      }
+   friend TextWriter &operator<<(TextWriter &w, const Value *v)
+      {
+      return w << "v" << v->id() << "_" << v->type();
+      }
+
+   void writeDictionary(TypeDictionary *types);
+   void writeType(Type *type, bool indent=true);
+   void writeOperation(Operation *op);
+
+   std::string endl()
+      {
+      return std::string("\n");
+      }
+
+   TextWriter & indent()
+      {
+      for (int32_t in=0;in < _indent;in++)
+         _os << _perIndent;
+      return *this;
+      }
+   void indentIn()
+      {
+      _indent++;
+      }
+   void indentOut()
+      {
+      _indent--;
+      }
+
+   protected:
+
+      virtual void visitFunctionBuilderPreOps(FunctionBuilder * fb);
+      virtual void visitFunctionBuilderPostOps(FunctionBuilder * fb);
+      virtual void visitBuilderPreOps(Builder * b);
+      virtual void visitBuilderPostOps(Builder * b);
+      virtual void visitOperation(Operation * op);
+      virtual void visitEnd();
+
+      void printTypePrefix(Type * type, bool indent=true);
+      void printOperationPrefix(Operation * op);
+
+      std::ostream & _os;
+      std::string _perIndent;
+      int32_t _indent;
+   };
+
+// RAII class for indenting log output
+class LogIndent
+   {
+   public:
+   LogIndent(TextWriter *log)
+      : _log(log)
+      {
+      if (log)
+         log->indentIn();
+      }
+
+   ~LogIndent()
+      {
+      if (_log)
+         _log->indentOut();
+      }
+   private:
+   TextWriter *_log;
+   };
+
+// This macro can be used to bracket a code region where log output should be indented
+#define LOG_INDENT_REGION(log) if (true) { LogIndent __log__indent__var(log);
+#define LOG_OUTDENT            }
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TEXTWRITER_INCL)

--- a/jitbuilder/jbil/Transformer.cpp
+++ b/jitbuilder/jbil/Transformer.cpp
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <climits>
+#include <sstream>
+#include "Transformer.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "TextWriter.hpp"
+
+
+void
+OMR::JitBuilder::Transformer::trace(std::string msg)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log)
+      log->indent() << msg << log->endl();
+   }
+
+void
+OMR::JitBuilder::Transformer::appendOrInline(Builder * root, Builder * branch)
+   {
+   if (branch->isTarget())
+      root->AppendBuilder(branch);
+   else
+      {
+      TextWriter * log = _fb->logger(traceEnabled());
+      if (log) *log << "Inlining operations from " << branch << " into " << root << log->endl();
+
+      // operations currently have branch as parent, change that to root
+      for (OperationIterator opIt = branch->OperationsBegin(); opIt != branch->OperationsEnd(); opIt++)
+         {
+         Operation * op = *opIt;
+         op->setParent(root);
+         }
+
+      root->operations().insert(root->OperationsEnd(),
+                                branch->OperationsBegin(),
+                                branch->OperationsEnd());
+
+      }
+   }
+
+void
+OMR::JitBuilder::Transformer::transform()
+   {
+   BuilderWorklist worklist;
+   std::vector<bool> visited(Builder::maxIndex());
+
+   transformFunctionBuilder(_fb);
+
+   processBuilder(_fb, visited, worklist);
+
+   while(!worklist.empty())
+      {
+      Builder *b = worklist.back();
+      processBuilder(b, visited, worklist);
+      worklist.pop_back();
+      }
+
+   transformFunctionBuilderAtEnd(_fb);
+   }
+
+bool
+OMR::JitBuilder::Transformer::performTransformation(Operation * op, Builder * transformed, std::string msg)
+   {
+   static int64_t lastTransformation = LLONG_MAX;
+   int64_t number = _fb->incrementTransformation();
+   int64_t lastIndex = _fb->config()->lastTransformationIndex();
+   bool succeed = (lastIndex < 0 || number < lastIndex);
+
+   if (traceEnabled())
+      {
+      if (succeed)
+         {
+         std::ostringstream oss;
+         oss << "( " << number << " ) Transformation: " << msg;
+         trace(oss.str());
+         TextWriter *log= _fb->logger(traceEnabled());
+         LOG_INDENT_REGION(log)
+            {
+            if (log) log->indentIn();
+            if (log) log->print(op);
+            if (log) log->indent() << "Replaced with operations from : " << log->endl();
+            if (log) log->print(transformed);
+            if (log) log->indentOut();
+            }
+         LOG_OUTDENT
+         }
+      else
+         trace("Transformation not applied: " + msg);
+      }
+
+   return succeed;
+   }
+
+void
+OMR::JitBuilder::Transformer::processBuilder(Builder * b, std::vector<bool> & visited, BuilderWorklist & worklist)
+   {
+   int64_t id = b->id();
+   if (visited[id])
+      return;
+
+   visited[id] = true;
+
+   transformBuilderBeforeOperations(b);
+
+   TextWriter *log= _fb->logger(traceEnabled());
+   for (OperationIterator opIt = b->OperationsBegin(); opIt != b->OperationsEnd(); opIt++)
+      {
+      Operation *op = *opIt;
+      if (log)
+         {
+         if (log) log->indent() << std::string("Visit ");
+         if (log) log->print(op);
+         }
+      Builder *transformation = transformOperation(op);
+      if (transformation != NULL)
+         {
+         if (performTransformation(op, transformation))
+            {
+            opIt = b->operations().erase(opIt); // remove the operation we just transformed
+
+            bool replaceWithBuilder=false;
+            if (replaceWithBuilder)
+               {
+               // replace the current operation with the Builder object containing its transformation
+               //    could also be done immutably by generating a new array of Operations
+               //    and returning new Builder but let's do in place for now
+               opIt = b->operations().insert(opIt, AppendBuilder::create(b, transformation));
+               }
+            else
+               {
+               // replace the operation with the operations inside the builder
+               // removing the builder object means each operation's parent changes
+               for (OperationIterator it = transformation->OperationsBegin(); it != transformation->OperationsEnd(); it++)
+                  {
+                  Operation * op = *it;
+                  op->setParent(b);
+                  }
+               opIt = b->operations().insert(opIt,
+                                             transformation->OperationsBegin(),
+                                             transformation->OperationsEnd());
+               for (OperationIterator it = transformation->OperationsBegin(); it != transformation->OperationsEnd(); it++)
+                  {
+                  // scan transformed operations for builder objects we need to traverse
+                  Operation *op = *it;
+                  for (BuilderIterator bIt = op->BuildersBegin(); bIt != op->BuildersEnd(); bIt++)
+                     {
+                     Builder *inner_b = *bIt;
+                     if (inner_b && !visited[inner_b->id()])
+                        worklist.push_front(inner_b);
+                     }
+                  opIt++; // skip over inserted operations
+                  }
+               opIt--; // compensate for increment on loop back edge
+               }
+
+            // operation has changed, but any internal builders will be found by iterating
+            // over the transformed operations we just inserted
+            }
+         }
+      else
+         {
+         // operation wasn't transformed, so scan it for builder objects
+         for (BuilderIterator bIt = op->BuildersBegin(); bIt != op->BuildersEnd(); bIt++)
+            {
+            Builder *inner_b = *bIt;
+            if (inner_b && !visited[inner_b->id()])
+               worklist.push_front(inner_b);
+            }
+         }
+      }
+
+   transformBuilderAfterOperations(b);
+
+   }

--- a/jitbuilder/jbil/Transformer.hpp
+++ b/jitbuilder/jbil/Transformer.hpp
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TRANSFORMER_INCL
+#define TRANSFORMER_INCL
+
+#include <string>
+#include "Object.hpp"
+#include "Visitor.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Transformer
+   {
+   public:
+   Transformer(FunctionBuilder * fb)
+      : _fb(fb)
+      , _traceEnabled(false)
+      { }
+
+   FunctionBuilder *fb() const { return _fb; }
+
+   void transform();
+   void transform(FunctionBuilder *fb)
+      {
+      FunctionBuilder *saved = _fb;
+      _fb = fb;
+      transform();
+      _fb = saved;
+      }
+   Transformer * setTraceEnabled(bool v=true) { _traceEnabled = v; return this; }
+
+   private:
+   // used internally to iteratively visit each builder once
+   void processBuilder(Builder * b, std::vector<bool> & visited, BuilderWorklist & worklist);
+
+   protected:
+   bool traceEnabled()               { return _traceEnabled; }
+
+   void appendOrInline(Builder * root, Builder * branch);
+
+   // To implement any transformation, subclass Transformer
+   //   and override the virtual functions below as needed
+
+   // called once on each FunctionBuilder before any other processing
+   virtual FunctionBuilder * transformFunctionBuilder(FunctionBuilder * fb) { return NULL; }
+
+   // called once each Builder object before its operations are processed
+   virtual Builder * transformBuilderBeforeOperations(Builder * b) { return NULL; }
+
+   // called once on each operation
+   // the operation will be replaced by the contents of any non-NULL Builder object returned
+   virtual Builder * transformOperation(Operation * op) { return NULL; }
+
+   // called once each Builder object after its operations are processed
+   virtual Builder * transformBuilderAfterOperations(Builder * b) { return NULL; }
+
+   // called once on each FunctionBuilder after transformation is complete
+   virtual FunctionBuilder * transformFunctionBuilderAtEnd(FunctionBuilder * fb) { return NULL; }
+
+   // logging support: output msg to the log if enabled
+   void trace(std::string msg);
+
+   // logging support: returns true if the transformation is allowed
+   //                  and if log enabled, logs details if performed and "not applied" message if not
+   bool performTransformation(Operation * op, Builder * transformed, std::string msg="");
+   bool performTransformation(Builder * b, Builder * transformed, std::string msg="");
+   bool performTransformation(FunctionBuilder * fb, Builder * transformed, std::string msg="");
+
+   FunctionBuilder * _fb;
+   bool              _traceEnabled;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TRANSFORMER_INCL)

--- a/jitbuilder/jbil/Type.cpp
+++ b/jitbuilder/jbil/Type.cpp
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Type.hpp"
+#include "TextWriter.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+int64_t OMR::JitBuilder::Type::globalIndex = 0;
+
+
+void
+NoTypeType::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name();
+   }
+
+void
+Int8Type::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<int8_t *>(p);
+   }
+
+void
+Int16Type::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<int16_t *>(p);
+   }
+
+void
+Int32Type::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<int32_t *>(p);
+   }
+
+void
+Int64Type::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<int64_t *>(p);
+   }
+
+void
+FloatType::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<float *>(p);
+   }
+
+void
+DoubleType::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *reinterpret_cast<double *>(p);
+   }
+
+void
+AddressType::printer(TextWriter *w, const Type *t, void *p)
+   {
+   *w << t->name() << " " << *(reinterpret_cast<void **>(p));
+   }
+
+void
+Type::printType(TextWriter *w)
+   {
+   }
+
+void
+PointerType::printType(TextWriter *w)
+   {
+   }
+
+void
+PointerType::printValue(TextWriter *w, void *p) const
+   {
+   *w << name() << " " << *(reinterpret_cast<void **>(p));
+   }
+
+void
+FieldType::printType(TextWriter *w)
+   {
+   }
+
+void
+FieldType::printValue(TextWriter *w, void *p) const
+   {
+   }
+
+FieldType *
+StructType::addField(LiteralValue *name, Type *type, size_t offset)
+   {
+   assert(name->kind() == T_string || name->kind() == T_typename);
+   FieldType *field = LookupField(name->getString());
+   if (field)
+      return field;
+
+   field = FieldType::create(owningDictionary(), this, name, type, offset);
+   _fieldsByName.insert({name->getString(), field});
+   _fieldsByOffset.insert({offset, field});
+
+   if (_size < offset + type->size())
+      _size = offset + type->size();
+
+   return field;
+   }
+
+FieldIterator
+StructType::RemoveField(FieldIterator &it)
+   {
+   FieldType *fieldType = it->second;
+
+   // iterator is for _fieldsByName, so just erase
+   auto it1 = _fieldsByName.erase(it);
+
+   // have to look for it in _fieldsByOffset and erase from it
+   auto it2 = _fieldsByOffset.find(fieldType->offset());
+   while (it2 != _fieldsByOffset.end())
+      {
+      // can have multiple fields at an offset so make sure we remove the right one
+      FieldType *fType = it2->second;
+      if (fType == fieldType)
+         {
+         _fieldsByOffset.erase(it2);
+         break;
+         }
+      else
+         it2++;
+      }
+
+   return it1;
+   }
+
+void
+StructType::printType(TextWriter *w)
+   {
+   }
+
+void
+StructType::printValue(TextWriter *w, void *p) const
+   {
+   }
+
+void
+UnionType::printType(TextWriter *w)
+   {
+   // TODO
+   }
+
+void
+UnionType::printValue(TextWriter *w, void *p) const
+   {
+   // TODO
+   }
+
+FunctionType *
+FunctionType::create(TypeDictionary *dict,
+                     std::string name,
+                     Type *returnType,
+                     int32_t numParms,
+                     Type ** parmTypes)
+   {
+   return new FunctionType(dict, name, returnType, numParms, parmTypes);
+   }
+
+void
+FunctionType::printType(TextWriter *w)
+   {
+   // TODO
+   }
+
+void
+FunctionType::printValue(TextWriter *w, void *p) const
+   {
+   // TODO
+   }
+
+//
+// User type instances
+// BEGIN here {
+
+// } END here
+// User type instances
+// 
+
+
+} // namespace JitBuilder
+} // namespace OMR

--- a/jitbuilder/jbil/Type.hpp
+++ b/jitbuilder/jbil/Type.hpp
@@ -89,16 +89,14 @@ public:
    virtual bool isUnion() const        { return false; }
    virtual bool isField() const        { return false; }
    virtual bool isFunction() const     { return false; }
-
-   // for Types with multiple elements, should a Value of the Type be considered a "sum" of those elements?
-   virtual bool isAdditive() const     { return false; }
+   virtual bool isDynamic() const      { return false; }
 
    virtual void printType(TextWriter *w);
    virtual void printValue(TextWriter *w, void *p) const { assert(_valuePrinter); _valuePrinter(w, this, p); }
 
    // returning NULL from the next function means that values of this type cannot be broken down further
-   virtual StructType *layout() { return NULL; }
-   virtual LiteralMapper *explode(LiteralValue *value, LiteralMapper *m=NULL) { return NULL; }
+   virtual StructType *layout() const { return NULL; }
+   virtual LiteralMapper *explode(LiteralValue *value, LiteralMapper *m=NULL) const { return NULL; }
 
    static TypeID maxID() { return globalIndex; }
 

--- a/jitbuilder/jbil/Type.hpp
+++ b/jitbuilder/jbil/Type.hpp
@@ -1,0 +1,425 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TYPE_INCL
+#define TYPE_INCL
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+
+#include "LiteralValue.hpp"
+#include "Mapper.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class FieldType;
+class StructType;
+class TextWriter;
+class Type;
+class TypeDictionary;
+
+class Int8Type;
+class Int16Type;
+class Int32Type;
+class Int64Type;
+class FloatType;
+class DoubleType;
+class AddressType;
+
+//
+// User type forward declarations
+// BEGIN here {
+
+// } END here
+// User type forward declarations
+//
+
+typedef int64_t TypeID;
+
+class Type
+   {
+   friend class TypeDictionary;
+protected:
+   typedef void (ValuePrinter)(TextWriter *w, const Type *t, void *p);
+
+public:
+   std::string name() const                 { return _name; }
+   TypeDictionary *owningDictionary() const { return _dict; }
+   TypeID id() const                        { return _id; }
+   size_t size() const                      { return _size; }
+   ValuePrinter *printer() const            { return _valuePrinter; }
+
+   bool operator!=(const Type & other) const
+      {
+      return _id != other._id;
+      }
+   bool operator==(const Type & other) const
+      {
+      return _id == other._id;
+      }
+   virtual bool isPointer() const      { return false; }
+   virtual bool isStruct() const       { return false; }
+   virtual bool isUnion() const        { return false; }
+   virtual bool isField() const        { return false; }
+   virtual bool isFunction() const     { return false; }
+
+   // for Types with multiple elements, should a Value of the Type be considered a "sum" of those elements?
+   virtual bool isAdditive() const     { return false; }
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const { assert(_valuePrinter); _valuePrinter(w, this, p); }
+
+   // returning NULL from the next function means that values of this type cannot be broken down further
+   virtual StructType *layout() { return NULL; }
+   virtual LiteralMapper *explode(LiteralValue *value, LiteralMapper *m=NULL) { return NULL; }
+
+   static TypeID maxID() { return globalIndex; }
+
+   //
+   // User type api
+   // BEGIN here {
+
+   // } END here
+   // User type api
+   // 
+
+protected:
+   static Type * create(TypeDictionary *dict, std::string name, size_t size, ValuePrinter *printer) { return new Type(dict, name, size, printer); }
+   Type(TypeDictionary *dict, std::string name, size_t size, ValuePrinter *printer=NULL)
+      : _dict(dict)
+      , _id(globalIndex++)
+      , _name(name)
+      , _size(size)
+      , _valuePrinter(printer)
+      { }
+
+   TypeDictionary * _dict;
+   TypeID           _id;
+   std::string      _name;
+   size_t           _size;
+   ValuePrinter *   _valuePrinter;
+
+   static TypeID globalIndex;
+   };
+
+class NoTypeType : public Type
+   {
+   public:
+   static NoTypeType * create(TypeDictionary *dict) { return new NoTypeType(dict); }
+
+   protected:
+   NoTypeType(TypeDictionary *dict) : Type(dict, "NoType", 0, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+
+class NumericType : public Type
+   {
+   protected:
+   NumericType(TypeDictionary *dict, std::string name, size_t size, Type::ValuePrinter *printer=NULL)
+      : Type(dict, name, size, printer)
+      { }
+   };
+
+class IntegerType : public NumericType
+   {
+   protected:
+   IntegerType(TypeDictionary *dict, std::string name, size_t size, Type::ValuePrinter *printer=NULL)
+      : NumericType(dict, name, size, printer)
+      { }
+   };
+
+class Int8Type : public IntegerType
+   {
+   public:
+   static Int8Type * create(TypeDictionary *dict) { return new Int8Type(dict); }
+
+   protected:
+   Int8Type(TypeDictionary *dict) : IntegerType(dict, "Int8", 8, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class Int16Type : public IntegerType
+   {
+   public:
+   static Int16Type * create(TypeDictionary *dict) { return new Int16Type(dict); }
+
+   protected:
+   Int16Type(TypeDictionary *dict) : IntegerType(dict, "Int16", 16, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class Int32Type : public IntegerType
+   {
+   public:
+   static Int32Type * create(TypeDictionary *dict) { return new Int32Type(dict); }
+
+   protected:
+   Int32Type(TypeDictionary *dict) : IntegerType(dict, "Int32", 32, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class Int64Type : public IntegerType
+   {
+   public:
+   static Int64Type * create(TypeDictionary *dict) { return new Int64Type(dict); }
+
+   protected:
+   Int64Type(TypeDictionary *dict) : IntegerType(dict, "Int64", 64, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class FloatingPointType : public NumericType
+   {
+   protected:
+   FloatingPointType(TypeDictionary *dict, std::string name, size_t size, Type::ValuePrinter *printer=NULL)
+      : NumericType(dict, name, size, printer)
+      { }
+   };
+
+class FloatType : public FloatingPointType
+   {
+   public:
+   static FloatType * create(TypeDictionary *dict) { return new FloatType(dict); }
+
+   protected:
+   FloatType(TypeDictionary *dict) : FloatingPointType(dict, "Float", 32, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class DoubleType : public FloatingPointType
+   {
+   public:
+   static DoubleType * create(TypeDictionary *dict) { return new DoubleType(dict); }
+
+   protected:
+   DoubleType(TypeDictionary *dict) : FloatingPointType(dict, "Double", 64, &printer) { }
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+class AddressType : public Type
+   {
+   public:
+   static AddressType * create(TypeDictionary *dict) { return new AddressType(dict); }
+
+   protected:
+   AddressType(TypeDictionary *dict) : Type(dict, "Address", 64, &printer) { } // should be 32/64
+   AddressType(TypeDictionary *dict, std::string name) : Type(dict, name, 64) { } // should be 32/64
+   static void printer(TextWriter *w, const Type *t, void *p);
+   };
+
+
+class PointerType : public AddressType
+   {
+   friend class Type;
+   friend class TypeDictionary;
+
+public:
+   virtual bool isPointer() const { return true; }
+
+   Type * BaseType() { return _baseType; }
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const;
+
+protected:
+   static PointerType * create(TypeDictionary *dict, std::string name, Type * baseType) { return new PointerType(dict, name, baseType); }
+   PointerType(TypeDictionary *dict, std::string name, Type * baseType)
+      : AddressType(dict, name) // should really be 32 or 64
+      , _baseType(baseType)
+      { }
+   Type * _baseType;
+   };
+
+typedef std::map<std::string, FieldType *>::const_iterator FieldIterator;
+
+class StructType : public Type
+   {
+   friend class TypeDictionary;
+
+   public:
+   virtual bool isStruct() const { return true; }
+
+   bool closed() const           { return _closed; }
+   void setClosed(bool c=true)   { _closed = c; }
+
+   virtual FieldType * addField(LiteralValue *name, Type *type, size_t offset);
+   FieldIterator FieldsBegin() const { return _fieldsByName.cbegin(); }
+   FieldIterator FieldsEnd() const   { return _fieldsByName.cend(); }
+   FieldType *LookupField(std::string fieldName)
+      {
+      auto it = _fieldsByName.find(fieldName);
+      if (it == _fieldsByName.end())
+         return NULL;
+      return it->second;
+      }
+   FieldIterator RemoveField(FieldIterator &it);
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const;
+
+   protected:
+   static StructType * create(TypeDictionary *dict, std::string name)
+      {
+      return new StructType(dict, name, 0);
+      }
+
+   static StructType * create(TypeDictionary *dict, std::string name, size_t size)
+      {
+      return new StructType(dict, name, size); // size in bits, used to be bytes!
+      }
+
+   StructType(TypeDictionary *dict, std::string name, size_t size)
+      : Type(dict, name, size)
+      , _closed(false)
+      { }
+
+   bool _closed;
+   std::map<std::string, FieldType *> _fieldsByName;
+   std::multimap<size_t, FieldType *> _fieldsByOffset;
+   };
+
+class FieldType : public Type
+   {
+   public:
+   static FieldType * create(TypeDictionary *dict, StructType *structType, LiteralValue *fieldName, Type *type, size_t offset)
+      {
+      return new FieldType(dict, structType, fieldName, type, offset);
+      }
+
+   StructType *owningStruct() const  { return _structType; }
+   LiteralValue *fieldName() const   { return _fieldName; }
+   Type *type() const                { return _type; }
+   size_t offset() const             { return _offset; }
+
+   virtual bool isField() const      { return true; }
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const;
+
+   protected:
+   FieldType(TypeDictionary *dict, StructType *structType, LiteralValue *fieldName, Type *type, size_t offset)
+      : Type(dict, fieldName->getString(), type->size())
+      , _structType(structType)
+      , _fieldName(fieldName)
+      , _type(type)
+      , _offset(offset)
+      { }
+
+   StructType *_structType;
+   LiteralValue *_fieldName;
+   Type *_type;
+   size_t _offset;
+   };
+
+class UnionType : public StructType
+   {
+   friend class TypeDictionary;
+
+   public:
+   virtual bool isUnion() const { return true; }
+
+   virtual FieldType * addField(LiteralValue *name, Type *type, size_t unused)
+      {
+      if (type->size() > _size)
+         _size = type->size();
+      return this->StructType::addField(name, type, 0);
+      }
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const;
+
+   protected:
+   static UnionType * create(TypeDictionary *dict, std::string name)
+      {
+      return new UnionType(dict, name, 0);
+      }
+   static UnionType * create(TypeDictionary *dict, std::string name, size_t size)
+      {
+      return new UnionType(dict, name, size);
+      }
+
+   UnionType(TypeDictionary *dict, std::string name, size_t size)
+      : StructType(dict, name, size)
+      { }
+   };
+
+class FunctionType : public Type
+   {
+   friend class TypeDictionary;
+
+   public:
+   static FunctionType * create(TypeDictionary *dict, std::string name, Type *returnType, int32_t numParms, Type ** parmTypes);
+
+   ~FunctionType()
+      {
+      delete[] _parmTypes;
+      }
+
+   virtual bool isFunction() const
+      {
+      return true;
+      }
+
+   Type *returnType() const { return _returnType; }
+   int32_t numParms() const { return _numParms; }
+   Type *parmType(int p) const { return _parmTypes[p]; }
+   Type **parmTypes() const { return _parmTypes; }
+
+   virtual void printType(TextWriter *w);
+   virtual void printValue(TextWriter *w, void *p) const;
+
+   protected:
+   FunctionType(TypeDictionary *dict, std::string name, Type *returnType, int32_t numParms, Type ** parmTypes)
+      : Type(dict, name, 0)
+      , _returnType(returnType)
+      , _numParms(numParms)
+      , _parmTypes(parmTypes)
+      {
+      }
+
+   Type *_returnType;
+   int32_t _numParms;
+   Type **_parmTypes;
+   };
+
+//
+// User type classes
+// BEGIN here {
+
+// } END here
+// User type classes
+// 
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TYPE_INCL)

--- a/jitbuilder/jbil/TypeDictionary.cpp
+++ b/jitbuilder/jbil/TypeDictionary.cpp
@@ -20,6 +20,8 @@
  *******************************************************************************/
 
 #include <string>
+#include "DynamicOperation.hpp"
+#include "DynamicType.hpp"
 #include "Operation.hpp"
 #include "Type.hpp"
 #include "TypeGraph.hpp"
@@ -239,6 +241,20 @@ OMR::JitBuilder::TypeDictionary::registerPointerType(PointerType * pointerType)
 
    _graph->registerValidOperation(baseType, aLoadAt, pointerType);
    _graph->registerValidOperation(NoType, aStoreAt, pointerType, baseType);
+   }
+
+void
+OMR::JitBuilder::TypeDictionary::registerDynamicType(DynamicType * dynamicType)
+   {
+   addType(dynamicType);
+   _graph->registerType(dynamicType);
+   dynamicType->initializeTypeProductions(this, _graph);
+   }
+
+void
+OMR::JitBuilder::TypeDictionary::registerDynamicOperation(OperationBuilder * operationBuilder)
+   {
+   operationBuilder->initializeTypeProductions(this, _graph);
    }
 
 Type *

--- a/jitbuilder/jbil/TypeDictionary.cpp
+++ b/jitbuilder/jbil/TypeDictionary.cpp
@@ -1,0 +1,478 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <string>
+#include "Operation.hpp"
+#include "Type.hpp"
+#include "TypeGraph.hpp"
+#include "TypeDictionary.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+int64_t OMR::JitBuilder::TypeDictionary::globalIndex = 0;
+
+// Type * OMR::JitBuilder::TypeDictionary::NoType  = Type::NoType;
+// Type * OMR::JitBuilder::TypeDictionary::Int8    = Type::Int8;
+// Type * OMR::JitBuilder::TypeDictionary::Int16   = Type::Int16;
+// Type * OMR::JitBuilder::TypeDictionary::Int32   = Type::Int32;
+// Type * OMR::JitBuilder::TypeDictionary::Int64   = Type::Int64;
+// Type * OMR::JitBuilder::TypeDictionary::Float   = Type::Float;
+// Type * OMR::JitBuilder::TypeDictionary::Double  = Type::Double;
+// Type * OMR::JitBuilder::TypeDictionary::Address = Type::Address;
+
+// Should really be either Int64 or Int32 based on Config
+// Type * OMR::JitBuilder::TypeDictionary::Word = OMR::JitBuilder::TypeDictionary::Int64;
+
+//
+// User types
+// BEGIN {
+
+// } END
+// User types
+// 
+
+TypeDictionary *TypeDictionary::globalDict = NULL;
+
+TypeDictionary *
+TypeDictionary::global()
+   {
+   if (globalDict == NULL)
+      globalDict = new TypeDictionary("GlobalTD");
+
+   return globalDict;
+   }
+
+TypeDictionary::TypeDictionary()
+   : _id(globalIndex++)
+   , _name("")
+   , _maxTypeID(1)
+   , _graph(new TypeGraph(this))
+   , _linkedDictionary(NULL)
+   {
+   createPrimitiveTypes();
+   initializeGraph();
+   }
+
+TypeDictionary::TypeDictionary(std::string name)
+   : _id(globalIndex++)
+   , _name(name)
+   , _maxTypeID(1)
+   , _graph(new TypeGraph(this))
+   , _linkedDictionary(NULL)
+   {
+   createPrimitiveTypes();
+   initializeGraph();
+   }
+
+TypeDictionary::TypeDictionary(TypeGraph * graph)
+   : _id(globalIndex++)
+   , _name("")
+   , _maxTypeID(1)
+   , _graph(graph)
+   , _linkedDictionary(NULL)
+   {
+   createPrimitiveTypes();
+   initializeGraph();
+   }
+
+TypeDictionary::TypeDictionary(std::string name, TypeGraph * graph)
+   : _id(globalIndex++)
+   , _name("")
+   , _maxTypeID(1)
+   , _graph(graph)
+   , _linkedDictionary(NULL)
+   {
+   createPrimitiveTypes();
+   initializeGraph();
+   }
+
+// Only accessible to subclasses
+TypeDictionary::TypeDictionary(std::string name, TypeDictionary * linkedTypes)
+   : _id(globalIndex++)
+   , _name(name)
+   , _maxTypeID(linkedTypes->MaxTypeID())
+   , _graph(new TypeGraph(this, linkedTypes->_graph))
+   , _linkedDictionary(linkedTypes)
+   {
+   for (TypeIterator typeIt = linkedTypes->TypesBegin(); typeIt != linkedTypes->TypesEnd(); typeIt++)
+      {
+      Type *type = *typeIt;
+      addType(type);
+      }
+   _maxTypeID = linkedTypes->_maxTypeID;
+   NoType = linkedTypes->NoType;
+   Int8 = linkedTypes->Int8;
+   Int16 = linkedTypes->Int16;
+   Int32 = linkedTypes->Int32;
+   Int64 = linkedTypes->Int64;
+   Float = linkedTypes->Float;
+   Double = linkedTypes->Double;
+   Address = linkedTypes->Address;
+   Word = linkedTypes->Word;
+
+   //
+   // User type copying
+   // BEGIN {
+
+   // } END
+   // User type copying
+   //
+
+   _pointerTypeFromBaseType = linkedTypes->_pointerTypeFromBaseType;
+   _structTypeFromName = linkedTypes->_structTypeFromName;
+   _functionTypeFromName = linkedTypes->_functionTypeFromName;
+
+   // TODO: copy entire linked type graph?
+   //initializeGraph();
+   }
+
+void
+TypeDictionary::createPrimitiveTypes()
+   {
+   NoType = NoTypeType::create(this);
+   addType(NoType);
+
+   Int8 = Int8Type::create(this);
+   addType(Int8);
+
+   Int16 = Int16Type::create(this);
+   addType(Int16);
+
+   Int32 = Int32Type::create(this);
+   addType(Int32);
+
+   Int64 = Int64Type::create(this);
+   addType(Int64);
+
+   Float = FloatType::create(this);
+   addType(Float);
+
+   Double = DoubleType::create(this);
+   addType(Double);
+
+   Address = PointerType::create(this, "Address", Int8);
+   addType(Address);
+
+   Word = Int64; // should really be changed based on Config
+
+   //
+   // User type handling
+   // BEGIN {
+
+   // } END
+   // User type handling
+   //
+
+   }
+
+void
+TypeDictionary::initializeGraph()
+   {
+   _graph->registerType(NoType);
+   _graph->registerType(Int8);
+   _graph->registerType(Int16);
+   _graph->registerType(Int32);
+   _graph->registerType(Int64);
+   _graph->registerType(Float);
+   _graph->registerType(Double);
+   _graph->registerType(Address);
+
+   //
+   // User initialization
+   // BEGIN {
+
+   // } END
+   // User initialization
+   // 
+
+   Add::initializeTypeProductions(this, _graph);
+   Sub::initializeTypeProductions(this, _graph);
+   Mul::initializeTypeProductions(this, _graph);
+
+   ForLoop::initializeTypeProductions(this, _graph);
+   IfCmpGreaterOrEqual::initializeTypeProductions(this, _graph);
+   IfCmpGreaterThan::initializeTypeProductions(this, _graph);
+   IfCmpLessOrEqual::initializeTypeProductions(this, _graph);
+   IfCmpLessThan::initializeTypeProductions(this, _graph);
+   IfThenElse::initializeTypeProductions(this, _graph);
+   Return::initializeTypeProductions(this, _graph);
+   Switch::initializeTypeProductions(this, _graph);
+   }
+
+void
+OMR::JitBuilder::TypeDictionary::registerReturnType(Type *type)
+   {
+   _graph->registerValidOperation(type, aReturn, type);
+   }
+
+void
+OMR::JitBuilder::TypeDictionary::registerPointerType(PointerType * pointerType)
+   {
+   _graph->registerType(pointerType);
+
+   Type * baseType = pointerType->BaseType();
+   _graph->registerValidOperation(pointerType, aAdd, pointerType, Word);
+   _graph->registerValidOperation(Word, aSub, pointerType, pointerType);
+
+   _graph->registerValidOperation(pointerType, aIndexAt, pointerType, Word);
+   if (Word != Int32)
+      _graph->registerValidOperation(pointerType, aIndexAt, pointerType, Int32);
+
+   _graph->registerValidOperation(baseType, aLoadAt, pointerType);
+   _graph->registerValidOperation(NoType, aStoreAt, pointerType, baseType);
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(Action a, Value *v)
+   {
+   return _graph->producedType(a, v->type());
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(Action a, Value *left, Value *right)
+   {
+   return _graph->producedType(a, left->type(), right->type());
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(Action a, Value *one, Value *two, Value *three)
+   {
+   return _graph->producedType(a, one->type(), two->type(), three->type());
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(Action a, FieldType *fieldType, Value *structBase, Value *value)
+   {
+   if (value)
+      return _graph->producedType(a, fieldType, structBase->type(), value->type());
+   else
+      return _graph->producedType(a, fieldType, structBase->type());
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(FunctionType *type, int32_t numArgs, va_list args)
+   {
+   Type *argTypes[numArgs];
+   for (int32_t a=0;a < numArgs;a++)
+      argTypes[a] = (va_arg(args, Value *))->type();
+   return _graph->producedType(type, numArgs, argTypes);
+   }
+
+Type *
+OMR::JitBuilder::TypeDictionary::producedType(FunctionType *type, int32_t numArgs, Value **args)
+   {
+   Type *argTypes[numArgs];
+   for (int32_t a=0;a < numArgs;a++)
+      argTypes[a] = args[a]->type();
+   return _graph->producedType(type, numArgs, argTypes);
+   }
+
+PointerType *
+TypeDictionary::PointerTo(Type * baseType)
+   {
+   // don't replicate types
+   std::map<Type *,PointerType *>::iterator found = _pointerTypeFromBaseType.find(baseType);
+   if (found != _pointerTypeFromBaseType.end())
+      {
+      PointerType *t = found->second;
+      return t;
+      }
+
+   // if not found already, then create it
+   PointerType * newType = PointerType::create(this, std::string("PointerTo(") + baseType->name()  + std::string(")"), baseType);
+   addType(newType);
+   _pointerTypeFromBaseType[baseType] = newType;
+   registerPointerType(newType);
+   return newType;
+   }
+
+Type *
+TypeDictionary::LookupType(uint64_t id)
+   {
+   for (auto it = TypesBegin(); it != TypesEnd(); it++)
+      {
+      Type *type = *it;
+      if (type->id() == id)
+         return type;
+      }
+
+   return NULL;
+   }
+
+void
+TypeDictionary::forgetType(Type *type)
+   {
+   // brutal performance; should really collect these and do in one pass
+   for (auto it = _types.begin(); it != _types.end(); )
+      {
+      if (*it == type)
+         it = _types.erase(it);
+      else
+         ++it;
+      }
+   }
+
+void
+TypeDictionary::RemoveType(Type *type)
+   {
+
+   if (type->isField())
+      ; // nothing special for fields themselves
+   else if (type->isStruct() || type->isUnion())
+      {
+      StructType *sType = static_cast<StructType *>(type);
+      bool fullyRemove = (type->owningDictionary() == this);
+      for (auto it = sType->FieldsBegin(); it != sType->FieldsEnd(); )
+         {
+         FieldType *fType = it->second;
+         forgetType(fType);
+
+         if (fullyRemove)
+            it = sType->RemoveField(it);
+         else
+            it++;
+         }
+
+      _structTypeFromName.erase(type->name());
+      }
+   else if (type->isPointer())
+      {
+      PointerType *ptrType = static_cast<PointerType *>(type);
+      _pointerTypeFromBaseType.erase(ptrType->BaseType());
+      }
+   else if (type->isFunction())
+      _functionTypeFromName.erase(type->name());
+
+   forgetType(type);
+
+   // TODO but not *strictly* necessary: _graph->unregister(type);
+   }
+
+StructType *
+TypeDictionary::LookupStruct(std::string structName)
+   {
+   std::map<std::string,StructType *>::iterator found = _structTypeFromName.find(structName);
+   if (found != _structTypeFromName.end())
+      return found->second;
+
+   return NULL;
+   }
+
+StructType *
+TypeDictionary::DefineStruct(std::string structName, size_t size)
+   {
+   StructType *existingType = LookupStruct(structName);
+   if (existingType)
+      {
+      assert(existingType->size() == size);
+      return existingType;
+      }
+
+   StructType * newType = StructType::create(this, structName, size);
+   addType(newType);
+   _structTypeFromName.insert({structName, newType});
+   _graph->registerType(newType);
+   _graph->registerType(PointerTo(newType));
+   return newType;
+   }
+
+UnionType *
+TypeDictionary::DefineUnion(std::string unionName)
+   {
+   StructType *existingType = LookupStruct(unionName);
+   if (existingType)
+      {
+      assert(existingType->isUnion());
+      return static_cast<UnionType *>(existingType);
+      }
+
+   UnionType * newType = UnionType::create(this, unionName);
+   addType(newType);
+   _structTypeFromName.insert({unionName, newType});
+   _graph->registerType(newType);
+   _graph->registerType(PointerTo(newType));
+   return newType;
+   }
+
+FieldType *
+TypeDictionary::DefineField(StructType *structType, LiteralValue *fieldName, Type * fType, size_t offset)
+   {
+   assert(structType);
+   if (structType->closed())
+      {
+      // TODO: useful error message
+      return NULL;
+      }
+
+   assert(fieldName->kind() == T_string || fieldName->kind() == T_typename);
+   FieldType *fieldType = structType->LookupField(fieldName->getString());
+   if (fieldType)
+      {
+      assert(fieldType->type() == fType && fieldType->offset() == offset);
+      return fieldType;
+      }
+
+   fieldType = structType->addField(fieldName, fType, offset);
+   addType(fieldType);
+   _graph->registerValidDirectFieldAccess(fieldType, structType);
+   _graph->registerValidIndirectFieldAccess(fieldType, PointerTo(structType));
+   return fieldType;
+   }
+
+void
+TypeDictionary::CloseStruct(Type *type)
+   {
+   assert(type && type->isStruct());
+   StructType *structType = static_cast<StructType *>(type);
+   structType->setClosed();
+   }
+
+void
+TypeDictionary::CloseUnion(Type *type)
+   {
+   assert(type && type->isUnion());
+   UnionType *unionType = static_cast<UnionType *>(type);
+   unionType->setClosed();
+   }
+
+FunctionType *
+TypeDictionary::DefineFunctionType(std::string name,
+                                   Type *returnType,
+                                   int32_t numParms,
+                                   Type **parmTypes)
+   {
+   // don't replicate types
+   std::map<std::string,FunctionType *>::iterator found = _functionTypeFromName.find(name);
+   if (found != _functionTypeFromName.end())
+      {
+      FunctionType *t = found->second;
+      assert(t->returnType() == returnType && t->numParms() == numParms);
+      for (int p=0;p < numParms;p++)
+         assert(t->parmType(p) == parmTypes[p]);
+      return t;
+      }
+
+   FunctionType * newType = FunctionType::create(this, name, returnType, numParms, parmTypes);
+   addType(newType);
+   _graph->registerFunctionType(newType);
+   return newType;
+   }

--- a/jitbuilder/jbil/TypeDictionary.hpp
+++ b/jitbuilder/jbil/TypeDictionary.hpp
@@ -37,12 +37,16 @@ namespace OMR
 namespace JitBuilder
 {
 
-class TypeGraph;
 class DebugDictionary;
+class DynamicType;
+class OperationBuilder;
+class TypeGraph;
 
 class TypeDictionary
    {
    friend class DebugDictionary;
+   friend class DynamicType;
+   friend class OperationBuilder;
 
 public:
    TypeDictionary();
@@ -149,6 +153,8 @@ protected:
    void initializeGraph();
    void registerPointerType(PointerType * pointerType);
    void forgetType(Type *type);
+   void registerDynamicOperation(OperationBuilder * dynamicOperationBuilder);
+   void registerDynamicType(DynamicType * dynamicType);
 
    int64_t                              _id;
    std::string                          _name;

--- a/jitbuilder/jbil/TypeDictionary.hpp
+++ b/jitbuilder/jbil/TypeDictionary.hpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TYPEDICTIONARY_INCL
+#define TYPEDICTIONARY_INCL
+
+
+#include <stdint.h>
+#include <map>
+#include <vector>
+#include "Action.hpp"
+#include "Iterator.hpp"
+#include "Operation.hpp"
+#include "Type.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class TypeGraph;
+class DebugDictionary;
+
+class TypeDictionary
+   {
+   friend class DebugDictionary;
+
+public:
+   TypeDictionary();
+   TypeDictionary(std::string name);
+   TypeDictionary(TypeGraph * graph);
+   TypeDictionary(std::string name, TypeGraph * graph);
+
+   static TypeDictionary *global();
+
+   Type * NoType;
+   Type * Int8;
+   Type * Int16;
+   Type * Int32;
+   Type * Int64;
+   Type * Float;
+   Type * Double;
+   Type * Address;
+   Type * Word;
+
+   // new types
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // new public types
+
+   int64_t NewTypeID() { return _maxTypeID++; }
+   int64_t MaxTypeID() const { return _maxTypeID; }
+
+   PointerType * PointerTo(Type * baseType);
+   StructType * DefineStruct(std::string structName, size_t size);
+   UnionType * DefineUnion(std::string unionName);
+   FieldType * DefineField(std::string structName, std::string fieldName, Type * fieldType, size_t offset)
+      { // deprecated
+      return DefineField(LookupStruct(structName), LiteralValue::create(this, fieldName), fieldType, offset);
+      }
+   FieldType * DefineField(StructType *structType, std::string fieldName, Type * fieldType, size_t offset)
+      {
+      return DefineField(structType, LiteralValue::create(this, fieldName), fieldType, offset);
+      }
+   FieldType * DefineField(StructType *structType, LiteralValue *fieldName, Type * fieldType, size_t offset);
+   void CloseStruct(std::string structName)
+      { // deprecated
+      CloseStruct(LookupStruct(structName));
+      }
+   void CloseStruct(Type *structType);
+   void CloseUnion(std::string unionName)
+      { // deprecated
+      CloseUnion(static_cast<UnionType *>(LookupStruct(unionName)));
+      }
+   void CloseUnion(Type *unionType);
+   FunctionType *DefineFunctionType(std::string name, Type *returnType, int32_t numParms, Type **parmTypes);
+
+   TypeIterator TypesBegin() const
+      {
+      return TypeIterator(_types);
+      }
+   TypeIterator TypesEnd() const   { return TypeIterator(); }
+
+   StructType *LookupStruct(std::string name);
+   Type *LookupType(uint64_t id);
+   void RemoveType(Type *type);
+
+   int64_t id() const       { return _id; }
+   std::string name() const { return _name; }
+   bool hasLinkedDictionary() const { return _linkedDictionary != NULL; }
+   TypeDictionary *linkedDictionary() { return _linkedDictionary; }
+
+   void registerReturnType(Type *type);
+
+   // get the Type produced by Action a on Value v
+   Type * producedType(Action a, Value *v);
+
+   // get the Type produced by Action a on Values left and right
+   Type * producedType(Action a, Value *left, Value *right);
+
+   // get the Type produced by Action a on Values one, two, and three
+   Type * producedType(Action a, Value *one, Value *two, Value *three);
+
+   // get the Type produced by Action a with struct/union and field and struct base pointer value and (optionally) value
+   Type * producedType(Action a, FieldType *fieldType, Value *structBase, Value *value=NULL);
+
+   // get the Type produced for a set of argument types passed to a FunctionType
+   Type * producedType(FunctionType *type, int32_t numArgs, va_list args);
+   Type * producedType(FunctionType *type, int32_t numArgs, Value **args);
+
+   // new public API
+   // BEGIN {
+   //
+
+   //
+   // } END
+   // new public API
+
+protected:
+   TypeDictionary(std::string name, TypeDictionary *linkedTypes);
+
+   void createPrimitiveTypes();
+   void addType(Type *type)
+      {
+      _types.push_back(type);
+      }
+   void initializeGraph();
+   void registerPointerType(PointerType * pointerType);
+   void forgetType(Type *type);
+
+   int64_t                              _id;
+   std::string                          _name;
+   std::vector<Type *>                  _types;
+   int64_t                              _maxTypeID;
+   std::map<Type *,PointerType*>        _pointerTypeFromBaseType;
+   std::map<std::string,StructType *>   _structTypeFromName;
+   std::map<std::string,FunctionType *> _functionTypeFromName;
+   TypeGraph                          * _graph;
+   TypeDictionary                     * _linkedDictionary;
+
+   static int64_t globalIndex;
+   static TypeDictionary *globalDict;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TYPEDICTIONARY_INCL)

--- a/jitbuilder/jbil/TypeGraph.cpp
+++ b/jitbuilder/jbil/TypeGraph.cpp
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "TypeGraph.hpp"
+#include "Operation.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+
+
+using namespace OMR::JitBuilder;
+
+uint64_t OMR::JitBuilder::TypeGraph::globalIndex = 0;
+uint64_t OMR::JitBuilder::TypeGraph::OperationNode::globalID = 0;
+
+OMR::JitBuilder::TypeGraph::TypeGraph(TypeDictionary * types)
+   : _id(globalIndex++)
+   , _types(types)
+   , _linkedGraph(NULL)
+   {
+   }
+
+OMR::JitBuilder::TypeGraph::TypeGraph(TypeDictionary * types, TypeGraph *linkedGraph)
+   : _id(globalIndex++)
+   , _types(types)
+   , _linkedGraph(linkedGraph)
+   {
+   }
+
+OMR::JitBuilder::TypeGraph::TypeNode *
+OMR::JitBuilder::TypeGraph::lookupType(Type * type)
+   {
+   std::map<Type *,TypeNode *>::iterator found=_typeToNode.find(type);
+   if (found != _typeToNode.end())
+      return found->second;
+
+   if (_linkedGraph)
+      return _linkedGraph->lookupType(type);
+
+   assert(false);
+   return NULL;
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerType(Type * type)
+   {
+   std::map<Type *,TypeNode *>::iterator found=_typeToNode.find(type);
+   if (found == _typeToNode.end())
+      {
+      TypeNode * node = new TypeNode(type);
+      _typeToNode[type] = node;
+      }
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerFunctionType(FunctionType *function)
+   {
+   registerType(function);
+
+   NodeList *list = lookupNodeList(aCall);
+   TypeNode *functionTypeNode = lookupType(function);
+   int32_t numParms = function->numParms();
+   TypeNode **parmTypeNodes = new TypeNode*[numParms];
+   for (int32_t p=0;p < numParms;p++)
+      {
+      parmTypeNodes[p] = lookupType(function->parmType(p));
+      }
+   TypeNode *returnTypeNode = lookupType(function->returnType());
+
+   OperationNode *newFunctionType = new FunctionOperationNode(returnTypeNode, aCall, functionTypeNode, numParms, parmTypeNodes);
+   list->push_back(newFunctionType);
+   }
+
+OMR::JitBuilder::TypeGraph::NodeList *
+OMR::JitBuilder::TypeGraph::lookupNodeList(Action a)
+   {
+   NodeList *list = NULL;
+   std::map<Action, NodeList *>::iterator found = _nodesForAction.find(a);
+   if (found != _nodesForAction.end())
+      return found->second;
+
+   if (_linkedGraph)
+      list = _linkedGraph->lookupNodeList(a);
+
+   if (!list)
+      {
+      list = new NodeList();
+      _nodesForAction[a] = list;
+      }
+
+   assert(list);
+   return list;
+   }
+
+Type *
+OMR::JitBuilder::TypeGraph::producedType(Action a, Type * t)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *tNode = lookupType(t);
+
+   for (NodeList::iterator it=list->begin(); it != list->end(); it++)
+      {
+      Node * n = *it;
+      if (n->kind == UnaryOperationKind)
+         {
+         UnaryOperationNode *op = static_cast<UnaryOperationNode *>(n);
+         if (op->operand == tNode)
+            return op->produces->type;
+         }
+      }
+
+   // no match found, so operation is not valid
+   return NULL;
+   }
+
+Type *
+OMR::JitBuilder::TypeGraph::producedType(Action a, Type *left, Type *right)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *leftTypeNode = lookupType(left);
+   TypeNode *rightTypeNode = lookupType(right);
+
+   for (NodeList::iterator it=list->begin(); it != list->end(); it++)
+      {
+      Node * n = *it;
+      if (n->kind == BinaryOperationKind)
+         {
+         BinaryOperationNode *op = static_cast<BinaryOperationNode *>(n);
+         if (op->left == leftTypeNode && op->right == rightTypeNode)
+            return op->produces->type;
+         }
+      }
+
+   // no match found, so operation is not valid
+   return NULL;
+   }
+
+Type *
+OMR::JitBuilder::TypeGraph::producedType(Action a, Type *one, Type *two, Type *three)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *oneTypeNode = lookupType(one);
+   TypeNode *twoTypeNode = lookupType(two);
+   TypeNode *threeTypeNode = lookupType(three);
+
+   for (NodeList::iterator it=list->begin(); it != list->end(); it++)
+      {
+      Node * n = *it;
+      if (n->kind == TrinaryOperationKind)
+         {
+         TrinaryOperationNode *op = static_cast<TrinaryOperationNode *>(n);
+         if (op->first == oneTypeNode && op->second == twoTypeNode && op->third == threeTypeNode)
+            return op->produces->type;
+         }
+      }
+
+   // no match found, so operation is not valid
+   return NULL;
+   }
+
+Type *
+OMR::JitBuilder::TypeGraph::producedType(FunctionType *function, int32_t numArgs, Type ** argTypes)
+   {
+   NodeList *list = lookupNodeList(aCall);
+   TypeNode *functionTypeNode = lookupType(function);
+   TypeNode **argTypeNodes = new TypeNode*[numArgs];
+   for (int32_t a=0;a < numArgs;a++)
+      {
+      argTypeNodes[a] = lookupType(argTypes[a]);
+      }
+   
+   for (NodeList::iterator it=list->begin(); it != list->end(); it++)
+      {
+      Node * n = *it;
+      if (n->kind == FunctionOperationKind)
+         {
+         FunctionOperationNode *op = static_cast<FunctionOperationNode *>(n);
+         if (op->function == functionTypeNode && op->numParms == numArgs)
+            {
+            int32_t a=0;
+            for (a=0;a < numArgs;a++)
+               if (op->parmTypes[a] != argTypeNodes[a])
+                  break;
+            if (a == numArgs)
+               return op->produces->type;
+            }
+         }
+      }
+
+   // no match found, so operation is not valid
+   return NULL;
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerValidOperation(Type * produces, Action a, Type * operand)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *producesTypeNode = lookupType(produces);
+   TypeNode *operandTypeNode = lookupType(operand);
+   OperationNode *newType = new UnaryOperationNode(producesTypeNode, a, operandTypeNode);
+   list->push_back(newType);
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerValidOperation(Type * produces, Action a, Type * left, Type * right)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *producesTypeNode = lookupType(produces);
+   TypeNode *leftTypeNode = lookupType(left);
+   TypeNode *rightTypeNode = lookupType(right);
+   OperationNode *newType = new BinaryOperationNode(producesTypeNode, a, leftTypeNode, rightTypeNode);
+   list->push_back(newType);
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerValidOperation(Type * produces, Action a, Type * one, Type * two, Type * three)
+   {
+   NodeList *list = lookupNodeList(a);
+   TypeNode *producesTypeNode = lookupType(produces);
+   TypeNode *oneTypeNode = lookupType(one);
+   TypeNode *twoTypeNode = lookupType(two);
+   TypeNode *threeTypeNode = lookupType(three);
+   OperationNode *newType = new TrinaryOperationNode(producesTypeNode, a, oneTypeNode, twoTypeNode, threeTypeNode);
+   list->push_back(newType);
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerValidDirectFieldAccess(FieldType *fieldType, StructType *structBaseType)
+   {
+   registerType(fieldType);
+
+   TypeNode *fieldTypeNode = lookupType(fieldType);
+   TypeNode *structBaseTypeNode = lookupType(structBaseType);
+
+   NodeList *loadList = lookupNodeList(aLoadField);
+   TypeNode *producesTypeNode = lookupType(fieldType->type());
+   OperationNode *newLoadType = new BinaryOperationNode(producesTypeNode, aLoadField, fieldTypeNode, structBaseTypeNode);
+   loadList->push_back(newLoadType);
+
+   NodeList *storeList = lookupNodeList(aStoreField);
+   producesTypeNode = lookupType(_types->NoType);
+   TypeNode *valueNode = lookupType(fieldType->type());
+   OperationNode *newStoreType = new TrinaryOperationNode(producesTypeNode, aStoreField, fieldTypeNode, structBaseTypeNode, valueNode);
+   storeList->push_back(newStoreType);
+   }
+
+void
+OMR::JitBuilder::TypeGraph::registerValidIndirectFieldAccess(FieldType *fieldType, PointerType *pStructBaseType)
+   {
+   Type *baseType = pStructBaseType->BaseType();
+   assert(baseType->isStruct());
+
+   TypeNode *fieldTypeNode = lookupType(fieldType);
+   TypeNode *pStructBaseTypeNode = lookupType(pStructBaseType);
+
+   NodeList *loadList = lookupNodeList(aLoadIndirect);
+   TypeNode *producesTypeNode = lookupType(fieldType->type());
+   OperationNode *newLoadType = new BinaryOperationNode(producesTypeNode, aLoadIndirect, fieldTypeNode, pStructBaseTypeNode);
+   loadList->push_back(newLoadType);
+
+   NodeList *storeList = lookupNodeList(aStoreIndirect);
+   producesTypeNode = lookupType(_types->NoType);
+   TypeNode *valueNode = lookupType(fieldType->type());
+   OperationNode *newStoreType = new TrinaryOperationNode(producesTypeNode, aStoreIndirect, fieldTypeNode, pStructBaseTypeNode, valueNode);
+   storeList->push_back(newStoreType);
+   }

--- a/jitbuilder/jbil/TypeGraph.hpp
+++ b/jitbuilder/jbil/TypeGraph.hpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TYPEGRAPH_INCL
+#define TYPEGRAPH_INCL
+
+#include <map>
+#include <list>
+#include <string>
+
+#include "Action.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class FieldType;
+class FunctionType;
+class PointerType;
+class StructType;
+class Type;
+class TypeDictionary;
+class TypeSignature;
+class Value;
+
+class TypeGraph
+   {
+public:
+   TypeGraph(TypeDictionary * types);
+   TypeGraph(TypeDictionary * types, TypeGraph *linkedGraph);
+
+   int64_t id() const { return _id; }
+
+   // create a node representing the given type
+   void registerType(Type * type);
+
+   // create a node representing the given function type
+   void registerFunctionType(FunctionType * function);
+
+   // get the Type produced by Action a on Value v
+   Type * producedType(Action a, Type *t);
+
+   // get the Type produced by Action a on Values left and right
+   Type * producedType(Action a, Type *left, Type *right);
+
+   // get the Type produced by Action a on Values one, two, and three
+   Type * producedType(Action a, Type *one, Type *two, Type *three);
+
+   // get the Type produced by Action a calling FunctionType type provided a varargs set of argument types
+   Type * producedType(FunctionType *type, int32_t numArgs, Type ** argTypes);
+
+   void registerValidOperation(Type * produces, Action a, Type * operand);
+   void registerValidOperation(Type * produces, Action a, Type * left, Type * right);
+   void registerValidOperation(Type * produces, Action a, Type * one, Type * two, Type * three);
+   void registerValidDirectFieldAccess(FieldType *fieldType, StructType *structBaseType);
+   void registerValidIndirectFieldAccess(FieldType *fieldType, PointerType *pStructBaseType);
+
+protected:
+   enum NodeKind
+      {
+      TypeKind=0,
+      StringKind,
+      SignatureOperationKind,
+      UnaryOperationKind,
+      BinaryOperationKind,
+      TrinaryOperationKind,
+      FieldAccessOperationKind,
+      FunctionOperationKind,
+      ExtensionKind
+      };
+
+   struct Node
+      {
+      Node(NodeKind k) : kind(k) { }
+      NodeKind kind;
+      };
+
+   struct TypeNode : public Node
+      {
+      TypeNode(Type * t) : Node(TypeKind), type(t) { }
+      Type * type;
+      bool operator==(TypeNode & other) { return &other==this; }
+      };
+
+   struct OperationNode : public Node
+      {
+      OperationNode(NodeKind k, TypeNode * p, Action a)
+         : Node(k)
+         , produces(p)
+         , action(a)
+         , sig(NULL)
+         , id(globalID++)
+         { }
+      OperationNode(Action a, TypeSignature *sig) // takes ownership of "sig" object
+         : Node(SignatureOperationKind)
+         , produces(NULL)
+         , action(a)
+         , sig(sig)
+         , id(globalID++)
+         { }
+      TypeNode * produces;
+      Action action;
+      TypeSignature *sig;
+
+      static uint64_t globalID;
+      uint64_t id;
+      };
+
+   typedef std::list<OperationNode*> NodeList;
+
+   struct UnaryOperationNode : public OperationNode
+      {
+      UnaryOperationNode(TypeNode * produces, Action a, TypeNode * o)
+         : OperationNode(UnaryOperationKind, produces, a)
+         , operand(o)
+         { }
+      TypeNode * operand;
+      };
+
+   struct BinaryOperationNode : public OperationNode
+      {
+      BinaryOperationNode(TypeNode * produces, Action a, TypeNode * one, TypeNode * two)
+         : OperationNode(BinaryOperationKind, produces, a)
+         , left(one)
+         , right(two)
+         { }
+      TypeNode * left;
+      TypeNode * right;
+      };
+
+   struct TrinaryOperationNode : public OperationNode
+      {
+      TrinaryOperationNode(TypeNode * produces, Action a, TypeNode * one, TypeNode * two, TypeNode * three)
+         : OperationNode(TrinaryOperationKind, produces, a)
+         , first(one)
+         , second(two)
+         , third(three)
+         { }
+      TypeNode * first;
+      TypeNode * second;
+      TypeNode * third;
+      };
+
+   struct FunctionOperationNode : public OperationNode
+      {
+      FunctionOperationNode(TypeNode * produces, Action a, TypeNode *func, int32_t totalParms, TypeNode ** parms)
+         : OperationNode(FunctionOperationKind, produces, a)
+         , function(func)
+         , numParms(totalParms)
+         , parmTypes(parms)
+         { }
+      TypeNode  * function;
+      int32_t     numParms;
+      TypeNode ** parmTypes;
+      };
+
+   TypeNode * lookupType(Type * t);
+   NodeList * lookupNodeList(Action a);
+
+   uint64_t                     _id;
+   std::map<Type *,TypeNode *>  _typeToNode;
+   std::map<Action, NodeList *> _nodesForAction;
+   TypeDictionary             * _types;
+   TypeGraph                  * _linkedGraph;
+
+   static uint64_t globalIndex;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TYPEGRAPH_INCL)

--- a/jitbuilder/jbil/TypeReplacer.cpp
+++ b/jitbuilder/jbil/TypeReplacer.cpp
@@ -1,0 +1,1198 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "TypeReplacer.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "Operation.hpp"
+#include "Symbol.hpp"
+#include "TextWriter.hpp"
+#include "Type.hpp"
+#include "TypeDictionary.hpp"
+#include "Value.hpp"
+
+using namespace OMR::JitBuilder;
+
+// TypeReplacer is responsible for rewriting a FunctionBuilder according to a
+// list of types to be replaced (with a corresponding list of replacement types)
+// as well as "exploding" a list of types to be replaced by their layout types.
+// Typically, user defined types are exploded before they can be generated. For
+// example, a user defined Complex type might be exploded into two Double values.
+// Upon creation, one can describe the types to be replaced/exploded by calling
+// replaceType/explodeType on the TypeReplacer:
+// e.g.
+//    TypeReplacer *tr = new TypeReplacer(fb)
+//                       ->explodeType(fb->Complex)
+//                       ->explodeType(fb->Point3D)
+//                       ->replaceType(fb-Double, fb->Float)
+//                       ->replaceType(fb->T, fb->Int32);
+//
+// TypeReplacer uses Mappers to perform explosion and replacement: a Mapper provides
+// a way to repetitively iterate through a Type's replacement Type or through the
+// Types that result from exploding a Type's layout. By creating a specific Mapper
+// for each element (operand, literal value, type, symbol) of an Operation, the
+// Operation can be transformed into as many replacement Operations as needed by
+// simply cloning it repeatedly from the Mappers built from the original Operation's
+// elements, with each clone asking for the "next" element from each corresponding
+// Mapper. Non-exploded elements will simply keep providing the same (possibly replaced)
+// element type for each clone, whereas exploded elements will provide a different
+// element for each clone of the Operation.
+//
+// To save space and time, TypeReplacer caches all Mapper objects created so they
+// can be reused by later replacing/exploding similar kinds of elements. It begins by
+// walking each Type to see if it references a Type that needs to be "transformed"
+// (either replaced or exploded or built directly or indirectly from such a Type).
+// The FunctionBuilder's signature elements (return value, parameters) are then
+// processed, followed by an iteration over all the Operations in the FunctionBuilder.
+//
+// When an element (Value, LiteralValue, Type, Symbol) is first encountered while
+// visiting the operations of the FunctionBuilder, that element is transformed to
+// an appropriate Mapper object (ValueMapper, LiteralMapper, TypeMapper, SymbolMapper)
+// and then recorded in a std::map from the original element to its Mapper object.
+// The collection of Mapper objects is fed into the cloneTo() function of the original
+// Operation to create new Operations. As these new Operations are created, if
+// they produce result Values, these Values are added to a new ValueMapper which, once
+// completely filled, is recorded into the ValueMapper cache so that subsequent
+// uses of the original result Value will find the result ValueMapper object.
+//
+// A FunctionBuilder's signature (set of parameters) are also remapped in this
+// way, so the resulting FunctionBuilder may take more parameters than the
+// original FunctionBuilder (if any Types were exploded, for example). The
+// same is true for all LocalSymbols (they may be exploded into multiple scalar
+// values). Note that Type's cannot be exploded if they are referenced via a
+// PointerType, so TypeReplacer replaces PointerTo(explodedType) with
+// PointerTo(explodedType->layout())
+//
+// A type that "explodes" will be replaced with its layout fields where ever
+// it is used. Similarly, structs that have a field defined as an exploded type
+// will have their fields exploded into the containing struct. Parameters of an
+// exploded Type will be replaced with multiple parameters from the fields of the
+// layout struct. Local symbols are similarly expanded. Unions with a field of an
+// exploded type will be replaced with the layout struct type.
+//
+// Types that do not directly refer to exploded or replaced Types may still be changed
+// by this pass. For example, PointerTo(PointerTo(explodedType)) must be changed because
+// PointerTo(explodedType) will be changed to a set of PointerTo types for each field
+// of the exploded Type's layout, and therefore the original Type reference will also
+// need to change to set of PointerTo(PointerTo(all fields of explodedType->layout()))
+//
+
+
+TypeReplacer::TypeReplacer(FunctionBuilder * fb)
+   : Transformer(fb)
+   , _typesTransformed(false)
+   {
+   setTraceEnabled(fb->config()->traceReducer());
+   }
+
+TypeReplacer *
+TypeReplacer::replace(Type *oldType, Type *newType)
+   {
+   assert(newType != oldType || oldType->isStruct());
+   _typesToReplace[oldType->id()] = newType->id();
+   return this;
+   }
+
+TypeReplacer *
+TypeReplacer::explode(Type *type)
+   {
+   assert(type->layout() != NULL);
+   assert(type->layout()->size() == type->size());
+   _typesToExplode.insert(type->id());
+   return this;
+   }
+
+void
+TypeReplacer::recordMapper(Type *type, TypeMapper *mapper)
+   {
+   _typeMappers[type] = mapper;
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log)
+      {
+      log->indent() << "type t" << type->id() << " mapper registered:" << log->endl();
+      LOG_INDENT_REGION(log)
+         {
+         for (int i=0;i < mapper->size();i++)
+            {
+            Type *newType = mapper->current();
+            if (log) log->indent() << i << " : " << "\"" << mapper->name() << "\"" << " offset " << mapper->offset() << " : ";
+            if (log) log->writeType(newType, false);
+            mapper->next();
+            }
+         }
+      LOG_OUTDENT
+      }
+   }
+
+void
+TypeReplacer::recordOriginalType(Type *type)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->indent() << "type t" << type->id() << " unchanged" << log->endl();
+   if (_typeMappers.find(type) == _typeMappers.end())
+      {
+      TypeMapper *m = new TypeMapper(type);
+      recordMapper(type, m);
+      }
+   assert(_modifiedType.find(type) == _modifiedType.end());
+   }
+
+Type *
+TypeReplacer::singleMappedType(Type *type)
+   {
+   auto it = _typeMappers.find(type);
+   assert(it != _typeMappers.end());
+   TypeMapper *m = it->second;
+   assert(m->size() == 1); // should map only to a Struct
+   return m->next();
+   }
+
+Type *
+TypeReplacer::mappedLayout(Type *t)
+   {
+   Type *layout = t->layout();
+   assert(layout);
+   if (_modifiedType.find(layout) != _modifiedType.end())
+      {
+      layout = singleMappedType(layout);
+      assert(layout->isStruct());
+      }
+
+   return layout;
+   }
+
+std::string
+TypeReplacer::explodedName(std::string & baseName, FieldType *field)
+   {
+   LiteralValue *name = field->fieldName();
+   if (baseName.length() > 0)
+      return baseName + "." + name->getString();
+   return name->getString();
+   }
+
+void
+TypeReplacer::explodeLayoutTypes(TypeDictionary *dict, StructType *layout, size_t baseOffset, TypeMapper *m)
+   {
+   for (auto fIt = layout->FieldsBegin(); fIt != layout->FieldsEnd(); fIt++)
+      {
+      FieldType *fType = fIt->second;
+      Type *t = fType->type();
+      transformTypeIfNeeded(dict, t);
+
+      size_t fieldOffset = baseOffset + fType->offset();
+      if (_typesToExplode.find(t->id()) != _typesToExplode.end())
+         {
+         StructType *innerLayout = t->layout();
+         assert(innerLayout);
+         explodeLayoutTypes(dict, innerLayout, fieldOffset, m);
+         }
+      else
+         {
+         Type *mappedType = singleMappedType(t);
+         LiteralValue *name = fType->fieldName();
+         std::string fieldName = name->getString();
+         if (name->kind() == T_typename)
+            fieldName = mappedType->name();
+         m->add(mappedType, fieldName, fieldOffset);
+         }
+      }
+   }
+
+void
+TypeReplacer::transformExplodedType(TypeDictionary *dict, Type *type)
+   {
+   TypeMapper *m = new TypeMapper();
+   StructType *layout = type->layout();
+   assert(layout);
+
+   explodeLayoutTypes(dict, layout, 0, m);
+
+   _explodedType.insert(type);
+   recordMapper(type, m);
+
+   _typesToRemove.insert(type);
+
+   // also explode the layout type itself, in case it has inner exploded types
+   transformTypeIfNeeded(dict, layout);
+   }
+
+void
+TypeReplacer::transformPointerType(TypeDictionary *dict, PointerType *ptrType)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   Type *baseType = ptrType->BaseType();
+   Type *newBaseType = NULL;
+   if (_explodedType.find(baseType) != _explodedType.end())
+      newBaseType = mappedLayout(baseType);
+   else
+      newBaseType = singleMappedType(baseType);
+
+   Type *newPtrType = dict->PointerTo(newBaseType);
+   TypeMapper *ptrTypeMapper = new TypeMapper(newPtrType);
+   _modifiedType.insert(ptrType);
+   _examinedType.insert(newPtrType); // avoid looking at it again
+
+   recordMapper(ptrType, ptrTypeMapper);
+   LOG_INDENT_REGION(log)
+      {
+      recordOriginalType(newPtrType);
+      }
+   LOG_OUTDENT
+
+   _typesToRemove.insert(ptrType);
+   }
+
+void
+TypeReplacer::transformStructFields(TypeDictionary *dict, StructType *origStruct, StructType *structType, std::string baseName, size_t baseOffset, StructType *type, TypeMapper *mapper)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   bool removeFields = true;
+   if (type == origStruct && _typesToRemove.find(origStruct) != _typesToRemove.end())
+      removeFields = false;
+
+   for (auto fIt = type->FieldsBegin(); fIt != type->FieldsEnd(); fIt++)
+      {
+      FieldType *fType = fIt->second;
+      std::string fieldName = explodedName(baseName, fType);
+      Type *t = fType->type();
+      if (_typesToExplode.find(t->id()) != _typesToExplode.end())
+         {
+         TypeMapper *m = new TypeMapper();
+         transformStructFields(dict, origStruct, structType, fieldName, fType->offset(), t->layout(), m);
+         recordMapper(fType, m);
+         }
+      else
+         {
+         Type *mappedType = singleMappedType(t);
+         LiteralValue *name = fType->fieldName();
+         LiteralValue *newFieldName = NULL;
+         if (name->kind() == T_typename)
+            newFieldName = LiteralValue::create(dict, mappedType);
+         else
+            newFieldName = LiteralValue::create(dict, fieldName);
+         FieldType *newType = dict->DefineField(structType, newFieldName, mappedType, baseOffset + fType->offset());
+         _examinedType.insert(newType); // avoid looking at later
+         recordMapper(fType, new TypeMapper(newType));
+         if (mapper)
+            mapper->add(newType);
+         LOG_INDENT_REGION(log)
+            {
+            recordOriginalType(newType);
+            }
+         LOG_OUTDENT
+
+         if (removeFields)
+            _typesToRemove.insert(fType);
+         }
+      }
+   }
+
+void
+TypeReplacer::transformStructType(TypeDictionary *dict, StructType *sType)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->indent() << "TransformStructType " << sType->name() << " because at least one field modified" << log->endl();
+
+   std::string newName = std::string("_X_::") + sType->name();
+   StructType *newType = NULL;
+   if (sType->isStruct())
+      newType = dict->DefineStruct(newName, sType->size());
+   else if (sType->isUnion())
+      newType = dict->DefineUnion(newName);
+   else
+      assert(0);
+
+   // do this now so fields of sType don't need to add themselves for removal
+   _typesToRemove.insert(sType);
+
+   std::string baseName("");
+   transformStructFields(dict, sType, newType, baseName, 0, sType, NULL);
+
+   dict->CloseStruct(newType);
+   _modifiedType.insert(sType);
+   _examinedType.insert(newType); // avoid looking at later
+
+   TypeMapper *m = new TypeMapper(newType);
+   recordMapper(sType, m);
+   LOG_INDENT_REGION(log)
+      {
+      recordOriginalType(newType);
+      }
+   LOG_OUTDENT
+   }
+
+void
+TypeReplacer::transformFunctionType(TypeDictionary *dict, FunctionType *fnType)
+   {
+   Type *returnType = fnType->returnType();
+   assert(_typesToExplode.find(returnType->id()) == _typesToExplode.end()); // can't explode return types yet
+   Type *newReturnType = singleMappedType(returnType);
+
+   // count how many parameters needed
+   int32_t numParms = fnType->numParms();
+   int32_t numNewParms = 0; // each original parameter explodes to at least one remapped parameter
+   for (int32_t p=0;p < numParms;p++)
+      {
+      Type *parmType = fnType->parmType(p);
+      auto it = _typeMappers.find(parmType);
+      assert(it != _typeMappers.end());
+      TypeMapper *parmMapper = it->second;
+      numNewParms += parmMapper->size();
+      }
+
+   // allocate array and then assign the new parameter types
+   Type **newParmTypes = new Type *[numNewParms];
+   int parmNum = 0;
+   for (int32_t p=0;p < numParms;p++)
+      {
+      Type *parmType = fnType->parmType(p);
+      auto it = _typeMappers.find(parmType);
+      assert(it != _typeMappers.end());
+      TypeMapper *parmMapper = it->second;
+      for (int i=0;i < parmMapper->size();i++)
+         newParmTypes[parmNum++] = parmMapper->next();
+      }
+
+   assert(parmNum == numNewParms);
+
+   FunctionType *newType = FunctionType::create(dict, fnType->name(), newReturnType, numNewParms, newParmTypes);
+   _modifiedType.insert(fnType);
+   _examinedType.insert(newType);
+
+   TypeMapper *m = new TypeMapper(newType);
+   recordMapper(fnType, m);
+   recordOriginalType(newType);
+
+   _typesToRemove.insert(fnType);
+   }
+
+void
+TypeReplacer::transformTypeIfNeeded(TypeDictionary *dict, Type *type)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->writeType(type);
+
+   uint64_t typeID = type->id();
+   if (_examinedType.find(type) != _examinedType.end())
+      return;
+
+   _examinedType.insert(type);
+   _modifiedType.erase(type);
+   _explodedType.erase(type);
+
+   LOG_INDENT_REGION(log)
+      {
+      // pointer to a type that has been transformed must be transformed to refer
+      //   to the new base type
+      if (type->isPointer())
+         {
+         PointerType *ptrType = static_cast<PointerType *>(type);
+         Type *baseType = ptrType->BaseType();
+
+         LOG_INDENT_REGION(log)
+            {
+            if (log) log->indent() << "PointerType base t" << baseType->id() << log->endl();
+
+            transformTypeIfNeeded(dict, baseType);
+            if (_modifiedType.find(baseType) != _modifiedType.end())
+               transformPointerType(dict, ptrType);
+            else
+               recordOriginalType(type);
+            }
+         LOG_OUTDENT
+         }
+
+      else if (type->isField())
+         {
+         FieldType *fType = static_cast<FieldType *>(type);
+         Type *fieldType = fType->type();
+         LOG_INDENT_REGION(log)
+            {
+            if (log) log->indent() << "FieldType " << fType->name() << " type t" << fieldType->id() << log->endl();
+
+            transformTypeIfNeeded(dict, fieldType);
+            if (_modifiedType.find(fieldType) == _modifiedType.end())
+               recordOriginalType(type); // ensure recorded
+            else
+               {
+               // modified types are handled via struct/union types so just ignore here
+               if (log) log->indent() << "modified field to be handled when struct is transformed" << log->endl();
+               }
+            }
+         LOG_OUTDENT
+         }
+
+      // for structs/unions, look for any remapped field types (recursively!) and if we find one (doesn't matter what it maps to here)
+      //   then construct a new struct/union with remapped fields
+      else if (type->isStruct() || type->isUnion())
+         {
+         StructType *sType = static_cast<StructType *>(type);
+         bool transform = false;
+
+         LOG_INDENT_REGION(log)
+            {
+            if (log) log->indent() << "Struct/UnionType" << log->endl();
+
+            for (auto fIt = sType->FieldsBegin(); fIt != sType->FieldsEnd(); fIt++)
+               {
+               FieldType *fType = fIt->second;
+               if (log) log->indent() << "Examining field " << fType << " ( " << fType->name() << " )" << log->endl();
+
+               transformTypeIfNeeded(dict, fType);
+               if (_modifiedType.find(fType->type()) != _modifiedType.end())
+                  transform = true;
+               }
+
+            if (transform)
+               transformStructType(dict, sType);
+            else
+               recordOriginalType(type);
+            }
+         LOG_OUTDENT
+         }
+
+      // for functions, if return type or any parameter type needs to be changed (doesn't matter to what, here)
+      //   then construct a new function type with new types
+      else if (type->isFunction())
+         {
+         FunctionType *fnType = static_cast<FunctionType *>(type);
+         bool transform = false;
+
+         LOG_INDENT_REGION(log)
+            {
+            if (log) log->indent() << "FunctionType" << log->endl();
+
+            Type *returnType = fnType->returnType();
+            transformTypeIfNeeded(dict, returnType);
+
+            if (_modifiedType.find(returnType) != _modifiedType.end())
+               transform = true;
+
+            for (int32_t p=0;p < fnType->numParms();p++)
+               {
+               Type *pType = fnType->parmType(p);
+               transformTypeIfNeeded(dict, pType);
+
+               if (_modifiedType.find(pType) != _modifiedType.end())
+                  transform = true;
+               }
+
+            if (transform)
+               transformFunctionType(dict, fnType);
+            else
+               recordOriginalType(type);
+            }
+         LOG_OUTDENT
+         }
+
+      //
+      // User composite type handling here
+      // BEGIN {
+
+      // } END
+      // User composite type handling here
+      //
+
+      else if (_typesToExplode.find(type->id()) != _typesToExplode.end())
+         {
+         transformExplodedType(dict, type);
+         _modifiedType.insert(type);
+         _explodedType.insert(type);
+         }
+      else
+         {
+         auto it = _typesToReplace.find(typeID);
+         if (it != _typesToReplace.end())
+            {
+            Type *typeToReplace = dict->LookupType(it->second);
+            TypeMapper *m = new TypeMapper(typeToReplace);
+            recordMapper(type, m);
+            _modifiedType.insert(type);
+            }
+         else
+            recordOriginalType(type);
+         }
+      }
+      LOG_OUTDENT
+   }
+
+void
+TypeReplacer::transformTypes(TypeDictionary *dict)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log)
+      {
+      log->indent() << "TypeReplacer::transformTypes " << dict << log->endl();
+      log->writeDictionary(dict);
+      (*log) << log->endl();
+      log->indent() << "Types to explode:" << log->endl();
+      LOG_INDENT_REGION(log)
+         {
+         for (auto it = dict->TypesBegin();it != dict->TypesEnd();it++)
+            {
+            Type *type = *it;
+            if (_typesToExplode.find(type->id()) != _typesToExplode.end())
+               log->indent() << type << log->endl();
+            }
+         }
+      LOG_OUTDENT
+
+      (*log) << log->endl();
+      log->indent() << "Types to replace:" << log->endl();
+      LOG_INDENT_REGION(log)
+         {
+         for (auto it = dict->TypesBegin();it != dict->TypesEnd();it++)
+            {
+            Type *type = *it;
+            auto it2 = _typesToReplace.find(type->id());
+            if (it2 != _typesToReplace.end())
+               log->indent() << "Replace " << type << " with " << dict->LookupType(it2->second) << log->endl();
+            }
+         }
+      LOG_OUTDENT
+      log->indent() << "Transforming now:" << log->endl();
+      }
+
+   // just to make sure and in case someone calls it twice?
+   _examinedType.clear();
+   _modifiedType.clear();
+   _explodedType.clear();
+
+   LOG_INDENT_REGION(log)
+      {
+      for (TypeIterator typeIt = dict->TypesBegin(); typeIt != dict->TypesEnd(); typeIt++)
+         {
+         Type *type = *typeIt;
+         transformTypeIfNeeded(dict, type);
+         }
+      }
+   LOG_OUTDENT
+
+   if (log) log->indent() << log->endl() << "Transformed dictionary:" << log->endl();
+   if (log) log->writeDictionary(dict);
+
+   _typesTransformed = true;
+   if (log)
+      {
+      log->indent() << "Types to remove in final step:" << log->endl();
+      LOG_INDENT_REGION(log)
+         {
+         for (auto it = dict->TypesBegin();it != dict->TypesEnd();it++)
+            {
+            Type *type = *it;
+            if (_typesToRemove.find(type) != _typesToRemove.end())
+               log->indent() << type << log->endl();
+            }
+         }
+      LOG_OUTDENT
+      }
+   }
+
+FunctionBuilder *
+TypeReplacer::transformFunctionBuilder(FunctionBuilder * fb)
+   {
+   TypeDictionary *dict = fb->dict();
+
+   TextWriter *log = fb->logger(traceEnabled());
+   if (log) log->indent() << "TypeReplacer::transformFunctionBuilder F" << fb->id() << log->endl();
+
+   if (log) log->indent() << "TypeReplacer::look for new Types:" << log->endl();
+   LOG_INDENT_REGION(log)
+      {
+      for (auto it = dict->TypesBegin(); it != dict->TypesEnd(); it++)
+         {
+         Type *type = *it;
+         if (_examinedType.find(type) == _examinedType.end())
+            transformTypeIfNeeded(dict, type);
+         }
+      }
+   LOG_OUTDENT
+
+   // replace return type if needed
+   Type *returnType = fb->getReturnType();
+   Type *newReturnType = singleMappedType(returnType);
+   if (newReturnType != returnType)
+      fb->DefineReturnType(newReturnType);
+
+   if (log) log->indent() << "Return type t" << returnType->id() << " -> t" << newReturnType->id() << log->endl();
+
+   // replace parameters if needed, creating new Symbols and filling in _remapSymbol
+   bool changeSomeParm = false;
+   for (auto pIt = fb->ParametersBegin(); pIt != fb->ParametersEnd(); pIt++)
+      {
+      ParameterSymbol *parm = *pIt;
+      Type *parmType = parm->type();
+      if (_modifiedType.find(parmType) != _modifiedType.end())
+         {
+         changeSomeParm = true;
+         break;
+         }
+      else
+         _symbolMappers[parm] = new SymbolMapper(parm);
+      }
+
+   if (changeSomeParm)
+      {
+      ParameterSymbolVector prevParameters = fb->ResetParameters();
+      for (auto pIt = prevParameters.begin(); pIt != prevParameters.end(); pIt++)
+         {
+         ParameterSymbol *parm = *pIt;
+         Type *parmType = parm->type();
+         if (log) log->indent() << "Parm " << parm->name() << " (" << parmType->name() << " t" << parmType->id() << "):" << log->endl();
+         LOG_INDENT_REGION(log)
+            {
+            auto it = _typeMappers.find(parm->type());
+            TypeMapper *parmTypeMapper = it->second;
+            SymbolMapper *parmSymMapper = new SymbolMapper();
+            if (parmTypeMapper->size() == 1)
+               {
+               Type *newType = parmTypeMapper->next();
+               fb->DefineParameter(parm->name(), newType);
+               if (log) log->indent() << "now DefineParameter " << parm->name() << " (" << newType->name() << " t" << newType->id() << ")" << log->endl();
+               Symbol *newSym = fb->getSymbol(parm->name());
+               parmSymMapper->add(newSym);
+               _symbolMappers[newSym] = new SymbolMapper(newSym);
+               }
+            else
+               {
+               for (int i=0;i < parmTypeMapper->size();i++)
+                  {
+                  std::string name = parmTypeMapper->name();
+                  std::string parmName = parm->name() + "." + name;
+                  Type *parmType = parmTypeMapper->next();
+                  fb->DefineParameter(parmName, parmType);
+                  if (log) log->indent() << "now DefineParameter " << parmName << " (" << parmType->name() << " t" << parmType->id() << ")" << log->endl();
+                  Symbol *newSym = fb->getSymbol(parmName);
+                  parmSymMapper->add(newSym);
+                  _symbolMappers[newSym] = new SymbolMapper(newSym);
+                  }
+               }
+            _symbolMappers[parm] = parmSymMapper;
+            }
+         LOG_OUTDENT
+         }
+      }
+
+   // replace locals if needed, creating new Symbols and filling in _remapSymbol
+   bool changeSomeLocal = false;
+   for (auto lIt = fb->LocalsBegin(); lIt != fb->LocalsEnd(); lIt++)
+      {
+      Symbol *local = *lIt;
+      Type *type = local->type();
+      if (_modifiedType.find(type) != _modifiedType.end())
+         {
+         changeSomeLocal = true;
+         break;
+         }
+      else
+         _symbolMappers[local] = new SymbolMapper(local);
+      }
+
+   if (changeSomeLocal)
+      {
+      LocalSymbolVector locals = fb->ResetLocals();
+      for (auto lIt = locals.begin(); lIt != locals.end(); lIt++)
+         {
+         Symbol *local = *lIt;
+         Type *type = local->type();
+         auto it = _typeMappers.find(type);
+         TypeMapper *typeMapper = it->second;
+         SymbolMapper *symMapper = new SymbolMapper();
+
+         if (log) log->indent() << "Local " << local->name() << " (" << type->name() << " t" << type->id() << "):" << log->endl();
+         LOG_INDENT_REGION(log)
+            {
+            if (typeMapper->size() == 1)
+               {
+               Type *newType = typeMapper->next();
+               fb->DefineLocal(local->name(), newType);
+               if (log) log->indent() << "now DefineLocal " << local->name() << " (" << newType->name() << " t" << newType->id() << ")" << log->endl();
+               Symbol *newSym = fb->getSymbol(local->name());
+               symMapper->add(newSym);
+               _symbolMappers[newSym] = new SymbolMapper(newSym);
+              }
+            else
+               {
+               for (int i=0;i < typeMapper->size();i++)
+                  {
+                  std::string name = typeMapper->name();
+                  std::string newName = local->name() + "." + name;
+                  Type *newType = typeMapper->next();
+                  fb->DefineLocal(newName, newType);
+                  if (log) log->indent() << "now DefineLocal " << newName << " (" << newType->name() << " t" << newType->id() << ")" << log->endl();
+                  Symbol *newSym = fb->getSymbol(newName);
+                  symMapper->add(newSym);
+                  _symbolMappers[newSym] = new SymbolMapper(newSym);
+                  }
+               }
+            }
+         LOG_OUTDENT
+         _symbolMappers[local] = symMapper;
+         }
+      }
+
+   bool changeSomeFunction = false;
+   for (auto fnIt = fb->FunctionsBegin(); fnIt != fb->FunctionsEnd(); fnIt++)
+      {
+      FunctionSymbol *function = *fnIt;
+      FunctionType *type = function->functionType();
+      if (_modifiedType.find(type) != _modifiedType.end())
+         {
+         changeSomeFunction = true;
+         break;
+         }
+      else
+         _symbolMappers[function] = new SymbolMapper(function);
+      }
+
+   if (changeSomeFunction)
+      {
+      // replace functions if needed, creating new Symbols and filling in _remapSymbol
+      FunctionSymbolVector functions = fb->ResetFunctions();
+      for (auto fnIt = functions.begin(); fnIt != functions.end(); fnIt++)
+         {
+         FunctionSymbol *function = *fnIt;
+         FunctionType *type = function->functionType();
+         if (log) log->indent() << "Function " << function->name() << " (" << type->name() << " t" << type->id() << "):" << log->endl();
+
+         auto it = _typeMappers.find(type);
+         TypeMapper *typeMapper = it->second;
+         assert(typeMapper->size() == 1); // shouldn't be multiple FunctionTypes
+         SymbolMapper *symMapper = new SymbolMapper();
+
+         LOG_INDENT_REGION(log)
+            {
+            Type *newType = typeMapper->next();
+            assert(newType->isFunction());
+            FunctionType *newFnType = static_cast<FunctionType *>(newType);
+            fb->DefineFunction(function->name(),
+                               function->fileName(),
+                               function->lineNumber(),
+                               function->entryPoint(),
+                               newFnType->returnType(),
+                               newFnType->numParms(),
+                               newFnType->parmTypes());
+            if (log) log->indent() << "now DefineFunction " << function->name() << " (" << newType->name() << " t" << newType->id() << ")" << log->endl();
+            FunctionSymbol *newSym = fb->LookupFunction(function->name());
+            symMapper->add(newSym);
+            _symbolMappers[newSym] = new SymbolMapper(newSym);
+            if (newType != type)
+               _typesToRemove.insert(type);
+            }
+         LOG_OUTDENT
+         _symbolMappers[function] = symMapper;
+         }
+      }
+
+   // values in operations will be replaced last, handled by transformOperation
+   // first, set up a set of Mappers for those operations to use
+   _mappedResultsSize = 1;
+   _mappedResults = new ValueMapper *[1];
+   _mappedResults[0] = NULL;
+
+   _mappedOperandsSize = 2;
+   _mappedOperands = new ValueMapper *[2];
+   _mappedOperands[0] = NULL;
+   _mappedOperands[1] = NULL;
+
+   _mappedTypesSize = 1;
+   _mappedTypes = new TypeMapper *[1];
+   _mappedTypes[0] = new TypeMapper();
+
+   _mappedSymbolsSize = 1;
+   _mappedSymbols = new SymbolMapper *[1];
+   _mappedSymbols[0] = new SymbolMapper();
+
+   _mappedLiteralsSize = 1;
+   _mappedLiterals = new LiteralMapper *[1];
+   _mappedLiterals[0] = new LiteralMapper();
+
+   if (log) log->indent() << log->endl() << "About to transform operations" << log->endl() << log->endl();
+
+   return NULL;
+   }
+
+void
+TypeReplacer::transformLiteral(TypeDictionary *dict, LiteralValue *lv)
+   {
+   LiteralMapper *m = new LiteralMapper();
+   Type *t = lv->type();
+   TypeID typeID = t->id();
+
+   if (lv->kind() == T_typename)
+      {
+      Type *namedType = lv->getType();
+      auto it = _typeMappers.find(namedType);
+      TypeMapper *typeMapper = it->second;
+      for (int i=0;i < typeMapper->size();i++)
+         m->add(LiteralValue::create(dict, m->next()));
+      }
+   else if (_explodedType.find(t) != _explodedType.end())
+      m = t->explode(lv);
+   else if (_modifiedType.find(t) != _modifiedType.end())
+      {
+      // TODO: m = t->convert(lv, _typeMappers.find(t));
+      }
+   else
+      m = new LiteralMapper(lv);
+
+   _literalMappers[lv] = m;
+   }
+
+Builder *
+TypeReplacer::transformOperation(Operation * op)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   TypeDictionary *dict = _fb->dict();
+   Builder *b = NULL;
+
+   LOG_INDENT_REGION(log)
+      {
+      int numMaps = 0;
+      bool cloneNeeded = false;
+
+      // make sure there are enough mapper slots for this operation's result Values
+      if (op->numResults() > _mappedResultsSize)
+         {
+         delete[] _mappedResults;
+         _mappedResults = new ValueMapper *[op->numResults()];
+         _mappedResultsSize = op->numResults();
+         }
+
+      for (int i=0;i < _mappedResultsSize;i++)
+         _mappedResults[i] = new ValueMapper();
+      // mapOperation() will add result Values to the result mappers as they are mapped
+      // nothing more to do here
+
+      // make sure there are enough mapper slots for this operation's operands Values
+      if (op->numOperands() > _mappedOperandsSize)
+         {
+         delete[] _mappedOperands;
+         _mappedOperands = new ValueMapper *[op->numOperands()];
+         _mappedOperandsSize = op->numOperands();
+         }
+
+      // fill in appropriate mappers based on this operation's operand Values
+      for (int o=0;o < op->numOperands();o++)
+         {
+         Value *v = op->operand(o);
+         auto it = _valueMappers.find(v);
+         assert(it != _valueMappers.end()); // must have been produced earlier
+         ValueMapper *valueMapper = it->second;
+         _mappedOperands[o] = valueMapper;
+         valueMapper->start();
+         if (valueMapper->size() != 1 || valueMapper->current()->id() != v->id())
+            cloneNeeded = true;
+         int s = valueMapper->size();
+         if (s > numMaps)
+            numMaps = s;
+         }
+
+      // make sure there are enough mappers for this operation's LiteralValues
+      if (op->numLiterals() > _mappedLiteralsSize)
+         {
+         delete[] _mappedLiterals;
+         _mappedLiterals = new LiteralMapper *[op->numLiterals()];
+         _mappedLiteralsSize = op->numLiterals();
+         }
+
+      // transform literals as needed and fill in appropriate mappers for this operation's LiteralValues
+      for (int l=0;l < op->numLiterals();l++)
+         {
+         LiteralValue *lv = op->literal(l);
+         if (_literalMappers.find(lv) == _literalMappers.end())
+            transformLiteral(dict, lv);
+
+         auto it = _literalMappers.find(lv);
+         assert(it != _literalMappers.end());
+         LiteralMapper *literalMapper = it->second;
+         _mappedLiterals[l] = literalMapper;
+         literalMapper->start();
+
+         if (literalMapper->size() != 1
+             || (literalMapper->current()->type() != NULL && literalMapper->current()->type()->id() != lv->type()->id()))
+            cloneNeeded = true;
+
+         int s = _mappedLiterals[l]->size();
+         if (s > numMaps)
+            numMaps = s;
+         }
+
+      // make sure there are enough mappers for this operation's Symbols
+      if (op->numSymbols() > _mappedSymbolsSize)
+         {
+         delete[] _mappedSymbols;
+         _mappedSymbols = new SymbolMapper *[op->numSymbols()];
+         _mappedSymbolsSize = op->numSymbols();
+         }
+
+      // fill in appropriate mappers for this operations Symbols
+      for (int i=0;i < op->numSymbols();i++)
+         {
+         Symbol *sym = op->symbol(i);
+         if (_modifiedType.find(sym->type()) != _modifiedType.end())
+            cloneNeeded = true;
+
+         auto it = _symbolMappers.find(sym);
+         assert(it != _symbolMappers.end());
+         SymbolMapper *symbolMapper = it->second;
+         _mappedSymbols[i] = symbolMapper;
+         symbolMapper->start();
+
+         if (symbolMapper->size() != 1 || symbolMapper->current()->id() != sym->id())
+            cloneNeeded = true;
+
+         int s = it->second->size();
+         if (s > numMaps)
+            numMaps = s;
+         }
+
+      // make sure there are enough mappers for this operation's Types
+      if (op->numTypes() > _mappedTypesSize)
+         {
+         delete[] _mappedTypes;
+         _mappedTypes = new TypeMapper *[op->numTypes()];
+         _mappedTypesSize = op->numTypes();
+         }
+
+      // fill in appropriate mappers for this operation's Types
+      for (int t=0;t < op->numTypes();t++)
+         {
+         Type *type = op->type(t);
+         auto it = _typeMappers.find(type);
+         assert(it != _typeMappers.end());
+         TypeMapper *typeMapper = it->second;
+         _mappedTypes[t] = typeMapper;
+         typeMapper->start();
+
+         if (typeMapper->size() != 1 || typeMapper->current()->id() != type->id())
+            cloneNeeded = true;
+
+         int s = it->second->size();
+         if (s > numMaps)
+            numMaps = s;
+         }
+
+      // make sure there are enough mappers for this operation's Builders
+      if (op->numBuilders() > _mappedBuildersSize)
+         {
+         delete[] _mappedBuilders;
+         _mappedBuilders = new BuilderMapper *[op->numBuilders()];
+         _mappedBuildersSize = op->numBuilders();
+         }
+
+      // no Builder mappings are done at this time, so just create a mapper for each Builder
+      //   initialized with the operation's original Builder
+      for (int b=0;b < op->numBuilders();b++)
+         {
+         _mappedBuilders[b] = new BuilderMapper(op->builder(b));
+         if (numMaps < 1)
+            numMaps = 1;
+         }
+
+      if (!cloneNeeded)
+         {
+         if (log) log->indent() << "No clone needed, using original operation result(s) if any" << log->endl();
+
+         // just map results to themselves and we're done
+         for (int i=0;i < op->numResults();i++)
+            {
+            Value *result = op->result(i);
+            _valueMappers[result] = new ValueMapper(result);
+            }
+         return NULL;
+         }
+
+      // otherwise this operation needs to be cloned
+      b = fb()->OrphanBuilder();
+      cloneOperation(b, op, numMaps);
+
+      // store any new result mappings
+      for (int i=0;i < op->numResults();i++)
+         {
+         Value *result = op->result(i);
+         assert(_valueMappers.find(result) == _valueMappers.end());
+         _valueMappers[result] = _mappedResults[i];
+         }
+      }
+   LOG_OUTDENT
+   return b;
+   }
+
+void
+TypeReplacer::cloneOperation(Builder *b, Operation *op, int numMaps)
+   {
+   TextWriter *log = _fb->logger(traceEnabled());
+   if (log) log->indent() << "Cloning operation" << log->endl();
+   switch (op->action())
+      {
+      // TODO: Return needs special handling eventually if returnType was exploded
+      //       (currently, not supported to explode a return type)
+
+#if 0
+      case aIndexAt :
+         {
+         Type *ptrType = op->type();
+         assert(ptrType->isPointer());
+         Type *baseType = static_cast<PointerType *>(ptrType)->BaseType();
+
+         if (_explodedType.find(baseType) != _explodedType.end())
+            {
+            // IndexAt for a pointer to an exploded type should be exploded
+
+            assert(numMaps == 1); // not expecting IndexAt to be exploded already
+            // we need to explode the result of the IndexAt to Add the offsets for the exploded type elements
+
+            // first, clone the IndexAt and collect its result
+            ValueMapper **indexAtResults = new ValueMapper *[1];
+            ValueMapper *indexAtResult = indexAtResults[0] = new ValueMapper();
+            op->cloneTo(b, indexAtResults, _mappedOperands, _mappedTypes, _mappedLiterals, _mappedSymbols, _mappedBuilders);
+
+            // now, iterate over the exploded type fields, Adding each ones's offset to the IndexAt result
+            // and collecting those results into the operation's resultMappers
+            auto it = _typeMappers.find(baseType);
+            TypeMapper *m = it->second;
+            TypeDictionary *dict = ptrType->owningDictionary();
+            for (int i=0;i < m->size();i++)
+               {
+               size_t offset = m->offset();
+               Type *type = m->next();
+               Type *destType = dict->PointerTo(type);
+               transformTypeIfNeeded(dict, destType);
+               Value *convertedPtr = b->CoercePointer(destType, indexAtResult->next());
+               _mappedResults[0]->add(b->Add(convertedPtr, b->ConstInt64(offset)));
+               }
+
+            delete indexAtResult;
+            delete[] indexAtResults;
+
+            return; // cloning is complete at this point
+            }
+         }
+         break;
+#endif
+
+      case aLoadAt :
+      case aStoreAt :
+         {
+         Type *ptrType = op->operand(0)->type();
+         assert(ptrType->isPointer());
+         TypeDictionary *dict = ptrType->owningDictionary();
+         Type *baseType = static_cast<PointerType *>(ptrType)->BaseType();
+
+         if (_explodedType.find(baseType) != _explodedType.end())
+            {
+            // convert to sequence of LoadIndirect/StoreIndirect for each field in layout
+            StructType *layout = baseType->layout();
+            assert(layout);
+
+            bool isLoad = (op->action() == aLoadAt);
+            assert(_mappedOperands[0]->size() == 1);
+            Value *basePtr = b->CoercePointer(dict->PointerTo(layout), _mappedOperands[0]->next());
+            for (auto it = layout->FieldsBegin(); it != layout->FieldsEnd(); it++)
+               {
+               FieldType *fType = it->second;
+               if (isLoad)
+                  _mappedResults[0]->add(b->LoadIndirect(fType, basePtr));
+               else
+                  b->StoreIndirect(fType, basePtr, _mappedOperands[1]->next());
+               }
+            return;
+#if 0
+            // need to specialize the TypeMapper for this operation
+            assert(_mappedTypesSize == 1);
+            auto it = _typeMappers.find(baseType);
+            TypeMapper *m = it->second;
+            TypeMapper **newMappers = new TypeMapper *[1];
+            TypeMapper *newMapper = newMappers[0] = new TypeMapper();
+            TypeDictionary *dict = ptrType->owningDictionary();
+            for (int i=0;i < m->size();i++)
+               {
+               Type *newPtrType = dict->PointerTo(m->next());
+               transformTypeIfNeeded(dict, newPtrType);
+               newMapper->add(newPtrType);
+               }
+            // dodn't delete _mappedTypes[0] because it originally came from _typeMappers (stll live)
+            delete[] _mappedTypes;
+            _mappedTypes = newMappers;
+#endif
+            }
+         }
+         break;
+
+   //
+   // Special user operation handling
+   // BEGIN {
+
+   // } END
+   // Special user operation handling
+   //
+
+      default:
+         break;
+      } // switch(op->action())
+
+   // otherwise, map the operation generically
+   for (int i=0;i < numMaps;i++)
+      op->cloneTo(b, _mappedResults, _mappedOperands, _mappedTypes, _mappedLiterals, _mappedSymbols, _mappedBuilders);
+   }
+
+FunctionBuilder *
+TypeReplacer::transformFunctionBuilderAtEnd(FunctionBuilder * fb)
+   {
+   finalCleanup(fb);
+   return NULL;
+   }
+
+void
+TypeReplacer::finalCleanup(FunctionBuilder * fb)
+   {
+   TextWriter *log = fb->logger(traceEnabled());
+   if (log) log->indent() << "Final stage: removing types (" << _typesToRemove.size() << " types registered for removal):" << log->endl();
+
+   LOG_INDENT_REGION(log)
+      {
+      TypeDictionary *dict = fb->dict();
+      for (auto typeIt = _typesToRemove.begin(); typeIt != _typesToRemove.end(); typeIt++)
+         {
+         Type *typeToRemove = *typeIt;
+         if (typeToRemove->isField())
+            {
+            // be careful: make sure owning struct isn't marked for removal
+            //             if it is, then we would remove this field type twice
+            FieldType *fType = static_cast<FieldType *>(typeToRemove);
+            if (fType->owningStruct()->owningDictionary() == dict
+                && _typesToRemove.find(fType->owningStruct()) != _typesToRemove.end())
+               {
+               if (log) log->indent() << "Ignoring field type inside to-be-removed struct: ";
+               if (log) log->writeType(typeToRemove);
+               continue;
+               }
+            }
+         if (log) log->indent() << "Removing ";
+         if (log) log->writeType(typeToRemove);
+         dict->RemoveType(typeToRemove);
+         }
+      }
+   LOG_OUTDENT
+
+   if (log) log->indent() << "Final dictionary:" << log->endl();
+   if (log) log->writeDictionary(fb->dict());
+   }

--- a/jitbuilder/jbil/TypeReplacer.hpp
+++ b/jitbuilder/jbil/TypeReplacer.hpp
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TYPEREPLACER_INCL
+#define TYPEREPLACER_INCL
+
+
+#include <map>
+#include <set>
+#include <vector>
+#include "Transformer.hpp"
+#include "Mapper.hpp"
+#include "Type.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class FieldType;
+class FunctionBuilder;
+class FunctionType;
+class Operation;
+class PointerType;
+class StructType;
+class Type;
+
+class TypeReplacer : public Transformer
+   {
+public:
+   TypeReplacer(FunctionBuilder * fb);
+
+   // all references of oldType will be changed to newType
+   // when transform() returns, there will be no remaining references to oldType
+   // (though the type itself is not erased from the FunctionBuilder's TypeDictionary)
+   TypeReplacer *replace(Type *oldType, Type *newType=NULL);
+
+   // type must return a non-NULL layout()
+   // when transform() returns, there will be no remaining references to type
+   // (though the type itself is not erased from the FunctionBuilder's TypeDictionary)
+   TypeReplacer *explode(Type *type);
+
+   void transformTypes(TypeDictionary *dict);
+   void finalCleanup(FunctionBuilder * fb);
+
+protected:
+   // override Transformer functions
+   virtual FunctionBuilder * transformFunctionBuilder(FunctionBuilder * fb);
+   virtual Builder * transformOperation(Operation * op);
+   virtual FunctionBuilder * transformFunctionBuilderAtEnd(FunctionBuilder * fb);
+
+   // overrideable functions from TypeReducer
+   virtual void cloneOperation(Builder *b, Operation *op, int numMaps);
+
+   // helper functions
+   void recordMapper(Type *type, TypeMapper *mapper);
+   void recordOriginalType(Type *type);
+   Type * singleMappedType(Type *type);
+   Type * mappedLayout(Type *t);
+   std::string explodedName(std::string & name, FieldType *field);
+
+   void explodeLayoutTypes(TypeDictionary *dict, StructType *layout, size_t baseOOffset, TypeMapper *m);
+   void transformExplodedType(TypeDictionary *dict, Type *type);
+   void transformPointerType(TypeDictionary *dict, PointerType *ptrType);
+   void transformStructFields(TypeDictionary *dict, StructType *origStruct, StructType *structType, std::string baseName, size_t baseOffset, StructType *type, TypeMapper *mapper);
+   void transformStructType(TypeDictionary *dict, StructType *sType);
+   void transformFunctionType(TypeDictionary *dict, FunctionType *fnType);
+   void transformLiteral(TypeDictionary *dict, LiteralValue *lv);
+   void transformTypeIfNeeded(TypeDictionary *dict, Type *type);
+
+   bool                                     _typesTransformed;
+
+   std::set<Type *>                         _typesToRemove;
+
+   std::set<TypeID>                         _typesToExplode;
+   std::map<TypeID,TypeID>                  _typesToReplace;
+
+   std::map<LiteralValue *,LiteralMapper *> _literalMappers;
+   std::map<Symbol *,SymbolMapper *>        _symbolMappers;
+   std::map<Type *,TypeMapper *>            _typeMappers;
+   std::map<Value *,ValueMapper *>          _valueMappers;
+
+   std::set<Type *>                         _explodedType;
+   std::set<Type *>                         _modifiedType;
+   std::set<Type *>                         _examinedType;
+
+   // below are mappers that will be initialized according to the current operation
+   size_t _mappedResultsSize;
+   ValueMapper **_mappedResults;
+
+   size_t _mappedOperandsSize;
+   ValueMapper **_mappedOperands;
+
+   size_t _mappedSymbolsSize;
+   SymbolMapper **_mappedSymbols;
+
+   size_t _mappedLiteralsSize;
+   LiteralMapper **_mappedLiterals;
+
+   size_t _mappedTypesSize;
+   TypeMapper **_mappedTypes;
+
+   size_t _mappedBuildersSize;
+   BuilderMapper **_mappedBuilders;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(TYPEREPLACER_INCL)

--- a/jitbuilder/jbil/Value.cpp
+++ b/jitbuilder/jbil/Value.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Value.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+
+using namespace OMR::JitBuilder;
+
+int64_t OMR::JitBuilder::Value::globalIndex = 0;
+
+Value *
+Value::create(Builder * parent, Type * type)
+   {
+   Value *value = new Value(parent, type);
+   parent->fb()->registerObject(value);
+   return value;
+   }
+
+Value::Value(Builder * parent, Type * type)
+   : Object(parent->fb())
+   , _id(globalIndex++)
+   , _parent(parent)
+   , _type(type)
+   { }

--- a/jitbuilder/jbil/Value.hpp
+++ b/jitbuilder/jbil/Value.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef VALUE_INCL
+#define VALUE_INCL
+
+#include <stdint.h>
+#include <vector>
+#include <iostream>
+#include "Object.hpp"
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Builder;
+class BuilderBase;
+class OperationCloner;
+class Type;
+
+class Value : public Object
+   {
+   friend class Builder;
+   friend class BuilderBase;
+   friend class OperationCloner;
+
+public:
+   uint64_t id() const           { return _id; }
+   Type * type() const           { return _type; }
+
+   virtual size_t size() const   { return sizeof(Value); }
+
+   static uint64_t maxID()       { return globalIndex; }
+
+protected:
+   static Value * create(Builder * parent, Type * type);
+   Value(Builder * parent, Type * type);
+
+   int64_t   _id;
+   Builder * _parent;
+   Type    * _type;
+
+   static int64_t globalIndex;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(VALUE_INCL)

--- a/jitbuilder/jbil/Visitor.cpp
+++ b/jitbuilder/jbil/Visitor.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "Visitor.hpp"
+#include "Builder.hpp"
+#include "FunctionBuilder.hpp"
+#include "TextWriter.hpp"
+
+void
+OMR::JitBuilder::Visitor::start()
+   {
+   visitBegin();
+
+   BuilderWorklist worklist;
+   std::vector<bool> visited(Builder::maxIndex());
+
+   visitFunctionBuilderPreOps(_fb);
+   visitOperations(_fb, worklist);
+   visitFunctionBuilderPostOps(_fb);
+
+   while(!worklist.empty())
+      {
+      Builder *b = worklist.back();
+      visitBuilder(b, visited, worklist);
+      worklist.pop_back();
+      }
+   visitEnd();
+   }
+
+void
+OMR::JitBuilder::Visitor::start(Builder * b)
+   {
+   BuilderWorklist worklist;
+   std::vector<bool> visited(Builder::maxIndex());
+   visitBuilder(b, visited, worklist);
+   }
+
+void
+OMR::JitBuilder::Visitor::start(Operation * op)
+   {
+   visitOperation(op);
+   }
+
+void
+OMR::JitBuilder::Visitor::visitBuilder(Builder *b, std::vector<bool> & visited, BuilderWorklist & worklist)
+   {
+   int64_t id = b->id();
+   if (visited[id])
+      return;
+
+   visited[id] = true;
+
+   visitBuilderPreOps(b);
+   visitOperations(b, worklist);
+   visitBuilderPostOps(b);
+   }
+
+void
+OMR::JitBuilder::Visitor::visitOperations(Builder *b, BuilderWorklist & worklist)
+   {
+   for (OperationIterator opIt = b->OperationsBegin(); opIt != b->OperationsEnd(); opIt++)
+      {
+      Operation * op = *opIt;
+      visitOperation(op);
+
+      for (BuilderIterator bIt = op->BuildersBegin(); bIt != op->BuildersEnd(); bIt++)
+         {
+         Builder * inner_b = *bIt;
+         if (inner_b)
+            worklist.push_front(inner_b);
+         }
+      }
+   }
+
+void
+OMR::JitBuilder::Visitor::trace(std::string msg)
+   {
+   TextWriter *log = _fb->logger();
+   if (log)
+      {
+      log->indent() << msg << log->endl();
+      }
+   }
+

--- a/jitbuilder/jbil/Visitor.hpp
+++ b/jitbuilder/jbil/Visitor.hpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef VISITOR_INCL
+#define VISITOR_INCL
+
+#include <vector>
+#include <deque>
+#include "Object.hpp"
+
+
+namespace OMR
+{
+
+namespace JitBuilder
+{
+
+class Type;
+class TypeDictionary;
+class FunctionBuilder;
+class Builder;
+class Operation;
+
+typedef std::deque<Builder *> BuilderWorklist;
+
+class Visitor
+   {
+   public:
+   Visitor(FunctionBuilder * fb, bool visitAppendedBuilders=false)
+      : _fb(fb)
+      , _visitAppendedBuilders(visitAppendedBuilders)
+      { }
+
+   void start();
+   void start(Builder * b);
+   void start(Operation * op);
+
+   void setVisitAppendedBuilders(bool v) { _visitAppendedBuilders = v; }
+
+   FunctionBuilder *fb() const { return _fb; }
+
+   protected:
+   void visitBuilder(Builder * b, std::vector<bool> & visited, BuilderWorklist & list);
+   void visitOperations(Builder * b, BuilderWorklist & worklist);
+
+   // subclass Visitor and override these functions as needed
+   virtual void visitBegin()                                      { }
+   virtual void visitFunctionBuilderPreOps(FunctionBuilder * fb)  { }
+   virtual void visitFunctionBuilderPostOps(FunctionBuilder * fb) { }
+   virtual void visitBuilderPreOps(Builder * b)                   { }
+   virtual void visitBuilderPostOps(Builder * b)                  { }
+   virtual void visitOperation(Operation * op)                    { }
+   virtual void visitEnd()                                        { }
+
+   // logging support: output msg to the log if enabled
+   void trace(std::string msg);
+
+   FunctionBuilder * _fb;
+   bool _visitAppendedBuilders;
+   };
+
+} // namespace JitBuilder
+
+} // namespace OMR
+
+#endif // defined(VISITOR_INCL)

--- a/jitbuilder/jbil/complex.hpp
+++ b/jitbuilder/jbil/complex.hpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef COMPLEX_INCL
+#define COMPLEX_INCL
+
+template<typename T> struct complex {
+public:
+   complex() { real=0.0; imag=0.0; }
+   complex(T r, T i) { real = r; imag=i; }
+   T real;
+   T imag;
+};
+
+#endif // defined(COMPLEX_INCL)

--- a/jitbuilder/jbil/testTypeGraph.cpp
+++ b/jitbuilder/jbil/testTypeGraph.cpp
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2021 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <sstream>
+#include "Action.hpp"
+#include "TypeDictionary.hpp"
+#include "TypeGraph.hpp"
+
+using namespace OMR::JitBuilder;
+
+class Tester
+   {
+   public:
+      Tester(bool verbose=false)
+         : _total(0)
+         , _pass(0)
+         , _verbose(verbose)
+         { }
+      void report()
+         {
+         if (_pass == _total)
+            std::cout << "Passed all tests!\n";
+         else
+            std::cout << "Failed some test\n";
+         }
+
+   protected:
+      bool performTest(std::ostringstream & oss)
+         {
+         if (_verbose)
+            std::cout << "[ " << _total << " ] Performing " << oss.str() << "\n";
+         return true;
+         }
+
+      int _total;
+      int _pass;
+      bool _verbose;
+   };
+
+class TypeGraphTester : public Tester
+   {
+public :
+   TypeGraphTester(bool verbose=false)
+      : Tester(verbose)
+      { }
+
+   Type ** testAllUnaryTypeCombinations(TypeGraph & g, Action a, int numTypes, Type ** types)
+      {
+      Type **results = new Type *[numTypes];
+      for (int t = 0;t < numTypes; t++)
+         {
+         results[t] = g.producedType(a, types[t]);
+         }
+      return results;
+      }
+
+   Type *** testAllBinaryTypeCombinations(TypeGraph & g, Action a, int numTypes, Type ** types)
+      {
+      Type ***results = new Type **[numTypes];
+      for (int t1 = 0;t1 < numTypes;t1++)
+         {
+         results[t1] = new Type *[numTypes];
+         for (int t2 = 0;t2 < numTypes; t2++)
+            {
+            results[t1][t2] = g.producedType(a, types[t1], types[t2]);
+            }
+         }
+      return results;
+      }
+
+   int countProducedTypes(int numTypes, Type ** results)
+      {
+      int numNonNullResults = 0;
+      for (int t = 0;t < numTypes;t++)
+         {
+         numNonNullResults += (results[t] != NULL) ? 1 : 0;
+         }
+      return numNonNullResults;
+      }
+
+   int countProducedTypes(int numTypes, Type *** results)
+      {
+      int numNonNullResults = 0;
+      for (int t1 = 0;t1 < numTypes;t1++)
+         {
+         for (int t2 = 0;t2 < numTypes; t2++)
+            {
+            numNonNullResults += (results[t1][t2] != NULL) ? 1 : 0;
+            }
+         }
+      return numNonNullResults;
+      }
+
+   void testSingleTypeProducedBinaryActions()
+      {
+      std::cout << "Binary operation tests:\n";
+
+      int pass=0;
+      int total=0;
+      TypeDictionary types;
+
+      Action actions[] = {
+                         aAdd,
+                         aSub,
+                         aMul
+                         };
+      const int numActions = sizeof(actions) / sizeof (Action);
+      const char *actionName[] = {
+                                  "Add",
+                                  "Sub",
+                                  "Mul"
+                                  };
+      const int numActionNames = sizeof(actionName) / sizeof (const char *);
+      static_assert(numActionNames == numActions, "wrong number of action names");
+
+      Type * baseTypes[] = {
+                           types.NoType,
+                           types.Int8,
+                           types.Int16,
+                           types.Int32,
+                           types.Int64,
+                           types.Float,
+                           types.Double
+                           };
+      const int numTypes = sizeof(baseTypes) / sizeof (Type *);
+   
+      for (int aIdx = 0;aIdx < numActions;aIdx++)
+         {
+         Action a = actions[aIdx];
+         for (int t1Idx=0;t1Idx < numTypes;t1Idx++)
+            {
+            Type * t1 = baseTypes[t1Idx];
+            for (int t2Idx=0;t2Idx < numTypes; t2Idx++)
+               {
+               Type * t2 = baseTypes[t2Idx];
+               for (int t3Idx=0;t3Idx < numTypes; t3Idx++)
+                  {
+                  Type * t3 = baseTypes[t3Idx];
+
+                  std::ostringstream oss;
+                  oss << "Test " << t1->name() << " <- " << actionName[aIdx] << "( " << t2->name() << ", " << t3->name() << " )";
+                  if (performTest(oss))
+                     {
+                     // initialize a graph with a set of types
+                     TypeGraph g(&types);
+                     for (int tt=0;tt < numTypes;tt++)
+                        g.registerType(baseTypes[tt]);
+   
+                     // permit only one possible combination for this action and type
+                     g.registerValidOperation(t1, a, t2, t3);
+   
+                     // test all combinations and capture results
+                     Type *** r = testAllBinaryTypeCombinations(g, a, numTypes, baseTypes);
+   
+                     // validate only one result possible and that it's the one we expect
+                     int c = countProducedTypes(numTypes, r);
+                     if (c == 1 && r[t2Idx][t3Idx] == t1)
+                        _pass++;
+                     else
+                        {
+                        std::cout << "Fail: c is " << c << " (expecting 1) and produced type is ";
+                        if (r[t2Idx][t3Idx])
+                           std::cout << r[t2Idx][t3Idx]->name() << " (expecting " << t1->name() << ")\n";
+                        else
+                           std::cout << "nullptr (expecting " << t1->name() << ")\n";
+                        }
+
+                     _total++;
+
+                     // release the results array
+                     for (int tt=0;tt < numTypes;tt++)
+                       delete[] r[tt];
+                     delete[] r;
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+   void testSingleTypeProducedUnaryActions()
+      {
+      std::cout << "Unary operation tests:\n";
+
+      int pass=0;
+      int total=0;
+      TypeDictionary types;
+
+      Action actions[] = {
+                         aStore,
+                         aIfThenElse,
+                         aSwitch,
+                         };
+      const int numActions = sizeof(actions) / sizeof (Action);
+      const char *actionName[] = {
+                                  "Store",
+                                  "IfThenElse",
+                                  "Switch"
+                                  };
+      const int numActionNames = sizeof(actionName) / sizeof (const char *);
+      static_assert(numActionNames == numActions, "wrong number of action names");
+
+      Type * baseTypes[] = {
+                           types.NoType,
+                           types.Int8,
+                           types.Int16,
+                           types.Int32,
+                           types.Int64,
+                           types.Float,
+                           types.Double
+                           };
+      const int numTypes = sizeof(baseTypes) / sizeof (Type *);
+   
+      for (int aIdx = 0;aIdx < numActions;aIdx++)
+         {
+         Action a = actions[aIdx];
+         for (int t1Idx=0;t1Idx < numTypes;t1Idx++)
+            {
+            Type * t1 = baseTypes[t1Idx];
+            for (int t2Idx=0;t2Idx < numTypes; t2Idx++)
+               {
+               Type * t2 = baseTypes[t2Idx];
+
+               std::ostringstream oss;
+               oss << "Test " << t1->name() << " <- " << actionName[aIdx] << "( " << t2->name() << " )";
+               if (performTest(oss))
+                  {
+                  // initialize a graph with a set of types
+                  TypeGraph g(&types);
+                  for (int tt=0;tt < numTypes;tt++)
+                     g.registerType(baseTypes[tt]);
+
+                  // permit only one possible combination for this action and type
+                  g.registerValidOperation(t1, a, t2);
+
+                  // test all combinations and capture results
+                  Type ** r = testAllUnaryTypeCombinations(g, a, numTypes, baseTypes);
+
+                  // validate only one result possible and that it's the one we expect
+                  int c = countProducedTypes(numTypes, r);
+                  if (c == 1 && r[t2Idx] == t1)
+                     _pass++;
+                  else
+                     {
+                     std::cout << "Fail: c is " << c << " (expecting 1) and produced type is ";
+                     if (r[t2Idx])
+                        std::cout << r[t2Idx]->name() << " (expecting " << t1->name() << ")\n";
+                     else
+                        std::cout << "nullptr (expecting " << t1->name() << ")\n";
+                     }
+
+                  _total++;
+
+                  // release the results array
+                  delete[] r;
+                  }
+               }
+            }
+         }
+      }
+   };
+
+int
+main(int argc, char *argv[])
+   {
+   bool verbose=false;
+   for (int a=1; a < argc; a++)
+      {
+      if (strncmp(argv[a], "-verbose", strlen("-verbose")) == 0)
+         verbose = true;
+      else
+         {
+         std::cerr << "Error: unrecognized option " << argv[a] << ", aborting without running tests\n";
+         exit(-1);
+         }
+      }
+
+   TypeGraphTester t(verbose);
+
+   t.testSingleTypeProducedBinaryActions();
+   t.testSingleTypeProducedUnaryActions();
+
+   t.report();
+   }

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -134,6 +134,7 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::treeSimplification,                        OMR::IfEnabled                },
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup                                },
+   { OMR::localDeadStoreElimination,                                               },
    { OMR::globalDeadStoreGroup,                                                    },
    { OMR::redundantGotoElimination,                  OMR::IfEnabled                }, // if global register allocator created new block
    { OMR::rematerialization                                                        },
@@ -197,6 +198,8 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
       new (comp->allocator()) TR::OptimizationManager(self(), TR_TrivialInliner::create, OMR::inlining);
    _opts[OMR::switchAnalyzer] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR::SwitchAnalyzer::create, OMR::switchAnalyzer);
+   _opts[OMR::localDeadStoreElimination] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalDeadStoreElimination::create, OMR::localDeadStoreElimination);
 
    // Initialize optimization groups
    _opts[OMR::cheapTacticalGlobalRegisterAllocatorGroup] =


### PR DESCRIPTION
**I've marked this PR as WIP to say: even if you're wiling, I think you'll be wasting your time if you go through this PR with a fine toothed comb.**

This PR contains the initial commit for JitBuilder2, an enhanced version of JitBuilder that currently relies on JitBuilder (and hence Ecllipse OMR compiler) for code generation. Please note that JitBuilder2 does not contain a lot of JitBuilder API (so this is still properly considered a prototype). Eventually, JitBuilder2 will eliminate its dependence on JitBuilder and generate directly to the Eclipse OMR compiler (or, in principle, any other compiler back end). There are a few small commits to the OMR compiler and JitBuilder that facilitate JitBuilder2. The entire JitBuilder2 code base is brought in as a single huge commit, which I am fully aware makes for a difficult review process. Like other initial commits that squash history, however, I felt that collapsing the history was better, that the blow-by-blow commit history would not have helped with the challenge to review so much code.

The code is currently disconnected from Eclipse OMR: it's not part of the make system at all. I have located the code in the `omr/jitbuilder/jbil` directory as a starting point. There is a simple `Makefile` in that directory that can be used to build it. This `Makefile` assumes that the JitBuilder library has already been built in OMR, and it assumes that was done in the `omr/build` directory (easily changeable at the top of the `Makefile`).

I am submitting this as a pull request for review, although there are lots of things about this implementation that I'm not happy about. Nonetheless, at over 9,300 lines of code and being reasonably operational, I'm starting to feel pretty silly holding it back. Many of the things I'm unhappy about, however, may also be things people will be unhappy to see in the project proper, so we'll need to make a decision about how to move this forward. We could force me to make all requested fixes to the code, we could put the code in a branch until it's ready to be brought into the code base, or we could pull it into the code base and simply accept that it's still under development, in a well scoped part of the repository, and does not currently impact the quality of any of the existing OMR components. I welcome people's thoughts here.

The coolest parts of this new compiler are the newest bits: TypeReplacer.cpp and Debugger.cpp . TypeReplacer establishes a model for how user defined Types can be worked with in the compiler. Debugger provides an IL level debug environment that leverages the compiler itself in interesting ways so that it can single step through complex IL operations without requiring an "interpreter" or second implementation of the semantics of these operations. So long as the compiler has been taught how to generate code for a user-defined operation or type, the Debugger should be able to debug it (that's the theory, anyway).

*** 2021-08-04 Update Begin ***
I have tacked in some additional commits to include support to dynamically add new Types and Operations into the compiler. By constructing an OperationBuilder you can dynamically define a new kind of Operation. That OperationBuilder can then be used to instantiate specific Operations into a Builder object (filling in the operands, symbols, literals, builders, types and generating result values). A DynamicType can be used to create an object that represents a new primitive type. The main concept behind such a type is that you need to define its "layout" which is a StructType defining how values of the type are laid out. From this layout struct, TypeReplacer has a mechanism to "lower" uses of the type into known types so that code can be generated, the debugger can operate on it, etc. Dynamic types are added to a TypeDictionary. These dynamic types and operations can set up rules in the TypeGraph so that only permitted combinations are permitted, although this facility isn't really as general as it should be. The advantage of specifying dynamic types and operations is that you don't have to modify the base Operation, Builder, Type, etc. classes. In fact, the support for new types and operations can be implemented in a separate file that doesn't have to become part of the JitBuilder2 library. I demonstrate that with a ComplexSupport file that adds support for a simple Complex type and used in memory and simple calculations. It also introduces a new operation called ConstComplex. I also included ComplexMatMult that demonstrates how little needed to be changed to turn the regular "Double" MatMult code sample into a Complex matrix multiplication sample. The Debugger works on ComplexMatMult *unmodified*: you can single step, print values and symbols (even if they have Complex type), and set breakpoints throughout the execution of the sample.
** 2021-08-04 Update End ***

I'll present a bit about JitBuilder2 in the next OMR architecture meeting on the afternoon of August 5, including some thoughts on where I intend to go next with it (see #6110 for details on how to join).