### PR TITLE
Split _options and _optionString in OptionSet into separate fields

### DIFF
--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -148,7 +148,7 @@ public:
 
    OptionSet(char *s) { init(s); }
 
-   void init(char *s) { _optionString = s; _next = 0; _methodRegex = 0; _optLevelRegex = 0; _start=0; _end=0; }
+   void init(char *s) { _optionString = s; _next = 0; _methodRegex = 0; _optLevelRegex = 0; _start=0; _end=0; _options = NULL; }
 
    OptionSet *getNext() {return _next;}
 
@@ -176,11 +176,8 @@ private:
    TR::SimpleRegex *_optLevelRegex;
    int32_t _start;
    int32_t _end;
-   union
-      {
-      TR::Options *_options;
-      char *_optionString;
-      };
+   TR::Options *_options;
+   char *_optionString;
    };
 
 }

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ TR::FILE *TR_Debug::findLogFile(TR::Options *cmdLineOptions, TR::OptionSet *optS
       {
       for (TR::OptionSet *prev = cmdLineOptions->getFirstOptionSet(); prev && prev != optSet; prev = prev->getNext())
          {
-         fileName = prev->getOptions()->getLogFileName();
+         fileName = prev->getOptions() ? prev->getOptions()->getLogFileName() : NULL;
          if (fileName && !STRICMP(logFileName, fileName))
             {
             logFile = prev->getOptions()->getLogFile();
@@ -129,7 +129,7 @@ void TR_Debug::findLogFile(const char *logFileName, TR::Options *cmdOptions, TR:
       }
    for (TR::OptionSet *optSet = cmdOptions->getFirstOptionSet(); optSet; optSet = optSet->getNext())
       {
-      if (optSet->getOptions()->getLogFileName() && !STRICMP(logFileName, optSet->getOptions()->getLogFileName()))
+      if (optSet->getOptions() && optSet->getOptions()->getLogFileName() && !STRICMP(logFileName, optSet->getOptions()->getLogFileName()))
          {
          if (index < arraySize)
             optionsArray[index] = optSet->getOptions();


### PR DESCRIPTION
When both AOT and JIT have logs specified and when one is processed
first, the `OptionSet._options` for the other one has not been set up
properly yet. Since `setOptions` has not been called for the other
command option, `getOptions` returns a char pointer to `_optionString`
that is implicitly casted as `TR::Options *` because `OptionSet._options`
and `OptionSet._optionString` are `union`. To properly check if
`OptionSet._options` is valid, it needs to be a separate field.

Fixes #6189

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>