### PR TITLE
Consider parm invariance when merging def nodes for GVP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -2101,7 +2101,7 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
             // the parameter.
             //
             TR::SymbolReference *symRef = node->getSymbolReference();
-            if (symRef && symRef->getSymbol()->getParmSymbol() && _parmValues)
+            if (symRef && symRef->getSymbol()->getParmSymbol() && _parmValues && isParmInvariant(symRef->getSymbol()))
                {
                int32_t parmNum = symRef->getSymbol()->getParmSymbol()->getOrdinal();
                defConstraint = _parmValues[parmNum];
@@ -4726,7 +4726,7 @@ TR_BitVector *TR::GlobalValuePropagation::mergeDefinedOnAllPaths(TR_StructureSub
       EdgeConstraints  *constraints = getEdgeConstraints(*itr);
       if (isUnreachablePath(constraints))
          continue;
-      
+
       TR_BitVector *predDefinedOnAllPaths = (*_definedOnAllPaths)[*itr];
       if (trace())
          {

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4027,7 +4027,7 @@ void OMR::ValuePropagation::getParmValues()
 bool OMR::ValuePropagation::isParmInvariant(TR::Symbol *sym)
    {
    int32_t index = sym->getParmSymbol()->getOrdinal();
-   return (_parmInfo[index] ? false : true);
+   return (_parmMayBeVariant[index] ? false : true);
    }
 
 

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -834,7 +834,7 @@ class ValuePropagation : public TR::Optimization
    TR_Array<TR::CFGEdge *> *_edgesToBeRemoved;
 
    CallNodeToGuardNodesMap *_callNodeToGuardNodes;
-   
+
    // Cached constraints
    //
    TR::VPNullObject        *_nullObjectConstraint;
@@ -909,7 +909,7 @@ class ValuePropagation : public TR::Optimization
    List<ObjCloneInfo> _objectCloneTypes;
    List<ArrayCloneInfo> _arrayCloneTypes;
 
-   int32_t    *_parmInfo;
+   int32_t    *_parmMayBeVariant;
    bool       *_parmTypeValid;
 
    };


### PR DESCRIPTION
It is possible in DLT compiles for a store to a parm slot to be missed
by GVP analysis because it appears in a part of the method that occurred
prior to the DLT entry point and hence IL trees were never generated
for it.  It may then be possible for GVP to conclude that the only def
to the parm slot is at method entry and then assume that the characteristics
of the parm slot at entry (such as its type) are how uses of the parm
slot should be constrained.  This is incorrect in DLT compiles and the
analysis needs to be made more conservative and assume parms are variant.