### PR TITLE
Create configuration that favors throughput over other metrics

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2667,7 +2667,7 @@ OMR::Options::jitPreProcess()
       //
       if (this == OMR::Options::getJITCmdLineOptions() || this == OMR::Options::getAOTCmdLineOptions())
          {
-         if (_aggressivenessLevel >= 0 && _aggressivenessLevel <= 5)
+         if (_aggressivenessLevel >= 0 && _aggressivenessLevel < LAST_AGGRESSIVENESS_LEVEL)
             {
             // Set some default values for JIT and AOT main command line options
             //
@@ -2689,6 +2689,9 @@ OMR::Options::jitPreProcess()
                   break;
                case OMR::Options::CONSERVATIVE_QUICKSTART: // conservative quickstart
                   self()->setConservativeQuickStart();
+                  break;
+               case OMR::Options::AGGRESSIVE_THROUGHPUT: // Enabled with -Xtune:throughput
+                  self()->setAggressiveThroughput();
                   break;
                } // end switch
             }
@@ -5170,6 +5173,27 @@ void OMR::Options::setConservativeDefaultBehavior()
    // conservative upgrades ?
    _coldUpgradeSampleThreshold = 30; // instead of 3 or even 2
    // query for Xaggressive must return false
+   }
+
+
+void OMR::Options::setAggressiveThroughput()
+   {
+   self()->setOption(TR_DontDowngradeToCold); // This will prevent AOT compilations as well, unless -Xaot:forceaot is present
+   self()->setOption(TR_DisableSelectiveNoOptServer);
+#ifdef J9_PROJECT_SPECIFIC
+   TR::Options::_scorchingSampleThreshold = 500; // 6% CPU
+   TR::Options::_veryHotSampleThreshold = 1000; // 3% CPU
+#endif
+   self()->setOption(TR_DisablePersistIProfile); // Want to rely on freshly collected IProfiler data
+   self()->setOption(TR_UseHigherMethodCounts); // Increase counts to gather more IProfiler data
+   // The following options are candidates for inclusion in this
+   // policy but they need more experimental validation
+   //self()->setOption(TR_ProcessHugeMethods);
+   //TR::Options::setScratchSpaceLimit(2 * DEFAULT_SCRATCH_SPACE_LIMIT_KB * 1024); // Increase scratchSpaceLimit
+   //self()->setMoreAggressiveInlining();
+#ifdef J9_PROJECT_SPECIFIC
+   //TR::Options::_bigAppThreshold = 3000;
+#endif
    }
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1356,6 +1356,8 @@ public:
       AGGRESSIVE_AOT,
       CONSERVATIVE_DEFAULT,
       DEFAULT,
+      AGGRESSIVE_THROUGHPUT,
+      LAST_AGGRESSIVENESS_LEVEL
    };
 
    static TR::OptionFunctionPtr negateProcessingMethod(TR::OptionFunctionPtr);
@@ -1599,6 +1601,7 @@ public:
    void setLocalAggressiveAOT();
    void setInlinerOptionsForAggressiveAOT();
    void setConservativeDefaultBehavior();
+   void setAggressiveThroughput();
 
    static bool getCountsAreProvidedByUser() { return _countsAreProvidedByUser; } // set very late in setCounts()
    static TR_YesNoMaybe startupTimeMatters() { return _startupTimeMatters; } // set very late in setCounts()


### PR DESCRIPTION
The new configuration, called "AGGRESSIVE_THROUGHPUT" will enable some
options that are likely to improve throughput of applications. Some of
these options are specific to Java, while others are more generic.
The downstream OpenJ9 project will enable the new configuration with
`-Xtune:throughput`. Individual options under the new configuration
can still be overridden with -Xjit options.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>