### PR TITLE
Improve non-overridden guard optimization in globalVP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -80,6 +80,10 @@ extern const ValuePropagationPtr constraintHandlers[];
 typedef TR::typed_allocator<std::pair<TR::CFGEdge * const, TR_BitVector*>, TR::Region &> DefinedOnAllPathsMapAllocator;
 typedef std::map<TR::CFGEdge *, TR_BitVector *, std::less<TR::CFGEdge *>, DefinedOnAllPathsMapAllocator> DefinedOnAllPathsMap;
 
+typedef TR::typed_allocator<std::pair<TR::Node * const, List<TR_Pair<TR::TreeTop, TR::CFGEdge>> *>, TR::Region &> CallNodeToGuardNodesMapAllocator;
+typedef std::map<TR::Node *, List<TR_Pair<TR::TreeTop, TR::CFGEdge>> *, std::less<TR::Node *>, CallNodeToGuardNodesMapAllocator> CallNodeToGuardNodesMap;
+
+
 namespace TR {
 
 class ArraycopyTransformation : public TR::Optimization
@@ -765,6 +769,8 @@ class ValuePropagation : public TR::Optimization
    //
    TR_Array<TR::CFGEdge *> *_edgesToBeRemoved;
 
+   CallNodeToGuardNodesMap *_callNodeToGuardNodes;
+   
    // Cached constraints
    //
    TR::VPNullObject        *_nullObjectConstraint;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -266,9 +266,15 @@ void OMR::ValuePropagation::initialize()
    _blocksToBeRemoved = new (trStackMemory()) TR_Array<TR::CFGNode*>(trMemory(), 8, false, stackAlloc);
    _curDefinedOnAllPaths = NULL;
    if (_isGlobalPropagation)
+      {
       _definedOnAllPaths = new (trStackMemory()) DefinedOnAllPathsMap(std::less<TR::CFGEdge *>(), trMemory()->currentStackRegion());
+      _callNodeToGuardNodes = new (trStackMemory()) CallNodeToGuardNodesMap(std::less<TR::Node *>(), trMemory()->currentStackRegion());
+      }
    else
+      {
       _definedOnAllPaths = NULL;
+      _callNodeToGuardNodes = NULL;
+      }
    _defMergedNodes = new (trStackMemory()) TR_BitVector(0, trMemory(), stackAlloc, growable);
    _vcHandler.setRoot(_curConstraints, NULL);
 

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -916,7 +916,7 @@ TR_InnerPreexistence::GuardInfo::GuardInfo(TR::Compilation * comp, TR::Block *bl
    {
    TR::Node *guardNode = block->getLastRealTreeTop()->getNode();
    TR::Node * callNode = guardNode->getVirtualCallNodeForGuard();
-   TR_ASSERT(callNode->getOpCode().isIndirect(), "Guarded calls must be indirect");
+   TR_ASSERT_FATAL(callNode->getOpCode().isIndirect(), "Guarded calls must be indirect");
 
    _argVNs = new (comp->trStackMemory()) TR_BitVector(20, comp->trMemory(), stackAlloc, growable);
    _innerSubTree = new (comp->trStackMemory()) TR_BitVector(numInlinedSites, comp->trMemory(), stackAlloc, notGrowable);


### PR DESCRIPTION
- handle direct calls, use call site index and bytecode index to
  find the right call
- sometimes, at the time the guard is seen not all constraints
  are available for the call. Keep a side table that maps call node
  to the corresponding guard and try to eliminate the guard at the
  time the call is encountered
- support multiple guards pointing to the same block
- Check isTheVirtualCallNodeForAGuardedInlinedCall inside getVirtualCallTreeForGuard
