### PR TITLE
Use xxspltib when broadcasting immediate value into ByteVector

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1801,6 +1801,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
          else
             return false;
       case TR::vsplats:
+         if ((dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double))
+            return true;
       case TR::getvelem:
          if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
             return true;

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -898,7 +898,7 @@
    xxsel,            // VSX Select (Operands usage are diffent than fsel)
    xxsldwi,          // VSX Shift Left Double by Word Immediate
    xxspltw,          // VSX Splat Word
-// xxspltib,         // VSX Vector Splat Immediate Byte
+   xxspltib,         // VSX Vector Splat Immediate Byte
 // xxperm,           // VSX Vector Permute
    xxpermdi,         // VSX Permute Doubleword Immediate
 // xxpermr,          // VSX Vector Permute Right-indexed

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -10678,17 +10678,17 @@
                         PPCOpProp_SyncSideEffectFree,
    },
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::xxspltib, */
-   /* .name        =    "xxspltib", */
+  {
+   /* .mnemonic    = */   OMR::InstOpCode::xxspltib,
+   /* .name        = */  "xxspltib",
    /* .description =    "VSX Vector Splat Immediate Byte", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0xF00002D0, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-   /* .properties  =    PPCOpProp_IsVSX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */   0x00000000,
+   /* .opcode      = */   0xF00002D0,
+   /* .format      = */   FORMAT_XT_IMM8,
+   /* .minimumALS  = */   OMR_PROCESSOR_PPC_P9,
+   /* .properties  = */   PPCOpProp_IsVSX |
+                          PPCOpProp_SyncSideEffectFree,
+   },
 
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::xxperm, */

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1019,6 +1019,20 @@ static void fillFieldR(TR::Instruction *instr, uint32_t *cursor, uint32_t val)
    cursor[0] |= (val << 20);
    }
 
+/**
+ * Fills in the 8-bit IMM8 field of a binary-encoded instruction with the provided immediate value:
+ *
+ * +----------------------+---------------------------------------+
+ * |                      | IMM8            |                     |
+ * | 0                    | 13              | 21                  |
+ * +----------------------+---------------------------------------+
+ */
+static void fillFieldIMM8(TR::Instruction *instr, uint32_t *cursor, uint32_t val)
+   {
+   TR_ASSERT_FATAL_WITH_INSTRUCTION(instr, (val & 0xffu) == val || isValidInSignExtendedField(val, 0xffu), "0x%x is out-of-range for IMM8(8) field", val);
+   *cursor |= (val & 0xff) << 11;
+   }
+
 uint8_t *
 OMR::Power::Instruction::generateBinaryEncoding()
    {
@@ -1660,6 +1674,11 @@ TR::PPCTrg1ImmInstruction::fillBinaryEncodingFields(uint32_t *cursor)
          fillFieldXT5(self(), cursor + 1, trg);
          fillFieldD34(self(), cursor, static_cast<int64_t>(static_cast<int32_t>(imm)));
          fillFieldR(self(), cursor, 1);
+         break;
+
+      case FORMAT_XT_IMM8:
+         fillFieldXT(self(), cursor, trg);
+         fillFieldIMM8(self(), cursor, imm);
          break;
 
       default:

--- a/compiler/p/codegen/PPCOpsDefines.hpp
+++ b/compiler/p/codegen/PPCOpsDefines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -926,7 +926,17 @@ FORMAT_VRS_D34_RA_R,
 // |     | XS        | RA       | d1                              |
 // | 0   | 5         | 11       | 16                              |
 // +-----+-----------+----------+---------------------------------+
-FORMAT_XS5_D34_RA_R
+FORMAT_XS5_D34_RA_R,
+
+
+// Formats for instructions with an XT field encoding the target VSX register and an IMM8
+// field:
+//
+// +------+----------+------+----------------+----------------+----+
+// |      | XT       |      | IMM8           |                | XT |
+// | 0    | 6        | 11   | 13             | 21             | 31 |
+// +------+----------+------+----------------+----------------+----+
+FORMAT_XT_IMM8
 
 };
 

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -2669,6 +2669,13 @@ INSTANTIATE_TEST_CASE_P(VSXVectorFixed, PPCTrg1Src3EncodingTest, ::testing::Valu
     std::make_tuple(TR::InstOpCode::xxsel, TR::RealRegister::vsr0,  TR::RealRegister::vsr0,  TR::RealRegister::vsr0,  TR::RealRegister::vsr63, TRTest::BinaryInstruction("f00007f8"))
 ));
 
+INSTANTIATE_TEST_CASE_P(VSXVectorFixed, PPCTrg1ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::xxspltib, TR::RealRegister::vsr31, 0x00000000u, TRTest::BinaryInstruction("f3e002d0")),
+    std::make_tuple(TR::InstOpCode::xxspltib, TR::RealRegister::vsr0,  0x0000000fu, TRTest::BinaryInstruction("f0007ad0")),
+    std::make_tuple(TR::InstOpCode::xxspltib, TR::RealRegister::vsr15, 0xfffffff0u, TRTest::BinaryInstruction("f1e782d0")),
+    std::make_tuple(TR::InstOpCode::xxspltib, TR::RealRegister::vsr16, 0xffffffffu, TRTest::BinaryInstruction("f207fad0"))
+));
+
 INSTANTIATE_TEST_CASE_P(VSXVectorFixed, PPCRecordFormSanityTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::xxland,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::xxlandc,  TR::InstOpCode::bad, TRTest::BinaryInstruction()),
@@ -2682,7 +2689,8 @@ INSTANTIATE_TEST_CASE_P(VSXVectorFixed, PPCRecordFormSanityTest, ::testing::Valu
     std::make_tuple(TR::InstOpCode::xxpermdi, TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::xxsel,    TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::xxsldwi,  TR::InstOpCode::bad, TRTest::BinaryInstruction()),
-    std::make_tuple(TR::InstOpCode::xxspltw,  TR::InstOpCode::bad, TRTest::BinaryInstruction())
+    std::make_tuple(TR::InstOpCode::xxspltw,  TR::InstOpCode::bad, TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::xxspltib, TR::InstOpCode::bad, TRTest::BinaryInstruction())
 ));
 
 INSTANTIATE_TEST_CASE_P(VSXVectorFloat, PPCTrg1Src1EncodingTest, ::testing::Values(


### PR DESCRIPTION
This contribution includes the following changes: 

- vsplats has been enabled for all vector types
- `xxspltib` instruction has been enabled and a binary encoding routine for its instruction format has been added
- On P9 and up, `xxspltib` is used to broadcast 8-bit immediate values into ByteVectors
- Binary encoder unit test has been added for `xxspltib`