### PR TITLE
Check __cplusplus is defined before checking its value

### DIFF
--- a/compiler/codegen/CCData_inlines.hpp
+++ b/compiler/codegen/CCData_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2020 IBM Corp. and others
+ * Copyright (c) 2020, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #ifndef OMR_CCDATA_INLINES_INCL
 #define OMR_CCDATA_INLINES_INCL
 
-#if (__cplusplus >= 201103L)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #include <type_traits>
 #include "omrcomp.h"
 #endif
@@ -43,7 +43,7 @@ CCData::key_t CCData::key(const T value)
 template <typename T>
 bool CCData::put(const T value, const key_t * const key, index_t &index)
    {
-#if (__cplusplus >= 201103L)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
    static_assert(OMR_IS_TRIVIALLY_COPYABLE(T), "T must be trivially copyable.");
 #endif
    return put(&value, sizeof(value), alignof(value), key, index);
@@ -52,7 +52,7 @@ bool CCData::put(const T value, const key_t * const key, index_t &index)
 template <typename T>
 bool CCData::get(const index_t index, T &value) const
    {
-#if (__cplusplus >= 201103L)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
    static_assert(OMR_IS_TRIVIALLY_COPYABLE(T), "T must be trivially copyable.");
 #endif
    return get(index, &value, sizeof(value));

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -609,12 +609,12 @@ typedef struct U_128 {
 #define OMR_ALIGNOF(x) alignof(x)
 #endif /* defined(_MSC_VER) && (1900 > _MSC_VER) */
 
-#if (__cplusplus >= 201103L)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #if defined(__GNUC__) && (__GNUC__ < 5) /* GCC<=5 claims C++11 support but doesn't actually provide this trait; it does however provide a close enough extension. */
 #define OMR_IS_TRIVIALLY_COPYABLE(t) __has_trivial_copy(t)
 #else /* C++>=11 && (!GCC || GCC>=5) */
 #define OMR_IS_TRIVIALLY_COPYABLE(t) std::is_trivially_copyable<t>::value
 #endif /* defined(__GNUC__) && (__GNUC__ < 5) */
-#endif /* (__cplusplus >= 201103L) */
+#endif /* defined(__cplusplus) && (__cplusplus >= 201103L) */
 
 #endif /* OMRCOMP_H */


### PR DESCRIPTION
If __cplusplus isn't defined when omrcomp.h is included, it can cause a compiler warning to be emitted:

include_core/omrcomp.h:612:6: error: "__cplusplus" is not defined, evaluates to 0 [-Werror=undef]
  612 | #if (__cplusplus >= 201103L)