### PR TITLE
Avoid symbol reference sharing for dummy resolved methods

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1450,7 +1450,7 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
               && owningMethodIndex == symRef->getOwningMethodIndex()
               && cpIndex != -1
               && symRef->getSymbol()->getMethodSymbol()->getMethodKind() == callKind
-              && !(resolvedMethod && symRef->isUnresolved())
+              && !(resolvedMethod && (symRef->isUnresolved() || symRef->getSymbol()->isDummyResolvedMethod()))
             )
           return symRef;
         }


### PR DESCRIPTION
It's possible to encounter an unresolved call, then to resolve its CP entry in another thread, and finally encounter another call with the same CP index, which is now resolved. In this situation, sharing is usually prevented due to the `!(resolvedMethod && symRef->isUnresolved())` condition. However, a dummy resolved method does not satisfy `symRef->isUnresolved()`.

It's important not to share the symbol reference because the dummy resolved method used in the unresolved case may expect arguments of a different type or a different number of arguments from the real resolved method.