### PR TITLE
AArch64: Enable GCR Patching

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2105,8 +2105,8 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
 #ifdef LINUX // On Linux compilation threads can be starved
          self()->setOption(TR_EnableAppThreadYield);
 #endif
-#if defined(TR_TARGET_X86)
-         // Currently GCR patching only works correctly on x86
+#if defined(TR_TARGET_X86) || defined(TR_TARGET_ARM64)
+         // Currently GCR patching only works correctly on x86 and aarch64
          self()->setOption(TR_EnableGCRPatching);
 #else
 


### PR DESCRIPTION
Enable GCR Patching on aarch64.

Depends on:
https://github.com/eclipse/omr/pull/6227
https://github.com/eclipse-openj9/openj9/pull/13867

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>