### PR TITLE
Fix compiler warnings

### DIFF
--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,10 +22,10 @@
 #ifndef FRONTEND_INCL
 #define FRONTEND_INCL
 
-//  __   ___  __   __   ___  __       ___  ___  __
-// |  \ |__  |__) |__) |__  /  `  /\   |  |__  |  \
-// |__/ |___ |    |  \ |___ \__, /~~\  |  |___ |__/
-//
+/*  __   ___  __   __   ___  __       ___  ___  __
+ * |  \ |__  |__) |__) |__  /  `  /\   |  |__  |  \
+ * |__/ |___ |    |  \ |___ \__, /~~\  |  |___ |__/
+ */
 
 // The FrontEnd interface is a legacy interface to a language frontend.
 // It is deprecated and new functions should not be added to this interface.

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -19,14 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-//  __   ___  __   __   ___  __       ___  ___  __
-// |  \ |__  |__) |__) |__  /  `  /\   |  |__  |  \
-// |__/ |___ |    |  \ |___ \__, /~~\  |  |___ |__/
-//
-// This file is now deprecated and its contents are slowly
-// being moved back to codegen and other directories. Please do not
-// add more interfaces here.
-//
+/*  __   ___  __   __   ___  __       ___  ___  __
+ * |  \ |__  |__) |__) |__  /  `  /\   |  |__  |  \
+ * |__/ |___ |    |  \ |___ \__, /~~\  |  |___ |__/
+ *
+ * This file is now deprecated and its contents are slowly
+ * being moved back to codegen and other directories. Please do not
+ * add more interfaces here.
+ */
 
 #ifndef DEBUG_INCL
 #define DEBUG_INCL


### PR DESCRIPTION
With `-Wall`, gcc complains about the multi-line comments (notice the trailing `\` in the letter D).