### PR TITLE
Define TR_VerboseLog::CriticalSection as a vlog RAII lock guard

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1124,7 +1124,7 @@ int32_t OMR::Compilation::compile()
          {
          int32_t jittedBodyHash = strHash(self()->signature());
          char callerBuf[501], calleeBuf[501];
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          TR_VerboseLog::writeLine(TR_Vlog_INL, "%d methods inlined into %x %s @ %p", self()->getNumInlinedCallSites(), jittedBodyHash, self()->signature(), self()->cg()->getCodeStart());
          for (int32_t i = 0; i < self()->getNumInlinedCallSites(); i++)
             {
@@ -1182,7 +1182,6 @@ int32_t OMR::Compilation::compile()
                   }
                }
             }
-         TR_VerboseLog::vlogRelease();
          }
 #endif
       }

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -377,7 +377,7 @@ compileMethodFromDetails(
          if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCompileEnd, TR_VerbosePerformance))
             {
             const char *signature = compilee.signature(&trMemory);
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::write(TR_Vlog_COMP, "(%s) %s @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT,
                                            compiler.getHotnessName(compiler.getMethodHotness()),
                                            signature,
@@ -394,7 +394,6 @@ compileMethodFromDetails(
                }
 
             trfflush(jitConfig->options.vLogFile);
-            TR_VerboseLog::vlogRelease();
             }
 
          if (

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2236,7 +2236,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
 
       if (self()->getOption(TR_MimicInterpreterFrameShape))
          {
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          if (self()->getFixedOptLevel() != -1 && self()->getFixedOptLevel() != noOpt)
             TR_VerboseLog::writeLine(TR_Vlog_FSD, "Ignoring user specified optLevel");
          if (_countString)
@@ -2255,7 +2255,6 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
                }
             }
          _countString = 0;
-         TR_VerboseLog::vlogRelease();
          }
 
       if (TR::Options::isAnyVerboseOptionSet(TR_VerboseOptimizer)
@@ -3093,12 +3092,11 @@ OMR::Options::validateOptionsTables(void *feBase, TR_FrontEnd *fe)
          }
       if (_numJitEntries > 0 && stricmp_ignore_locale((opt-1)->name, opt->name) >= 0)
          {
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          TR_VerboseLog::write(TR_Vlog_FAILURE, "JIT option table entries out of order: ");
          TR_VerboseLog::write((opt-1)->name);
          TR_VerboseLog::write(", ");
          TR_VerboseLog::writeLine(opt->name);
-         TR_VerboseLog::vlogRelease();
          return false;
          }
 #endif
@@ -3120,12 +3118,11 @@ OMR::Options::validateOptionsTables(void *feBase, TR_FrontEnd *fe)
          }
       if (_numVmEntries > 0 && stricmp_ignore_locale((opt-1)->name, opt->name) >= 0)
          {
-         TR_VerboseLog::vlogAcquire();
+         TR_VerboseLog::CriticalSection vlogLock;
          TR_VerboseLog::writeLine(TR_Vlog_FAILURE,"FE option table entries out of order: ");
          TR_VerboseLog::write((opt-1)->name);
          TR_VerboseLog::write(", ");
          TR_VerboseLog::write(opt->name);
-         TR_VerboseLog::vlogRelease();
          return false;
          }
 #endif

--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -100,7 +100,7 @@ public:
          // Dump the options
          if (TR::Options::getVerboseOption(TR_VerbosePerformance))
             {
-            TR_VerboseLog::vlogAcquire();
+            TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::write("Profiling %s compile time with:", comp->signature());
             char **iter = options;
             while (*iter)
@@ -109,7 +109,6 @@ public:
                iter++;
                }
             TR_VerboseLog::writeLine("");
-            TR_VerboseLog::vlogRelease();
             }
 
          _pid = fork();

--- a/compiler/env/TRPersistentMemory.cpp
+++ b/compiler/env/TRPersistentMemory.cpp
@@ -107,11 +107,10 @@ TR_PersistentMemory::printMemStats()
 void
 TR_PersistentMemory::printMemStatsToVlog()
    {
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    TR_VerboseLog::writeLine(TR_Vlog_MEMORY, "TR_PersistentMemory Stats:");
    for (uint32_t i = 0; i < TR_MemoryBase::NumObjectTypes; i++)
       {
       TR_VerboseLog::writeLine(TR_Vlog_MEMORY, "\t_totalPersistentAllocations[%s]=%lu", objectName[i], (unsigned long)_totalPersistentAllocations[i]);
       }
-   TR_VerboseLog::vlogRelease();
    }

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -90,7 +90,7 @@ void TR_VerboseLog::writeLine(const char *format, ...)
 void TR_VerboseLog::writeLineLocked(TR_VlogTag tag, const char *format, ...)
    {
    TR_ASSERT(tag != TR_Vlog_null, "TR_Vlog_null is not a valid Vlog tag");
-   vlogAcquire();
+   CriticalSection lock;
    va_list args;
    va_start(args, format);
    writeTimeStamp();
@@ -98,7 +98,6 @@ void TR_VerboseLog::writeLineLocked(TR_VlogTag tag, const char *format, ...)
    vwrite(format, args);
    write("\n");
    va_end(args);
-   vlogRelease();
    }
 
 void TR_VerboseLog::write(const char *format, ...)

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -82,8 +82,9 @@ enum TR_VlogTag
 class TR_VerboseLog
    {
    public:
-   //writeLine and write provide multi line write capabilities, and are to be used with vlogAcquire() and vlogRelease(),
-   //this ensures nice formatted verbose logs
+   // writeLine and write provide multi line write capabilities, and are to be
+   // used with CriticalSection or vlogAcquire() and vlogRelease() to ensure
+   // nicely formatted verbose logs
    static void write(const char *format, ...);
    static void write(TR_VlogTag tag, const char *format, ...);
    static void writeLine(TR_VlogTag tag, const char *format, ...);
@@ -92,6 +93,29 @@ class TR_VerboseLog
    static void writeLineLocked(TR_VlogTag tag, const char *format, ...);
    static void vlogAcquire(); //defined in each front end
    static void vlogRelease(); //defined in each front end
+
+   class CriticalSection
+      {
+      public:
+      CriticalSection(bool lock = true) : _locked(false)
+         {
+         if (lock)
+            {
+            vlogAcquire();
+            _locked = true;
+            }
+         }
+
+      ~CriticalSection()
+         {
+         if (_locked)
+            vlogRelease();
+         }
+
+      private:
+      bool _locked;
+      };
+
    //only called once early on, after we can print to the vlog
    static void initialize(void *config);
    private:

--- a/compiler/infra/SimpleRegex.cpp
+++ b/compiler/infra/SimpleRegex.cpp
@@ -393,13 +393,12 @@ bool SimpleRegex::match(const char *s, bool isCaseSensitive, bool useLocale)
 
 void SimpleRegex::print(bool negate)
    {
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    TR_VerboseLog::write("{");
    if (negate ^ _negate)
       TR_VerboseLog::write("^");
    _regex->print();
    TR_VerboseLog::write("}");
-   TR_VerboseLog::vlogRelease();
    }
 
 
@@ -409,9 +408,8 @@ void SimpleRegex::Regex::print()
       simple->print();
    if (remainder)
       {
-      TR_VerboseLog::vlogAcquire();
+      TR_VerboseLog::CriticalSection vlogLock;
       TR_VerboseLog::write("|");
-      TR_VerboseLog::vlogRelease();
       remainder->print();
       }
    }
@@ -419,7 +417,7 @@ void SimpleRegex::Regex::print()
 
 void SimpleRegex::Simple::print()
    {
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    int32_t i;
    switch (component->type)
       {
@@ -458,7 +456,6 @@ void SimpleRegex::Simple::print()
       }
    if (remainder)
       remainder->print();
-   TR_VerboseLog::vlogRelease();
    }
 
 

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -786,6 +786,7 @@ void TR_FilterBST::insert(TR_FilterBST *node)
 void
 TR_Debug::print(TR_FilterBST * filter)
    {
+   TR_VerboseLog::CriticalSection vlogLock;
    /*
    if (filter->_optionSet)
       TR_VerboseLog::write("   {%d}", filter->_optionSet);
@@ -793,7 +794,6 @@ TR_Debug::print(TR_FilterBST * filter)
    if (filter->_lineNumber)
       TR_VerboseLog::write("   [%d]", filter->_lineNumber);
    */
-   TR_VerboseLog::vlogAcquire();
 
    switch (filter->_filterType)
       {
@@ -861,8 +861,6 @@ TR_Debug::print(TR_FilterBST * filter)
          printFilters(filter->subGroup);
          TR_VerboseLog::write("   ]\n");
          }
-      
-      TR_VerboseLog::vlogRelease();
    }
 
 void
@@ -895,7 +893,7 @@ TR_Debug::printFilters(TR::CompilationFilters * filters)
 void
 TR_Debug::printFilters()
    {
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    TR_VerboseLog::writeLine("<compilationFilters>");
    printFilters(_compilationFilters);
    TR_VerboseLog::writeLine("</compilationFilters>");
@@ -907,7 +905,6 @@ TR_Debug::printFilters()
    TR_VerboseLog::writeLine("<inlineFilters>");
    printFilters(_inlineFilters);
    TR_VerboseLog::writeLine("</inlineFilters>");
-   TR_VerboseLog::vlogRelease();
    }
 
 void
@@ -1250,7 +1247,7 @@ TR_Debug::methodCanBeRelocated(TR_Memory *trMemory, TR_ResolvedMethod *method, T
 int32_t *
 TR_Debug::loadCustomStrategy(char *fileName)
    {
-   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::CriticalSection vlogLock;
    int32_t *customStrategy = NULL;
    FILE *optFile = fopen(fileName, "r");
    if (optFile)
@@ -1308,6 +1305,5 @@ TR_Debug::loadCustomStrategy(char *fileName)
       {
       TR_VerboseLog::writeLine(TR_Vlog_INFO, "optFile not found: '%s'", fileName);
       }
-   TR_VerboseLog::vlogRelease();
    return customStrategy;
    }

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -148,7 +148,6 @@ static bool regexExcludes(TR::SimpleRegex *regex, const char *string)
 
 void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * firstOfe, TR::SimpleRegex *nameFilter)
    {
-   TR_VerboseLog::vlogAcquire();
    static int optionLineWidth=0;
 
    if (!optionLineWidth)
@@ -162,6 +161,7 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
 
    TR::OptionTable * entry;
 
+   TR_VerboseLog::CriticalSection vlogLock;
    TR_VerboseLog::writeLine(TR_Vlog_INFO,"Usage: -Xjit:option([,option]*)\n");
 
    for (int32_t cat = 0; optionCategories[cat]; cat++)
@@ -276,7 +276,6 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
       }
    TR_VerboseLog::writeLine("");
    TR_VerboseLog::writeLine(TR_Vlog_INFO, "");
-   TR_VerboseLog::vlogRelease();
    }
 
 void
@@ -290,7 +289,6 @@ TR_Debug::dumpOptions(
       void * feBase,
       TR_FrontEnd *fe)
    {
-   TR_VerboseLog::vlogAcquire();
    TR::OptionTable *entry;
    char *base;
    TR::Compilation* comp = TR::comp();
@@ -300,6 +298,8 @@ TR_Debug::dumpOptions(
 #ifdef J9_PROJECT_SPECIFIC
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
 #endif
+
+   TR_VerboseLog::CriticalSection vlogLock;
 
    if(!vmCounter)
       TR_VerboseLog::writeLine(TR_Vlog_INFO,"_______________________________________");
@@ -512,5 +512,4 @@ TR_Debug::dumpOptions(
       TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs shiftAmount=%d", TR::Compiler->om.compressedReferenceShift());
       }
 #endif
-      TR_VerboseLog::vlogRelease();
    }


### PR DESCRIPTION
The verbose log can now be locked by declaring a local variable of type `TR_VerboseLog::CriticalSection`, and the lock will be automatically released at the end of the variable's scope. Locking this way is advantageous because it's not possible to forget to release the lock, and because the lock will always be released even if an exception is thrown.

In general, releasing a lock while unexpectedly unwinding for an exception could leave a program in a bad state. If the lock protects an invariant, it's possible to take the lock, temporarily violate the invariant, and then unwind before restoring it. However, in the case of the verbose log lock specifically, the only effect of unlocking on unwind will be to prematurely truncate the output being generated at the time. The output is just diagnostic, so it's best to simply release the lock.

There is an optional boolean parameter to specify whether or not to actually acquire the lock. This is useful for cases where we are incrementally generating output that needs to stay together, but we're doing so conditionally in the midst of other logic, e.g.

    if (verbose)
        TR_VerboseLog::write(...);

    ...

    if (verbose)
        TR_VerboseLog::write(...);

    ...

    if (verbose)
        TR_VerboseLog::writeLine(...);

The boolean parameter allows for a sequence like this to use `CriticalSection` while still only locking when necessary:

    TR_VerboseLog::CriticalSection vlogLock(verbose);

Without it, the use of `CriticalSection` would force the code either to lock each write individually, which is too fine a granularity and allows unwanted interleaving, or to take the lock even when not outputting to the verbose log.

----

Pairs of calls to `vlogAcquire()` and `vlogRelease()` are changed to use `CriticalSection` instead.