### PR TITLE
[WIP] TLH Alignment for Spanning Sweep Chunks & LOA resizing

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1374,6 +1374,8 @@ public:
 	bool isSATBBarrierActive();
 	bool usingSATBBarrier();
 
+	MMINLINE bool needSweepAlignedTLH() { return isSATBBarrierActive(); }
+
 	MM_GCExtensionsBase()
 		: MM_BaseVirtual()
 #if defined(OMR_GC_MODRON_SCAVENGER)

--- a/gc/base/MemoryPool.cpp
+++ b/gc/base/MemoryPool.cpp
@@ -110,6 +110,12 @@ MM_MemoryPool::getMemoryPool(MM_EnvironmentBase *env, void *addrBase, void *addr
 	return this;
 }								
 
+MM_MemoryPool *
+MM_MemoryPool::getMemoryPoolForSweep(MM_EnvironmentBase *env, void *addrBase, void *addrTop, void * &highAddr)
+{
+	return getMemoryPool(env, addrBase, addrTop, highAddr);
+}
+
 void
 MM_MemoryPool::registerMemoryPool(MM_MemoryPool *memoryPool)
 {

--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -123,6 +123,7 @@ public:
 	virtual MM_MemoryPool *getMemoryPool(void * addr);
 	virtual MM_MemoryPool *getMemoryPool(uintptr_t size);
 	virtual MM_MemoryPool *getMemoryPool(MM_EnvironmentBase *env, void *addrBase, void *addrTop, void * &highAddr);
+	virtual MM_MemoryPool *getMemoryPoolForSweep(MM_EnvironmentBase *env, void *addrBase, void *addrTop, void * &highAddr);
 										
 	virtual uintptr_t getMemoryPoolCount() { return 1; }
 	virtual uintptr_t getActiveMemoryPoolCount() { return 1; }

--- a/gc/base/MemoryPoolAddressOrderedList.hpp
+++ b/gc/base/MemoryPoolAddressOrderedList.hpp
@@ -72,6 +72,7 @@ public:
  * Function members
  */	
 private:
+	bool alignTLHForGC(MM_EnvironmentBase *env, MM_HeapLinkedFreeHeader *freeEntry, uintptr_t *consumedSize);
 	void addHint(MM_HeapLinkedFreeHeader *freeEntry, uintptr_t lookupSize);
 	J9ModronAllocateHint *findHint(uintptr_t lookupSize);
 	void removeHint(MM_HeapLinkedFreeHeader *freeEntry);

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -574,6 +574,11 @@ MM_MemorySubSpace::getMemoryPool(MM_EnvironmentBase* env, void* addrBase, void* 
 	return getMemoryPool();
 }
 
+MM_MemoryPool*
+MM_MemorySubSpace::getMemoryPoolForSweep(MM_EnvironmentBase* env, void* addrBase, void* addrTop, void*& highAddr)
+{
+	return getMemoryPool(env, addrBase, addrTop, highAddr);
+}
 
 MM_LargeObjectAllocateStats*
 MM_MemorySubSpace::getLargeObjectAllocateStats()

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -158,6 +158,7 @@ public:
 	virtual MM_MemoryPool *getMemoryPool(void *addr);
 	virtual MM_MemoryPool *getMemoryPool(uintptr_t size);
 	virtual MM_MemoryPool *getMemoryPool(MM_EnvironmentBase *env, void *addrBase, void *addrTop, void * &highAddr);
+	virtual MM_MemoryPool *getMemoryPoolForSweep(MM_EnvironmentBase *env, void *addrBase, void *addrTop, void * &highAddr);
 
 	virtual uintptr_t getMemoryPoolCount();
 	virtual uintptr_t getActiveMemoryPoolCount();

--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -109,6 +109,11 @@ MM_MemorySubSpaceGeneric::getMemoryPool(MM_EnvironmentBase* env, void* addrBase,
 	return _memoryPool->getMemoryPool(env, addrBase, addrTop, highAddr);
 }
 
+MM_MemoryPool*
+MM_MemorySubSpaceGeneric::getMemoryPoolForSweep(MM_EnvironmentBase* env, void* addrBase, void* addrTop, void*& highAddr)
+{
+	return _memoryPool->getMemoryPoolForSweep(env, addrBase, addrTop, highAddr);
+}
 
 /* ***************************************
  * Allocation

--- a/gc/base/MemorySubSpaceGeneric.hpp
+++ b/gc/base/MemorySubSpaceGeneric.hpp
@@ -55,6 +55,7 @@ public:
 	virtual MM_MemoryPool* getMemoryPool(void* addr);
 	virtual MM_MemoryPool* getMemoryPool(uintptr_t size);
 	virtual MM_MemoryPool* getMemoryPool(MM_EnvironmentBase* env, void* addrBase, void* addrTop, void*& highAddr);
+	virtual MM_MemoryPool* getMemoryPoolForSweep(MM_EnvironmentBase* env, void* addrBase, void* addrTop, void*& highAddr);
 
 	virtual uintptr_t getMemoryPoolCount();
 	virtual uintptr_t getActiveMemoryPoolCount();

--- a/gc/base/SweepHeapSectioning.hpp
+++ b/gc/base/SweepHeapSectioning.hpp
@@ -68,6 +68,8 @@ public:
 	void* getBackingStoreAddress();
 	uintptr_t getBackingStoreSize();
 
+	void getChunkBoundariesForAddr(MM_EnvironmentBase* env, void* addrToCheck, void* &sweepChunkBaseBoundary, void* &sweepChunkTopBoundary);
+
 	MM_SweepHeapSectioning(MM_EnvironmentBase* env)
 		: _head(NULL)
 		, _totalUsed(0)


### PR DESCRIPTION
Normally, a TLH can span multiple sweep chunks without any issues. However, with SATB, we require the TLH to be contained within a single sweep chunk. This is a requirement with batch marked TLHs for SATB. This is problematic for sweep because sweep must determine last obj in a chunk. With a batch marked TLH spanning multiple chunks, first slice of TLH contained in a chunk will be completely marked, all mark bits will be set to the end of the chunk, as a result the last live obj in chunk is undiscoverable. Hence, we must align the TLHs to sweep chunk boundaries when a pool freeEntry spans multiple chunks during TLH allocation.

To do so, we first determine the chunk boundaries containing the freeEntry baseAddr. If freeEntry topAddr is past the chunk top boundary (the freeEntry spans multiple chunks) then we clip part of the freeEntry which flows into next chunk.

This method of aligning chunks is sensitive to specific heap resizing that takes places
- After TLH allocation/alignment
- Before actual sweep and assignment of chunks.

When we're aligning TLHs we are essentially predicting the chunk assignment during sweep, with heap resizing these predictions are wrong. During alignment of TLH we expect different boundaries. This is only problematic  for 1 specific case, LOA expansion during pre-collect. This specific case shifts the boundaries of the pools such that the TLH that is at the bounds of SOA/LOA ends up spanning multiple chunks (LOA consumes allocated SOA).  To address this issue we preserve the old LOA boundary for sweep purposes when we have this problematic case.

Signed-off-by: Salman Rana <salman.rana@ibm.com>