### PR TITLE
Misc. improvements to JIT logging pathlength

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1109,7 +1109,6 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
                           symRefName(this),
                           symRefKind(this),
                           otherInfo(this),
-                          symRefWCodeId(this),
                           symRefObjIndex(this),
                           labelSymbol(this);
 
@@ -1269,9 +1268,9 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
        output.appendf("%s:%*s", symRefNum.getStr(), numSpaces, "");
 
        if (hideHelperMethodInfo)
-          output.appendf(" %s%s[%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefOffset.getStr(), symRefObjIndex.getStr());
+          output.appendf(" %s[%s]%s", labelSymbol.getStr(), symRefOffset.getStr(), symRefObjIndex.getStr());
        else
-          output.appendf(" %s%s%s[%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ",
+          output.appendf(" %s%s[%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ",
                 symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
 
        output.appendf(" [%s]", symRefAddress.getStr());
@@ -1288,10 +1287,10 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
    else
       {
       if (hideHelperMethodInfo)
-         output.appendf(" %s%s[%s%s%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(),
+         output.appendf(" %s[%s%s%s]%s", labelSymbol.getStr(), symRefNum.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(),
                symRefObjIndex.getStr());
       else
-         output.appendf(" %s%s%s[%s%s%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefKind.isEmpty() ? "" : " ",
+         output.appendf(" %s%s[%s%s%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefNum.getStr(), symRefKind.isEmpty() ? "" : " ",
                symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
       }
 

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -387,24 +387,26 @@ TR_Debug::newRegister(TR::Register *reg)
 void
 TR_Debug::newVariableSizeSymbol(TR::AutomaticSymbol *sym)
    {
-   TR_ASSERT(_comp, "Required compilation object is NULL.\n");
    int32_t strLength = static_cast<int32_t>(strlen(TR_VSS_NAME)) + TR::getMaxSignedPrecision<TR::Int32>() + 7;
    char *buf = (char *)_comp->trMemory()->allocateHeapMemory(strLength);
-
-   TR::SimpleRegex * regex = NULL;
-
-   _comp->getToStringMap().Add((void *)sym, buf);
    sprintf(buf, "%s_%d",  TR_VSS_NAME, _nextVariableSizeSymbolNumber);
 
-   regex = _comp->getOptions()->getBreakOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      breakOn();
+   _comp->getToStringMap().Add((void *)sym, buf);
 
-   regex = _comp->getOptions()->getDebugOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      debugOnCreate();
+   if (_comp->getOptions()->getBreakOnCreate() ||
+       _comp->getOptions()->getDebugOnCreate())
+      {
+      TR::SimpleRegex * regex = NULL;
+      regex = _comp->getOptions()->getBreakOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         breakOn();
 
-    _nextVariableSizeSymbolNumber++;
+      regex = _comp->getOptions()->getDebugOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         debugOnCreate();
+      }
+
+   _nextVariableSizeSymbolNumber++;
    }
 
 void

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -290,19 +290,22 @@ TR_Debug::roundAddressEnumerationCounters(uint32_t boundary)
 void
 TR_Debug::newNode(TR::Node *node)
    {
-   char buf[20];
-   TR::SimpleRegex * regex;
+   if (_comp->getOptions()->getBreakOnCreate() ||
+       _comp->getOptions()->getDebugOnCreate())
+      {
+      char buf[20];
+      TR::SimpleRegex * regex;
 
-   sprintf(buf, "ND_%04x", node->getGlobalIndex());
+      sprintf(buf, "ND_%04x", node->getGlobalIndex());
 
-   regex = _comp->getOptions()->getBreakOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      breakOn();
+      regex = _comp->getOptions()->getBreakOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         breakOn();
 
-   regex = _comp->getOptions()->getDebugOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      debugOnCreate();
-
+      regex = _comp->getOptions()->getDebugOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         debugOnCreate();
+      }
    }
 
 void

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -361,26 +361,27 @@ TR_Debug::newInstruction(TR::Instruction *instr)
 void
 TR_Debug::newRegister(TR::Register *reg)
    {
-   TR_ASSERT(_comp, "Required compilation object is NULL.\n");
-   char buf[20];
-   TR::SimpleRegex * regex;
-
-   regex = _comp->getOptions()->getBreakOnCreate();
-
    if (_comp->getAddressEnumerationOption(TR_EnumerateRegister))
       _comp->getToNumberMap().Add((void *)reg, (intptr_t)_nextRegisterNumber);
 
-   sprintf(buf, "GPR_%04x", _nextRegisterNumber );
+   if (_comp->getOptions()->getBreakOnCreate() ||
+       _comp->getOptions()->getDebugOnCreate())
+      {
+      char buf[20];
+      TR::SimpleRegex * regex;
 
-   regex = _comp->getOptions()->getBreakOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      breakOn();
+      sprintf(buf, "GPR_%04x", _nextRegisterNumber );
 
-   regex = _comp->getOptions()->getDebugOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      debugOnCreate();
+      regex = _comp->getOptions()->getBreakOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         breakOn();
 
-    _nextRegisterNumber++;
+      regex = _comp->getOptions()->getDebugOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         debugOnCreate();
+      }
+
+   _nextRegisterNumber++;
    }
 
 void

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1145,39 +1145,39 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
    if (sym)
       {
       if (symRef->isUnresolved())
-         symRefKind.append(" unresolved");
+         symRefKind.appends(" unresolved");
       switch (symRef->hasBeenAccessedAtRuntime())
          {
-         case TR_yes: symRefKind.append( " accessed");    break;
-         case TR_no:  symRefKind.append( " notAccessed"); break;
+         case TR_yes: symRefKind.appends( " accessed");    break;
+         case TR_no:  symRefKind.appends( " notAccessed"); break;
          default: break;
          }
       if (symRef->getSymbol()->isFinal())
-         symRefKind.append(" final");
+         symRefKind.appends(" final");
       if (symRef->getSymbol()->isVolatile())
-         symRefKind.append(" volatile");
+         symRefKind.appends(" volatile");
       switch (sym->getKind())
          {
          case TR::Symbol::IsAutomatic:
             symRefName.append(" %s", getName(symRef));
             if (sym->getAutoSymbol()->getName() == NULL)
-               symRefKind.append(" Auto");
+               symRefKind.appends(" Auto");
             else
                symRefKind.append(" %s", sym->getAutoSymbol()->getName());
             break;
          case TR::Symbol::IsParameter:
-            symRefKind.append(" Parm");
+            symRefKind.appends(" Parm");
             symRefName.append(" %s", getName(symRef));
             break;
          case TR::Symbol::IsStatic:
             if(symRef->isFromLiteralPool())
              {
-               symRefKind.append(" DLP-Static");
+               symRefKind.appends(" DLP-Static");
                symRefName.append( " %s", getName(symRef));
              }
             else
                {
-               symRefKind.append(" Static");
+               symRefKind.appends(" Static");
                if (sym->isNamed())
                   {
                   symRefName.append(" \"%s\"", ((TR::StaticSymbol*)sym)->getName());
@@ -1191,44 +1191,44 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
             {
             TR::MethodSymbol *methodSym = sym->castToMethodSymbol();
             if (methodSym->isNative())
-               symRefKind.append(" native");
+               symRefKind.appends(" native");
             switch (methodSym->getMethodKind())
                {
                case TR::MethodSymbol::Virtual:
-                  symRefKind.append(" virtual");
+                  symRefKind.appends(" virtual");
                   break;
                case TR::MethodSymbol::Interface:
-                  symRefKind.append(" interface");
+                  symRefKind.appends(" interface");
                   break;
                case TR::MethodSymbol::Static:
-                  symRefKind.append(" static");
+                  symRefKind.appends(" static");
                   break;
                case TR::MethodSymbol::Special:
-                  symRefKind.append(" special");
+                  symRefKind.appends(" special");
                   break;
                case TR::MethodSymbol::Helper:
-                  symRefKind.append(" helper");
+                  symRefKind.appends(" helper");
                   break;
                case TR::MethodSymbol::ComputedStatic:
-                  symRefKind.append(" computed-static");
+                  symRefKind.appends(" computed-static");
                   break;
                case TR::MethodSymbol::ComputedVirtual:
-                  symRefKind.append(" computed-virtual");
+                  symRefKind.appends(" computed-virtual");
                   break;
                default:
-                     symRefKind.append(" UNKNOWN");
+                     symRefKind.appends(" UNKNOWN");
                   break;
                }
 
-            symRefKind.append(" Method");
+            symRefKind.appends(" Method");
             symRefName.append(" %s", getName(symRef));
             TR_OpaqueClassBlock *clazz = containingClass(symRef);
             if (clazz)
                {
                if (TR::Compiler->cls.isInterfaceClass(_comp, clazz))
-                  otherInfo.append( " (Interface class)");
+                  otherInfo.appends(" (Interface class)");
                else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
-                  otherInfo.append( " (Abstract class)");
+                  otherInfo.appends(" (Abstract class)");
                }
             }
             break;
@@ -1241,18 +1241,18 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
                }
             else
                {
-               symRefKind.append(" Shadow");
+               symRefKind.appends(" Shadow");
                symRefName.append(" %s", getName(symRef));
                }
             break;
          case TR::Symbol::IsMethodMetaData:
-            symRefKind.append(" MethodMeta");
+            symRefKind.appends(" MethodMeta");
             symRefName.append(" %s", symRef->getSymbol()->getMethodMetaDataSymbol()->getName());
             break;
          case TR::Symbol::IsLabel:
             print(sym->castToLabelSymbol(), labelSymbol);
             if (!labelSymbol.isEmpty())
-               labelSymbol.append( " " );
+               labelSymbol.appends(" ");
             break;
          default:
             TR_ASSERT(0, "unexpected symbol kind");
@@ -1281,7 +1281,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
           output.append (" (%s)",TR::DataType::getName(sym->getDataType()));
           if (sym->isVolatile())
              {
-             output.append(" [volatile]");
+             output.appends(" [volatile]");
              }
           }
       }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -311,20 +311,24 @@ TR_Debug::newNode(TR::Node *node)
 void
 TR_Debug::newLabelSymbol(TR::LabelSymbol *labelSymbol)
    {
-   TR_ASSERT(_comp, "Required compilation object is NULL.\n");
-   char buf[20];
-   TR::SimpleRegex * regex = NULL;
-
    _comp->getToNumberMap().Add((void *)labelSymbol, (intptr_t)_nextLabelNumber);
-   sprintf(buf, "L%04x", _nextLabelNumber);
 
-   regex = _comp->getOptions()->getBreakOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      breakOn();
+   if (_comp->getOptions()->getBreakOnCreate() ||
+       _comp->getOptions()->getDebugOnCreate())
+      {
+      char buf[20];
+      TR::SimpleRegex * regex = NULL;
 
-   regex = _comp->getOptions()->getDebugOnCreate();
-   if (regex && TR::SimpleRegex::match(regex, buf, false))
-      debugOnCreate();
+      sprintf(buf, "L%04x", _nextLabelNumber);
+
+      regex = _comp->getOptions()->getBreakOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         breakOn();
+
+      regex = _comp->getOptions()->getDebugOnCreate();
+      if (regex && TR::SimpleRegex::match(regex, buf, false))
+         debugOnCreate();
+      }
 
    _nextLabelNumber++;
    }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -288,23 +288,26 @@ TR_Debug::roundAddressEnumerationCounters(uint32_t boundary)
    }
 
 void
+TR_Debug::breakOrDebugOnCreate(char *artifactName)
+   {
+   TR::SimpleRegex *regex = _comp->getOptions()->getBreakOnCreate();
+   if (regex && TR::SimpleRegex::match(regex, artifactName, false))
+      breakOn();
+
+   regex = _comp->getOptions()->getDebugOnCreate();
+   if (regex && TR::SimpleRegex::match(regex, artifactName, false))
+      debugOnCreate();
+   }
+
+void
 TR_Debug::newNode(TR::Node *node)
    {
    if (_comp->getOptions()->getBreakOnCreate() ||
        _comp->getOptions()->getDebugOnCreate())
       {
       char buf[20];
-      TR::SimpleRegex * regex;
-
       sprintf(buf, "ND_%04x", node->getGlobalIndex());
-
-      regex = _comp->getOptions()->getBreakOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         breakOn();
-
-      regex = _comp->getOptions()->getDebugOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         debugOnCreate();
+      breakOrDebugOnCreate(buf);
       }
    }
 
@@ -317,17 +320,8 @@ TR_Debug::newLabelSymbol(TR::LabelSymbol *labelSymbol)
        _comp->getOptions()->getDebugOnCreate())
       {
       char buf[20];
-      TR::SimpleRegex * regex = NULL;
-
       sprintf(buf, "L%04x", _nextLabelNumber);
-
-      regex = _comp->getOptions()->getBreakOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         breakOn();
-
-      regex = _comp->getOptions()->getDebugOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         debugOnCreate();
+      breakOrDebugOnCreate(buf);
       }
 
    _nextLabelNumber++;
@@ -336,25 +330,16 @@ TR_Debug::newLabelSymbol(TR::LabelSymbol *labelSymbol)
 void
 TR_Debug::newInstruction(TR::Instruction *instr)
    {
-   TR_ASSERT(_comp, "Required compilation object is NULL.\n");
    if (_comp->getAddressEnumerationOption(TR_EnumerateInstruction) ||
-      _comp->getOptions()->getBreakOnCreate())
+      _comp->getOptions()->getBreakOnCreate() ||
+      _comp->getOptions()->getDebugOnCreate())
       {
       char buf[20];
-      TR::SimpleRegex * regex;
-
       _comp->getToNumberMap().Add((void *)instr, (intptr_t)_nextInstructionNumber);
       sprintf(buf, "IN_%04x", _nextInstructionNumber);
-
-      regex = _comp->getOptions()->getBreakOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         breakOn();
-
-      regex = _comp->getOptions()->getDebugOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         debugOnCreate();
-
+      breakOrDebugOnCreate(buf);
       }
+
    _nextInstructionNumber++;
    }
 
@@ -368,17 +353,8 @@ TR_Debug::newRegister(TR::Register *reg)
        _comp->getOptions()->getDebugOnCreate())
       {
       char buf[20];
-      TR::SimpleRegex * regex;
-
       sprintf(buf, "GPR_%04x", _nextRegisterNumber );
-
-      regex = _comp->getOptions()->getBreakOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         breakOn();
-
-      regex = _comp->getOptions()->getDebugOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         debugOnCreate();
+      breakOrDebugOnCreate(buf);
       }
 
    _nextRegisterNumber++;
@@ -396,14 +372,7 @@ TR_Debug::newVariableSizeSymbol(TR::AutomaticSymbol *sym)
    if (_comp->getOptions()->getBreakOnCreate() ||
        _comp->getOptions()->getDebugOnCreate())
       {
-      TR::SimpleRegex * regex = NULL;
-      regex = _comp->getOptions()->getBreakOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         breakOn();
-
-      regex = _comp->getOptions()->getDebugOnCreate();
-      if (regex && TR::SimpleRegex::match(regex, buf, false))
-         debugOnCreate();
+      breakOrDebugOnCreate(buf);
       }
 
    _nextVariableSizeSymbolNumber++;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -968,133 +968,133 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    {
    char *format = "%s";
 
-   output.append(format, node->printHasFoldedImplicitNULLCHK());
-   output.append(format, node->printIsHighWordZero());
-   output.append(format, node->printIsUnsigned());
-   output.append(format, node->printIsClassPointerConstant());
-   output.append(format, node->printIsMethodPointerConstant());
-   output.append(format, node->printIsSafeToSkipTableBoundCheck());
-   output.append(format, node->printIsProfilingCode());
-   output.append(format, node->printIsZero());
-   output.append(format, node->printIsNonZero());
-   output.append(format, node->printIsNonNegative());
-   output.append(format, node->printIsNonPositive());
-   output.append(format, node->printPointsToNull());
-   output.append(format, node->printRequiresConditionCodes());
-   output.append(format, node->printIsUnneededConversion());
-   output.append(format, node->printParentSupportsLazyClobber());
-   output.append(format, node->printIsFPStrictCompliant());
-   output.append(format, node->printCannotOverflow());
-   output.append(format, node->printPointsToNonNull());
+   output.appendf(format, node->printHasFoldedImplicitNULLCHK());
+   output.appendf(format, node->printIsHighWordZero());
+   output.appendf(format, node->printIsUnsigned());
+   output.appendf(format, node->printIsClassPointerConstant());
+   output.appendf(format, node->printIsMethodPointerConstant());
+   output.appendf(format, node->printIsSafeToSkipTableBoundCheck());
+   output.appendf(format, node->printIsProfilingCode());
+   output.appendf(format, node->printIsZero());
+   output.appendf(format, node->printIsNonZero());
+   output.appendf(format, node->printIsNonNegative());
+   output.appendf(format, node->printIsNonPositive());
+   output.appendf(format, node->printPointsToNull());
+   output.appendf(format, node->printRequiresConditionCodes());
+   output.appendf(format, node->printIsUnneededConversion());
+   output.appendf(format, node->printParentSupportsLazyClobber());
+   output.appendf(format, node->printIsFPStrictCompliant());
+   output.appendf(format, node->printCannotOverflow());
+   output.appendf(format, node->printPointsToNonNull());
 
-   output.append(format, node->printIsInvalid8BitGlobalRegister());
-   output.append(format, node->printIsDirectMemoryUpdate());
-   output.append(format, node->printIsTheVirtualCallNodeForAGuardedInlinedCall());
-   output.append(format, node->printIsDontTransformArrayCopyCall());
-   output.append(format, node->printIsNodeRecognizedArrayCopyCall());
-   output.append(format, node->printCanDesynchronizeCall());
-   output.append(format, node->printContainsCompressionSequence());
-   output.append(format, node->printIsInternalPointer());
-   output.append(format, node->printIsMaxLoopIterationGuard());
-   output.append(format, node->printIsProfiledGuard()     );
-   output.append(format, node->printIsInterfaceGuard()    );
-   output.append(format, node->printIsAbstractGuard()     );
-   output.append(format, node->printIsHierarchyGuard()    );
-   output.append(format, node->printIsNonoverriddenGuard());
-   output.append(format, node->printIsSideEffectGuard()   );
-   output.append(format, node->printIsDummyGuard()        );
-   output.append(format, node->printIsHCRGuard()          );
-   output.append(format, node->printIsOSRGuard()          );
-   output.append(format, node->printIsBreakpointGuard()          );
-   output.append(format, node->printIsMutableCallSiteTargetGuard() );
-   output.append(format, node->printIsByteToByteTranslate());
-   output.append(format, node->printIsByteToCharTranslate());
-   output.append(format, node->printIsCharToByteTranslate());
-   output.append(format, node->printIsCharToCharTranslate());
-   output.append(format, node->printSetSourceIsByteArrayTranslate() );
-   output.append(format, node->printSetTargetIsByteArrayTranslate() );
-   output.append(format, node->printSetTermCharNodeIsHint()         );
-   output.append(format, node->printSetTableBackedByRawStorage()    );
-   output.append(format, node->printIsForwardArrayCopy());
-   output.append(format, node->printIsBackwardArrayCopy());
-   output.append(format, node->printIsRarePathForwardArrayCopy());
-   output.append(format, node->printIsNoArrayStoreCheckArrayCopy());
-   output.append(format, node->printIsReferenceArrayCopy());
-   output.append(format, node->printIsHalfWordElementArrayCopy());
-   output.append(format, node->printIsWordElementArrayCopy());
-   output.append(format, node->printIsHeapObjectWrtBar());
-   output.append(format, node->printIsNonHeapObjectWrtBar());
-   output.append(format, node->printIsSkipWrtBar());
-   output.append(format, node->printIsArrayChkPrimitiveArray1());
-   output.append(format, node->printIsArrayChkReferenceArray1());
-   output.append(format, node->printIsArrayChkPrimitiveArray2());
-   output.append(format, node->printIsArrayChkReferenceArray2());
-   output.append(format, node->printIsSignExtendedTo32BitAtSource());
-   output.append(format, node->printIsSignExtendedTo64BitAtSource());
-   output.append(format, node->printIsZeroExtendedTo32BitAtSource());
-   output.append(format, node->printIsZeroExtendedTo64BitAtSource());
-   output.append(format, node->printNeedsSignExtension());
-   output.append(format, node->printSkipSignExtension());
-   output.append(format, node->printSetUseSignExtensionMode());
-   output.append(format, node->printIsSeenRealReference());
-   output.append(format, node->printNormalizeNanValues());
-   output.append(format, node->printCannotTrackLocalUses());
-   output.append(format, node->printIsSkipSync());
-   output.append(format, node->printIsReadMonitor());
-   output.append(format, node->printIsLocalObjectMonitor());
-   output.append(format, node->printIsPrimitiveLockedRegion());
-   output.append(format, node->printIsSyncMethodMonitor());
-   output.append(format, node->printIsStaticMonitor());
-   output.append(format, node->printIsNormalizedShift());
-   output.append(format, node->printIsSimpleDivCheck());
-   output.append(format, node->printIsOmitSync());
-   output.append(format, node->printIsNOPLongStore());
-   output.append(format, node->printIsStoredValueIsIrrelevant());
-   output.append(format, node->printIsThrowInsertedByOSR());
-   output.append(format, node->printCanSkipZeroInitialization());
-   output.append(format, node->printIsDontMoveUnderBranch());
-   output.append(format, node->printIsPrivatizedInlinerArg());
-   output.append(format, node->printArrayCmpLen());
-   output.append(format, node->printArrayCmpSign());
-   output.append(format, node->printXorBitOpMem());
-   output.append(format, node->printOrBitOpMem());
-   output.append(format, node->printAndBitOpMem());
+   output.appendf(format, node->printIsInvalid8BitGlobalRegister());
+   output.appendf(format, node->printIsDirectMemoryUpdate());
+   output.appendf(format, node->printIsTheVirtualCallNodeForAGuardedInlinedCall());
+   output.appendf(format, node->printIsDontTransformArrayCopyCall());
+   output.appendf(format, node->printIsNodeRecognizedArrayCopyCall());
+   output.appendf(format, node->printCanDesynchronizeCall());
+   output.appendf(format, node->printContainsCompressionSequence());
+   output.appendf(format, node->printIsInternalPointer());
+   output.appendf(format, node->printIsMaxLoopIterationGuard());
+   output.appendf(format, node->printIsProfiledGuard()     );
+   output.appendf(format, node->printIsInterfaceGuard()    );
+   output.appendf(format, node->printIsAbstractGuard()     );
+   output.appendf(format, node->printIsHierarchyGuard()    );
+   output.appendf(format, node->printIsNonoverriddenGuard());
+   output.appendf(format, node->printIsSideEffectGuard()   );
+   output.appendf(format, node->printIsDummyGuard()        );
+   output.appendf(format, node->printIsHCRGuard()          );
+   output.appendf(format, node->printIsOSRGuard()          );
+   output.appendf(format, node->printIsBreakpointGuard()          );
+   output.appendf(format, node->printIsMutableCallSiteTargetGuard() );
+   output.appendf(format, node->printIsByteToByteTranslate());
+   output.appendf(format, node->printIsByteToCharTranslate());
+   output.appendf(format, node->printIsCharToByteTranslate());
+   output.appendf(format, node->printIsCharToCharTranslate());
+   output.appendf(format, node->printSetSourceIsByteArrayTranslate() );
+   output.appendf(format, node->printSetTargetIsByteArrayTranslate() );
+   output.appendf(format, node->printSetTermCharNodeIsHint()         );
+   output.appendf(format, node->printSetTableBackedByRawStorage()    );
+   output.appendf(format, node->printIsForwardArrayCopy());
+   output.appendf(format, node->printIsBackwardArrayCopy());
+   output.appendf(format, node->printIsRarePathForwardArrayCopy());
+   output.appendf(format, node->printIsNoArrayStoreCheckArrayCopy());
+   output.appendf(format, node->printIsReferenceArrayCopy());
+   output.appendf(format, node->printIsHalfWordElementArrayCopy());
+   output.appendf(format, node->printIsWordElementArrayCopy());
+   output.appendf(format, node->printIsHeapObjectWrtBar());
+   output.appendf(format, node->printIsNonHeapObjectWrtBar());
+   output.appendf(format, node->printIsSkipWrtBar());
+   output.appendf(format, node->printIsArrayChkPrimitiveArray1());
+   output.appendf(format, node->printIsArrayChkReferenceArray1());
+   output.appendf(format, node->printIsArrayChkPrimitiveArray2());
+   output.appendf(format, node->printIsArrayChkReferenceArray2());
+   output.appendf(format, node->printIsSignExtendedTo32BitAtSource());
+   output.appendf(format, node->printIsSignExtendedTo64BitAtSource());
+   output.appendf(format, node->printIsZeroExtendedTo32BitAtSource());
+   output.appendf(format, node->printIsZeroExtendedTo64BitAtSource());
+   output.appendf(format, node->printNeedsSignExtension());
+   output.appendf(format, node->printSkipSignExtension());
+   output.appendf(format, node->printSetUseSignExtensionMode());
+   output.appendf(format, node->printIsSeenRealReference());
+   output.appendf(format, node->printNormalizeNanValues());
+   output.appendf(format, node->printCannotTrackLocalUses());
+   output.appendf(format, node->printIsSkipSync());
+   output.appendf(format, node->printIsReadMonitor());
+   output.appendf(format, node->printIsLocalObjectMonitor());
+   output.appendf(format, node->printIsPrimitiveLockedRegion());
+   output.appendf(format, node->printIsSyncMethodMonitor());
+   output.appendf(format, node->printIsStaticMonitor());
+   output.appendf(format, node->printIsNormalizedShift());
+   output.appendf(format, node->printIsSimpleDivCheck());
+   output.appendf(format, node->printIsOmitSync());
+   output.appendf(format, node->printIsNOPLongStore());
+   output.appendf(format, node->printIsStoredValueIsIrrelevant());
+   output.appendf(format, node->printIsThrowInsertedByOSR());
+   output.appendf(format, node->printCanSkipZeroInitialization());
+   output.appendf(format, node->printIsDontMoveUnderBranch());
+   output.appendf(format, node->printIsPrivatizedInlinerArg());
+   output.appendf(format, node->printArrayCmpLen());
+   output.appendf(format, node->printArrayCmpSign());
+   output.appendf(format, node->printXorBitOpMem());
+   output.appendf(format, node->printOrBitOpMem());
+   output.appendf(format, node->printAndBitOpMem());
 #ifdef J9_PROJECT_SPECIFIC
-   output.append(format, node->printSkipCopyOnStore());
-   output.append(format, node->printSkipCopyOnLoad());
-   output.append(format, node->printSkipPadByteClearing());
-   output.append(format, node->printUseStoreAsAnAccumulator());
-   output.append(format, node->printCleanSignInPDStoreEvaluator());
+   output.appendf(format, node->printSkipCopyOnStore());
+   output.appendf(format, node->printSkipCopyOnLoad());
+   output.appendf(format, node->printSkipPadByteClearing());
+   output.appendf(format, node->printUseStoreAsAnAccumulator());
+   output.appendf(format, node->printCleanSignInPDStoreEvaluator());
 #endif
-   output.append(format, node->printUseCallForFloatToFixedConversion());
+   output.appendf(format, node->printUseCallForFloatToFixedConversion());
 #ifdef J9_PROJECT_SPECIFIC
-   output.append(format, node->printCleanSignDuringPackedLeftShift());
-   output.append(format, node->printIsInMemoryCopyProp());
+   output.appendf(format, node->printCleanSignDuringPackedLeftShift());
+   output.appendf(format, node->printIsInMemoryCopyProp());
 #endif
-   output.append(format, node->printAllocationCanBeRemoved());
-   output.append(format, node->printArrayTRT());
-   output.append(format, node->printCannotTrackLocalStringUses());
-   output.append(format, node->printCharArrayTRT());
-   output.append(format, node->printEscapesInColdBlock());
-   output.append(format, node->printIsDirectMethodGuard());
+   output.appendf(format, node->printAllocationCanBeRemoved());
+   output.appendf(format, node->printArrayTRT());
+   output.appendf(format, node->printCannotTrackLocalStringUses());
+   output.appendf(format, node->printCharArrayTRT());
+   output.appendf(format, node->printEscapesInColdBlock());
+   output.appendf(format, node->printIsDirectMethodGuard());
 #ifdef J9_PROJECT_SPECIFIC
-   output.append(format, node->printIsDontInlineUnsafePutOrderedCall());
+   output.appendf(format, node->printIsDontInlineUnsafePutOrderedCall());
 #endif
-   output.append(format, node->printIsHeapificationStore());
-   output.append(format, node->printIsHeapificationAlloc());
-   output.append(format, node->printIsIdentityless());
-   output.append(format, node->printIsLiveMonitorInitStore());
-   output.append(format, node->printIsMethodEnterExitGuard());
-   output.append(format, node->printReturnIsDummy());
+   output.appendf(format, node->printIsHeapificationStore());
+   output.appendf(format, node->printIsHeapificationAlloc());
+   output.appendf(format, node->printIsIdentityless());
+   output.appendf(format, node->printIsLiveMonitorInitStore());
+   output.appendf(format, node->printIsMethodEnterExitGuard());
+   output.appendf(format, node->printReturnIsDummy());
 #ifdef J9_PROJECT_SPECIFIC
-   output.append(format, node->printSharedMemory());
+   output.appendf(format, node->printSharedMemory());
 #endif
-   output.append(format, node->printSourceCellIsTermChar());
+   output.appendf(format, node->printSourceCellIsTermChar());
 #ifdef J9_PROJECT_SPECIFIC
-   output.append(format, node->printSpineCheckWithArrayElementChild());
+   output.appendf(format, node->printSpineCheckWithArrayElementChild());
 #endif
-   output.append(format, node->printStoreAlreadyEvaluated());
-   output.append(format, node->printCopyToNewVirtualRegister());
+   output.appendf(format, node->printStoreAlreadyEvaluated());
+   output.appendf(format, node->printCopyToNewVirtualRegister());
    }
 
 
@@ -1115,7 +1115,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
 
    TR::Symbol * sym = symRef->getSymbol();
 
-   symRefAddress.append("%s", getName(sym));
+   symRefAddress.appendf("%s", getName(sym));
 
 
    if (sym)
@@ -1130,16 +1130,16 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
 
    if (symRef->getOffset() + displacement)
       {
-      symRefOffset.append( "%+d", displacement + symRef->getOffset());
+      symRefOffset.appendf( "%+d", displacement + symRef->getOffset());
       }
 
    if (symRef->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN)
-      symRefObjIndex.append( " (obj%d)", (int)symRef->getKnownObjectIndex());
+      symRefObjIndex.appendf( " (obj%d)", (int)symRef->getKnownObjectIndex());
    else if (sym && sym->isFixedObjectRef() && comp()->getKnownObjectTable() && !symRef->isUnresolved())
       {
       TR::KnownObjectTable::Index i = comp()->getKnownObjectTable()->getExistingIndexAt((uintptr_t*)sym->castToStaticSymbol()->getStaticAddress());
       if (i != TR::KnownObjectTable::UNKNOWN)
-         symRefObjIndex.append( " (==obj%d)", (int)i);
+         symRefObjIndex.appendf( " (==obj%d)", (int)i);
       }
 
    if (sym)
@@ -1159,30 +1159,30 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
       switch (sym->getKind())
          {
          case TR::Symbol::IsAutomatic:
-            symRefName.append(" %s", getName(symRef));
+            symRefName.appendf(" %s", getName(symRef));
             if (sym->getAutoSymbol()->getName() == NULL)
                symRefKind.appends(" Auto");
             else
-               symRefKind.append(" %s", sym->getAutoSymbol()->getName());
+               symRefKind.appendf(" %s", sym->getAutoSymbol()->getName());
             break;
          case TR::Symbol::IsParameter:
             symRefKind.appends(" Parm");
-            symRefName.append(" %s", getName(symRef));
+            symRefName.appendf(" %s", getName(symRef));
             break;
          case TR::Symbol::IsStatic:
             if(symRef->isFromLiteralPool())
              {
                symRefKind.appends(" DLP-Static");
-               symRefName.append( " %s", getName(symRef));
+               symRefName.appendf(" %s", getName(symRef));
              }
             else
                {
                symRefKind.appends(" Static");
                if (sym->isNamed())
                   {
-                  symRefName.append(" \"%s\"", ((TR::StaticSymbol*)sym)->getName());
+                  symRefName.appendf(" \"%s\"", ((TR::StaticSymbol*)sym)->getName());
                   }
-               symRefName.append(" %s", getName(symRef));
+               symRefName.appendf(" %s", getName(symRef));
                }
             break;
 
@@ -1221,7 +1221,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
                }
 
             symRefKind.appends(" Method");
-            symRefName.append(" %s", getName(symRef));
+            symRefName.appendf(" %s", getName(symRef));
             TR_OpaqueClassBlock *clazz = containingClass(symRef);
             if (clazz)
                {
@@ -1236,18 +1236,18 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
          case TR::Symbol::IsShadow:
             if (sym->isNamedShadowSymbol() && sym->getNamedShadowSymbol()->getName() != NULL)
                {
-               symRefKind.append(" %s", sym->getNamedShadowSymbol()->getName());
-               symRefName.append(" %s", getName(symRef));
+               symRefKind.appendf(" %s", sym->getNamedShadowSymbol()->getName());
+               symRefName.appendf(" %s", getName(symRef));
                }
             else
                {
                symRefKind.appends(" Shadow");
-               symRefName.append(" %s", getName(symRef));
+               symRefName.appendf(" %s", getName(symRef));
                }
             break;
          case TR::Symbol::IsMethodMetaData:
             symRefKind.appends(" MethodMeta");
-            symRefName.append(" %s", symRef->getSymbol()->getMethodMetaDataSymbol()->getName());
+            symRefName.appendf(" %s", symRef->getSymbol()->getMethodMetaDataSymbol()->getName());
             break;
          case TR::Symbol::IsLabel:
             print(sym->castToLabelSymbol(), labelSymbol);
@@ -1257,28 +1257,28 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
          default:
             TR_ASSERT(0, "unexpected symbol kind");
          }
-         otherInfo.append( " [flags 0x%x 0x%x ]", sym->getFlags(),sym->getFlags2());
+         otherInfo.appendf( " [flags 0x%x 0x%x ]", sym->getFlags(),sym->getFlags2());
       }
 
    numSpaces = getNumSpacesAfterIndex( symRef->getReferenceNumber(), getIntLength(_comp->getSymRefTab()->baseArray.size()) );
 
-      symRefNum.append("#%d", symRef->getReferenceNumber());
+      symRefNum.appendf("#%d", symRef->getReferenceNumber());
 
    if (verbose)
       {
-       output.append("%s:%*s", symRefNum.getStr(), numSpaces, "");
+       output.appendf("%s:%*s", symRefNum.getStr(), numSpaces, "");
 
        if (hideHelperMethodInfo)
-          output.append(" %s%s[%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefOffset.getStr(), symRefObjIndex.getStr());
+          output.appendf(" %s%s[%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefOffset.getStr(), symRefObjIndex.getStr());
        else
-          output.append(" %s%s%s[%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ",
+          output.appendf(" %s%s%s[%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ",
                 symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
 
-       output.append(" [%s]", symRefAddress.getStr());
+       output.appendf(" [%s]", symRefAddress.getStr());
 
        if(sym)
           {
-          output.append (" (%s)",TR::DataType::getName(sym->getDataType()));
+          output.appendf(" (%s)",TR::DataType::getName(sym->getDataType()));
           if (sym->isVolatile())
              {
              output.appends(" [volatile]");
@@ -1288,10 +1288,10 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
    else
       {
       if (hideHelperMethodInfo)
-         output.append(" %s%s[%s%s%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(),
+         output.appendf(" %s%s[%s%s%s]%s", labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(),
                symRefObjIndex.getStr());
       else
-         output.append(" %s%s%s[%s%s%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefKind.isEmpty() ? "" : " ",
+         output.appendf(" %s%s%s[%s%s%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefWCodeId.getStr(), symRefNum.getStr(), symRefKind.isEmpty() ? "" : " ",
                symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
       }
 
@@ -1309,7 +1309,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::LabelSymbol * labelSymbol)
 void
 TR_Debug::print(TR::LabelSymbol * labelSymbol, TR_PrettyPrinterString& output)
    {
-   output.append( "%s", getName(labelSymbol));
+   output.appendf( "%s", getName(labelSymbol));
    }
 
 const char *

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1249,13 +1249,26 @@ class TR_PrettyPrinterString
    public:
       TR_PrettyPrinterString(TR_Debug* debug);
       void append(const char* format, ...);
+
+      /**
+       * @brief Append a null-terminated string to the buffer.  No format specifiers
+       *        are permitted.  The buffer is guaranteed not to overflow and will be
+       *        null-terminated.
+       *
+       * @param[in] str : null-terminated string to append
+       */
+      void appends(char const *str);
+
       const char* getStr() {return buffer;}
-      int getLength() {return len;}
+      int32_t getLength() {return len;}
       void reset() {buffer[0] = '\0'; len = 0;}
       bool isEmpty() { return len <= 0; }
+
+      static const int32_t maxBufferLength = 2000;
+
    private:
-      char buffer[2000];
-      int len;
+      char buffer[maxBufferLength];
+      int32_t len;
       TR::Compilation *_comp;
       TR_Debug *_debug;
    };

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -414,6 +414,14 @@ public:
    virtual void newInstruction(TR::Instruction *);
    virtual void addInstructionComment(TR::Instruction *, char*, ...);
 
+   /**
+    * @brief Check whether to trigger debugger breakpoint or launch debugger
+    *        when \c artifact name is created.
+    *
+    * @param[in] artifactName : name of artifact to break or debug on
+    */
+   void breakOrDebugOnCreate(char *artifactName);
+
    virtual TR::CompilationFilters * getInlineFilters() { return _inlineFilters; }
 
    virtual TR_FrontEnd *fe() { return _fe; }

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1248,7 +1248,15 @@ class TR_PrettyPrinterString
    {
    public:
       TR_PrettyPrinterString(TR_Debug* debug);
-      void append(const char* format, ...);
+
+      /**
+       * @brief Append a null-terminated string with format specifiers to the buffer.
+       *        The buffer is guaranteed not to overflow and will be null-terminated.
+       *
+       * @param[in] format : null-terminated string to append with optional format specifiers
+       * @param[in] ... : optional arguments for format specifiers
+       */
+      void appendf(char const *format, ...);
 
       /**
        * @brief Append a null-terminated string to the buffer.  No format specifiers

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -79,8 +79,6 @@ extern int32_t addressWidth;
 void
 TR_Debug::printTopLegend(TR::FILE *pOutFile)
    {
-   //-index--|--------------------------------------node---------------------------------------|--address---|-----bci-----|-rc-|-vc-|-vn-|--li--|-udi-|-nc-|--sa--
-
    if (pOutFile == NULL) return;
 
    trfprintf(pOutFile, "\n------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n");
@@ -92,9 +90,9 @@ TR_Debug::printBottomLegend(TR::FILE *pOutFile)
    {
    if (pOutFile == NULL) return;
 
-   trfprintf(pOutFile,    "\n"
-                              "index:       node global index\n"
-                              );
+   trfprintf(pOutFile, "\n"
+                       "index:       node global index\n"
+                       );
    char const *lineOrStatement = "line-number";
    char const *bciOrLoc        = "bci";
    char const *bciOrLocVerbose = "bytecode-index";
@@ -102,15 +100,15 @@ TR_Debug::printBottomLegend(TR::FILE *pOutFile)
    trfprintf(pOutFile, "%s=[x,y,z]: byte-code-info [callee-index, %s, %s]\n",
                  bciOrLoc, bciOrLocVerbose, lineOrStatement);
 
-   trfprintf(pOutFile,    "rc:          reference count\n"
-                              "vc:          visit count\n"
-                              "vn:          value number\n"
-                              "li:          local index\n"
-                              "udi:         use/def index\n"
-                              "nc:          number of children\n"
-                              "addr:        address size in bytes\n"
-                              "flg:         node flags\n"
-                        );
+   trfprintf(pOutFile, "rc:          reference count\n"
+                       "vc:          visit count\n"
+                       "vn:          value number\n"
+                       "li:          local index\n"
+                       "udi:         use/def index\n"
+                       "nc:          number of children\n"
+                       "addr:        address size in bytes\n"
+                       "flg:         node flags\n"
+                       );
    trfflush(pOutFile);
    }
 
@@ -194,51 +192,42 @@ TR_Debug::printLoadConst(TR::FILE *pOutFile, TR::Node *node)
 void
 TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
    {
+   char const *fmtStr;
    bool isUnsigned = node->getOpCode().isUnsigned();
    switch (node->getDataType())
       {
       case TR::Int8:
-         if(isUnsigned)
+         if (isUnsigned)
             output.appendf(" %3u", node->getUnsignedByte());
          else
             output.appendf(" %3d", node->getByte());
          break;
       case TR::Int16:
-         if (valueIsProbablyHex(node))
-            output.appendf(" 0x%4x", node->getConst<uint16_t>());
-         else
-            output.appendf(" '%5d' ", node->getConst<uint16_t>());
+         fmtStr = valueIsProbablyHex(node) ? " 0x%4x" : " '%5d' ";
+         output.appendf(fmtStr, node->getConst<uint16_t>());
          break;
       case TR::Int32:
-         if(isUnsigned)
+         if (isUnsigned)
             {
-            if (valueIsProbablyHex(node))
-               output.appendf(" 0x%x", node->getUnsignedInt());
-            else
-               output.appendf(" %u", node->getUnsignedInt());
+            fmtStr = valueIsProbablyHex(node) ? " 0x%x" : " %u";
+            output.appendf(fmtStr, node->getUnsignedInt());
             }
          else
             {
-            if (valueIsProbablyHex(node))
-               output.appendf(" 0x%x", node->getInt());
-            else
-               output.appendf(" %d", node->getInt());
+            fmtStr = valueIsProbablyHex(node) ? " 0x%x" : " %d";
+            output.appendf(fmtStr, node->getInt());
             }
          break;
       case TR::Int64:
-         if(isUnsigned)
+         if (isUnsigned)
             {
-            if (valueIsProbablyHex(node))
-               output.appendf(" " UINT64_PRINTF_FORMAT_HEX, node->getUnsignedLongInt());
-            else
-               output.appendf(" " UINT64_PRINTF_FORMAT , node->getUnsignedLongInt());
+            fmtStr = valueIsProbablyHex(node) ? " " UINT64_PRINTF_FORMAT_HEX : " " UINT64_PRINTF_FORMAT;
+            output.appendf(fmtStr, node->getUnsignedLongInt());
             }
          else
             {
-            if (valueIsProbablyHex(node))
-               output.appendf(" " INT64_PRINTF_FORMAT_HEX, node->getLongInt());
-            else
-               output.appendf(" " INT64_PRINTF_FORMAT , node->getLongInt());
+            fmtStr = valueIsProbablyHex(node) ? " " INT64_PRINTF_FORMAT_HEX : " " INT64_PRINTF_FORMAT;
+            output.appendf(fmtStr, node->getLongInt());
             }
          break;
       case TR::Float:
@@ -1104,20 +1093,16 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Node * node, uint32_t indentation, bool 
                printBasicPreNodeInfoAndIndent(pOutFile, node->getChild(i), indentation);
                nodeCount++;
 
+               char const *fmtStr;
                if (sizeof(CASECONST_TYPE) == 8)
                   {
-                  if (unsigned_case)
-                     output.appendf(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
-                  else
-                     output.appendf(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
+                  fmtStr = unsigned_case ? INT64_PRINTF_FORMAT_HEX ":\t" : INT64_PRINTF_FORMAT ":\t";
                   }
                else
                   {
-                  if (unsigned_case)
-                     output.appendf("%u:\t", node->getChild(i)->getCaseConstant());
-                  else
-                     output.appendf("%d:\t", node->getChild(i)->getCaseConstant());
+                  fmtStr = unsigned_case ? "%u:\t" : "%d:\t";
                   }
+               output.appendf(fmtStr, node->getChild(i)->getCaseConstant());
 
                _comp->incrNodeOpCodeLength( output.getLength() );
                trfprintf(pOutFile, "%s", output.getStr());
@@ -1270,23 +1255,18 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
       if (printRefCounts)
          {
          trfprintf(pOutFile, "%s%s%dn%*s  (%3d) %*s==>%s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", node->getReferenceCount(), indentation, " ", getName(node->getOpCode()));
-         if (node->getOpCode().isLoadConst())
-            printLoadConst(pOutFile, node);
-#ifdef J9_PROJECT_SPECIFIC
-         printBCDNodeInfo(pOutFile, node);
-#endif
-//         trfprintf(pOutFile, " at n%d", node->getGlobalIndex());
          }
       else
          {
          trfprintf(pOutFile, "%s%s%dn%*s  %*s==>%s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ", getName(node->getOpCode()));
-         if (node->getOpCode().isLoadConst())
-            printLoadConst(pOutFile, node);
-#ifdef J9_PROJECT_SPECIFIC
-         printBCDNodeInfo(pOutFile, node);
-#endif
-         //  trfprintf(pOutFile, " at n%d", node->getGlobalIndex());
          }
+
+      if (node->getOpCode().isLoadConst())
+         printLoadConst(pOutFile, node);
+#ifdef J9_PROJECT_SPECIFIC
+      printBCDNodeInfo(pOutFile, node);
+#endif
+
       if (_comp->cg()->getAppendInstruction() != NULL && node->getDataType() != TR::NoType && node->getRegister() != NULL)
          {
          output.appendf(" (in %s)", getName(node->getRegister()));
@@ -1359,20 +1339,18 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
                trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
                nodeCount++;
 
+               char const *fmtStr;
                if (sizeof(CASECONST_TYPE) == 8)
                   {
-                  if (node->getFirstChild()->getOpCode().isUnsigned())
-                     output.appendf(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
-                  else
-                     output.appendf(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
+                  fmtStr = (node->getFirstChild()->getOpCode().isUnsigned()) ?
+                     INT64_PRINTF_FORMAT_HEX ":\t" :
+                     INT64_PRINTF_FORMAT ":\t";
                   }
                else
                   {
-                  if (node->getFirstChild()->getOpCode().isUnsigned())
-                     output.appendf("%u:\t", node->getChild(i)->getCaseConstant());
-                  else
-                     output.appendf("%d:\t", node->getChild(i)->getCaseConstant());
+                  fmtStr = (node->getFirstChild()->getOpCode().isUnsigned()) ? "%u:\t" : "%d:\t";
                   }
+               output.appendf(fmtStr, node->getChild(i)->getCaseConstant());
                _comp->incrNodeOpCodeLength( output.getLength() );
                trfprintf(pOutFile, "%s", output.getStr());
                output.reset();
@@ -1448,7 +1426,7 @@ TR_Debug::printDestination( TR::TreeTop *treeTop, TR_PrettyPrinterString& output
    output.appends(" --> ");
    if (block->getNumber() >= 0)
       output.appendf("block_%d", block->getNumber());
-      output.appendf(" BBStart at n%dn", node->getGlobalIndex());
+   output.appendf(" BBStart at n%dn", node->getGlobalIndex());
    }
 
 void
@@ -1485,10 +1463,7 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
 
    int32_t lineNumber = _comp->getLineNumber(node);
 
-   output.appendf( "[%s] ",
-      //node->getOpCode().getSize(),
-      //getName(node->getDataType()),
-      getName(node));
+   output.appendf("[%s] ", getName(node));
 
    char const * bciOrLoc = "bci";
 
@@ -1498,7 +1473,6 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
          "%s=[%d,%d,-] rc=", bciOrLoc,
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex());
-      output.appendf("%d", node->getReferenceCount());
       }
    else
       {
@@ -1507,10 +1481,9 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex(),
          lineNumber);
-      output.appendf("%d", node->getReferenceCount());
       }
 
-   output.appendf(" vc=%d", node->getVisitCount());
+   output.appendf("%d vc=%d", node->getReferenceCount(), node->getVisitCount());
 
    if (_comp->getOptimizer() && _comp->getOptimizer()->getValueNumberInfo())
       output.appendf(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
@@ -1739,35 +1712,40 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       if (getCurrentParent() && getCurrentParent()->getOpCodeValue() == TR::newarray && getCurrentParent()->getSecondChild() == node)
          {
          output.appends("   ; array type is ");
+
+         char *typeStr;
          switch (node->getInt())
             {
             case 4:
-               output.appends("boolean");
+               typeStr = "boolean";
                break;
             case 5:
-               output.appends("char");
+               typeStr = "char";
                break;
             case 6:
-               output.appends("float");
+               typeStr = "float";
                break;
             case 7:
-               output.appends("double");
+               typeStr = "double";
                break;
             case 8:
-               output.appends("byte");
+               typeStr = "byte";
                break;
             case 9:
-               output.appends("short");
+               typeStr = "short";
                break;
             case 10:
-               output.appends("int");
+               typeStr = "int";
                break;
             case 11:
-               output.appends("long");
+               typeStr = "long";
                break;
             default:
-               TR_ASSERT(0, "Wrong array type");
+               TR_ASSERT_FATAL(0, "Unexpected array type");
+               typeStr = "unknown";
             }
+
+         output.appends(typeStr);
          }
       }
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1252,14 +1252,13 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
    uint32_t numSpaces,
             globalIndex;
 
-   TR_PrettyPrinterString globalIndexPrefix(this),
-                          output(this);
+   TR_PrettyPrinterString output(this);
 
    if (pOutFile == NULL) return 0;
 
    _comp->setNodeOpCodeLength(0);
 
-   globalIndexPrefix.appends("n");
+   char const * const globalIndexPrefix = "n";
 
    globalIndex = node->getGlobalIndex();
    numSpaces = getNumSpacesAfterIndex( globalIndex, MAX_GLOBAL_INDEX_LENGTH );
@@ -1270,7 +1269,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
       {
       if (printRefCounts)
          {
-         trfprintf(pOutFile, "%s%s%dn%*s  (%3d) %*s==>%s", prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", node->getReferenceCount(), indentation, " ", getName(node->getOpCode()));
+         trfprintf(pOutFile, "%s%s%dn%*s  (%3d) %*s==>%s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", node->getReferenceCount(), indentation, " ", getName(node->getOpCode()));
          if (node->getOpCode().isLoadConst())
             printLoadConst(pOutFile, node);
 #ifdef J9_PROJECT_SPECIFIC
@@ -1280,7 +1279,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
          }
       else
          {
-         trfprintf(pOutFile, "%s%s%dn%*s  %*s==>%s", prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ", getName(node->getOpCode()));
+         trfprintf(pOutFile, "%s%s%dn%*s  %*s==>%s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ", getName(node->getOpCode()));
          if (node->getOpCode().isLoadConst())
             printLoadConst(pOutFile, node);
 #ifdef J9_PROJECT_SPECIFIC
@@ -1305,9 +1304,9 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
    _nodeChecklist.set(node->getGlobalIndex());
 
    if (printRefCounts)
-      trfprintf(pOutFile, "%s%s%dn%*s  (%3d) %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", node->getReferenceCount(), indentation, " ");
+      trfprintf(pOutFile, "%s%s%dn%*s  (%3d) %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", node->getReferenceCount(), indentation, " ");
    else
-      trfprintf(pOutFile, "%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
+      trfprintf(pOutFile, "%s%s%dn%*s  %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
 
    int32_t nodeCount = 1; // Count this node
    int32_t i;
@@ -1335,7 +1334,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
          globalIndex = node->getSecondChild()->getGlobalIndex();
          numSpaces = getNumSpacesAfterIndex( globalIndex, MAX_GLOBAL_INDEX_LENGTH );
 
-         trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
+         trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
          nodeCount++;
          output.appends("default ");
          _comp->incrNodeOpCodeLength( output.getLength() );
@@ -1357,7 +1356,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
                globalIndex = node->getChild(i)->getGlobalIndex();
                numSpaces = getNumSpacesAfterIndex( globalIndex, MAX_GLOBAL_INDEX_LENGTH );
 
-               trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
+               trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
                nodeCount++;
 
                if (sizeof(CASECONST_TYPE) == 8)
@@ -1393,7 +1392,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
                globalIndex = node->getChild(i)->getGlobalIndex();
                numSpaces = getNumSpacesAfterIndex( globalIndex, MAX_GLOBAL_INDEX_LENGTH );
 
-               trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
+               trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
                nodeCount++;
                output.appendf("%d", i-2);
                _comp->incrNodeOpCodeLength( output.getLength() );
@@ -1456,7 +1455,6 @@ void
 TR_Debug::printBasicPreNodeInfoAndIndent(TR::FILE *pOutFile, TR::Node * node, uint32_t indentation)
    {
    uint32_t numSpaces;
-   TR_PrettyPrinterString globalIndexPrefix(this);
 
    if (pOutFile == NULL) return;
 
@@ -1467,10 +1465,10 @@ TR_Debug::printBasicPreNodeInfoAndIndent(TR::FILE *pOutFile, TR::Node * node, ui
       trfprintf(pOutFile, "\n");
       }
 
-   globalIndexPrefix.appends("n");
+   char const * const globalIndexPrefix = "n";
 
    numSpaces = getNumSpacesAfterIndex( node->getGlobalIndex(), MAX_GLOBAL_INDEX_LENGTH );
-   trfprintf(pOutFile, "%s%dn%*s %*s", globalIndexPrefix.getStr(), node->getGlobalIndex(), numSpaces, "", indentation, " ");
+   trfprintf(pOutFile, "%s%dn%*s %*s", globalIndexPrefix, node->getGlobalIndex(), numSpaces, "", indentation, " ");
 
    _comp->setNodeOpCodeLength( 0 );
    }
@@ -1553,9 +1551,7 @@ TR_Debug::printNodeInfo(TR::FILE *pOutFile, TR::Node * node)
 void
 TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool prettyPrint)
    {
-   TR_PrettyPrinterString globalIndexPrefix(this);
-
-   globalIndexPrefix.appends("n");
+   char const * const globalIndexPrefix = "n";
 
    if (!prettyPrint || (node->getOpCodeValue() != TR::BBStart && node->getOpCodeValue() != TR::BBEnd))
       {
@@ -1568,13 +1564,13 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
    if (node->getOpCode().isNullCheck())
       {
       if (node->getNullCheckReference())
-         output.appendf(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
+         output.appendf(" on %s%dn", globalIndexPrefix, node->getNullCheckReference()->getGlobalIndex());
       else output.appends(" on null NullCheckReference ----- INVALID tree!!");
       }
    else if (node->getOpCodeValue() == TR::allocationFence)
       {
       if(node->getAllocation())
-         output.appendf(" on %s%dn", globalIndexPrefix.getStr(), node->getAllocation()->getGlobalIndex());
+         output.appendf(" on %s%dn", globalIndexPrefix, node->getAllocation()->getGlobalIndex());
       else
          output.appends(" on ALL");
       }

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -253,9 +253,9 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
          break;
       case TR::Address:
          if (node->getAddress() == 0)
-            output.append(" NULL");
+            output.appends(" NULL");
          else if (_comp->getOption(TR_MaskAddresses))
-            output.append(" *Masked*");
+            output.appends(" *Masked*");
          else
             output.append(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
          if (node->isClassPointerConstant())
@@ -265,9 +265,9 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
             if (clazz)
                {
                if (TR::Compiler->cls.isInterfaceClass(_comp, clazz))
-                  output.append(" Interface");
+                  output.appends(" Interface");
                else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
-                  output.append(" Abstract");
+                  output.appends(" Abstract");
                }
             output.append(" (%.*s.class)", len, sig);
             }
@@ -1074,7 +1074,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Node * node, uint32_t indentation, bool 
          printBasicPreNodeInfoAndIndent(pOutFile, node->getSecondChild(), indentation);
          nodeCount++;
 
-         output.append("default ");
+         output.appends("default ");
          _comp->incrNodeOpCodeLength( output.getLength() );
          trfprintf(pOutFile, "%s", output.getStr());
          output.reset();
@@ -1259,7 +1259,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
 
    _comp->setNodeOpCodeLength(0);
 
-      globalIndexPrefix.append( "n" );
+   globalIndexPrefix.appends("n");
 
    globalIndex = node->getGlobalIndex();
    numSpaces = getNumSpacesAfterIndex( globalIndex, MAX_GLOBAL_INDEX_LENGTH );
@@ -1337,7 +1337,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
 
          trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
          nodeCount++;
-         output.append("default ");
+         output.appends("default ");
          _comp->incrNodeOpCodeLength( output.getLength() );
          trfprintf(pOutFile, "%s", output.getStr());
          output.reset();
@@ -1446,7 +1446,7 @@ TR_Debug::printDestination( TR::TreeTop *treeTop, TR_PrettyPrinterString& output
 
    TR::Node *node = treeTop->getNode();
    TR::Block *block = node->getBlock();
-   output.append(" --> ");
+   output.appends(" --> ");
    if (block->getNumber() >= 0)
       output.append("block_%d", block->getNumber());
       output.append(" BBStart at n%dn", node->getGlobalIndex());
@@ -1467,7 +1467,7 @@ TR_Debug::printBasicPreNodeInfoAndIndent(TR::FILE *pOutFile, TR::Node * node, ui
       trfprintf(pOutFile, "\n");
       }
 
-      globalIndexPrefix.append( "n" );
+   globalIndexPrefix.appends("n");
 
    numSpaces = getNumSpacesAfterIndex( node->getGlobalIndex(), MAX_GLOBAL_INDEX_LENGTH );
    trfprintf(pOutFile, "%s%dn%*s %*s", globalIndexPrefix.getStr(), node->getGlobalIndex(), numSpaces, "", indentation, " ");
@@ -1481,7 +1481,7 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
    TR_PrettyPrinterString output(this);
    if (pOutFile == NULL) return;
 
-   output.append("  ");
+   output.appends("  ");
    if ((_comp->getNodeOpCodeLength() + indentation) < DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT)
       output.append( "%*s", DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT - ( _comp->getNodeOpCodeLength() + indentation ), "");
 
@@ -1517,17 +1517,17 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
    if (_comp->getOptimizer() && _comp->getOptimizer()->getValueNumberInfo())
       output.append(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
    else
-      output.append(" vn=-");
+      output.appends(" vn=-");
 
    if (node->getLocalIndex())
       output.append(" li=%d", node->getLocalIndex());
    else
-      output.append(" li=-");
+      output.appends(" li=-");
 
    if (node->getUseDefIndex())
       output.append(" udi=%d", node->getUseDefIndex());
    else
-      output.append(" udi=-");
+      output.appends(" udi=-");
 
    output.append(" nc=%d", node->getNumChildren());
 
@@ -1555,7 +1555,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
    {
    TR_PrettyPrinterString globalIndexPrefix(this);
 
-      globalIndexPrefix.append( "n" );
+   globalIndexPrefix.appends("n");
 
    if (!prettyPrint || (node->getOpCodeValue() != TR::BBStart && node->getOpCodeValue() != TR::BBEnd))
       {
@@ -1569,14 +1569,14 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       {
       if (node->getNullCheckReference())
          output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
-      else output.append(" on null NullCheckReference ----- INVALID tree!!");
+      else output.appends(" on null NullCheckReference ----- INVALID tree!!");
       }
    else if (node->getOpCodeValue() == TR::allocationFence)
       {
       if(node->getAllocation())
          output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getAllocation()->getGlobalIndex());
       else
-         output.append(" on ALL");
+         output.appends(" on ALL");
       }
 
    if (node->getOpCode().hasSymbolReference() && node->getSymbolReference())
@@ -1596,18 +1596,18 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       if (node->getNumRelocations() > 0)
          {
          if (node->getRelocationType() == TR_AbsoluteAddress)
-            output.append(" Absolute [");
+            output.appends(" Absolute [");
          else if (node->getRelocationType() == TR_ExternalAbsoluteAddress)
-            output.append(" External Absolute [");
+            output.appends(" External Absolute [");
          else
-            output.append(" Relative [");
+            output.appends(" Relative [");
 
          if (!_comp->getOption(TR_MaskAddresses))
             {
             for (auto i = 0U; i < node->getNumRelocations(); ++i)
                output.append(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
             }
-         output.append(" ]");
+         output.appends(" ]");
          }
       }
    else if (node->getOpCodeValue() == TR::BBStart)
@@ -1622,7 +1622,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       if (block->getFrequency()>=0)
          output.append(" (freq %d)",block->getFrequency());
       if (block->isExtensionOfPreviousBlock())
-         output.append(" (extension of previous block)");
+         output.appends(" (extension of previous block)");
       if (block->isCatchBlock())
          {
          int32_t length;
@@ -1641,16 +1641,16 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
 
          if (block->isOSRCatchBlock())
             {
-            output.append(" (OSR handler)");
+            output.appends(" (OSR handler)");
             }
          }
       if (block->isSuperCold())
-         output.append(" (super cold)");
+         output.appends(" (super cold)");
       else if (block->isCold())
-         output.append(" (cold)");
+         output.appends(" (cold)");
 
       if (block->isLoopInvariantBlock())
-         output.append(" (loop pre-header)");
+         output.appends(" (loop pre-header)");
       TR_BlockStructure *blockStructure = block->getStructureOf();
       if (blockStructure)
          {
@@ -1682,14 +1682,14 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          {
          output.append(" </block_%d>",block->getNumber());
          if (block->isSuperCold())
-            output.append(" (super cold)");
+            output.appends(" (super cold)");
          else if (block->isCold())
-            output.append(" (cold)");
+            output.appends(" (cold)");
          }
 
 
       if ((nextBlock = block->getNextBlock()) && !nextBlock->isExtensionOfPreviousBlock()) //end of a block that is not the last block and the next block is not an extension of it
-         output.append(" =====");
+         output.appends(" =====");
       }
    else if (node->getOpCode().isArrayLength())
       {
@@ -1742,32 +1742,32 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
 
       if (getCurrentParent() && getCurrentParent()->getOpCodeValue() == TR::newarray && getCurrentParent()->getSecondChild() == node)
          {
-         output.append("   ; array type is ");
+         output.appends("   ; array type is ");
          switch (node->getInt())
             {
             case 4:
-               output.append("boolean");
+               output.appends("boolean");
                break;
             case 5:
-               output.append("char");
+               output.appends("char");
                break;
             case 6:
-               output.append("float");
+               output.appends("float");
                break;
             case 7:
-               output.append("double");
+               output.appends("double");
                break;
             case 8:
-               output.append("byte");
+               output.appends("byte");
                break;
             case 9:
-               output.append("short");
+               output.appends("short");
                break;
             case 10:
-               output.append("int");
+               output.appends("int");
                break;
             case 11:
-               output.append("long");
+               output.appends("long");
                break;
             default:
                TR_ASSERT(0, "Wrong array type");
@@ -1790,9 +1790,9 @@ TR_Debug::printNodeFlags(TR::FILE *pOutFile, TR::Node * node)
 
    if (node->getFlags().getValue())
       {
-      output.append(" (");
+      output.appends(" (");
       nodePrintAllFlags(node, output);
-      output.append(")");
+      output.appends(")");
       }
 
    trfprintf(pOutFile, "%s", output.getStr());
@@ -1864,22 +1864,22 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
          }
       if (!node->getOpCode().isStore())
          {
-         output.append("sign=");
+         output.appends("sign=");
          if (node->hasKnownOrAssumedCleanSign() || node->hasKnownOrAssumedPreferredSign() || node->hasKnownOrAssumedSignCode())
             {
             if (node->signStateIsKnown())
-               output.append("known(");
+               output.appends("known(");
             else
-               output.append("assumed(");
+               output.appends("assumed(");
             if (node->hasKnownOrAssumedCleanSign())
-               output.append("clean");
+               output.appends("clean");
             if (node->hasKnownOrAssumedPreferredSign())
                output.append("%spreferred",node->hasKnownOrAssumedCleanSign() ? "/":"");
             if (node->hasKnownOrAssumedSignCode())
                output.append("%s%s",
                              node->hasKnownOrAssumedCleanSign() || node->hasKnownOrAssumedPreferredSign() ? "/":"",
                              getName(node->hasKnownSignCode() ? node->getKnownSignCode() : node->getAssumedSignCode()));
-            output.append(") ");
+            output.appends(") ");
             }
          else if (node->getOpCode().isLoad())
             {
@@ -1887,7 +1887,7 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
             }
          else
             {
-            output.append("? ");
+            output.appends("? ");
             }
          }
       if (node->isSetSignValueOnNode())
@@ -1906,7 +1906,7 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
       }
    if (node->castedToBCD())
       {
-      output.append(" <castedToBCD=true> ");
+      output.appends(" <castedToBCD=true> ");
       }
    }
 #endif

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -199,56 +199,56 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
       {
       case TR::Int8:
          if(isUnsigned)
-            output.append(" %3u", node->getUnsignedByte());
+            output.appendf(" %3u", node->getUnsignedByte());
          else
-            output.append(" %3d", node->getByte());
+            output.appendf(" %3d", node->getByte());
          break;
       case TR::Int16:
          if (valueIsProbablyHex(node))
-            output.append(" 0x%4x", node->getConst<uint16_t>());
+            output.appendf(" 0x%4x", node->getConst<uint16_t>());
          else
-            output.append(" '%5d' ", node->getConst<uint16_t>());
+            output.appendf(" '%5d' ", node->getConst<uint16_t>());
          break;
       case TR::Int32:
          if(isUnsigned)
             {
             if (valueIsProbablyHex(node))
-               output.append(" 0x%x", node->getUnsignedInt());
+               output.appendf(" 0x%x", node->getUnsignedInt());
             else
-               output.append(" %u", node->getUnsignedInt());
+               output.appendf(" %u", node->getUnsignedInt());
             }
          else
             {
             if (valueIsProbablyHex(node))
-               output.append(" 0x%x", node->getInt());
+               output.appendf(" 0x%x", node->getInt());
             else
-               output.append(" %d", node->getInt());
+               output.appendf(" %d", node->getInt());
             }
          break;
       case TR::Int64:
          if(isUnsigned)
             {
             if (valueIsProbablyHex(node))
-               output.append(" " UINT64_PRINTF_FORMAT_HEX, node->getUnsignedLongInt());
+               output.appendf(" " UINT64_PRINTF_FORMAT_HEX, node->getUnsignedLongInt());
             else
-               output.append(" " UINT64_PRINTF_FORMAT , node->getUnsignedLongInt());
+               output.appendf(" " UINT64_PRINTF_FORMAT , node->getUnsignedLongInt());
             }
          else
             {
             if (valueIsProbablyHex(node))
-               output.append(" " INT64_PRINTF_FORMAT_HEX, node->getLongInt());
+               output.appendf(" " INT64_PRINTF_FORMAT_HEX, node->getLongInt());
             else
-               output.append(" " INT64_PRINTF_FORMAT , node->getLongInt());
+               output.appendf(" " INT64_PRINTF_FORMAT , node->getLongInt());
             }
          break;
       case TR::Float:
             {
-            output.append(" %g [0x%08x]", node->getFloat(), node->getFloatBits());
+            output.appendf(" %g [0x%08x]", node->getFloat(), node->getFloatBits());
             }
          break;
       case TR::Double:
             {
-            output.append(" %g [" UINT64_PRINTF_FORMAT_HEX "]", node->getDouble(), node->getDoubleBits());
+            output.appendf(" %g [" UINT64_PRINTF_FORMAT_HEX "]", node->getDouble(), node->getDoubleBits());
             }
          break;
       case TR::Address:
@@ -257,7 +257,7 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
          else if (_comp->getOption(TR_MaskAddresses))
             output.appends(" *Masked*");
          else
-            output.append(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
+            output.appendf(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
          if (node->isClassPointerConstant())
             {
             TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock*)node->getAddress();
@@ -269,12 +269,12 @@ TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString& output)
                else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
                   output.appends(" Abstract");
                }
-            output.append(" (%.*s.class)", len, sig);
+            output.appendf(" (%.*s.class)", len, sig);
             }
          break;
 
       default:
-         output.append(" Bad Type %s", node->getDataType().toString());
+         output.appendf(" Bad Type %s", node->getDataType().toString());
          break;
       }
    }
@@ -988,7 +988,7 @@ TR_Debug::formattedString(char *buf, uint32_t bufLen, const char *format, va_lis
    return buf;
    }
 
-void TR_PrettyPrinterString::append(const char* format, ...)
+void TR_PrettyPrinterString::appendf(const char* format, ...)
    {
    va_list args;
    va_start (args, format);
@@ -1107,16 +1107,16 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Node * node, uint32_t indentation, bool 
                if (sizeof(CASECONST_TYPE) == 8)
                   {
                   if (unsigned_case)
-                     output.append(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
+                     output.appendf(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
                   else
-                     output.append(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
+                     output.appendf(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
                   }
                else
                   {
                   if (unsigned_case)
-                     output.append("%u:\t", node->getChild(i)->getCaseConstant());
+                     output.appendf("%u:\t", node->getChild(i)->getCaseConstant());
                   else
-                     output.append("%d:\t", node->getChild(i)->getCaseConstant());
+                     output.appendf("%d:\t", node->getChild(i)->getCaseConstant());
                   }
 
                _comp->incrNodeOpCodeLength( output.getLength() );
@@ -1143,7 +1143,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Node * node, uint32_t indentation, bool 
                {
                printBasicPreNodeInfoAndIndent(pOutFile, node->getChild(i), indentation);
                nodeCount++;
-               output.append("%d", i-2);
+               output.appendf("%d", i-2);
                _comp->incrNodeOpCodeLength( output.getLength() );
                trfprintf(pOutFile, "%s", output.getStr());
                output.reset();
@@ -1290,7 +1290,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
          }
       if (_comp->cg()->getAppendInstruction() != NULL && node->getDataType() != TR::NoType && node->getRegister() != NULL)
          {
-         output.append(" (in %s)", getName(node->getRegister()));
+         output.appendf(" (in %s)", getName(node->getRegister()));
          _comp->incrNodeOpCodeLength( output.getLength() );
          trfprintf(pOutFile, "%s", output.getStr());
          output.reset();
@@ -1315,7 +1315,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
    printNodeInfo(pOutFile, node);
    if (_comp->cg()->getAppendInstruction() != NULL && node->getDataType() != TR::NoType && node->getRegister() != NULL)
       {
-      output.append(" (in %s)", getName(node->getRegister()));
+      output.appendf(" (in %s)", getName(node->getRegister()));
       _comp->incrNodeOpCodeLength( output.getLength() );
       trfprintf(pOutFile, "%s", output.getStr());
       output.reset();
@@ -1363,16 +1363,16 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
                if (sizeof(CASECONST_TYPE) == 8)
                   {
                   if (node->getFirstChild()->getOpCode().isUnsigned())
-                     output.append(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
+                     output.appendf(INT64_PRINTF_FORMAT_HEX ":\t", node->getChild(i)->getCaseConstant());
                   else
-                     output.append(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
+                     output.appendf(INT64_PRINTF_FORMAT ":\t", node->getChild(i)->getCaseConstant());
                   }
                else
                   {
                   if (node->getFirstChild()->getOpCode().isUnsigned())
-                     output.append("%u:\t", node->getChild(i)->getCaseConstant());
+                     output.appendf("%u:\t", node->getChild(i)->getCaseConstant());
                   else
-                     output.append("%d:\t", node->getChild(i)->getCaseConstant());
+                     output.appendf("%d:\t", node->getChild(i)->getCaseConstant());
                   }
                _comp->incrNodeOpCodeLength( output.getLength() );
                trfprintf(pOutFile, "%s", output.getStr());
@@ -1395,7 +1395,7 @@ TR_Debug::printWithFixedPrefix(TR::FILE *pOutFile, TR::Node * node, uint32_t ind
 
                trfprintf(pOutFile,"\n%s%s%dn%*s  %*s",prefix, globalIndexPrefix.getStr(), globalIndex, numSpaces, "", indentation, " ");
                nodeCount++;
-               output.append("%d", i-2);
+               output.appendf("%d", i-2);
                _comp->incrNodeOpCodeLength( output.getLength() );
                trfprintf(pOutFile, "%s", output.getStr());
                output.reset();
@@ -1448,8 +1448,8 @@ TR_Debug::printDestination( TR::TreeTop *treeTop, TR_PrettyPrinterString& output
    TR::Block *block = node->getBlock();
    output.appends(" --> ");
    if (block->getNumber() >= 0)
-      output.append("block_%d", block->getNumber());
-      output.append(" BBStart at n%dn", node->getGlobalIndex());
+      output.appendf("block_%d", block->getNumber());
+      output.appendf(" BBStart at n%dn", node->getGlobalIndex());
    }
 
 void
@@ -1483,11 +1483,11 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
 
    output.appends("  ");
    if ((_comp->getNodeOpCodeLength() + indentation) < DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT)
-      output.append( "%*s", DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT - ( _comp->getNodeOpCodeLength() + indentation ), "");
+      output.appendf( "%*s", DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT - ( _comp->getNodeOpCodeLength() + indentation ), "");
 
    int32_t lineNumber = _comp->getLineNumber(node);
 
-   output.append( "[%s] ",
+   output.appendf( "[%s] ",
       //node->getOpCode().getSize(),
       //getName(node->getDataType()),
       getName(node));
@@ -1496,43 +1496,43 @@ TR_Debug::printBasicPostNodeInfo(TR::FILE *pOutFile, TR::Node * node, uint32_t i
 
    if (lineNumber < 0)
       {
-      output.append(
+      output.appendf(
          "%s=[%d,%d,-] rc=", bciOrLoc,
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex());
-      output.append("%d", node->getReferenceCount());
+      output.appendf("%d", node->getReferenceCount());
       }
    else
       {
-      output.append(
+      output.appendf(
          "%s=[%d,%d,%d] rc=", bciOrLoc,
          node->getByteCodeInfo().getCallerIndex(),
          node->getByteCodeInfo().getByteCodeIndex(),
          lineNumber);
-      output.append("%d", node->getReferenceCount());
+      output.appendf("%d", node->getReferenceCount());
       }
 
-   output.append(" vc=%d", node->getVisitCount());
+   output.appendf(" vc=%d", node->getVisitCount());
 
    if (_comp->getOptimizer() && _comp->getOptimizer()->getValueNumberInfo())
-      output.append(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
+      output.appendf(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
    else
       output.appends(" vn=-");
 
    if (node->getLocalIndex())
-      output.append(" li=%d", node->getLocalIndex());
+      output.appendf(" li=%d", node->getLocalIndex());
    else
       output.appends(" li=-");
 
    if (node->getUseDefIndex())
-      output.append(" udi=%d", node->getUseDefIndex());
+      output.appendf(" udi=%d", node->getUseDefIndex());
    else
       output.appends(" udi=-");
 
-   output.append(" nc=%d", node->getNumChildren());
+   output.appendf(" nc=%d", node->getNumChildren());
 
    if (node->getFlags().getValue())
-      output.append(" flg=0x%x", node->getFlags().getValue());
+      output.appendf(" flg=0x%x", node->getFlags().getValue());
 
    trfprintf(pOutFile, "%s", output.getStr());
 
@@ -1559,22 +1559,22 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
 
    if (!prettyPrint || (node->getOpCodeValue() != TR::BBStart && node->getOpCodeValue() != TR::BBEnd))
       {
-      output.append("%s", getName(node->getOpCode()));
+      output.appendf("%s", getName(node->getOpCode()));
       }
 
    if (node->hasKnownObjectIndex())
-      output.append(" (node obj%d)", node->getKnownObjectIndex());
+      output.appendf(" (node obj%d)", node->getKnownObjectIndex());
 
    if (node->getOpCode().isNullCheck())
       {
       if (node->getNullCheckReference())
-         output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
+         output.appendf(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
       else output.appends(" on null NullCheckReference ----- INVALID tree!!");
       }
    else if (node->getOpCodeValue() == TR::allocationFence)
       {
       if(node->getAllocation())
-         output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getAllocation()->getGlobalIndex());
+         output.appendf(" on %s%dn", globalIndexPrefix.getStr(), node->getAllocation()->getGlobalIndex());
       else
          output.appends(" on ALL");
       }
@@ -1605,7 +1605,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          if (!_comp->getOption(TR_MaskAddresses))
             {
             for (auto i = 0U; i < node->getNumRelocations(); ++i)
-               output.append(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
+               output.appendf(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
             }
          output.appends(" ]");
          }
@@ -1616,11 +1616,11 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       if (block->getNumber() >= 0)
          {
          //trfprintf(pOutFile, " <block_%d>",block->getNumber());
-         output.append(" <block_%d>",block->getNumber());
+         output.appendf(" <block_%d>",block->getNumber());
          }
 
       if (block->getFrequency()>=0)
-         output.append(" (freq %d)",block->getFrequency());
+         output.appendf(" (freq %d)",block->getFrequency());
       if (block->isExtensionOfPreviousBlock())
          output.appends(" (extension of previous block)");
       if (block->isCatchBlock())
@@ -1630,13 +1630,13 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          if (classNameChars)
             {
             length = block->getExceptionClassNameLength();
-            output.append(" (catches %.*s)", length, getName(classNameChars, length));
+            output.appendf(" (catches %.*s)", length, getName(classNameChars, length));
             }
          else
             {
             classNameChars = "...";
             length = 3;
-            output.append(" (catches %.*s)", length, classNameChars);   // passing literal string shouldn't use getName()
+            output.appendf(" (catches %.*s)", length, classNameChars);   // passing literal string shouldn't use getName()
             }
 
          if (block->isOSRCatchBlock())
@@ -1663,14 +1663,14 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
                if (region->isNaturalLoop() ||
                    region->containsInternalCycles())
                   {
-                  output.append(" (in loop %d)", region->getNumber());
+                  output.appendf(" (in loop %d)", region->getNumber());
                   break;
                   }
                parent = parent->getParent();
                }
             TR_BlockStructure *dupBlock = blockStructure->getDuplicatedBlock();
             if (dupBlock)
-               output.append(" (dup of block_%d)", dupBlock->getNumber());
+               output.appendf(" (dup of block_%d)", dupBlock->getNumber());
             }
          }
       }
@@ -1680,7 +1680,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
                *nextBlock;
       if (block->getNumber() >= 0)
          {
-         output.append(" </block_%d>",block->getNumber());
+         output.appendf(" </block_%d>",block->getNumber());
          if (block->isSuperCold())
             output.appends(" (super cold)");
          else if (block->isCold())
@@ -1696,14 +1696,14 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       int32_t stride = node->getArrayStride();
 
       if (stride > 0)
-         output.append(" (stride %d)",stride);
+         output.appendf(" (stride %d)",stride);
       }
    else if (node->getOpCode().isLoadReg() || node->getOpCode().isStoreReg())
       {
       if ((node->getType().isInt64() && _comp->target().is32Bit() && !_comp->cg()->use64BitRegsOn32Bit()))
-         output.append(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber()), getGlobalRegisterName(node->getLowGlobalRegisterNumber()));
+         output.appendf(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber()), getGlobalRegisterName(node->getLowGlobalRegisterNumber()));
       else
-         output.append(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber()));
+         output.appendf(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber()));
 
       if (node->getOpCode().isLoadReg())
          print(node->getRegLoadStoreSymbolReference(), output);
@@ -1723,17 +1723,17 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          else                    size = TR_DoubleWordReg;
          if ((node->getFirstChild()->getType().isInt64() &&
               _comp->target().is32Bit()))
-            output.append(" %s:%s ",
+            output.appendf(" %s:%s ",
                           getGlobalRegisterName(node->getHighGlobalRegisterNumber(), size),
                           getGlobalRegisterName(node->getLowGlobalRegisterNumber(), size));
          else
-            output.append(" %s ",
+            output.appendf(" %s ",
                           getGlobalRegisterName(node->getGlobalRegisterNumber(), size));
          }
       }
    else if(node->getOpCode().hasNoDataType())
       {
-      output.append(" (%s)", getName(node->getDataType()));
+      output.appendf(" (%s)", getName(node->getDataType()));
       }
 
    if (node->getOpCode().isLoadConst())
@@ -1824,28 +1824,28 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
          {
          if (node->hasSourcePrecision())
             {
-            output.append(" <prec=%d (len=%d) srcprec=%d> ",
+            output.appendf(" <prec=%d (len=%d) srcprec=%d> ",
                           node->getDecimalPrecision(),
                           node->getSize(),
                           node->getSourcePrecision());
             }
          else
             {
-            output.append(" <prec=%d (len=%d)> ",
+            output.appendf(" <prec=%d (len=%d)> ",
                           node->getDecimalPrecision(),
                           node->getSize());
             }
          }
       else if (node->getOpCode().isLoad())
          {
-         output.append(" <prec=%d (len=%d) adj=%d> ",
+         output.appendf(" <prec=%d (len=%d) adj=%d> ",
                        node->getDecimalPrecision(),
                        node->getSize(),
                        node->getDecimalAdjust());
          }
       else if (node->canHaveSourcePrecision())
          {
-         output.append(" <prec=%d (len=%d) srcprec=%d %s=%d round=%d> ",
+         output.appendf(" <prec=%d (len=%d) srcprec=%d %s=%d round=%d> ",
                        node->getDecimalPrecision(),
                        node->getSize(),
                        node->getSourcePrecision(),
@@ -1855,7 +1855,7 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
          }
       else
          {
-         output.append(" <prec=%d (len=%d) %s=%d round=%d> ",
+         output.appendf(" <prec=%d (len=%d) %s=%d round=%d> ",
                        node->getDecimalPrecision(),
                        node->getSize(),
                        node->getOpCode().isConversionWithFraction() ? "frac":"adj",
@@ -1874,16 +1874,16 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
             if (node->hasKnownOrAssumedCleanSign())
                output.appends("clean");
             if (node->hasKnownOrAssumedPreferredSign())
-               output.append("%spreferred",node->hasKnownOrAssumedCleanSign() ? "/":"");
+               output.appendf("%spreferred",node->hasKnownOrAssumedCleanSign() ? "/":"");
             if (node->hasKnownOrAssumedSignCode())
-               output.append("%s%s",
+               output.appendf("%s%s",
                              node->hasKnownOrAssumedCleanSign() || node->hasKnownOrAssumedPreferredSign() ? "/":"",
                              getName(node->hasKnownSignCode() ? node->getKnownSignCode() : node->getAssumedSignCode()));
             output.appends(") ");
             }
          else if (node->getOpCode().isLoad())
             {
-            output.append("%s ",node->hasSignStateOnLoad()?"hasState":"noState");
+            output.appendf("%s ",node->hasSignStateOnLoad()?"hasState":"noState");
             }
          else
             {
@@ -1892,17 +1892,17 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
          }
       if (node->isSetSignValueOnNode())
          {
-         output.append("setSign=%s ",getName(node->getSetSign()));
+         output.appendf("setSign=%s ",getName(node->getSetSign()));
          }
       }
    else
       if (node->getOpCode().isConversionWithFraction())
       {
-      output.append(" <frac=%d> ",node->getDecimalFraction());
+      output.appendf(" <frac=%d> ",node->getDecimalFraction());
       }
    else if ((node->getType()).isAggregate())
       {
-      output.append(" <size=%lld bytes>", (int64_t)0);
+      output.appendf(" <size=%lld bytes>", (int64_t)0);
       }
    if (node->castedToBCD())
       {

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -992,9 +992,29 @@ void TR_PrettyPrinterString::append(const char* format, ...)
    {
    va_list args;
    va_start (args, format);
-   len+=vsnprintf(buffer+len,2000-len,format,args);
+   len += vsnprintf(buffer+len, maxBufferLength-len, format, args);
    va_end(args);
 
+   }
+
+void TR_PrettyPrinterString::appends(char const *str)
+   {
+   size_t const strLen0 = strlen(str) + 1; // include terminating '\0'
+   size_t const bufLenBytes = maxBufferLength-len;
+
+   char *buf = buffer+len;
+
+   if (strLen0 < bufLenBytes)
+      {
+      memcpy(buf, str, strLen0);
+      len += static_cast<int32_t>(strLen0 - 1);
+      }
+   else if (bufLenBytes != 0)
+      {
+      memcpy(buf, str, bufLenBytes-1);
+      buf[bufLenBytes-1] = '\0';
+      len += static_cast<int32_t>(bufLenBytes - 1);
+      }
    }
 
 int32_t


### PR DESCRIPTION
* Introduce appends() function to TR_PrettyPrinterString class 
* Use TR_PrettyPrinterString::appends() where appropriate 
* Rename TR_PrettyPrinterString::append() to appendf() 
* Remove log printing for obsolete symRefWCodeId 
* Remove excessive TR_PrettyPrinterString usage for globalIndexPrefix 
* Reduce calls to TR_PrettyPrinterString.appends() 
* Improve pathlength in TR_Debug::newNode() 
* Improve pathlength in TR_Debug::newLabelSymbol() 
* Improve pathlength in TR_Debug::newRegister() 
* Improve pathlength in TR_Debug::newVariableSizeSymbol() 
* Common break or debug on create functionality in TR_Debug 