### PR TITLE
Update macOS version for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ jobs:
   - job:
     displayName: 'x86-64 macOS'
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     variables:
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
     steps:


### PR DESCRIPTION
This commit update the macOS version for Azure Pipelines from 10.14 to
10.15.

Fixes: #6296

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>