### PR TITLE
Cache known object info on TR::Nodes

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -37,6 +37,7 @@ namespace OMR { typedef OMR::Node NodeConnector; }
 #include <string.h>
 #include "codegen/RegisterConstants.hpp"
 #include "cs2/hashtab.h"
+#include "env/KnownObjectTable.hpp"
 #include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
@@ -816,6 +817,24 @@ public:
    inline scount_t setLocalIndex(scount_t li);
    inline scount_t incLocalIndex();
    inline scount_t decLocalIndex();
+
+   /**
+    * @brief Sets a known object index on this node
+    * @param[in] koi : the known object index
+    */
+   void setKnownObjectIndex(TR::KnownObjectTable::Index koi) { _knownObjectIndex = koi; }
+
+   /**
+    * @brief Retrieve the known object index associated with this node, if any.
+    * @return Known object index, or TR::KnownObjectTable::UNKNOWN if none.
+    */
+   TR::KnownObjectTable::Index getKnownObjectIndex() { return _knownObjectIndex; }
+
+   /**
+    * @brief Inquires whether this node has a known object index associated with it.
+    * @return true if a known object index is cached; false otherwise.
+    */
+   bool hasKnownObjectIndex() { return _knownObjectIndex != TR::KnownObjectTable::UNKNOWN; }
 
    inline scount_t getFutureUseCount();
    inline scount_t setFutureUseCount(scount_t li);
@@ -1641,8 +1660,8 @@ public:
    bool chkOpsNodeRequiresConditionCodes();
    const char *printRequiresConditionCodes();
 
-   // Clear out relevant flags set on the node.
-   void resetFlagsForCodeMotion();
+   // Clear out relevant flags and properties set on the node.
+   void resetFlagsAndPropertiesForCodeMotion();
 
    /**
     * Node flags functions end
@@ -1838,6 +1857,15 @@ protected:
 
    /// References to this node.
    rcount_t _referenceCount;
+
+   /// Known object index associated with this node, if any.
+   ///
+   /// This field allows for more accurate placement of known object information
+   /// as it applies to a particular node.
+   ///
+   /// If no such information is available this field is TR::KnownObjectTable::UNKNOWN
+   ///
+   TR::KnownObjectTable::Index _knownObjectIndex;
 
    UnionA                 _unionA;
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -9871,7 +9871,7 @@ TR_LoopVersioner::LoopEntryPrep *TR_LoopVersioner::createLoopEntryPrep(
       {
       // This is the top-level call. Ensure that node's flags have been reset
       // for code motion.
-      node->resetFlagsForCodeMotion();
+      node->resetFlagsAndPropertiesForCodeMotion();
       }
 
    // Because node will no longer appear verbatim in the trees, print it to

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -500,7 +500,7 @@ int32_t TR_PartialRedundancy::perform()
       if (nextRedundantComputation != 0)
          {
          supportedNodesAsArray[nextRedundantComputation] =  supportedNodesAsArray[nextRedundantComputation]->duplicateTreeWithCommoning(comp()->allocator());
-         supportedNodesAsArray[nextRedundantComputation]->resetFlagsForCodeMotion();
+         supportedNodesAsArray[nextRedundantComputation]->resetFlagsAndPropertiesForCodeMotion();
          }
       }
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1510,6 +1510,8 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       output.append("%s", getName(node->getOpCode()));
       }
 
+   if (node->hasKnownObjectIndex())
+      output.append(" (node obj%d)", node->getKnownObjectIndex());
 
    if (node->getOpCode().isNullCheck())
       {


### PR DESCRIPTION
Allow known object information to be associated with arbitrary nodes.
This will permit more accurate association of refined known object
info, and allow it to be placed on arbitrary nodes.

A new 32-bit bit field is added to the Node class in the padding
space between two fields.  This incurs no TR::Node footprint increase
on 64-bit architectures.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>