### PR TITLE
Disable Internal Pointers for PPC under OptServer

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -376,7 +376,6 @@ OMR::Compilation::Compilation(
       {
       if(self()->getMethodHotness() <= warm)
          {
-         if (!self()->target().cpu.isPower()) // Temporarily exclude PPC due to perf regression
             self()->setOption(TR_DisableInternalPointers);
          }
       }


### PR DESCRIPTION
To stay consistent with other platforms, internal pointers will be disabled for PPC under OptServer. They were temporarily re-enabled due to a 20% regression on WAS and Liberty, but this occurred nearly seven years ago, so the chances of reproducing it now are low. As of the time of this commit, further investigation is being done into Liberty performance, so if this does expose a bug or regression, it will be caught, and a permanent fix can be implemented.

Signed-off-by: midronij <jackie.midroni@ibm.com>