### PR TITLE
Call perror() when SIGSEM_INIT fails in port library startup

### DIFF
--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1596,6 +1596,7 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 
 	/* The asynchronous signal reporter will wait on this semaphore  */
 	if (SIGSEM_ERROR == SIGSEM_INIT(wakeUpASyncReporter, SIGSEM_NAME(0))) {
+		perror("initializeSignalTools() SIGSEM_INIT");
 		return OMRPORT_ERROR_STARTUP_SIGNAL_TOOLS7;
 	}
 	SIGSEM_UNLINK(SIGSEM_NAME(0));


### PR DESCRIPTION
Help to diagnose a rare port library startup issue on OSX.

Issue https://github.com/eclipse-openj9/openj9/issues/12526