### PR TITLE
Prep work to remove x87 register assigner

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1027,8 +1027,6 @@ public:
 
    TR_Array<TR::Register *>& getRegisterArray() {return _registerArray;}
 
-   bool needToAvoidCommoningInGRA() {return false;}
-
    bool considerTypeForGRA(TR::Node *node) {return true;}
    bool considerTypeForGRA(TR::DataType dt) {return true;}
    bool considerTypeForGRA(TR::SymbolReference *symRef) {return true;}
@@ -1090,7 +1088,7 @@ public:
     * @return the list of registers which is assigned first time in OOL cold path
     */
    TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
-   
+
    /**
     * @brief Sets the list of registers which is assigned first time in OOL cold path
     *

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2766,8 +2766,6 @@ static TR::Register *l2fd(TR::Node *node, TR::RealRegister *target, TR::InstOpCo
    {
    TR::Node                *child = node->getFirstChild();
    TR::MemoryReference  *tempMR;
-
-   TR_ASSERT(cg->useSSEForSinglePrecision(), "assertion failure");
 
    if (child->getRegister() == NULL &&
        child->getReferenceCount() == 1 &&

--- a/compiler/x/codegen/FPCompareAnalyser.cpp
+++ b/compiler/x/codegen/FPCompareAnalyser.cpp
@@ -380,8 +380,6 @@ TR::Register *TR_IA32XMMCompareAnalyser::xmmCompareAnalyser(TR::Node       *root
       _cg->evaluate(secondChild);
       }
 
-   TR::TreeEvaluator::coerceFPOperandsToXMMRs(root, _cg);
-
    firstRegister  = firstChild->getRegister();
    secondRegister = secondChild->getRegister();
 

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -106,21 +106,6 @@ TR::Register *OMR::X86::TreeEvaluator::coerceFPRToXMMR(TR::Node *node, TR::Regis
    }
 
 
-void OMR::X86::TreeEvaluator::coerceFPOperandsToXMMRs(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   for (int i = 0; i < node->getNumChildren(); i++)
-      {
-      TR::Node     *child = node->getChild(i);
-      TR::Register *reg   = child->getRegister();
-
-      if (reg && reg->getKind() == TR_X87 /* && child->getReferenceCount() > 1 */)
-         {
-         TR::TreeEvaluator::coerceFPRToXMMR(child, reg, cg);
-         }
-      }
-   }
-
-
 TR::Register *OMR::X86::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *targetRegister = cg->allocateSinglePrecisionRegister(TR_FPR);
@@ -1048,10 +1033,7 @@ TR::Register *OMR::X86::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGene
 TR::Register *OMR::X86::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node     *child = node->getFirstChild();
-   TR::Register *targetRegister;
-
-   TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
-   targetRegister = cg->doubleClobberEvaluate(child);
+   TR::Register *targetRegister = cg->doubleClobberEvaluate(child);
    targetRegister->setIsSinglePrecision(true);
    generateRegRegInstruction(TR::InstOpCode::CVTSD2SSRegReg, node, targetRegister, targetRegister, cg);
 

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -418,13 +418,6 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
       generateMemInstruction(x87OpCode, node, generateX86MemoryReference(*tempMR, 0, cg), cg);
       }
 
-   // Restore the default FPCW if it has been forced to single precision mode.
-   //
-   if (comp->getJittedMethodSymbol()->usesSinglePrecisionMode() && !cg->useSSEForDoublePrecision())
-      {
-      generateMemInstruction(TR::InstOpCode::LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
-      }
-
    TR::RegisterDependencyConditions *dependencies = NULL;
    if (machineReturnRegister != TR::RealRegister::NoReg)
       {

--- a/compiler/x/codegen/IA32LinkageUtils.cpp
+++ b/compiler/x/codegen/IA32LinkageUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,10 +217,7 @@ TR::Register *IA32LinkageUtils::pushFloatArg(
    TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, child, espReal, 4, cg);
 
-   if (cg->useSSEForSinglePrecision() && pushRegister->getKind() == TR_FPR)
-      generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
-   else
-      generateFPMemRegInstruction(TR::InstOpCode::FSTMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
 
    cg->decReferenceCount(child);
    return pushRegister;
@@ -286,10 +283,7 @@ TR::Register *IA32LinkageUtils::pushDoubleArg(
    TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, child, espReal, 8, cg);
 
-   if (cg->useSSEForSinglePrecision() && pushRegister->getKind() == TR_FPR)
-      generateMemRegInstruction(TR::InstOpCode::MOVSDMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
-   else
-      generateFPMemRegInstruction(TR::InstOpCode::DSTMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
+   generateMemRegInstruction(TR::InstOpCode::MOVSDMemReg, child, generateX86MemoryReference(espReal, 0, cg), pushRegister, cg);
 
    cg->decReferenceCount(child);
    return pushRegister;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3060,12 +3060,6 @@ void OMR::X86::CodeGenerator::dumpPostGPRegisterAssignment(TR::Instruction * ins
    }
 #endif
 
-bool
-OMR::X86::CodeGenerator::needToAvoidCommoningInGRA()
-   {
-   return false;
-   }
-
 int32_t
 OMR::X86::CodeGenerator::arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget)
    {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -261,8 +261,6 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 
    TR_ASSERT_FATAL(supportsSSE2, "Target processor/OS must support SSE2");
 
-   self()->setUseSSEForSinglePrecision();
-   self()->setUseSSEForDoublePrecision();
    self()->setSupportsAutoSIMD();
    self()->setSupportsJavaFloatSemantics();
 
@@ -3063,20 +3061,8 @@ void OMR::X86::CodeGenerator::dumpPostGPRegisterAssignment(TR::Instruction * ins
 #endif
 
 bool
-OMR::X86::CodeGenerator::useSSEFor(TR::DataType type)
-   {
-   if (type == TR::Float)
-      return self()->useSSEForSinglePrecision();
-   else if (type == TR::Double)
-      return self()->useSSEForDoublePrecision();
-   else
-      return false;
-   }
-
-bool
 OMR::X86::CodeGenerator::needToAvoidCommoningInGRA()
    {
-   if (!self()->useSSEForSinglePrecision() && !self()->useSSEForDoublePrecision()) return true;
    return false;
    }
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -814,8 +814,6 @@ protected:
       }
    void setEnableTLHPrefetching() {_flags.set(EnableTLHPrefetching);}
 
-   bool needToAvoidCommoningInGRA();
-
    bool generateMasmListingSyntax()    {return _flags.testAny(GenerateMasmListingSyntax);}
    void setGenerateMasmListingSyntax() {_flags.set(GenerateMasmListingSyntax);}
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -746,8 +746,8 @@ protected:
       EnableSinglePrecisionMethods             = 0x00000008, ///< support changing FPCW to single precision for individual methods
       EnableRegisterInterferences              = 0x00000010, ///< consider register interferences during register assignment
       EnableRegisterWeights                    = 0x00000020, ///< use register weights in choosing a best register candidate
-      UseSSEForSinglePrecision                 = 0x00000040, ///< use SSE extensions for single precision
-      UseSSEForDoublePrecision                 = 0x00000080, ///< use SSE extensions for double precision
+      // Available                             = 0x00000040,
+      // Available                             = 0x00000080,
       EnableImplicitDivideCheck                = 0x00000100, ///< platform can catch hardware exceptions for divide overflow and divide by zero
       GenerateMasmListingSyntax                = 0x00000200, ///< generate Masm-style syntax in the debug listings
       MapAutosTo8ByteSlots                     = 0x00000400, ///< don't round up sizes of autos to an 8-byte slot size when the stack is mapped
@@ -801,25 +801,6 @@ protected:
       return _flags.testAny(EnableRegisterAssociations);
       }
    void setEnableRegisterAssociations() {_flags.set(EnableRegisterAssociations);}
-
-   bool useSSEForSinglePrecision()
-      {
-      return _flags.testAny(UseSSEForSinglePrecision);
-      }
-   void setUseSSEForSinglePrecision() {_flags.set(UseSSEForSinglePrecision);}
-
-   bool useSSEForDoublePrecision()
-      {
-      return _flags.testAny(UseSSEForDoublePrecision);
-      }
-   void setUseSSEForDoublePrecision() {_flags.set(UseSSEForDoublePrecision);}
-
-   bool useSSEForSingleAndDoublePrecision()
-      {
-      return _flags.testAll(UseSSEForSinglePrecision | UseSSEForDoublePrecision);
-      }
-
-   bool useSSEFor(TR::DataType type);
 
    bool targetSupportsSoftwarePrefetches()
       {

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -314,7 +314,20 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
       TR::SymbolReference &symRef,
       TR::CodeGenerator   *cg);
 
-   static TR::Register *coerceFPRToXMMR(TR::Node *node, TR::Register *fpRegister, TR::CodeGenerator *cg);
+   /**
+    * @brief Coerce the value in x87 ST0 into a TR_FPR register.
+    *
+    * @param[in] node : \c TR::Node under evaluation
+    * @param[in] dt : \c TR::DataType in ST0
+    * @param[in] cg : \c TR::CodeGenerator object
+    * @param[in] xmmReg : Optional \c TR::Register with \c TR_FPR kind to store the
+    *               coerced result.  If provided, then St0 will be coerecd into that
+    *               register.  Otherwise, a new \c TR_FPR register will be allocated
+    *               to hold the result and returned.
+    *
+    * @return \c TR::Register of kind \c TR_FPR that holds the coerced result
+    */
+   static TR::Register *coerceST0ToFPR(TR::Node *node, TR::DataType dt, TR::CodeGenerator *cg, TR::Register *xmmReg = NULL);
 
    enum
       {

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -315,7 +315,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
       TR::CodeGenerator   *cg);
 
    static TR::Register *coerceFPRToXMMR(TR::Node *node, TR::Register *fpRegister, TR::CodeGenerator *cg);
-   static void coerceFPOperandsToXMMRs(TR::Node *node, TR::CodeGenerator *cg);
 
    enum
       {

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -260,10 +260,18 @@ TR::IA32SystemLinkage::buildVolatileAndReturnDependencies(
          returnReg = integerReturnReg = cg()->allocateCollectedReferenceRegister();
          break;
       case TR::Float:
-         returnReg = fpReturnReg = cg()->allocateSinglePrecisionRegister(TR_X87);
-         break;
       case TR::Double:
-         returnReg = fpReturnReg = cg()->allocateRegister(TR_X87);
+         /**
+          * x87 registers can no longer be added to register dependencies because
+          * the x87 register assigner has been removed.  Instead, the dispatch code
+          * must insert code to shuffle from ST0 to XMM0 manually.  The floating
+          * point result register will therefore be XMM0.
+          */
+         returnReg = fpReturnReg = cg()->allocateRegister(TR_FPR);
+         if (callNode->getDataType() == TR::Float)
+            {
+            fpReturnReg->setIsSinglePrecision();
+            }
          break;
       case TR::Int64:
          returnReg = longReturnReg = (TR::Register*)cg()->allocateRegisterPair(cg()->allocateRegister(), cg()->allocateRegister());
@@ -281,7 +289,6 @@ TR::IA32SystemLinkage::buildVolatileAndReturnDependencies(
    TR_ASSERT(_properties.getIntegerReturnRegister()  == TR::RealRegister::eax, "assertion failure");
    TR_ASSERT(_properties.getLongLowReturnRegister()  == TR::RealRegister::eax, "assertion failure");
    TR_ASSERT(_properties.getLongHighReturnRegister() == TR::RealRegister::edx, "assertion failure");
-   TR_ASSERT(_properties.getFloatReturnRegister()    == TR::RealRegister::st0, "assertion failure");
 
    if (longReturnReg)
       {
@@ -301,10 +308,10 @@ TR::IA32SystemLinkage::buildVolatileAndReturnDependencies(
 
    deps->addPostCondition(cg()->allocateRegister(), TR::RealRegister::ecx, cg());
 
-   // st0
+   // st0 -> xmm0
    if (fpReturnReg)
       {
-      deps->addPostCondition(returnReg, _properties.getFloatReturnRegister(), cg());
+      deps->addPostCondition(returnReg, TR::RealRegister::xmm0, cg());
       }
 
  // The reg dependency is left open intentionally, and need to be closed by
@@ -397,6 +404,15 @@ TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, boo
          );
       }
 
+   /**
+    * For floating point return values, move the value passed in ST0 to an XMM register.
+    * The x87 stack will be popped.
+    */
+   if (callNode->getDataType() == TR::Float || callNode->getDataType() == TR::Double)
+      {
+      TR::TreeEvaluator::coerceST0ToFPR(callNode, callNode->getDataType(), cg(), returnReg);
+      }
+
    // Label denoting end of dispatch code sequence; dependencies are on
    // this label rather than on the call
    //
@@ -407,16 +423,6 @@ TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, boo
    //
    if (deps)
       stopUsingKilledRegisters(deps, returnReg);
-
-   // If the method returns a floating point value that is not used, insert a dummy store to
-   // eventually pop the value from the floating point stack.
-   //
-   if ((callNode->getDataType() == TR::Float ||
-        callNode->getDataType() == TR::Double) &&
-       callNode->getReferenceCount() == 1)
-      {
-      generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, callNode, returnReg, returnReg, cg());
-      }
 
    if (cg()->enableRegisterAssociations())
       associatePreservedRegisters(deps, returnReg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -5362,9 +5362,11 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::Co
 
    target->setMayNeedPrecisionAdjustment();
    target->setNeedsPrecisionAdjustment();
+   cg->stopUsingRegister(target);
+
+   target = coerceST0ToFPR(node, TR::Float, cg);
+
    node->setRegister(target);
-   if (cg->useSSEForSinglePrecision())
-      target = coerceFPRToXMMR(node, target, cg);
 
    return target;
    }
@@ -5396,9 +5398,11 @@ TR::Register *OMR::X86::I386::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::Co
 
    target->setMayNeedPrecisionAdjustment();
    target->setNeedsPrecisionAdjustment();
+   cg->stopUsingRegister(target);
+
+   target = coerceST0ToFPR(node, TR::Double, cg);
+
    node->setRegister(target);
-   if (cg->useSSEForDoublePrecision())
-      target = coerceFPRToXMMR(node, target, cg);
 
    return target;
    }

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -2762,7 +2762,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
 
          if (isVolatile)
             {
-            if (cg->useSSEForDoublePrecision() && performTransformation(comp, "O^O Using SSE for volatile store %s\n", cg->getDebug()->getName(node)))
+            if (performTransformation(comp, "O^O Using SSE for volatile store %s\n", cg->getDebug()->getName(node)))
                {
                //Get stack piece
                TR::MemoryReference *stackLow  = cg->machine()->getDummyLocalMR(TR::Int64);
@@ -5424,7 +5424,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::performLload(TR::Node *node, TR::Me
       {
       TR::Machine *machine = cg->machine();
 
-      if (cg->useSSEForDoublePrecision() && performTransformation(comp, "O^O Using SSE for volatile load %s\n", cg->getDebug()->getName(node)))
+      if (performTransformation(comp, "O^O Using SSE for volatile load %s\n", cg->getDebug()->getName(node)))
          {
          TR_X86ProcessorInfo &p = cg->getX86ProcessorInfo();
 


### PR DESCRIPTION
* Remove x87 coerceFPOperandsToXMMRs()  
* Re-implement x87->xmm coercion specialized for ST0 
* Coerce IA32 floating point return register to xmm0 for system linkage 
* Remove remaining remnants of useSSEFor[Single|Double]Precision