### PR TITLE
Rename JIT methods that control inlining of OpenJ9 Reference methods

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -955,7 +955,7 @@ int32_t OMR::Compilation::compile()
          }
       }
 
-   self()->setGetImplInlineable(self()->fej9()->isGetImplInliningSupported());
+   self()->setGetImplAndRefersToInlineable(self()->fej9()->isGetImplAndRefersToInliningSupported());
 #endif
 
    if (self()->getOption(TR_BreakBeforeCompile))


### PR DESCRIPTION
The OpenJ9 JIT compiler methods that query or control whether the `java.lang.ref.Reference.getImpl`method can be inlined are now also used for `Reference.refersTo`, and so, have been renamed.

This change in OpenJ9-specific code uses the new JIT method names.

This change is dependent on [OpenJ9 pull request #13619](https://github.com/eclipse-openj9/openj9/pull/13619).