### PR TITLE
Remove obsolete overloading of ArrayStoreCHK

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1955,13 +1955,6 @@ OMR::Block::StandardException OMR::Block::_standardExceptions[] =
    {99, "", 0 }
    };
 
-OMR::Block::StandardException OMR::Block::_valueTypesExceptions[] =
-   {
-   {20, "NullPointerException", CanCatchArrayStoreCheck },
-   {99, "", 0 }
-   };
-
-
 static TR::Node *
 findFirstReference(TR::Node * n, TR::Symbol * sym, vcount_t visitCount)
    {
@@ -2475,24 +2468,6 @@ OMR::Block::setExceptionClassName(char *name, int32_t length, TR::Compilation *c
          {
          _catchBlockExtension->_exceptionsCaught |= excp.exceptions;
          break;
-         }
-      }
-
-   // For value types support, certain kinds of catch blocks are able to catch
-   // additional exceptions that might be thrown by check operations
-   //
-   if (TR::Compiler->om.areValueTypesEnabled())
-      {
-      for (int32_t i = 0; ; ++i)
-         {
-         StandardException &excp = _valueTypesExceptions[i];
-         if (excp.length > length)
-            break;
-         if (excp.length == length && !strncmp(name, excp.name, length))
-            {
-            _catchBlockExtension->_exceptionsCaught |= excp.exceptions;
-            break;
-            }
          }
       }
    }

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -508,8 +508,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    static StandardException _standardExceptions[];
 
-   static StandardException _valueTypesExceptions[];
-
    enum // flag bits for _flags
       {
       _isExtensionOfPreviousBlock           = 0x00000001,

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3651,10 +3651,6 @@ OMR::Node::exceptionsRaised()
          break;
       case TR::ArrayStoreCHK:
          possibleExceptions |= TR::Block:: CanCatchArrayStoreCheck;
-         if (TR::Compiler->om.areValueTypesEnabled())
-            {
-            possibleExceptions |= TR::Block:: CanCatchNullCheck;
-            }
          break;
       case TR::ArrayCHK:
          possibleExceptions |= TR::Block:: CanCatchArrayStoreCheck;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12306,15 +12306,10 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPConstraint *object = vp->getConstraint(objectRef, isGlobal);
       TR::VPConstraint *array  = vp->getConstraint(arrayRef, isGlobal);
 
-      TR_YesNoMaybe arrayCompIsValueType = vp->isArrayCompTypeValueType(array);
-
       // If the object reference is null we can remove this check, if the
       // array's element type is not a value type
-      // Null references are not allowed for value types, so only remove the
-      // check if the array type is resolved and cannot be of a type whose
-      // actual component type can be a value type
       //
-      if (object && object->isNullObject() && arrayCompIsValueType == TR_no)
+      if (object && object->isNullObject())
          {
          canBeRemoved = true;
          }
@@ -12365,21 +12360,7 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
                if (isInstance == TR_yes)
                   {
                   vp->registerPreXClass(object);
-
-                  // Arrays with value type component types must throw NPE if
-                  // the value assigned is null.  Can only remove the check if
-                  // the array cannot have a value type as its component type
-                  // or the value cannot be a null reference
-                  //
-                  // VALUE_TYPES_TODO:  For case where array component type is
-                  // definitely a value type and source might be null, can
-                  // remove the ArrayStoreCHK and add a NullCHK of the source
-                  // object.
-                  //
-                  if (arrayCompIsValueType == TR_no || object->isNonNullObject())
-                     {
-                     canBeRemoved = true;
-                     }
+                  canBeRemoved = true;
                   }
                else if (isInstance == TR_no && debug("enableMustFailArrayStoreCheckOpt"))
                   {


### PR DESCRIPTION
A downstream project used overloading of `ArrayStoreCHK` to allow for checking of whether a null reference was being stored to an array whose component type is one that does not allow for null references.  That overloading is no longer used in the downstream project, and the new `nonNullableArrayNullStoreCheck` non-helper symbol can be used to achieve the same effect.  This change removes the now obsolete potential overloading of `ArrayStoreCHK`.