### PR TITLE
AArch64: Enable Locals Compaction

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -175,6 +175,9 @@ OMR::ARM64::CodeGenerator::initialize()
       cg->setEnforceStoreOrder();
 
    cg->setSupportsAutoSIMD();
+   // Enable compaction of local stack slots.  i.e. variables with non-overlapping live ranges
+   // can share the same slot.
+   cg->setSupportsCompactedLocals();
    }
 
 void


### PR DESCRIPTION
This commit enables locals compaction on aarch64.

Depends on https://github.com/eclipse-openj9/openj9/pull/14624

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>