### PR TITLE
Correct compilation errors detected by clang on Mac

### DIFF
--- a/compiler/compile/CompilationTypes.hpp
+++ b/compiler/compile/CompilationTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -201,7 +201,7 @@ public:
    struct Method : TR_Link<Method>
       {
       Method(char * name, int32_t nameLen, char * sig, int32_t sigLen)
-         : _name(name), _nameLen(nameLen), _sig(sig), _sigLen(sigLen)
+         : _name(name), _sig(sig), _nameLen(nameLen), _sigLen(sigLen)
          { }
       char * _name, * _sig;
       int32_t _nameLen, _sigLen;

--- a/compiler/cs2/arrayof.h
+++ b/compiler/cs2/arrayof.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1996, 2018 IBM Corp. and others
+ * Copyright (c) 1996, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -525,7 +525,7 @@ template <class AElementType, class Allocator, size_t segmentBits = 8, class Ini
     if (pmid!=from)
       Swap(CS2_BASEARDECL::ElementAt(pmid), CS2_BASEARDECL::ElementAt(from));
 
-    size_t i,low=from+1, high=to-1;
+    size_t low=from+1, high=to-1;
 
     AElementType &pivot=CS2_BASEARDECL::ElementAt(from);
     do {

--- a/compiler/cs2/hashtab.h
+++ b/compiler/cs2/hashtab.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -551,8 +551,8 @@ CS2_HT_TEMP inline bool CS2_HT_DECL::Add(const AKeyType& key, const ADataType& d
 CS2_HT_TEMP inline const ADataType& CS2_HT_DECL::Get(const AKeyType& key) const
 {
   HashIndex hashIndex;
-  const bool found = Locate(key, hashIndex);
-  CS2Assert(found, ("Key was not found."));
+  if(false == Locate(key, hashIndex))
+    CS2Assert(false, ("Key was not found."));
   return DataAt(hashIndex);
 }
 
@@ -977,10 +977,9 @@ inline CS2_HT_DECL::Add (const AKeyType &key, const ADataType &data,
   if (fNextFree == 0) {
     Grow();
 
-    // The grow routine rehashes everything, so we need to rehash this key.
-    bool foundThisRecord = Locate (key, hashIndex, hashValue);
-    CS2Assert (! foundThisRecord,
-            ("Failed to relocate entry to an empty record\n"));
+  // The grow routine rehashes everything, so we need to rehash this key.
+  if(false == Locate (key, hashIndex, hashValue))
+    CS2Assert (false, ("Failed to relocate entry to an empty record\n"));
   }
 
   // hashIndex points at either an invalid hash table entry or the last

--- a/compiler/env/OMRPersistentInfo.hpp
+++ b/compiler/env/OMRPersistentInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@ class TR_PseudoRandomNumbersListElement
    public:
 
    TR_PseudoRandomNumbersListElement()
-     :_next(0), _curIndex(0)
+     :_curIndex(0), _next(0)
       {}
 
    int32_t _pseudoRandomNumbers[PSEUDO_RANDOM_NUMBERS_SIZE];
@@ -68,12 +68,12 @@ class PersistentInfo
    friend class ::OMR::Options;
    PersistentInfo(TR_PersistentMemory *pm) :
          _persistentMemory(pm),
-         _lastDebugCounterResetSeconds(0),
          _pseudoRandomNumbersListHead(NULL),
          _curPseudoRandomNumbersListElem(NULL),
          _curIndex(0),
-         _dynamicCounters(NULL),
          _staticCounters(NULL),
+         _dynamicCounters(NULL),
+         _lastDebugCounterResetSeconds(0),
          _persistentTOC(NULL)
       {}
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1108,14 +1108,14 @@ namespace TR
       static char* Name(bool csv = false)
          {
          if (csv)
-            return "Allocs";
+            return const_cast<char *>("Allocs");
          else
-            return "Memory Usage (bytes)";
+            return const_cast<char *>("Memory Usage (bytes)");
          }
 
       static char *UnitsText(bool alternativeFormat = false /* ignored */)
          {
-            return "allocated (% total)  freed (% total)  maxLive (% total)";
+            return const_cast<char *>("allocated (% total)  freed (% total)  maxLive (% total)");
          }
 
       static uint32_t sprintf_part(char *line, uint64_t bytes, uint64_t total)

--- a/compiler/infra/BitVector.hpp
+++ b/compiler/infra/BitVector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,9 +56,9 @@ class TR_BitContainer
    public:
    TR_ALLOC(TR_Memory::BitVector)
 
-   TR_BitContainer() : _type(bitvector), _bitVector(NULL) {}
-   TR_BitContainer(int32_t index) : _type(singleton), _singleBit(index) {}
-   TR_BitContainer(TR_BitVector *bv) : _type(bitvector), _bitVector(bv) {}
+   TR_BitContainer() : _bitVector(NULL), _type(bitvector) {}
+   TR_BitContainer(int32_t index) : _singleBit(index), _type(singleton) {}
+   TR_BitContainer(TR_BitVector *bv) : _bitVector(bv), _type(bitvector) {}
    operator TR_BitVector *()
       {
       TR_ASSERT(_type == bitvector, "BitContainer cannot be converted to BitVector\n");
@@ -160,8 +160,8 @@ class TR_BitVector
 
    // Construct an empty bit vector. All bits are initially off.
    //
-   TR_BitVector() : _numChunks(0), _chunks(NULL), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _growable(growable), _region(0) { }
-   TR_BitVector(TR::Region &region) : _numChunks(0), _chunks(NULL), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _growable(growable), _region(&region) { }
+   TR_BitVector() : _chunks(NULL), _region(0), _numChunks(0), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _growable(growable) { }
+   TR_BitVector(TR::Region &region) : _chunks(NULL), _region(&region), _numChunks(0), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _growable(growable) { }
 
    /**
     * @brief Constructor to create a new BitVector by reading serialized data from the memory buffer
@@ -270,7 +270,7 @@ class TR_BitVector
    // Construct a bit vector from a second bit vector
    //
    TR_BitVector(const TR_BitVector &v2)
-      : _numChunks(0), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _chunks(NULL), _growable(growable)
+      : _chunks(NULL), _numChunks(0), _firstChunkWithNonZero(0), _lastChunkWithNonZero(-1), _growable(growable)
       {
       _region = v2._region;
       *this = v2;
@@ -1348,8 +1348,6 @@ private:
 //
 template <class BitVector>
 inline void Assign(BitVector &cs2bv, TR_BitVector &trbv, bool clear=true) {
-  uint32_t count=0;
-
   if (clear)
      cs2bv = CS2_TR_BitVector(trbv);
   else


### PR DESCRIPTION
  -Wunused-variable
   unused variable
  -Wreorder-ctor
   field 1 will be initialized after field 2
  -Wwritable-strings
   ISO C++11 does not allow conversion from string literal to 'char *'

Signed-off-by: Tao Guan <james_mango@yahoo.com>