### PR TITLE
Use ZOSV2R2 since ZOSV1R13 is discontinued

### DIFF
--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,9 +114,9 @@ elseif(OMR_OS_LINUX)
 	)
 elseif(OMR_OS_ZOS)
 	set(OMR_ZOS_COMPILE_ARCHITECTURE "7" CACHE STRING "z/OS compile machine architecture")
-	set(OMR_ZOS_COMPILE_TARGET "zOSV1R13" CACHE STRING "z/OS compile target operating system")
+	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R2" CACHE STRING "z/OS compile target operating system")
 	set(OMR_ZOS_COMPILE_TUNE "10" CACHE STRING "z/OS compile machine architecture tuning")
-	set(OMR_ZOS_LINK_COMPAT "ZOSV1R13" CACHE STRING "z/OS link compatible operating system")
+	set(OMR_ZOS_LINK_COMPAT "ZOSV2R2" CACHE STRING "z/OS link compatible operating system")
 
 	# TODO: This should technically be -qhalt=w however c89 compiler used to compile the C sources does not like this
 	# flag. We'll need to investigate whether we actually need c89 for C sources or if we can use xlc and what to do

--- a/configure
+++ b/configure
@@ -1747,11 +1747,11 @@ Some influential environment variables:
   OMR_ZOS_COMPILE_ARCHITECTURE
               The z/OS compile machine architecture. (Default: 7)
   OMR_ZOS_COMPILE_TARGET
-              The z/OS compile target operating system. (Default: zOSV1R13)
+              The z/OS compile target operating system. (Default: ZOSV2R2)
   OMR_ZOS_COMPILE_TUNE
               The z/OS compile machine architecture tuning. (Default: 10)
   OMR_ZOS_LINK_COMPAT
-              The z/OS link compatible operating system. (Default: ZOSV1R13)
+              The z/OS link compatible operating system. (Default: ZOSV2R2)
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
@@ -2880,9 +2880,9 @@ OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"OMR"}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"0.1"}
 
 OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}
-OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"zOSV1R13"}
+OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"ZOSV2R2"}
 OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"10"}
-OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV1R13"}
+OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV2R2"}
 
 # Check whether --enable-optimized was given.
 if test "${enable_optimized+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2021 IBM Corp. and others
+# Copyright (c) 2015, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,11 +69,11 @@ AC_ARG_VAR([OMR_PRODUCT_DESCRIPTION],
 AC_ARG_VAR([OMR_ZOS_COMPILE_ARCHITECTURE],
   [The z/OS compile machine architecture. (Default: 7)])
 AC_ARG_VAR([OMR_ZOS_COMPILE_TARGET],
-  [The z/OS compile target operating system. (Default: zOSV1R13)])
+  [The z/OS compile target operating system. (Default: ZOSV2R2)])
 AC_ARG_VAR([OMR_ZOS_COMPILE_TUNE],
   [The z/OS compile machine architecture tuning. (Default: 10)])
 AC_ARG_VAR([OMR_ZOS_LINK_COMPAT],
-  [The z/OS link compatible operating system. (Default: ZOSV1R13)])
+  [The z/OS link compatible operating system. (Default: ZOSV2R2)])
 
 OMR_COMPANY_NAME=${OMR_COMPANY_NAME:-""}
 OMR_COMPANY_COPYRIGHT=${OMR_COMPANY_COPYRIGHT:-""}
@@ -82,9 +82,9 @@ OMR_PRODUCT_NAME=${OMR_PRODUCT_NAME:-"AC_PACKAGE_NAME"}
 OMR_PRODUCT_VERSION=${OMR_PRODUCT_VERSION:-"AC_PACKAGE_VERSION"}
 
 OMR_ZOS_COMPILE_ARCHITECTURE=${OMR_ZOS_COMPILE_ARCHITECTURE:-"7"}
-OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"zOSV1R13"}
+OMR_ZOS_COMPILE_TARGET=${OMR_ZOS_COMPILE_TARGET:-"ZOSV2R2"}
 OMR_ZOS_COMPILE_TUNE=${OMR_ZOS_COMPILE_TUNE:-"10"}
-OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV1R13"}
+OMR_ZOS_LINK_COMPAT=${OMR_ZOS_LINK_COMPAT:-"ZOSV2R2"}
 
 AC_ARG_ENABLE([optimized],
 	AS_HELP_STRING([--enable-optimized], [Create an optimized build. (Default: yes)]),

--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -63,12 +63,15 @@ endif # ENABLE_DDR
 ifeq ($(OMR_OPTIMIZE),1)
     COPTFLAGS=-O3 -Wc,"TUNE($(OMR_ZOS_COMPILE_TUNE))" -Wc,"inline(auto,noreport,600,5000)"
 
-    # OMRTODO: The COMPAT=ZOSV1R13 option does not appear to be related to
-    # optimizations.  This linker option is supplied only on the compile line,
+    # 28 Feb 2022: ZOSV2R2 is adopted since ZOSV1R13 is discontinued.
+    #
+    # Note: The COMPAT=ZOSV1R13 option does not appear to be related to
+    # optimizations. This linker option is supplied only on the compile line,
     # and never when we link. It might be relevant to note that this was added
     # at the same time as the compilation flag "-Wc,target=ZOSV1R10", which
     # would give a performance boost.
-    # option means: "COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs"
+    #
+    # COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs.
     # http://www-01.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab100/compat.htm
     COPTFLAGS+=-Wl,compat=$(OMR_ZOS_LINK_COMPAT)
 else


### PR DESCRIPTION
The following message is seen in every zOS PR build: "TARGET suboption
ZOSV1R13 is discontinued. Unexpected behavior might occur if an
out-of-support TARGET level is specified. Use a TARGET level of ZOSV2R2,
or later instead".

To fix the above issue, ZOSV2R2 should be adopted.

Related: https://github.com/eclipse/omr/issues/6368

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>