### PR TITLE
AArch64 macOS: Call pthread_jit_write_protect_np()

### DIFF
--- a/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,13 @@ extern void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
    int64_t distance = (int64_t)destinationAddr - (int64_t)locationAddr;
+
+#if defined(OSX)
+   pthread_jit_write_protect_np(0);
+#endif
    *(uint32_t *)locationAddr = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b) | ((distance >> 2) & 0x3ffffff); /* imm26 */
    arm64CodeSync((unsigned char *)locationAddr, ARM64_INSTRUCTION_LENGTH);
+#if defined(OSX)
+   pthread_jit_write_protect_np(1);
+#endif
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2344,6 +2344,10 @@ OMR::CodeGenerator::emitSnippets()
    uint8_t *codeOffset;
    uint8_t *retVal;
 
+#if defined(OSX) && defined(AARCH64)
+   pthread_jit_write_protect_np(0);
+#endif
+
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
       codeOffset = (*iterator)->emitSnippet();
@@ -2366,6 +2370,10 @@ OMR::CodeGenerator::emitSnippets()
       {
       self()->emitDataSnippets();
       }
+
+#if defined(OSX) && defined(AARCH64)
+   pthread_jit_write_protect_np(1);
+#endif
 
    return retVal;
    }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -838,8 +838,17 @@ OMR::CodeCacheManager::allocateCodeCacheRepository(size_t repositorySize)
       // The VM expects the first entry in the segment to be a pointer to
       // a TR::CodeCache structure and the first two entries in the cache
       // to be warmCodeAlloc and coldCodeAlloc.
+
+#if defined(OSX) && defined(AARCH64)
+      pthread_jit_write_protect_np(0);
+#endif
+
       uint8_t * start = _codeCacheRepositorySegment->segmentAlloc();
       *((TR::CodeCache**)start) = self()->getRepositoryCodeCacheAddress();
+
+#if defined(OSX) && defined(AARCH64)
+      pthread_jit_write_protect_np(1);
+#endif
 
       _codeCacheRepositorySegment->adjustAlloc(sizeof(TR::CodeCache*)); // jump over the pointer we setup
 

--- a/port/osx/omrvmem.c
+++ b/port/osx/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -496,6 +496,13 @@ reserveMemory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteA
 		flags = MAP_ANON | MAP_PRIVATE;
 		useBackingSharedFile = FALSE;
 	}
+
+#if defined(AARCH64)
+	if (category->categoryCode == OMRMEM_CATEGORY_JIT_CODE_CACHE) {
+		flags |= MAP_JIT;
+		protectionFlags &= ~PROT_EXEC;
+	}
+#endif /* defined(AARCH64) */
 
 	result = mmap(address, (size_t)byteAmount, protectionFlags, flags, fd, 0);
 	if (MAP_FAILED == result) {


### PR DESCRIPTION
This commit adds calls to pthread_jit_write_protect_np() for AArch64 macOS
in some places.

AArch64 macOS requires JIT compiler to change the memory access permissions
using the API.
- readable and executable (R-X)
- readable and writable (RW-)

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>