### PR TITLE
AArch64: Add vector ABS and FABS instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -781,6 +781,12 @@ static const char *opCodeToNameMap[] =
    "vfdup2d",
    "vfsqrt4s",
    "vfsqrt2d",
+   "vabs16b",
+   "vabs8h",
+   "vabs4s",
+   "vabs2d",
+   "vfabs4s",
+   "vfabs2d",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -758,8 +758,14 @@
 		vdup2d,                                               		/* 0x4E080C00	DUP      	 */
 		vfdup4s,                                                  	/* 0x4E040400	DUP      	 */
 		vfdup2d,                                                  	/* 0x4E080400	DUP      	 */
-		vfsqrt4s,                                                	/* 0x6EA1F800	FSQRT   	 */
-		vfsqrt2d,                                                	/* 0x6EE1F800	FSQRT   	 */
+		vfsqrt4s,                                                	/* 0x6EA1F800	FSQRT    	 */
+		vfsqrt2d,                                                	/* 0x6EE1F800	FSQRT    	 */
+		vabs16b,                                                 	/* 0x4E20B800	ABS      	 */
+		vabs8h,                                                  	/* 0x4E60B800	ABS      	 */
+		vabs4s,                                                  	/* 0x4EA0B800	ABS      	 */
+		vabs2d,                                                  	/* 0x4EE0B800	ABS      	 */
+		vfabs4s,                                                 	/* 0x4EA0F800	FABS     	 */
+		vfabs2d,                                                 	/* 0x4EE0F800	FABS     	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -768,6 +768,12 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E080400,	/* DUP      	vfdup2d  */
 		0x6EA1F800,	/* FSQRT   	vfsqrt4s */
 		0x6EE1F800,	/* FSQRT   	vfsqrt2d */
+		0x4E20B800,	/* ABS     	vabs16b  */
+		0x4E60B800,	/* ABS     	vabs8h   */
+		0x4EA0B800,	/* ABS     	vabs4s   */
+		0x4EE0B800,	/* ABS     	vabs2d   */
+		0x4EA0F800,	/* ABS     	vfabs4s  */
+		0x4EE0F800,	/* ABS     	vfabs2d  */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -336,3 +336,35 @@ INSTANTIATE_TEST_CASE_P(VectorMLA, ARM64Trg1Src2EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vmla4s,  TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eaf9400"),
     std::make_tuple(TR::InstOpCode::vmla4s,  TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4ebf9400")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorABS, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v15, TR::RealRegister::v0, "4e20b80f"),
+    std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v31, TR::RealRegister::v0, "4e20b81f"),
+    std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v0, TR::RealRegister::v15, "4e20b9e0"),
+    std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v0, TR::RealRegister::v31, "4e20bbe0"),
+
+    std::make_tuple(TR::InstOpCode::vabs8h,  TR::RealRegister::v15, TR::RealRegister::v0, "4e60b80f"),
+    std::make_tuple(TR::InstOpCode::vabs8h,  TR::RealRegister::v31, TR::RealRegister::v0, "4e60b81f"),
+    std::make_tuple(TR::InstOpCode::vabs8h,  TR::RealRegister::v0, TR::RealRegister::v15, "4e60b9e0"),
+    std::make_tuple(TR::InstOpCode::vabs8h,  TR::RealRegister::v0, TR::RealRegister::v31, "4e60bbe0"),
+
+    std::make_tuple(TR::InstOpCode::vabs4s,  TR::RealRegister::v15, TR::RealRegister::v0, "4ea0b80f"),
+    std::make_tuple(TR::InstOpCode::vabs4s,  TR::RealRegister::v31, TR::RealRegister::v0, "4ea0b81f"),
+    std::make_tuple(TR::InstOpCode::vabs4s,  TR::RealRegister::v0, TR::RealRegister::v15, "4ea0b9e0"),
+    std::make_tuple(TR::InstOpCode::vabs4s,  TR::RealRegister::v0, TR::RealRegister::v31, "4ea0bbe0"),
+
+    std::make_tuple(TR::InstOpCode::vabs2d,  TR::RealRegister::v15, TR::RealRegister::v0, "4ee0b80f"),
+    std::make_tuple(TR::InstOpCode::vabs2d,  TR::RealRegister::v31, TR::RealRegister::v0, "4ee0b81f"),
+    std::make_tuple(TR::InstOpCode::vabs2d,  TR::RealRegister::v0, TR::RealRegister::v15, "4ee0b9e0"),
+    std::make_tuple(TR::InstOpCode::vabs2d,  TR::RealRegister::v0, TR::RealRegister::v31, "4ee0bbe0"),
+
+    std::make_tuple(TR::InstOpCode::vfabs4s,  TR::RealRegister::v15, TR::RealRegister::v0, "4ea0f80f"),
+    std::make_tuple(TR::InstOpCode::vfabs4s,  TR::RealRegister::v31, TR::RealRegister::v0, "4ea0f81f"),
+    std::make_tuple(TR::InstOpCode::vfabs4s,  TR::RealRegister::v0, TR::RealRegister::v15, "4ea0f9e0"),
+    std::make_tuple(TR::InstOpCode::vfabs4s,  TR::RealRegister::v0, TR::RealRegister::v31, "4ea0fbe0"),
+
+    std::make_tuple(TR::InstOpCode::vfabs2d,  TR::RealRegister::v15, TR::RealRegister::v0, "4ee0f80f"),
+    std::make_tuple(TR::InstOpCode::vfabs2d,  TR::RealRegister::v31, TR::RealRegister::v0, "4ee0f81f"),
+    std::make_tuple(TR::InstOpCode::vfabs2d,  TR::RealRegister::v0, TR::RealRegister::v15, "4ee0f9e0"),
+    std::make_tuple(TR::InstOpCode::vfabs2d,  TR::RealRegister::v0, TR::RealRegister::v31, "4ee0fbe0")
+));


### PR DESCRIPTION
This commit adds support for vector `abs` and `fabs` instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>