### PR TITLE
Add OMRMEM_CATEGORY_10_CHILDREN in omrmemcategories.h

### DIFF
--- a/include_core/omrmemcategories.h
+++ b/include_core/omrmemcategories.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corp. and others
+ * Copyright (c) 2010, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,6 +123,9 @@ typedef struct OMRMemCategorySet {
 #define OMRMEM_CATEGORY_9_CHILDREN(description, code, c1, c2, c3, c4, c5, c6, c7, c8, c9) \
 	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5, c6, c7, c8, c9}; \
 	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 9, _omrmem_##code##_child_categories}
+#define OMRMEM_CATEGORY_10_CHILDREN(description, code, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) \
+	static uint32_t _omrmem_##code##_child_categories[] = {c1, c2, c3, c4, c5, c6, c7, c8, c9, c10}; \
+	static OMRMemCategory _omrmem_category_##code = {description, code, 0, 0, 10, _omrmem_##code##_child_categories}
 
 #define CATEGORY_TABLE_ENTRY(name) &_omrmem_category_##name
 


### PR DESCRIPTION
The change is to add a new macro for categories with 10 children.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>