### PR TITLE
AArch64: Remove a suffix of a double constant

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -240,7 +240,7 @@ OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg
 
       dvalue.d = node->getDouble();
 
-      if(dvalue.d == +0.0d && signbit(dvalue.d) == 0)
+      if(dvalue.d == +0.0 && signbit(dvalue.d) == 0)
          {
          generateTrgInstruction(cg, TR::InstOpCode::movi0d, node, trgReg);
          }


### PR DESCRIPTION
This commit removes a suffix "d" from a double constant in C++ code.
Suffix "f" is used for a float constant, but double constants do not
take any suffix.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>