### PR TITLE
Update method for inserting and coalescing heap chunk back free list

### DIFF
--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -338,6 +338,8 @@ public:
 	 * @param bytes the number of bytes to increase the recorded estimate
 	 */
 	MMINLINE void incrementDarkMatterBytes(uintptr_t bytes) { _darkMatterBytes += bytes; }
+	MMINLINE void incrementDarkMatterBytesAtomic(uintptr_t bytes) { MM_AtomicOperations::add(&_darkMatterBytes, bytes); }
+
 	/**
 	 * @return the recorded estimate of dark matter in the receiver
 	 */
@@ -373,6 +375,12 @@ public:
 	}
 
 	virtual bool recycleHeapChunk(void* chunkBase, void* chunkTop)
+	{
+		Assert_MM_unreachable();
+		return false;
+	}
+
+	virtual bool recycleHeapChunk(MM_EnvironmentBase *env, void* chunkBase, void* chunkTop)
 	{
 		Assert_MM_unreachable();
 		return false;

--- a/gc/base/MemoryPoolAddressOrderedList.hpp
+++ b/gc/base/MemoryPoolAddressOrderedList.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,11 @@ public:
 	virtual void expandWithRange(MM_EnvironmentBase *env, uintptr_t expandSize, void *lowAddress, void *highAddress, bool canCoalesce);
 	virtual void *contractWithRange(MM_EnvironmentBase *env, uintptr_t contractSize, void *lowAddress, void *highAddress);
 
-	bool recycleHeapChunk(void* chunkBase, void* chunkTop);
+	bool recycleHeapChunk(void* chunkBase, void* chunkTop)
+	{
+		return recycleHeapChunk(NULL, chunkBase, chunkTop);
+	}
+	bool recycleHeapChunk(MM_EnvironmentBase *env, void* chunkBase, void* chunkTop);
 	bool recycleHeapChunk(void *addrBase, void *addrTop, MM_HeapLinkedFreeHeader *previousFreeEntry, MM_HeapLinkedFreeHeader *nextFreeEntry);
 
 	virtual void *findFreeEntryEndingAtAddr(MM_EnvironmentBase *env, void *addr);


### PR DESCRIPTION
	- update incrementDarkMatterBytes(), the methods have atomic
	change option to protect thread race condition.
	- update method recycleHeapChunk() in MM_MemoryPoolAddressOrderedList
	to handle insert and coalesce heap chunk back free list.


Signed-off-by: Lin Hu <linhu@ca.ibm.com>