### PR TITLE
Decompression sequence results should be placed in memref's base

### DIFF
--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1494,8 +1494,17 @@ OMR::Z::MemoryReference::populateShiftLeftTree(TR::Node * subTree, TR::CodeGener
 
    if (!strengthReducedShift)
       {
-      _indexRegister = cg->evaluate(subTree);
-      _indexNode = subTree;
+      if (subTree->containsCompressionSequence())
+         {
+         // Evaluate the object reference into base register as this is part of a decompression sequence.
+         _baseRegister = cg->evaluate(subTree);
+         _baseNode = subTree;
+         }
+      else
+         {
+         _indexRegister = cg->evaluate(subTree);
+         _indexNode = subTree;
+         }
       }
    }
 


### PR DESCRIPTION
The current z codegen behaviour is to place the register returned
by evaluate() in the memref's index register when handling a
shift left tree. In the case of a shift left for a decompression
sequence the result should be placed in the memref's base register
for better performance.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>