### PR TITLE
Clean up TR_AOT and TR_(En|Dis)ableCompilationThread

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1232,7 +1232,7 @@ static void lookupScheme3(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced
       }
 
    /* TODO: AOT fixup */
-   if (!cg->comp()->getOption(TR_AOT))
+   if (!cg->comp()->compileRelocatableCode())
       {
       armLoadConstant(node, address, addrRegister, cg, NULL);
       }

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -1346,10 +1346,10 @@ static void loadRelocatableConstant(TR::Node               *node,
    bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
    bool isClass = isStatic && symbol->isClassObject();
    bool isPicSite = isClass;
-   if (isPicSite && !cg->comp()->compileRelocatableCode()
+   if (isPicSite
+       && !cg->comp()->compileRelocatableCode()
        && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)symbol->getStaticSymbol()->getStaticAddress(), node))
       {
-      TR_ASSERT(!comp->getOption(TR_AOT), "HCR: AOT is currently no supported");
       intptr_t address = (intptr_t)symbol->getStaticSymbol()->getStaticAddress();
       loadAddressConstantInSnippet(cg, node ? node : cg->getCurrentEvaluationTreeTop()->getNode(), address, reg); // isStore ? TR::InstOpCode::Op_st : TR::InstOpCode::Op_load
       return;

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -122,8 +122,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"alwaysFatalAssert",       "I\tAlways execute fatal assertion for testing purposes",           SET_OPTION_BIT(TR_AlwaysFatalAssert), "F"},
    {"alwaysSafeFatalAssert", "I\tAlways issue a safe fatal assertion for testing purposes",      SET_OPTION_BIT(TR_AlwaysSafeFatal), "F"},
    {"alwaysWorthInliningThreshold=", "O<nnn>\t", TR::Options::set32BitNumeric, offsetof(OMR::Options, _alwaysWorthInliningThreshold), 0, "F%d" },
-   {"aot",                "O\tahead-of-time compilation",
-        SET_OPTION_BIT(TR_AOT), "F", NOT_IN_SUBSET},
    {"aotOnlyFromBootstrap", "O\tahead-of-time compilation allowed only for methods from bootstrap classes",
         SET_OPTION_BIT(TR_AOTCompileOnlyFromBootstrap), "F", NOT_IN_SUBSET },
    {"aotrtDebugLevel=", "R<nnn>\tprint aotrt debug output according to level", TR::Options::set32BitNumeric, offsetof(OMR::Options,_newAotrtDebugLevel), 0, "F%d"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -287,7 +287,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableCompactNullChecks",           "O\tdisable compact null checks",                    TR::Options::disableOptimization, compactNullChecks, 0, "P"},
    {"disableCompareAndBranchInstruction", "O\tdisable compareAndBranch instruction",           SET_OPTION_BIT(TR_DisableCompareAndBranchInstruction), "F"},
    {"disableCompilationAfterDLT",         "O\tdisable queueing of normal compilation for method that has been DLT compiled.", SET_OPTION_BIT(TR_DisableCompilationAfterDLT), "F"},
-   {"disableCompilationThread",           "M\tdisable compilation on a separate thread",       SET_OPTION_BIT(TR_DisableCompilationThread), "F"},
    {"disableConservativeColdInlining",   "O\tDo not be conservative with inlining at cold", SET_OPTION_BIT(TR_DisableConservativeColdInlining), "F" },
    {"disableConservativeHotRecompForServerMode", "R\tDo not be more conservative in server mode", SET_OPTION_BIT(TR_DisableConservativeHotRecompilationForServerMode), "F", NOT_IN_SUBSET},
    {"disableConservativeInlining",        "O\tDo not be conservative with inlining", SET_OPTION_BIT(TR_DisableConservativeInlining), "F" },
@@ -2284,9 +2283,6 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableConservativeColdInlining);
          TR::Options::getCmdLineOptions()->setOption(TR_DisableConservativeColdInlining);
          }
-
-      if (self()->getOption(TR_DisableCompilationThread))
-         self()->setOption(TR_DisableNoVMAccess);
 
       // YieldVMAccess and NoVMAccess are incompatible. If the user enables YieldVMAccess
       // make sure NoVMAccess is disabled

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -189,7 +189,7 @@ enum TR_CompilationOptions
    TR_DisableAotAtCheapWarm               = 0x00001000 + 3,
    TR_Profile                             = 0x00002000 + 3,
    TR_DisableAsyncCompilation             = 0x00004000 + 3,
-   TR_DisableCompilationThread            = 0x00008000 + 3,
+   // Available                           = 0x00008000 + 3,
    // Available                           = 0x00010000 + 3,
    TR_EnableJITServerHeuristics           = 0x00020000 + 3,
    TR_SoftFailOnAssume                    = 0x00040000 + 3,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -84,7 +84,7 @@ enum TR_CompilationOptions
    // Option word 0
    //
    TR_AOTCompileOnlyFromBootstrap= 0x00000020,
-   TR_AOT                        = 0x00000040,
+   // Available                  = 0x00000040,
    TR_ReportMethodEnter          = 0x00000080,
    TR_ReportMethodExit           = 0x00000100,
    TR_EntryBreakPoints           = 0x00000200,
@@ -190,7 +190,7 @@ enum TR_CompilationOptions
    TR_Profile                             = 0x00002000 + 3,
    TR_DisableAsyncCompilation             = 0x00004000 + 3,
    TR_DisableCompilationThread            = 0x00008000 + 3,
-   TR_EnableCompilationThread             = 0x00010000 + 3,
+   // Available                           = 0x00010000 + 3,
    TR_EnableJITServerHeuristics           = 0x00020000 + 3,
    TR_SoftFailOnAssume                    = 0x00040000 + 3,
    TR_DisableNewBlockOrdering             = 0x00080000 + 3,

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1545,10 +1545,10 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
    bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
    bool isClass = isStatic && symbol->isClassObject();
    bool isPicSite = isClass;
-   if (isPicSite && !cg->comp()->compileRelocatableCode()
+   if (isPicSite
+       && !cg->comp()->compileRelocatableCode()
        && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)symbol->getStaticSymbol()->getStaticAddress(), node))
       {
-      TR_ASSERT(!comp->getOption(TR_AOT), "HCR: AOT is currently no supported");
       TR::Register *reg = _baseRegister = cg->allocateRegister();
       intptr_t address = (intptr_t)symbol->getStaticSymbol()->getStaticAddress();
       loadAddressConstantInSnippet(cg, node ? node : cg->getCurrentEvaluationTreeTop()->getNode(), address, reg, NULL, isStore?TR::InstOpCode::Op_st :TR::InstOpCode::Op_load, false, NULL);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5863,7 +5863,11 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
       else
          {
          int64_t  offset = mref->getOffset(*comp);
-         if (mref->hasDelayedOffset() || !mref->getBaseRegister() || mref->getLabel() || offset!=0 || comp->getOption(TR_AOT))
+         if (mref->hasDelayedOffset()
+             || !mref->getBaseRegister()
+             || mref->getLabel()
+             || offset!=0
+             || comp->compileRelocatableCode())
             {
             resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
             generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, resultReg, mref);

--- a/compiler/p/codegen/PPCAOTRelocation.cpp
+++ b/compiler/p/codegen/PPCAOTRelocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/codegen/PPCAOTRelocation.cpp
+++ b/compiler/p/codegen/PPCAOTRelocation.cpp
@@ -38,7 +38,7 @@
 
 void TR::PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    {
-   if (cg->comp()->getOption(TR_AOT))
+   if (cg->comp()->compileRelocatableCode())
       {
       // The validation and inlined method ExternalRelocations are added after
       // binary encoding is finished so that their actual relocation records


### PR DESCRIPTION
`TR_AOT` is a legacy option that isn't the way AOT compilations are controlled in downstream projects. `TR_EnableCompilationThread`/`TR_DisableCompilationThread` is no longer need in OpenJ9.

Needs to be merged together with https://github.com/eclipse-openj9/openj9/pull/13304 to prevent an OpenJ9 build break.