### PR TITLE
AArch64: Add a method to kill placeholder registers in registrer dependency

### DIFF
--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -411,6 +411,14 @@ void OMR::ARM64::RegisterDependencyConditions::stopUsingDepRegs(TR::CodeGenerato
       _postConditions->stopUsingDepRegs(getAddCursorForPost(), NULL, returnRegister, cg);
    }
 
+void OMR::ARM64::RegisterDependencyConditions::stopUsingDepRegs(TR::CodeGenerator *cg, int numRetReg, TR::Register **retReg)
+   {
+   if (_preConditions != NULL)
+      _preConditions->stopUsingDepRegs(getAddCursorForPre(), numRetReg, retReg, cg);
+   if (_postConditions != NULL)
+      _postConditions->stopUsingDepRegs(getAddCursorForPost(), numRetReg, retReg, cg);
+   }
+
 void OMR::ARM64::RegisterDependencyGroup::assignRegisters(
                         TR::Instruction *currentInstruction,
                         TR_RegisterKinds kindToBeAssigned,

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -296,6 +296,14 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    void stopUsingDepRegs(TR::CodeGenerator *cg, TR::Register *returnRegister = NULL);
 
    void stopUsingDepRegs(TR::CodeGenerator *cg, TR::Register * ret1, TR::Register *ret2);
+
+   /**
+    * @brief Kills placeholder registers held by the RegisterDependencyConditions
+    * @param[in] cg : CodeGenerator
+    * @param[in] numRetReg : number of regisgters in retReg
+    * @param[in] retReg : an array of return registers
+    */
+   void stopUsingDepRegs(TR::CodeGenerator *cg, int numRetReg, TR::Register **retReg);
    };
 
 } // ARM64


### PR DESCRIPTION
Add a variant of `stopUsingDepRegs` method which takes an array of registers to keep alive.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>