### PR TITLE
AArch64: Preserve vector registers across calls on system linkage

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -26,6 +26,7 @@
 #include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/LiveRegister.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "compile/Compilation.hpp"
 #include "il/Node.hpp"
@@ -408,4 +409,11 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
    // Return the last instruction we inserted, whether or not it was a load.
    //
    return loadCursor? loadCursor : cursor;
+   }
+
+bool OMR::ARM64::Linkage::killsVectorRegisters()
+   {
+   // We need to kill vector registers if there is any live one.
+   TR_LiveRegisters *liveRegs = cg()->getLiveRegisters(TR_VRF);
+   return (!liveRegs || liveRegs->getNumberOfLiveRegisters() > 0);
    }

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -397,6 +397,13 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     * @return The instruction cursor after copies inserted.
     */
    TR::Instruction *copyParametersToHomeLocation(TR::Instruction *cursor, bool parmsHaveBeenStored = false);
+
+   /**
+    * @brief Answers if vector registers need to be spilled
+    *
+    * @return true if vector registers need to be spilled.
+    */
+   bool killsVectorRegisters();
    };
 } // ARM64
 } // TR


### PR DESCRIPTION
Preserve vector registers across function calls using system linkage.

Resolves https://github.com/eclipse/omr/issues/6318

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>