### PR TITLE
VLHGC survivor region count

### DIFF
--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 1998, 2021 IBM Corp. and others
+// Copyright (c) 1998, 2022 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -592,7 +592,7 @@ TraceEvent=Trc_MM_FrequentObjectStats_AllocationCacheIndexableObjectAllocation O
 TraceEvent=Trc_MM_FrequentObjectStats_AllocationCacheObjectAllocation Overhead=1 Level=1 Template="Frequently allocated object in allocation cache: class=%p (%.*s); object size=%zu; allocations counted=%zu, estimated total allocations:%zu"
 
 TraceEntry=Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_Entry Overhead=1 Level=1 Group=kickoff Template="MM_SchedulingDelegate_partialGarbageCollectCompleted reclaimableRegions=%zu defragmentReclaimableRegions=%zu"
-TraceEvent=Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_stats Overhead=1 Level=1 Group=kickoff Template="Evacuated %zu Eden + %zu non-Eden regions into %zu + %zu regions. Eden was %zu regions."
+TraceEvent=Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_statsOld Obsolete Overhead=1 Level=1 Group=kickoff Template="Evacuated %zu Eden + %zu non-Eden regions into %zu + %zu regions. Eden was %zu regions."
 TraceExit=Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_Exit Overhead=1 Level=1 Group=kickoff Template="MM_SchedulingDelegate_partialGarbageCollectCompleted"
 
 TraceEntry=Trc_MM_CollectionSetDelegate_createNurseryCollectionSet_Entry Overhead=1 Level=1 Group=dynamiccollectionset Template="MM_CollectionSetDelegate_createNurseryCollectionSet dynamic=%s"
@@ -965,3 +965,5 @@ TraceEvent=Trc_MM_SchedulingDelegate_updatePgcTimePrediction Overhead=1 Level=3 
 TraceEvent=Trc_MM_IncrementalGenerationalGC_calculateConcurrentMarkWorkTime Overhead=1 Level=2 Group=resize Template="IncrementalGenerationalGC_calculateConcurrentMarkWorkTime Concurrent GMP ratio %f previous increment concurrent worktime %llu Total concurrent worktime %llu"
 
 TraceEvent=Trc_MM_SweepEndBalancedGC Overhead=1 Level=1 Group=gclogger Template="Sweep end. Duration %llu us"
+
+TraceEvent=Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_stats Overhead=1 Level=1 Group=kickoff Template="Evacuated %zu Eden + %zu non-Eden regions into copy-forward %zu + %zu and compact %zu regions. Eden was %zu regions."

--- a/gc/stats/CompactVLHGCStats.hpp
+++ b/gc/stats/CompactVLHGCStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,6 +91,8 @@ public:
 	uint64_t _rebuildNextMarkMapStartTime;	/**< hires start time to rebuild the next mark map from the next work packets (only done in GMP is active) */
 	uint64_t _rebuildNextMarkMapEndTime;	/**< hires end time to rebuild the next mark map from the next work packets (only done in GMP is active) */
 
+	uintptr_t _survivorRegionCount; /* total count (including both eden and non-eden) that were used as destination (hence not freed) */
+
 	void clear()
 	{
 		_compactReason = COMPACT_NONE;
@@ -110,6 +112,8 @@ public:
 		_rootFixupEndTime = 0;
 		_moveStallTime = 0;
 		_rebuildStallTime = 0;
+
+		_survivorRegionCount = 0;
 	};
 
 	MMINLINE void addToMoveStallTime(uint64_t startTime, uint64_t endTime)


### PR DESCRIPTION
Introduced a count of regions that were used as destination (hence not
freed up) during sliding compaction, as used in VLHGC.

Also a new trace point was introduced that will report it (along exising
survivor counts used in Copy-Forward)

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>