### PR TITLE
Update allocateHint during incremental card alignment

### DIFF
--- a/gc/base/MemoryPoolAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolAddressOrderedList.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1774,6 +1774,7 @@ MM_MemoryPoolAddressOrderedList::doFreeEntryAlignmentUpTo(MM_EnvironmentBase *en
 			if (((uintptr_t)newEndFreeEntry - (uintptr_t)newStartFreeEntry) < _minimumFreeEntrySize) {
 				/* remove currentFreeEntry */
 				removeFromFreeList((void *)currentFreeEntry, endFreeEntry, previousFreeEntry, nextFreeEntry);
+				removeHint(currentFreeEntry);
 				lostToAlignment += freeEntrySize;
 				freeEntryCount -= 1;
 				freeEntrySize = 0;
@@ -1781,6 +1782,7 @@ MM_MemoryPoolAddressOrderedList::doFreeEntryAlignmentUpTo(MM_EnvironmentBase *en
 			} else {
 				if ((uintptr_t) currentFreeEntry != (uintptr_t) newStartFreeEntry) {
 					fillWithHoles((void *)currentFreeEntry, newStartFreeEntry);
+					updateHint(currentFreeEntry, (MM_HeapLinkedFreeHeader *)newStartFreeEntry);
 				}
 				if ((uintptr_t) endFreeEntry != (uintptr_t) newEndFreeEntry) {
 					fillWithHoles(newEndFreeEntry, endFreeEntry);


### PR DESCRIPTION
For Balanced GC, during allocation for collector, free entry might need
to be card aligned, the alignment might cause free entry to be removed
or starting address changed, in these cases if the free entry also is in
the Hint list, we need to remove/update hint to avoid the stale hint
causing the issues, in general case, the memory hole has been set for
removing part of free entry, it would not cause direct crash, but if
there is 8 bytes shift for the starting address due to the alignment,
the size of memory hole would be overwritten by aligned free entry, then
it could cause an assert or crash.


Signed-off-by: Lin Hu <linhu@ca.ibm.com>