### PR TITLE
Add -Xjit:aggressiveSwitchingToProfiling option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -116,6 +116,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"aggressiveRecompilationChances=", "O<nnn>\tnumber of chances per method to recompile with the "
                                        "aggressive recompilation mechanism",
                                TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_aggressiveRecompilationChances, 0, "F%d", NOT_IN_SUBSET},
+   {"aggressiveSwitchingToProfiling", "O\tAllow switching hot methods to profiling more aggressively", SET_OPTION_BIT(TR_AggressiveSwitchingToProfiling), "F" },
    {"allowVPRangeNarrowingBasedOnDeclaredType",
       "I\tallow value propagation to assume that integers declared "
       "narrower than 32-bits (boolean, byte, char, short) are in-range",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -84,7 +84,7 @@ enum TR_CompilationOptions
    // Option word 0
    //
    TR_AOTCompileOnlyFromBootstrap= 0x00000020,
-   // Available                  = 0x00000040,
+   TR_AggressiveSwitchingToProfiling = 0x00000040,
    TR_ReportMethodEnter          = 0x00000080,
    TR_ReportMethodExit           = 0x00000100,
    TR_EntryBreakPoints           = 0x00000200,


### PR DESCRIPTION
This option will be used in a downstream project (OpenJ9)
to replace the effect -Xaggressive had on switching hot
compilations to profiling

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>