### PR TITLE
Update JNI Target relocation record to have offset to the reloLocation.

### DIFF
--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1094,10 +1094,27 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   int rType = methodSym->getMethodKind()-1;  //method kinds are 1-based
                   TR_ASSERT(reloTypes[rType], "There shouldn't be direct JNI interface calls!");
 
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
-                        getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                        (TR_ExternalRelocationTargetKind) reloTypes [rType], cg()),
-                        __FILE__, __LINE__, getNode());
+                  uint8_t *startOfInstruction = self()->getBinaryEncoding();
+                  uint8_t *startOfImmediate = cursor;
+                  intptr_t diff = reinterpret_cast<intptr_t>(startOfImmediate) - reinterpret_cast<intptr_t>(startOfInstruction);
+                  TR_ASSERT_FATAL(diff > 0, "Address of immediate %p less than address of instruction %p\n",
+                                  startOfImmediate, startOfInstruction);
+
+                  TR_RelocationRecordInformation *info =
+                     reinterpret_cast<TR_RelocationRecordInformation *>(
+                        comp->trMemory()->allocateHeapMemory(sizeof(TR_RelocationRecordInformation)));
+                  info->data1 = static_cast<uintptr_t>(diff);
+                  info->data2 = reinterpret_cast<uintptr_t>(getNode()->getSymbolReference());
+                  int16_t inlinedSiteIndex = getNode() ? getNode()->getInlinedSiteIndex() : -1;
+                  info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
+
+                  cg()->addExternalRelocation(
+                     new (cg()->trHeapMemory()) TR::ExternalRelocation(
+                                                   startOfInstruction,
+                                                   reinterpret_cast<uint8_t *>(info),
+                                                   static_cast<TR_ExternalRelocationTargetKind>(reloTypes[rType]),
+                                                   cg()),
+                     __FILE__, __LINE__, getNode());
                   }
                else if (resolvedMethod)
                   {
@@ -2767,13 +2784,46 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                          __FILE__, __LINE__, getNode());
                   }
                break;
-            case TR_JNIStaticTargetAddress:
-            case TR_JNISpecialTargetAddress:
-            case TR_JNIVirtualTargetAddress:
             case TR_StaticRamMethodConst:
             case TR_VirtualRamMethodConst:
             case TR_SpecialRamMethodConst:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,  (TR_ExternalRelocationTargetKind) _reloKind, cg()),  __FILE__,__LINE__, getNode());
+               cg()->addExternalRelocation(
+                  new (cg()->trHeapMemory()) TR::ExternalRelocation(
+                                                cursor,
+                                                (uint8_t *) getNode()->getSymbolReference(),
+                                                getNode()
+                                                   ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex()
+                                                   : (uint8_t *)-1,
+                                                (TR_ExternalRelocationTargetKind) _reloKind,
+                                                cg()),
+                     __FILE__,__LINE__, getNode());
+               break;
+            case TR_JNIStaticTargetAddress:
+            case TR_JNISpecialTargetAddress:
+            case TR_JNIVirtualTargetAddress:
+               {
+               uint8_t *startOfInstruction = self()->getBinaryEncoding();
+               uint8_t *startOfImmediate = cursor;
+               intptr_t diff = reinterpret_cast<intptr_t>(startOfImmediate) - reinterpret_cast<intptr_t>(startOfInstruction);
+               TR_ASSERT_FATAL(diff > 0, "Address of immediate %p less than address of instruction %p\n",
+                               startOfImmediate, startOfInstruction);
+
+               TR_RelocationRecordInformation *info =
+                  reinterpret_cast<TR_RelocationRecordInformation *>(
+                     comp->trMemory()->allocateHeapMemory(sizeof(TR_RelocationRecordInformation)));
+               info->data1 = static_cast<uintptr_t>(diff);
+               info->data2 = reinterpret_cast<uintptr_t>(getNode()->getSymbolReference());
+               int16_t inlinedSiteIndex = getNode() ? getNode()->getInlinedSiteIndex() : -1;
+               info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
+
+               cg()->addExternalRelocation(
+                  new (cg()->trHeapMemory()) TR::ExternalRelocation(
+                                                startOfInstruction,
+                                                reinterpret_cast<uint8_t *>(info),
+                                                static_cast<TR_ExternalRelocationTargetKind>(_reloKind),
+                                                cg()),
+                     __FILE__,__LINE__, getNode());
+               }
                break;
             }
          }

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,10 +135,20 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_JNIVirtualTargetAddress:
          {
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
-                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                        (TR_ExternalRelocationTargetKind) reloType, cg()),
-                        __FILE__, __LINE__, getNode());
+
+         TR_RelocationRecordInformation *info = new (comp->trHeapMemory()) TR_RelocationRecordInformation();
+         info->data1 = 0;
+         info->data2 = reinterpret_cast<uintptr_t>(getNode()->getSymbolReference());
+         int16_t inlinedSiteIndex = getNode() ? getNode()->getInlinedSiteIndex() : -1;
+         info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
+
+         cg()->addExternalRelocation(
+            new (cg()->trHeapMemory()) TR::ExternalRelocation(
+               cursor,
+               reinterpret_cast<uint8_t *>(info),
+               static_cast<TR_ExternalRelocationTargetKind>(reloType),
+               cg()),
+            __FILE__, __LINE__, getNode());
          }
          break;
 


### PR DESCRIPTION
Reverts<sup>1</sup> eclipse/omr#6330 which was a revert of https://github.com/eclipse/omr/pull/6326

On x86, the JNI Target relocation puts the incorrect address when
generating a Runtime Assumption. However, the address that the
relocation infra itself needs to patch is correct. Thus, the relo record
has to hold not just the location to patch but also the location to
register the assumption against. This is the same on most platforms, but
different on x86.

https://github.com/eclipse-openj9/openj9/pull/14421 depends on this change; OpenJ9 will be broken without a coordinated merge.

<hr/>

1. Note: because of the force push, this is no longer technically a revert. However, the force push only updated copyrights in a comment block, and so there is no functional difference between this PR and https://github.com/eclipse/omr/pull/6326.