### PR TITLE
Enable vadd and vsub for Byte and Short vectors of size 128

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -999,7 +999,7 @@ OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::D
       {
       case TR::vadd:
       case TR::vsub:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
             return true;
          else
             return false;


### PR DESCRIPTION
The [logic](https://github.com/eclipse/omr/blob/master/compiler/x/codegen/OMRTreeEvaluator.cpp#L4092-L4093) is already implemented, this PR simply enables vadd and vsub for auto-simd.

Signed-off-by: BradleyWood <bradley.wood@ibm.com>