### PR TITLE
Prevent compacting NULLCHKs into computed call trees; add new symbol J9JNIMethodIDvTableIndexFieldSymbol

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -365,7 +365,12 @@
     */
    j9VMThreadFloatTemp1Symbol,
 
-   OMRlastPrintableCommonNonhelperSymbol = j9VMThreadFloatTemp1Symbol,
+   /** \brief
+    * This symbol represents the vTableIndex field in struct J9JNIMethodID
+    */
+   J9JNIMethodIDvTableIndexFieldSymbol,
+
+   OMRlastPrintableCommonNonhelperSymbol = J9JNIMethodIDvTableIndexFieldSymbol,
 
    firstPerCodeCacheHelperSymbol,
    lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -443,7 +443,13 @@ class SymbolReferenceTable
        */
       j9VMThreadFloatTemp1Symbol,
 
-      OMRlastPrintableCommonNonhelperSymbol = j9VMThreadFloatTemp1Symbol,
+
+      /** \brief
+       * This symbol represents the vTableIndex field in struct J9JNIMethodID
+       */
+      J9JNIMethodIDvTableIndexFieldSymbol,
+
+      OMRlastPrintableCommonNonhelperSymbol = J9JNIMethodIDvTableIndexFieldSymbol,
 
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2226,17 +2226,6 @@ bool TR_CompactNullChecks::replacePassThroughIfPossible(TR::Node *currentNode, T
             if (child->getOpCodeValue() != TR::loadaddr) //For loadaddr, IsNonNull is always true
                child->setIsNonNull(false); // it is no longer known that the reference is non null
 
-            if (0 && comp()->useAnchors() &&
-                  currentTree->getNode()->getOpCode().isAnchor())
-               {
-               TR::TreeTop *prevTree = currentTree;
-               while (prevTree->getNode() != prevNode)
-                  prevTree = prevTree->getPrevTreeTop();
-               TR::TreeTop *preceedingTree = currentTree->getPrevTreeTop();
-               preceedingTree->join(currentTree->getNextTreeTop());
-               prevTree->getPrevTreeTop()->join(currentTree);
-               currentTree->join(prevTree);
-               }
             return true;
             }
          }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1656,6 +1656,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<j9VMThreadFloatTemp1Symbol>";
          case TR::SymbolReferenceTable::objectEqualityComparisonSymbol:
              return "<objectEqualityComparison>";
+         case TR::SymbolReferenceTable::J9JNIMethodIDvTableIndexFieldSymbol:
+             return "<J9JNIMethodIDvTableIndexFieldSymbol>";
          }
       }
 
@@ -2116,7 +2118,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<jProfileValueWithNullCHKSymbol>",
    "<j9VMThreadTempSlotField>",
    "<computedStaticCallSymbol>",
-   "<j9VMThreadFloatTemp1>"
+   "<j9VMThreadFloatTemp1>",
+   "<J9JNIMethodIDvTableIndexFieldSymbol>"
    };
 
 const char *


### PR DESCRIPTION
Compacting NULLCHK into computed calls will result in the NULLCHK
not being performed before dispatching into the call target if
there is no need for dereferencing of the reference child to
dispatch.

Furthermore, this PR introduces a new symbol required for eclipse-openj9/openj9#12341

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>