### PR TITLE
AArch64: Remove redundant vorr2d instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -742,7 +742,6 @@ static const char *opCodeToNameMap[] =
    "vbicimm4s",
    "vorrimm8h",
    "vorrimm4s",
-   "vorr2d",
    "vadd16b",
    "vadd8h",
    "vadd4s",

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -720,7 +720,6 @@
 		vorrimm8h,                                              	/* 0x4F009400,	ORR       	 */
 		vorrimm4s,                                              	/* 0x4F001400,	ORR       	 */
 	/* Vector Data-processing (2 source) */
-		vorr2d,                                                  	/* 0x4EA01C00   ORR       	 */
 		vadd16b,                                                  	/* 0x4E208400	ADD      	 */
 		vadd8h,                                                  	/* 0x4E608400	ADD      	 */
 		vadd4s,                                                  	/* 0x4EA08400	ADD      	 */

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -678,7 +678,7 @@ static void registerCopy(TR::Instruction *precedingInstruction,
          generateTrg1Src1Instruction(cg, TR::InstOpCode::fmovd, node, targetReg, sourceReg, precedingInstruction);
          break;
       case TR_VRF:
-         generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr2d, node, targetReg, sourceReg, sourceReg, precedingInstruction);
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, sourceReg, sourceReg, precedingInstruction);
          break;
       default:
          TR_ASSERT(false, "Unsupported RegisterKind.");

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -115,7 +115,7 @@ OMR::ARM64::RegisterDependencyConditions::RegisterDependencyConditions(
          else if (kind == TR_VRF)
             {
                copyReg = cg->allocateRegister(TR_VRF);
-               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr2d, node, copyReg, reg, reg, iCursor);
+               iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, copyReg, reg, reg, iCursor);
             }
          else
             {

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -727,7 +727,6 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4F001400,	/* ORR      	vorrimm4s */
 
 	/* Vector Data-processing (2 source) */
-		0x4EA01C00,	/* ORR      	vorr2d	 */
 		0x4E208400,	/* ADD      	vadd16b	 */
 		0x4E608400,	/* ADD      	vadd8h	 */
 		0x4EA08400,	/* ADD      	vadd4s	 */


### PR DESCRIPTION
This commit removes the vorr2d instruction from AArch64 instruction
table.  It is redundant because vorr16b does the same.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>