### PR TITLE
AArch64: Add vector BIC instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -759,6 +759,7 @@ static const char *opCodeToNameMap[] =
    "vfdiv4s",
    "vfdiv2d",
    "vand16b",
+   "vbic16b",
    "vorr16b",
    "veor16b",
    "vmla16b",

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -737,6 +737,7 @@
 		vfdiv4s,                                                  	/* 0x6E20FC00	FDIV      	 */
 		vfdiv2d,                                                  	/* 0x6E60FC00	FDIV      	 */
 		vand16b,                                                  	/* 0x4E201C00	AND      	 */
+		vbic16b,                                                  	/* 0x4E601C00	BIC      	 */
 		vorr16b,                                                  	/* 0x4EA01C00	ORR      	 */
 		veor16b,                                                  	/* 0x6E201C00	EOR      	 */
 		vmla16b,                                                  	/* 0x4E209400	MLA      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -744,6 +744,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6E20FC00,	/* FDIV      	vfdiv4s	 */
 		0x6E60FC00,	/* FDIV      	vfdiv2d	 */
 		0x4E201C00,	/* AND      	vand16b	 */
+		0x4E601C00,	/* BIC      	vbic16b	 */
 		0x4EA01C00,	/* ORR      	vorr16b	 */
 		0x6E201C00,	/* EOR      	veor16b	 */
 		0x4E209400,	/* MLA       	vmla16b	 */

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -411,6 +411,33 @@ INSTANTIATE_TEST_CASE_P(VectorMAX, ARM64Trg1Src2EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vfmax2d,  TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e7ff400")
 ));
 
+INSTANTIATE_TEST_CASE_P(VectorLogic, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e201c0f"),
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e201c1f"),
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e201de0"),
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e201fe0"),
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e2f1c00"),
+    std::make_tuple(TR::InstOpCode::vand16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e3f1c00"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e601c0f"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e601c1f"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e601de0"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e601fe0"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e6f1c00"),
+    std::make_tuple(TR::InstOpCode::vbic16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e7f1c00"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4ea01c0f"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4ea01c1f"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4ea01de0"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4ea01fe0"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eaf1c00"),
+    std::make_tuple(TR::InstOpCode::vorr16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4ebf1c00"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "6e201c0f"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e201c1f"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e201de0"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e201fe0"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e2f1c00"),
+    std::make_tuple(TR::InstOpCode::veor16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e3f1c00")
+));
+
 INSTANTIATE_TEST_CASE_P(VectorABS, ARM64Trg1Src1EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v15, TR::RealRegister::v0, "4e20b80f"),
     std::make_tuple(TR::InstOpCode::vabs16b,  TR::RealRegister::v31, TR::RealRegister::v0, "4e20b81f"),


### PR DESCRIPTION
This commit adds vector `bic` instruction and
binary encoding unit tests for vector logic binary instructions.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>