### PR TITLE
Check whether relocations are needed for debug counters

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -500,15 +500,18 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          }
       else if (sr.getSymbol()->isDebugCounter())
          {
-         TR::DebugCounterBase *counter = cg->comp()->getCounterFromStaticAddress(&sr);
-         if (counter == NULL)
+         if (cg->needRelocationsForStatics())
             {
-            cg->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad\n");
+            TR::DebugCounterBase *counter = cg->comp()->getCounterFromStaticAddress(&sr);
+            if (counter == NULL)
+               {
+               cg->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad\n");
+               }
+            TR::DebugCounter::generateRelocation(cg->comp(),
+                                                 displacementLocation,
+                                                 containingInstruction->getNode(),
+                                                 counter);
             }
-         TR::DebugCounter::generateRelocation(cg->comp(),
-                                              displacementLocation,
-                                              containingInstruction->getNode(),
-                                              counter);
          }
       }
    else

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -2897,15 +2897,18 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
          case TR_DebugCounter:
             {
-            TR::DebugCounterBase *counter = cg()->comp()->getCounterFromStaticAddress(getSymbolReference());
-            if (counter == NULL)
+            if (cg()->needRelocationsForStatics())
                {
-               cg()->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress\n");
+               TR::DebugCounterBase *counter = cg()->comp()->getCounterFromStaticAddress(getSymbolReference());
+               if (counter == NULL)
+                  {
+                  cg()->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress\n");
+                  }
+               TR::DebugCounter::generateRelocation(cg()->comp(),
+                                                    cursor,
+                                                    getNode(),
+                                                    counter);
                }
-            TR::DebugCounter::generateRelocation(cg()->comp(),
-                                                 cursor,
-                                                 getNode(),
-                                                 counter);
             }
             break;
          case TR_BlockFrequency:


### PR DESCRIPTION
Code was unconditionally adding relocation records for debug counters without first checking that they are required.  This resulted in intermittent compilation failures for dynamic debug counters.