### PR TITLE
AArch64: Fix mulConstant32/64 to use correct instrutions

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -636,11 +636,11 @@ static void mulConstant32(TR::Node *node, TR::Register *treg, TR::Register *sreg
       }
    else if (value == 1)
       {
-      generateMovInstruction(cg, node, treg, sreg);
+      generateMovInstruction(cg, node, treg, sreg, false);
       }
    else if (value == -1)
       {
-      generateNegInstruction(cg, node, treg, sreg);
+      generateNegInstruction(cg, node, treg, sreg, false);
       }
    else
       {
@@ -660,11 +660,11 @@ static void mulConstant64(TR::Node *node, TR::Register *treg, TR::Register *sreg
       }
    else if (value == 1)
       {
-      generateMovInstruction(cg, node, treg, sreg);
+      generateMovInstruction(cg, node, treg, sreg, true);
       }
    else if (value == -1)
       {
-      generateNegInstruction(cg, node, treg, sreg);
+      generateNegInstruction(cg, node, treg, sreg, true);
       }
    else
       {


### PR DESCRIPTION
Fix `mulConstant32` and `mulConstant64` to use correct 32bit/64bit variant
of `mov` and `neg` instructions.

Resolves https://github.com/eclipse-openj9/openj9/issues/13401

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>