### PR TITLE
Proper Overflow Handling For SATB

### DIFF
--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1896,7 +1896,7 @@ MM_ConcurrentGC::concurrentFinalCollection(MM_EnvironmentBase *env, MM_MemorySub
  *
  */
 void
-MM_ConcurrentGC::concurrentWorkStackOverflow()
+MM_ConcurrentGC::workStackOverflow()
 {
 	_stats.setConcurrentWorkStackOverflowOcurred(true);
 	_stats.incConcurrentWorkStackOverflowCount();
@@ -1907,14 +1907,9 @@ MM_ConcurrentGC::concurrentWorkStackOverflow()
  *
  */
 void
-MM_ConcurrentGC::clearConcurrentWorkStackOverflow()
+MM_ConcurrentGC::clearWorkStackOverflow()
 {
 	_stats.setConcurrentWorkStackOverflowOcurred(false);
-
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	MM_WorkPacketsConcurrent *packets = (MM_WorkPacketsConcurrent *)_markingScheme->getWorkPackets();
-	packets->resetWorkPacketsOverflow();
-#endif /* OMR_GC_MODRON_SCAVENGER */
 }
 
 /**
@@ -2113,7 +2108,7 @@ MM_ConcurrentGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace 
 	}
 
 	 /* Reset concurrent work stack overflow flags for next cycle */
-	clearConcurrentWorkStackOverflow();
+	clearWorkStackOverflow();
 
 	/* Re tune for next concurrent cycle if we have had a heap resize or we got far enough
 	 * last time. We only re-tune on a system GC in the event of a heap resize.

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -259,8 +259,6 @@ private:
 
 	virtual bool internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription);
 
-	void clearConcurrentWorkStackOverflow();
-
 	virtual uintptr_t getTraceTarget() = 0;
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 	void concurrentSweep(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, MM_AllocateDescription *allocDescription);
@@ -342,6 +340,8 @@ protected:
 	virtual bool contractInternalConcurrentStructures(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress) { return true; };
 
 	virtual bool canSkipObjectRSScan(MM_EnvironmentBase *env, omrobjectptr_t objectPtr) { return false; };
+
+	virtual void clearWorkStackOverflow();
 
 	MMINLINE virtual uintptr_t getMutatorTotalTraced() { return _stats.getTraceSizeCount(); };
 
@@ -452,7 +452,7 @@ public:
 
 	MMINLINE MM_ConcurrentGCStats *getConcurrentGCStats() { return &_stats; };
 
-	void concurrentWorkStackOverflow();
+	virtual void workStackOverflow();
 	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env);
 	
 	MM_ConcurrentGC(MM_EnvironmentBase *env)

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
@@ -1406,4 +1406,15 @@ MM_ConcurrentGCIncrementalUpdate::postConcurrentUpdateStatsAndReport(MM_Environm
 	MM_ConcurrentGC::postConcurrentUpdateStatsAndReport(env);
 }
 
+void
+MM_ConcurrentGCIncrementalUpdate::clearWorkStackOverflow()
+{
+	MM_ConcurrentGC::clearWorkStackOverflow();
+
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	MM_WorkPacketsConcurrent *packets = (MM_WorkPacketsConcurrent *)_markingScheme->getWorkPackets();
+	packets->resetWorkPacketsOverflow();
+#endif /* OMR_GC_MODRON_SCAVENGER */
+}
+
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
@@ -170,6 +170,8 @@ protected:
 
 	virtual void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats = NULL, UDATA bytesConcurrentlyScanned = 0);
 
+	virtual void clearWorkStackOverflow();
+
 	virtual uintptr_t getTraceTarget() {
 		if (_pass2Started) {
 			return (_traceTargetPass1 + _traceTargetPass2);

--- a/gc/base/standard/ConcurrentOverflow.cpp
+++ b/gc/base/standard/ConcurrentOverflow.cpp
@@ -108,13 +108,13 @@ void
 MM_ConcurrentOverflow::emptyToOverflow(MM_EnvironmentBase *env, MM_Packet *packet, MM_OverflowType type)
 {
 	MM_ConcurrentGCIncrementalUpdate *collector = (MM_ConcurrentGCIncrementalUpdate *)_extensions->getGlobalCollector();
-	void *objectPtr;
+	void *objectPtr = NULL;
 
 	_overflow = true;
 
 	/* Broadcast the overflow to the concurrent collector
 	 * so it can take any remedial action */
-	collector->concurrentWorkStackOverflow();
+	collector->workStackOverflow();
 
 	_extensions->globalGCStats.workPacketStats.setSTWWorkStackOverflowOccured(true);
 	_extensions->globalGCStats.workPacketStats.incrementSTWWorkStackOverflowCount();
@@ -151,7 +151,7 @@ MM_ConcurrentOverflow::overflowItem(MM_EnvironmentBase *env, void *item, MM_Over
 	/* Broadcast the overflow to the concurrent collector
 	 * so it can take any remedial action 
 	 */
-	collector->concurrentWorkStackOverflow();
+	collector->workStackOverflow();
 
 	_extensions->globalGCStats.workPacketStats.setSTWWorkStackOverflowOccured(true);
 	_extensions->globalGCStats.workPacketStats.incrementSTWWorkStackOverflowCount();

--- a/gc/base/standard/OverflowStandard.cpp
+++ b/gc/base/standard/OverflowStandard.cpp
@@ -69,9 +69,13 @@ MM_OverflowStandard::tearDown(MM_EnvironmentBase *env)
 void
 MM_OverflowStandard::emptyToOverflow(MM_EnvironmentBase *env, MM_Packet *packet, MM_OverflowType type)
 {
-	void *objectPtr;
+	MM_ParallelGlobalGC *collector = (MM_ParallelGlobalGC *)_extensions->getGlobalCollector();
+	void *objectPtr = NULL;
 
 	_overflow = true;
+
+	/* Broadcast the overflow to the concurrent collector so it can take any remedial action */
+	collector->workStackOverflow();
 
 	_extensions->globalGCStats.workPacketStats.setSTWWorkStackOverflowOccured(true);
 	_extensions->globalGCStats.workPacketStats.incrementSTWWorkStackOverflowCount();
@@ -88,7 +92,11 @@ MM_OverflowStandard::emptyToOverflow(MM_EnvironmentBase *env, MM_Packet *packet,
 void
 MM_OverflowStandard::overflowItem(MM_EnvironmentBase *env, void *item, MM_OverflowType type)
 {
+	MM_ParallelGlobalGC *collector = (MM_ParallelGlobalGC *)_extensions->getGlobalCollector();
 	_overflow = true;
+
+	/* Broadcast the overflow to the concurrent collector so it can take any remedial action */
+	collector->workStackOverflow();
 
 	_extensions->globalGCStats.workPacketStats.setSTWWorkStackOverflowOccured(true);
 	_extensions->globalGCStats.workPacketStats.incrementSTWWorkStackOverflowCount();

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -332,6 +332,8 @@ public:
 	 */	
 	virtual void notifyAcquireExclusiveVMAccess(MM_EnvironmentBase *env);
 
+	virtual void workStackOverflow() {}
+
 	MM_ParallelGlobalGC(MM_EnvironmentBase *env)
 		: MM_GlobalCollector()
 		, _extensions(MM_GCExtensionsBase::getExtensions(env->getOmrVM()))


### PR DESCRIPTION
Standard Overflow handler  must notify the Concurrent Collector when an overflow occurs (e.g to increment overflow stats and set proper flags specific to concurrent collector). This is now required because SATB makes use of this overflow handler, previously this handler was exclusive to non-concurrent collection. This mirrors the Incremental CGC overflow handler (in ConcurrentOverflowHandler). 
 - This is done by introducing empty implementation in base class ParallelGlobalGC (since Standard Overflow is used by both concurrent SATB and non-concurrent global)

Furthermore, logic from `clearConcurrentWorkStackOverflow` specific to Concurrent Incremental has been pulled out from base. This resulted in memory corruption discovered when testing with `-Xcheck:memory`