### PR TITLE
Relocate Value Propagation analysis of ArrayStoreCHK and arraylength

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1694,6 +1694,147 @@ TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypeValueType(TR::VPConstraint *
    {
    return TR::Compiler->om.areValueTypesEnabled() ? TR_maybe : TR_no;
    }
+
+
+bool OMR::ValuePropagation::isArrayStoreCheckNeeded(TR::Node *arrayRef, TR::Node *objectRef, bool &mustFail,
+           TR_OpaqueClassBlock* &storeClassForCheck, TR_OpaqueClassBlock* &componentClassForCheck)
+   {
+   bool isNeeded = true;
+   mustFail = false;
+   storeClassForCheck = NULL;
+   componentClassForCheck = NULL;
+
+   if (arrayRef == objectRef)
+      {
+      isNeeded = false;
+      }
+   else
+      {
+      bool isGlobal;
+      TR::VPConstraint *object = getConstraint(objectRef, isGlobal);
+      TR::VPConstraint *array  = getConstraint(arrayRef, isGlobal);
+
+      // If the object reference is null we can remove this check
+      //
+      if (object && object->isNullObject())
+         {
+         isNeeded = false;
+         }
+
+      // If the array reference is null we can remove this check, since there
+      // will be a nullcheck on the array reference before storing into it.
+      //
+      else if (array && array->isNullObject())
+         {
+         isNeeded = false;
+         }
+
+      // If the array is a resolved class and known to be an array type we may
+      // still be able to remove the check ...
+      //
+      else if (array && array->getClass())
+         {
+         int32_t len;
+         const char *sig = array->getClassSignature(len);
+         if (sig && sig[0] == '[')
+            {
+            // If the array is known to be a fixed array of Object,
+            // the check can be removed
+            // TODO -  get a pointer to the Object class from somewhere and
+            // compare object pointers instead of signatures
+            //
+            if (len == 19 && array->isFixedClass()
+                && !strncmp(sig, "[Ljava/lang/Object;", 19))
+               {
+               isNeeded = false;
+               }
+
+            // If the object's class is resolved too, see if we can prove the
+            // check will succeed.
+            //
+            else if (object && object->getClass())
+               {
+               TR_OpaqueClassBlock *arrayComponentClass = fe()->getComponentClassFromArrayClass(array->getClass());
+               TR_OpaqueClassBlock *objectClass = object->getClass();
+               if (object->asClass() && object->isClassObject() == TR_yes)
+                  {
+                  objectClass = fe()->getClassClassPointer(objectClass);
+                  }
+
+               if (array->asClass() && array->isClassObject() == TR_yes)
+                  {
+                  arrayComponentClass = fe()->getClassClassPointer(array->getClass());
+                  }
+
+               TR_YesNoMaybe isInstance = TR_maybe;
+               if (arrayComponentClass)
+                  {
+                  isInstance = fe()->isInstanceOf(objectClass, arrayComponentClass, object->isFixedClass(), array->isFixedClass());
+                  }
+
+               if (isInstance == TR_yes)
+                  {
+                  registerPreXClass(object);
+                  isNeeded = false;
+                  }
+               else if (isInstance == TR_no && debug("enableMustFailArrayStoreCheckOpt"))
+                  {
+                  registerPreXClass(object);
+                  mustFail = true;
+                  }
+               else if (arrayComponentClass && objectClass && !TR::Compiler->cls.isClassArray(comp(), arrayComponentClass) &&
+                        (arrayComponentClass == objectClass) && !comp()->fe()->classHasBeenExtended(objectClass))
+                  {
+                  // Component class of the array is the same as that of the object reference
+                  // and not yet seen to have been extended.  Any ArrayStoreCHK can be NOPed
+                  // on whether the class is extended.
+                  //
+                  storeClassForCheck = objectClass;
+                  }
+
+              else if ( !comp()->compileRelocatableCode() &&
+                        !(comp()->getOption(TR_DisableArrayStoreCheckOpts))  &&
+                        arrayComponentClass &&
+                        objectClass  &&
+                        fe()->isInstanceOf(objectClass, arrayComponentClass,true,true)
+                        )
+                  {
+                  // If the component class of the array really is arrayComponentClass
+                  // and class of the object really is objectClass at run-time, the
+                  // assignment will succeed.  Any ArrayStoreCHK use a fast path
+                  // test of whether the component class actually is this type to
+                  // avoid further run-time testing for the object's type.
+                  //
+                  componentClassForCheck = arrayComponentClass;
+                  }
+               }
+            }
+         }
+      }
+
+   return isNeeded;
+   }
+
+
+void OMR::ValuePropagation::getArrayLengthLimits(TR::VPConstraint *constraint, int32_t &lowerBoundLimit, int32_t &upperBoundLimit, int32_t &elementSize, bool &isKnownObj)
+   {
+   lowerBoundLimit = 0;
+   upperBoundLimit = static_cast<int32_t>(TR::getMaxSigned<TR::Int32>());
+   elementSize = 0;
+   isKnownObj = false;
+
+   if (constraint)
+      {
+      TR::VPArrayInfo *arrayInfo = constraint->getArrayInfo();
+      if (arrayInfo)
+         {
+         lowerBoundLimit = arrayInfo->lowBound();
+         upperBoundLimit = arrayInfo->highBound();
+         elementSize     = arrayInfo->elementSize();
+         }
+      }
+   }
+
 
 void OMR::ValuePropagation::checkTypeRelationship(TR::VPConstraint *lhs, TR::VPConstraint *rhs,
                                                 int32_t &value, bool isInstanceOf, bool isCheckCast)

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4859,19 +4859,17 @@ TR::Node *constrainArraylength(OMR::ValuePropagation *vp, TR::Node *node)
    // See if the underlying array has bound limits
    //
    TR::Node *objectRef = node->getFirstChild();
+
    bool isGlobal;
    TR::VPConstraint *constraint = vp->getConstraint(objectRef, isGlobal);
 
-   if (constraint)
-      {
-      TR::VPArrayInfo *arrayInfo = constraint->getArrayInfo();
-      if (arrayInfo)
-         {
-         lowerBoundLimit = arrayInfo->lowBound();
-         upperBoundLimit = arrayInfo->highBound();
-         elementSize     = arrayInfo->elementSize();
-         }
+   bool isKnownObj;
+
+   vp->getArrayLengthLimits(constraint, lowerBoundLimit, upperBoundLimit, elementSize, isKnownObj);
+
 #ifdef J9_PROJECT_SPECIFIC
+   if (constraint && !isKnownObj)
+      {
       TR::KnownObjectTable *knot = vp->comp()->getKnownObjectTable();
       TR::VPKnownObject *kobj = constraint->getKnownObject();
       if (knot && kobj)
@@ -4883,13 +4881,21 @@ TR::Node *constrainArraylength(OMR::ValuePropagation *vp, TR::Node *node)
             uintptr_t array = knot->getPointer(kobj->getIndex());
             if (vp->comp()->fej9()->isClassArray(vp->comp()->fej9()->getObjectClass(array)))
                {
-               uintptr_t length = vp->comp()->fej9()->getArrayLengthInElements(array);
-               vp->replaceByConstant(node, TR::VPIntConst::create(vp, length), isGlobal);
-               return node;
+               isKnownObj = true;
+               lowerBoundLimit = vp->comp()->fej9()->getArrayLengthInElements(array);
+               upperBoundLimit = lowerBoundLimit;
                }
             }
          }
+      }
 #endif
+
+   // If this is a known array object, we definitely know its length
+   //
+   if (isKnownObj)
+      {
+      vp->replaceByConstant(node, TR::VPIntConst::create(vp, lowerBoundLimit), isGlobal);
+      return node;
       }
 
    // If the element size is still not known, try to get it from the node or
@@ -12194,14 +12200,10 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
    constrainChildren(vp, node);
 
    TR::Node *child = node->getFirstChild();
-   TR::Node *objectRef;
-   TR::Node *arrayRef;
-   bool canBeRemoved = false;
+   TR::Node *objectRef = child->getSecondChild();
+   TR::Node *arrayRef = child->getChild(2);
    bool mustFail = false;
-   bool isGlobal;
-
-   objectRef = child->getSecondChild();
-   arrayRef = child->getChild(2);
+   bool valueIsFromSameArray = false;
 
    if (objectRef->getOpCode().isLoadVar() &&
        objectRef->getOpCode().isIndirect() &&
@@ -12215,104 +12217,17 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
             base = base->getFirstChild()->getFirstChild();
          }
 
-      if (base == arrayRef)
-         canBeRemoved = true;
+         valueIsFromSameArray = (vp->getValueNumber(base) == vp->getValueNumber(arrayRef));
       }
 
-   if (canBeRemoved != true)
-      {
-      TR::VPConstraint *object = vp->getConstraint(objectRef, isGlobal);
-      TR::VPConstraint *array  = vp->getConstraint(arrayRef, isGlobal);
-
-      // If the object reference is null we can remove this check, if the
-      // array's element type is not a value type
-      //
-      if (object && object->isNullObject())
-         {
-         canBeRemoved = true;
-         }
-
-      // If the array reference is null we can remove this check, since there
-      // will be a nullcheck on the array reference before storing into it.
-      //
-      else if (array && array->isNullObject())
-         canBeRemoved = true;
-
-      // If the array is a resolved class and known to be an array type we may
-      // still be able to remove the check ...
-      //
-      else if (array && array->getClass())
-         {
-         int32_t len;
-         const char *sig = array->getClassSignature(len);
-         if (sig && sig[0] == '[')
-            {
-            // If the array is known to be a fixed array of Object,
-            // the check can be removed
-            // TODO -  get a pointer to the Object class from somewhere and
-            // compare object pointers instead of signatures
-            //
-            if (len == 19 && array->isFixedClass()
-                && !strncmp(sig, "[Ljava/lang/Object;", 19))
-               {
-               canBeRemoved = true;
-               }
-
-            // If the object's class is resolved too, see if we can prove the
-            // check will succeed.
-            //
-            else if (object && object->getClass())
-               {
-               TR_OpaqueClassBlock *arrayComponentClass = vp->fe()->getComponentClassFromArrayClass(array->getClass());
-               TR_OpaqueClassBlock *objectClass = object->getClass();
-               if (object->asClass() && object->isClassObject() == TR_yes)
-                  objectClass = vp->fe()->getClassClassPointer(objectClass);
-               if (array->asClass() && array->isClassObject() == TR_yes)
-                  arrayComponentClass = vp->fe()->getClassClassPointer(array->getClass());
-
-               TR_YesNoMaybe isInstance = TR_maybe;
-               if (arrayComponentClass)
-                  isInstance = vp->fe()->isInstanceOf(objectClass, arrayComponentClass, object->isFixedClass(), array->isFixedClass());
-                  //isInstance = vp->fe()->isInstanceOf(object->getClass(), arrayComponentClass, object->isFixedClass(), array->isFixedClass());
-
-               if (isInstance == TR_yes)
-                  {
-                  vp->registerPreXClass(object);
-                  canBeRemoved = true;
-                  }
-               else if (isInstance == TR_no && debug("enableMustFailArrayStoreCheckOpt"))
-                  {
-                  vp->registerPreXClass(object);
-                  mustFail = true;
-                  }
-               else if (arrayComponentClass && objectClass && !TR::Compiler->cls.isClassArray(vp->comp(), arrayComponentClass) &&
-                        (arrayComponentClass == objectClass) && !vp->comp()->fe()->classHasBeenExtended(objectClass))
-                  {
-                  if (vp->trace())
-                     traceMsg(vp->comp(),"Setting arrayStoreClass on ArrayStoreChk node [%p] to [%p]\n", node, objectClass);
-                  node->setArrayStoreClassInNode(objectClass);
-                  }
-
-              else if ( !vp->comp()->compileRelocatableCode() &&
-                        !(vp->comp()->getOption(TR_DisableArrayStoreCheckOpts))  &&
-                        arrayComponentClass &&
-                        objectClass  &&
-                        vp->fe()->isInstanceOf(objectClass, arrayComponentClass,true,true)
-                        )
-                  {
-                  if (vp->trace())
-                     traceMsg(vp->comp(),"Setting arrayComponentClass on ArrayStoreChk node [%p] to [%p]\n", node, arrayComponentClass);
-                  node->setArrayComponentClassInNode(arrayComponentClass);
-                  }
-
-               }
-            }
-         }
-      }
+   TR_OpaqueClassBlock *storeClassForCheck = NULL;
+   TR_OpaqueClassBlock *componentClassForCheck = NULL;
+   bool isStoreCheckNeeded = !valueIsFromSameArray
+                             && vp->isArrayStoreCheckNeeded(arrayRef, objectRef, mustFail, storeClassForCheck, componentClassForCheck);
 
    // Remove the check if we can
    //
-   if (canBeRemoved)
+   if (!isStoreCheckNeeded)
       {
       // Change the write barrier into iastore
       //
@@ -12333,6 +12248,23 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
          vp->setChecksRemoved();
          return node;
          }
+      }
+
+   if (storeClassForCheck != NULL)
+      {
+      if (vp->trace())
+         {
+         traceMsg(vp->comp(),"Setting arrayStoreClass on ArrayStoreChk node [%p] to [%p]\n", node, storeClassForCheck);
+         }
+      node->setArrayStoreClassInNode(storeClassForCheck);
+      }
+   else if (componentClassForCheck != NULL)
+      {
+      if (vp->trace())
+         {
+         traceMsg(vp->comp(),"Setting arrayComponentClass on ArrayStoreChk node [%p] to [%p]\n", node, componentClassForCheck);
+         }
+      node->setArrayComponentClassInNode(componentClassForCheck);
       }
 
    vp->createExceptionEdgeConstraints(TR::Block::CanCatchArrayStoreCheck, NULL, node);


### PR DESCRIPTION
Move some analysis of `ArrayStoreCHK` and `arraylength` operations out of VPHandlers.cpp so they can be shared with other parts of Value Propagation, particularly in downstream projects.

Some [OpenJ9-specific code in `constrainArrayLength` in VPHandlers.cpp](https://github.com/hzongaro/omr/blob/d95d9718595d098b4a12537f7585fa9465072e83/compiler/optimizer/VPHandlers.cpp#L4870-L4891) will be removed in a follow up pull request after it is transferred to that downstream project.

This is the first planned pull request mentioned in [OpenJ9 issue #14402](https://github.com/eclipse-openj9/openj9/issues/14402#issuecomment-1027104497)