### PR TITLE
AArch64: Fix register assigner for vector register case

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -355,7 +355,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
             }
          else
             {
-            location = cg->allocateSpill(8, false, NULL);
+            location = cg->allocateSpill((rk == TR_FPR) ? 8 : 16, false, NULL);
             if (debugObj)
                cg->traceRegisterAssignment("\nSpilling FPR %R to (%p)\n", registerToSpill, location);
             }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -492,8 +492,10 @@ void OMR::ARM64::RegisterDependencyGroup::assignRegisters(
             traceMsg (comp,"\nOOL: Releasing backing storage (%p)\n", location);
             if (rk == TR_GPR)
                dataSize = TR::Compiler->om.sizeofReferenceAddress();
-            else
+            else if (rk == TR_FPR)
                dataSize = 8;
+            else /* TR_VRF */
+               dataSize = 16;
             location->setMaxSpillDepth(0);
             cg->freeSpill(location, dataSize, 0);
             virtReg->setBackingStorage(NULL);


### PR DESCRIPTION
Use 16 byte slot when spilling/restoring a vector register.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>