### PR TITLE
Add high code cache occupancy options

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1613,6 +1613,8 @@ public:
    void    setInitialMILCount(int32_t n){ _initialMILCount = n; }
    int32_t getInitialColdRunCount()  { return _initialColdRunCount; }
    int32_t getInitialColdRunBCount() { return _initialColdRunBCount; }
+   static int32_t getHighCodeCacheOccupancyCount() { return _highCodeCacheOccupancyCount; }
+   static int32_t getHighCodeCacheOccupancyBCount() { return _highCodeCacheOccupancyBCount; }
    int32_t getMaxSpreadCountLoopless() { return _maxSpreadCountLoopless; }
    int32_t getMaxSpreadCountLoopy()    { return _maxSpreadCountLoopy; }
 
@@ -1717,6 +1719,7 @@ public:
    static int32_t _maxNumVisitedSubclasses;
    static int32_t _minProfiledCheckcastFrequency; // as a percentage
    static int32_t _lowCodeCacheThreshold; // Turn off Iprofiler if available code cache space is lower than this value
+   static int32_t _highCodeCacheOccupancyPercentage;
 
 
    static uint32_t _memExpensiveCompThreshold; // threshold for when compilations are considered memory hungry
@@ -2164,6 +2167,8 @@ protected:
    int32_t                     _initialColdRunBCount;
    int32_t                     _maxSpreadCountLoopless;
    int32_t                     _maxSpreadCountLoopy;
+   static int32_t              _highCodeCacheOccupancyCount;
+   static int32_t              _highCodeCacheOccupancyBCount;
    int32_t                     _GCRCount;
    int32_t                     _GCRDecCount;
    int32_t                     _GCRResetCount;

--- a/compiler/runtime/OMRCodeCacheConfig.hpp
+++ b/compiler/runtime/OMRCodeCacheConfig.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,6 +92,7 @@ class OMR_EXTENSIBLE CodeCacheConfig
          _codeCacheMethodBodyAllocRetries(3),
          _codeCacheTempTrampolineSyncArraySize(256),
          _codeCacheHashEntryAllocatorSlabSize(4096),
+         _highCodeCacheOccupancyThresholdInBytes(0),
          _largeCodePageSize(0),
          _largeCodePageFlags(0),
          _allowedToGrowCache(false),
@@ -159,6 +160,8 @@ class OMR_EXTENSIBLE CodeCacheConfig
 
    size_t codeCacheHashEntryAllocatorSlabSize() const { return _codeCacheHashEntryAllocatorSlabSize; }
 
+   size_t highCodeCacheOccupancyThresholdInBytes() const { return _highCodeCacheOccupancyThresholdInBytes; }
+
    size_t largeCodePageSize() const { return _largeCodePageSize; }
    uint32_t largeCodePageFlags() const { return _largeCodePageFlags; }
    bool allowedToGrowCache() const { return _allowedToGrowCache; }
@@ -186,6 +189,7 @@ class OMR_EXTENSIBLE CodeCacheConfig
    size_t _codeCachePadKB;
    size_t _codeCacheAlignment;
 
+   size_t _highCodeCacheOccupancyThresholdInBytes;
 
    size_t _largeCodePageSize;
    uint32_t _largeCodePageFlags;


### PR DESCRIPTION
One way to help relieve the pressure on a code cache with high occupancy
is to increase the initial invocation counts of newly-introduced
methods. New options introduced to support this are:

- OMR::Options::_highCodeCacheOccupancyPercentage, which defines the
  threshold at which a code cache is considered to have high occupancy
- OMR::Options::_highOccupancyInitialCount and
  OMR::Options::_highOccupancyInitialBCount, which store the initial
  invocation counts to be used at high occupancy

Related: https://github.com/eclipse-openj9/openj9/pull/14344
Signed-off-by: Christian Despres <despresc@ibm.com>

Attn @mpirvu. ~None of the options can be changed from their defaults. I still need to look for what I need to change to fix that.~