### PR TITLE
Misc. LabelSymbol improvements

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2597,7 +2597,7 @@ TR::Instruction
          continue;
          }
 
-      if (nextI->isPatchBarrier() || self()->comp()->isPICSite(nextI))
+      if (nextI->isPatchBarrier(self()) || self()->comp()->isPICSite(nextI))
          return NULL;
 
       if (nextI->getEstimatedBinaryLength() > 0)
@@ -2650,7 +2650,7 @@ OMR::CodeGenerator::sizeOfInstructionToBePatchedHCRGuard(TR::Instruction *vgnop)
          continue;
          }
 
-      if (nextI->isPatchBarrier() || self()->comp()->isPICSite(nextI))
+      if (nextI->isPatchBarrier(self()) || self()->comp()->isPICSite(nextI))
          break;
 
       accumulatedSize += nextI->getBinaryLengthLowerBound();

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,8 +178,10 @@ class OMR_EXTENSIBLE Instruction
 
    /*
     * Answers whether the instruction can be included in a guard patch point
+    *
+    * @param[in] cg : CodeGenerator object
     */
-   virtual bool isPatchBarrier() { return false; }
+   virtual bool isPatchBarrier(TR::CodeGenerator *cg) { return false; }
 
    /*
     * A 24-bit value indicating an approximate ordering of instructions.  Note that for an

--- a/compiler/il/LabelSymbol.hpp
+++ b/compiler/il/LabelSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,18 +34,15 @@ class OMR_EXTENSIBLE LabelSymbol : public OMR::LabelSymbolConnector
 
 protected:
 
-   LabelSymbol() :
-      OMR::LabelSymbolConnector() { }
+   LabelSymbol(TR::CodeGenerator *cg) :
+      OMR::LabelSymbolConnector(cg) { }
 
-   LabelSymbol(TR::CodeGenerator *codeGen) :
-      OMR::LabelSymbolConnector(codeGen) { }
-
-   LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb):
-      OMR::LabelSymbolConnector(codeGen, labb) { }
+   LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb):
+      OMR::LabelSymbolConnector(cg, labb) { }
 
 private:
 
-   // When adding another class to the heirarchy, add it as a friend here
+   // When adding another class to the hierarchy, add it as a friend here
    friend class OMR::LabelSymbol;
 
    };

--- a/compiler/il/OMRLabelSymbol.cpp
+++ b/compiler/il/OMRLabelSymbol.cpp
@@ -89,9 +89,9 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb) :
    }
 
 TR_YesNoMaybe
-OMR::LabelSymbol::isTargeted()
+OMR::LabelSymbol::isTargeted(TR::CodeGenerator *cg)
    {
-   if (TR::comp()->cg() && TR::comp()->cg()->getCodeGeneratorPhase() <= TR::CodeGenPhase::InstructionSelectionPhase)
+   if (cg->getCodeGeneratorPhase() <= TR::CodeGenPhase::InstructionSelectionPhase)
       return TR_maybe;
    return _directlyTargeted ? TR_yes : TR_no;
    }

--- a/compiler/il/OMRLabelSymbol.cpp
+++ b/compiler/il/OMRLabelSymbol.cpp
@@ -47,24 +47,18 @@ OMR::LabelSymbol::self()
    }
 
 template <typename AllocatorType>
-TR::LabelSymbol * OMR::LabelSymbol::create(AllocatorType t)
+TR::LabelSymbol * OMR::LabelSymbol::create(AllocatorType t, TR::CodeGenerator *cg)
    {
-   return new (t) TR::LabelSymbol();
+   return new (t) TR::LabelSymbol(cg);
    }
 
 template <typename AllocatorType>
-TR::LabelSymbol * OMR::LabelSymbol::create(AllocatorType t, TR::CodeGenerator* c)
+TR::LabelSymbol * OMR::LabelSymbol::create(AllocatorType t, TR::CodeGenerator *cg, TR::Block *b)
    {
-   return new (t) TR::LabelSymbol(c);
+   return new (t) TR::LabelSymbol(cg, b);
    }
 
-template <typename AllocatorType>
-TR::LabelSymbol * OMR::LabelSymbol::create(AllocatorType t, TR::CodeGenerator* c, TR::Block* b)
-   {
-   return new (t) TR::LabelSymbol(c,b);
-   }
-
-OMR::LabelSymbol::LabelSymbol() :
+OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *cg) :
    TR::Symbol(),
    _instruction(NULL),
    _codeLocation(NULL),
@@ -74,37 +68,24 @@ OMR::LabelSymbol::LabelSymbol() :
    {
    self()->setIsLabel();
 
-   TR::Compilation *comp = TR::comp();
-   if (comp && comp->getDebug())
-      comp->getDebug()->newLabelSymbol(self());
+   TR_Debug *debug = cg->comp()->getDebug();
+   if (debug)
+      debug->newLabelSymbol(self());
    }
 
-OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen) :
+OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb) :
    TR::Symbol(),
    _instruction(NULL),
    _codeLocation(NULL),
    _estimatedCodeLocation(0),
-   _snippet(NULL)
+   _snippet(NULL),
+   _directlyTargeted(false)
    {
    self()->setIsLabel();
 
-   TR::Compilation *comp = TR::comp();
-   if (comp && comp->getDebug())
-      comp->getDebug()->newLabelSymbol(self());
-   }
-
-OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb) :
-   TR::Symbol(),
-   _instruction(NULL),
-   _codeLocation(NULL),
-   _estimatedCodeLocation(0),
-   _snippet(NULL)
-   {
-   self()->setIsLabel();
-
-   TR::Compilation *comp = TR::comp();
-   if (comp && comp->getDebug())
-      comp->getDebug()->newLabelSymbol(self());
+   TR_Debug *debug = cg->comp()->getDebug();
+   if (debug)
+      debug->newLabelSymbol(self());
    }
 
 TR_YesNoMaybe
@@ -154,23 +135,16 @@ template <typename AllocatorType>
 TR::LabelSymbol *
 OMR::LabelSymbol::createRelativeLabel(AllocatorType m, TR::CodeGenerator * cg, intptr_t offset)
    {
-   TR::LabelSymbol * rel = new (m) TR::LabelSymbol();
+   TR::LabelSymbol * rel = new (m) TR::LabelSymbol(cg);
    rel->makeRelativeLabelSymbol(offset);
    return rel;
    }
 
 // Explicit instantiation
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_HeapMemory t);
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_HeapMemory t, TR::CodeGenerator* c);
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_HeapMemory t, TR::CodeGenerator* c, TR::Block* b);
-template TR::LabelSymbol * OMR::LabelSymbol::createRelativeLabel(TR_HeapMemory m, TR::CodeGenerator * cg, intptr_t offset);
+template TR::LabelSymbol * OMR::LabelSymbol::create(TR_HeapMemory t, TR::CodeGenerator* cg);
+template TR::LabelSymbol * OMR::LabelSymbol::create(TR_HeapMemory t, TR::CodeGenerator* cg, TR::Block* b);
+template TR::LabelSymbol * OMR::LabelSymbol::createRelativeLabel(TR_HeapMemory m, TR::CodeGenerator* cg, intptr_t offset);
 
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_StackMemory t);
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_StackMemory t, TR::CodeGenerator* c);
-template TR::LabelSymbol * OMR::LabelSymbol::create(TR_StackMemory t, TR::CodeGenerator* c, TR::Block* b);
-template TR::LabelSymbol * OMR::LabelSymbol::createRelativeLabel(TR_StackMemory m, TR::CodeGenerator * cg, intptr_t offset);
-
-template TR::LabelSymbol * OMR::LabelSymbol::create(PERSISTENT_NEW_DECLARE t);
-template TR::LabelSymbol * OMR::LabelSymbol::create(PERSISTENT_NEW_DECLARE t, TR::CodeGenerator* c);
-template TR::LabelSymbol * OMR::LabelSymbol::create(PERSISTENT_NEW_DECLARE t, TR::CodeGenerator* c, TR::Block* b);
-template TR::LabelSymbol * OMR::LabelSymbol::createRelativeLabel(PERSISTENT_NEW_DECLARE m, TR::CodeGenerator * cg, intptr_t offset);
+template TR::LabelSymbol * OMR::LabelSymbol::create(TR_StackMemory t, TR::CodeGenerator* cg);
+template TR::LabelSymbol * OMR::LabelSymbol::create(TR_StackMemory t, TR::CodeGenerator* cg, TR::Block* b);
+template TR::LabelSymbol * OMR::LabelSymbol::createRelativeLabel(TR_StackMemory m, TR::CodeGenerator* cg, intptr_t offset);

--- a/compiler/il/OMRLabelSymbol.hpp
+++ b/compiler/il/OMRLabelSymbol.hpp
@@ -65,9 +65,6 @@ public:
    TR::LabelSymbol * self();
 
    template <typename AllocatorType>
-   static TR::LabelSymbol * create(AllocatorType);
-
-   template <typename AllocatorType>
    static TR::LabelSymbol * create(AllocatorType, TR::CodeGenerator*);
 
    template <typename AllocatorType>
@@ -75,9 +72,8 @@ public:
 
 protected:
 
-   LabelSymbol();
-   LabelSymbol(TR::CodeGenerator *codeGen);
-   LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb);
+   LabelSymbol(TR::CodeGenerator *cg);
+   LabelSymbol(TR::CodeGenerator *cg, TR::Block *labb);
 
 public:
 

--- a/compiler/il/OMRLabelSymbol.hpp
+++ b/compiler/il/OMRLabelSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,8 +50,6 @@ namespace TR { class StaticSymbol; }
 namespace TR { class SymbolReference; }
 template <class T> class List;
 
-typedef uintptr_t TR_UniqueCompilationId;
-const TR_UniqueCompilationId nullCompilationId(~(TR_UniqueCompilationId) 0);
 
 namespace OMR
 {

--- a/compiler/il/OMRLabelSymbol.hpp
+++ b/compiler/il/OMRLabelSymbol.hpp
@@ -95,7 +95,7 @@ public:
    TR::Snippet * setSnippet(TR::Snippet *s) { return (_snippet = s); }
 
    void setDirectlyTargeted() { _directlyTargeted = true; }
-   TR_YesNoMaybe isTargeted();
+   TR_YesNoMaybe isTargeted(TR::CodeGenerator *cg);
 
 private:
 

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -320,7 +320,7 @@ class PPCLabelInstruction : public TR::Instruction
       }
 
    virtual Kind getKind() { return IsLabel; }
-   virtual bool isPatchBarrier() { return getOpCodeValue() == TR::InstOpCode::label && _symbol && _symbol->isTargeted() != TR_no; }
+   virtual bool isPatchBarrier(TR::CodeGenerator *cg) { return getOpCodeValue() == TR::InstOpCode::label && _symbol && _symbol->isTargeted(cg) != TR_no; }
 
    TR::LabelSymbol *getLabelSymbol() {return _symbol;}
    TR::LabelSymbol *setLabelSymbol(TR::LabelSymbol *sym)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2820,7 +2820,7 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
                      TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/staticPIC", blockFrequency));
                      break;
                      }
-                  if (ninst->isPatchBarrier())
+                  if (ninst->isPatchBarrier(self()))
                      {
                      if (ninst->getOpCodeValue() != TR::InstOpCode::label)
                         TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/patchBarrier", blockFrequency));

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -109,7 +109,7 @@ bool OMR::X86::Instruction::isRegRegMove()
       }
    }
 
-bool OMR::X86::Instruction::isPatchBarrier()
+bool OMR::X86::Instruction::isPatchBarrier(TR::CodeGenerator *cg)
    {
    Kind kind = self()->getKind();
    return kind == TR::Instruction::IsPatchableCodeAlignment

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -100,7 +100,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual bool isBranchOp() {return _opcode.isBranchOp() != 0;}
    virtual bool isLabel();
    virtual bool isRegRegMove();
-   virtual bool isPatchBarrier();
+   virtual bool isPatchBarrier(TR::CodeGenerator *cg);
 
    TR::RegisterDependencyConditions *getDependencyConditions() {return _conditions;}
    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond) { return (_conditions = cond); }
@@ -117,7 +117,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual bool     needsRepPrefix();
    virtual bool     needsLockPrefix();
    virtual EnlargementResult enlarge(int32_t requestedEnlargementSize, int32_t maxEnlargementSize, bool allowPartialEnlargement) { return EnlargementResult(0, 0); }
-   
+
    virtual TR::X86RegInstruction *getX86RegInstruction() { return NULL; }
 
    virtual TR::X86LabelInstruction *getX86LabelInstruction() { return NULL; }

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -319,7 +319,7 @@ class X86LabelInstruction : public TR::Instruction
    void prohibitShortening() { _permitShortening = false; }
 
    virtual char *description() { return "X86LabelInstruction"; }
-   virtual bool isPatchBarrier() { return getOpCodeValue() == TR::InstOpCode::label && _symbol && _symbol->isTargeted() != TR_no; }
+   virtual bool isPatchBarrier(TR::CodeGenerator *cg) { return getOpCodeValue() == TR::InstOpCode::label && _symbol && _symbol->isTargeted(cg) != TR_no; }
 
    uint8_t    getReloType() {return _reloType; };
    void       setReloType(uint8_t rt) { _reloType = rt;};

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -624,11 +624,11 @@ class S390PseudoInstruction : public TR::Instruction
 
    virtual uint8_t *generateBinaryEncoding();
 
-   uint64_t setCallDescValue(uint64_t cdv, TR_Memory * m)
+   uint64_t setCallDescValue(uint64_t cdv, TR_Memory * m, TR::CodeGenerator *cg)
       {
       if (!_callDescLabel)
          {
-         _callDescLabel = TR::LabelSymbol::create(m->trHeapMemory());
+         _callDescLabel = TR::LabelSymbol::create(m->trHeapMemory(), cg);
          }
       return _callDescValue = cdv;
       }


### PR DESCRIPTION
* Remove unused LabelSymbol nullCompilationId
* Fix LabelSymbol constructor to always require a CodeGenerator
* Add CodeGenerator parm to LabelSymbol::isPatchBarrier()