### PR TITLE
Remove J9-specific code from constrainArraylength

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4862,29 +4862,6 @@ TR::Node *constrainArraylength(OMR::ValuePropagation *vp, TR::Node *node)
 
    vp->getArrayLengthLimits(constraint, lowerBoundLimit, upperBoundLimit, elementSize, isKnownObj);
 
-#ifdef J9_PROJECT_SPECIFIC
-   if (constraint && !isKnownObj)
-      {
-      TR::KnownObjectTable *knot = vp->comp()->getKnownObjectTable();
-      TR::VPKnownObject *kobj = constraint->getKnownObject();
-      if (knot && kobj)
-         {
-         TR::VMAccessCriticalSection constrainArraylengthCriticalSection(vp->comp(),
-                     TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-         if (constrainArraylengthCriticalSection.hasVMAccess())
-            {
-            uintptr_t array = knot->getPointer(kobj->getIndex());
-            if (vp->comp()->fej9()->isClassArray(vp->comp()->fej9()->getObjectClass(array)))
-               {
-               isKnownObj = true;
-               lowerBoundLimit = vp->comp()->fej9()->getArrayLengthInElements(array);
-               upperBoundLimit = lowerBoundLimit;
-               }
-            }
-         }
-      }
-#endif
-
    // If this is a known array object, we definitely know its length
    //
    if (isKnownObj)


### PR DESCRIPTION
Some J9-specific code in the `constrainArraylength` handler for Value Propagation has moved to that downstream project.  Removing that now redundant code from OMR.

The downstream pull request was [OpenJ9 pull request #14729](https://github.com/eclipse-openj9/openj9/pull/14729).

This is the last pull request planned for [OpenJ9 issue #14402](https://github.com/eclipse-openj9/openj9/issues/14402)