### PR TITLE
Implement new vector types

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -295,10 +295,7 @@ TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
       if (localCursor->getGCMapIndex() < 0
           && localCursor->getDataType() != TR::Int64
           && localCursor->getDataType() != TR::Double
-          && localCursor->getDataType() != TR::VectorInt8
-          && localCursor->getDataType() != TR::VectorInt16
-          && localCursor->getDataType() != TR::VectorFloat
-          && localCursor->getDataType() != TR::VectorDouble)
+          && !localCursor->getDataType().isVector())
          {
          localCursor->setOffset(stackIndex);
          stackIndex += (localCursor->getSize() + 3) & (~3);
@@ -329,10 +326,7 @@ TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    // map vector automatics
    while (localCursor != NULL)
       {
-      if (localCursor->getDataType() == TR::VectorInt8
-          || localCursor->getDataType() == TR::VectorInt16
-          || localCursor->getDataType() == TR::VectorFloat
-          || localCursor->getDataType() == TR::VectorDouble)
+      if (localCursor->getDataType().isVector())
          {
          localCursor->setOffset(stackIndex);
          stackIndex += (localCursor->getSize() + 15) & (~15);

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -550,25 +550,28 @@ inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnem
 TR::Register *
 OMR::ARM64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic addOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          addOp = TR::InstOpCode::vadd16b;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          addOp = TR::InstOpCode::vadd8h;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          addOp = TR::InstOpCode::vadd4s;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          addOp = TR::InstOpCode::vadd2d;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          addOp = TR::InstOpCode::vfadd4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          addOp = TR::InstOpCode::vfadd2d;
          break;
       default:
@@ -581,25 +584,28 @@ OMR::ARM64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic subOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          subOp = TR::InstOpCode::vsub16b;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          subOp = TR::InstOpCode::vsub8h;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          subOp = TR::InstOpCode::vsub4s;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          subOp = TR::InstOpCode::vsub2d;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          subOp = TR::InstOpCode::vfsub4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          subOp = TR::InstOpCode::vfsub2d;
          break;
       default:
@@ -612,22 +618,25 @@ OMR::ARM64::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic mulOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          mulOp = TR::InstOpCode::vmul16b;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          mulOp = TR::InstOpCode::vmul8h;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          mulOp = TR::InstOpCode::vmul4s;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          mulOp = TR::InstOpCode::vfmul4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          mulOp = TR::InstOpCode::vfmul2d;
          break;
       default:
@@ -640,13 +649,16 @@ OMR::ARM64::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic divOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorFloat:
+      case TR::Float:
          divOp = TR::InstOpCode::vfdiv4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          divOp = TR::InstOpCode::vfdiv2d;
          break;
       default:
@@ -659,10 +671,13 @@ OMR::ARM64::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic andOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          andOp = TR::InstOpCode::vand16b;
          break;
       default:
@@ -675,10 +690,13 @@ OMR::ARM64::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic orrOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          orrOp = TR::InstOpCode::vorr16b;
          break;
       default:
@@ -691,10 +709,13 @@ OMR::ARM64::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic xorOp;
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          xorOp = TR::InstOpCode::veor16b;
          break;
       default:
@@ -1091,7 +1112,7 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
       {
       uint64_t shiftedMask = (maskValue >> shiftValue);
       /*
-       * If the lsb of shiftedMask is set and the shiftedMask has consecutive 1s, then this operation is copying 
+       * If the lsb of shiftedMask is set and the shiftedMask has consecutive 1s, then this operation is copying
        * consecutive 1s starting from the bit position shiftValue of the source register to the least significant bits of the destination register.
        */
       if (((shiftedMask & 1) == 1) && contiguousBits(shiftedMask))
@@ -1680,7 +1701,7 @@ generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGenerator *cg)
       else /* right shift*/
          {
          /*
-          * If the lsb of maskValue is set and the msb is not set and the maskValue has consecutive 1s, then this operation is copying 
+          * If the lsb of maskValue is set and the msb is not set and the maskValue has consecutive 1s, then this operation is copying
           * consecutive 1s starting from the bit position shiftValue of the source register to the least significant bits of the destination register.
           * We consider arithmetic shift only.
           */

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -615,8 +615,10 @@ int64_t OMR::ARM64::CodeGenerator::getSmallestPosConstThatMustBeMaterialized()
    }
 
 
-bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
+bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
    {
+   if(length != TR::VectorLength128) return false;
+
    // implemented vector opcodes
    switch (opcode.getOpCodeValue())
       {

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -422,7 +422,7 @@ public:
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
    TR_GlobalRegisterNumber _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
 
    /**
     * @brief Answers whether a trampoline is required for a direct call instruction to
@@ -544,9 +544,9 @@ public:
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter
-    * @param[in] delta:    delta for debug counter 
+    * @param[in] delta:    delta for debug counter
     * @param[in] cond:     register dependency conditions
-    * 
+    *
     * @return instruction
     */
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond);
@@ -555,9 +555,9 @@ public:
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter
-    * @param[in] deltaReg: register holding delta for debug counter 
+    * @param[in] deltaReg: register holding delta for debug counter
     * @param[in] cond:     register dependency conditions
-    * 
+    *
     * @return instruction
     */
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR::RegisterDependencyConditions *cond);
@@ -566,9 +566,9 @@ public:
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter
-    * @param[in] delta:    delta for debug counter 
+    * @param[in] delta:    delta for debug counter
     * @param[in] srm:      scratch register manager
-    * 
+    *
     * @return instruction
     */
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm);
@@ -577,9 +577,9 @@ public:
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter
-    * @param[in] deltaReg: register holding delta for debug counter 
+    * @param[in] deltaReg: register holding delta for debug counter
     * @param[in] srm:      scratch register manager
-    * 
+    *
     * @return instruction
     */
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1183,29 +1183,32 @@ OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *c
 
    TR::InstOpCode::Mnemonic op;
 
-   switch (node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch (node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup16b;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup8h;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup4s;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
          op = TR::InstOpCode::vdup2d;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
          op = TR::InstOpCode::vfdup4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
          op = TR::InstOpCode::vfdup2d;
          break;

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,24 +132,27 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
    {
    TR::InstOpCode::Mnemonic negOp;
 
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          negOp = TR::InstOpCode::vneg16b;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          negOp = TR::InstOpCode::vneg8h;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          negOp = TR::InstOpCode::vneg4s;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          negOp = TR::InstOpCode::vneg2d;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          negOp = TR::InstOpCode::vfneg4s;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          negOp = TR::InstOpCode::vfneg2d;
          break;
       default:
@@ -163,9 +166,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeG
    {
    TR::InstOpCode::Mnemonic notOp;
 
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          notOp = TR::InstOpCode::vnot16b;
          break;
       default:

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1628,7 +1628,7 @@ public:
    bool getSupportsAutoSIMD() { return _flags4.testAny(SupportsAutoSIMD);}
    void setSupportsAutoSIMD() { _flags4.set(SupportsAutoSIMD);}
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType) { return false; }
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength) { return false; }
 
    bool removeRegisterHogsInLowerTreesWalk() { return _flags3.testAny(RemoveRegisterHogsInLowerTreesWalk);}
    void setRemoveRegisterHogsInLowerTreesWalk() { _flags3.set(RemoveRegisterHogsInLowerTreesWalk);}

--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,8 +44,8 @@ OMR::AliasBuilder::AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t size
      _intStaticSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _nonIntPrimitiveStaticSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _methodSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
-     _arrayElementSymRefs(TR::NumTypes, c->trMemory(), heapAlloc, growable),
-     _arrayletElementSymRefs(TR::NumTypes, c->trMemory(), heapAlloc, growable),
+     _arrayElementSymRefs(TR::NumAllTypes, c->trMemory(), heapAlloc, growable),
+     _arrayletElementSymRefs(TR::NumAllTypes, c->trMemory(), heapAlloc, growable),
      _unsafeSymRefNumbers(sizeHint, c->trMemory(), heapAlloc, growable),
      _unsafeArrayElementSymRefs(sizeHint, c->trMemory(), heapAlloc, growable),
      _gcSafePointSymRefNumbers(sizeHint, c->trMemory(), heapAlloc, growable),

--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,9 +34,9 @@
 
    firstArrayShadowSymbol,
 
-   firstArrayletShadowSymbol = firstArrayShadowSymbol + TR::NumTypes,
+   firstArrayletShadowSymbol = firstArrayShadowSymbol + TR::NumAllTypes,
 
-   firstCommonNonhelperNonArrayShadowSymbol = firstArrayletShadowSymbol + TR::NumTypes,
+   firstCommonNonhelperNonArrayShadowSymbol = firstArrayletShadowSymbol + TR::NumAllTypes,
 
    OMRfirstPrintableCommonNonhelperSymbol = firstCommonNonhelperNonArrayShadowSymbol,
 

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,9 +95,9 @@ class SymbolReferenceTable
 
       firstArrayShadowSymbol,
 
-      firstArrayletShadowSymbol = firstArrayShadowSymbol + TR::NumTypes,
+      firstArrayletShadowSymbol = firstArrayShadowSymbol + TR::NumAllTypes,
 
-      firstCommonNonhelperNonArrayShadowSymbol = firstArrayletShadowSymbol + TR::NumTypes,
+      firstCommonNonhelperNonArrayShadowSymbol = firstArrayletShadowSymbol + TR::NumAllTypes,
 
       OMRfirstPrintableCommonNonhelperSymbol = firstCommonNonhelperNonArrayShadowSymbol,
 

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -695,7 +695,12 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             {
             if (!aliases)
                aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
-            aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().scalarToVector()));
+
+            // alias with vectors of all supported lengths
+            for (int32_t i = 1; i <= TR::NumVectorLengths; i++)
+               {
+               aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().scalarToVector((TR::VectorLength)i)));
+               }
             }
 
          if (_symbol->isArrayShadowSymbol() &&

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,6 +216,18 @@ enum TR_SharedCacheHint
 namespace TR
 {
 
+enum VectorLength
+   {
+   NoVectorLength=0,
+   VectorLength128,
+   VectorLength256,
+   VectorLength512,
+   VectorLength64,
+   // TODO: Redefine, preferably based on platform, when some platform starts supporting other than 128-bit
+   // Defining per platform is not necessary for functional correctness but for reducing NumAllTypes
+   NumVectorLengths = VectorLength128
+   };
+
 /**
  * Data type supported by OMR and whatever the configured language is.
  */
@@ -229,18 +241,20 @@ enum DataTypes
    Float,
    Double,
    Address,
-   VectorInt8,
-   VectorInt16,
-   VectorInt32,
-   VectorInt64,
-   VectorFloat,
-   VectorDouble,
    Aggregate,
    NumOMRTypes,
 #include "il/DataTypesEnum.hpp"
-   NumTypes
+   NumScalarTypes,
+   NumVectorElementTypes = Double,
+   //
+   // this space is reserved for vector types generated at runtime
+   // the generated types can be used to index tables of size NumAllTypes as any other type
+   //
+   NumAllTypes =  NumScalarTypes + NumVectorElementTypes * NumVectorLengths
    };
 }
+
+
 
 /**
  * @name OMRDataTypeIntegerLimits
@@ -337,6 +351,16 @@ namespace OMR
 class OMR_EXTENSIBLE DataType
    {
 public:
+
+   // will be removed when all vector opcodes are switched to new ones
+   // as well as TRIL and JitBuilder
+   static const TR::DataTypes Vector128Int8;
+   static const TR::DataTypes Vector128Int16;
+   static const TR::DataTypes Vector128Int32;
+   static const TR::DataTypes Vector128Int64;
+   static const TR::DataTypes Vector128Float;
+   static const TR::DataTypes Vector128Double;
+
    DataType() : _type(TR::NoType) { }
    DataType(TR::DataTypes t) : _type(t) { }
 
@@ -387,11 +411,87 @@ public:
    bool canGetMaxPrecisionFromType();
    int32_t getMaxPrecisionFromType();
 
-   TR::DataType getVectorIntegralType();
-   TR::DataType getVectorElementType();
+  /** \brief
+   *     Checks if the type is OMR type
+   *
+   *  \return
+   *     True if OMR type and false otherwise
+   */
+   bool isOMRDataType() {return (_type < TR::NumOMRTypes) || isVector(); }
 
+  /** \brief
+   *     Returns vector type with integral element type of the same size as the original element type
+   *
+   *  \return
+   *     Vector type
+   */
+   TR::DataType getVectorIntegralType();
+
+  /** \brief
+   *     Returns vector element type
+   *
+   *  \return
+   *     Vector element type
+   */
+   inline TR::DataType getVectorElementType();
+
+   /** \brief
+   *     Returns vector length
+   *
+   *  \return
+   *     Vector length
+   */
+   inline TR::VectorLength getVectorLength();
+
+  /** \brief
+   *     Creates vector type based on element type and vector length
+   *
+   *  \param elementType
+   *     Element type
+   *
+   *  \param length
+   *     Vector length
+   *
+   *  \return
+   *     Vector data type
+   */
+   inline static TR::DataTypes createVectorType(TR::DataTypes elementType, TR::VectorLength length);
+
+  /** \brief
+   *     Converts length in bits to TR::VectorLength
+   *
+   *  \param bits
+   *     vector length in bits
+   *
+   *  \return
+   *     corresponding TR::VectorLength
+   */
+   inline static TR::VectorLength bitsToVectorLength(int32_t bits);
+
+  /** \brief
+   *     Initializes static table with all vector type names
+   *
+   */
+   static bool initVectorNames();
+
+  /** \brief
+   *     Returns vector element type
+   *
+   *  \return
+   *     Vector element type
+   */
    TR::DataType vectorToScalar();
-   TR::DataType scalarToVector();
+
+  /** \brief
+   *     Creates vector type based on element type and provided vector length
+   *
+   *  \param length
+   *     Vector length
+   *
+   *  \return
+   *     Vector type
+   */
+   TR::DataType scalarToVector(TR::VectorLength length);
 
    const char * toString() const;
 
@@ -406,7 +506,6 @@ public:
    static const char    * getName(TR::DataType dt);
    static int32_t         getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);
-   static const char    * getPrefix(TR::DataType dt);
 
    template <typename T> static bool isSignedInt8()  { return false; }
    template <typename T> static bool isSignedInt16() { return false; }

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,12 +35,6 @@ TR::ILOpCodes OMR::IL::opCodesForConst[] =
    TR::fconst,   // Float
    TR::dconst,   // Double
    TR::aconst,   // Address
-   TR::vconst,   // VectorInt8
-   TR::vconst,   // VectorInt16
-   TR::vconst,   // VectorInt32
-   TR::vconst,   // VectorInt64
-   TR::vconst,   // VectorFloat
-   TR::vconst,   // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -54,12 +48,6 @@ TR::ILOpCodes OMR::IL::opCodesForDirectLoad[] =
    TR::fload,    // Float
    TR::dload,    // Double
    TR::aload,    // Address
-   TR::vload,    // VectorInt8
-   TR::vload,    // VectorInt16
-   TR::vload,    // VectorInt32
-   TR::vload,    // VectorInt64
-   TR::vload,    // VectorFloat
-   TR::vload,    // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -73,12 +61,6 @@ TR::ILOpCodes OMR::IL::opCodesForDirectReadBarrier[] =
    TR::frdbar,   // Float
    TR::drdbar,   // Double
    TR::ardbar,   // Address
-   TR::BadILOp,  // VectorInt8
-   TR::BadILOp,  // VectorInt16
-   TR::BadILOp,  // VectorInt32
-   TR::BadILOp,  // VectorInt64
-   TR::BadILOp,  // VectorFloat
-   TR::BadILOp,  // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -92,12 +74,6 @@ TR::ILOpCodes OMR::IL::opCodesForDirectStore[] =
    TR::fstore,   // Float
    TR::dstore,   // Double
    TR::astore,   // Address
-   TR::vstore,   // VectorInt8
-   TR::vstore,   // VectorInt16
-   TR::vstore,   // VectorInt32
-   TR::vstore,   // VectorInt64
-   TR::vstore,   // VectorFloat
-   TR::vstore,   // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -111,12 +87,6 @@ TR::ILOpCodes OMR::IL::opCodesForDirectWriteBarrier[] =
    TR::fwrtbar,   // Float
    TR::dwrtbar,   // Double
    TR::awrtbar,   // Address
-   TR::BadILOp,   // VectorInt8
-   TR::BadILOp,   // VectorInt16
-   TR::BadILOp,   // VectorInt32
-   TR::BadILOp,   // VectorInt64
-   TR::BadILOp,   // VectorFloat
-   TR::BadILOp,   // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -130,12 +100,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectLoad[] =
    TR::floadi,   // Float
    TR::dloadi,   // Double
    TR::aloadi,   // Address
-   TR::vloadi,   // TR::VectorInt8
-   TR::vloadi,   // TR::VectorInt16
-   TR::vloadi,   // TR::VectorInt32
-   TR::vloadi,   // TR::VectorInt64
-   TR::vloadi,   // TR::VectorFloat
-   TR::vloadi,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -149,12 +113,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectReadBarrier[] =
    TR::frdbari,  // Float
    TR::drdbari,  // Double
    TR::ardbari,  // Address
-   TR::BadILOp,  // TR::VectorInt8
-   TR::BadILOp,  // TR::VectorInt16
-   TR::BadILOp,  // TR::VectorInt32
-   TR::BadILOp,  // TR::VectorInt64
-   TR::BadILOp,  // TR::VectorFloat
-   TR::BadILOp,  // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -168,12 +126,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectStore[] =
    TR::fstorei,  // Float
    TR::dstorei,  // Double
    TR::astorei,  // Address
-   TR::vstorei,  // TR::VectorInt8
-   TR::vstorei,  // TR::VectorInt16
-   TR::vstorei,  // TR::VectorInt32
-   TR::vstorei,  // TR::VectorInt64
-   TR::vstorei,  // TR::VectorFloat
-   TR::vstorei,  // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -187,12 +139,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectWriteBarrier[] =
    TR::fwrtbari,   // Float
    TR::dwrtbari,   // Double
    TR::awrtbari,   // Address
-   TR::BadILOp,   // VectorInt8
-   TR::BadILOp,   // VectorInt16
-   TR::BadILOp,   // VectorInt32
-   TR::BadILOp,   // VectorInt64
-   TR::BadILOp,   // VectorFloat
-   TR::BadILOp,   // VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -206,12 +152,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectArrayLoad[] =
    TR::floadi,   // Float
    TR::dloadi,   // Double
    TR::aloadi,   // Address
-   TR::vloadi,   // TR::VectorInt8
-   TR::vloadi,   // TR::VectorInt16
-   TR::vloadi,   // TR::VectorInt32
-   TR::vloadi,   // TR::VectorInt64
-   TR::vloadi,   // TR::VectorFloat
-   TR::vloadi,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -225,12 +165,6 @@ TR::ILOpCodes OMR::IL::opCodesForIndirectArrayStore[] =
    TR::fstorei,  // Float
    TR::dstorei,  // Double
    TR::astorei,  // Address
-   TR::vstorei,  // TR::VectorInt8
-   TR::vstorei,  // TR::VectorInt16
-   TR::vstorei,  // TR::VectorInt32
-   TR::vstorei,  // TR::VectorInt64
-   TR::vstorei,  // TR::VectorFloat
-   TR::vstorei,  // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -244,12 +178,6 @@ TR::ILOpCodes OMR::IL::opCodesForRegisterLoad[] =
    TR::fRegLoad,  // Float
    TR::dRegLoad,  // Double
    TR::aRegLoad,  // Address
-   TR::vsRegLoad, // TR::VectorInt8
-   TR::vbRegLoad, // TR::VectorInt16
-   TR::viRegLoad, // TR::VectorInt32
-   TR::vlRegLoad, // TR::VectorInt64
-   TR::vfRegLoad, // TR::VectorFloat
-   TR::vdRegLoad, // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -263,12 +191,6 @@ TR::ILOpCodes OMR::IL::opCodesForRegisterStore[] =
    TR::fRegStore,  // Float
    TR::dRegStore,  // Double
    TR::aRegStore,  // Address
-   TR::vbRegStore, // TR::VectorInt8
-   TR::vsRegStore, // TR::VectorInt16
-   TR::viRegStore, // TR::VectorInt32
-   TR::vlRegStore, // TR::VectorInt64
-   TR::vfRegStore, // TR::VectorFloat
-   TR::vdRegStore, // TR::VectorDouble
    TR::BadILOp,    // TR::Aggregate
    };
 
@@ -282,12 +204,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareEquals[] =
    TR::fcmpeq,   // Float
    TR::dcmpeq,   // Double
    TR::acmpeq,   // Address
-   TR::vcmpeq,   // TR::VectorInt8
-   TR::vcmpeq,   // TR::VectorInt16
-   TR::vcmpeq,   // TR::VectorInt32
-   TR::vcmpeq,   // TR::VectorInt64
-   TR::vcmpeq,   // TR::VectorFloat
-   TR::vcmpeq,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -301,12 +217,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareEquals[] =
    TR::iffcmpeq,  // Float
    TR::ifdcmpeq,  // Double
    TR::ifacmpeq,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -320,12 +230,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareNotEquals[] =
    TR::fcmpne,   // Float
    TR::dcmpne,   // Double
    TR::acmpne,   // Address
-   TR::vcmpne,   // TR::VectorInt8
-   TR::vcmpne,   // TR::VectorInt16
-   TR::vcmpne,   // TR::VectorInt32
-   TR::vcmpne,   // TR::VectorInt64
-   TR::vcmpne,   // TR::VectorFloat
-   TR::vcmpne,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -339,12 +243,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareNotEquals[] =
    TR::iffcmpne,  // Float
    TR::ifdcmpne,  // Double
    TR::ifacmpne,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -358,12 +256,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareLessThan[] =
    TR::fcmplt,   // Float
    TR::dcmplt,   // Double
    TR::acmplt,   // Address
-   TR::vcmplt,   // TR::VectorInt8
-   TR::vcmplt,   // TR::VectorInt16
-   TR::vcmplt,   // TR::VectorInt32
-   TR::vcmplt,   // TR::VectorInt64
-   TR::vcmplt,   // TR::VectorFloat
-   TR::vcmplt,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -377,12 +269,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareLessOrEquals[] =
    TR::fcmple,   // Float
    TR::dcmple,   // Double
    TR::acmple,   // Address
-   TR::vcmple,   // TR::VectorInt8
-   TR::vcmple,   // TR::VectorInt16
-   TR::vcmple,   // TR::VectorInt32
-   TR::vcmple,   // TR::VectorInt64
-   TR::vcmple,   // TR::VectorFloat
-   TR::vcmple,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -396,12 +282,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareLessThan[] =
    TR::iffcmplt,  // Float
    TR::ifdcmplt,  // Double
    TR::ifacmplt,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -415,12 +295,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareLessOrEquals[] =
    TR::iffcmple,  // Float
    TR::ifdcmple,  // Double
    TR::ifacmple,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -434,12 +308,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareGreaterThan[] =
    TR::fcmpgt,   // Float
    TR::dcmpgt,   // Double
    TR::acmpgt,   // Address
-   TR::vcmpgt,   // TR::VectorInt8
-   TR::vcmpgt,   // TR::VectorInt16
-   TR::vcmpgt,   // TR::VectorInt32
-   TR::vcmpgt,   // TR::VectorInt64
-   TR::vcmpgt,   // TR::VectorFloat
-   TR::vcmpgt,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -453,12 +321,6 @@ TR::ILOpCodes OMR::IL::opCodesForCompareGreaterOrEquals[] =
    TR::fcmpge,   // Float
    TR::dcmpge,   // Double
    TR::acmpge,   // Address
-   TR::vcmpge,   // TR::VectorInt8
-   TR::vcmpge,   // TR::VectorInt16
-   TR::vcmpge,   // TR::VectorInt32
-   TR::vcmpge,   // TR::VectorInt64
-   TR::vcmpge,   // TR::VectorFloat
-   TR::vcmpge,   // TR::VectorDouble
    TR::BadILOp,  // TR::Aggregate
    };
 
@@ -472,12 +334,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareGreaterThan[] =
    TR::iffcmpgt,  // Float
    TR::ifdcmpgt,  // Double
    TR::ifacmpgt,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -491,12 +347,6 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareGreaterOrEquals[] =
    TR::iffcmpge,  // Float
    TR::ifdcmpge,  // Double
    TR::ifacmpge,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
@@ -510,77 +360,9 @@ TR::ILOpCodes OMR::IL::opCodesForSelect [] =
    TR::fselect,  // Float
    TR::dselect,  // Double
    TR::aselect,  // Address
-   TR::BadILOp,   // TR::VectorInt8
-   TR::BadILOp,   // TR::VectorInt16
-   TR::BadILOp,   // TR::VectorInt32
-   TR::BadILOp,   // TR::VectorInt64
-   TR::BadILOp,   // TR::VectorFloat
-   TR::BadILOp,   // TR::VectorDouble
    TR::BadILOp,   // TR::Aggregate
    };
 
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForConst) / sizeof(OMR::IL::opCodesForConst[0])),
-              "OMR::IL::opCodesForConst is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectLoad) / sizeof(OMR::IL::opCodesForDirectLoad[0])),
-              "OMR::IL::opCodesForDirectLoad is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectStore) / sizeof(OMR::IL::opCodesForDirectStore[0])),
-              "OMR::IL::opCodesForDirectStore is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectLoad) / sizeof(OMR::IL::opCodesForIndirectLoad[0])),
-              "OMR::IL::opCodesForIndirectLoad is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectStore) / sizeof(OMR::IL::opCodesForIndirectStore[0])),
-              "OMR::IL::opCodesForIndirectStore is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayLoad) / sizeof(OMR::IL::opCodesForIndirectArrayLoad[0])),
-              "OMR::IL::opCodesForIndirectArrayLoad is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayStore) / sizeof(OMR::IL::opCodesForIndirectArrayStore[0])),
-              "OMR::IL::opCodesForIndirectArrayStore is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForRegisterLoad) / sizeof(OMR::IL::opCodesForRegisterLoad[0])),
-              "OMR::IL::opCodesForRegisterLoad is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForRegisterStore) / sizeof(OMR::IL::opCodesForRegisterStore[0])),
-              "OMR::IL::opCodesForRegisterStore is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareEquals) / sizeof(OMR::IL::opCodesForCompareEquals[0])),
-              "OMR::IL::opCodesForCompareEquals is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareEquals) / sizeof(OMR::IL::opCodesForIfCompareEquals[0])),
-              "OMR::IL::opCodesForIfCompareEquals is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareNotEquals) / sizeof(OMR::IL::opCodesForCompareNotEquals[0])),
-              "OMR::IL::opCodesForCompareNotEquals is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareNotEquals) / sizeof(OMR::IL::opCodesForIfCompareNotEquals[0])),
-              "OMR::IL::opCodesForIfCompareNotEquals is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareLessThan) / sizeof(OMR::IL::opCodesForCompareLessThan[0])),
-              "OMR::IL::opCodesForCompareLessThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareLessOrEquals) / sizeof(OMR::IL::opCodesForCompareLessOrEquals[0])),
-              "OMR::IL::opCodesForCompareLessThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessThan) / sizeof(OMR::IL::opCodesForIfCompareLessThan[0])),
-              "OMR::IL::opCodesForIfCompareLessThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessOrEquals) / sizeof(OMR::IL::opCodesForIfCompareLessOrEquals[0])),
-              "OMR::IL::opCodesForIfCompareLessThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareGreaterThan) / sizeof(OMR::IL::opCodesForCompareGreaterThan[0])),
-              "OMR::IL::opCodesForCompareGreaterThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareGreaterOrEquals) / sizeof(OMR::IL::opCodesForCompareGreaterOrEquals[0])),
-              "OMR::IL::opCodesForCompareGreaterThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterThan) / sizeof(OMR::IL::opCodesForIfCompareGreaterThan[0])),
-              "OMR::IL::opCodesForIfCompareGreaterThan is not the correct size");
-
-static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals) / sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals[0])),
-              "OMR::IL::opCodesForIfCompareGreaterThan is not the correct size");
 
 
 TR::ILOpCodes
@@ -739,6 +521,11 @@ OMR::IL::opCodeForCorrespondingDirectStore(TR::ILOpCodes storeOpCode)
 TR::ILOpCodes
 OMR::IL::opCodeForSelect(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForSelect) / sizeof(OMR::IL::opCodesForSelect[0])),
+              "OMR::IL::opCodesForSelect is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
 
    return OMR::IL::opCodesForSelect[dt];
@@ -747,6 +534,11 @@ OMR::IL::opCodeForSelect(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForConst(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForConst) / sizeof(OMR::IL::opCodesForConst[0])),
+              "OMR::IL::opCodesForConst is not the correct size");
+
+   if (dt.isVector()) return TR::vconst;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForConst[dt];
@@ -755,6 +547,11 @@ OMR::IL::opCodeForConst(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForDirectLoad(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectLoad) / sizeof(OMR::IL::opCodesForDirectLoad[0])),
+              "OMR::IL::opCodesForDirectLoad is not the correct size");
+
+   if (dt.isVector()) return TR::vload;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForDirectLoad[dt];
@@ -763,6 +560,11 @@ OMR::IL::opCodeForDirectLoad(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForDirectReadBarrier(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectReadBarrier) / sizeof(OMR::IL::opCodesForDirectReadBarrier[0])),
+              "OMR::IL::opCodesForDirectReadBarrier is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForDirectReadBarrier[dt];
@@ -771,6 +573,11 @@ OMR::IL::opCodeForDirectReadBarrier(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForDirectStore(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectStore) / sizeof(OMR::IL::opCodesForDirectStore[0])),
+              "OMR::IL::opCodesForDirectStore is not the correct size");
+
+   if (dt.isVector()) return TR::vstore;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForDirectStore[dt];
@@ -779,6 +586,11 @@ OMR::IL::opCodeForDirectStore(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForDirectWriteBarrier(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectWriteBarrier) / sizeof(OMR::IL::opCodesForDirectWriteBarrier[0])),
+              "OMR::IL::opCodesForDirectWriteBarrier is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForDirectWriteBarrier[dt];
@@ -788,6 +600,11 @@ OMR::IL::opCodeForDirectWriteBarrier(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectLoad(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectLoad) / sizeof(OMR::IL::opCodesForIndirectLoad[0])),
+              "OMR::IL::opCodesForIndirectLoad is not the correct size");
+
+   if (dt.isVector()) return TR::vloadi;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectLoad[dt];
@@ -796,6 +613,11 @@ OMR::IL::opCodeForIndirectLoad(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectReadBarrier(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectReadBarrier) / sizeof(OMR::IL::opCodesForIndirectReadBarrier[0])),
+              "OMR::IL::opCodesForIndirectReadBarrier is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectReadBarrier[dt];
@@ -804,6 +626,11 @@ OMR::IL::opCodeForIndirectReadBarrier(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectStore(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectStore) / sizeof(OMR::IL::opCodesForIndirectStore[0])),
+              "OMR::IL::opCodesForIndirectStore is not the correct size");
+
+   if (dt.isVector()) return TR::vstorei;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectStore[dt];
@@ -812,6 +639,11 @@ OMR::IL::opCodeForIndirectStore(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectWriteBarrier) / sizeof(OMR::IL::opCodesForIndirectWriteBarrier[0])),
+              "OMR::IL::opCodesForIndirectWriteBarrier is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectWriteBarrier[dt];
@@ -820,6 +652,11 @@ OMR::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayLoad) / sizeof(OMR::IL::opCodesForIndirectArrayLoad[0])),
+              "OMR::IL::opCodesForIndirectArrayLoad is not the correct size");
+
+   if (dt.isVector()) return TR::vloadi;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectArrayLoad[dt];
@@ -828,6 +665,11 @@ OMR::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIndirectArrayStore(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayStore) / sizeof(OMR::IL::opCodesForIndirectArrayStore[0])),
+              "OMR::IL::opCodesForIndirectArrayStore is not the correct size");
+
+   if (dt.isVector()) return TR::vstorei;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIndirectArrayStore[dt];
@@ -836,6 +678,22 @@ OMR::IL::opCodeForIndirectArrayStore(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForRegisterLoad(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForRegisterLoad) / sizeof(OMR::IL::opCodesForRegisterLoad[0])),
+              "OMR::IL::opCodesForRegisterLoad is not the correct size");
+
+   if (dt.isVector())
+      {
+      switch (dt.getVectorElementType())
+         {
+         case TR::Int8:   return TR::vbRegLoad;
+         case TR::Int16:  return TR::vsRegLoad;
+         case TR::Int32:  return TR::viRegLoad;
+         case TR::Int64:  return TR::vlRegLoad;
+         case TR::Float:  return TR::vfRegLoad;
+         case TR::Double: return TR::vdRegLoad;
+         }
+      }
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForRegisterLoad[dt];
@@ -844,6 +702,22 @@ OMR::IL::opCodeForRegisterLoad(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForRegisterStore(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForRegisterStore) / sizeof(OMR::IL::opCodesForRegisterStore[0])),
+              "OMR::IL::opCodesForRegisterStore is not the correct size");
+
+   if (dt.isVector())
+      {
+      switch (dt.getVectorElementType())
+         {
+         case TR::Int8:   return TR::vbRegStore;
+         case TR::Int16:  return TR::vsRegStore;
+         case TR::Int32:  return TR::viRegStore;
+         case TR::Int64:  return TR::vlRegStore;
+         case TR::Float:  return TR::vfRegStore;
+         case TR::Double: return TR::vdRegStore;
+         }
+      }
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForRegisterStore[dt];
@@ -852,6 +726,11 @@ OMR::IL::opCodeForRegisterStore(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareEquals) / sizeof(OMR::IL::opCodesForCompareEquals[0])),
+              "OMR::IL::opCodesForCompareEquals is not the correct size");
+
+   if (dt.isVector()) return TR::vcmpeq;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareEquals[dt];
@@ -860,6 +739,11 @@ OMR::IL::opCodeForCompareEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareEquals) / sizeof(OMR::IL::opCodesForIfCompareEquals[0])),
+              "OMR::IL::opCodesForIfCompareEquals is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareEquals[dt];
@@ -868,6 +752,11 @@ OMR::IL::opCodeForIfCompareEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareNotEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareNotEquals) / sizeof(OMR::IL::opCodesForCompareNotEquals[0])),
+              "OMR::IL::opCodesForCompareNotEquals is not the correct size");
+
+   if (dt.isVector()) return TR::vcmpne;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareNotEquals[dt];
@@ -876,6 +765,11 @@ OMR::IL::opCodeForCompareNotEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareNotEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareNotEquals) / sizeof(OMR::IL::opCodesForIfCompareNotEquals[0])),
+              "OMR::IL::opCodesForIfCompareNotEquals is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareNotEquals[dt];
@@ -884,6 +778,11 @@ OMR::IL::opCodeForIfCompareNotEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareLessThan(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareLessThan) / sizeof(OMR::IL::opCodesForCompareLessThan[0])),
+              "OMR::IL::opCodesForCompareLessThan is not the correct size");
+
+   if (dt.isVector()) return TR::vcmplt;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareLessThan[dt];
@@ -892,6 +791,11 @@ OMR::IL::opCodeForCompareLessThan(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareLessOrEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareLessOrEquals) / sizeof(OMR::IL::opCodesForCompareLessOrEquals[0])),
+              "OMR::IL::opCodesForCompareLessOrEquals is not the correct size");
+
+   if (dt.isVector()) return TR::vcmple;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareLessOrEquals[dt];
@@ -900,6 +804,11 @@ OMR::IL::opCodeForCompareLessOrEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareLessThan(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessThan) / sizeof(OMR::IL::opCodesForIfCompareLessThan[0])),
+              "OMR::IL::opCodesForIfCompareLessThan is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareLessThan[dt];
@@ -908,6 +817,11 @@ OMR::IL::opCodeForIfCompareLessThan(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareLessOrEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessOrEquals) / sizeof(OMR::IL::opCodesForIfCompareLessOrEquals[0])),
+              "OMR::IL::opCodesForIfCompareLessOrEquals is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareLessOrEquals[dt];
@@ -916,6 +830,11 @@ OMR::IL::opCodeForIfCompareLessOrEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareGreaterThan(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareGreaterThan) / sizeof(OMR::IL::opCodesForCompareGreaterThan[0])),
+              "OMR::IL::opCodesForCompareGreaterThan is not the correct size");
+
+   if (dt.isVector()) return TR::vcmpgt;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareGreaterThan[dt];
@@ -924,6 +843,11 @@ OMR::IL::opCodeForCompareGreaterThan(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForCompareGreaterOrEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForCompareGreaterOrEquals) / sizeof(OMR::IL::opCodesForCompareGreaterOrEquals[0])),
+              "OMR::IL::opCodesForCompareGreaterOrEquals is not the correct size");
+
+   if (dt.isVector()) return TR::vcmpge;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForCompareGreaterOrEquals[dt];
@@ -932,6 +856,11 @@ OMR::IL::opCodeForCompareGreaterOrEquals(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareGreaterThan(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterThan) / sizeof(OMR::IL::opCodesForIfCompareGreaterThan[0])),
+              "OMR::IL::opCodesForIfCompareGreaterThan is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareGreaterThan[dt];
@@ -939,6 +868,11 @@ OMR::IL::opCodeForIfCompareGreaterThan(TR::DataType dt)
 TR::ILOpCodes
 OMR::IL::opCodeForIfCompareGreaterOrEquals(TR::DataType dt)
    {
+   static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals) / sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals[0])),
+              "OMR::IL::opCodesForIfCompareGreaterOrEquals is not the correct size");
+
+   if (dt.isVector()) return TR::BadILOp;
+
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
    return OMR::IL::opCodesForIfCompareGreaterOrEquals[dt];

--- a/compiler/il/OMRIL.hpp
+++ b/compiler/il/OMRIL.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,10 +43,9 @@ namespace OMR
 class OMR_EXTENSIBLE IL
    {
 
-   public:
+   private:
 
-   TR::IL* self();
-
+   // these tables require special treatment of vector opcodes
    static TR::ILOpCodes opCodesForConst[];
    static TR::ILOpCodes opCodesForDirectLoad[];
    static TR::ILOpCodes opCodesForDirectReadBarrier[];
@@ -73,6 +72,10 @@ class OMR_EXTENSIBLE IL
    static TR::ILOpCodes opCodesForIfCompareGreaterThan[];
    static TR::ILOpCodes opCodesForIfCompareGreaterOrEquals[];
    static TR::ILOpCodes opCodesForSelect[];
+
+   public:
+
+   TR::IL* self();
 
    TR::ILOpCodes opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode);
    TR::ILOpCodes opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode);

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -674,6 +674,8 @@ public:
 
    static TR::ILOpCodes addOpCode(TR::DataType type, bool is64Bit)
       {
+      if (type.isVector()) return TR::vadd;
+
       switch(type)
          {
          case TR::Int8:     return TR::badd;
@@ -683,12 +685,6 @@ public:
          case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
          case TR::Float:    return TR::fadd;
          case TR::Double:   return TR::dadd;
-         case TR::VectorInt8:   return TR::vadd;
-         case TR::VectorInt16:  return TR::vadd;
-         case TR::VectorInt32:  return TR::vadd;
-         case TR::VectorInt64:  return TR::vadd;
-         case TR::VectorFloat:  return TR::vadd;
-         case TR::VectorDouble: return TR::vadd;
          default: TR_ASSERT(0, "no add opcode for this datatype");
          }
       return TR::BadILOp;
@@ -710,6 +706,8 @@ public:
 
    static TR::ILOpCodes subtractOpCode(TR::DataType type)
       {
+      if (type.isVector()) return TR::vsub;
+
       switch(type)
          {
          case TR::Int8:    return TR::bsub;
@@ -718,12 +716,6 @@ public:
          case TR::Int64:   return TR::lsub;
          case TR::Float:   return TR::fsub;
          case TR::Double:  return TR::dsub;
-         case TR::VectorInt8:   return TR::vsub;
-         case TR::VectorInt16:  return TR::vsub;
-         case TR::VectorInt32:  return TR::vsub;
-         case TR::VectorInt64:  return TR::vsub;
-         case TR::VectorFloat:  return TR::vsub;
-         case TR::VectorDouble: return TR::vsub;
          default: TR_ASSERT(0, "no sub opcode for this datatype");
          }
       return TR::BadILOp;
@@ -731,6 +723,8 @@ public:
 
    static TR::ILOpCodes multiplyOpCode(TR::DataType type)
       {
+      if (type.isVector()) return TR::vmul;
+
       switch(type)
          {
          case TR::Int8:    return TR::bmul;
@@ -739,12 +733,6 @@ public:
          case TR::Int64:   return TR::lmul;
          case TR::Float:   return TR::fmul;
          case TR::Double:  return TR::dmul;
-         case TR::VectorInt8:   return TR::vmul;
-         case TR::VectorInt16:  return TR::vmul;
-         case TR::VectorInt32:  return TR::vmul;
-         case TR::VectorInt64:  return TR::vmul;
-         case TR::VectorFloat:  return TR::vmul;
-         case TR::VectorDouble: return TR::vmul;
          default: TR_ASSERT(0, "no mul opcode for this datatype");
          }
       return TR::BadILOp;
@@ -752,6 +740,8 @@ public:
 
    static TR::ILOpCodes divideOpCode(TR::DataType type)
       {
+      if (type.isVector()) return TR::vdiv;
+
       switch(type)
          {
          case TR::Int8:    return TR::bdiv;
@@ -760,12 +750,6 @@ public:
          case TR::Int64:   return TR::ldiv;
          case TR::Float:   return TR::fdiv;
          case TR::Double:  return TR::ddiv;
-         case TR::VectorInt8:   return TR::vdiv;
-         case TR::VectorInt16:  return TR::vdiv;
-         case TR::VectorInt32:  return TR::vdiv;
-         case TR::VectorInt64:  return TR::vdiv;
-         case TR::VectorFloat:  return TR::vdiv;
-         case TR::VectorDouble: return TR::vdiv;
          default: TR_ASSERT(0, "no div opcode for this datatype");
          }
       return TR::BadILOp;

--- a/compiler/il/OMRILProps.hpp
+++ b/compiler/il/OMRILProps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,7 @@ namespace ILChildProp
 
 // make sure that all TR::DataTypes can fit in one byte
 // (remembering that 255 is a reserved value)
-static_assert(TR::NumTypes < 254, "There are too many data types to fit in one byte.");
+static_assert(TR::NumAllTypes < 254, "There are too many data types to fit in one byte.");
 
 #define FIRST_CHILD(type)     (type) <<  0
 #define SECOND_CHILD(type)    (type) <<  8

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2120,11 +2120,6 @@ OMR::Node::isConstZeroBytes()
          return self()->getFloatBits() == 0;
       case TR::Double:
          return self()->getDoubleBits() == 0;
-      case TR::VectorInt8:
-      case TR::VectorInt16:
-      case TR::VectorInt32:
-      case TR::VectorInt64:
-      case TR::VectorDouble:
       default:
          TR_ASSERT(false, "Unrecognized const node %s can't be checked for zero bytes");
          return false;
@@ -2160,11 +2155,6 @@ OMR::Node::isConstZeroValue()
          TR::Compilation *comp = TR::comp();
          return self()->getDoubleBits() == DOUBLE_POS_ZERO;
          }
-      case TR::VectorInt8:
-      case TR::VectorInt16:
-      case TR::VectorInt32:
-      case TR::VectorInt64:
-      case TR::VectorDouble:
       default:
          TR_ASSERT(false, "Unrecognized constant node can't be checked for zero");
          return false;
@@ -5269,7 +5259,8 @@ OMR::Node::computeDataType()
          else if (_opCode.isVectorReduction())
             _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getVectorElementType().getDataType();
          else if (_opCode.getOpCodeValue() == TR::vsplats)
-            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().scalarToVector().getDataType();
+            // TODO: convert vsplats into 'true' vector opcode that has proper element type and length
+            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().scalarToVector(TR::VectorLength128).getDataType();
          else
             _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getDataType();
 

--- a/compiler/il/OMROpcodes.enum
+++ b/compiler/il/OMROpcodes.enum
@@ -6106,7 +6106,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6122,7 +6122,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6154,7 +6154,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6170,7 +6170,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6186,7 +6186,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6202,7 +6202,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6218,7 +6218,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6234,7 +6234,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6250,7 +6250,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6266,7 +6266,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6298,7 +6298,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6314,7 +6314,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6346,7 +6346,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::Unspecified, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6362,7 +6362,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::Unspecified, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6378,7 +6378,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::Unspecified, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6410,7 +6410,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::Unspecified, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6426,7 +6426,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Max, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6442,7 +6442,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Min, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6458,7 +6458,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfEqual, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmpeq, \
@@ -6474,7 +6474,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmpne, \
@@ -6490,7 +6490,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfGreater, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmplt, \
@@ -6506,7 +6506,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfGreater | ILProp3::CompareTrueIfEqual, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmple, \
@@ -6522,7 +6522,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfLess, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmpgt, \
@@ -6538,7 +6538,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfEqual, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::vdcmpge, \
@@ -6554,7 +6554,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3          = */ ILProp3::LikeUse, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Floating_Point | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -6938,7 +6938,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ ILProp2::ValueNumberShare, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7002,7 +7002,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt8, \
+   /* .dataType             = */ OMR::DataType::Vector128Int8, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7018,7 +7018,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt16, \
+   /* .dataType             = */ OMR::DataType::Vector128Int16, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7034,7 +7034,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7050,7 +7050,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7066,7 +7066,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorFloat, \
+   /* .dataType             = */ OMR::DataType::Vector128Float, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7082,7 +7082,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ILChildProp::NoChildren, \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7098,7 +7098,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt8, \
+   /* .dataType             = */ OMR::DataType::Vector128Int8, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7114,7 +7114,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt16, \
+   /* .dataType             = */ OMR::DataType::Vector128Int16, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7130,7 +7130,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt32, \
+   /* .dataType             = */ OMR::DataType::Vector128Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7146,7 +7146,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorInt64, \
+   /* .dataType             = */ OMR::DataType::Vector128Int64, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7162,7 +7162,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorFloat, \
+   /* .dataType             = */ OMR::DataType::Vector128Float, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
@@ -7178,7 +7178,7 @@ OPCODE_MACRO(\
    /* .properties2          = */ 0, \
    /* .properties3          = */ 0, \
    /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::VectorDouble, \
+   /* .dataType             = */ OMR::DataType::Vector128Double, \
    /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Integer | ILTypeProp::Vector, \
    /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \

--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,12 +86,12 @@ OMR::IlInjector::initPrimitiveTypes()
    Float        = _types->PrimitiveType(TR::Float);
    Double       = _types->PrimitiveType(TR::Double);
    Address      = _types->PrimitiveType(TR::Address);
-   VectorInt8   = _types->PrimitiveType(TR::VectorInt8);
-   VectorInt16  = _types->PrimitiveType(TR::VectorInt16);
-   VectorInt32  = _types->PrimitiveType(TR::VectorInt32);
-   VectorInt64  = _types->PrimitiveType(TR::VectorInt64);
-   VectorFloat  = _types->PrimitiveType(TR::VectorFloat);
-   VectorDouble = _types->PrimitiveType(TR::VectorDouble);
+   VectorInt8   = _types->PrimitiveType(TR::DataType::createVectorType(TR::Int8,  TR::VectorLength128));
+   VectorInt16  = _types->PrimitiveType(TR::DataType::createVectorType(TR::Int16, TR::VectorLength128));
+   VectorInt32  = _types->PrimitiveType(TR::DataType::createVectorType(TR::Int32, TR::VectorLength128));
+   VectorInt64  = _types->PrimitiveType(TR::DataType::createVectorType(TR::Int64, TR::VectorLength128));
+   VectorFloat  = _types->PrimitiveType(TR::DataType::createVectorType(TR::Float, TR::VectorLength128));
+   VectorDouble = _types->PrimitiveType(TR::DataType::createVectorType(TR::Double,TR::VectorLength128));
 
    if (TR::Compiler->target.is64Bit())
       Word = Int64;

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -595,7 +595,7 @@ OMR::IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLo
    TR_ASSERT_FATAL(primType != TR::NoType, "Dereferencing an untyped pointer.");
    TR::DataType symRefType = primType;
    if (isVectorLoad)
-      symRefType = symRefType.scalarToVector();
+      symRefType = symRefType.scalarToVector(TR::VectorLength128);
 
    TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, addr);
 
@@ -656,7 +656,7 @@ OMR::IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    if (!dt.isVector())
       {
       valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
-      dt = dt.scalarToVector();
+      dt = dt.scalarToVector(TR::VectorLength128);
       }
 
    if (!_methodBuilder->symbolDefined(varName))

--- a/compiler/ilgen/OMRIlType.cpp
+++ b/compiler/ilgen/OMRIlType.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,12 @@ OMR::IlType::signatureNameForType[TR::NumOMRTypes] =
    "F",  // Float
    "D",  // Double
    "L",  // Address
+   "A"   // Aggregate
+   };
+
+const char *
+OMR::IlType::signatureNameForVectorType[TR::NumVectorElementTypes] =
+   {
    "V1", // VectorInt8
    "V2", // VectorInt16
    "V4", // VectorInt32
@@ -70,6 +76,16 @@ OMR::IlType::primitiveTypeAlignment[TR::NumOMRTypes] =
 #else
    4,  // Address/Word
 #endif
+#if TR_TARGET_64BIT // HOST?
+   8,  // Address/Word
+#else
+   4,  // Address/Word
+#endif
+   };
+
+const uint8_t
+OMR::IlType::primitiveVectorTypeAlignment[TR::NumVectorElementTypes] =
+   {
    16, // VectorInt8
    16, // VectorInt16
    16, // VectorInt32
@@ -84,6 +100,10 @@ OMR::IlType::getSignatureName()
    TR::DataType dt = getPrimitiveType();
    if (dt == TR::Address)
       return (char *)_name;
+
+   if (dt.isVector())
+      return (char *) signatureNameForVectorType[dt.getVectorElementType() - 1];
+
    return (char *) signatureNameForType[dt];
    }
 

--- a/compiler/ilgen/OMRIlType.hpp
+++ b/compiler/ilgen/OMRIlType.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -121,7 +121,9 @@ protected:
    const char           * _name;
 
    static const char    * signatureNameForType[TR::NumOMRTypes];
+   static const char    * signatureNameForVectorType[TR::NumVectorElementTypes];
    static const uint8_t   primitiveTypeAlignment[TR::NumOMRTypes];
+   static const uint8_t   primitiveVectorTypeAlignment[TR::NumVectorElementTypes];
    };
 
 } // namespace OMR

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,7 @@ public:
     * @brief Begin definition of a new structure type
     * @param structName the name of the new type
     * @return pointer to IlType instance of the new type being defined
-    * 
+    *
     * The name of the new type will have to be used when specifying
     * fields of the type. This method must be invoked once before any
     * calls to `DefineField()` and `CloseStruct()`.
@@ -72,14 +72,14 @@ public:
     * @param fieldName the name of the field
     * @param type the IlType instance representing the type of the field
     * @param offset the offset of the field within the structure (in bytes)
-    * 
+    *
     * Fields defined using this method must be defined in offset order.
     * Specifically, the `offset` on any call to this method must be greater
     * than or equal to the size of the new struct at the time of the call
     * (`getSize() <= offset`). Failure to meet this condition will result
     * in a runtime failure. This was done as an initial attempt to prevent
     * struct fields from overlapping in memory.
-    * 
+    *
     * This method can only be called after a call to `DefineStruct` and
     * before a call to `CloseStruct` with the same `structName`.
     */
@@ -90,13 +90,13 @@ public:
     * @param structName the name of the struct type on which to define the field
     * @param fieldName the name of the field
     * @param type the IlType instance representing the type of the field
-    * 
+    *
     * This is an overloaded method. Since no offset for the new struct field is
     * specified, it will be added to the end of the struct using alignment rules
     * internally defined by JitBuilder. These are not guaranteed match the rules
     * used by a C/C++ compiler as alignment rules are compiler specific. However,
     * the alignment should be the same in most cases.
-    * 
+    *
     * This method can only be called after a call to `DefineStruct` and
     * before a call to `CloseStruct` with the same `structName`.
     */
@@ -106,7 +106,7 @@ public:
     * @brief End definition of a new structure type
     * @param structName the name of the new type of which the definition is ended
     * @param finalSize the final size (in bytes) of the type
-    * 
+    *
     * The `finalSize` of the struct must be greater than or equal to the size of
     * the new struct at the time of the call (`getSize() <= finalSize`). If
     * `finalSize` is greater, the size of the struct will be adjusted. Failure to
@@ -119,7 +119,7 @@ public:
    /**
     * @brief End definition of a new structure type
     * @param structName the name of the new type of which the definition is ended
-    * 
+    *
     * This is an overloaded method. Since the final size of the struct is not
     * specified, the size of the new struct at the time of call to this method
     * will be the final size of the new struct type.
@@ -241,7 +241,7 @@ protected:
 
 public:
    // convenience for primitive types
-   TR::IlType       * _primitiveType[TR::NumOMRTypes];
+   TR::IlType       * _primitiveType[TR::NumAllTypes];
    TR::IlType       * NoType;
    TR::IlType       * Int8;
    TR::IlType       * Int16;
@@ -258,7 +258,7 @@ public:
    TR::IlType       * VectorFloat;
    TR::IlType       * VectorDouble;
 
-   TR::IlType       * _pointerToPrimitiveType[TR::NumOMRTypes];
+   TR::IlType       * _pointerToPrimitiveType[TR::NumAllTypes];
    TR::IlType       * pNoType;
    TR::IlType       * pInt8;
    TR::IlType       * pInt16;

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2474,14 +2474,6 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
                if (node1->getAddress() != node2->getAddress())
                   return false;
                break;
-            case TR::VectorInt64:
-            case TR::VectorInt32:
-            case TR::VectorInt16:
-            case TR::VectorInt8:
-            case TR::VectorDouble:
-               if (node1->getLiteralPoolOffset() != node2->getLiteralPoolOffset())
-                  return false;
-               break;
 #ifdef J9_PROJECT_SPECIFIC
             case TR::Aggregate:
                if (!areBCDAggrConstantNodesEquivalent(node1, node2, _comp))
@@ -2492,6 +2484,12 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
                break;
             default:
                {
+               if (node1->getDataType().isVector())
+                  {
+                  if (node1->getLiteralPoolOffset() != node2->getLiteralPoolOffset())
+                     return false;
+                  break;
+                  }
 #ifdef J9_PROJECT_SPECIFIC
                if (node1->getDataType().isBCD())
                   {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,25 +163,25 @@
          }\
       }
 
-static TR::ILOpCodes addOps[TR::NumTypes] = { TR::BadILOp,
+static TR::ILOpCodes addOps[TR::NumAllTypes] = { TR::BadILOp,
                                                TR::badd,    TR::sadd,    TR::iadd,    TR::ladd,
                                                TR::fadd,    TR::dadd,
                                                TR::BadILOp, TR::BadILOp, TR::BadILOp,
                                                TR::BadILOp, TR::BadILOp,  TR::BadILOp};
 
-static TR::ILOpCodes subOps[TR::NumTypes] = { TR::BadILOp,
+static TR::ILOpCodes subOps[TR::NumAllTypes] = { TR::BadILOp,
                                                TR::bsub,    TR::ssub,    TR::isub,    TR::lsub,
                                                TR::fsub,    TR::dsub,
                                                TR::asub,    TR::BadILOp, TR::BadILOp,
                                                TR::BadILOp, TR::BadILOp, TR::BadILOp};
 
-static TR::ILOpCodes constOps[TR::NumTypes] = { TR::BadILOp,
+static TR::ILOpCodes constOps[TR::NumAllTypes] = { TR::BadILOp,
                                                  TR::bconst,  TR::sconst,  TR::iconst,    TR::lconst,
                                                  TR::fconst,  TR::dconst,
                                                  TR::aconst,  TR::BadILOp,  TR::BadILOp,
                                                  TR::BadILOp, TR::BadILOp, TR::BadILOp};
 
-static TR::ILOpCodes negOps[TR::NumTypes] = { TR::BadILOp,
+static TR::ILOpCodes negOps[TR::NumAllTypes] = { TR::BadILOp,
                                                TR::bneg,    TR::sneg,    TR::ineg,    TR::lneg,
                                                TR::fneg,    TR::dneg,
                                                TR::BadILOp, TR::BadILOp, TR::BadILOp,

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -577,7 +577,7 @@ bool decodeConversionOpcode(TR::ILOpCode op, TR::DataType nodeDataType, TR::Data
       {
       targetDataType = nodeDataType;
       TR::ILOpCodes opValue = op.getOpCodeValue();
-      for (int i = 0; i < TR::NumTypes; i++)
+      for (int i = 0; i < TR::NumAllTypes; i++)
           {
           sourceDataType = (TR::DataTypes)i;
           if (opValue == TR::ILOpCode::getProperConversion(sourceDataType, targetDataType, false /*!wantZeroExtension*/))

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,7 +91,7 @@
  *                                   set to true.
  */
 TR_UseDefInfo::TR_UseDefInfo(TR::Compilation *comp, TR::CFG *cfg, TR::Optimizer *optimizer,
-      bool requiresGlobals, bool prefersGlobals, bool loadsShouldBeDefs, bool cannotOmitTrivialDefs, bool conversionRegsOnly, 
+      bool requiresGlobals, bool prefersGlobals, bool loadsShouldBeDefs, bool cannotOmitTrivialDefs, bool conversionRegsOnly,
       bool doCompletion, bool callsShouldBeUses)
    : _region(comp->trMemory()->heapMemoryRegion()),
      _compilation(comp),
@@ -1382,7 +1382,7 @@ bool TR_UseDefInfo::findUseDefNodes(
             comp()->getOptions()->realTimeGC())
       {
       localIndex = _numExpandedDefOnlyNodes;
-      _numExpandedDefOnlyNodes += TR::NumTypes + 1; // == arraylet shadows + read barrier....encode this where?  SymRefTab probably
+      _numExpandedDefOnlyNodes += TR::NumAllTypes + 1; // == arraylet shadows + read barrier....encode this where?  SymRefTab probably
       useDefIndex = _numDefOnlyNodes++;
       }
    //else

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -308,10 +308,13 @@ TR::Register *OMR::Power::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::Node *child = node->getFirstChild();
    static bool disableDirectMove = feGetEnv("TR_disableDirectMove") ? true : false;
 
-   if (node->getDataType() == TR::VectorInt8)
+   if (node->getDataType().getVectorElementType() == TR::Int8)
       {
       TR::Register *trgReg = cg->allocateRegister(TR_VRF);
 
@@ -322,7 +325,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
          }
       else
          {
-         TR::SymbolReference *temp    = cg->allocateLocalTemp(TR::VectorInt8);
+         TR::SymbolReference *temp    = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int8, TR::VectorLength128));
          TR::MemoryReference *tempMR  = TR::MemoryReference::createWithSymRef(cg, node, temp, 1);
 
          TR::Register *srcReg = cg->evaluate(child);
@@ -346,9 +349,9 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       return trgReg;
       }
-   else if (node->getDataType() == TR::VectorInt16)
+   else if (node->getDataType().getVectorElementType() == TR::Int16)
       {
-      TR::SymbolReference    *temp    = cg->allocateLocalTemp(TR::VectorInt16);
+      TR::SymbolReference    *temp    = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int16, TR::VectorLength128));
       TR::MemoryReference *tempMR  = TR::MemoryReference::createWithSymRef(cg, node, temp, 2);
       TR::Register *srcReg = cg->evaluate(child);
       generateMemSrc1Instruction(cg, TR::InstOpCode::sth, node, tempMR, srcReg);
@@ -371,7 +374,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       return trgReg;
       }
-   else if (node->getDataType() == TR::VectorInt32)
+   else if (node->getDataType().getVectorElementType() == TR::Int32)
       {
       TR::Register *tempReg = cg->evaluate(child);
       TR::Register *resReg = cg->allocateRegister(TR_VRF);
@@ -403,7 +406,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
 
       return resReg;
       }
-   else if (node->getDataType() == TR::VectorInt64)
+   else if (node->getDataType().getVectorElementType() == TR::Int64)
       {
       TR::Register *srcReg = cg->evaluate(child);
       TR::Register *trgReg = cg->allocateRegister(TR_VRF);
@@ -450,7 +453,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       return trgReg;
       }
-   else if (node->getDataType() == TR::VectorFloat)
+   else if (node->getDataType().getVectorElementType() == TR::Float)
       {
       TR::Register   *srcReg = cg->evaluate(child);
       TR::Register   *trgReg  = cg->allocateRegister(TR_VRF);
@@ -463,7 +466,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       return trgReg;
       }
 
-   TR_ASSERT(node->getDataType() == TR::VectorDouble, "unsupported splats type");
+   TR_ASSERT(node->getDataType().getVectorElementType() == TR::Double, "unsupported splats type");
 
    TR::Register *resReg = node->setRegister(cg->allocateRegister(TR_VSX_VECTOR));
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1075,15 +1075,20 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
          lastVolIndex = _lastVolatileGPR;
          break;
 
-      case TR::VectorInt32:
-      case TR::VectorDouble:
-          isVector = true;
-          firstIndex = self()->getFirstGlobalVRF();
-          lastIndex = self()->getLastGlobalVRF();
-          lastVolIndex = lastIndex;  // TODO: preserved VRF's !!
-         break;
-
       default:
+         if (sym->getDataType().isVector())
+            {
+            if (sym->getDataType().getVectorElementType() == TR::Int32 ||
+                sym->getDataType().getVectorElementType() == TR::Double)
+               {
+               isVector = true;
+               firstIndex = self()->getFirstGlobalVRF();
+               lastIndex = self()->getLastGlobalVRF();
+               lastVolIndex = lastIndex;  // TODO: preserved VRF's !!
+               break;
+               }
+            }
+
          firstIndex = _firstGPR;
          lastIndex  = _lastFPR ;
          lastVolIndex = _lastVolatileGPR;
@@ -1755,8 +1760,9 @@ OMR::Power::CodeGenerator::freeAndResetTransientLongs()
 
 
 
-bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
+bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
    {
+   if(length != TR::VectorLength128) return false;
 
    // alignment issues
    if (!self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -282,7 +282,7 @@ public:
       return false;
       }
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
 
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -2570,29 +2570,32 @@ TR::Register *OMR::Power::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic opcode;
    TR_RegisterKinds kind;
 
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt8:
+     case TR::Int8:
          opcode = cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9) ? TR::InstOpCode::lxvb16x : TR::InstOpCode::lxvw4x;
          kind = TR_VRF;
          break;
-     case TR::VectorInt16:
+     case TR::Int16:
          opcode = cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9) ? TR::InstOpCode::lxvh8x : TR::InstOpCode::lxvw4x;
          kind = TR_VRF;
          break;
-     case TR::VectorInt32:
-     case TR::VectorFloat:
+     case TR::Int32:
+     case TR::Float:
 	      opcode = TR::InstOpCode::lxvw4x;
 	      kind = TR_VRF;
 	      break;
-     case TR::VectorInt64:
+     case TR::Int64:
 	      opcode = TR::InstOpCode::lxvd2x;
 	      kind = TR_VRF;
          break;
-     case TR::VectorDouble:
+     case TR::Double:
 	      opcode = TR::InstOpCode::lxvd2x;
 	      kind = TR_VSX_VECTOR;
 	      break;
@@ -2610,22 +2613,25 @@ TR::Register *OMR::Power::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s lenght:%d", node->getDataType().toString(), node->getDataType().getVectorLength());
+
    TR::InstOpCode::Mnemonic opcode;
 
-   switch(node->getDataType())
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt8:
+     case TR::Int8:
          opcode = cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9) ? TR::InstOpCode::stxvb16x : TR::InstOpCode::stxvw4x;
          break;
-     case TR::VectorInt16:
+     case TR::Int16:
          opcode = cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9) ? TR::InstOpCode::stxvh8x : TR::InstOpCode::stxvw4x;
          break;
-     case TR::VectorInt32:
-     case TR::VectorFloat:
+     case TR::Int32:
+     case TR::Float:
          opcode = TR::InstOpCode::stxvw4x;
          break;
-     case TR::VectorInt64:
-     case TR::VectorDouble:
+     case TR::Int64:
+     case TR::Double:
          opcode = TR::InstOpCode::stxvd2x;
          break;
      default:
@@ -2800,13 +2806,16 @@ TR::Register *OMR::Power::TreeEvaluator::vimaxEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
 
-   switch (node->getDataType())
+   switch (node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
-      case TR::VectorInt16:
-      case TR::VectorInt32:
+      case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
          opCode = TR::InstOpCode::vand;
          break;
       default:
@@ -2819,13 +2828,16 @@ TR::Register *OMR::Power::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
 
-   switch (node->getDataType())
+   switch (node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
-      case TR::VectorInt16:
-      case TR::VectorInt32:
+      case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
          opCode = TR::InstOpCode::vor;
          break;
       default:
@@ -2837,13 +2849,16 @@ TR::Register *OMR::Power::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
 
-   switch (node->getDataType())
+   switch (node->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
-      case TR::VectorInt16:
-      case TR::VectorInt32:
+      case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
          opCode = TR::InstOpCode::vxor;
          break;
       default:
@@ -2874,7 +2889,7 @@ TR::Register *OMR::Power::TreeEvaluator::vigetelemEvaluator(TR::Node *node, TR::
    TR::Register *resReg = node->setRegister(cg->allocateRegister());
 
    TR::Register *addrReg = cg->evaluate(firstChild);
-   TR::SymbolReference    *localTemp = cg->allocateLocalTemp(TR::VectorInt32);
+   TR::SymbolReference    *localTemp = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int32, TR::VectorLength128));
    generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, resReg, TR::MemoryReference::createWithSymRef(cg, node, localTemp, 16));
    generateMemSrc1Instruction(cg, TR::InstOpCode::stxvw4x, node, TR::MemoryReference::createWithIndexReg(cg, NULL, resReg, 16), addrReg);
 
@@ -2930,17 +2945,21 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
    TR::Register *tempVectorReg = cg->allocateRegister(TR_VSX_VECTOR);
 
    int32_t elementCount = -1;
-   switch (firstChild->getDataType())
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch (firstChild->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
-      case TR::VectorInt16:
+      case TR::Int8:
+      case TR::Int16:
          TR_ASSERT(false, "unsupported vector type %s in getvelemEvaluator.\n", firstChild->getDataType().toString());
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          elementCount = 4;
          resReg = cg->allocateRegister();
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          elementCount = 2;
          if (cg->comp()->target().is32Bit())
             {
@@ -2953,11 +2972,11 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
             resReg = cg->allocateRegister();
             }
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          elementCount = 4;
          resReg = cg->allocateSinglePrecisionRegister();
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          elementCount = 2;
          resReg = cg->allocateRegister(TR_FPR);
          break;
@@ -2980,18 +2999,19 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
           * The splat is skipped if the data is already in the right slot.
           * If the splat is skipped, the input data will be in srcVectorReg instead of intermediateResReg.
           */
-         bool skipSplat = (firstChild->getDataType() == TR::VectorInt32 && 1 == elem) || (firstChild->getDataType() == TR::VectorFloat && 0 == elem);
+         bool skipSplat = (firstChild->getDataType().getVectorElementType() == TR::Int32 && 1 == elem) ||
+                          (firstChild->getDataType().getVectorElementType() == TR::Float && 0 == elem);
 
          if (!skipSplat)
             {
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, intermediateResReg, srcVectorReg, elem);
             }
 
-         if (firstChild->getDataType() == TR::VectorInt32)
+         if (firstChild->getDataType().getVectorElementType() == TR::Int32)
             {
             generateMvFprGprInstructions(cg, node, fpr2gprLow, false, resReg, skipSplat ? srcVectorReg : intermediateResReg);
             }
-         else //firstChild->getDataType() == TR::VectorFloat
+         else // TR::Float
             {
             generateTrg1Src1Instruction(cg, TR::InstOpCode::xscvspdp, node, resReg, skipSplat ? srcVectorReg : intermediateResReg);
             }
@@ -3008,15 +3028,15 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
             generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxsldwi, node, intermediateResReg, srcVectorReg, srcVectorReg, 0x2);
             }
 
-         if (cg->comp()->target().is32Bit() && firstChild->getDataType() == TR::VectorInt64)
+         if (cg->comp()->target().is32Bit() && firstChild->getDataType().getVectorElementType() == TR::Int64)
             {
             generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highResReg, lowResReg, readElemOne ? intermediateResReg : srcVectorReg, tempVectorReg);
             }
-         else if (firstChild->getDataType() == TR::VectorInt64)
+         else if (firstChild->getDataType().getVectorElementType() == TR::Int64)
             {
             generateMvFprGprInstructions(cg, node, fpr2gprHost64, false, resReg, readElemOne ? intermediateResReg : srcVectorReg);
             }
-         else //firstChild->getDataType() == TR::VectorDouble
+         else // TR::Double
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::xxlor, node, resReg, readElemOne ? intermediateResReg : srcVectorReg, readElemOne ? intermediateResReg : srcVectorReg);
             }
@@ -3038,7 +3058,7 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
       deps->addPostCondition(indexReg, TR::RealRegister::NoReg);
       deps->addPostCondition(condReg, TR::RealRegister::NoReg);
 
-      if (firstChild->getDataType() == TR::VectorInt32)
+      if (firstChild->getDataType().getVectorElementType() == TR::Int32)
          {
          /*
           * Conditional statements are used to determine if the indexReg has the value 0, 1, 2 or 3. Other values are invalid.
@@ -3069,7 +3089,7 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
          generateDepLabelInstruction(cg, TR::InstOpCode::label, node, jumpLabelDone, deps);
          generateMvFprGprInstructions(cg, node, fpr2gprLow, false, resReg, intermediateResReg);
          }
-      else if (firstChild->getDataType() == TR::VectorFloat)
+      else if (firstChild->getDataType().getVectorElementType() == TR::Float)
          {
          /*
           * Conditional statements are used to determine if the indexReg has the value 0, 1, 2 or 3. Other values are invalid.
@@ -3118,11 +3138,11 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemDirectMoveHelper(TR::Node *node
          generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxsldwi, node, intermediateResReg, srcVectorReg, srcVectorReg, 0x2);
          generateDepLabelInstruction(cg, TR::InstOpCode::label, node, jumpLabelDone, deps);
 
-         if (cg->comp()->target().is32Bit() && firstChild->getDataType() == TR::VectorInt64)
+         if (cg->comp()->target().is32Bit() && firstChild->getDataType().getVectorElementType() == TR::Int64)
             {
             generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highResReg, lowResReg, intermediateResReg, tempVectorReg);
             }
-         else if (firstChild->getDataType() == TR::VectorInt64)
+         else if (firstChild->getDataType().getVectorElementType() == TR::Int64)
             {
             generateMvFprGprInstructions(cg, node, fpr2gprHost64, false, resReg, intermediateResReg);
             }
@@ -3156,18 +3176,22 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
    int32_t elementCount = 4;
    TR::InstOpCode::Mnemonic loadOpCode = TR::InstOpCode::lwz;
    TR::InstOpCode::Mnemonic vecStoreOpCode = TR::InstOpCode::stxvw4x;
-   switch (firstChild->getDataType())
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch (firstChild->getDataType().getVectorElementType())
       {
-      case TR::VectorInt8:
-      case TR::VectorInt16:
+      case TR::Int8:
+      case TR::Int16:
          TR_ASSERT(false, "unsupported vector type %s in getvelemEvaluator.\n", firstChild->getDataType().toString());
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          elementCount = 4;
          loadOpCode = TR::InstOpCode::lwz;
          vecStoreOpCode = TR::InstOpCode::stxvw4x;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          elementCount = 2;
          if (cg->comp()->target().is64Bit())
             loadOpCode = TR::InstOpCode::ld;
@@ -3175,13 +3199,13 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
             loadOpCode = TR::InstOpCode::lwz;
          vecStoreOpCode = TR::InstOpCode::stxvd2x;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          elementCount = 4;
          loadOpCode = TR::InstOpCode::lfs;
          fResReg = cg->allocateSinglePrecisionRegister();
          vecStoreOpCode = TR::InstOpCode::stxvw4x;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          elementCount = 2;
          loadOpCode = TR::InstOpCode::lfd;
          fResReg = cg->allocateRegister(TR_FPR);
@@ -3202,12 +3226,14 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
 
       TR_ASSERT(elem >= 0 && elem < elementCount, "Element can only be 0 to %u\n", elementCount - 1);
 
-      if (firstChild->getDataType() == TR::VectorFloat || firstChild->getDataType() == TR::VectorDouble)
+      if (firstChild->getDataType().getVectorElementType() == TR::Float ||
+          firstChild->getDataType().getVectorElementType() == TR::Double)
          {
          generateTrg1MemInstruction(cg, loadOpCode, node, fResReg, TR::MemoryReference::createWithDisplacement(cg, resReg, elem * (16 / elementCount), 16 / elementCount));
          cg->stopUsingRegister(resReg);
          }
-      else if (cg->comp()->target().is32Bit() && firstChild->getDataType() == TR::VectorInt64)
+      else if (cg->comp()->target().is32Bit() &&
+               firstChild->getDataType().getVectorElementType() == TR::Int64)
          {
          if (!cg->comp()->target().cpu.isLittleEndian())
             {
@@ -3233,7 +3259,8 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
       cg->decReferenceCount(firstChild);
       cg->decReferenceCount(secondChild);
 
-      if (firstChild->getDataType() == TR::VectorFloat || firstChild->getDataType() == TR::VectorDouble)
+      if (firstChild->getDataType().getVectorElementType() == TR::Float ||
+          firstChild->getDataType().getVectorElementType() == TR::Double)
          {
          node->setRegister(fResReg);
          return fResReg;
@@ -3249,12 +3276,14 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
    TR::Register *offsetReg = cg->allocateRegister();
    generateTrg1Src1ImmInstruction (cg, TR::InstOpCode::mulli, node, offsetReg, idxReg, 16 / elementCount);
 
-   if (firstChild->getDataType() == TR::VectorFloat || firstChild->getDataType() == TR::VectorDouble)
+   if (firstChild->getDataType().getVectorElementType() == TR::Float ||
+       firstChild->getDataType().getVectorElementType() == TR::Double)
       {
       generateTrg1MemInstruction(cg, loadOpCode, node, fResReg, TR::MemoryReference::createWithIndexReg(cg, resReg, offsetReg, 16 / elementCount));
       cg->stopUsingRegister(resReg);
       }
-   else if (cg->comp()->target().is32Bit() && firstChild->getDataType() == TR::VectorInt64)
+   else if (cg->comp()->target().is32Bit() &&
+            firstChild->getDataType().getVectorElementType() == TR::Int64)
       {
       if (!cg->comp()->target().cpu.isLittleEndian())
          {
@@ -3284,7 +3313,8 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
    cg->decReferenceCount(firstChild);
    cg->decReferenceCount(secondChild);
 
-   if (firstChild->getDataType() == TR::VectorFloat || firstChild->getDataType() == TR::VectorDouble)
+   if (firstChild->getDataType().getVectorElementType() == TR::Float ||
+       firstChild->getDataType().getVectorElementType() == TR::Double)
       {
       node->setRegister(fResReg);
       return fResReg;
@@ -3300,6 +3330,10 @@ TR::Register *OMR::Power::TreeEvaluator::getvelemMemoryMoveHelper(TR::Node *node
 TR::Register *OMR::Power::TreeEvaluator::visetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();
+
+   TR_ASSERT_FATAL_WITH_NODE(node, firstChild->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::Node *secondChild = node->getSecondChild();
    TR::Node *thirdChild = node->getThirdChild();
    TR::Register *vectorReg = cg->evaluate(firstChild);
@@ -3307,7 +3341,7 @@ TR::Register *OMR::Power::TreeEvaluator::visetelemEvaluator(TR::Node *node, TR::
    TR::Register *resReg = node->setRegister(cg->allocateRegister(TR_VRF));
 
    TR::Register *addrReg = cg->allocateRegister();
-   TR::SymbolReference    *localTemp = cg->allocateLocalTemp(TR::VectorInt32);
+   TR::SymbolReference    *localTemp = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int32, TR::VectorLength128));
    generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, addrReg, TR::MemoryReference::createWithSymRef(cg, node, localTemp, 16));
    generateMemSrc1Instruction(cg, TR::InstOpCode::stxvw4x, node, TR::MemoryReference::createWithIndexReg(cg, NULL, addrReg, 16), vectorReg);
 
@@ -3399,14 +3433,17 @@ TR::Register *OMR::Power::TreeEvaluator::vdcmpltEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt8:   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vaddubm);
-     case TR::VectorInt16:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduhm);
-     case TR::VectorInt32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduwm);
-     case TR::VectorInt64:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vaddudm);
-     case TR::VectorFloat:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvaddsp);
-     case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvadddp);
+     case TR::Int8:   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vaddubm);
+     case TR::Int16:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduhm);
+     case TR::Int32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vadduwm);
+     case TR::Int64:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vaddudm);
+     case TR::Float:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvaddsp);
+     case TR::Double: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvadddp);
      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
@@ -3414,27 +3451,33 @@ TR::Register *OMR::Power::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt8:   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsububm);
-     case TR::VectorInt16:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuhm);
-     case TR::VectorInt32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuwm);
-     case TR::VectorInt64:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubudm);
-     case TR::VectorFloat:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubsp);
-     case TR::VectorDouble: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubdp);
+     case TR::Int8:   return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsububm);
+     case TR::Int16:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuhm);
+     case TR::Int32:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubuwm);
+     case TR::Int64:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::vsubudm);
+     case TR::Float:  return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubsp);
+     case TR::Double: return TR::TreeEvaluator::inlineVectorBinaryOp(node, cg, TR::InstOpCode::xvsubdp);
      default: TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
      }
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt32:
+     case TR::Int32:
        return TR::TreeEvaluator::vnegInt32Helper(node,cg);
-     case TR::VectorFloat:
+     case TR::Float:
        return TR::TreeEvaluator::vnegFloatHelper(node,cg);
-     case TR::VectorDouble:
+     case TR::Double:
        return TR::TreeEvaluator::vnegDoubleHelper(node,cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
@@ -3471,19 +3514,22 @@ TR::Register *OMR::Power::TreeEvaluator::vnegDoubleHelper(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt8:
+     case TR::Int8:
        return TR::TreeEvaluator::vmulInt8Helper(node, cg);
-     case TR::VectorInt16:
+     case TR::Int16:
        return TR::TreeEvaluator::vmulInt16Helper(node,cg);
-     case TR::VectorInt32:
+     case TR::Int32:
        return TR::TreeEvaluator::vmulInt32Helper(node,cg);
-     case TR::VectorInt64:
+     case TR::Int64:
        return TR::TreeEvaluator::vmulInt64Helper(node,cg);
-     case TR::VectorFloat:
+     case TR::Float:
        return TR::TreeEvaluator::vmulFloatHelper(node,cg);
-     case TR::VectorDouble:
+     case TR::Double:
        return TR::TreeEvaluator::vmulDoubleHelper(node,cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
@@ -3637,13 +3683,16 @@ TR::Register *OMR::Power::TreeEvaluator::vmulDoubleHelper(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   switch(node->getDataType())
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
+   switch(node->getDataType().getVectorElementType())
      {
-     case TR::VectorInt32:
+     case TR::Int32:
 	return TR::TreeEvaluator::vdivInt32Helper(node, cg);
-     case TR::VectorFloat:
+     case TR::Float:
 	return TR::TreeEvaluator::vdivFloatHelper(node, cg);
-     case TR::VectorDouble:
+     case TR::Double:
 	return TR::TreeEvaluator::vdivDoubleHelper(node, cg);
      default:
        TR_ASSERT(false, "unrecognized vector type %s\n", node->getDataType().toString()); return NULL;
@@ -3662,6 +3711,9 @@ TR::Register *OMR::Power::TreeEvaluator::vdivDoubleHelper(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vdivInt32Helper(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
+                   "Only 128-bit vectors are supported %s", node->getDataType().toString());
+
    TR::Node *firstChild = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
    TR::Register *lhsReg = NULL, *rhsReg = NULL;
@@ -3672,8 +3724,8 @@ TR::Register *OMR::Power::TreeEvaluator::vdivInt32Helper(TR::Node *node, TR::Cod
    TR::Register *srcV1IdxReg = cg->allocateRegister();
    TR::Register *srcV2IdxReg = cg->allocateRegister();
 
-   TR::SymbolReference    *srcV1 = cg->allocateLocalTemp(TR::VectorInt32);
-   TR::SymbolReference    *srcV2 = cg->allocateLocalTemp(TR::VectorInt32);
+   TR::SymbolReference    *srcV1 = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int32, TR::VectorLength128));
+   TR::SymbolReference    *srcV2 = cg->allocateLocalTemp(TR::DataType::createVectorType(TR::Int32, TR::VectorLength128));
 
    generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, srcV1IdxReg, TR::MemoryReference::createWithSymRef(cg, node, srcV1, 16));
    generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, srcV2IdxReg, TR::MemoryReference::createWithSymRef(cg, node, srcV2, 16));

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -931,10 +931,6 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
             numFloatArgs++;
             break;
 
-         case TR::VectorDouble:
-            // TODO : finish implementation
-            numVectorArgs++;
-            break;
          case TR::Aggregate:
             {
             size_t size = child->getSymbolReference()->getSymbol()->getSize();
@@ -949,6 +945,14 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
             }
             break;
          default:
+            if (child->getDataType().isVector() &&
+                child->getDataType().getVectorElementType() == TR::Double)
+               {
+               // TODO : finish implementation
+               numVectorArgs++;
+               break;
+               }
+
             TR_ASSERT(false, "Argument type %s is not supported\n", child->getDataType().toString());
          }
       }
@@ -1286,7 +1290,10 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
 
             }    // end of for loop
             break;
-         case TR::VectorDouble:
+
+         default:
+            if (!childType.isVector() || childType.getVectorElementType() != TR::Double)
+               break;
             argRegister = pushThis(child);
             TR::Register * argReg;
             argReg = argRegister;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1519,7 +1519,7 @@ TR_Debug::getName(TR::SymbolReference * symRef)
    if (index < nonhelperIndex)
       {
       if (index >= numHelperSymbols + TR::SymbolReferenceTable::firstArrayShadowSymbol &&
-          index < numHelperSymbols + TR::SymbolReferenceTable::firstArrayShadowSymbol + TR::NumTypes)
+          index < numHelperSymbols + TR::SymbolReferenceTable::firstArrayShadowSymbol + TR::NumAllTypes)
          return "<array-shadow>";
       if (index >= numHelperSymbols + TR::SymbolReferenceTable::firstPerCodeCacheHelperSymbol &&
           index <= numHelperSymbols + TR::SymbolReferenceTable::lastPerCodeCacheHelperSymbol)

--- a/compiler/ras/ILValidationRules.cpp
+++ b/compiler/ras/ILValidationRules.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -461,11 +461,11 @@ void TR::ValidateChildTypes::validate(TR::Node *node)
 
             const auto expChildType = opcode.expectedChildType(i);
             const auto actChildType = childOpcode.getDataType().getDataType();
-            const auto expChildTypeName = (expChildType >= TR::NumTypes) ?
+            const auto expChildTypeName = (expChildType >= TR::NumAllTypes) ?
                                            "UnspecifiedChildType" :
                                            TR::DataType::getName(expChildType);
             const auto actChildTypeName = TR::DataType::getName(actChildType);
-            TR::checkILCondition(node, (expChildType >= TR::NumTypes || actChildType == expChildType),
+            TR::checkILCondition(node, (expChildType >= TR::NumAllTypes || actChildType == expChildType),
                                  comp(), "Child %d has unexpected type %s (expected %s)",
                                  i, actChildTypeName, expChildTypeName);
             }

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -572,7 +572,7 @@ TR::Register *OMR::X86::TreeEvaluator::dsqrtEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register* OMR::X86::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT_FATAL(node->getDataType() == TR::VectorDouble, "Unsupported datatype for vdsqrt opcode");
+   TR_ASSERT_FATAL(node->getDataType().getVectorElementType() == TR::Double, "Unsupported datatype for vdsqrt opcode");
    return TR::TreeEvaluator::unaryVectorArithmeticEvaluator(node, cg);
    }
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -986,8 +986,10 @@ bool OMR::X86::CodeGenerator::supportsAddressRematerialization()         { stati
 #undef CAN_REMATERIALIZE
 
 bool
-OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
+OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
    {
+   if(length != TR::VectorLength128) return false;
+
    /*
     * Most of the vector evaluators for opcodes used in AutoSIMD have been implemented.
     * The cases that return false are placeholders that should be updated as support for more vector evaluators is added.

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -358,7 +358,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool hasComplexAddressingMode() { return true; }
    bool getSupportsBitOpCodes() { return true; }
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
    bool getSupportsEncodeUtf16BigWithSurrogateTest();
 

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -197,7 +197,7 @@ OMR::X86::Machine::Machine
    self()->resetFPStackRegisters();
    self()->resetXMMGlobalRegisters();
 
-   for (int i=0; i<TR::NumTypes; i++)
+   for (int i=0; i<TR::NumAllTypes; i++)
       {
       _dummyLocal[i] = NULL;
       }

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -119,7 +119,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    List<TR::Register>      *_spilledRegistersList;
 
-   TR::SymbolReference     *_dummyLocal[TR::NumTypes];
+   TR::SymbolReference     *_dummyLocal[TR::NumAllTypes];
 
    int32_t                 _fpStackShape[TR_X86FPStackRegister::NumRegisters];
    int32_t                 _fpTopOfStack;

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4052,14 +4052,22 @@ static const TR::InstOpCode::Mnemonic BinaryArithmeticOpCodesForReg[TR::NumOMRTy
    { TR::InstOpCode::bad, TR::InstOpCode::ADDSSRegReg, TR::InstOpCode::SUBSSRegReg, TR::InstOpCode::MULSSRegReg,  TR::InstOpCode::DIVSSRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Float
    { TR::InstOpCode::bad, TR::InstOpCode::ADDSDRegReg, TR::InstOpCode::SUBSDRegReg, TR::InstOpCode::MULSDRegReg,  TR::InstOpCode::DIVSDRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Double
    { TR::InstOpCode::bad, TR::InstOpCode::bad,   TR::InstOpCode::bad,   TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Address
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDBRegReg, TR::InstOpCode::PSUBBRegReg, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorInt8
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDWRegReg, TR::InstOpCode::PSUBWRegReg, TR::InstOpCode::PMULLWRegReg, TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorInt16
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDDRegReg, TR::InstOpCode::PSUBDRegReg, TR::InstOpCode::PMULLDRegReg, TR::InstOpCode::bad,   TR::InstOpCode::PANDRegReg, TR::InstOpCode::PORRegReg, TR::InstOpCode::PXORRegReg }, // VectorInt32
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDQRegReg, TR::InstOpCode::PSUBQRegReg, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::PANDRegReg, TR::InstOpCode::PORRegReg, TR::InstOpCode::PXORRegReg }, // VectorInt64
-   { TR::InstOpCode::bad, TR::InstOpCode::ADDPSRegReg, TR::InstOpCode::SUBPSRegReg, TR::InstOpCode::MULPSRegReg,  TR::InstOpCode::DIVPSRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorFloat
-   { TR::InstOpCode::bad, TR::InstOpCode::ADDPDRegReg, TR::InstOpCode::SUBPDRegReg, TR::InstOpCode::MULPDRegReg,  TR::InstOpCode::DIVPDRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorDouble
    { TR::InstOpCode::bad, TR::InstOpCode::bad,   TR::InstOpCode::bad,   TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Aggregate
+
    };
+
+static const TR::InstOpCode::Mnemonic VectorBinaryArithmeticOpCodesForReg[TR::NumVectorElementTypes][NumBinaryArithmeticOps] =
+   {
+   //  Invalid,       Add,         Sub,         Mul,         Div,          And,         Or,       Xor
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDBRegReg, TR::InstOpCode::PSUBBRegReg, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Int8
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDWRegReg, TR::InstOpCode::PSUBWRegReg, TR::InstOpCode::PMULLWRegReg, TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Int16
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDDRegReg, TR::InstOpCode::PSUBDRegReg, TR::InstOpCode::PMULLDRegReg, TR::InstOpCode::bad,   TR::InstOpCode::PANDRegReg, TR::InstOpCode::PORRegReg, TR::InstOpCode::PXORRegReg }, // Int32
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDQRegReg, TR::InstOpCode::PSUBQRegReg, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::PANDRegReg, TR::InstOpCode::PORRegReg, TR::InstOpCode::PXORRegReg }, // Int64
+   { TR::InstOpCode::bad, TR::InstOpCode::ADDPSRegReg, TR::InstOpCode::SUBPSRegReg, TR::InstOpCode::MULPSRegReg,  TR::InstOpCode::DIVPSRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Float
+   { TR::InstOpCode::bad, TR::InstOpCode::ADDPDRegReg, TR::InstOpCode::SUBPDRegReg, TR::InstOpCode::MULPDRegReg,  TR::InstOpCode::DIVPDRegReg, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Double
+   };
+
+
 
 static const TR::InstOpCode::Mnemonic BinaryArithmeticOpCodesForMem[TR::NumOMRTypes][NumBinaryArithmeticOps] =
    {
@@ -4072,14 +4080,21 @@ static const TR::InstOpCode::Mnemonic BinaryArithmeticOpCodesForMem[TR::NumOMRTy
    { TR::InstOpCode::bad, TR::InstOpCode::ADDSSRegMem, TR::InstOpCode::SUBSSRegMem, TR::InstOpCode::MULSSRegMem,  TR::InstOpCode::DIVSSRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Float
    { TR::InstOpCode::bad, TR::InstOpCode::ADDSDRegMem, TR::InstOpCode::SUBSDRegMem, TR::InstOpCode::MULSDRegMem,  TR::InstOpCode::DIVSDRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Double
    { TR::InstOpCode::bad, TR::InstOpCode::bad,   TR::InstOpCode::bad,   TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Address
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDBRegMem, TR::InstOpCode::PSUBBRegMem, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorInt8
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDWRegMem, TR::InstOpCode::PSUBWRegMem, TR::InstOpCode::PMULLWRegMem, TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorInt16
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDDRegMem, TR::InstOpCode::PSUBDRegMem, TR::InstOpCode::PMULLDRegMem, TR::InstOpCode::bad,   TR::InstOpCode::PANDRegMem, TR::InstOpCode::PORRegMem, TR::InstOpCode::PXORRegMem }, // VectorInt32
-   { TR::InstOpCode::bad, TR::InstOpCode::PADDQRegMem, TR::InstOpCode::PSUBQRegMem, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::PANDRegMem, TR::InstOpCode::PORRegMem, TR::InstOpCode::PXORRegMem }, // VectorInt64
-   { TR::InstOpCode::bad, TR::InstOpCode::ADDPSRegMem, TR::InstOpCode::SUBPSRegMem, TR::InstOpCode::MULPSRegMem,  TR::InstOpCode::DIVPSRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorFloat
-   { TR::InstOpCode::bad, TR::InstOpCode::ADDPDRegMem, TR::InstOpCode::SUBPDRegMem, TR::InstOpCode::MULPDRegMem,  TR::InstOpCode::DIVPDRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // VectorDouble
    { TR::InstOpCode::bad, TR::InstOpCode::bad,   TR::InstOpCode::bad,   TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Aggregate
    };
+
+
+static const TR::InstOpCode::Mnemonic VectorBinaryArithmeticOpCodesForMem[TR::NumVectorElementTypes][NumBinaryArithmeticOps] =
+   {
+   //  Invalid,       Add,         Sub,         Mul,         Div,          And,         Or,       Xor
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDBRegMem, TR::InstOpCode::PSUBBRegMem, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Int8
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDWRegMem, TR::InstOpCode::PSUBWRegMem, TR::InstOpCode::PMULLWRegMem, TR::InstOpCode::bad,   TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Int16
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDDRegMem, TR::InstOpCode::PSUBDRegMem, TR::InstOpCode::PMULLDRegMem, TR::InstOpCode::bad,   TR::InstOpCode::PANDRegMem, TR::InstOpCode::PORRegMem, TR::InstOpCode::PXORRegMem }, // Int32
+   { TR::InstOpCode::bad, TR::InstOpCode::PADDQRegMem, TR::InstOpCode::PSUBQRegMem, TR::InstOpCode::bad,    TR::InstOpCode::bad,   TR::InstOpCode::PANDRegMem, TR::InstOpCode::PORRegMem, TR::InstOpCode::PXORRegMem }, // Int64
+   { TR::InstOpCode::bad, TR::InstOpCode::ADDPSRegMem, TR::InstOpCode::SUBPSRegMem, TR::InstOpCode::MULPSRegMem,  TR::InstOpCode::DIVPSRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Float
+   { TR::InstOpCode::bad, TR::InstOpCode::ADDPDRegMem, TR::InstOpCode::SUBPDRegMem, TR::InstOpCode::MULPDRegMem,  TR::InstOpCode::DIVPDRegMem, TR::InstOpCode::bad,  TR::InstOpCode::bad, TR::InstOpCode::bad  }, // Double
+   };
+
 
 static const TR::ILOpCodes MemoryLoadOpCodes[TR::NumOMRTypes] =
    {
@@ -4091,18 +4106,17 @@ static const TR::ILOpCodes MemoryLoadOpCodes[TR::NumOMRTypes] =
    TR::fload  , // Float
    TR::dload  , // Double
    TR::BadILOp, // Address
-   TR::vload  , // VectorInt8
-   TR::vload  , // VectorInt16
-   TR::vload  , // VectorInt32
-   TR::vload  , // VectorInt64
-   TR::vload  , // VectorFloat
-   TR::vload  , // VectorDouble
    TR::BadILOp, // Aggregate
    };
 
 // For ILOpCode that can be translated to single SSE/AVX instructions
 TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEvaluator(TR::Node* node, TR::CodeGenerator* cg)
    {
+   TR::DataType type = node->getDataType();
+
+   TR_ASSERT_FATAL_WITH_NODE(node, !type.isVector() || type.getVectorLength() == TR::VectorLength128,
+                             "Only 128-bit vectors are supported right now\n");
+
    auto arithmetic = BinaryArithmeticInvalid;
 
    switch (node->getOpCodeValue())
@@ -4140,8 +4154,6 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
          TR_ASSERT(false, "Unsupported OpCode");
       }
 
-   TR::DataType type = node->getDataType();
-
    TR::Node* operandNode0 = node->getChild(0);
    TR::Node* operandNode1 = node->getChild(1);
 
@@ -4152,8 +4164,9 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
       {
       if (operandNode1->getRegister()                               ||
           operandNode1->getReferenceCount() != 1                    ||
-          operandNode1->getOpCodeValue() != MemoryLoadOpCodes[type] ||
-          BinaryArithmeticOpCodesForMem[type][arithmetic] == TR::InstOpCode::bad)
+          operandNode1->getOpCodeValue() != (type.isVector() ? TR::vload : MemoryLoadOpCodes[type]) ||
+          (type.isVector() ? VectorBinaryArithmeticOpCodesForMem[type.getVectorElementType() - 1][arithmetic]
+                           : BinaryArithmeticOpCodesForMem[type][arithmetic]) == TR::InstOpCode::bad)
          {
          useRegMemForm = false;
          }
@@ -4164,7 +4177,11 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
    TR::Register* resultReg = cg->allocateRegister(operandReg0->getKind());
    resultReg->setIsSinglePrecision(operandReg0->isSinglePrecision());
 
-   TR::InstOpCode::Mnemonic opCode = useRegMemForm ? BinaryArithmeticOpCodesForMem[type][arithmetic] : BinaryArithmeticOpCodesForReg[type][arithmetic];
+   TR::InstOpCode::Mnemonic opCode = useRegMemForm ? (type.isVector() ? VectorBinaryArithmeticOpCodesForMem[type.getVectorElementType() - 1][arithmetic] :
+                                                                        BinaryArithmeticOpCodesForMem[type][arithmetic]) :
+                                                                        (type.isVector() ? VectorBinaryArithmeticOpCodesForReg[type.getVectorElementType() - 1][arithmetic] :
+                                                                        BinaryArithmeticOpCodesForReg[type][arithmetic]);
+
    TR_ASSERT(opCode != TR::InstOpCode::bad, "FloatingPointAndVectorBinaryArithmeticEvaluator: unsupported data type or arithmetic.");
 
    if (cg->comp()->target().cpu.supportsAVX())

--- a/compiler/x/codegen/UnaryEvaluator.cpp
+++ b/compiler/x/codegen/UnaryEvaluator.cpp
@@ -137,6 +137,11 @@ TR::Register *OMR::X86::TreeEvaluator::integerAbsEvaluator(TR::Node *node, TR::C
 TR::Register*
 OMR::X86::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
+   TR::DataType type = node->getDataType();
+
+   TR_ASSERT_FATAL_WITH_NODE(node, type.getVectorLength() == TR::VectorLength128,
+                             "Only 128-bit vectors are supported right now\n");
+
    TR::Node *valueNode = node->getChild(0);
    TR::Register *resultReg = cg->allocateRegister(TR_VRF);
    TR::Register *valueReg = cg->evaluate(valueNode);
@@ -145,24 +150,24 @@ OMR::X86::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, resultReg, resultReg, cg);
    TR::InstOpCode::Mnemonic subOpcode;
 
-   switch (node->getDataType())
+   switch (type.getVectorElementType())
       {
-      case TR::VectorInt8:
+      case TR::Int8:
          subOpcode = TR::InstOpCode::PSUBBRegReg;
          break;
-      case TR::VectorInt16:
+      case TR::Int16:
          subOpcode = TR::InstOpCode::PSUBWRegReg;
          break;
-      case TR::VectorInt32:
+      case TR::Int32:
          subOpcode = TR::InstOpCode::PSUBDRegReg;
          break;
-      case TR::VectorInt64:
+      case TR::Int64:
          subOpcode = TR::InstOpCode::PSUBQRegReg;
          break;
-      case TR::VectorFloat:
+      case TR::Float:
          subOpcode = TR::InstOpCode::SUBPSRegReg;
          break;
-      case TR::VectorDouble:
+      case TR::Double:
          subOpcode = TR::InstOpCode::SUBPDRegReg;
          break;
       default:

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4719,8 +4719,9 @@ bool OMR::Z::CodeGenerator::isDispInRange(int64_t disp)
    return (MINLONGDISP <= disp) && (disp <= MAXLONGDISP);
    }
 
-bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
+bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
    {
+   if(length != TR::VectorLength128) return false;
 
    /*
     * Prior to z14, vector operations that operated on floating point numbers only supported

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -256,7 +256,6 @@ public:
 
 protected:
 
-   
    CodeGenerator(TR::Compilation *comp);
 
 public:
@@ -750,7 +749,7 @@ public:
 
    virtual bool isDispInRange(int64_t disp);
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
 
    TR::Instruction *_ccInstruction;
    TR::Instruction* ccInstruction() { return _ccInstruction; }

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -363,7 +363,6 @@ TR::S390zLinuxSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethod
                {
                lri = numFPRArgs;
                }
-            
             numFPRArgs++;
             break;
             }
@@ -374,23 +373,24 @@ TR::S390zLinuxSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethod
             break;
             }
 
-         case TR::VectorInt8:
-         case TR::VectorInt16:
-         case TR::VectorInt32:
-         case TR::VectorInt64:
-         case TR::VectorDouble:
-            {
-            if (numVRFArgs < getNumVectorArgumentRegisters())
-               {
-               lri = numVRFArgs;
-               }
-
-            numVRFArgs++;
-            break;
-            }
-
          default:
             {
+            if (paramCursor->getDataType().isVector())
+               {
+               TR::DataType elementType = paramCursor->getDataType().getVectorElementType();
+               if (elementType == TR::Int8 || elementType == TR::Int16 ||
+                   elementType == TR::Int32 || elementType == TR::Int64 || elementType == TR::Double)
+                  {
+                  if (numVRFArgs < getNumVectorArgumentRegisters())
+                     {
+                     lri = numVRFArgs;
+                     }
+
+                  numVRFArgs++;
+                  break;
+                  }
+               }
+
             TR_ASSERT_FATAL(false, "Unknown data type %s", paramCursor->getDataType().toString());
             break;
             }
@@ -589,16 +589,21 @@ TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, 
                      }
                   }
             break;
-         case TR::VectorInt8:
-         case TR::VectorInt16:
-         case TR::VectorInt32:
-         case TR::VectorInt64:
-         case TR::VectorDouble:
-            indexInArgRegistersArray = numVectorArgs;
-            argRegNum = getVectorArgumentRegister(indexInArgRegistersArray);
-            numVectorArgs ++;
+         default:
+            {
+            if (parmCursor->getDataType().isVector())
+               {
+               TR::DataType elementType = parmCursor->getDataType().getVectorElementType();
+               if (elementType == TR::Int8 || elementType == TR::Int16 ||
+                   elementType == TR::Int32 || elementType == TR::Int64 || elementType == TR::Double)
+                  {
+                  indexInArgRegistersArray = numVectorArgs;
+                  argRegNum = getVectorArgumentRegister(indexInArgRegistersArray);
+                  numVectorArgs++;
+                  }
+               }
             break;
-         default: break;
+            }
          }
       if (argRegNum == TR::RealRegister::NoReg)
          {

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -329,7 +329,7 @@ TR::S390zOSSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSym
                {
                lri = numFPRArgs;
                }
-            
+
             // On 64-bit XPLINK floating point arguments leave "holes" in the GPR linkage registers, but not vice versa
             numGPRArgs++;
             numFPRArgs++;
@@ -342,25 +342,26 @@ TR::S390zOSSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSym
             break;
             }
 
-         case TR::VectorInt8:
-         case TR::VectorInt16:
-         case TR::VectorInt32:
-         case TR::VectorInt64:
-         case TR::VectorDouble:
-            {
-            if (numVRFArgs < getNumVectorArgumentRegisters())
-               {
-               lri = numVRFArgs;
-               }
-            
-            // On 64-bit XPLINK floating point arguments leave "holes" in the GPR linkage registers, but not vice versa
-            numGPRArgs++;
-            numVRFArgs++;
-            break;
-            }
-
          default:
             {
+            if (paramCursor->getDataType().isVector())
+               {
+               TR::DataType elementType = paramCursor->getDataType().getVectorElementType();
+               if (elementType == TR::Int8 || elementType == TR::Int16 ||
+                   elementType == TR::Int32 || elementType == TR::Int64 || elementType == TR::Double)
+                  {
+                  if (numVRFArgs < getNumVectorArgumentRegisters())
+                     {
+                     lri = numVRFArgs;
+                     }
+
+                  // On 64-bit XPLINK floating point arguments leave "holes" in the GPR linkage registers, but not vice versa
+                  numGPRArgs++;
+                  numVRFArgs++;
+                  break;
+                  }
+               }
+
             TR_ASSERT_FATAL(false, "Unknown data type %s", paramCursor->getDataType().toString());
             break;
             }
@@ -535,7 +536,7 @@ TR::S390zOSSystemLinkage::generateInstructionsForCall(TR::Node * callNode, TR::R
     //             a) disp is an offset in the environment (aka ADA) containing the
     //                function descriptor body (i.e. not pointer to function descriptor)
     TR_XPLinkCallTypes callType;
-    
+
     TR::Register* aeReg = deps->searchPostConditionRegister(getENVPointerRegister());
     TR::Register* epReg = deps->searchPostConditionRegister(getEntryPointRegister());
     TR::Register* raReg = deps->searchPostConditionRegister(getReturnAddressRegister());
@@ -621,15 +622,15 @@ TR::S390zOSSystemLinkage::genCallNOPAndDescriptor(TR::Instruction* cursor, TR::N
    if (comp()->target().is32Bit())
       {
       // The XPLINK Call Descriptor is created only on 31-bit targets when:
-      // 
+      //
       // 1. The call site is so far removed from the Entry Point Marker of the function that its offset cannot be contained
       // in the space available in the call NOP descriptor following the call site.
-      // 
+      //
       // 2. The call contains a return value or parameters that are passed in registers or in ways incompatible with non-
       // XPLINK code.
-      // 
+      //
       // The XPLINK Call Descriptor has the following format:
-      // 
+      //
       //                                        0x01                               0x02                               0x03
       // 0x00 +----------------------------------+----------------------------------+----------------------------------+----------------------------------+
       //      | Signed offset, in bytes, to Entry Point Marker (if it exists)                                                                             |

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "infra/Flags.hpp"
 
-namespace Tril { 
+namespace Tril {
 /**
  * @brief Gets the TR::DataTypes value from the data type's name
  * @param name is the name of the data type as a string
@@ -41,12 +41,12 @@ static TR::DataTypes getTRDataTypes(const std::string& name) {
    else if (name == "Address") return TR::Address;
    else if (name == "Float") return TR::Float;
    else if (name == "Double") return TR::Double;
-   else if (name == "VectorInt8") return TR::VectorInt8;
-   else if (name == "VectorInt16") return TR::VectorInt16;
-   else if (name == "VectorInt32") return TR::VectorInt32;
-   else if (name == "VectorInt64") return TR::VectorInt64;
-   else if (name == "VectorFloat") return TR::VectorFloat;
-   else if (name == "VectorDouble") return TR::VectorDouble;
+   else if (name == "VectorInt8") return OMR::DataType::Vector128Int8;
+   else if (name == "VectorInt16") return OMR::DataType::Vector128Int16;
+   else if (name == "VectorInt32") return OMR::DataType::Vector128Int32;
+   else if (name == "VectorInt64") return OMR::DataType::Vector128Int64;
+   else if (name == "VectorFloat") return OMR::DataType::Vector128Float;
+   else if (name == "VectorDouble") return OMR::DataType::Vector128Double;
    else if (name == "NoType") return TR::NoType;
    else {
       throw std::runtime_error(static_cast<const std::string&>(std::string("Unknown type name: ").append(name)));
@@ -54,13 +54,13 @@ static TR::DataTypes getTRDataTypes(const std::string& name) {
 }
 
 /**
- * @brief Return a parsed array of DataTypes from a node with an 
+ * @brief Return a parsed array of DataTypes from a node with an
  *        "args" list.
  * @param node is the node being processed.
- * @return the std::vector of TR::DataTypes corresponding to the 
- *         args=[Type1,Type2,...] attached to the ASTNode. 
+ * @return the std::vector of TR::DataTypes corresponding to the
+ *         args=[Type1,Type2,...] attached to the ASTNode.
  */
-static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) { 
+static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) {
 
    std::vector<TR::DataTypes> argTypes;
    auto argTypesArg = node->getArgByName("args");
@@ -99,20 +99,20 @@ static OMR::flags32_t parseFlags(const ASTNode* node) {
 }
 
 /**
- * @brief  Convert a linkage convention name to a LinkageConvention 
- *         appropriate for setting on a MethodSymbol. 
+ * @brief  Convert a linkage convention name to a LinkageConvention
+ *         appropriate for setting on a MethodSymbol.
  *
- * @return the linkage convention, or TR_None if the name is not 
- *         recognized. 
+ * @return the linkage convention, or TR_None if the name is not
+ *         recognized.
  */
-static TR_LinkageConventions convertStringToLinkage(const char * linkageName) { 
-   std::string ln = linkageName;  
+static TR_LinkageConventions convertStringToLinkage(const char * linkageName) {
+   std::string ln = linkageName;
    if (ln == "system") {
       return TR_System;
    }
 
    // Not found
-   return TR_None; 
+   return TR_None;
 }
 
 }


### PR DESCRIPTION
- remove VectorInt8 - VectorDouble from OMR::DataTypes
- allocate space for vector enums just before TR::NumAllTypes(former TR::NumTypes)
- vector enums are generated at runtime using createVectorType()
- value returned by createVectorType() can be used to dereference tables
  of size TR::NumAllTypes as before, but cannot be used to dereference
  tables of size TR::NumOMRTypes
- typeless vector opcodes such as vsub, vadd, etc. (have ILTypeProp::HasNoDataType property)
  can start using the new types
- codegen evaluators for those opcodes can use isVector(), getVectorElementType(), getVectorLength()
  on the node's DataType
- note that getVectorElementType() and getVectorLength() can only be called on vector types, otherwise there will be an assert
- to enable new vector length on specific platform, NumVectorLenghts must be defined corresponfingly in
  OMRDataTypes.hpp
- TRIL and JITBuilder will use 128-bit vectors for now

- ATTENTION: for safety reasons, renamed TR::NumTypes to TR::NumAllTypes. Please adjust your code correspondingly if it does not compile. In fact, any code that relies on specific values of TR::NumTypes, TR::NumOMRTypes, as well as vector opcodes being smaller than TR::NumOMRTypes will need to be adjusted. All that work is already done for openj9(https://github.com/eclipse-openj9/openj9/pull/14513).