### PR TITLE
Initialize dummy in gtest-death-test to prevent compiler warnings

### DIFF
--- a/third_party/gtest-1.8.0/src/gtest-death-test.cc
+++ b/third_party/gtest-1.8.0/src/gtest-death-test.cc
@@ -997,14 +997,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // correct answer.
 void StackLowerThanAddress(const void* ptr, bool* result) GTEST_NO_INLINE_;
 void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Using recent compilers, such as gcc 11, where -Wmaybe-uninitialized is part of -Wall, a warning is emitted for gtest-death-test.cc (part of the google test suite):

```
g++  -I. -I../../third_party/gtest-1.8.0 -I../../third_party/gtest-1.8.0/include -I../../third_party/gtest-1.8.0/src -I../../include_core -I../../nls -DLINUX -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c -MMD -MP -fno-strict-aliasing -std=c++0x -fno-exceptions -fno-rtti -fno-threadsafe-statics -fPIC -ggdb -m64 -Wreturn-type -Werror -Wall -Wno-non-virtual-dtor -O0 -fexceptions  -o omrGtest.o omrGtest.cpp
In file included from ../../third_party/gtest-1.8.0/src/gtest-all.cc:43,
                 from omrGtest.cpp:39:
../../third_party/gtest-1.8.0/src/gtest-death-test.cc: In function 'bool testing::internal::StackGrowsDown()':
../../third_party/gtest-1.8.0/src/gtest-death-test.cc:1009:24: error: 'dummy' may be used uninitialized [-Werror=maybe-uninitialized]
 1009 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
../../third_party/gtest-1.8.0/src/gtest-death-test.cc:999:6: note: by argument 1 of type 'const void*' to 'void testing::internal::StackLowerThanAddress(const void*, bool*)' declared here
  999 | void StackLowerThanAddress(const void* ptr, bool* result) {
      |      ^~~~~~~~~~~~~~~~~~~~~
../../third_party/gtest-1.8.0/src/gtest-death-test.cc:1007:7: note: 'dummy' declared here
 1007 |   int dummy;
      |       ^~~~~
```

This has already been fixed upstream by initializing dummy to zero.

Signed-off-by: David McCann mccannd@uk.ibm.com