### PR TITLE
Implement vmul for IntVectors, ShortVectors, and ByteVectors of size 128

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1774,13 +1774,11 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
       {
       case TR::vadd:
       case TR::vsub:
-         if (dt == TR::Int16 || dt == TR::Int8 || dt == TR::Int32 || dt == TR::Float || dt == TR::Double)
+      case TR::vmul:
+         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Float || dt == TR::Double)
             return true;
          else
             return false;
-      case TR::vmul:
-         if (dt == TR::Int16)
-            return true;
       case TR::vdiv:
       case TR::vneg:
          if (dt == TR::Int32 || dt == TR::Float || dt == TR::Double)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1779,6 +1779,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
          else
             return false;
       case TR::vmul:
+         if (dt == TR::Int16)
+            return true;
       case TR::vdiv:
       case TR::vneg:
          if (dt == TR::Int32 || dt == TR::Float || dt == TR::Double)

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -711,7 +711,7 @@
    vsubuws,          // vector subtract unsigned word saturate
 // vmhaddshs,        // Vector Multiply-High-Add Signed Hword Saturate
 // vmhraddshs,       // Vector Multiply-High-Round-Add Signed Hword Saturate
-// vmladduhm,        // Vector Multiply-Low-Add Unsigned Hword Modulo
+   vmladduhm,        // Vector Multiply-Low-Add Unsigned Hword Modulo
 // vmsummbm,         // Vector Multiply-Sum Mixed Byte Modulo
 // vmsumshm,         // Vector Multiply-Sum Signed Hword Modulo
 // vmsumshs,         // Vector Multiply-Sum Signed Hword Saturate

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -718,10 +718,10 @@
 // vmsumubm,         // Vector Multiply-Sum Unsigned Byte Modulo
 // vmsumuhs,         // Vector Multiply-Sum Unsigned Hword Saturate
 // vmulesb,          // Vector Multiply Even Signed Byte
-// vmuleub,          // Vector Multiply Even Unsigned Byte
+   vmuleub,          // Vector Multiply Even Unsigned Byte
 // vmuleuh,          // Vector Multiply Even Unsigned Hword
 // vmulosb,          // Vector Multiply Odd Signed Byte
-// vmuloub,          // Vector Multiply Odd Unsigned Byte
+   vmuloub,          // Vector Multiply Odd Unsigned Byte
    vmulesh,          // vector multiply even signed halfword
    vmulosh,          // vector multiply odd signed halfword
    vmulouh,          // vector multiply odd unsigned halfword

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -8361,7 +8361,7 @@
    /* .opcode      = */   0x10000022,
    /* .format      = */   FORMAT_VRT_VRA_VRB_VRC,
    /* .minimumALS  = */   OMR_PROCESSOR_PPC_P6,
-   /* .properties  = */   PPCOpProp_IsVMX | 
+   /* .properties  = */   PPCOpProp_IsVMX |
                           PPCOpProp_SyncSideEffectFree,
    },
 
@@ -8437,17 +8437,17 @@
    /*                   PPCOpProp_SyncSideEffectFree, */
    /* }, */
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vmuleub, */
-   /* .name        =    "vmuleub", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vmuleub,
+   /* .name        = */ "vmuleub",
    /* .description =    "Vector Multiply Even Unsigned Byte", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10000208, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P6, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10000208,
+   /* .format      = */ FORMAT_VRT_VRA_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P6,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::vmuleuh, */
@@ -8473,17 +8473,17 @@
    /*                   PPCOpProp_SyncSideEffectFree, */
    /* }, */
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vmuloub, */
-   /* .name        =    "vmuloub", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vmuloub,
+   /* .name        = */ "vmuloub",
    /* .description =    "Vector Multiply Odd Unsigned Byte", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10000008, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P6, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10000008,
+   /* .format      = */ FORMAT_VRT_VRA_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P6,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::vmulesh,

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corp. and others
+ * Copyright (c) 2019, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -8353,17 +8353,17 @@
    /*                   PPCOpProp_SyncSideEffectFree, */
    /* }, */
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vmladduhm, */
-   /* .name        =    "vmladduhm", */
-   /* .description =    "Vector Multiply-Low-Add Unsigned Hword Modulo", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10000022, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P6, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   {
+   /* .mnemonic    = */   OMR::InstOpCode::vmladduhm,
+   /* .name        = */   "vmladduhm",
+   /* .description =      "Vector Multiply-Low-Add Unsigned Hword Modulo", */
+   /* .prefix      = */   0x00000000,
+   /* .opcode      = */   0x10000022,
+   /* .format      = */   FORMAT_VRT_VRA_VRB_VRC,
+   /* .minimumALS  = */   OMR_PROCESSOR_PPC_P6,
+   /* .properties  = */   PPCOpProp_IsVMX | 
+                          PPCOpProp_SyncSideEffectFree,
+   },
 
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::vmsummbm, */

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3466,9 +3466,42 @@ TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeG
        return TR::TreeEvaluator::vmulFloatHelper(node,cg);
      case TR::VectorDouble:
        return TR::TreeEvaluator::vmulDoubleHelper(node,cg);
+     case TR::VectorInt16:
+       return TR::TreeEvaluator::vmulInt16Helper(node,cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::vmulInt16Helper(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::Node *firstChild;
+   TR::Node *secondChild;
+   TR::Register *lhsReg, *rhsReg;
+   TR::Register *productReg;
+   TR::Register *temp;
+
+   firstChild = node->getFirstChild();
+   secondChild = node->getSecondChild();
+   lhsReg = NULL;
+   rhsReg = NULL;
+
+   lhsReg = cg->evaluate(firstChild);
+   rhsReg = cg->evaluate(secondChild);
+
+   productReg = cg->allocateRegister(TR_VRF);
+   temp = cg->allocateRegister(TR_VRF);
+
+   node->setRegister(productReg);
+
+   generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltish, node, temp, 0);
+   generateTrg1Src3Instruction(cg, TR::InstOpCode::vmladduhm, node, productReg, lhsReg, rhsReg, temp);
+
+   cg->stopUsingRegister(temp);
+   cg->decReferenceCount(firstChild);
+   cg->decReferenceCount(secondChild);
+
+   return productReg;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vmulInt32Helper(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3473,41 +3473,7 @@ TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::vmulInt32Helper(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Node *firstChild;
-   TR::Node *secondChild;
-   TR::Register *lhsReg, *rhsReg;
-   TR::Register *resReg;
-   TR::Register *tempA;
-   TR::Register *tempB;
-   TR::Register *tempC;
-
-   firstChild = node->getFirstChild();
-   secondChild = node->getSecondChild();
-   lhsReg = NULL;
-   rhsReg = NULL;
-
-   lhsReg = cg->evaluate(firstChild);
-   rhsReg = cg->evaluate(secondChild);
-
-   resReg = cg->allocateRegister(TR_VRF);
-   tempA = cg->allocateRegister(TR_VRF);
-   tempB = cg->allocateRegister(TR_VRF);
-   tempC = cg->allocateRegister(TR_VRF);
-   node->setRegister(resReg);
-   generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltisw, node, tempA, -16);
-   generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltisw, node, tempB, 0);
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vmulouh, node, tempC, lhsReg, rhsReg);
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vrlw, node, resReg, rhsReg, tempA);
-   generateTrg1Src3Instruction(cg, TR::InstOpCode::vmsumuhm, node, tempB, lhsReg, resReg, tempB);
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vslw, node, tempA, tempB, tempA);
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vadduhm, node, resReg, tempA, tempC);
-
-   cg->stopUsingRegister(tempA);
-   cg->stopUsingRegister(tempB);
-   cg->stopUsingRegister(tempC);
-   cg->decReferenceCount(firstChild);
-   cg->decReferenceCount(secondChild);
-   return resReg;
+   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vmuluwm);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vmulFloatHelper(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -638,6 +638,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vmulInt8Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulInt16Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulInt32Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulFloatHelper(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -638,6 +638,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vmulInt16Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulInt32Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulFloatHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulDoubleHelper(TR::Node *node, TR::CodeGenerator *cg);

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2331,6 +2331,12 @@ INSTANTIATE_TEST_CASE_P(VMX, PPCTrg1Src2EncodingTest, ::testing::ValuesIn(*TRTes
     std::make_tuple(TR::InstOpCode::vmuluwm,  TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e00089u),
     std::make_tuple(TR::InstOpCode::vmuluwm,  TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x101f0089u),
     std::make_tuple(TR::InstOpCode::vmuluwm,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x1000f889u),
+    std::make_tuple(TR::InstOpCode::vmuleub,  TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e00208u),
+    std::make_tuple(TR::InstOpCode::vmuleub,  TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x101f0208u),
+    std::make_tuple(TR::InstOpCode::vmuleub,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x1000fa08u),
+    std::make_tuple(TR::InstOpCode::vmuloub,  TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e00008u),
+    std::make_tuple(TR::InstOpCode::vmuloub,  TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x101f0008u),
+    std::make_tuple(TR::InstOpCode::vmuloub,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x1000f808u),
     std::make_tuple(TR::InstOpCode::vnor,     TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e00504u),
     std::make_tuple(TR::InstOpCode::vnor,     TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x101f0504u),
     std::make_tuple(TR::InstOpCode::vnor,     TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x1000fd04u),
@@ -2439,7 +2445,11 @@ INSTANTIATE_TEST_CASE_P(VMX, PPCTrg1Src3EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vsel,     TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e0002au),
     std::make_tuple(TR::InstOpCode::vsel,     TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x101f002au),
     std::make_tuple(TR::InstOpCode::vsel,     TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x1000f82au),
-    std::make_tuple(TR::InstOpCode::vsel,     TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x100007eau)
+    std::make_tuple(TR::InstOpCode::vsel,     TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x100007eau),
+    std::make_tuple(TR::InstOpCode::vmladduhm,TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x13e00022u),
+    std::make_tuple(TR::InstOpCode::vmladduhm,TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  TR::RealRegister::vr0,  0x101f0022u),
+    std::make_tuple(TR::InstOpCode::vmladduhm,TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, TR::RealRegister::vr0,  0x1000f822u),
+    std::make_tuple(TR::InstOpCode::vmladduhm,TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr0,  TR::RealRegister::vr31, 0x100007e2u)
 ));
 
 INSTANTIATE_TEST_CASE_P(VMX, PPCRecordFormSanityTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::InstOpCode::Mnemonic, BinaryInstruction>>(
@@ -2482,6 +2492,9 @@ INSTANTIATE_TEST_CASE_P(VMX, PPCRecordFormSanityTest, ::testing::ValuesIn(*TRTes
     std::make_tuple(TR::InstOpCode::vmulosh,  TR::InstOpCode::bad,        BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vmulouh,  TR::InstOpCode::bad,        BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vmuluwm,  TR::InstOpCode::bad,        BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::vmladduhm,TR::InstOpCode::bad,        BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::vmuleub,  TR::InstOpCode::bad,        BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::vmuloub,  TR::InstOpCode::bad,        BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vnor,     TR::InstOpCode::bad,        BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vor,      TR::InstOpCode::bad,        BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vperm,    TR::InstOpCode::bad,        BinaryInstruction()),


### PR DESCRIPTION
This contribution includes the following changes:

- The seven instruction sequence previously used for vmul for IntVectors has been replaced with a single vmuluwm instruction
- vmul for ShortVectors and ByteVectors have each been implemented with multi-instruction sequences, since there is no single PPC assembly insruction that can perform this operation for these vector types
- Binary encoder unit tests have been added for newly enabled instructions