### PR TITLE
Fix problems compiling with gcc 10

### DIFF
--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,8 @@
 
 #ifndef OMR_REGISTER_DEPENDENCY_GROUP_CONNECTOR
 #define OMR_REGISTER_DEPENDENCY_GROUP_CONNECTOR
-namespace OMR { namespace X86 { class RegisterDependencyGroup; } }
-namespace OMR { typedef OMR::X86::RegisterDependencyGroup RegisterDependencyGroupConnector; }
+   namespace OMR { namespace X86 { class RegisterDependencyGroup; } }
+   namespace OMR { typedef OMR::X86::RegisterDependencyGroup RegisterDependencyGroupConnector; }
 #endif
 
 #include "compiler/codegen/OMRRegisterDependency.hpp"
@@ -63,15 +63,9 @@ namespace X86
 {
 class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGroup
    {
-   bool _mayNeedToPopFPRegisters;
-   bool _needToClearFPStack;
-
    public:
 
-   RegisterDependencyGroup()
-      : _mayNeedToPopFPRegisters(false),
-        _needToClearFPStack(false)
-      {}
+   RegisterDependencyGroup() : OMR::RegisterDependencyGroup() {}
 
    void setDependencyInfo(uint32_t   index,
                           TR::Register                   *vr,
@@ -79,7 +73,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
                           TR::CodeGenerator              *cg,
                           uint8_t                         flag = UsesDependentRegister,
                           bool                            isAssocRegDependency = false);
-
 
    TR::RegisterDependency *findDependency(TR::Register *vr, uint32_t stop)
       {
@@ -285,7 +278,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                                   uint32_t   numConditions,
                                   char                           *prefix,
                                   FILE                           *pOutFile);
-#endif
+#endif /* defined(DEBUG) || defined(PROD_WITH_ASSUMES) */
 
    };
 }
@@ -298,4 +291,4 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(TR::Node *, TR::CodeGenerator *, uint32_t = 0, List<TR::Register> * = 0);
 TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(uint32_t, uint32_t, TR::CodeGenerator *);
 
-#endif
+#endif /* OMR_X86_REGISTER_DEPENDENCY_INCL */

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
    {
    public:
 
-   RegisterDependencyGroup() : _numUses(0) {}
+   RegisterDependencyGroup() : OMR::RegisterDependencyGroup() {}
 
    uint32_t genBitMapOfAssignableGPRs(TR::CodeGenerator *cg, uint32_t numberOfRegisters);
 
@@ -91,7 +91,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
 
    protected:
 
-   int8_t _numUses;
    };
 
 class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
@@ -124,8 +123,8 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                                         TR::CodeGenerator *cg);
 
    RegisterDependencyConditions(TR::RegisterDependencyGroup *_preConditions,
-				       TR::RegisterDependencyGroup *_postConditions,
-				       uint16_t numPreConds, uint16_t numPostConds, TR::CodeGenerator *cg)
+                                TR::RegisterDependencyGroup *_postConditions,
+                                uint16_t numPreConds, uint16_t numPostConds, TR::CodeGenerator *cg)
       : _preConditions(_preConditions),
         _postConditions(_postConditions),
         _numPreConditions(numPreConds),
@@ -133,7 +132,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _numPostConditions(numPostConds),
         _addCursorForPost(numPostConds),
         _isUsed(false),
-	_cg(cg)
+        _cg(cg)
       {}
 
    RegisterDependencyConditions()
@@ -144,7 +143,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _numPostConditions(0),
         _addCursorForPost(0),
         _isUsed(false),
-	_cg(NULL)
+        _cg(NULL)
       {}
 
    //VMThread work: implicitly add an extra post condition for a possible vm thread
@@ -269,10 +268,10 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    bool addPreConditionIfNotAlreadyInserted(TR::RegisterDependency *regDep);
    bool addPreConditionIfNotAlreadyInserted(TR::Register *vr,
                                             TR::RealRegister::RegNum rr,
-				                                uint8_t flag = ReferencesDependentRegister);
+                                            uint8_t flag = ReferencesDependentRegister);
    bool addPreConditionIfNotAlreadyInserted(TR::Register *vr,
                                             TR::RealRegister::RegDep rr,
-				                                uint8_t flag = ReferencesDependentRegister);
+                                            uint8_t flag = ReferencesDependentRegister);
 
    /**
     * @brief Adds the provided \c TR::RegisterDependency to the set of postconditions if it
@@ -286,10 +285,10 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
    bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
                                              TR::RealRegister::RegNum rr,
-				                                 uint8_t flag = ReferencesDependentRegister);
+                                             uint8_t flag = ReferencesDependentRegister);
    bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
                                              TR::RealRegister::RegDep rr,
-				                                 uint8_t flag = ReferencesDependentRegister);
+                                             uint8_t flag = ReferencesDependentRegister);
 
    TR::RegisterDependencyConditions *clone(TR::CodeGenerator *cg, int32_t additionalRegDeps);
 
@@ -335,4 +334,4 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 }
 }
 
-#endif
+#endif /* OMR_Z_REGISTER_DEPENDENCY_INCL */


### PR DESCRIPTION
Use a flexible array for `RegisterDependencyGroup._dependencies`, and promote architecture-specific fields so they don't follow that flexible array.

Fixes: eclipse-openj9/openj9#14219.