### PR TITLE
AArch64: Enable live register support for vector registers

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -92,8 +92,10 @@ OMR::ARM64::CodeGenerator::initialize()
 
    cg->addSupportedLiveRegisterKind(TR_GPR);
    cg->addSupportedLiveRegisterKind(TR_FPR);
+   cg->addSupportedLiveRegisterKind(TR_VRF);
    cg->setLiveRegisters(new (cg->trHeapMemory()) TR_LiveRegisters(comp), TR_GPR);
    cg->setLiveRegisters(new (cg->trHeapMemory()) TR_LiveRegisters(comp), TR_FPR);
+   cg->setLiveRegisters(new (cg->trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
 
    cg->setSupportsVirtualGuardNOPing();
 


### PR DESCRIPTION
This commit enables live register support for vector registers.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>