### PR TITLE
AArch64: Privatize constructors of MemoryReference class

### DIFF
--- a/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/compiler/aarch64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@ namespace TR
 
 class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
    {
-   public:
+   private:
 
    /**
     * @brief Constructor
@@ -100,6 +100,8 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::SymbolReference *symRef,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(node, symRef, cg) {}
+
+   public:
 
    static TR::MemoryReference *create(TR::CodeGenerator *cg);
    static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg, uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,19 +78,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    uint8_t _flag;
    uint8_t _scale;
 
-   public:
-
-   TR_ALLOC(TR_Memory::MemoryReference)
-
-   typedef enum
-      {
-      TR_ARM64MemoryReferenceControl_Base_Modifiable  = 0x01,
-      TR_ARM64MemoryReferenceControl_Index_Modifiable = 0x02,
-      TR_ARM64MemoryReferenceControl_Index_SignExtendedByte = 0x04,
-      TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf = 0x08,
-      TR_ARM64MemoryReferenceControl_Index_SignExtendedWord = 0x10,
-      /* To be added more if necessary */
-      } TR_ARM64MemoryReferenceControl;
+   protected:
 
    /**
     * @brief Constructor
@@ -147,6 +135,20 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
     * @param[in] cg : CodeGenerator object
     */
    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg);
+
+   public:
+
+   TR_ALLOC(TR_Memory::MemoryReference)
+
+   typedef enum
+      {
+      TR_ARM64MemoryReferenceControl_Base_Modifiable  = 0x01,
+      TR_ARM64MemoryReferenceControl_Index_Modifiable = 0x02,
+      TR_ARM64MemoryReferenceControl_Index_SignExtendedByte = 0x04,
+      TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf = 0x08,
+      TR_ARM64MemoryReferenceControl_Index_SignExtendedWord = 0x10,
+      /* To be added more if necessary */
+      } TR_ARM64MemoryReferenceControl;
 
    /**
     * @brief Gets base register


### PR DESCRIPTION
This is a part of a series of PRs to implement https://github.com/eclipse/omr/issues/5173.
Make constructors of MemoryReference class private.

Depends on:
https://github.com/eclipse/omr/pull/6279
https://github.com/eclipse-openj9/openj9/pull/14195
https://github.com/eclipse-openj9/openj9/pull/14196

Resolves https://github.com/eclipse/omr/issues/5173.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>