### PR TITLE
AArch64: Add support for Int32 and Int64 in vnegEvaluator

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -753,6 +753,8 @@ static const char *opCodeToNameMap[] =
    "veor16b",
    "vneg16b",
    "vneg8h",
+   "vneg4s",
+   "vneg2d",
    "vfneg4s",
    "vfneg2d",
    "vnot16b",

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -586,6 +586,7 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
       {
       case TR::vadd:
       case TR::vsub:
+      case TR::vneg:
          if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
             return true;
          else
@@ -600,11 +601,6 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
             return true;
          else
             return false; // Int8/ Int16/ Int32/ Int64 are not supported
-      case TR::vneg:
-         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Float || dt == TR::Double)
-            return true;
-         else
-            return false; // Int32/ Int64 are not supported
       case TR::vand:
       case TR::vor:
       case TR::vxor:

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -732,6 +732,8 @@
 	/* Vector Data-processing (1 source) */
 		vneg16b,                                                  	/* 0x6E20B800	NEG      	 */
 		vneg8h,                                                  	/* 0x6E60B800	NEG      	 */
+		vneg4s,                                                 	/* 0x6EA0B800	NEG      	 */
+		vneg2d,                                                 	/* 0x6EE0B800	NEG      	 */
 		vfneg4s,                                                  	/* 0x6EA0F800	FNEG      	 */
 		vfneg2d,                                                  	/* 0x6EE0F800	FNEG      	 */
 		vnot16b,                                                  	/* 0x6E205800	NOT      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -738,6 +738,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 	/* Vector Data-processing (1 source) */
 		0x6E20B800,	/* NEG      	vneg16b	 */
 		0x6E60B800,	/* NEG      	vneg8h	 */
+		0x6EA0B800,	/* NEG      	vneg4s	 */
+		0x6EE0B800,	/* NEG      	vneg2d	 */
 		0x6EA0F800,	/* FNEG      	vfneg4s	 */
 		0x6EE0F800,	/* FNEG      	vfneg2d	 */
 		0x6E205800,	/* NOT      	vnot16b	 */

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -140,6 +140,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
       case TR::VectorInt16:
          negOp = TR::InstOpCode::vneg8h;
          break;
+      case TR::VectorInt32:
+         negOp = TR::InstOpCode::vneg4s;
+         break;
+      case TR::VectorInt64:
+         negOp = TR::InstOpCode::vneg2d;
+         break;
       case TR::VectorFloat:
          negOp = TR::InstOpCode::vfneg4s;
          break;

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -739,6 +739,82 @@ TEST_F(VectorTest, VInt16Neg) {
     }
 }
 
+TEST_F(VectorTest, VInt32Neg) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address]                   "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorInt32 offset=0                         "
+                     "         (aload parm=0)                                         "
+                     "            (vneg                                               "
+                     "                 (vloadi type=VectorInt32 (aload parm=1))))     "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(int32_t[],int32_t[])>();
+    // This test currently assumes 128bit SIMD
+
+    int32_t output[] =  {0, 0, 0, 0};
+    int32_t inputA[] =  {567890, 1234, 0, -20};
+
+    entry_point(output,inputA);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_EQ((-1) * inputA[i], output[i]);
+    }
+}
+
+TEST_F(VectorTest, VInt64Neg) {
+
+   auto inputTrees = "(method return= NoType args=[Address,Address]                   "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorInt64 offset=0                         "
+                     "         (aload parm=0)                                         "
+                     "            (vneg                                               "
+                     "                 (vloadi type=VectorInt64 (aload parm=1))))     "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
+    SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
+    SKIP_ON_RISCV(MissingImplementation);
+    SKIP_ON_POWER(MissingImplementation);
+    SKIP_ON_X86(MissingImplementation);
+    SKIP_ON_HAMMER(MissingImplementation);
+
+    Tril::DefaultCompiler compiler(trees);
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(int64_t[],int64_t[])>();
+    // This test currently assumes 128bit SIMD
+
+    int64_t output[] =  {0, 0};
+    int64_t inputA[] =  {60, -123456};
+
+    entry_point(output,inputA);
+
+    for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
+        EXPECT_EQ((-1) * inputA[i], output[i]);
+    }
+}
+
 TEST_F(VectorTest, VFloatNeg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "


### PR DESCRIPTION
This commit adds support for Int32 and Int64 in AArch64 vnegEvaluator.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>