### PR TITLE
Add an unresolved check for mapOpCode() P10 prefix-instr mapping

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1125,7 +1125,7 @@ void OMR::Power::MemoryReference::mapOpCode(TR::Instruction *currentInstruction)
             break;
          }
       }
-   else if ((self()->getOffset() < LOWER_IMMED || self()->getOffset() > UPPER_IMMED || self()->getLabel()) && currentInstruction->cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
+   else if ((self()->getUnresolvedSnippet() == NULL) && (self()->getOffset() < LOWER_IMMED || self()->getOffset() > UPPER_IMMED || self()->getLabel()) && currentInstruction->cg()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P10))
       {
       switch (currentInstruction->getOpCodeValue())
          {


### PR DESCRIPTION
The current code for patching unresolved addresses does not handles
P10's 8byte prefix instructions, this commit adds a check to mapOpCode
to not map memory instruction to prefix-instr in P10 if the reference
is to an unresolved symbol.

Mostly affects cases where the `expandForUnresolvedSnippet()` regenerates the load-instr immediately after the `bl` (i.e. non-indexed 32bit) and when generating a prefix-instr, it ends up with the patch code patching the prefix offset (resulting change in 0xXXXX0000 of the load address) instead of the suffix offset (0x0000XXXX).

~~[WIP] Finishing tests...~~

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>