### PR TITLE
RISC-V: remove `hasToBeOnStack` from `OMRLinkage`

### DIFF
--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,11 +106,6 @@ void OMR::RV::Linkage::initRVRealRegisterLinkage()
 void OMR::RV::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
    {
    /* do nothing */
-   }
-
-bool OMR::RV::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
-   {
-   return(false);
    }
 
 TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, int32_t offset, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::RVMemoryArgument &memArg)

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -315,12 +315,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     */
    Linkage (TR::CodeGenerator *cg) : OMR::Linkage(cg) {}
 
-   /**
-    * @brief Parameter has to be on stack or not
-    * @param[in] parm : parameter symbol
-    * @return true if the parameter has to be on stack, false otherwise
-    */
-   virtual bool hasToBeOnStack(TR::ParameterSymbol *parm);
    /**
     * @brief Maps symbols to locations on stack
     * @param[in] method : method for which symbols are mapped on stack


### PR DESCRIPTION
Remove `OMR::RV::Linkage::hasToBeOnStack` so that the common
implementation `OMR::Linkage::hasToBeOnStack` is used.