### PR TITLE
Revert "Remove misc. dead x87 code"

### DIFF
--- a/compiler/x/amd64/codegen/RealRegisterEnum.hpp
+++ b/compiler/x/amd64/codegen/RealRegisterEnum.hpp
@@ -86,10 +86,11 @@
    LastSpillReg            = xmm15,
    LastXMMR                = xmm15,
 
-   ByteReg                 = 42,
-   BestFreeReg             = 43,
-   SpilledReg              = 44,
-   NumRegisters            = 45,
+   AllFPRegisters          = 42,
+   ByteReg                 = 43,
+   BestFreeReg             = 44,
+   SpilledReg              = 45,
+   NumRegisters            = 46,
 
    NumXMMRegisters         = LastXMMR - FirstXMMR + 1,
    MaxAssignableRegisters  = NumXMMRegisters + (LastAssignableGPR - FirstGPR + 1) - 1 // -1 for stack pointer

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -215,7 +215,7 @@ uint32_t OMR::X86::Instruction::totalReferencedFPRegisters(TR::CodeGenerator * c
    {
    if (self()->getDependencyConditions())
       {
-      return self()->getNumOperandReferencedFPRegisters();
+      return self()->getNumOperandReferencedFPRegisters() + self()->getDependencyConditions()->numReferencedFPRegisters(cg);
       }
 
    return self()->getNumOperandReferencedFPRegisters();

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -97,6 +97,11 @@ class OMR_EXTENSIBLE RegisterDependencyGroup : public OMR::RegisterDependencyGro
                         uint32_t          numberOfRegisters,
                         TR::CodeGenerator *cg);
 
+   void assignFPRegisters(TR::Instruction   *currentInstruction,
+                          TR_RegisterKinds  kindsToBeAssigned,
+                          uint32_t          numberOfRegisters,
+                          TR::CodeGenerator *cg);
+
    void blockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    void unblockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    };
@@ -257,6 +262,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    uint32_t numReferencedGPRegisters(TR::CodeGenerator *);
+   uint32_t numReferencedFPRegisters(TR::CodeGenerator *);
    void printFullRegisterDependencyInfo(FILE *pOutFile);
    void printDependencyConditions(TR::RegisterDependencyGroup *conditions,
                                   uint32_t   numConditions,

--- a/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
+++ b/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,12 @@ namespace X86
 
 struct RegisterDependency : OMR::RegisterDependency
    {
+   /**
+    * @return Answers \c true if this register dependency refers to all x87 floating
+    *         point registers collectively; \c false otherwise.
+    */
+   bool isAllFPRegisters() { return _realRegister == TR::RealRegister::AllFPRegisters; }
+
    /**
     * @return Answers \c true if this register dependency is a request for the
     *         best free register from the perspective of the register assigner;

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -2934,6 +2934,103 @@ void TR::X86FPST0STiRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToB
       }
    }
 
+////////////////////////////////////////////////////////////////////////////////
+// TR::X86FPArithmeticRegRegInstruction:: member functions
+////////////////////////////////////////////////////////////////////////////////
+
+TR::X86FPArithmeticRegRegInstruction::X86FPArithmeticRegRegInstruction(TR::InstOpCode::Mnemonic  op,
+                                                                           TR::Node        *node,
+                                                                           TR::Register    *treg,
+                                                                           TR::Register    *sreg,
+                                                                           TR::CodeGenerator *cg)
+   : TR::X86FPRegRegInstruction(sreg, treg, node, op, cg)
+   {
+   }
+
+TR::X86FPArithmeticRegRegInstruction::X86FPArithmeticRegRegInstruction(TR::Instruction *precedingInstruction,
+                                                                           TR::InstOpCode::Mnemonic  op,
+                                                                           TR::Register    *treg,
+                                                                           TR::Register    *sreg,
+                                                                           TR::CodeGenerator *cg)
+   : TR::X86FPRegRegInstruction(sreg, treg, op, precedingInstruction, cg)
+   {
+   }
+
+void TR::X86FPArithmeticRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
+   {
+
+   if (kindsToBeAssigned & TR_X87_Mask)
+      {
+      TR::Register *sourceRegister = getSourceRegister();
+      TR::Register *targetRegister = getTargetRegister();
+      TR::Machine *machine = cg()->machine();
+      uint32_t             result = 0;
+      TR::RealRegister      *fpReg;
+
+      result = TR::X86FPRegRegInstruction::assignTargetSourceRegisters();
+
+      TR_ASSERT( result & kSourceOnFPStack,
+              "TR::X86FPArithmeticRegRegInstruction::assignRegisters ==> source not on FP stack!" );
+
+      TR_ASSERT( result & kTargetOnFPStack,
+              "TR::X86FPArithmeticRegRegInstruction::assignRegisters ==> target not on FP stack!" );
+
+      //Dead tree elimination doesn't always eliminate dead trees and we can eventually pop the target as well, TODO: ensure proper stack balance.
+      //TR_ASSERT( !(result & kTargetCanBePopped),
+      //        "TR::X86FPArithmeticRegRegInstruction::assignRegisters ==> target register cannot be popped!" );
+
+      if (result & kSourceCanBePopped)
+         {
+         TR::InstOpCode::Mnemonic popOpCode;
+
+         if (!machine->isFPRTopOfStack(sourceRegister) &&
+              machine->isFPRTopOfStack(targetRegister))
+            {
+            // The target operand is already at TOS: generate a reverse and pop instruction.
+            //
+            TR::InstOpCode::Mnemonic reverseOpCode = machine->fpDetermineReverseOpCode(getOpCodeValue());
+            popOpCode = machine->fpDeterminePopOpCode(reverseOpCode);
+
+            (void)machine->fpStackFXCH(this->getPrev(), sourceRegister, false);
+
+            // don't exchange operands - they're virtual registers; the StackFXCH does the exchange
+            }
+         else
+            {
+            popOpCode = machine->fpDeterminePopOpCode(getOpCodeValue());
+            if (!machine->isFPRTopOfStack(sourceRegister))
+               {
+               (void)machine->fpStackFXCH(this->getPrev(), sourceRegister);
+               }
+            }
+
+         setOpCodeValue(popOpCode);
+         }
+      else
+         {
+         // Both operands are live after the instruction.
+         //
+         if ( !machine->isFPRTopOfStack(targetRegister) &&
+              !machine->isFPRTopOfStack(sourceRegister) )
+            {
+            (void)machine->fpStackFXCH(this->getPrev(), targetRegister);
+            }
+         }
+
+      // Final assignment of real registers to this instruction
+      //
+      fpReg = machine->fpMapToStackRelativeRegister(sourceRegister);
+      setSourceRegister(fpReg);
+      fpReg = machine->fpMapToStackRelativeRegister(targetRegister);
+      setTargetRegister(fpReg);
+
+      if (result & kSourceCanBePopped)
+         {
+         machine->fpStackPop();
+         }
+      }
+   }
+
 
 TR::InstOpCode::Mnemonic getBranchOrSetOpCodeForFPComparison(TR::ILOpCodes cmpOp)
    {
@@ -3040,6 +3137,80 @@ TR::InstOpCode::Mnemonic getBranchOrSetOpCodeForFPComparison(TR::ILOpCodes cmpOp
    return op;
    }
 
+////////////////////////////////////////////////////////////////////////////////
+// TR::X86FPRemainderRegRegInstruction:: member functions
+////////////////////////////////////////////////////////////////////////////////
+
+TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic  op,
+                                                                       TR::Node        *node,
+                                                                       TR::Register    *treg,
+                                                                       TR::Register    *sreg,
+                                                                       TR::CodeGenerator *cg)
+   : TR::X86FPST0ST1RegRegInstruction( op, node, treg, sreg, cg)
+   {
+   }
+
+TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic  op,
+                                                                       TR::Node        *node,
+                                                                       TR::Register    *treg,
+                                                                       TR::Register    *sreg,
+                                                                       TR::Register    *accReg,
+                                                                       TR::RegisterDependencyConditions  *cond,
+                                                                       TR::CodeGenerator *cg)
+   : TR::X86FPST0ST1RegRegInstruction( op, node, treg, sreg, cond, cg), _accRegister(accReg)
+   {
+   useRegister(accReg);
+   }
+
+TR::X86FPRemainderRegRegInstruction::X86FPRemainderRegRegInstruction( TR::Instruction *precedingInstruction,
+                                                                       TR::InstOpCode::Mnemonic  op,
+                                                                       TR::Register    *treg,
+                                                                       TR::Register    *sreg,
+                                                                       TR::CodeGenerator *cg)
+   : TR::X86FPST0ST1RegRegInstruction( precedingInstruction, op, treg, sreg, cg)
+   {
+   }
+
+void TR::X86FPRemainderRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
+   {
+
+   if (kindsToBeAssigned & TR_GPR_Mask) //TODO: Move this code generation in FPTreeEvaluator.cpp rather than doing it here
+      {
+      OMR::X86::Instruction::assignRegisters( kindsToBeAssigned);
+
+      TR::RealRegister *accReg = toRealRegister(_accRegister->getAssignedRegister());
+      TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
+      TR::RegisterDependencyConditions  *deps = getDependencyConditions();
+
+      new (cg()->trHeapMemory()) TR::X86LabelInstruction(getPrev(), TR::InstOpCode::label, loopLabel, cg());
+      TR::Instruction  *cursor = new (cg()->trHeapMemory()) TR::X86RegInstruction( this, TR::InstOpCode::STSWAcc, accReg, cg());
+      cursor = new (cg()->trHeapMemory()) TR::X86RegImmInstruction( cursor, TR::InstOpCode::TEST2RegImm2, accReg, 0x0400, cg());
+      new (cg()->trHeapMemory()) TR::X86LabelInstruction( cursor, TR::InstOpCode::JNE4, loopLabel, deps, cg());
+
+      if (_accRegister->decFutureUseCount() == 0)
+         {
+         _accRegister->setAssignedRegister(NULL);
+         accReg->setState(TR::RealRegister::Free);
+         accReg->setAssignedRegister(NULL);
+         }
+      }
+
+   else if (kindsToBeAssigned & TR_X87_Mask)
+      {
+      TR::Register    *sourceRegister = getSourceRegister();
+      TR::Register    *targetRegister = getTargetRegister();
+      TR::Machine *machine = cg()->machine();
+      TR::RealRegister *fpReg;
+
+      TR::X86FPRegRegInstruction::assignTargetSourceRegisters();
+      machine->fpCoerceRegistersToTopOfStack(this->getPrev(), targetRegister, sourceRegister, true);
+
+      fpReg = machine->fpMapToStackRelativeRegister(sourceRegister);
+      setSourceRegister(fpReg);
+      fpReg = machine->fpMapToStackRelativeRegister(targetRegister);
+      setTargetRegister(fpReg);
+      }
+   }
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPMemRegInstruction:: member functions
@@ -4080,6 +4251,24 @@ TR::X86FPSTiST0RegRegInstruction  *
 generateFPSTiST0RegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * treg, TR::Register * sreg, TR::CodeGenerator *cg, bool forcePop)
    {
    return new (cg->trHeapMemory()) TR::X86FPSTiST0RegRegInstruction(op, node, treg, sreg, cg, forcePop);
+   }
+
+TR::X86FPArithmeticRegRegInstruction  *
+generateFPArithmeticRegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * treg, TR::Register * sreg, TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::X86FPArithmeticRegRegInstruction(op, node, treg, sreg, cg);
+   }
+
+TR::X86FPRemainderRegRegInstruction  *
+generateFPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * treg, TR::Register * sreg, TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::X86FPRemainderRegRegInstruction( op, node, treg, sreg, cg);
+   }
+
+TR::X86FPRemainderRegRegInstruction  *
+generateFPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * treg, TR::Register * sreg, TR::Register *accReg, TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::X86FPRemainderRegRegInstruction( op, node, treg, sreg, accReg, cond, cg);
    }
 
 TR::X86FPMemRegInstruction  *

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -2502,6 +2502,87 @@ class X86FPSTiST0RegRegInstruction : public TR::X86FPRegRegInstruction
    };
 
 
+class X86FPArithmeticRegRegInstruction : public TR::X86FPRegRegInstruction
+   {
+   public:
+
+   X86FPArithmeticRegRegInstruction(TR::InstOpCode::Mnemonic    op,
+                                        TR::Node          *node,
+                                        TR::Register      *treg,
+                                        TR::Register      *sreg,
+                                        TR::CodeGenerator *cg);
+
+   X86FPArithmeticRegRegInstruction(TR::Instruction   *precedingInstruction,
+                                        TR::InstOpCode::Mnemonic    op,
+                                        TR::Register      *treg,
+                                        TR::Register      *sreg,
+                                        TR::CodeGenerator *cg);
+
+   virtual char *description() { return "X86FPArithmeticRegReg"; }
+
+   virtual Kind getKind() { return IsFPArithmeticRegReg; }
+
+   void applyDestinationBitToOpCode(uint8_t *opCode, TR::Machine * machine)
+      {
+      TR::RealRegister *reg = toRealRegister(getTargetRegister());
+      if (reg->getRegisterNumber() != TR::RealRegister::st0)
+         {
+         *opCode |= 0x04;
+         }
+      }
+
+   void applyDirectionBitToOpCode(uint8_t *opCode, TR::Machine * machine)
+      {
+      uint8_t reverse, destination;
+
+      TR::RealRegister *reg = toRealRegister(getTargetRegister());
+      destination = (reg->getRegisterNumber() != TR::RealRegister::st0) ? 1 : 0;
+      reverse = (this->getOpCode().sourceOpTarget()) ? 1 : 0;
+
+      if (destination ^ reverse)
+         {
+         *opCode |= 0x08;
+         }
+      }
+
+   virtual void assignRegisters(TR_RegisterKinds kindsToBeAssigned);
+   virtual uint8_t* generateOperand(uint8_t* cursor);
+   };
+
+
+class X86FPRemainderRegRegInstruction : public TR::X86FPST0ST1RegRegInstruction
+   {
+   TR::Register *_accRegister;
+
+   public:
+
+   X86FPRemainderRegRegInstruction(TR::InstOpCode::Mnemonic     op,
+                                      TR::Node          *node,
+                                      TR::Register      *treg,
+                                      TR::Register      *sreg,
+                                      TR::CodeGenerator *cg);
+
+   X86FPRemainderRegRegInstruction(TR::InstOpCode::Mnemonic                        op,
+                                      TR::Node                             *node,
+                                      TR::Register                         *treg,
+                                      TR::Register                         *sreg,
+                                      TR::Register                         *accReg,
+                                      TR::RegisterDependencyConditions  *cond,
+                                      TR::CodeGenerator                    *cg);
+
+   X86FPRemainderRegRegInstruction(TR::Instruction   *precedingInstruction,
+                                      TR::InstOpCode::Mnemonic     op,
+                                      TR::Register      *treg,
+                                      TR::Register      *sreg,
+                                      TR::CodeGenerator *cg);
+
+   virtual char *description() { return "X86FPRemainderRegReg"; }
+
+   virtual Kind getKind() { return IsFPRemainderRegReg; }
+   virtual void assignRegisters(TR_RegisterKinds kindsToBeAssigned);
+   };
+
+
 class X86FPMemRegInstruction : public TR::X86MemRegInstruction
    {
 
@@ -3007,6 +3088,11 @@ TR::X86FPRegInstruction  * generateFPRegInstruction(TR::InstOpCode::Mnemonic op,
 TR::X86FPST0ST1RegRegInstruction  * generateFPST0ST1RegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::CodeGenerator *cg);
 TR::X86FPST0STiRegRegInstruction  * generateFPST0STiRegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::CodeGenerator *cg);
 TR::X86FPSTiST0RegRegInstruction  * generateFPSTiST0RegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::CodeGenerator *cg, bool forcePop = false);
+
+TR::X86FPArithmeticRegRegInstruction  * generateFPArithmeticRegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::CodeGenerator *cg);
+
+TR::X86FPRemainderRegRegInstruction  * generateFPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::CodeGenerator *cg);
+TR::X86FPRemainderRegRegInstruction  * generateFPRemainderRegRegInstruction( TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::Register * reg2, TR::Register *accReg, TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg);
 
 TR::X86FPMemRegInstruction  * generateFPMemRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::MemoryReference  * mr, TR::Register * reg1, TR::CodeGenerator *cg);
 TR::X86FPRegMemInstruction  * generateFPRegMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *, TR::Register * reg1, TR::MemoryReference  * mr, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -2571,6 +2571,29 @@ uint8_t* TR::X86FPST0ST1RegRegInstruction::generateOperand(uint8_t* cursor)
    }
 
 
+// TR::X86FPArithmeticRegRegInstruction:: member functions
+
+uint8_t* TR::X86FPArithmeticRegRegInstruction::generateOperand(uint8_t* cursor)
+   {
+   uint8_t *opCode = cursor - 1;
+
+   TR::Machine *machine = cg()->machine();
+   applyRegistersToOpCode(opCode, machine);
+   if (getOpCode().hasDirectionBit())
+      {
+      applyDirectionBitToOpCode(opCode, machine);
+      }
+
+   if (getOpCode().modifiesTarget())
+      {
+      opCode = cursor - 2;
+      applyDestinationBitToOpCode(opCode, machine);
+      }
+
+   return cursor;
+   }
+
+
 // TR::X86FPST0STiRegRegInstruction:: member functions
 
 uint8_t* TR::X86FPST0STiRegRegInstruction::generateOperand(uint8_t* cursor)

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -240,7 +240,11 @@ TR_Debug::printDependencyConditions(
 
       *(cursor++) = '(';
       TR::RegisterDependency *regDep = conditions->getRegisterDependency(i);
-      if (regDep->isNoReg())
+      if (regDep->isAllFPRegisters())
+         {
+         len = sprintf(cursor, "AllFP");
+         }
+      else if (regDep->isNoReg())
          {
          len = sprintf(cursor, "NoReg");
          }
@@ -315,22 +319,29 @@ TR_Debug::dumpDependencyGroup(TR::FILE *                         pOutFile,
 
       if (omitNullDependencies)
          {
-         if (!virtReg)
+         if (!virtReg && !regDep->isAllFPRegisters())
             continue;
          }
 
-      r = regDep->getRealRegister();
-      trfprintf(pOutFile, " [%s : ", getName(virtReg));
-      if (regDep->isNoReg())
-         trfprintf(pOutFile, "NoReg]");
-      else if (regDep->isByteReg())
-         trfprintf(pOutFile, "ByteReg]");
-      else if (regDep->isBestFreeReg())
-         trfprintf(pOutFile, "BestFreeReg]");
-      else if (regDep->isSpilledReg())
-         trfprintf(pOutFile, "SpilledReg]");
+      if (regDep->isAllFPRegisters())
+         {
+         trfprintf(pOutFile, " [All FPRs]");
+         }
       else
-         trfprintf(pOutFile, "%s]", getName(_cg->machine()->getRealRegister(r)));
+         {
+         r = regDep->getRealRegister();
+         trfprintf(pOutFile, " [%s : ", getName(virtReg));
+         if (regDep->isNoReg())
+            trfprintf(pOutFile, "NoReg]");
+         else if (regDep->isByteReg())
+            trfprintf(pOutFile, "ByteReg]");
+         else if (regDep->isBestFreeReg())
+            trfprintf(pOutFile, "BestFreeReg]");
+         else if (regDep->isSpilledReg())
+            trfprintf(pOutFile, "SpilledReg]");
+         else
+            trfprintf(pOutFile, "%s]", getName(_cg->machine()->getRealRegister(r)));
+         }
 
       foundDep = true;
       }

--- a/compiler/x/i386/codegen/RealRegisterEnum.hpp
+++ b/compiler/x/i386/codegen/RealRegisterEnum.hpp
@@ -68,10 +68,11 @@
    xmm7                    = 25,
    LastXMMR                = xmm7,
 
-   ByteReg                 = 26,
-   BestFreeReg             = 27,
-   SpilledReg              = 28,
-   NumRegisters            = 29,
+   AllFPRegisters          = 26,
+   ByteReg                 = 27,
+   BestFreeReg             = 28,
+   SpilledReg              = 29,
+   NumRegisters            = 30,
 
    NumXMMRegisters         = LastXMMR - FirstXMMR + 1,
    MaxAssignableRegisters  = NumXMMRegisters + (LastAssignableGPR - FirstGPR + 1) - 1 // -1 for stack pointer


### PR DESCRIPTION
Reverts eclipse/omr#6378

Causing 32-bit downstream project failures on Linux.