### PR TITLE
AArch64: Use mvn instruction for xor with -1

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1268,6 +1268,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1ZeroSrc1Instruction *instr)
       {
       // mov alias
       trfprintf(pOutFile, "mov%c \t", (op == TR::InstOpCode::orrx) ? 'x' : 'w');
+      }
+   else if (op == TR::InstOpCode::ornx || op == TR::InstOpCode::ornw)
+      {
+      // mvn alias
+      trfprintf(pOutFile, "mvn%c \t", (op == TR::InstOpCode::ornx) ? 'x' : 'w');
       }
    else if (op == TR::InstOpCode::subx || op == TR::InstOpCode::subw)
       {

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1475,25 +1475,32 @@ logicBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstOpC
          {
          value = secondChild->getInt();
          }
-      bool N;
-      uint32_t immEncoded;
-      if (logicImmediateHelper(is64Bit ? value : (uint32_t)value, is64Bit, N, immEncoded))
+      if (node->getOpCode().isXor() && (value == -1))
          {
-         generateLogicalImmInstruction(cg, regOpImm, node, trgReg, src1Reg, N, immEncoded);
+         generateMvnInstruction(cg, node, trgReg, src1Reg, is64Bit);
          }
       else
          {
-         src2Reg = cg->allocateRegister();
-         if(is64Bit)
+         bool N;
+         uint32_t immEncoded;
+         if (logicImmediateHelper(is64Bit ? value : (uint32_t)value, is64Bit, N, immEncoded))
             {
-            loadConstant64(cg, node, value, src2Reg);
+            generateLogicalImmInstruction(cg, regOpImm, node, trgReg, src1Reg, N, immEncoded);
             }
          else
             {
-            loadConstant32(cg, node, value, src2Reg);
+            src2Reg = cg->allocateRegister();
+            if(is64Bit)
+               {
+               loadConstant64(cg, node, value, src2Reg);
+               }
+            else
+               {
+               loadConstant32(cg, node, value, src2Reg);
+               }
+            generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
+            cg->stopUsingRegister(src2Reg);
             }
-         generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
-         cg->stopUsingRegister(src2Reg);
          }
       }
    else

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -487,6 +487,18 @@ TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node,
    /* Alias of ORR instruction */
 
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::orrx : TR::InstOpCode::orrw;
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, cg);
+   }
+
+TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, bool is64bit, TR::Instruction *preced)
+   {
+   /* Alias of ORN instruction */
+
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::ornx : TR::InstOpCode::ornw;
 
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, preced, cg);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -897,6 +897,24 @@ TR::Instruction *generateTestInstruction(
  * @return generated instruction
  */
 TR::Instruction *generateMovInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  bool is64bit = true,
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates MVN (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] sreg : source register
+ * @param[in] is64bit : true when it is 64-bit operation
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMvnInstruction(
                   TR::CodeGenerator *cg,
                   TR::Node *node,
                   TR::Register *treg,


### PR DESCRIPTION
Use mvn (Bitwise NOT) instruction for xor with -1.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>