### PR TITLE
Add a new symbol flag to mark addresses within method bounds

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1226,6 +1226,7 @@ OMR::SymbolReferenceTable::findOrCreateGCRPatchPointSymbolRef()
       sym->setStaticAddress(0);
       sym->setGCRPatchPoint(); // set the flag
       sym->setNotDataAddress();
+      sym->setStaticAddressWithinMethodBounds();
       element(gcrPatchPointSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), gcrPatchPointSymbol, sym);
       }
    return element(gcrPatchPointSymbol);
@@ -1241,6 +1242,7 @@ OMR::SymbolReferenceTable::findOrCreateStartPCSymbolRef()
       sym->setStaticAddress(0);
       sym->setStartPC();
       sym->setNotDataAddress();
+      sym->setStaticAddressWithinMethodBounds();
       element(startPCSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), startPCSymbol, sym);
       }
    return element(startPCSymbol);

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -353,6 +353,9 @@ public:
    inline void setConstantPoolAddress();
    inline bool isConstantPoolAddress();
 
+   inline void setStaticAddressWithinMethodBounds();
+   inline bool isStaticAddressWithinMethodBounds();
+
    // flag methods specific to resolved
    //
    inline bool isJittedMethod();
@@ -516,6 +519,7 @@ public:
       CountForRecompile         = 0x02000000,
       RecompilationCounter      = 0x01000000,
       GCRPatchPoint             = 0x00400000,
+      StaticAddressWithinMethodBounds = 0x00800000, // Address is inside a method body and can be accessed with RIP addressing without relocations
 
       //Only Used by Symbols for which isResolvedMethod is true;
       IsJittedMethod            = 0x80000000,

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -596,6 +596,19 @@ OMR::Symbol::setConstantPoolAddress()
    }
 
 bool
+OMR::Symbol::isStaticAddressWithinMethodBounds()
+   {
+   return self()->isStatic() && _flags.testAny(StaticAddressWithinMethodBounds);
+   }
+
+void
+OMR::Symbol::setStaticAddressWithinMethodBounds()
+   {
+   TR_ASSERT(self()->isStatic(), "Symbol must be static");
+   _flags.set(StaticAddressWithinMethodBounds);
+   }
+
+bool
 OMR::Symbol::isConstMethodHandle()
    {
    return self()->isStatic() && _flags2.testAny(ConstMethodHandle);

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -298,7 +298,7 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
       return true; // If a class gets replaced, it may no longer fit in an immediate
    else if (IS_32BIT_SIGNED(displacement))
       return false;
-   else if (cg->comp()->isOutOfProcessCompilation() && sr.getSymbol() && sr.getSymbol()->isStatic() && !sr.getSymbol()->isNotDataAddress())
+   else if (cg->comp()->isOutOfProcessCompilation() && sr.getSymbol() && sr.getSymbol()->isStatic() && !sr.getSymbol()->isStaticAddressWithinMethodBounds())
       return true;
    else if (IS_32BIT_RIP(displacement, nextInstructionAddress))
       return false;


### PR DESCRIPTION
A new flag AddressWithinMethodBounds indicates that an address
stored in a static symbol is inside method bounds, and can be
accessed using RIP addressing during an out-of-process compilation.