### PR TITLE
AArch64: Provide factory methods for MemoryReference objects

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -544,7 +544,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
    // save link register (x30)
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
+      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, 0);
       cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::x30), cursor);
       }
 
@@ -555,7 +555,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
          cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, rr, cursor);
          offset += 8;
          }
@@ -565,7 +565,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
          cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::vstrimmq, firstNode, stackSlot, rr, cursor);
          offset += 16;
          }
@@ -591,7 +591,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
          cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, rr, stackSlot, cursor);
          offset += 8;
          }
@@ -601,7 +601,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
          cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::vldrimmq, lastNode, rr, stackSlot, cursor);
          offset += 16;
          }
@@ -611,7 +611,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, codeGen);
+      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, 0);
       cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
       }
 

--- a/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,7 +100,14 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::SymbolReference *symRef,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(node, symRef, cg) {}
+
+   static TR::MemoryReference *create(TR::CodeGenerator *cg);
+   static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);
+   static TR::MemoryReference *createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement);
+   static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore);
+   static TR::MemoryReference *createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef);
    };
+
 } // TR
 
 #endif

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -34,6 +34,7 @@
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/LiveRegister.hpp"
+#include "codegen/MemoryReference.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/RegisterIterator.hpp"
@@ -699,9 +700,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = self()->allocateRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor, false, TR_DebugCounter);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addimmw, node, counterReg, counterReg, delta, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), counterReg, cursor);
 
    if (cond)
       {
@@ -726,9 +727,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = self()->allocateRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor, false, TR_DebugCounter);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::addw, node, counterReg, counterReg, deltaReg, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), counterReg, cursor);
 
    if (cond)
       {
@@ -763,9 +764,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor, false, TR_DebugCounter);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addimmw, node, counterReg, counterReg, delta, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), counterReg, cursor);
 
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
@@ -783,9 +784,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor, false, TR_DebugCounter);
-   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), cursor);
+   cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::addw, node, counterReg, counterReg, deltaReg, cursor);
-   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, self()), counterReg, cursor);
+   cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, TR::MemoryReference::createWithDisplacement(self(), addrReg, 0), counterReg, cursor);
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
    return cursor;

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register
    {
    const TR::ARM64LinkageProperties& properties = self()->getProperties();
 
-   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(argMemReg, 8, cg()); // post-increment
+   TR::MemoryReference *result = TR::MemoryReference::createWithDisplacement(cg(), argMemReg, 8); // post-increment
    memArg.argRegister = argReg;
    memArg.argMemory = result;
    memArg.opCode = opCode; // opCode must be post-index form
@@ -267,7 +267,7 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
                diagnostic("copyParametersToHomeLocation: Loading %d\n", ai);
 
             // ai := stack
-            TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
+            TR::MemoryReference *stackMR = TR::MemoryReference::createWithDisplacement(cg(), stackPtr, offset);
             loadCursor = generateTrg1MemInstruction(cg(), getOpCodeForParmLoads(paramType), NULL, machine->getRealRegister(ai), stackMR, loadCursor);
             }
          }
@@ -291,7 +291,7 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
                   diagnostic("copyParametersToHomeLocation: Storing %d\n", sourceIndex);
 
                TR::RealRegister *linkageReg = machine->getRealRegister(sourceIndex);
-               TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
+               TR::MemoryReference *stackMR = TR::MemoryReference::createWithDisplacement(cg(), stackPtr, offset);
                cursor = generateMemSrc1Instruction(cg(), getOpCodeForParmStores(paramType), NULL, stackMR, linkageReg, cursor);
                }
             }

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -367,7 +367,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
 
    registerToSpill->setBackingStorage(location);
 
-   tmemref = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), cg);
+   tmemref = TR::MemoryReference::createWithSymRef(cg, currentNode, location->getSymbolReference());
 
    if (!cg->isOutOfLineColdPath())
       {
@@ -484,7 +484,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
                   targetRegister->getRegisterName(comp));
       }
 
-   tmemref = new (self()->cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
+   tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference());
 
    switch (rk)
       {

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -33,6 +33,30 @@
 #include "il/Node_inlines.hpp"
 #include "il/StaticSymbol.hpp"
 
+TR::MemoryReference *TR::MemoryReference::create(TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t scale, TR::ARM64ExtendCode extendCode)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg, int64_t displacement)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, displacement, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(rootLoadOrStore, cg);
+   }
+
+TR::MemoryReference *TR::MemoryReference::createWithSymRef(TR::CodeGenerator *cg, TR::Node *node, TR::SymbolReference *symRef)
+   {
+   return new (cg->trHeapMemory()) TR::MemoryReference(node, symRef, cg);
+   }
 
 static void loadRelocatableConstant(TR::Node *node,
                                     TR::SymbolReference *ref,

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -45,6 +45,7 @@ namespace OMR { typedef OMR::ARM64::MemoryReference MemoryReferenceConnector; }
 
 namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
+namespace TR { class MemoryReference; }
 namespace TR { class Node; }
 namespace TR { class UnresolvedDataSnippet; }
 

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -447,7 +447,7 @@ void OMR::ARM64::RegisterDependencyGroup::assignRegisters(
             traceMsg (comp,"\nOOL: Found register spilled in main line and re-assigned inside OOL");
             TR::Node *currentNode = currentInstruction->getNode();
             TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-            TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference(), cg);
+            TR::MemoryReference *tempMR = TR::MemoryReference::createWithSymRef(cg, currentNode, (TR::SymbolReference*)virtReg->getBackingStorage()->getSymbolReference());
             TR_RegisterKinds rk = virtReg->getKind();
             TR::InstOpCode::Mnemonic opCode;
             switch (rk)


### PR DESCRIPTION
This is a part of a series of PRs to implement https://github.com/eclipse/omr/issues/5173.
Introduce static factory methods for MemoryReference objects into aarch64 codegen.
Replace all direct calls to MemoryReference constructors with corresponding factory methods.
The separate PR will make MemoryReference constructors private.

Depends on https://github.com/eclipse-openj9/openj9/pull/14195

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>