### PR TITLE
AArch64: Disable forward/backward arraycopy helper entries

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -3309,7 +3309,12 @@ OMR::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator 
    TR::addDependency(deps, NULL, TR::RealRegister::x3, TR_GPR, cg);
    TR::addDependency(deps, NULL, TR::RealRegister::x4, TR_GPR, cg);
 
-   generateCallToArrayCopyHelper(node, srcAddrReg, dstAddrReg, lengthReg, deps, cg);
+   TR::SymbolReference *arrayCopyHelper = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64arrayCopy, false, false, false);
+
+   generateImmSymInstruction(cg, TR::InstOpCode::bl, node,
+                             (uintptr_t)arrayCopyHelper->getMethodAddress(),
+                             deps, arrayCopyHelper, NULL);
+   cg->machine()->setLinkRegisterKilled(true);
 
    if (!simpleCopy)
       {


### PR DESCRIPTION
This commit disables the helper entries of forward/backward arraycopy
temporarily.  Use the generic TR_ARM64arrayCopy.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>