### PR TITLE
Fix uses of BPX4ENV

### DIFF
--- a/port/zos390/omrgenerate_ieat_dump.s
+++ b/port/zos390/omrgenerate_ieat_dump.s
@@ -1,23 +1,23 @@
 ***********************************************************************
-* Copyright (c) 1991, 2016 IBM Corp. and others
-* 
-* This program and the accompanying materials are made available 
+* Copyright (c) 1991, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made available
 * under the terms of the Eclipse Public License 2.0 which accompanies
-* this distribution and is available at 
-* https://www.eclipse.org/legal/epl-2.0/ or the Apache License, 
+* this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache License,
 * Version 2.0 which accompanies this distribution and
 * is available at https://www.apache.org/licenses/LICENSE-2.0.
-* 
+*
 * This Source Code may also be made available under the following
 * Secondary Licenses when the conditions for such availability set
 * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-* General Public License, version 2 with the GNU Classpath 
+* General Public License, version 2 with the GNU Classpath
 * Exception [1] and GNU General Public License, version 2 with the
 * OpenJDK Assembly Exception [2].
-* 
+*
 * [1] https://www.gnu.org/software/classpath/license.html
 * [2] http://openjdk.java.net/legal/assembly-exception.html
-* 
+*
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR
 * GPL-2.0 WITH Classpath-exception-2.0 OR
 * LicenseRef-GPL-2.0 WITH Assembly-exception
@@ -27,7 +27,7 @@
 
          AIF ('&SYSPARM' EQ 'BIT64').JMP1
 _TDUMP   EDCXPRLG BASEREG=8
-*  IEATDUMP macro toast R1, so keep it in R3
+* IEATDUMP macro will toast R1, so keep it in R3
          LR    3,1
          USING IOPARMS,3
          CALL  BPX1ENV,                                                +
@@ -42,8 +42,8 @@ _TDUMP   EDCXPRLG BASEREG=8
                VL,MF=(E,PLIST)
          AGO .JMP2
 .JMP1    ANOP
-_TDUMP    CELQPRLG BASEREG=8
-*  IEATDUMP macro toast R1, so keep it in R3
+_TDUMP   CELQPRLG BASEREG=8
+* IEATDUMP macro will toast R1, so keep it in R3
          LR    3,1
          USING IOPARMS,3
          CALL  BPX4ENV,                                                +
@@ -53,14 +53,14 @@ _TDUMP    CELQPRLG BASEREG=8
                =AD(0),                                                 +
                =A(0),                                                  +
                RETVAL,                                                 +
-               RETVAL,                                                 +
-               RETVAL),                                                +
+               RETCODE,                                                +
+               RSNCODE),                                               +
                MF=(E,PLIST)
          SAM31
 .JMP2    ANOP
 
-* Note: the SDATA options below are echoed in the IEATDUMP progress 
-* message in tdump() in omrosdump.c. That message needs to be kept 
+* Note: the SDATA options below are echoed in the IEATDUMP progress
+* message in tdump() in omrosdump.c. That message needs to be kept
 * consistent with the actual options specified here.
          IEATDUMP DSN=(2),HDR=DUMPTITL,RETCODE=RETCODE,RSNCODE=RSNCODE,+
                SDATA=(LPA,GRSQ,LSQA,NUC,PSA,RGN,SQA,SUM,SWA,TRT),      +
@@ -88,8 +88,8 @@ _TDUMP    CELQPRLG BASEREG=8
                =AD(0),                                                 +
                =A(0),                                                  +
                RETVAL,                                                 +
-               RETVAL,                                                 +
-               RETVAL),                                                +
+               RETCODE,                                                +
+               RSNCODE),                                               +
                MF=(E,PLIST)
          CELQEPLG
 .JMP4    ANOP
@@ -99,7 +99,7 @@ DUMPTITL DC    AL1(DMPTLLEN)
          DC    C'TRANSACTION DUMP TO AN OPEN DCB'
 DMPTLLEN EQU   *-DUMPTITL-1
 
-ENV_TOGGLE_SEC       EQU   4    Toggle btw task/process security
+ENV_TOGGLE_SEC       EQU   4    Toggle between task/process security
 
 IOPARMS  DSECT
 PLIST    DS    256AD                 Calling parameter list


### PR DESCRIPTION
The last two arguments should be `RETCODE, RSNCODE`, not two more references to `RETVAL`.