### PR TITLE
Remove useless OMR_THR_TRACING configuration option

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -198,8 +198,7 @@ if(OMR_THR_YIELD_ALG)
 		MESSAGE "OMR_THR_YIELD_ALG enabled, but not supported on current platform"
 	)
 endif()
-#TODO set to disabled. Stuff fails to compile when its on
-set(OMR_THR_TRACING OFF CACHE BOOL "TODO: Document")
+# TODO set to disabled. Stuff fails to compile when its on
 set(OMR_THR_MCS_LOCKS OFF CACHE BOOL "Enable the usage of the MCS lock in the OMR thread monitor.")
 
 #TODO this should maybe be a OMRTHREAD_LIB string variable?

--- a/configure
+++ b/configure
@@ -706,7 +706,6 @@ OMR_GC_MODRON_SCAVENGER
 OMR_GC_MODRON_CONCURRENT_MARK
 OMR_GC_MODRON_COMPACTION
 OMR_GC_DYNAMIC_CLASS_UNLOADING
-OMR_THR_TRACING
 OMR_THR_LOCK_NURSERY
 OMR_THR_JLM_HOLD_TIMES
 OMR_THR_JLM
@@ -853,7 +852,6 @@ enable_OMR_THR_ADAPTIVE_SPIN
 enable_OMR_THR_JLM
 enable_OMR_THR_JLM_HOLD_TIMES
 enable_OMR_THR_LOCK_NURSERY
-enable_OMR_THR_TRACING
 enable_OMR_GC_DYNAMIC_CLASS_UNLOADING
 enable_OMR_GC_MODRON_COMPACTION
 enable_OMR_GC_MODRON_CONCURRENT_MARK
@@ -1613,8 +1611,6 @@ Optional Features:
   --disable-OMR_THR_JLM_HOLD_TIMES
 
   --disable-OMR_THR_LOCK_NURSERY
-
-  --enable-OMR_THR_TRACING
 
   --enable-OMR_GC_DYNAMIC_CLASS_UNLOADING
 
@@ -2879,8 +2875,8 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 OMR_COMPANY_NAME=${OMR_COMPANY_NAME:-""}
 OMR_COMPANY_COPYRIGHT=${OMR_COMPANY_COPYRIGHT:-""}
-OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
 OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"OMR 0.1 "}
+OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"0.1"}
 
 OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}
@@ -5301,25 +5297,7 @@ fi
 ############### Flags that are always disabled
 # Each flag must have a corresponding entry in omrcfg.h.in
 
-# Check whether --enable-OMR_THR_TRACING was given.
-if test "${enable_OMR_THR_TRACING+set}" = set; then :
-  enableval=$enable_OMR_THR_TRACING; if test "x${enableval}" = xyes; then :
-  OMR_THR_TRACING=1
-
-   $as_echo "#define OMR_THR_TRACING 1" >>confdefs.h
-
-else
-  OMR_THR_TRACING=0
-
-
-fi
-else
-  OMR_THR_TRACING=0
-
-
-fi
-
-
+# (no flags are always disabled)
 
 ############### Flags that are conditionally enabled.
 # Each flag must have a corresponding entry in omrcfg.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2020 IBM Corp. and others
+# Copyright (c) 2015, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -412,7 +412,7 @@ OMRCFG_DEFINE_FLAG_ON([OMR_THR_LOCK_NURSERY])
 ############### Flags that are always disabled
 # Each flag must have a corresponding entry in omrcfg.h.in
 
-OMRCFG_DEFINE_FLAG_OFF([OMR_THR_TRACING])
+# (no flags are always disabled)
 
 ############### Flags that are conditionally enabled.
 # Each flag must have a corresponding entry in omrcfg.h.in

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,12 +104,6 @@
  * ifRemoved: object header will contain the monitor word
  */
 #cmakedefine OMR_THR_LOCK_NURSERY
-
-/**
- * Output lots of thread statistics (Pentium only)
- * ifRemoved: Turn off in production VMs
- */
-#cmakedefine OMR_THR_TRACING 1
 
 #cmakedefine OMRTHREAD_LIB_AIX 1
 #cmakedefine OMRTHREAD_LIB_UNIX 1

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corp. and others
+ * Copyright (c) 2015, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,12 +102,6 @@
  * ifRemoved: object header will contain the monitor word
  */
 #undef OMR_THR_LOCK_NURSERY
-
-/**
- * Output lots of thread statistics (Pentium only)
- * ifRemoved: Turn off in production VMs
- */
-#undef OMR_THR_TRACING
 
 #undef OMRTHREAD_LIB_AIX
 #undef OMRTHREAD_LIB_UNIX

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -499,16 +499,6 @@ void
 omrthread_detach(omrthread_t thread);
 
 
-#if (defined(OMR_THR_TRACING))
-/**
-* @brief
-* @param thread
-* @return void
-*/
-void
-omrthread_dump_trace(omrthread_t thread);
-#endif /* OMR_THR_TRACING */
-
 /**
 * @brief
 * @param monitor
@@ -746,28 +736,6 @@ void
 omrthread_monitor_flush_destroyed_monitor_list(omrthread_t self);
 
 
-#if (defined(OMR_THR_TRACING))
-/**
-* @brief
-* @param void
-* @return void
-*/
-void
-omrthread_monitor_dump_all(void);
-#endif /* OMR_THR_TRACING */
-
-
-#if (defined(OMR_THR_TRACING))
-/**
-* @brief
-* @param monitor
-* @return void
-*/
-void
-omrthread_monitor_dump_trace(omrthread_monitor_t monitor);
-#endif /* OMR_THR_TRACING */
-
-
 /**
 * @brief
 * @param monitor
@@ -982,17 +950,6 @@ omrthread_priority_interrupt(omrthread_t thread);
 */
 uintptr_t
 omrthread_priority_interrupted(omrthread_t thread);
-
-
-#if (defined(OMR_THR_TRACING))
-/**
-* @brief
-* @param void
-* @return void
-*/
-void
-omrthread_reset_tracing(void);
-#endif /* OMR_THR_TRACING */
 
 
 /**

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2020 IBM Corp. and others
+# Copyright (c) 2015, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,6 @@ OMR_THR_JLM := @OMR_THR_JLM@
 OMR_THR_JLM_HOLD_TIMES := @OMR_THR_JLM_HOLD_TIMES@
 OMR_THR_LOCK_NURSERY := @OMR_THR_LOCK_NURSERY@
 OMR_THR_THREE_TIER_LOCKING := @OMR_THR_THREE_TIER_LOCKING@
-OMR_THR_TRACING := @OMR_THR_TRACING@
 OMR_THR_YIELD_ALG := @OMR_THR_YIELD_ALG@
 OMR_THR_SPIN_WAKE_CONTROL := @OMR_THR_SPIN_WAKE_CONTROL@
 OMR_THR_MCS_LOCKS := @OMR_THR_MCS_LOCKS@

--- a/thread/exports.cmake
+++ b/thread/exports.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2019 IBM Corp. and others
+# Copyright (c) 2019, 2021 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -183,16 +183,6 @@ endif()
 if(OMR_THR_ADAPTIVE_SPIN)
 	omr_add_exports(j9thr_obj
 		jlm_adaptive_spin_init
-	)
-endif()
-
-
-if(OMR_THR_TRACING)
-	omr_add_exports(j9thr_obj
-		omrthread_monitor_dump_trace
-		omrthread_monitor_dump_all
-		omrthread_dump_trace
-		omrthread_reset_tracing
 	)
 endif()
 

--- a/thread/thread_include.mk
+++ b/thread/thread_include.mk
@@ -1,19 +1,19 @@
 ###############################################################################
-# Copyright (c) 2015, 2019 IBM Corp. and others
-# 
+# Copyright (c) 2015, 2021 IBM Corp. and others
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
@@ -116,15 +116,6 @@ endif
 ifeq (1,$(OMR_THR_ADAPTIVE_SPIN))
 define WRITE_ADAPTIVE_SPIN_THREAD_EXPORTS
 @echo jlm_adaptive_spin_init >>$@
-endef
-endif
-
-ifeq (1,$(OMR_THR_TRACING))
-define WRITE_TRACING_THREAD_EXPORTS
-@echo omrthread_monitor_dump_trace >>$@
-@echo omrthread_monitor_dump_all >>$@
-@echo omrthread_dump_trace >>$@
-@echo omrthread_reset_tracing >>$@
 endef
 endif
 
@@ -280,5 +271,4 @@ $(WRITE_COMMON_THREAD_EXPORTS)
 $(WRITE_ZOS_THREAD_EXPORTS)
 $(WRITE_JLM_THREAD_EXPORTS)
 $(WRITE_ADAPTIVE_SPIN_THREAD_EXPORTS)
-$(WRITE_TRACING_THREAD_EXPORTS)
 endef


### PR DESCRIPTION
Enabling it wouldn't work: for example, it would offer `omrthread_reset_tracing()` which couldn't exist.