### PR TITLE
Use documented AIX atomic kernel services

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,6 +31,10 @@
 
 #if defined(OMRZTPF)
 #include <tpf/cmpswp.h>
+#endif
+
+#if defined(__xlC__)
+#include <sys/atomic_op.h>
 #endif
 
 #include <stdlib.h>
@@ -413,7 +417,12 @@ public:
 		csg((csg_t *)&oldValue, (csg_t *)address, (csg_t)newValue);
 		return oldValue;
 #elif defined(__xlC__) /* defined(OMRZTPF) */
+#if defined(__64BIT__)
 		__compare_and_swaplp((volatile long*)address, (long*)&oldValue, (long)newValue);
+#else /* defined(__64BIT__) */
+		/* __compare_and_swaplp is valid only in 64-bit mode. */
+		compare_and_swaplp((atomic_l)address, (long*)&oldValue, (long)newValue);
+#endif /* defined(__64BIT__) */
 		return oldValue;
 #elif defined(__GNUC__) /* defined(__xlC__) */
 #if defined(__riscv)


### PR DESCRIPTION
__compare_and_swaplp is valid only in 64-bit mode according to the AIX documentation whereas compare_and_swaplp is supported by both compilation modes. The functions should behave functionally the same.

resolves #6357

Signed-off-by: David McCann mccannd@uk.ibm.com