### PR TITLE
AArch64: Add convenience functions to generate ubfiz/ubfx instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1420,6 +1420,24 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(pOutFile, instr->getSource1Register(), TR_WordReg);
             trfprintf(pOutFile, ", %d", 63 - imms);
             }
+         else if (imms < immr)
+            {
+            // ubfiz alias
+            done = true;
+            trfprintf(pOutFile, "ubfizx \t");
+            print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", %d, %d", 64 - immr, imms + 1);
+            }
+         else
+            {
+            // ubfx alias
+            done = true;
+            trfprintf(pOutFile, "ubfxx \t");
+            print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", %d, %d", immr, imms + 1 - immr);
+            }
          }
       else if ((op == TR::InstOpCode::ubfmw) && ((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0))
          {
@@ -1448,6 +1466,24 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
             trfprintf(pOutFile, "uxt%cx \t", (imms == 7) ? 'b' : 'h');
             print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
             print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            }
+         else if (imms < immr)
+            {
+            // ubfiz alias
+            done = true;
+            trfprintf(pOutFile, "ubfizw \t");
+            print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", %d, %d", 32 - immr, imms + 1);
+            }
+         else
+            {
+            // ubfx alias
+            done = true;
+            trfprintf(pOutFile, "ubfxw \t");
+            print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+            print(pOutFile, instr->getSource1Register(), TR_WordReg);
+            trfprintf(pOutFile, ", %d, %d", immr, imms + 1 - immr);
             }
          }
       if (!done)

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -991,8 +991,6 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
           * to bit position shiftValue of the destination register.
           */
          uint32_t width = populationCount(maskValue);
-         uint32_t imms = (width - 1);
-         uint32_t immr = (is64bit ? 64 : 32) - shiftValue;
 
          TR::Register *reg;
          TR::Register *sreg = cg->evaluate(sourceNode);
@@ -1005,7 +1003,7 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
             reg = cg->allocateRegister();
             }
 
-         generateTrg1Src1ImmInstruction(cg, (is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw), shiftNode, reg, sreg, (immr << 6) | imms);
+         generateUBFIZInstruction(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
          shiftNode->setRegister(reg);
          cg->recursivelyDecReferenceCount(andNode);
          cg->decReferenceCount(shiftValueNode);
@@ -1026,8 +1024,6 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
 
          bool isRightShift = (width == shiftRemainderWidth);  /* In this case, it works as a shift. */
 
-         uint32_t imms = (shiftValue + width - 1);
-         uint32_t immr = shiftValue;
          TR::Register *reg;
          TR::Register *sreg = cg->evaluate(sourceNode);
          if (sourceNode->getReferenceCount() == 1)
@@ -1052,7 +1048,7 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
             }
          else
             {
-            generateTrg1Src1ImmInstruction(cg, (is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw), shiftNode, reg, sreg, (immr << 6) | imms);
+            generateUBFXInstruction(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
             }
          shiftNode->setRegister(reg);
          cg->recursivelyDecReferenceCount(andNode);
@@ -1574,8 +1570,6 @@ generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGenerator *cg)
              * to bit position shiftValue of the destination register.
              */
             uint32_t width = populationCount(shiftedMask);
-            uint32_t imms = (width - 1);
-            uint32_t immr = (is64bit ? 64 : 32) - shiftValue;
 
             TR::Register *reg;
             TR::Register *sreg = cg->evaluate(sourceNode);
@@ -1587,7 +1581,7 @@ generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGenerator *cg)
                {
                reg = cg->allocateRegister();
                }
-            generateTrg1Src1ImmInstruction(cg, (is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw), andNode, reg, sreg, (immr << 6) | imms);
+            generateUBFIZInstruction(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
             andNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(shiftNode);
             cg->decReferenceCount(maskNode);
@@ -1620,8 +1614,6 @@ generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGenerator *cg)
                }
             bool isLogicalShiftRight = (width == shiftRemainderWidth);  /* In this case, it works as a logical shift right. */
 
-            uint32_t imms = (shiftValue + width - 1);
-            uint32_t immr = shiftValue;
             TR::Register *reg;
             TR::Register *sreg = cg->evaluate(sourceNode);
             if (sourceNode->getReferenceCount() == 1)
@@ -1638,7 +1630,7 @@ generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGenerator *cg)
                }
             else
                {
-               generateTrg1Src1ImmInstruction(cg, (is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw), andNode, reg, sreg, (immr << 6) | imms);
+               generateUBFXInstruction(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
                }
             andNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(shiftNode);

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -556,6 +556,26 @@ TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *c
    return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, cg);
    }
 
+TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced)
+   {
+   uint32_t imms = (lsb + width - 1);
+   uint32_t immr = lsb;
+   TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
+                   "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
+   return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw, node, treg, sreg, (immr << 6) | imms, preced);
+   }
+
+TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced)
+   {
+   uint32_t imms = width - 1;
+   uint32_t immr = (is64bit ? 64 : 32) - lsb;
+   TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
+                   "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
+   return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw, node, treg, sreg, (immr << 6) | imms, preced);
+   }
+
 #ifdef J9_PROJECT_SPECIFIC
 TR::Instruction *generateVirtualGuardNOPInstruction(TR::CodeGenerator *cg,  TR::Node *n, TR_VirtualGuardSite *site,
    TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::Instruction *preced)

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1008,6 +1008,62 @@ TR::ARM64ExceptionInstruction *generateExceptionInstruction(
                   uint32_t imm,
                   TR::Instruction *preced = NULL);
 
+/**
+ * @brief Generates ubfx instruction
+ *
+ * @details Generates ubfx instruction which copies a bitfield of <width> bits
+ *          starting from bit position <lsb> in the source register to
+ *          the least significant bits of the target register.
+ *          The bits above the bitfield in the target register is set to 0.
+ *
+ * @param[in] cg      : CodeGenerator
+ * @param[in] node    : node
+ * @param[in] treg    : target register
+ * @param[in] sreg    : source register
+ * @param[in] lsb     : the lsb to be copied in the source register
+ * @param[in] width   : the bitfield width to copy
+ * @param[in] is64bit : true if 64bit
+ * @param[in] preced  : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateUBFXInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t lsb,
+                  uint32_t width,
+                  bool is64bit,
+                  TR::Instruction *preced = NULL);
+
+/**
+ * @brief Generates ubfiz instruction
+ *
+ * @details Generates ubfiz instruction which copies a bitfield of <width> bits
+ *          from the least significant bits of the source register to
+ *          the bit position <lsb> of the target register.
+ *          The bits above and below the bitfield in the target register is set to 0.
+ *
+ * @param[in] cg      : CodeGenerator
+ * @param[in] node    : node
+ * @param[in] treg    : target register
+ * @param[in] sreg    : source register
+ * @param[in] lsb     : the bit position of the target register
+ * @param[in] width   : the bitfield width to copy
+ * @param[in] is64bit : true if 64bit
+ * @param[in] preced  : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateUBFIZInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t lsb,
+                  uint32_t width,
+                  bool is64bit,
+                  TR::Instruction *preced = NULL);
+
 #ifdef J9_PROJECT_SPECIFIC
 /*
  * @brief Generates virtual guard nop instruction


### PR DESCRIPTION
Add convenicence functions for generating ubfiz/ubfx instructions,
which are aliases of ubfm instruction.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>