### PR TITLE
Update z/OS compile to use V2R3

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -282,7 +282,7 @@ def SPECS = [
         'label' : 'compile:zos',
         'reference' : '',
         'environment' : [
-            "LIBPATH+EXTRA=/openzdk/jenkins/workspace/${workspaceName}/build",
+            "LIBPATH+EXTRA=/u/user1/workspace/${workspaceName}/build",
             "_C89_ACCEPTABLE_RC=0",
             "_CXX_ACCEPTABLE_RC=0"
         ],

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -331,7 +331,6 @@ timestamps {
                                         extensions: [[$class: 'CloneOption', honorRefspec: true, timeout: 30, reference: SPECS[params.BUILDSPEC].reference]],
                                         userRemoteConfigs: [[name: 'origin',
                                             refspec: "${refspec}",
-                                            credentialsId: 'github-bot-ssh',
                                             url: "${gitConfig.getUrl()}"]
                                         ]
                                     ]

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,10 +113,10 @@ elseif(OMR_OS_LINUX)
 		-qxflag=selinux
 	)
 elseif(OMR_OS_ZOS)
-	set(OMR_ZOS_COMPILE_ARCHITECTURE "7" CACHE STRING "z/OS compile machine architecture")
-	set(OMR_ZOS_COMPILE_TARGET "zOSV1R13" CACHE STRING "z/OS compile target operating system")
-	set(OMR_ZOS_COMPILE_TUNE "10" CACHE STRING "z/OS compile machine architecture tuning")
-	set(OMR_ZOS_LINK_COMPAT "ZOSV1R13" CACHE STRING "z/OS link compatible operating system")
+	set(OMR_ZOS_COMPILE_ARCHITECTURE "10" CACHE STRING "z/OS compile machine architecture")
+	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R3" CACHE STRING "z/OS compile target operating system")
+	set(OMR_ZOS_COMPILE_TUNE "12" CACHE STRING "z/OS compile machine architecture tuning")
+	set(OMR_ZOS_LINK_COMPAT "ZOSV2R3" CACHE STRING "z/OS link compatible operating system")
 
 	# TODO: This should technically be -qhalt=w however c89 compiler used to compile the C sources does not like this
 	# flag. We'll need to investigate whether we actually need c89 for C sources or if we can use xlc and what to do

--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@
 #
 #
 # Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+# Copyright (c) 2015, 2022 IBM Corp. and others
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -1745,13 +1746,13 @@ Some influential environment variables:
               A description of the product which is integrating OMR. (Default:
               OMR 0.1 )
   OMR_ZOS_COMPILE_ARCHITECTURE
-              The z/OS compile machine architecture. (Default: 7)
+              The z/OS compile machine architecture. (Default: 10)
   OMR_ZOS_COMPILE_TARGET
-              The z/OS compile target operating system. (Default: zOSV1R13)
+              The z/OS compile target operating system. (Default: ZOSV2R3)
   OMR_ZOS_COMPILE_TUNE
-              The z/OS compile machine architecture tuning. (Default: 10)
+              The z/OS compile machine architecture tuning. (Default: 12)
   OMR_ZOS_LINK_COMPAT
-              The z/OS link compatible operating system. (Default: ZOSV1R13)
+              The z/OS link compatible operating system. (Default: ZOSV2R3)
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
@@ -2879,10 +2880,10 @@ OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"OMR 0.1 "}
 OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"0.1"}
 
-OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}
-OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"zOSV1R13"}
-OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"10"}
-OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV1R13"}
+OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"10"}
+OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"ZOSV2R3"}
+OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"12"}
+OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV2R3"}
 
 # Check whether --enable-optimized was given.
 if test "${enable_optimized+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2021 IBM Corp. and others
+# Copyright (c) 2015, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,13 +67,13 @@ AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION],
   [A description of the product which is integrating OMR.] (Default: AC_PACKAGE_STRING AC_PACKAGE_URL))
 
 AC_ARG_VAR([OMR_ZOS_COMPILE_ARCHITECTURE],
-  [The z/OS compile machine architecture. (Default: 7)])
+  [The z/OS compile machine architecture. (Default: 10)])
 AC_ARG_VAR([OMR_ZOS_COMPILE_TARGET],
-  [The z/OS compile target operating system. (Default: zOSV1R13)])
+  [The z/OS compile target operating system. (Default: ZOSV2R3)])
 AC_ARG_VAR([OMR_ZOS_COMPILE_TUNE],
-  [The z/OS compile machine architecture tuning. (Default: 10)])
+  [The z/OS compile machine architecture tuning. (Default: 12)])
 AC_ARG_VAR([OMR_ZOS_LINK_COMPAT],
-  [The z/OS link compatible operating system. (Default: ZOSV1R13)])
+  [The z/OS link compatible operating system. (Default: ZOSV2R3)])
 
 OMR_COMPANY_NAME=${OMR_COMPANY_NAME:-""}
 OMR_COMPANY_COPYRIGHT=${OMR_COMPANY_COPYRIGHT:-""}
@@ -81,10 +81,10 @@ OMR_PRODUCT_DESCRIPTION=${OMR_PRODUCT_DESCRIPTION:-"AC_PACKAGE_STRING AC_PACKAGE
 OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"AC_PACKAGE_NAME"}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"AC_PACKAGE_VERSION"}
 
-OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}
-OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"zOSV1R13"}
-OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"10"}
-OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV1R13"}
+OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"10"}
+OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"ZOSV2R3"}
+OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"12"}
+OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV2R3"}
 
 AC_ARG_ENABLE([optimized],
 	AS_HELP_STRING([--enable-optimized], [Create an optimized build. (Default: yes)]),

--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2020 IBM Corp. and others
+# Copyright (c) 2015, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,12 +63,15 @@ endif # ENABLE_DDR
 ifeq ($(OMR_OPTIMIZE),1)
     COPTFLAGS=-O3 -Wc,"TUNE($(OMR_ZOS_COMPILE_TUNE))" -Wc,"inline(auto,noreport,600,5000)"
 
-    # OMRTODO: The COMPAT=ZOSV1R13 option does not appear to be related to
-    # optimizations.  This linker option is supplied only on the compile line,
+    # 28 Feb 2022: ZOSV2R3 is adopted since ZOSV1R13 is discontinued.
+    #
+    # Note: The COMPAT=ZOSV1R13 option does not appear to be related to
+    # optimizations. This linker option is supplied only on the compile line,
     # and never when we link. It might be relevant to note that this was added
     # at the same time as the compilation flag "-Wc,target=ZOSV1R10", which
     # would give a performance boost.
-    # option means: "COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs"
+    #
+    # COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs.
     # http://www-01.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab100/compat.htm
     COPTFLAGS+=-Wl,compat=$(OMR_ZOS_LINK_COMPAT)
 else


### PR DESCRIPTION
* with the z/OS guests being replaced with V2R4 systems the lowest level xlc compiles to that is supported is now V2R3.

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>