### PR TITLE
AArch64: Call redoTrampolineReservationIfNecessary() event if label is not null

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -121,6 +121,10 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
 
       TR::ResolvedMethodSymbol *sym = symRef->getSymbol()->getResolvedMethodSymbol();
 
+      if (cg()->hasCodeCacheSwitched())
+         {
+         cg()->redoTrampolineReservationIfNecessary(this, symRef);
+         }
       if (cg()->comp()->isRecursiveMethodTarget(sym))
          {
          intptr_t jitToJitStart = cg()->getLinkage()->entryPointFromCompiledMethod();
@@ -142,11 +146,6 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
       else
          {
          TR::MethodSymbol *method = symRef->getSymbol()->getMethodSymbol();
-
-         if (cg()->hasCodeCacheSwitched())
-            {
-            cg()->redoTrampolineReservationIfNecessary(this, symRef);
-            }
 
          if (method && method->isHelper())
             {


### PR DESCRIPTION
The commit changes `TR::ARM64ImmSymInstruction::generateBinaryEncoding` to
call `redoTrampolineReservationIfNecessary()` even if label is not null,
which happens when a direct call is done through a snippet.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>