### PR TITLE
RISC-V: implement areturn evaluator

### DIFF
--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,11 +51,16 @@ OMR::RV::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return genericReturnEvaluator(node, cg->getProperties().getIntegerReturnRegister(), TR_GPR, TR_IntReturn, cg);
    }
 
-// also handles areturn
 TR::Register *
 OMR::RV::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return genericReturnEvaluator(node, cg->getProperties().getLongReturnRegister(), TR_GPR, TR_LongReturn, cg);
+   }
+
+TR::Register *
+OMR::RV::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return genericReturnEvaluator(node, cg->getProperties().getLongReturnRegister(), TR_GPR, TR_ObjectReturn, cg);
    }
 
 // void return

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -299,12 +299,6 @@ OMR::RV::TreeEvaluator::GotoEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
-OMR::RV::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::lreturnEvaluator(node, cg);
-   }
-
-TR::Register*
 OMR::RV::TreeEvaluator::ReturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::returnEvaluator(node, cg);


### PR DESCRIPTION
We cannot simply use lreturn evaluator since areturn *must* use
TR_ObjectReturn as return info even though on RV64 both as 64bits. 
Otherwise, the J9's bytecode interpreter would crash upon return from 
JITed code in really confusing way.

Took me a looong evening to single-step through interpreter to figure this out...