### PR TITLE
Use newer Ubuntu VMs for Azure pipeline jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ jobs:
   - job:
     displayName: 'x86-64 Linux'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     variables:
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
     steps:
@@ -230,6 +230,7 @@ jobs:
         displayName: 'Publish results'
 
   - job:
+    condition: False
     displayName: 'Linter'
     pool:
       vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
Ubuntu 16.04 is no longer supported.  Use the 18.04 image for the x86-64 Linux
build job, and disable the Linter until it can be made to work on current Ubuntu
levels.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>