### PR TITLE
Port library startup should not return -1

### DIFF
--- a/include_core/omrporterror.h
+++ b/include_core/omrporterror.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2020 IBM Corp. and others
+ * Copyright (c) 1998, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,6 +103,8 @@
 #define OMRPORT_ERROR_STARTUP_SHSEM (OMRPORT_ERROR_STARTUP_BASE -23)
 #define OMRPORT_ERROR_STARTUP_SHMEM (OMRPORT_ERROR_STARTUP_BASE -24)
 #define OMRPORT_ERROR_STARTUP_SHMEM_MOSERVICE (OMRPORT_ERROR_STARTUP_BASE -25)
+#define OMRPORT_ERROR_STARTUP_SYSINFO_MONITOR_INIT (OMRPORT_ERROR_STARTUP_BASE -26)
+#define OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS (OMRPORT_ERROR_STARTUP_BASE -27)
 
 /** @} */
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -768,7 +768,9 @@ omrsig_startup(struct OMRPortLibrary *portLibrary)
 			oldActions[index].restore = 0;
 		}
 
-		result = initializeSignalTools(portLibrary);
+		if (0 != initializeSignalTools(portLibrary)) {
+			result = OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS;
+		}
 
 	}
 	omrthread_monitor_exit(globalMonitor);

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -3546,7 +3546,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	 */
 	if (0 == attachedPortLibraries) {
 		if (omrthread_monitor_init_with_name(&cgroupEntryListMonitor, 0, "cgroup entry list monitor")) {
-			return -1;
+			return OMRPORT_ERROR_STARTUP_SYSINFO_MONITOR_INIT;
 		}
 	}
 	attachedPortLibraries += 1;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -470,7 +470,9 @@ omrsig_startup(struct OMRPortLibrary *portLibrary)
 		for (index = 1; index < ARRAY_SIZE_SIGNALS; index++) {
 			handlerInfo[index].restore = 0;
 		}
-		result = initializeSignalTools(portLibrary);
+		if (0 != initializeSignalTools(portLibrary)) {
+			result = OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS;
+		}
 	}
 
 	omrthread_monitor_exit(globalMonitor);

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -572,7 +572,9 @@ omrsig_startup(struct OMRPortLibrary *portLibrary)
 		for (index = 1; index < ARRAY_SIZE_SIGNALS; index++) {
 			handlerInfo[index].restore = 0;
 		}
-		result = initializeSignalTools(portLibrary);
+		if (0 != initializeSignalTools(portLibrary)) {
+			result = OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS;
+		}
 	}
 
 	memset(&unwindHistoryTable, 0, sizeof(UNWIND_HISTORY_TABLE));

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -613,7 +613,9 @@ omrsig_startup(struct OMRPortLibrary *portLibrary)
 		for (index = 0; index < MAX_UNIX_SIGNAL_TYPES ;index++) {
 			oldActions[index].restore = 0;
 		}
-		result = initializeSignalTools(portLibrary);
+		if (0 != initializeSignalTools(portLibrary)) {
+			result = OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS;
+		}
 	}
 	omrthread_monitor_exit(globalMonitor);
 


### PR DESCRIPTION
Returning -1 does not give any useful information about what failed.

See also https://github.com/eclipse-openj9/openj9/pull/13872
Issue https://github.com/ibmruntimes/Semeru-Runtimes/issues/5#issuecomment-962040999
Issue https://github.com/eclipse-openj9/openj9/issues/12526