### PR TITLE
Remove deprecated x87 features

### DIFF
--- a/compiler/codegen/OMRRegisterDependency.hpp
+++ b/compiler/codegen/OMRRegisterDependency.hpp
@@ -54,7 +54,7 @@ class OMR_EXTENSIBLE RegisterDependencyGroup
 #if defined(OMR_ARCH_S390)
       : _numUses(0)
 #elif defined(OMR_ARCH_X86) /* defined(OMR_ARCH_S390) */
-      : _mayNeedToPopFPRegisters(false), _needToClearFPStack(false)
+      : _mayNeedToPopFPRegisters(false)
 #elif defined(__GNUC__) && !defined(__clang__) /* defined(OMR_ARCH_S390) */
       : _unused('\0')
 #endif /* defined(OMR_ARCH_S390) */
@@ -207,7 +207,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup
    int8_t _numUses;
 #elif defined(OMR_ARCH_X86) /* defined(OMR_ARCH_S390) */
    bool _mayNeedToPopFPRegisters;
-   bool _needToClearFPStack;
 #elif defined(__GNUC__) && !defined(__clang__) /* defined(OMR_ARCH_S390) */
    /* a flexible array cannot be the only member of a class */
    private:
@@ -313,7 +312,7 @@ class RegisterDependencyMap
       TR_ASSERT(&deps[index] == dep, "Dependency pointer/index mismatch!");
       addDependency(dep->getRealRegister(), dep->getRegister()->getAssignedRealRegister(), index);
       }
-   
+
    /** \brief
     *     Gets the dependency whose source (virtual register) is currently assigned to \param regNum.
     *
@@ -337,7 +336,7 @@ class RegisterDependencyMap
     *     The real register target to look for.
     *
     *  \return
-    *     The dependency whose target (real register) is \param regNum if such a dependency exists; <c>NULL</c> 
+    *     The dependency whose target (real register) is \param regNum if such a dependency exists; <c>NULL</c>
     *     otherwise.
     */
    TR::RegisterDependency* getDependencyWithTarget(TR::RealRegister::RegNum regNum)

--- a/compiler/codegen/OMRRegisterDependency.hpp
+++ b/compiler/codegen/OMRRegisterDependency.hpp
@@ -53,8 +53,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup
    RegisterDependencyGroup()
 #if defined(OMR_ARCH_S390)
       : _numUses(0)
-#elif defined(OMR_ARCH_X86) /* defined(OMR_ARCH_S390) */
-      : _mayNeedToPopFPRegisters(false)
 #elif defined(__GNUC__) && !defined(__clang__) /* defined(OMR_ARCH_S390) */
       : _unused('\0')
 #endif /* defined(OMR_ARCH_S390) */
@@ -205,8 +203,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup
 
 #if defined(OMR_ARCH_S390)
    int8_t _numUses;
-#elif defined(OMR_ARCH_X86) /* defined(OMR_ARCH_S390) */
-   bool _mayNeedToPopFPRegisters;
 #elif defined(__GNUC__) && !defined(__clang__) /* defined(OMR_ARCH_S390) */
    /* a flexible array cannot be the only member of a class */
    private:

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3283,17 +3283,17 @@ OMR::Node::getVirtualCallTreeForGuard()
    TR::TreeTop * callTree = NULL;
    TR::Compilation *comp = TR::comp();
    int32_t guardInlinedSiteIndex = guard->getInlinedSiteIndex();
-      
+
    if (guardInlinedSiteIndex < 0)
       {
       // EscapeAnalysis can create a guard with index -1
       // in that case, return conservative result
       return NULL;
       }
-   
+
    int32_t guardCallerIndex = comp->getInlinedCallSite(guardInlinedSiteIndex)._byteCodeInfo.getCallerIndex();
    uint32_t guardCallerByteCodeIndex = comp->getInlinedCallSite(guardInlinedSiteIndex)._byteCodeInfo.getByteCodeIndex();
-   
+
    while (1)
       {
       // Call node is not necessarily the first real tree top in the call block
@@ -3331,7 +3331,7 @@ OMR::Node::getVirtualCallTreeForGuard()
                callNode->getByteCodeIndex() != guardCallerByteCodeIndex ||
                !callNode->isTheVirtualCallNodeForAGuardedInlinedCall())
          {
-         return NULL;         
+         return NULL;
          }
       else
          {
@@ -7134,38 +7134,6 @@ OMR::Node::printSkipSignExtension()
    {
    return self()->skipSignExtension() ? "SkipSignExt " : "";
    }
-
-
-
-bool
-OMR::Node::needsPrecisionAdjustment()
-   {
-   TR_ASSERT(self()->getOpCodeValue() == TR::fRegLoad || self()->getOpCodeValue() == TR::dRegLoad, "Opcode must be FP global reg load");
-   return _flags.testAny(precisionAdjustment);
-   }
-
-void
-OMR::Node::setNeedsPrecisionAdjustment(bool v)
-   {
-   TR::Compilation * c = TR::comp();
-   TR_ASSERT(self()->getOpCodeValue() == TR::fRegLoad || self()->getOpCodeValue() == TR::dRegLoad, "Opcode must be FP global reg load");
-   if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting needsPrecisionAdjustment flag on node %p to %d\n", self(), v))
-      _flags.set(precisionAdjustment, v);
-   }
-
-bool
-OMR::Node::chkNeedsPrecisionAdjustment()
-   {
-   return (self()->getOpCodeValue() == TR::fRegLoad || self()->getOpCodeValue() == TR::dRegLoad) && _flags.testAny(precisionAdjustment);
-   }
-
-const char *
-OMR::Node::printNeedsPrecisionAdjustment()
-   {
-   return self()->chkNeedsPrecisionAdjustment() ? "precisionAdjustment " : "";
-   }
-
-
 
 bool
 OMR::Node::isUseBranchOnCount()

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1347,12 +1347,6 @@ public:
    bool skipSignExtension();
    void setSkipSignExtension(bool b);
    const char * printSkipSignExtension();
-
-   // Flag used by FP regLoad/regStore
-   bool needsPrecisionAdjustment();
-   void setNeedsPrecisionAdjustment(bool v);
-   bool chkNeedsPrecisionAdjustment();
-   const char * printNeedsPrecisionAdjustment();
 
    // Flag used by TR_if or TR::istore/TR::iRegStore or TR::iadd, TR::ladd, TR::isub, TR::lsub
    bool isUseBranchOnCount();

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1029,7 +1029,6 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    output.append(format, node->printIsArrayChkReferenceArray1());
    output.append(format, node->printIsArrayChkPrimitiveArray2());
    output.append(format, node->printIsArrayChkReferenceArray2());
-   output.append(format, node->printNeedsPrecisionAdjustment());
    output.append(format, node->printIsSignExtendedTo32BitAtSource());
    output.append(format, node->printIsSignExtendedTo64BitAtSource());
    output.append(format, node->printIsZeroExtendedTo32BitAtSource());

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -742,9 +742,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    cg()->decReferenceCount(firstChild);
    cg()->decReferenceCount(secondChild);
 
-   if (deps)
-      deps->setMayNeedToPopFPRegisters(true);
-
    if (!popRegisters.isEmpty())
       {
       ListIterator<TR::Register> popRegsIt(&popRegisters);
@@ -948,9 +945,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
 
    cg()->decReferenceCount(firstChild);
    cg()->decReferenceCount(secondChild);
-
-   if (deps)
-      deps->setMayNeedToPopFPRegisters(true);
 
    if (!popRegisters.isEmpty())
       {

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -450,7 +450,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    TR::MemoryReference               *highMR           = NULL;
    TR::RegisterDependencyConditions  *deps             = NULL;
    uint32_t                           numAdditionalRegDeps = 5;
-   List<TR::Register>                 popRegisters(cg()->trMemory());
 
    if (getCmpReg1Mem2())
       {
@@ -475,7 +474,7 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
       //
       TR::Node *third = root->getChild(2);
       cg()->evaluate(third);
-      deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps, &popRegisters);
+      deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps);
       }
    else
       {
@@ -741,16 +740,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
 
    cg()->decReferenceCount(firstChild);
    cg()->decReferenceCount(secondChild);
-
-   if (!popRegisters.isEmpty())
-      {
-      ListIterator<TR::Register> popRegsIt(&popRegisters);
-      for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-         {
-         generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, root, popRegister, popRegister, cg());
-         cg()->stopUsingRegister(popRegister);
-         }
-      }
    }
 
 void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node        *root,
@@ -801,7 +790,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
    TR::MemoryReference               *highMR               = NULL;
    bool                               createdFirstLabel    = (firstBranchLabel == NULL ? true : false);
    uint32_t                           numAdditionalRegDeps = 5;
-   List<TR::Register>                 popRegisters(cg()->trMemory());
 
    if (getCmpReg1Mem2())
       {
@@ -827,11 +815,11 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
       if (firstBranchLabel == NULL)
          {
          firstBranchLabel = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
-         deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps, &popRegisters);
+         deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps);
          }
       else
          {
-         deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps, &popRegisters);
+         deps = generateRegisterDependencyConditions(third, cg(), numAdditionalRegDeps);
          }
       }
    else
@@ -945,16 +933,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
 
    cg()->decReferenceCount(firstChild);
    cg()->decReferenceCount(secondChild);
-
-   if (!popRegisters.isEmpty())
-      {
-      ListIterator<TR::Register> popRegsIt(&popRegisters);
-      for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-         {
-         generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, root, popRegister, popRegister, cg());
-         cg()->stopUsingRegister(popRegister);
-         }
-      }
    }
 
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2311,11 +2311,6 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
    cg->recursivelyDecReferenceCount(node->getFirstChild());
    cg->recursivelyDecReferenceCount(node->getSecondChild());
 
-   if (deps)
-      {
-      deps->setMayNeedToPopFPRegisters(true);
-      }
-
    if (!popRegisters.isEmpty())
       {
       ListIterator<TR::Register> popRegsIt(&popRegisters);

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1298,7 +1298,6 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
          TR::Node *third = node->getChild(2);
          cg->evaluate(third);
          deps = generateRegisterDependencyConditions(third, cg, 1, &popRegisters);
-         deps->setMayNeedToPopFPRegisters(true);
          deps->stopAddingConditions();
          }
       }
@@ -1319,7 +1318,7 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
          // on the last one.
          //
          TR::RegisterDependencyConditions  *deps1 = NULL;
-         if (deps && deps->getPreConditions() && deps->getPreConditions()->getMayNeedToPopFPRegisters())
+         if (deps && deps->getPreConditions())
             {
             deps1 = deps->clone(cg);
             deps1->setNumPostConditions(0, cg->trMemory());
@@ -1353,7 +1352,7 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
          fallThroughLabel->setEndInternalControlFlow();
 
          TR::RegisterDependencyConditions  *deps1 = NULL;
-         if (deps && deps->getPreConditions() && deps->getPreConditions()->getMayNeedToPopFPRegisters())
+         if (deps && deps->getPreConditions())
             {
             deps1 = deps->clone(cg);
             deps1->setNumPostConditions(0, cg->trMemory());

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1287,7 +1287,6 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
       bool generateBranch,
       TR::CodeGenerator *cg)
    {
-   List<TR::Register> popRegisters(cg->trMemory());
    TR::Register *targetRegister = NULL;
    TR::RegisterDependencyConditions *deps = NULL;
 
@@ -1297,7 +1296,7 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
          {
          TR::Node *third = node->getChild(2);
          cg->evaluate(third);
-         deps = generateRegisterDependencyConditions(third, cg, 1, &popRegisters);
+         deps = generateRegisterDependencyConditions(third, cg, 1);
          deps->stopAddingConditions();
          }
       }
@@ -1389,16 +1388,6 @@ TR::Register *OMR::X86::TreeEvaluator::generateBranchOrSetOnFPCompare(
          cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
          generateRegInstruction(op, node, targetRegister, cg);
          generateRegRegInstruction(TR::InstOpCode::MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
-         }
-      }
-
-   if (!popRegisters.isEmpty())
-      {
-      ListIterator<TR::Register> popRegsIt(&popRegisters);
-      for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-         {
-         generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, node, popRegister, popRegister, cg);
-         cg->stopUsingRegister(popRegister);
          }
       }
 

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -2400,16 +2400,6 @@ TR::Register *OMR::X86::Machine::fpStackPop()
    }
 
 
-// Pop every value off the FP stack.
-//
-void OMR::X86::Machine::popEntireStack()
-   {
-   int32_t topOfStack = self()->getFPTopOfStack();
-   for (int32_t i = 0; i < topOfStack+1; i++)
-      self()->fpStackPop();
-   }
-
-
 // Exchange a register with the top register on the FP stack.
 // It is assumed that both registers of interest are on the FP stack.
 //

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -253,7 +253,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    void fpStackPush(TR::Register *virtReg);
    void fpStackCoerce(TR::Register *virtReg, int32_t location);
    TR::Register *fpStackPop();
-   void popEntireStack();
 
    TR::Instruction  *fpStackFXCH(TR::Instruction *currentInstruction,
                                    TR::Register    *virtReg,

--- a/compiler/x/codegen/OMRRegister.cpp
+++ b/compiler/x/codegen/OMRRegister.cpp
@@ -18,11 +18,3 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-#include "codegen/Register.hpp"
-
-void
-OMR::X86::Register::resetMayNeedPrecisionAdjustment()
-    {
-    _flags.reset(MayNeedPrecisionAdjustment);
-    }

--- a/compiler/x/codegen/OMRRegister.cpp
+++ b/compiler/x/codegen/OMRRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,15 +22,7 @@
 #include "codegen/Register.hpp"
 
 void
-OMR::X86::Register::setNeedsPrecisionAdjustment()
-   {
-   _flags.set(NeedsPrecisionAdjustment);
-   TR_ASSERT(self()->mayNeedPrecisionAdjustment(), "setNeedsPrecisionAdjustment: precision adjustment flags must be consistent");
-   }
-
-void
 OMR::X86::Register::resetMayNeedPrecisionAdjustment()
     {
     _flags.reset(MayNeedPrecisionAdjustment);
-    TR_ASSERT(!self()->needsPrecisionAdjustment(), "resetMayNeedPrecisionAdjustment: precision adjustment flags must be consistent");
     }

--- a/compiler/x/codegen/OMRRegister.hpp
+++ b/compiler/x/codegen/OMRRegister.hpp
@@ -79,10 +79,6 @@ class OMR_EXTENSIBLE Register: public OMR::Register
     * Method for manipulating flags
     */
 
-   bool mayNeedPrecisionAdjustment()      {return _flags.testAny(MayNeedPrecisionAdjustment);}
-   void setMayNeedPrecisionAdjustment()   {_flags.set(MayNeedPrecisionAdjustment);}
-   void resetMayNeedPrecisionAdjustment();
-
    bool hasBetterSpillPlacement()          {return _flags.testAny(HasBetterSpillPlacement);}
    void setHasBetterSpillPlacement(bool v) {if (v) _flags.set(HasBetterSpillPlacement); else _flags.reset(HasBetterSpillPlacement);}
 
@@ -108,9 +104,7 @@ class OMR_EXTENSIBLE Register: public OMR::Register
    enum
       {
       // AVAILABLE                  = 0x0002,
-      MayNeedPrecisionAdjustment    = 0x0004, // IA32 flag that indicates that a store/reload of
-                                              // the value in this register may be required before
-                                              // it can be used in an FP-strict expression.
+      // AVAILABLE                  = 0x0004,
       NeedsLazyClobbering           = 0x0800, // X86 service releases only (well, originally the intent): node refcount = 1 is not enough to determine that this can be clobbered; must also check register node count
       UpperBitsAreZero              = 0x2000, // AMD64 many 32bit operations clear the upper bits
       HasBetterSpillPlacement       = 0x0100,

--- a/compiler/x/codegen/OMRRegister.hpp
+++ b/compiler/x/codegen/OMRRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,9 +78,6 @@ class OMR_EXTENSIBLE Register: public OMR::Register
    /*
     * Method for manipulating flags
     */
-   bool needsPrecisionAdjustment()      {return _flags.testAny(NeedsPrecisionAdjustment);}
-   void setNeedsPrecisionAdjustment();
-   void resetNeedsPrecisionAdjustment() {_flags.reset(NeedsPrecisionAdjustment);}
 
    bool mayNeedPrecisionAdjustment()      {return _flags.testAny(MayNeedPrecisionAdjustment);}
    void setMayNeedPrecisionAdjustment()   {_flags.set(MayNeedPrecisionAdjustment);}
@@ -110,11 +107,7 @@ class OMR_EXTENSIBLE Register: public OMR::Register
 
    enum
       {
-      NeedsPrecisionAdjustment      = 0x0002, // IA32 flag that indicates that a store/reload of
-                                              // the value in this register is required before
-                                              // it can be used in further computations. Required
-                                              // for single-precision FP registers (unless method
-                                              // is in single precision mode).
+      // AVAILABLE                  = 0x0002,
       MayNeedPrecisionAdjustment    = 0x0004, // IA32 flag that indicates that a store/reload of
                                               // the value in this register may be required before
                                               // it can be used in an FP-strict expression.

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -474,34 +474,23 @@ void OMR::X86::RegisterDependencyConditions::setMayNeedToPopFPRegisters(bool b)
       _postConditions->setMayNeedToPopFPRegisters(b);
    }
 
-void OMR::X86::RegisterDependencyConditions::setNeedToClearFPStack(bool b)
-   {
-   if (_preConditions)
-      _preConditions->setNeedToClearFPStack(b);
-   else
-      {
-      if (_postConditions)
-         _postConditions->setNeedToClearFPStack(b);
-      }
-   }
-
 TR::RegisterDependency *OMR::X86::RegisterDependencyConditions::findPreCondition (TR::Register *vr)
    {
    return _preConditions ->findDependency(vr, _addCursorForPre );
    }
 
 TR::RegisterDependency *OMR::X86::RegisterDependencyConditions::findPostCondition(TR::Register *vr)
-   { 
+   {
    return _postConditions->findDependency(vr, _addCursorForPost);
    }
-   
+
 TR::RegisterDependency *OMR::X86::RegisterDependencyConditions::findPreCondition (TR::RealRegister::RegNum rr)
-   { 
+   {
    return _preConditions ->findDependency(rr, _addCursorForPre );
    }
 
 TR::RegisterDependency *OMR::X86::RegisterDependencyConditions::findPostCondition(TR::RealRegister::RegNum rr)
-   { 
+   {
    return _postConditions->findDependency(rr, _addCursorForPost);
    }
 
@@ -715,7 +704,7 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction   *curre
    TR::RealRegister         *bestFreeRealReg      = NULL;
    TR::RealRegister::RegNum  bestFreeRealRegIndex = TR::RealRegister::NoReg;
    bool                      changed;
-   
+
    TR::Compilation *comp = cg->comp();
 
    TR::Machine *machine = cg->machine();

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -466,14 +466,6 @@ uint32_t OMR::X86::RegisterDependencyConditions::setNumPostConditions(uint32_t n
    return (_numPostConditions = n);
    }
 
-void OMR::X86::RegisterDependencyConditions::setMayNeedToPopFPRegisters(bool b)
-   {
-   if (_preConditions)
-      _preConditions->setMayNeedToPopFPRegisters(b);
-   if (_postConditions)
-      _postConditions->setMayNeedToPopFPRegisters(b);
-   }
-
 TR::RegisterDependency *OMR::X86::RegisterDependencyConditions::findPreCondition (TR::Register *vr)
    {
    return _preConditions ->findDependency(vr, _addCursorForPre );

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -86,8 +86,7 @@ OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(uint16_t nu
 OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(
       TR::Node *node,
       TR::CodeGenerator *cg,
-      uint16_t additionalRegDeps,
-      List<TR::Register> *popRegisters)
+      uint16_t additionalRegDeps)
    :_numPreConditions(-1),_numPostConditions(-1),
     _addCursorForPre(0),_addCursorForPost(0)
    {
@@ -1288,5 +1287,5 @@ generateRegisterDependencyConditions(TR::Node           *node,
                                      uint32_t           additionalRegDeps,
                                      List<TR::Register> *popRegisters)
    {
-   return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(node, cg, additionalRegDeps, popRegisters);
+   return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(node, cg, additionalRegDeps);
    }

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -102,9 +102,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
                           uint32_t          numberOfRegisters,
                           TR::CodeGenerator *cg);
 
-   void setMayNeedToPopFPRegisters(bool b) {_mayNeedToPopFPRegisters = b;}
-   bool getMayNeedToPopFPRegisters() {return _mayNeedToPopFPRegisters;}
-
    void blockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    void unblockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    };
@@ -143,8 +140,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    TR::RegisterDependencyConditions  *clone(TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0);
 
    TR::RegisterDependencyGroup *getPreConditions()  {return _preConditions;}
-
-   void setMayNeedToPopFPRegisters(bool b);
 
    uint32_t getNumPreConditions() {return _numPreConditions;}
 

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -133,7 +133,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
    RegisterDependencyConditions(uint16_t numPreConds, uint16_t numPostConds, TR_Memory * m);
 
-   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint16_t additionalRegDeps = 0, List<TR::Register> * = 0);
+   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint16_t additionalRegDeps = 0);
 
    void unionNoRegPostCondition(TR::Register *reg, TR::CodeGenerator *cg);
 

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -105,9 +105,6 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
    void setMayNeedToPopFPRegisters(bool b) {_mayNeedToPopFPRegisters = b;}
    bool getMayNeedToPopFPRegisters() {return _mayNeedToPopFPRegisters;}
 
-   void setNeedToClearFPStack(bool b) {_needToClearFPStack = b;}
-   bool getNeedToClearFPStack() {return _needToClearFPStack;}
-
    void blockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    void unblockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    };
@@ -148,8 +145,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    TR::RegisterDependencyGroup *getPreConditions()  {return _preConditions;}
 
    void setMayNeedToPopFPRegisters(bool b);
-
-   void setNeedToClearFPStack(bool b);
 
    uint32_t getNumPreConditions() {return _numPreConditions;}
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3397,8 +3397,6 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
       if (inst->getDependencyConditions())
          inst->getDependencyConditions()->setMayNeedToPopFPRegisters(true);
 
-      inst->setNeedToClearFPStack(true);
-
       node->getLabel()->setInstruction(inst);
       block->setFirstInstruction(inst);
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3356,7 +3356,6 @@ TR::Register *OMR::X86::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR::
 TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Block *block = node->getBlock();
-   List<TR::Register> popRegisters(cg->trMemory());
    TR::Compilation *comp = cg->comp();
 
    cg->setCurrentBlock(block);
@@ -3390,7 +3389,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
          }
 
       if (node->getNumChildren() > 0)
-         inst = generateLabelInstruction(TR::InstOpCode::label, node, label, node->getFirstChild(), &popRegisters, cg);
+         inst = generateLabelInstruction(TR::InstOpCode::label, node, label, node->getFirstChild(), true, cg);
       else
          inst = generateLabelInstruction(TR::InstOpCode::label, node, node->getLabel(), cg);
 
@@ -3421,16 +3420,6 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
       }
 
    cg->generateDebugCounter((node->getBlock()->isExtensionOfPreviousBlock())? "cg.blocks/extensions":"cg.blocks", 1, TR::DebugCounter::Exorbitant);
-
-   if (!popRegisters.isEmpty())
-      {
-      ListIterator<TR::Register> popRegsIt(&popRegisters);
-      for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-         {
-         generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, node, popRegister, popRegister, cg);
-         cg->stopUsingRegister(popRegister);
-         }
-      }
 
    if (block->isCatchBlock())
       {
@@ -3472,7 +3461,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGe
       // This label is also used by RegisterDependency to detect the end of a block.
       TR::Instruction *labelInst = NULL;
       if (node->getNumChildren() > 0)
-         labelInst = generateLabelInstruction(TR::InstOpCode::label, node, generateLabelSymbol(cg), node->getFirstChild(), NULL, cg);
+         labelInst = generateLabelInstruction(TR::InstOpCode::label, node, generateLabelSymbol(cg), node->getFirstChild(), true, cg);
       else
          labelInst = generateLabelInstruction(TR::InstOpCode::label, node, generateLabelSymbol(cg), cg);
 
@@ -3931,8 +3920,7 @@ OMR::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       {
       GRANode = fallThroughNode->getFirstChild();
       cg->evaluate(GRANode);
-      List<TR::Register> popRegisters(cg->trMemory());
-      fallThroughConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+      fallThroughConditions = generateRegisterDependencyConditions(GRANode, cg, 0);
       cg->decReferenceCount(GRANode);
       }
 
@@ -3940,8 +3928,7 @@ OMR::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       {
       GRANode = persistentFailureNode->getFirstChild();
       cg->evaluate(GRANode);
-      List<TR::Register> popRegisters(cg->trMemory());
-      persistentConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+      persistentConditions = generateRegisterDependencyConditions(GRANode, cg, 0);
       cg->decReferenceCount(GRANode);
       }
 
@@ -3949,8 +3936,7 @@ OMR::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       {
       GRANode = transientFailureNode->getFirstChild();
       cg->evaluate(GRANode);
-      List<TR::Register> popRegisters(cg->trMemory());
-      transientConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+      transientConditions = generateRegisterDependencyConditions(GRANode, cg, 0);
       cg->decReferenceCount(GRANode);
       }
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3394,9 +3394,6 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
       else
          inst = generateLabelInstruction(TR::InstOpCode::label, node, node->getLabel(), cg);
 
-      if (inst->getDependencyConditions())
-         inst->getDependencyConditions()->setMayNeedToPopFPRegisters(true);
-
       node->getLabel()->setInstruction(inst);
       block->setFirstInstruction(inst);
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -3814,7 +3814,6 @@ generateLabelInstruction(TR::InstOpCode::Mnemonic     opCode,
                          TR::Node           *node,
                          TR::LabelSymbol     *label,
                          TR::Node           *glRegDep,
-                         List<TR::Register> *popRegisters,
                          bool               evaluateGlRegDeps,
                          TR::CodeGenerator *cg)
    {
@@ -3827,7 +3826,7 @@ generateLabelInstruction(TR::InstOpCode::Mnemonic     opCode,
       generateLabelInstruction(opCode,
                                node,
                                label,
-                               generateRegisterDependencyConditions(glRegDep, cg, 0, popRegisters),
+                               generateRegisterDependencyConditions(glRegDep, cg, 0),
                                cg);
 
    return instr;
@@ -3854,7 +3853,6 @@ generateJumpInstruction(
                                       jumpNode,
                                       destinationLabel,
                                       jumpNode->getFirstChild(),
-                                      0,
                                       evaluateGlRegDeps,
                                       cg) :
              inst = generateLabelInstruction(opCode,
@@ -3876,22 +3874,8 @@ generateConditionalJumpInstruction(
 
    if (ifNode->getNumChildren() == 3)
       {
-      List<TR::Register> popRegisters(cg->trMemory());
       TR::Node* glRegDep = ifNode->getChild(2);
-      inst = generateLabelInstruction(opCode, ifNode, destinationLabel, glRegDep, &popRegisters, cg);
-
-      if (!popRegisters.isEmpty())
-         {
-         ListIterator<TR::Register> popRegsIt(&popRegisters);
-         for (TR::Register *popRegister = popRegsIt.getFirst();
-              popRegister != NULL;
-              popRegister = popRegsIt.getNext())
-            {
-            generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, ifNode, popRegister, popRegister,
-            cg);
-            cg->stopUsingRegister(popRegister);
-            }
-         }
+      inst = generateLabelInstruction(opCode, ifNode, destinationLabel, glRegDep, true, cg);
       }
    else
       {

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -153,10 +153,9 @@ TR::RealRegister *assignGPRegister(TR::Instruction   *instr,
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86LabelInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
-void TR::X86LabelInstruction::initialize(TR::LabelSymbol* sym, bool b)
+void TR::X86LabelInstruction::initialize(TR::LabelSymbol *sym)
    {
    _symbol = sym;
-   _needToClearFPStack = b;
    _outlinedInstructionBranch = NULL;
    _reloType = TR_NoRelocation;
    _permitShortening = true;
@@ -169,43 +168,39 @@ void TR::X86LabelInstruction::initialize(TR::LabelSymbol* sym, bool b)
 TR::X86LabelInstruction::X86LabelInstruction(TR::InstOpCode::Mnemonic      op,
                                              TR::Node*          node,
                                              TR::LabelSymbol*   sym,
-                                             TR::CodeGenerator* cg,
-                                             bool               b)
+                                             TR::CodeGenerator* cg)
   : TR::Instruction(node, op, cg)
    {
-   initialize(sym, b);
+   initialize(sym);
    }
 
 TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction*   precedingInstruction,
                                              TR::InstOpCode::Mnemonic      op,
                                              TR::LabelSymbol*   sym,
-                                             TR::CodeGenerator* cg,
-                                             bool               b)
+                                             TR::CodeGenerator* cg)
   : TR::Instruction(op, precedingInstruction, cg)
    {
-   initialize(sym, b);
+   initialize(sym);
    }
 
 TR::X86LabelInstruction::X86LabelInstruction(TR::InstOpCode::Mnemonic                     op,
                                              TR::Node*                         node,
                                              TR::LabelSymbol*                  sym,
                                              TR::RegisterDependencyConditions* cond,
-                                             TR::CodeGenerator*                cg,
-                                             bool                              b)
+                                             TR::CodeGenerator*                cg)
   : TR::Instruction(cond, node, op, cg)
    {
-   initialize(sym, b);
+   initialize(sym);
    }
 
 TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction*                  precedingInstruction,
                                              TR::InstOpCode::Mnemonic                     op,
                                              TR::LabelSymbol*                  sym,
                                              TR::RegisterDependencyConditions* cond,
-                                             TR::CodeGenerator*                cg,
-                                             bool                              b)
+                                             TR::CodeGenerator*                cg)
   : TR::Instruction(cond, op, precedingInstruction, cg)
    {
-   initialize(sym, b);
+   initialize(sym);
    }
 
 TR::X86LabelInstruction  *TR::X86LabelInstruction::getX86LabelInstruction()
@@ -263,10 +258,6 @@ void TR::X86LabelInstruction::addPostDepsToOutlinedInstructionsBranch()
 void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
    TR::Compilation *comp = cg()->comp();
-   if (getNeedToClearFPStack())
-      {
-      cg()->machine()->popEntireStack();
-      }
 
    if (kindsToBeAssigned & TR_GPR_Mask)
       {

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -3880,11 +3880,6 @@ generateConditionalJumpInstruction(
       TR::Node* glRegDep = ifNode->getChild(2);
       inst = generateLabelInstruction(opCode, ifNode, destinationLabel, glRegDep, &popRegisters, cg);
 
-      if (inst->getDependencyConditions())
-         {
-         inst->getDependencyConditions()->setMayNeedToPopFPRegisters(true);
-         }
-
       if (!popRegisters.isEmpty())
          {
          ListIterator<TR::Register> popRegsIt(&popRegisters);

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -2923,11 +2923,9 @@ TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op,
 TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *prev, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
 TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
 TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *i, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
-TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::LabelSymbol *sym, TR::Node * glRegDep, List<TR::Register> *popRegs, bool evaluateGlRegDeps, TR::CodeGenerator *cg);
-inline TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::Node * glRegDep, List<TR::Register> *popRegs, TR::CodeGenerator *cg)
-   { return generateLabelInstruction(op, node, sym, glRegDep, popRegs, true, cg); }
-inline TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::Node * glRegDep, TR::CodeGenerator *cg)
-   { return generateLabelInstruction(op, node, sym, glRegDep, 0, true, cg); }
+
+TR::X86LabelInstruction  * generateLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::LabelSymbol *sym, TR::Node * glRegDep, bool evaluateGlRegDeps, TR::CodeGenerator *cg);
+
 TR::X86LabelInstruction  * generateLongLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
 TR::X86LabelInstruction  * generateLongLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
 

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -304,17 +304,16 @@ class X86LabelInstruction : public TR::Instruction
    {
    TR::LabelSymbol *_symbol;
    TR::X86LabelInstruction *_outlinedInstructionBranch;
-   bool _needToClearFPStack;
    uint8_t _reloType;
    bool _permitShortening;
-   void initialize(TR::LabelSymbol *sym, bool b);
+   void initialize(TR::LabelSymbol *sym);
 
    public:
 
-   X86LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::LabelSymbol *sym, TR::CodeGenerator *cg, bool b = false);
-   X86LabelInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::CodeGenerator *cg, bool b = false);
-   X86LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, bool b = false);
-   X86LabelInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, bool b = false);
+   X86LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
+   X86LabelInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
+   X86LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg);
+   X86LabelInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg);
 
    void prohibitShortening() { _permitShortening = false; }
 
@@ -329,9 +328,6 @@ class X86LabelInstruction : public TR::Instruction
 
    TR::LabelSymbol *getLabelSymbol()                    {return _symbol;}
    TR::LabelSymbol *setLabelSymbol(TR::LabelSymbol *sym) {return (_symbol = sym);}
-
-   bool getNeedToClearFPStack()             {return _needToClearFPStack;}
-   void setNeedToClearFPStack(bool b)       {_needToClearFPStack = b;}
 
    virtual TR::Snippet *getSnippetForGC();
    virtual uint8_t    *generateBinaryEncoding();

--- a/compiler/x/codegen/RegisterDependency.hpp
+++ b/compiler/x/codegen/RegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,6 @@ class TR_Memory;
 namespace TR { class CodeGenerator; }
 namespace TR { class Node; }
 namespace TR { class Register; }
-template <typename ListKind> class List;
 
 namespace TR
 {
@@ -45,8 +44,8 @@ class RegisterDependencyConditions : public OMR::RegisterDependencyConditionsCon
    RegisterDependencyConditions(uint32_t numPreConds, uint32_t numPostConds, TR_Memory * m) :
       OMR::RegisterDependencyConditionsConnector(numPreConds, numPostConds, m) {}
 
-   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0, List<TR::Register> *reglist = 0) :
-      OMR::RegisterDependencyConditionsConnector(node, cg, additionalRegDeps, reglist) {}
+   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0) :
+      OMR::RegisterDependencyConditionsConnector(node, cg, additionalRegDeps) {}
 
    };
 }

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -250,9 +250,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
 
       generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
 
-      if (deps)
-         deps->setMayNeedToPopFPRegisters(true);
-
       if (!popRegisters.isEmpty())
          {
          ListIterator<TR::Register> popRegsIt(&popRegisters);
@@ -5718,7 +5715,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             TR::Node *third = node->getChild(2);
             cg->evaluate(third);
             deps = generateRegisterDependencyConditions(third, cg, 2, &popRegisters);
-            deps->setMayNeedToPopFPRegisters(true);
             deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
             deps->stopAddingConditions();
@@ -5846,7 +5842,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             TR::Node *third = node->getChild(2);
             cg->evaluate(third);
             deps = generateRegisterDependencyConditions(third, cg, 1, &popRegisters);
-            deps->setMayNeedToPopFPRegisters(true);
             deps->stopAddingConditions();
             generateLabelInstruction(TR::InstOpCode::JNE4, node, destinationLabel, deps, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -5352,7 +5352,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::Co
       }
 
    target->setMayNeedPrecisionAdjustment();
-   target->setNeedsPrecisionAdjustment();
    cg->stopUsingRegister(target);
 
    target = coerceST0ToFPR(node, TR::Float, cg);
@@ -5388,7 +5387,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::Co
       }
 
    target->setMayNeedPrecisionAdjustment();
-   target->setNeedsPrecisionAdjustment();
    cg->stopUsingRegister(target);
 
    target = coerceST0ToFPR(node, TR::Double, cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -213,7 +213,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
       TR::LabelSymbol *startLabel       = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol *doneLabel        = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol *destinationLabel = node->getBranchDestination()->getNode()->getLabel();
-      List<TR::Register> popRegisters(cg->trMemory());
 
       startLabel->setStartInternalControlFlow();
       doneLabel->setEndInternalControlFlow();
@@ -226,7 +225,7 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          {
          TR::Node *third = node->getChild(2);
          cg->evaluate(third);
-         deps = generateRegisterDependencyConditions(third, cg, 2, &popRegisters);
+         deps = generateRegisterDependencyConditions(third, cg, 2);
          deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
          deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
          deps->stopAddingConditions();
@@ -249,16 +248,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          }
 
       generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
-
-      if (!popRegisters.isEmpty())
-         {
-         ListIterator<TR::Register> popRegsIt(&popRegisters);
-         for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-            {
-            generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, node, popRegister, popRegister, cg);
-            cg->stopUsingRegister(popRegister);
-            }
-         }
 
       cg->decReferenceCount(firstChild);
       cg->decReferenceCount(secondChild);
@@ -5690,7 +5679,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
          }
       else
          {
-         List<TR::Register>  popRegisters(cg->trMemory());
          TR::LabelSymbol     *startLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol     *doneLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
@@ -5710,7 +5698,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             {
             TR::Node *third = node->getChild(2);
             cg->evaluate(third);
-            deps = generateRegisterDependencyConditions(third, cg, 2, &popRegisters);
+            deps = generateRegisterDependencyConditions(third, cg, 2);
             deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
             deps->stopAddingConditions();
@@ -5730,16 +5718,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             }
 
          generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
-
-         if (!popRegisters.isEmpty())
-            {
-            ListIterator<TR::Register> popRegsIt(&popRegisters);
-            for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-               {
-               generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, node, popRegister, popRegister, cg);
-               cg->stopUsingRegister(popRegister);
-               }
-            }
          }
 
       cg->decReferenceCount(firstChild);
@@ -5762,7 +5740,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
    if (secondChild->getOpCodeValue() == TR::lconst &&
        secondChild->getRegister() == NULL)
       {
-      List<TR::Register>                    popRegisters(cg->trMemory());
       int32_t                              lowValue    = secondChild->getLongIntLow();
       int32_t                              highValue   = secondChild->getLongIntHigh();
       TR::Node                             *firstChild  = node->getFirstChild();
@@ -5837,22 +5814,12 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             {
             TR::Node *third = node->getChild(2);
             cg->evaluate(third);
-            deps = generateRegisterDependencyConditions(third, cg, 1, &popRegisters);
+            deps = generateRegisterDependencyConditions(third, cg, 1);
             deps->stopAddingConditions();
             generateLabelInstruction(TR::InstOpCode::JNE4, node, destinationLabel, deps, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);
             generateLabelInstruction(TR::InstOpCode::JNE4, node, destinationLabel, deps, cg);
             cg->decReferenceCount(third);
-
-            if (!popRegisters.isEmpty())
-               {
-               ListIterator<TR::Register> popRegsIt(&popRegisters);
-               for (TR::Register *popRegister = popRegsIt.getFirst(); popRegister != NULL; popRegister = popRegsIt.getNext())
-                  {
-                  generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, node, popRegister, popRegister, cg);
-                  cg->stopUsingRegister(popRegister);
-                  }
-               }
             }
          else
             {

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -5351,7 +5351,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       }
 
-   target->setMayNeedPrecisionAdjustment();
    cg->stopUsingRegister(target);
 
    target = coerceST0ToFPR(node, TR::Float, cg);
@@ -5386,7 +5385,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::Co
       cg->decReferenceCount(child);
       }
 
-   target->setMayNeedPrecisionAdjustment();
    cg->stopUsingRegister(target);
 
    target = coerceST0ToFPR(node, TR::Double, cg);


### PR DESCRIPTION
* Remove deprecated needToClearFPStack and related functions
* Remove deprecated _mayNeedToPopFPRegisters
* Remove NeedsPrecisionAdjustment Node flag
* Remove mayNeedPrecisionAdjustment register flag
* Remove popRegisters List from RegisterDependency API