### PR TITLE
AArch64: Introduce a pseudo real register for killing vector registers

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -2061,6 +2061,7 @@ getRegisterName(TR::RealRegister::RegNum num, bool is64bit)
       {
       case TR::RealRegister::NoReg: return "NoReg";
       case TR::RealRegister::SpilledReg: return "SpilledReg";
+      case TR::RealRegister::KillVectorRegs: return "KillVectorRegs";
       case TR::RealRegister::x0: return (is64bit ? "x0" : "w0");
       case TR::RealRegister::x1: return (is64bit ? "x1" : "w1");
       case TR::RealRegister::x2: return (is64bit ? "x2" : "w2");

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1478,7 +1478,7 @@ void
 OMR::ARM64::Machine::takeRegisterStateSnapShot()
    {
    int32_t i;
-   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 1; i++)
+   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 2; i++) // Skipping SpilledReg and KillVectorRegs
       {
       _registerStatesSnapShot[i] = _registerFile[i]->getState();
       _assignedRegisterSnapShot[i] = _registerFile[i]->getAssignedRegister();
@@ -1492,7 +1492,7 @@ void
 OMR::ARM64::Machine::restoreRegisterStateFromSnapShot()
    {
    int32_t i;
-   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 1; i++) // Skipping SpilledReg
+   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 2; i++) // Skipping SpilledReg and KillVectorRegs
       {
       _registerFile[i]->setWeight(_registerWeightSnapShot[i]);
       _registerFile[i]->setFlags(_registerFlagsSnapShot[i]);
@@ -1555,7 +1555,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
    // it is space conscious
    //
    TR::Compilation *comp = self()->cg()->comp();
-   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 1; i++)
+   for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 2; i++) // Skipping SpilledReg and KillVectorRegs
       {
       TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
 
@@ -1575,7 +1575,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
    if (c)
       {
       deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
-      for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 1; i++)
+      for (i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters - 2; i++) // Skipping SpilledReg and KillVectorRegs
          {
          TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
          if (realReg->getState() == TR::RealRegister::Assigned)

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,6 +216,13 @@ public:
       memset(_registerAssociations, 0, sizeof(TR::Register *) * (TR::RealRegister::NumRegisters));
       }
 
+   /**
+    * @brief Spills all vector registers
+    *
+    * @param[in] currentInstruction : current instruction
+    */
+   void spillAllVectorRegisters(TR::Instruction  *currentInstruction);
+
 private:
 
    // For register snap shot
@@ -229,6 +236,14 @@ private:
    TR::Register               *_registerAssociations[TR::RealRegister::NumRegisters];
 
    void initializeRegisterFile();
+
+   /**
+    * @brief Spills the specified virtual register
+    *
+    * @param[in] currentInstruction : current instruction
+    * @param[in] virtReg            : virtual register to spill
+    */
+   void spillRegister(TR::Instruction *currentInstruction, TR::Register *virtReg);
    };
 }
 }

--- a/compiler/aarch64/codegen/OMRRealRegister.cpp
+++ b/compiler/aarch64/codegen/OMRRealRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,5 +117,6 @@ const uint8_t OMR::ARM64::RealRegister::fullRegBinaryEncodings[TR::RealRegister:
       0x1d, // v29
       0x1e, // v30
       0x1f, // v31
-      0x00  // SpilledReg
+      0x00, // SpilledReg
+      0x00, // KillVectorRegs
    };

--- a/compiler/aarch64/codegen/RealRegisterEnum.hpp
+++ b/compiler/aarch64/codegen/RealRegisterEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,4 +98,5 @@
       LastFPR           = v31,
       LastAssignableFPR = v31,
       SpilledReg        = 66,
-      NumRegisters      = SpilledReg + 1
+      KillVectorRegs    = 67,
+      NumRegisters      = KillVectorRegs + 1


### PR DESCRIPTION
Introduce `spillAllVectorRegs` helper function to OMRMachine class.
Introduce `KillVectorRegs` pseudo real register.
Update the register dependency class to kill all vector registers by  calling `spillAllVectorRegs` helper function
when `KillVectorRegs` is in the dependencies.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>