### PR TITLE
AArch64: Add getOutgoingArgumentMemRef() to OMRLinkage

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -64,6 +64,18 @@ TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register
    return result;
    }
 
+TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register *baseReg, int32_t offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
+   {
+   const TR::ARM64LinkageProperties& properties = self()->getProperties();
+
+   TR::MemoryReference *result = TR::MemoryReference::createWithDisplacement(cg(), baseReg, offset);
+   memArg.argRegister = argReg;
+   memArg.argMemory = result;
+   memArg.opCode = opCode;
+
+   return result;
+   }
+
 TR::Instruction *OMR::ARM64::Linkage::saveParametersToStack(TR::Instruction *cursor)
    {
    TR_UNIMPLEMENTED();

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -309,6 +309,17 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     * @return MemoryReference for the argument
     */
    virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg);
+
+   /**
+    * @brief Returns a MemoryReference for an outgoing argument
+    * @param[in] baseReg : base register for memory access
+    * @param[in] offset : memory offset
+    * @param[in] argReg : register for the argument
+    * @param[in] opCode : instruction OpCode for store to memory
+    * @param[out] memArg : struct holding memory argument information
+    * @return MemoryReference for the argument
+    */
+   virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *baseReg, int32_t offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg);
 
    /**
     * @brief Loads parameters from stack


### PR DESCRIPTION
This commit adds a function getOutgoingArgumentMemRef() to OMRLinkage
for AArch64.
The existing function of the same name assumes the function arguments
are always stored at the 8-byte boundary.  The new one takes an offset
for flexibility.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>