### PR TITLE
Core Standard SATB Routines

### DIFF
--- a/example/glue/ConcurrentMarkingDelegate.hpp
+++ b/example/glue/ConcurrentMarkingDelegate.hpp
@@ -269,6 +269,12 @@ public:
 		return false;
 	}
 
+	MMINLINE bool
+	setupClassScanning(MM_EnvironmentBase *env)
+	{
+		return true;
+	}
+
 	/**
 	 * Deprecated. Use this default implementation unless otherwise required.
 	 */

--- a/example/glue/MarkingDelegate.cpp
+++ b/example/glue/MarkingDelegate.cpp
@@ -30,7 +30,7 @@
 #include "MarkingDelegate.hpp"
 
 void
-MM_MarkingDelegate::scanRoots(MM_EnvironmentBase *env)
+MM_MarkingDelegate::scanRoots(MM_EnvironmentBase *env, bool processLists)
 {
 	OMR_VM_Example *omrVM = (OMR_VM_Example *)env->getOmrVM()->_language_vm;
 	J9HashTableState state;

--- a/example/glue/MarkingDelegate.hpp
+++ b/example/glue/MarkingDelegate.hpp
@@ -156,7 +156,7 @@ public:
 	 *
 	 * @param env The environment for the calling thread
 	 */
-	void scanRoots(MM_EnvironmentBase *env);
+	void scanRoots(MM_EnvironmentBase *env, bool processLists = true);
 
 	/**
 	 * This method is called for every live object discovered during marking. It must return an object scanner instance that

--- a/gc/base/EnvironmentBase.cpp
+++ b/gc/base/EnvironmentBase.cpp
@@ -35,7 +35,6 @@
 #include "ConcurrentGCStats.hpp"
 #include "GCExtensionsBase.hpp"
 #include "GlobalAllocationManager.hpp"
-#include "GlobalCollector.hpp"
 #include "Heap.hpp"
 #include "MemorySpace.hpp"
 #include "ModronAssertions.h"

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -360,7 +360,7 @@ MM_MarkingScheme::markLiveObjectsInit(MM_EnvironmentBase *env, bool initMarkMap)
 void
 MM_MarkingScheme::markLiveObjectsRoots(MM_EnvironmentBase *env, bool processLists)
 {
-	_delegate.scanRoots(env);
+	_delegate.scanRoots(env, processLists);
 }
 
 void

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1495,6 +1495,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 						taxPaid = true;
 					}
 				} else {
+					Assert_MM_true(_extensions->configuration->isIncrementalUpdateBarrierEnabled());
 					/* TODO: Once optimizeConcurrentWB enabled by default this code will be deleted */
 					_stats.switchExecutionMode(CONCURRENT_INIT_COMPLETE, CONCURRENT_ROOT_TRACING);
 				}
@@ -1519,6 +1520,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 				break;
 
 			case CONCURRENT_ROOT_TRACING:
+				Assert_MM_true(_extensions->configuration->isIncrementalUpdateBarrierEnabled());
 				nextExecutionMode = _concurrentDelegate.getNextTracingMode(CONCURRENT_ROOT_TRACING);
 				Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) || (CONCURRENT_TRACE_ONLY == nextExecutionMode), "MM_ConcurrentMarkingDelegate::getNextTracingMode(CONCURRENT_ROOT_TRACING) = %zu\n", nextExecutionMode);
 				if(_stats.switchExecutionMode(CONCURRENT_ROOT_TRACING, nextExecutionMode)) {
@@ -1529,6 +1531,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 				break;
 
 			default:
+				Assert_MM_true(_extensions->configuration->isIncrementalUpdateBarrierEnabled());
 				/* Client language defines 1 or more execution modes with values > CONCURRENT_ROOT_TRACING */
 				Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < executionMode) && (CONCURRENT_TRACE_ONLY > executionMode), "MM_ConcurrentStats::_executionMode = %zu\n", executionMode);
 				nextExecutionMode = _concurrentDelegate.getNextTracingMode(executionMode);

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -390,6 +390,7 @@ public:
 
 	virtual void scanThread(MM_EnvironmentBase *env)
 	{
+		Assert_MM_true(!_extensions->usingSATBBarrier()); /* Threads are scanned in STW for Concurrent SATB, ensure we don't end up at this call back */
 		uintptr_t mode = _stats.getExecutionMode();
 		if ((CONCURRENT_ROOT_TRACING <= mode) && (CONCURRENT_EXHAUSTED > mode)) {
 			env->_workStack.reset(env, _markingScheme->getWorkPackets());

--- a/gc/base/standard/ConcurrentGCSATB.hpp
+++ b/gc/base/standard/ConcurrentGCSATB.hpp
@@ -29,7 +29,7 @@
 
 #include "OMR_VM.hpp"
 
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK) && defined(OMR_GC_REALTIME)
 #include "ConcurrentGC.hpp"
 
 /**
@@ -48,7 +48,11 @@ private:
 	/*
 	 * Function members
 	 */
+private:
+	void setThreadsScanned(MM_EnvironmentBase *env);
+
 protected:
+	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);
 
 	virtual uintptr_t doConcurrentTrace(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t sizeToTrace, MM_MemorySubSpace *subspace, bool tlhAllocation);
@@ -84,6 +88,6 @@ public:
 		}
 };
 
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK && OMR_GC_REALTIME */
 
 #endif /* CONCURRENTGCSATB_HPP_ */

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -31,7 +31,9 @@
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 #include "ConcurrentGCIncrementalUpdate.hpp"
+#if defined(OMR_GC_REALTIME)
 #include "ConcurrentGCSATB.hpp"
+#endif /* OMR_GC_REALTIME */
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 #include "ConcurrentSweepGC.hpp"
@@ -128,9 +130,12 @@ MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 	if (extensions->concurrentMark) {
+#if defined(OMR_GC_REALTIME)
 		if (isSnapshotAtTheBeginningBarrierEnabled()) {
 			return MM_ConcurrentGCSATB::newInstance(env);
-		} else {
+		} else
+#endif /* OMR_GC_REALTIME */
+		{
 			return MM_ConcurrentGCIncrementalUpdate::newInstance(env);
 		}
 	}

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1012,7 +1012,7 @@ MM_ParallelGlobalGC::mainThreadRestartAllocationCaches(MM_EnvironmentBase *env)
 		 * into the STW thread scan phase.
 		 */  
 		walkEnv->setThreadScanned(false);
-
+		walkEnv->setAllocationColor(GC_UNMARK);
 		walkEnv->_objectAllocationInterface->restartCache(env);
 	}
 }

--- a/gc/base/standard/RememberedSetSATB.hpp
+++ b/gc/base/standard/RememberedSetSATB.hpp
@@ -69,9 +69,9 @@ public:
 	void restoreLocalFragmentIndex(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment); /* Called by the root scanner to disable the double-barrier. */
 	void preserveGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that disables the barrier. */
 	void restoreGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that enables the barrier. */
-	/* Used to determine if the realtime write barrier is enabled. */
+	/* Used to determine if the SATB write barrier is enabled. */
 	MMINLINE bool
-	isGlobalFragmentIndexPreserved(MM_EnvironmentBase* env = NULL)
+	isGlobalFragmentIndexPreserved()
 	{
 		return (J9GC_REMEMBERED_SET_RESERVED_INDEX == _rememberedSetStruct.globalFragmentIndex);
 	}

--- a/gc/base/standard/StandardWriteBarrier.hpp
+++ b/gc/base/standard/StandardWriteBarrier.hpp
@@ -26,6 +26,7 @@
 #include "objectdescription.h"
 
 #include "CardTable.hpp"
+#include "Configuration.hpp"
 #include "EnvironmentStandard.hpp"
 #include "GCExtensionsBase.hpp"
 #include "ObjectModel.hpp"
@@ -62,7 +63,7 @@ standardWriteBarrier(OMR_VMThread *omrThread, omrobjectptr_t parentObject, omrob
 	}
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	if (extensions->concurrentMark) {
+	if ((extensions->concurrentMark) && (extensions->configuration->isIncrementalUpdateBarrierEnabled())) {
 		extensions->cardTable->dirtyCard(env, parentObject);
 	}
 #endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */


### PR DESCRIPTION
Implementation of SATB routines to enable SATB for `optavgpause` _(Limited to Xint+OOL Allocations)_

- Added obj alloc premarking to TLH Allocation interface
- Introduced some ASSERTS in shared ConcurrentGC code to ensure we don't transition to certain concurrent sates and we don't call certain callbacks known to be unreachable by SATB

_Implemented the following methods for SATB collector:_
- `setupForConcurrent` - initial STW to mark roots and set  allocation colour
- `doConcurrentTrace` - trace routine, adapted from incremental approach simplified to remove CARDS and "promote"  Background threads activity
- `completeConcurrentTracing`- final STW to flush barrier packets and complete any remaining tracing before handing off to ParallelGlobalGC
- `setThreadsScanned` - to shade threads "black"
- `initialize`; currently there is much this method does, but will be needed to register call backs for GENCON and premaking TLH