### PR TITLE
SATB TLH Batch Mark

### DIFF
--- a/example/glue/ObjectModelDelegate.hpp
+++ b/example/glue/ObjectModelDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -284,6 +284,9 @@ public:
 	 */
 	void calculateObjectDetailsForCopy(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, uintptr_t *objectCopySizeInBytes, uintptr_t *objectReserveSizeInBytes, uintptr_t *hotFieldAlignmentDescriptor);
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+
+	MMINLINE void
+	initializeMinimumSizeObject(MM_EnvironmentBase *env, void *allocAddr) {}
 
 	/**
 	 * Constructor receives a copy of OMR's object flags mask, normalized to low order byte.

--- a/gc/base/GlobalCollector.hpp
+++ b/gc/base/GlobalCollector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,7 +100,16 @@ public:
  	*/
 	virtual void deleteSweepPoolState(MM_EnvironmentBase* env, void* sweepPoolState) = 0;
 
-	virtual void checkColorAndMark(MM_EnvironmentBase* env, omrobjectptr_t objectPt) { Assert_MM_unreachable(); }
+	virtual void checkColorAndMark(MM_EnvironmentBase* env, omrobjectptr_t objectPt) {};
+
+	/* Size in bytes to be reserved in an allocation cache for the collector. Required for specific use cases (SATB TLH Premark) */
+	virtual uintptr_t reservedForGCAllocCacheSize() { return 0; }
+
+	/* Used to notify the collector that current TLH is about to be flushed (relates to reservedForGCAllocCacheSize())
+	 * @param base The base address of the cache
+	 * @param top  The start of the last obj in the cache
+	 */
+	virtual void preAllocCacheFlush(MM_EnvironmentBase *env, void *base, void *top) {};
 
 	MM_GlobalCollector()
 		: MM_Collector()

--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -204,6 +204,8 @@ public:
 
 		return marked;
 	}
+
+	void markObjectsForRange(MM_EnvironmentBase *env, uint8_t *objPtrLow, uint8_t *objPtrHigh);
 
 	uintptr_t numMarkBitsInRange(MM_EnvironmentBase *env, void *heapBase, void *heapTop);
 	uintptr_t setMarkBitsInRange(MM_EnvironmentBase *env, void *heapBase, void *heapTop, bool clear);

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -902,6 +902,20 @@ public:
 		setObjectFlags(destinationObjectPtr, OMR_OBJECT_METADATA_AGE_MASK, age);
 	}
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+
+	/**
+	 * Initialize an object of minimal object size at given addr.
+	 *
+	 * There is an assumption that the object is not visible (referred) by anyone, so the minimum initialization can be done.
+	 *
+	 * @param[in] env The environment for the calling thread.
+	 * @param[in] allocAddr address at which the object is created.
+	 */
+	MMINLINE void
+	initializeMinimumSizeObject(MM_EnvironmentBase *env, void *allocAddr)
+	{
+		_delegate.initializeMinimumSizeObject(env, allocAddr);
+	}
 
 	/**
 	 * Constructor.

--- a/gc/base/ParallelHeapWalker.cpp
+++ b/gc/base/ParallelHeapWalker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ MM_ParallelHeapWalker::allObjectsDoParallel(MM_EnvironmentBase *env, MM_HeapWalk
 	/* determine the size of the segment chunks to use for parallel walks */
 	uintptr_t threadCount = env->_currentTask->getThreadCount();
 	uintptr_t heapChunkFactor = 1;
-	if ((threadCount > 1) && _markMap->isMarkMapValid()) {
+	if ((threadCount > 1) && _markMap->isMarkMapValid() && (!extensions->usingSATBBarrier())) {
 		heapChunkFactor = threadCount * 8;
 	}
 	uintptr_t parallelChunkSize = extensions->heap->getMemorySize() / heapChunkFactor;

--- a/gc/base/TLHAllocationInterface.hpp
+++ b/gc/base/TLHAllocationInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 
 private:
-	void reconnect(MM_EnvironmentBase *env, bool shouldFlush);
+	void reconnect(MM_EnvironmentBase *env);
 	void *allocateFromTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool shouldCollectOnFailure);
 
 	/**

--- a/gc/base/segregated/SegregatedMarkingScheme.hpp
+++ b/gc/base/segregated/SegregatedMarkingScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,19 +62,8 @@ public:
 			 * => if there is only one object to premark than low will be equal to high
 			 */
 			uint8_t *objPtrHigh = (uint8_t *)cellList + preAllocatedBytes - cellSize;
-			uintptr_t slotIndexLow, slotIndexHigh;
-			uintptr_t bitMaskLow, bitMaskHigh;
 
-			_markMap->getSlotIndexAndBlockMask((omrobjectptr_t)objPtrLow, &slotIndexLow, &bitMaskLow, false /* high bit block mask for low slot word */);
-			_markMap->getSlotIndexAndBlockMask((omrobjectptr_t)objPtrHigh, &slotIndexHigh, &bitMaskHigh, true /* low bit block mask for high slot word */);
-
-			if (slotIndexLow == slotIndexHigh) {
-				_markMap->markBlockAtomic(slotIndexLow, bitMaskLow & bitMaskHigh);
-			} else {
-				_markMap->markBlockAtomic(slotIndexLow, bitMaskLow);
-				_markMap->setMarkBlock(slotIndexLow + 1, slotIndexHigh - 1, (uintptr_t)-1);
-				_markMap->markBlockAtomic(slotIndexHigh, bitMaskHigh);
-			}
+			markObjectsForRange(env, objPtrLow, objPtrHigh);
 		}
 	}
 protected:

--- a/gc/base/standard/CompactScheme.cpp
+++ b/gc/base/standard/CompactScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -572,7 +572,7 @@ MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, boo
 	 *    singlethreaded compaction per segment, and so should only be done in extreme OOM situations.
 	 *  o no worker GC threads
 	 */
-	if (aggressive || (1 == env->_currentTask->getThreadCount())) {
+	if (aggressive || (1 == env->_currentTask->getThreadCount())  || (_extensions->usingSATBBarrier())) {
 		singleThreaded = true;
 	}
 

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1582,7 +1582,7 @@ MM_ConcurrentGC::signalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env)
 		/* We may or may not have exclusive access but another thread may have beat us to it and
 		 * prepared the threads or even collected.
 		 */
-		if (env->acquireExclusiveVMAccessForGC(this, true, false)) {
+		if (acquireExclusiveVMAccessForCycleStart(env)) {
 			MM_CycleState *previousCycleState = env->_cycleState;
 			_concurrentCycleState = MM_CycleState();
 			_concurrentCycleState._type = _cycleType;
@@ -1874,7 +1874,7 @@ MM_ConcurrentGC::concurrentFinalCollection(MM_EnvironmentBase *env, MM_MemorySub
 		_concurrentPhaseStats._endTime = omrtime_hires_clock();
 		postConcurrentUpdateStatsAndReport(env);
 
-		if (env->acquireExclusiveVMAccessForGC(this, true, true)) {
+		if (acquireExclusiveVMAccessForCycleEnd(env)) {
 			/* We got exclusive control first so do collection */
 			reportConcurrentCollectionStart(env);
 			uint64_t startTime = omrtime_hires_clock();

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -372,6 +372,13 @@ protected:
 		}
 
 		return ret;
+	}
+
+	virtual bool acquireExclusiveVMAccessForCycleStart(MM_EnvironmentBase *env) = 0;
+
+	virtual bool acquireExclusiveVMAccessForCycleEnd(MM_EnvironmentBase *env)
+	{
+		return env->acquireExclusiveVMAccessForGC(this, true, true);
 	}
 
 public:

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,6 +190,11 @@ protected:
 
 	MMINLINE virtual uintptr_t workCompleted() {
 		return (getMutatorTotalTraced() + getConHelperTotalTraced());
+	}
+
+	virtual bool acquireExclusiveVMAccessForCycleStart(MM_EnvironmentBase *env)
+	{
+		return env->acquireExclusiveVMAccessForGC(this, true, false);
 	}
 
 public:

--- a/gc/base/standard/ConcurrentGCSATB.hpp
+++ b/gc/base/standard/ConcurrentGCSATB.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,10 +74,25 @@ protected:
 	virtual void oldToOldReferenceCreated(MM_EnvironmentBase *env, omrobjectptr_t objectPtr) {};
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
+	virtual bool acquireExclusiveVMAccessForCycleStart(MM_EnvironmentBase *env)
+	{
+		/* Caches must always be flushed, for both initial/final STW cycle.
+		 *
+		 * SATB marks all newly allocated objectes during active concurrent cycle.
+		 * Since it's done on TLH granularity we have to flush the current ones and start creating new ones, once the cycle starts.
+		 */
+		return env->acquireExclusiveVMAccessForGC(this, true, true);
+	}
+
 public:
 	virtual uintptr_t getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_CONCURRENTGC; };
 	static MM_ConcurrentGCSATB *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
+
+	virtual void preAllocCacheFlush(MM_EnvironmentBase *env, void *base, void *top);
+
+	/* Refer to preAllocCacheFlush implementation for reasoning behind this. */
+	virtual uintptr_t reservedForGCAllocCacheSize() { return (_extensions->isSATBBarrierActive() ? OMR_MINIMUM_OBJECT_SIZE : 0); }
 
 	MM_ConcurrentGCSATB(MM_EnvironmentBase *env)
 		: MM_ConcurrentGC(env)

--- a/gc/base/standard/ParallelSweepScheme.cpp
+++ b/gc/base/standard/ParallelSweepScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -509,7 +509,7 @@ MM_ParallelSweepScheme::sweepChunk(MM_EnvironmentBase *env, MM_ParallelSweepChun
 	uintptr_t darkMatterBytes = 0;
 	uintptr_t darkMatterCandidates = 0;
 	uintptr_t darkMatterSamples = 0;
-	const UDATA darkMatterSampleRate = (0 == _extensions->darkMatterSampleRate)?UDATA_MAX:_extensions->darkMatterSampleRate;
+	const UDATA darkMatterSampleRate = ((0 == _extensions->darkMatterSampleRate) || (_extensions->usingSATBBarrier())) ? UDATA_MAX:_extensions->darkMatterSampleRate;
 
 	/* Process inner chunks */
 	heapSlotFreeHead = NULL;


### PR DESCRIPTION
Objects allocated while CM (SATB) is active must be marked to preserve
the invariant required to guarantee correctness.

Instead of marking each obj individually, we can mark on the TLH level.
However, doing so is non-trivial: we must know the start of the last
object to mark the proper range of the TLH. That is, arbitrary bits at
the end of the TLH can't be marked, and this is problematic for sweep.

To get around this issue we seal the TLH with a bogus/dummy obj at the
end of the TLH. With this, we know the precise addr to mark up to.
However, we must guarantee that we have at least min obj size available
in the TLH.

These changes introduce a mechanism for the collector to reserve bytes
in a TLH. Whenever the TLH is refreshed, it queries the collector to
determine if it should reserve space for it. If so, part of TOP of the
TLH is hidden. Once the TLH is about to be flushed/cleared, we restore
the the TLH Top and notify the collector.

Signed-off-by: Salman Rana <salman.rana@ibm.com>