### PR TITLE
Enable code coverage setting

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -35,6 +35,10 @@ list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -pthread -fno-strict-aliasing)
 
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -std=c++0x)
 
+if(CODE_COVERAGE)
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -fprofile-arcs -ftest-coverage)
+endif()
+
 if(OMR_ARCH_X86)
 	if(OMR_ENV_DATA64)
 		list(APPEND OMR_PLATFORM_COMPILE_OPTIONS


### PR DESCRIPTION
- This PR needs to work with openj9 PR https://github.com/eclipse-openj9/openj9/pull/13386
- Generate and archive Code Coverage Files for xlinux, plinux, and zlinux
- Related Issues: https://github.com/eclipse-openj9/openj9/issues/12133

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>