### PR TITLE
Restrict rotate instruction optimization for lshl+land nodes

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1224,7 +1224,7 @@ genericLongShiftSingle(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::
 
             return trgReg;
             }
-         else if (firstChild->getOpCodeValue() == TR::land)
+         else if (firstChild->getOpCodeValue() == TR::land && firstChild->getReferenceCount() == 1)
             {
             if (trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, value, node->getOpCodeValue() == TR::lshl))
                {
@@ -1238,7 +1238,7 @@ genericLongShiftSingle(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::
       else if (node->getOpCodeValue() == TR::lshr || node->getOpCodeValue() == TR::lushr)
          {
          // Generate RISBGN for (lshr + land) and (lushr + land) sequences
-         if (firstChild->getOpCodeValue() == TR::land)
+         if (firstChild->getOpCodeValue() == TR::land && firstChild->getReferenceCount() == 1)
             {
             if (trgReg = TR::TreeEvaluator::tryToReplaceShiftLandWithRotateInstruction(firstChild, cg, -value, node->getOpCodeValue() == TR::lshr))
                {


### PR DESCRIPTION
This commit limits an optimization in the z codegen that tries to perform a shift + land operation using a single rotate instruction. The optimization skips the evaluation of the land node but evaluates its children. If the reference count of the land node > 1, then this can result in the code generator double decrementing the land node's children. This commit restricts this optimization to when the land node's ref count is equal to 1 so that the above described scenario is no longer possible.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>