### PR TITLE
Update JNI Target relocation record to have offset to the reloLocation.

### DIFF
--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -135,10 +135,20 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_JNIVirtualTargetAddress:
          {
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
-                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                        (TR_ExternalRelocationTargetKind) reloType, cg()),
-                        __FILE__, __LINE__, getNode());
+
+         TR_RelocationRecordInformation *info = new (comp->trHeapMemory()) TR_RelocationRecordInformation();
+         info->data1 = 0;
+         info->data2 = reinterpret_cast<uintptr_t>(getNode()->getSymbolReference());
+         int16_t inlinedSiteIndex = getNode() ? getNode()->getInlinedSiteIndex() : -1;
+         info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
+
+         cg()->addExternalRelocation(
+            new (cg()->trHeapMemory()) TR::ExternalRelocation(
+               cursor,
+               reinterpret_cast<uint8_t *>(info),
+               static_cast<TR_ExternalRelocationTargetKind>(reloType),
+               cg()),
+            __FILE__, __LINE__, getNode());
          }
          break;
 


### PR DESCRIPTION
On x86, the JNI Target relocation puts the incorrect address when
generating a Runtime Assumption. However, the address that the
relocation infra itself needs to patch is correct. Thus, the relo record
has to hold not just the location to patch but also the location to
register the assumption against. This is the same on most platforms, but
different on x86.

https://github.com/eclipse-openj9/openj9/pull/14421 depends on this change; OpenJ9 will be broken without a coordinated merge.