### PR TITLE
AArch64: Call decReferenceCount() for aladd node

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -456,6 +456,7 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
                            integerChild->getInt() : integerChild->getLongInt();
          self()->addToOffset(integerChild, amount, cg);
          cg->decReferenceCount(integerChild);
+         cg->decReferenceCount(subTree);
          }
       else if (subTree->getOpCodeValue() == TR::ishl &&
                subTree->getFirstChild()->getOpCode().isLoadConst() &&


### PR DESCRIPTION
This commit adds a call to decReferenceCount() in
populateMemoryReference() for the case of array access with constant
index.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>