### PR TITLE
Access SubNodeList directly from TR_RegionStructure

### DIFF
--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -230,9 +230,10 @@ void TR_LoopUnroller::unrollLoopOnce(TR_RegionStructure *loop, TR_StructureSubGr
 
    //Create duplicates of all sub structures in the loop
    TR_RegionStructure::Cursor nodeIt(*loop);
-   TR_StructureSubGraphNode *subNode;
-   for (subNode = nodeIt.getFirst(); subNode; subNode = nodeIt.getNext())
+   TR_StructureSubGraphNode *subNode = NULL;
+   for (uint32_t index = 0; index < loop->numSubNodes() && index < static_cast<uint32_t>(_iteration); ++index)
       {
+      subNode = nodeIt.getNthNode(index);
       if (subNode->getNumber() >= _numNodes)
          continue; //clone only original nodes
 

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -611,9 +611,7 @@ class TR_RegionStructure : public TR_Structure
    SubNodeList::iterator begin() { return _subNodes.begin(); }
    SubNodeList::iterator end()   { return _subNodes.end();   }
 
-   // The Cursor provides an immutable view of the elements of the region unlike the normal iterators
-   // above, note that there is a non-trivial cost to this Cursor because it must copy the structure's
-   // sublist into itself for the purposes of isolation
+   // The Cursor provides a convenient view of the elements of the region
    class Cursor
       {
       public:
@@ -624,9 +622,10 @@ class TR_RegionStructure : public TR_Structure
       TR_StructureSubGraphNode * getNext()  { _iter++; return getCurrent(); }
       TR_StructureSubGraphNode * getFirst() { return getCurrent(); }
       void reset() { _iter = _nodes.begin(); }
+      TR_StructureSubGraphNode * getNthNode(uint32_t index) { TR_ASSERT(index < _nodes.size(), "Out of Range of SubNodeList"); return _nodes[index]; }
 
       private:
-      SubNodeList _nodes;
+      SubNodeList &_nodes;
       SubNodeList::iterator _iter;
       };
 


### PR DESCRIPTION
As discussed in [6328](https://github.com/eclipse/omr/issues/6328) Architecture meeting, we can access SubNodeList directly instead of Cursor in TR_RegionStructure to avoid the [copy cost](https://github.com/eclipse/omr/blob/master/compiler/optimizer/Structure.hpp#L614).

Signed-off-by: Tao Guan <james_mango@yahoo.com>