### PR TITLE
Enable zNext exploitation by default

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2607,7 +2607,6 @@ OMR::Options::jitPreProcess()
    self()->setOption(TR_EnableCodeCacheConsolidation);
 #endif
 
-   self()->setOption(TR_DisableZNext);
    // --------------------------------------------------------------------------
    // J9-only
    //


### PR DESCRIPTION
Signed-off-by: Rahil Shah <rahil@ca.ibm.com>