### PR TITLE
CMake: update cross compilation support

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -168,13 +168,8 @@ def SPECS = [
         'buildSystem' : 'cmake',
         'builds' : [
             [
-                'buildDir' : 'build_native',
-                'configureArgs' : '-DOMR_THREAD=OFF -DOMR_PORT=OFF -DOMR_OMRSIG=OFF -DOMR_GC=OFF -DOMR_FVTEST=OFF',
-                'compile' : defaultCompile
-            ],
-            [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF "-DCMAKE_FIND_ROOT_PATH=${CROSS_SYSROOT_RISCV64}" -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake -DOMR_TOOLS_IMPORTFILE=../build_native/tools/ImportTools.cmake "-DOMR_TEST_LAUNCHER=qemu-riscv64;-L;${CROSS_SYSROOT_RISCV64}"',
+                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake "-DCMAKE_SYSROOT=${CROSS_SYSROOT_RISCV64}"',
                 'compile' : defaultCompile
             ]
         ],

--- a/cmake/modules/OmrCrossCompile.cmake
+++ b/cmake/modules/OmrCrossCompile.cmake
@@ -1,0 +1,85 @@
+###############################################################################
+# Copyright (c) 2021, 2022 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#############################################################################
+
+if(OMR_CROSS_COMPILE_)
+	return()
+endif()
+set(OMR_CROSS_COMPILE_ 1)
+
+# Building on cygwin but using MSVC will look like cross compiling, but we don't consider it to be.
+if(CMAKE_CROSSCOMPILING AND NOT CYGWIN)
+	set(OMR_CROSSCOMPILING ON CACHE INTERNAL "")
+else()
+	set(OMR_CROSSCOMPILING OFF CACHE INTERNAL "")
+endif()
+
+# If the user hasn't provided a way to launch executables, try to find one.
+if(OMR_CROSSCOMPILING AND NOT (OMR_EXE_LAUNCHER OR CMAKE_CROSSCOMPILING_EMULATOR))
+	# If we are targeting linux try looking
+	if(OMR_OS_LINUX)
+		# Determine the processor name used by qemu
+		if(OMR_ARCH_AARCH64)
+			set(qemu_system "aarch64")
+		elseif(OMR_ARCH_ARM)
+			set(qemu_system "arm")
+		elseif(OMR_ARCH_POWER)
+			if(OMR_ENV_DATA32)
+				set(qemu_system "power")
+			else()
+				if(OMR_ENV_LITTLE_ENDIAN)
+					set(qemu_system "ppc64le")
+				else()
+					set(qemu_system "ppc64")
+				endif()
+			endif()
+		elseif(OMR_ARCH_RISCV)
+			if(OMR_ENV_DATA32)
+				set(qemu_system "riscv32")
+			else()
+				set(qemu_system "riscv64")
+			endif()
+		elseif(OMR_ARCH_S390)
+			set(qemu_system "s390x")
+		elseif(OMR_ARCH_X86)
+			if(OMR_ENV_DATA32)
+				set(qemu_system "i386")
+			else()
+				set(qemu_system "x86_64")
+			endif()
+		endif()
+
+		find_program(OMR_QEMU_EXE NAMES "qemu-${qemu_system}" "qemu-${qemu_system}-static")
+
+		if(OMR_QEMU_EXE)
+			# If we have a sysroot, use that for the library search path (eg to find ld-linux.so)
+			if(CMAKE_SYSROOT)
+				list(APPEND OMR_QEMU_EXE "-L" "${CMAKE_SYSROOT}")
+			endif()
+			set(OMR_EXE_LAUNCHER "${OMR_QEMU_EXE}" CACHE STRING "")
+		endif()
+	endif()
+
+	# If we couldn't find anything issue a warning
+	if(NOT (OMR_EXE_LAUNCHER OR CMAKE_CROSSCOMPILING_EMULATOR))
+		message(WARNING "Cross compilation detected, but no exe launcher found in OMR_EXE_LAUNCHER or CMAKE_CROSSCOMPILING_EMULATOR")
+		message(WARNING "You may experience issues when running build tools (hookgen/tracegen/tracemerge).")
+	endif()
+endif()

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2021 IBM Corp. and others
+# Copyright (c) 2018, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ include(ExternalProject)
 include(OmrPlatform)
 
 # DDR is may supported when cross compiling, unless we are on Windows with CYGWIN in which case we do have support
-if(OMR_DDR AND NOT OMR_OS_WINDOWS AND CMAKE_CROSSCOMPILING)
+if(OMR_DDR AND OMR_CROSSCOMPILING)
 	message(FATAL_ERROR "DDR is not supported when cross-compiling. Use -DOMR_DDR=OFF to disable DDR.")
 endif()
 

--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,9 @@ include(platform/toolcfg/${OMR_TOOLCONFIG})
 
 # verify toolconfig
 include(platform/toolcfg/verify)
+
+# handle cross compilation logic
+include(OmrCrossCompile)
 
 macro(omr_platform_global_setup)
 	omr_assert(WARNING TEST NOT OMR_PLATFORM_GLOBALLY_INITIALIZED


### PR DESCRIPTION
 - Introduce OMR_CROSSCOMPILING which mirrors CMAKE_CROSSCOMPILING but
   ignores the case of building for windows from cygwin

 - Automatically attempt to find a version of qemu to launch executables
   if required.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>