### PR TITLE
RISC-V: provide prototype for `riscvCodeSync`

### DIFF
--- a/compiler/riscv/runtime/CodeSync.hpp
+++ b/compiler/riscv/runtime/CodeSync.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,16 +19,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <riscv/runtime/CodeSync.hpp>
+#ifndef CODESYNC_HPP_
+#define CODESYNC_HPP_
 
-void riscvCodeSync(void *codeStart, size_t codeSize)
-   {
-#if defined(TR_HOST_RISCV)
-#if defined(__GNUC__)
-   // GCC built-in function
-   __builtin___clear_cache(reinterpret_cast<char*>(codeStart), reinterpret_cast<char*>(codeStart)+codeSize);
-#else
-#error Not supported yet
-#endif
-#endif
-   }
+#include <cstddef>
+/**
+ * @brief Make sure the code gets from the data cache to the instruction cache.
+ */
+void riscvCodeSync(void *codeStart, size_t codeSize);
+
+#endif//CODESYNC_HPP_

--- a/compiler/riscv/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/riscv/runtime/VirtualGuardRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 #include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
 #include <infra/Assert.hpp>
+#include "runtime/CodeSync.hpp"
 
-extern void riscvCodeSync(unsigned char *codeStart, unsigned int codeSize);
 
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
    int64_t distance = (int64_t)destinationAddr - (int64_t)locationAddr;
    *(uint32_t *)locationAddr = TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::_jal), 0, distance);
-   riscvCodeSync((unsigned char *)locationAddr, RISCV_INSTRUCTION_LENGTH);
+   riscvCodeSync(locationAddr, RISCV_INSTRUCTION_LENGTH);
    }


### PR DESCRIPTION
This commit introduces new header `CodeSync.hpp` with prototype of
`riscvCodeSync`. This avoids to copy and paste `extern riscvCodeSync...`
on various places.

Also, change parameter types to `void*` and `size_t` to avoid the need
for explicit type casts when calling.