### PR TITLE
Stop versioning direct method guards

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -1393,6 +1393,7 @@ bool TR_LoopVersioner::detectInvariantTrees(TR_RegionStructure *whileLoop, List<
              && (thisChild || nextRealNode)
              && node->isTheVirtualGuardForAGuardedInlinedCall()
              && !node->isHCRGuard()
+             && !node->isDirectMethodGuard()
              && !node->isBreakpointGuard())
             {
             if (!guardInfo)
@@ -1463,7 +1464,7 @@ bool TR_LoopVersioner::detectInvariantTrees(TR_RegionStructure *whileLoop, List<
                   }
                }
             }
-         else if (!node->isHCRGuard() && !node->isBreakpointGuard())
+         else if (!node->isHCRGuard() && !node->isDirectMethodGuard() && !node->isBreakpointGuard())
             {
             for (int32_t childNum=0;childNum < node->getNumChildren(); childNum++)
                {


### PR DESCRIPTION
Direct method guards behave like HCR guards. They apply even to static methods, which don't have a receiver, never mind an invariant one. Even when there is a receiver, and even when the receiver is invariant, that condition is not sufficient (or even necessary) to version the guard, since the guard isn't checking the type of the receiver, but rather checking that the method has not been redefined.

Furthermore, attempting to version a direct method guard with a receiver (or, for a static method, a first argument) that satisfies `isDependentOnInvariant()` but not `isExprInvariant()` confuses `buildConditionalTree()`. The direct method guard uses a "nonoverridden test," which is really just a comparison against a fake static that must be implemented using `vgnop`. But `buildConditionalTree()` expects either a VFT test or a method test. If it sees a nonoverridden test instead, it will treat it as a method test and try to call `getFirstChild()` three levels deep, which results in a crash because the first child of the nonoverridden test is nullary.

This commit makes no attempt to start versioning direct method guards in the same way as HCR guards. That can be done later if/when needed. Ideally, direct method guards will eventually be eliminated, and there will hopefully be no pressing need to version them in the meantime.

Fixes eclipse-openj9/openj9#14459