### PR TITLE
Follow up to #5825

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -391,8 +391,6 @@ public:
 	uintptr_t heapFreeMinimumRatioMultiplier;
 	uintptr_t heapFreeMaximumRatioDivisor;
 	uintptr_t heapFreeMaximumRatioMultiplier;
-	uintptr_t heapExpansionGCTimeThreshold; /**< max percentage of time spent in gc before expansion - TO BE REMOVED IN FAVOUR OF `heapExpansionGCRatioThreshold` */
-	uintptr_t heapContractionGCTimeThreshold; /**< min percentage of time spent in gc before contraction - TO BE REMOVED IN FAVOUR OF `heapContractionGCRatioThreshold` */
 
 	MM_UserSpecifiedParameterUDATA heapExpansionGCRatioThreshold; /**< max percentage of time spent in gc before expansion */
 	MM_UserSpecifiedParameterUDATA heapContractionGCRatioThreshold; /**< min percentage of time spent in gc before contraction */
@@ -528,9 +526,6 @@ public:
 	bool dynamicNewSpaceSizing;
 	bool debugDynamicNewSpaceSizing;
 	bool dnssAvoidMovingObjects;
-
-	double dnssExpectedTimeRatioMinimum; /**< TO BE REMOVED IN FAVOUR OF `dnssExpectedRatioMinimum` - When the gc ratio for new/nursery space is below this value, new/nursery space should contract */
-	double dnssExpectedTimeRatioMaximum; /**< TO BE REMOVED IN FAVOUR OF `dnssExpectedRatioMaximum` - When the gc ratio for new/nursery space is above this value, new/nursery space should expand */
 
 	MM_UserSpecifiedParameterDouble dnssExpectedRatioMinimum; /**< When the gc ratio for new/nursery space is below this value, new/nursery space should contract */
 	MM_UserSpecifiedParameterDouble dnssExpectedRatioMaximum; /**< When the gc ratio for new/nursery space is above this value, new/nursery space should expand */
@@ -1515,8 +1510,6 @@ public:
 		, heapFreeMinimumRatioMultiplier(30)
 		, heapFreeMaximumRatioDivisor(100)
 		, heapFreeMaximumRatioMultiplier(60)
-		, heapExpansionGCTimeThreshold(13)
-		, heapContractionGCTimeThreshold(5)
 		, heapExpansionGCRatioThreshold()
 		, heapContractionGCRatioThreshold()
 		, heapExpansionStabilizationCount(0)
@@ -1631,8 +1624,6 @@ public:
 		, dynamicNewSpaceSizing(true)
 		, debugDynamicNewSpaceSizing(false)
 		, dnssAvoidMovingObjects(true)
-		, dnssExpectedTimeRatioMinimum(0.01)
-		, dnssExpectedTimeRatioMaximum(0.05)
 		, dnssExpectedRatioMinimum()
 		, dnssExpectedRatioMaximum()
 		, dnssWeightedTimeRatioFactorIncreaseSmall(0.2)

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -533,7 +533,7 @@ TraceEvent=Trc_MM_J9AllocateIndexableObject_outOfLineObjectAllocation Overhead=1
 TraceEvent=Trc_MM_J9AllocateObject_outOfLineObjectAllocation Overhead=1 Level=1 Template="object allocated out-of-line sampled: class=%p (%.*s); object size=%zu"
 
 TraceEntry=Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Entry Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateExpandSize Entry Bytes required = %zu"
-TraceExit=Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit1 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateExpandSize Exit1 Desired free bytes = %zu, current free bytes = %zu, returning expand size of %zu bytes"
+TraceExit=Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit1 Obsolete Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateExpandSize Exit1 Desired free bytes = %zu, current free bytes = %zu, returning expand size of %zu bytes"
 TraceEntry=Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Entry Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_checkForRatioExpand Entry Bytes required = %zu"
 TraceExit=Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Exit1 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_checkForRatioExpand Exit1 Free space already at -Xmaxf limit"
 TraceExit=Trc_MM_MemorySubSpaceTarok_checkForRatioExpand_Exit2 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_checkForRatioExpand Exit2 Percentage of time spent in garbage collection = %u, expansion not required"
@@ -551,7 +551,7 @@ TraceExit=Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit4 Overhead=1 Level=
 TraceExit=Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit5 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_timeForHeapContract Exit5 Do not contract a expansion ocurred on one of previous three garbage collection cycles"
 TraceExit=Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit6 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_timeForHeapContract Exit6 Do not contract as free bytes at start of system garbage collect, %zu, less than minimum free bytes, %zu"
 TraceExit=Trc_MM_MemorySubSpaceTarok_timeForHeapContract_Exit7 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_timeForHeapContract Exit7 Contraction required, size = %zu bytes"
-TraceEntry=Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Entry Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateTargetContractSize Entry Allocation size = %zu, ratio contract %s"
+TraceEntry=Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Entry Obsolete Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateTargetContractSize Entry Allocation size = %zu, ratio contract %s"
 TraceEvent=Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Event1 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateTargetContractSize Event1 Contraction size = %zu bytes"
 TraceEvent=Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Event2 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateTargetContractSize Event2 Contraction size = %zu bytes, maximum contraction size = %zu bytes"
 TraceExit=Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Exit1 Overhead=1 Level=1 Group=resize Template="MM_MemorySubSpaceTarok_calculateTargetContractSize Exit contraction size = %zu bytes"

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -82,11 +82,11 @@ MM_ConfigurationGenerational::initialize(MM_EnvironmentBase* env)
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
 	if (!extensions->dnssExpectedRatioMaximum._wasSpecified) {
-		extensions->dnssExpectedRatioMaximum._valueSpecified = extensions->dnssExpectedTimeRatioMaximum;
+		extensions->dnssExpectedRatioMaximum._valueSpecified = 0.05;
 	}
 
 	if (!extensions->dnssExpectedRatioMinimum._wasSpecified) {
-		extensions->dnssExpectedRatioMinimum._valueSpecified = extensions->dnssExpectedTimeRatioMinimum;
+		extensions->dnssExpectedRatioMinimum._valueSpecified = 0.01;
 	}
 
 	return MM_ConfigurationStandard::initialize(env);

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -86,11 +86,11 @@ MM_ConfigurationStandard::initialize(MM_EnvironmentBase* env)
 	}
 
 	if (!extensions->heapExpansionGCRatioThreshold._wasSpecified) {
-		extensions->heapExpansionGCRatioThreshold._valueSpecified = extensions->heapExpansionGCTimeThreshold;
+		extensions->heapExpansionGCRatioThreshold._valueSpecified = 13;
 	}
 
 	if (!extensions->heapContractionGCRatioThreshold._wasSpecified) {
-		extensions->heapContractionGCRatioThreshold._valueSpecified = extensions->heapContractionGCTimeThreshold;
+		extensions->heapContractionGCRatioThreshold._valueSpecified = 5;
 	}
 
 	return result;

--- a/gc/stats/GlobalVLHGCStats.hpp
+++ b/gc/stats/GlobalVLHGCStats.hpp
@@ -52,8 +52,8 @@ public:
 		uint64_t avgPgcTimeUs;
 		uint64_t avgPgcIntervalUs;
 		uint64_t pgcCountSinceGMPEnd;
-		uint64_t reservedSize;
-		uint64_t freeTenure;
+		uintptr_t reservedSize;
+		uintptr_t freeTenure;
 		intptr_t edenRegionChange;
 		bool readyToResizeAtGlobalEnd;
 


### PR DESCRIPTION
This commit contains the follow up items from https://github.com/eclipse/omr/pull/5825

This includes:
- making `Trc_MM_MemorySubSpaceTarok_calculateExpandSize_Exit1` and `Trc_MM_MemorySubSpaceTarok_calculateTargetContractSize_Entry` obsolete
- `dnssExpectedTimeRatioMaximum` and `dnssExpectedTimeRatioMinimum` were removed, since they are no longer used. The newer version (dnssExpectedRatioMaximum/Minimum) are more flexible for different GC policies
- `heapExpansionGCTimeThreshold` and `heapContractionGCTimeThreshold` were removed, since they are no longer used. The newer versions (`heapExpansionGCRatioThreshold` and `heapContractionGCRatioThreshold`) are more flexible for different GC policies

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>