### PR TITLE
Prevent sign-compare warning from createTest.cpp

### DIFF
--- a/thread/unix/omrthreadattr.c
+++ b/thread/unix/omrthreadattr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2016 IBM Corp. and others
+ * Copyright (c) 2007, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -466,9 +466,10 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 #if defined(LINUX) || defined(OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
-		long pageSafeMinimumStack = 2 * sysconf(_SC_PAGESIZE);
+		/* sysconf won't return a negative value for _SC_PAGESIZE. */
+		uintptr_t pageSafeMinimumStack = (uintptr_t)(2 * sysconf(_SC_PAGESIZE));
 
-		if (pageSafeMinimumStack < PTHREAD_STACK_MIN) {
+		if (pageSafeMinimumStack < (uintptr_t)PTHREAD_STACK_MIN) {
 			pageSafeMinimumStack = PTHREAD_STACK_MIN;
 		}
 		if (stacksize < pageSafeMinimumStack) {


### PR DESCRIPTION
In newer compilers that include -Wsign-compare as part of -Wall (for example gcc 11) a compiler warning is emitted from fvtest/threadtest/createTest.cpp:

```
g++  -I. -I../../fvtest/util -I../../third_party/gtest-1.8.0 -I../../third_party/gtest-1.8.0/include -I../../fvtest/omrGtestGlue -I../../thread -I../../include_core -I../../nls -DLINUX -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c -MMD -MP -fno-strict-aliasing -std=c++0x -fno-exceptions -fno-rtti -fno-threadsafe-statics -fPIC -ggdb -m64 -Wreturn-type -Werror -Wall -Wno-non-virtual-dtor -O0 -fexceptions  -o createTest.o createTest.cpp
createTest.cpp: In function 'size_t getOsStacksize(size_t)':
createTest.cpp:497:42: error: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'long int' [-Werror=sign-compare]
  497 |                 if (pageSafeMinimumStack < PTHREAD_STACK_MIN) {
      |                                          ^

```
Change pageSafeMinimumStack to be a long (as per omrthreadattr.c) and perform a cast in the comparison.

Signed-off-by: David McCann mccannd@uk.ibm.com