### PR TITLE
AArch64: Add vector MOVI, MOVN, and FMOV instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -430,6 +430,20 @@ uint8_t *TR::ARM64Trg1ImmInstruction::generateBinaryEncoding()
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
    insertTargetRegister(toARM64Cursor(cursor));
    insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1ImmShiftedInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   insertShift(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -206,7 +206,7 @@ OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeGenerator *cg
 
       if(fvalue.f == +0.0f && signbit(fvalue.f) == 0)
          {
-         generateTrgInstruction(cg, TR::InstOpCode::movi0s, node, trgReg);
+         generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2s, node, trgReg, 0);
          }
       else
          {
@@ -242,7 +242,7 @@ OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg
 
       if(dvalue.d == +0.0 && signbit(dvalue.d) == 0)
          {
-         generateTrgInstruction(cg, TR::InstOpCode::movi0d, node, trgReg);
+         generateTrg1ImmInstruction(cg, TR::InstOpCode::movid, node, trgReg, 0);
          }
       else
          {

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -189,6 +189,14 @@ TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCod
    return new (cg->trHeapMemory()) TR::ARM64Trg1ImmInstruction(op, node, treg, imm, cg);
    }
 
+TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1ImmShiftedInstruction(op, node, treg, imm, shiftAmount, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1ImmShiftedInstruction(op, node, treg, imm, shiftAmount, cg);
+   }
+
 TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -387,6 +387,26 @@ TR::Instruction *generateTrg1ImmInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates shifted imm--to-trg instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] imm : immediate value
+ * @param[in] shiftAmount : shift amount
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTrg1ImmShiftedInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg,
+                   uint32_t imm,
+                   uint32_t shiftAmount,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates imm-to-trg label instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -672,9 +672,6 @@
 	/* Floating-Point Immediate */
 		fmovimms,                                               	/* 0x1E201000	FMOV      	 */
 		fmovimmd,                                               	/* 0x1E601000	FMOV      	 */
-	/* Move Immediate */
-		movi0s,                                               		/* 0x0F000400	MOVI      	 */
-		movi0d,                                               		/* 0x2F00E400	MOVI      	 */
 	/* Floating-Point Compare */
 		fcmps,                                                  	/* 0x1E202000	FCMP      	 */
 		fcmps_zero,                                             	/* 0x1E202008	FCMP      	 */
@@ -705,6 +702,19 @@
 		fmaxd,                                                  	/* 0x1E604800	FMAX      	 */
 		fmins,                                                  	/* 0x1E205800	FMIN      	 */
 		fmind,                                                  	/* 0x1E605800	FMIN      	 */
+	/* Vector Immediate */
+		vmovi16b,                                               	/* 0x4F00E400,	MOVI      	 */
+		vmovi8h,                                                	/* 0x4F008400,	MOVI      	 */
+		vmovi2s,                                                	/* 0x0F000400,	MOVI      	 */
+		vmovi4s,                                                	/* 0x4F000400,	MOVI      	 */
+		vmovi4s_one,                                            	/* 0x4F00C400,	MOVI      	 */
+		movid,                                                  	/* 0x2F00E400,	MOVI      	 */
+		vmovi2d,                                                	/* 0x6F00E400,	MOVI      	 */
+		vfmov4s,                                                	/* 0x4F00F400,	FMOV      	 */
+		vfmov2d,                                                	/* 0x6F00F400,	FMOV      	 */
+		vmvni8h,                                                	/* 0x6F008400,	MVNI      	 */
+		vmvni4s,                                                	/* 0x6F000400,	MVNI      	 */
+		vmvni4s_one,                                            	/* 0x6F00C400,	MVNI      	 */
 	/* Vector Data-processing (2 source) */
 		vorr2d,                                                  	/* 0x4EA01C00   ORR       	 */
 		vadd16b,                                                  	/* 0x4E208400	ADD      	 */

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,6 +40,7 @@
    IsTrg1,
       IsTrg1Cond,
       IsTrg1Imm,
+         IsTrg1ImmShifted,
          IsTrg1ImmSym,
       IsTrg1ZeroSrc1,
       IsTrg1ZeroImm,

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -678,9 +678,6 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 	/* Floating-Point Immediate */
 		0x1E201000,	/* FMOV      	fmovimms	 */
 		0x1E601000,	/* FMOV      	fmovimmd	 */
-	/* Move Immediate */
-		0x0F000400,	/* MOVI      	movi0s	 */
-		0x2F00E400,	/* MOVI      	movi0d	 */
 	/* Floating-Point Compare */
 		0x1E202000,	/* FCMP      	fcmps	 */
 		0x1E202008,	/* FCMP      	fcmps_zero	 */
@@ -711,6 +708,20 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x1E604800,	/* FMAX      	fmaxd	 */
 		0x1E205800,	/* FMIN      	fmins	 */
 		0x1E605800,	/* FMIN      	fmind	 */
+	/* Vector Immediate */
+		0x4F00E400,	/* MOVI      	vmovi16b */
+		0x4F008400,	/* MOVI      	vmovi8h	 */
+		0x0F000400,	/* MOVI      	vmovi2s	 */
+		0x4F000400,	/* MOVI      	vmovi4s	 */
+		0x4F00C400,	/* MOVI      	vmovi4s_one */
+		0x2F00E400,	/* MOVI      	movid	 */
+		0x6F00E400,	/* MOVI      	vmovi2d	 */
+		0x4F00F400,	/* FMOV      	vfmov4s	 */
+		0x6F00F400,	/* FMOV      	vfmov2d	 */
+		0x6F008400,	/* MVNI      	vmovi8h	 */
+		0x6F000400,	/* MVNI      	vmovi4s	 */
+		0x6F00C400,	/* MVNI      	vmovi4s_one */
+
 	/* Vector Data-processing (2 source) */
 		0x4EA01C00,	/* ORR      	vorr2d	 */
 		0x4E208400,	/* ADD      	vadd16b	 */

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -342,6 +342,7 @@ namespace TR { class ARM64AdminInstruction; }
 namespace TR { class ARM64Trg1Instruction; }
 namespace TR { class ARM64Trg1CondInstruction; }
 namespace TR { class ARM64Trg1ImmInstruction; }
+namespace TR { class ARM64Trg1ImmShiftedInstruction; }
 namespace TR { class ARM64Trg1ImmSymInstruction; }
 namespace TR { class ARM64Trg1Src1Instruction; }
 namespace TR { class ARM64Trg1ZeroSrc1Instruction; }
@@ -1116,6 +1117,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1CondInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1ImmInstruction *);
+   void print(TR::FILE *, TR::ARM64Trg1ImmShiftedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1ImmSymInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1ZeroSrc1Instruction *);

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -44,6 +44,29 @@ std::ostream &operator<<(std::ostream &os, const ARM64BinaryInstruction &instr) 
     return os;
 }
 
+class ARM64Trg1ImmEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64Trg1ImmEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto imm = std::get<2>(GetParam());
+
+    auto instr = generateTrg1ImmInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm);
+
+    ASSERT_EQ(std::get<3>(GetParam()), encodeInstruction(instr));
+}
+
+class ARM64Trg1ImmShiftedEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, uint32_t, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64Trg1ImmShiftedEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto imm = std::get<2>(GetParam());
+    auto shiftAmount = std::get<3>(GetParam());
+
+    auto instr = generateTrg1ImmShiftedInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, imm, shiftAmount);
+
+    ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
+}
+
 class ARM64Trg1Src1EncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, ARM64BinaryInstruction>> {};
 
 TEST_P(ARM64Trg1Src1EncodingTest, encode) {
@@ -66,6 +89,204 @@ TEST_P(ARM64Trg1Src2EncodingTest, encode) {
 
     ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
 }
+
+INSTANTIATE_TEST_CASE_P(MOV, ARM64Trg1ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0, "d2800003"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0xffff, "d29fffe3"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0x1ffff, "d2bfffe3"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0x2ffff, "d2dfffe3"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0x3ffff, "d2ffffe3"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x28, 0, "d280001c"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x28, 0xffff, "d29ffffc"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x28, 0x1ffff, "d2bffffc"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x28, 0x2ffff, "d2dffffc"),
+    std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x28, 0x3ffff, "d2fffffc"),
+
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x3, 0, "f2800003"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x3, 0xffff, "f29fffe3"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x3, 0x1ffff, "f2bfffe3"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x3, 0x2ffff, "f2dfffe3"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x3, 0x3ffff, "f2ffffe3"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x28, 0, "f280001c"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x28, 0xffff, "f29ffffc"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x28, 0x1ffff, "f2bffffc"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x28, 0x2ffff, "f2dffffc"),
+    std::make_tuple(TR::InstOpCode::movkx,  TR::RealRegister::x28, 0x3ffff, "f2fffffc"),
+
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x3, 0, "92800003"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x3, 0xffff, "929fffe3"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x3, 0x1ffff, "92bfffe3"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x3, 0x2ffff, "92dfffe3"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x3, 0x3ffff, "92ffffe3"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x28, 0, "9280001c"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x28, 0xffff, "929ffffc"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x28, 0x1ffff, "92bffffc"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x28, 0x2ffff, "92dffffc"),
+    std::make_tuple(TR::InstOpCode::movnx,  TR::RealRegister::x28, 0x3ffff, "92fffffc"),
+
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x3, 0, "52800003"),
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x3, 0xffff, "529fffe3"),
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x3, 0x1ffff, "52bfffe3"),
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x28, 0, "5280001c"),
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x28, 0xffff, "529ffffc"),
+    std::make_tuple(TR::InstOpCode::movzw,  TR::RealRegister::x28, 0x1ffff, "52bffffc"),
+
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x3, 0, "72800003"),
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x3, 0xffff, "729fffe3"),
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x3, 0x1ffff, "72bfffe3"),
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x28, 0, "7280001c"),
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x28, 0xffff, "729ffffc"),
+    std::make_tuple(TR::InstOpCode::movkw,  TR::RealRegister::x28, 0x1ffff, "72bffffc"),
+
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x3, 0, "12800003"),
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x3, 0xffff, "129fffe3"),
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x3, 0x1ffff, "12bfffe3"),
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x28, 0, "1280001c"),
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x28, 0xffff, "129ffffc"),
+    std::make_tuple(TR::InstOpCode::movnw,  TR::RealRegister::x28, 0x1ffff, "12bffffc")
+));
+
+INSTANTIATE_TEST_CASE_P(FMOV, ARM64Trg1ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::fmovimmd,  TR::RealRegister::v0, 0, "1e601000"),    // abcdefgh = 0, expanded to 2.0
+    std::make_tuple(TR::InstOpCode::fmovimmd,  TR::RealRegister::v0, 0xff, "1e7ff000"), // abcdefgh = 0xff, expanded to -1.9375
+    std::make_tuple(TR::InstOpCode::fmovimmd,  TR::RealRegister::v31, 0, "1e60101f"),
+    std::make_tuple(TR::InstOpCode::fmovimmd,  TR::RealRegister::v31, 0xff, "1e7ff01f"),
+
+    std::make_tuple(TR::InstOpCode::fmovimms,  TR::RealRegister::v0, 0, "1e201000"),
+    std::make_tuple(TR::InstOpCode::fmovimms,  TR::RealRegister::v0, 0xff, "1e3ff000"),
+    std::make_tuple(TR::InstOpCode::fmovimms,  TR::RealRegister::v31, 0, "1e20101f"),
+    std::make_tuple(TR::InstOpCode::fmovimms,  TR::RealRegister::v31, 0xff, "1e3ff01f"),
+
+    std::make_tuple(TR::InstOpCode::vfmov2d,  TR::RealRegister::v0, 0, "6f00f400"),
+    std::make_tuple(TR::InstOpCode::vfmov2d,  TR::RealRegister::v0, 0xff, "6f07f7e0"),
+    std::make_tuple(TR::InstOpCode::vfmov2d,  TR::RealRegister::v31, 0, "6f00f41f"),
+    std::make_tuple(TR::InstOpCode::vfmov2d,  TR::RealRegister::v31, 0xff, "6f07f7ff"),
+
+    std::make_tuple(TR::InstOpCode::vfmov4s,  TR::RealRegister::v0, 0, "4f00f400"),
+    std::make_tuple(TR::InstOpCode::vfmov4s,  TR::RealRegister::v0, 0xff, "4f07f7e0"),
+    std::make_tuple(TR::InstOpCode::vfmov4s,  TR::RealRegister::v31, 0, "4f00f41f"),
+    std::make_tuple(TR::InstOpCode::vfmov4s,  TR::RealRegister::v31, 0xff, "4f07f7ff")
+));
+
+INSTANTIATE_TEST_CASE_P(MOVI, ARM64Trg1ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v0, 0, "4f00e400"),
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v0, 0x55, "4f02e6a0"),
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v0, 0xff, "4f07e7e0"),
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v31, 0, "4f00e41f"),
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v31, 0x55, "4f02e6bf"),
+    std::make_tuple(TR::InstOpCode::vmovi16b,  TR::RealRegister::v31, 0xff, "4f07e7ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v0, 0, "4f008400"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v0, 0x55, "4f0286a0"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v0, 0xff, "4f0787e0"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v31, 0, "4f00841f"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v31, 0x55, "4f0286bf"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v31, 0xff, "4f0787ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0, "4f000400"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0x55, "4f0206a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0xff, "4f0707e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0, "4f00041f"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0x55, "4f0206bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0xff, "4f0707ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v0, 0, "6f00e400"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v0, 0xaa, "6f05e540"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v0, 0x55, "6f02e6a0"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v0, 0xff, "6f07e7e0"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v31, 0, "6f00e41f"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v31, 0xaa, "6f05e55f"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v31, 0x55, "6f02e6bf"),
+    std::make_tuple(TR::InstOpCode::vmovi2d,  TR::RealRegister::v31, 0xff, "6f07e7ff"),
+
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v0, 0, "2f00e400"),
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v0, 0x55, "2f02e6a0"),
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v0, 0xff, "2f07e7e0"),
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v31, 0, "2f00e41f"),
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v31, 0x55, "2f02e6bf"),
+    std::make_tuple(TR::InstOpCode::movid,  TR::RealRegister::v31, 0xff, "2f07e7ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v0, 0, "0f000400"),
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v0, 0x55, "0f0206a0"),
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v0, 0xff, "0f0707e0"),
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v31, 0, "0f00041f"),
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v31, 0x55, "0f0206bf"),
+    std::make_tuple(TR::InstOpCode::vmovi2s,  TR::RealRegister::v31, 0xff, "0f0707ff")
+));
+
+INSTANTIATE_TEST_CASE_P(MVNI, ARM64Trg1ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v0, 0, "6f008400"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v0, 0x55, "6f0286a0"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v0, 0xff, "6f0787e0"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v31, 0, "6f00841f"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v31, 0x55, "6f0286bf"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v31, 0xff, "6f0787ff"),
+
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0, "6f000400"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0x55, "6f0206a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0xff, "6f0707e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0, "6f00041f"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0x55, "6f0206bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0xff, "6f0707ff")
+));
+
+INSTANTIATE_TEST_CASE_P(MOVI, ARM64Trg1ImmShiftedEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v0, 0x55, 8, "4f02a6a0"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v0, 0xff, 8, "4f07a7e0"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v31, 0x55, 8, "4f02a6bf"),
+    std::make_tuple(TR::InstOpCode::vmovi8h,  TR::RealRegister::v31, 0xff, 8, "4f07a7ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0x55, 8, "4f0226a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0xff, 8, "4f0727e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0x55, 16, "4f0246a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0xff, 16, "4f0747e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0x55, 24, "4f0266a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v0, 0xff, 24, "4f0767e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0x55, 8, "4f0226bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0xff, 8, "4f0727ff"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0x55, 16, "4f0246bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0xff, 16, "4f0747ff"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0x55, 24, "4f0266bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s,  TR::RealRegister::v31, 0xff, 24, "4f0767ff"),
+
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v0, 0x55, 8, "4f02c6a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v0, 0xff, 8, "4f07c7e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v0, 0x55, 16, "4f02d6a0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v0, 0xff, 16, "4f07d7e0"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v31, 0x55, 8, "4f02c6bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v31, 0xff, 8, "4f07c7ff"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v31, 0x55, 16, "4f02d6bf"),
+    std::make_tuple(TR::InstOpCode::vmovi4s_one,  TR::RealRegister::v31, 0xff, 16, "4f07d7ff")
+));
+
+INSTANTIATE_TEST_CASE_P(MVNI, ARM64Trg1ImmShiftedEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v0, 0x55, 8, "6f02a6a0"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v0, 0xff, 8, "6f07a7e0"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v31, 0x55, 8, "6f02a6bf"),
+    std::make_tuple(TR::InstOpCode::vmvni8h,  TR::RealRegister::v31, 0xff, 8, "6f07a7ff"),
+
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0x55, 8, "6f0226a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0xff, 8, "6f0727e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0x55, 16, "6f0246a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0xff, 16, "6f0747e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0x55, 24, "6f0266a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v0, 0xff, 24, "6f0767e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0x55, 8, "6f0226bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0xff, 8, "6f0727ff"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0x55, 16, "6f0246bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0xff, 16, "6f0747ff"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0x55, 24, "6f0266bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s,  TR::RealRegister::v31, 0xff, 24, "6f0767ff"),
+
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v0, 0x55, 8, "6f02c6a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v0, 0xff, 8, "6f07c7e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v0, 0x55, 16, "6f02d6a0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v0, 0xff, 16, "6f07d7e0"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v31, 0x55, 8, "6f02c6bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v31, 0xff, 8, "6f07c7ff"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v31, 0x55, 16, "6f02d6bf"),
+    std::make_tuple(TR::InstOpCode::vmvni4s_one,  TR::RealRegister::v31, 0xff, 16, "6f07d7ff")
+));
 
 INSTANTIATE_TEST_CASE_P(VectorSQRT, ARM64Trg1Src1EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vfsqrt4s,  TR::RealRegister::v15, TR::RealRegister::v0, "6ea1f80f"),


### PR DESCRIPTION
This commit adds support for vector `movi`, `movn`, and `fmov` instructions
and binary encoding unit tests.
`ARM64Trg1ImmShiftedInstruction` class is added to support shifted immediate
variant instructions.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>