### PR TITLE
Define nonNullableArrayNullStoreCheck non-helper symbol

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -135,6 +135,22 @@
     */
    objectEqualityComparisonSymbol,
 
+   /**
+    * \brief Tests, in some consumer-specific way, whether the array operand has a component type that
+    * is a non-nullable class, and if so, performs a NULLCHK on the value that needs to be assigned to
+    * an element of the array
+    *
+    * \code
+    *   call <nonNullableArrayNullStoreCheck>
+    *     value-reference-to-be-stored
+    *     array-reference-to-which-value-will-be-stored
+    * \endcode
+    *
+    * \note A call to this symbol is not to be evaluated by code generation; some optimization pass prior to
+    * code generation should transform it to more primitive operations.
+    */
+   nonNullableArrayNullStoreCheckSymbol,
+
    /** \brief
     *
     *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -213,6 +213,19 @@ class SymbolReferenceTable
        */
       objectEqualityComparisonSymbol,
 
+      /**
+       * \brief Tests, in some consumer-specific way, whether the array operand has a component type that
+       * is a non-nullable class, and if so, performs a NULLCHK on the value that needs to be assigned to
+       * an element of the array
+       *
+       * \code
+       *   call <nonNullableArrayNullStoreCheck>
+       *     value-reference-to-be-stored
+       *     array-reference-to-which-value-will-be-stored
+       * \endcode
+       */
+      nonNullableArrayNullStoreCheckSymbol,
+
       /** \brief
        *
        *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -142,6 +142,10 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             {
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
             }
+         if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol))
+            {
+            return &symRefTab->aliasBuilder.defaultMethodUseAliases();
+            }
 
          if (!methodSymbol->isHelper())
             {
@@ -329,7 +333,8 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::osrFearPointHelperSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol) ||
-             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol))
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol))
             {
             return &symRefTab->aliasBuilder.defaultMethodDefAliases();
             }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1656,6 +1656,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<j9VMThreadFloatTemp1Symbol>";
          case TR::SymbolReferenceTable::objectEqualityComparisonSymbol:
              return "<objectEqualityComparison>";
+         case TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol:
+             return "<nonNullableArrayNullStoreCheck>";
          }
       }
 
@@ -2102,6 +2104,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
    "<objectEqualityComparison>",
+   "<nonNullableArrayNullStoreCheck>",
    "<synchronizedFieldLoad>",
    "<atomicAdd>",
    "<atomicFetchAndAdd>",


### PR DESCRIPTION
Downstream projects might define classes that do not permit null references.  This change defines a non-helper symbol that takes an array reference and a value reference as arguments.  A downstream project can use this as a placeholder for a check of whether the component type of an array is a class that does not permit null references, and if so, whether the value that is being assigned to an element of the array is a null reference.