### PR TITLE
New method for inserting and coalescing heap chunk back free list

### DIFF
--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -337,7 +337,26 @@ public:
 	 * Increase the dark matter estimate for the receiver by the specified amount
 	 * @param bytes the number of bytes to increase the recorded estimate
 	 */
-	MMINLINE void incrementDarkMatterBytes(uintptr_t bytes) { _darkMatterBytes += bytes; }
+	MMINLINE void incrementDarkMatterBytes(uintptr_t bytes, bool needSync = false)
+	{
+		if (!needSync) {
+			_darkMatterBytes += bytes;
+		} else {
+			MM_AtomicOperations::add(&_darkMatterBytes, bytes);
+		}
+	}
+
+	MMINLINE void decrementDarkMatterBytes(uintptr_t bytes, bool needSync = false)
+	{
+		if (!needSync) {
+			_darkMatterBytes -= bytes;
+		} else {
+			MM_AtomicOperations::subtract(&_darkMatterBytes, bytes);
+		}
+	}
+
+
+
 	/**
 	 * @return the recorded estimate of dark matter in the receiver
 	 */
@@ -372,7 +391,7 @@ public:
 		Assert_MM_unreachable();
 	}
 
-	virtual bool recycleHeapChunk(void* chunkBase, void* chunkTop)
+	virtual bool recycleHeapChunk(MM_EnvironmentBase *env, void* chunkBase, void* chunkTop)
 	{
 		Assert_MM_unreachable();
 		return false;

--- a/gc/base/MemoryPoolAddressOrderedList.hpp
+++ b/gc/base/MemoryPoolAddressOrderedList.hpp
@@ -133,7 +133,7 @@ public:
 	virtual void expandWithRange(MM_EnvironmentBase *env, uintptr_t expandSize, void *lowAddress, void *highAddress, bool canCoalesce);
 	virtual void *contractWithRange(MM_EnvironmentBase *env, uintptr_t contractSize, void *lowAddress, void *highAddress);
 
-	bool recycleHeapChunk(void* chunkBase, void* chunkTop);
+	bool recycleHeapChunk(MM_EnvironmentBase *env, void* chunkBase, void* chunkTop);
 	bool recycleHeapChunk(void *addrBase, void *addrTop, MM_HeapLinkedFreeHeader *previousFreeEntry, MM_HeapLinkedFreeHeader *nextFreeEntry);
 
 	virtual void *findFreeEntryEndingAtAddr(MM_EnvironmentBase *env, void *addr);

--- a/gc/stats/CopyForwardStatsCore.hpp
+++ b/gc/stats/CopyForwardStatsCore.hpp
@@ -54,6 +54,10 @@ public:
 	uintptr_t _copyBytesTotal;  /**< Total bytes copied into survivor */
 	uintptr_t _copyDiscardBytesTotal;  /**< total bytes discarded due to copying into survivor */
 	uintptr_t _TLHRemainderCount;
+	uintptr_t _preparedRemainderBytes;
+	uintptr_t _preservedRemainderBytes;
+	uintptr_t _unusedPreservedRemainderBytes;
+
 	uintptr_t _scanObjectsTotal; /**< Total count of objects scanned in abort recovery */
 	uintptr_t _scanBytesTotal;   /**< Total bytes scanned in abort recovery */
 	
@@ -209,6 +213,10 @@ public:
 		_copyBytesTotal = 0;
 		_copyDiscardBytesTotal = 0;
 		_TLHRemainderCount = 0;
+		_preparedRemainderBytes = 0;
+		_preservedRemainderBytes = 0;
+		_unusedPreservedRemainderBytes = 0;
+
 		_scanObjectsTotal = 0;
 		_scanBytesTotal = 0;
 		
@@ -303,6 +311,10 @@ public:
 		_copyBytesTotal += stats->_copyBytesTotal;
 		_copyDiscardBytesTotal += stats->_copyDiscardBytesTotal;
 		_TLHRemainderCount += stats->_TLHRemainderCount;
+		_preparedRemainderBytes += stats->_preparedRemainderBytes;
+		_preservedRemainderBytes += stats->_preservedRemainderBytes;
+		_unusedPreservedRemainderBytes += stats->_unusedPreservedRemainderBytes;
+
 		_scanObjectsTotal += stats->_scanObjectsTotal;
 		_scanBytesTotal += stats->_scanBytesTotal;
 
@@ -346,6 +358,9 @@ public:
 		,_copyBytesTotal(0)
 		,_copyDiscardBytesTotal(0)
 		,_TLHRemainderCount(0)
+		,_preparedRemainderBytes(0)
+		,_preservedRemainderBytes(0)
+		,_unusedPreservedRemainderBytes(0)
 		,_scanObjectsTotal(0)
 		,_scanBytesTotal(0)
 		,_copyObjectsEden(0)


### PR DESCRIPTION
	- update incrementDarkMatterBytes()/decrementDarkMatterBytes(), the
	methods have atomic change option to protect thread race condition.
	- new method recycleHeapChunk() in MM_MemoryPoolAddressOrderedList
	to handle insert and coalesce heap chunk back free list.
	- add new stats	_preparedRemainderBytes, _preservedRemainderBytes and
	  _unusedPreservedRemainderBytes in CopyForwardStatsCore for debugging.


Signed-off-by: Lin Hu <linhu@ca.ibm.com>