### PR TITLE
Remove non-reference members in OMROption.hpp

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -2136,10 +2136,6 @@ protected:
           char *         _envOptions;
    static char *         _compilationStrategyName;
 
-
-   static TR::OptionFunctionPtr _processingMethod[];
-   static TR::OptionFunctionPtr _negateProcessingMethod[];
-
    // Option flag words
    //
    uint32_t                    _options[TR_OWM+1];


### PR DESCRIPTION
non-referenced members:
  static TR::OptionFunctionPtr _processingMethod[]
  static TR::OptionFunctionPtr _negateProcessingMethod[]

Signed-off-by: Tao Guan <james_mango@yahoo.com>