### PR TITLE
CMake: Fix compile flags on omrgc_tracegen

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -66,6 +66,11 @@ target_compile_definitions(omrgc_tracegen
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
+target_compile_options(omrgc_tracegen
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_OPTIONS>
+)
+
 set(omrgc_sources
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp


### PR DESCRIPTION
Ensure that the omr_base compile flags get applied to omrgc_tracegen.
This is important on z/OS to ensure that we get relevant ascii/ebcdic
flags.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>