### PR TITLE
AArch64: Add vector shift immediate instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -742,6 +742,18 @@ static const char *opCodeToNameMap[] =
    "vbicimm4s",
    "vorrimm8h",
    "vorrimm4s",
+   "vshl16b",
+   "vshl8h",
+   "vshl4s",
+   "vshl2d",
+   "vsshr16b",
+   "vsshr8h",
+   "vsshr4s",
+   "vsshr2d",
+   "vushr16b",
+   "vushr8h",
+   "vushr4s",
+   "vushr2d",
    "vcmeq16b",
    "vcmeq8h",
    "vcmeq4s",
@@ -1686,6 +1698,18 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
             trfprintf(pOutFile, ", 0x%lx", immediate);
             }
          }
+      }
+   else if ((op >= TR::InstOpCode::vshl16b) && (op <= TR::InstOpCode::vushr2d))
+      {
+      done = true;
+      bool isShiftLeft = (op <= TR::InstOpCode::vshl2d);
+      uint32_t elementSize = 8 << ((op - TR::InstOpCode::vshl16b) & 3);
+      uint32_t imm = instr->getSourceImmediate();
+      uint32_t shiftAmount = isShiftLeft ? (imm - elementSize) : (elementSize * 2 - imm);
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ", %d", shiftAmount);
       }
 
    if (!done)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2316,7 +2316,16 @@ class ARM64Trg1Src1ImmInstruction : public ARM64Trg1Src1Instruction
     */
    void insertImmediateField(uint32_t *instruction)
       {
-      *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */
+      TR::InstOpCode::Mnemonic op = getOpCodeValue();
+
+      if ((op >= TR::InstOpCode::vshl16b) && (op <= TR::InstOpCode::vushr2d))
+         {
+         *instruction |= ((_source1Immediate & 0x7f) << 16); /* immh:immb */
+         }
+      else
+         {
+         *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */
+         }
       }
 
    /**

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -596,6 +596,18 @@ TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node,
    return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw, node, treg, sreg, (immr << 6) | imms, preced);
    }
 
+TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+   {
+   bool isShiftLeft = (op <= TR::InstOpCode::vshl2d);
+   uint32_t elementSize = 8 << ((op - TR::InstOpCode::vshl16b) & 3);
+   TR_ASSERT_FATAL_WITH_NODE(node, (elementSize == 8) || (elementSize == 16) || (elementSize == 32) || (elementSize == 64), "Illegal element size: %d", elementSize);
+   TR_ASSERT_FATAL_WITH_NODE(node, (shiftAmount >= 0) && (shiftAmount < elementSize), "Illegal shift amount: %d", shiftAmount);
+
+   uint32_t imm = isShiftLeft ? (shiftAmount + elementSize) : (elementSize * 2 - shiftAmount);
+   return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm, preced);
+   }
+
 #ifdef J9_PROJECT_SPECIFIC
 TR::Instruction *generateVirtualGuardNOPInstruction(TR::CodeGenerator *cg,  TR::Node *n, TR_VirtualGuardSite *site,
    TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::Instruction *preced)

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1102,6 +1102,27 @@ TR::Instruction *generateUBFIZInstruction(
                   bool is64bit,
                   TR::Instruction *preced = NULL);
 
+/**
+ * @brief Generates vector shift left immediate instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] op          : opcode
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] shiftAmount : shift amount
+ * @param[in] preced  : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateVectorShiftImmediateInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t shiftAmount,
+                  TR::Instruction *preced = NULL);
+
 #ifdef J9_PROJECT_SPECIFIC
 /*
  * @brief Generates virtual guard nop instruction

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -719,6 +719,23 @@
 		vbicimm4s,                                              	/* 0x6F001400,	BIC       	 */
 		vorrimm8h,                                              	/* 0x4F009400,	ORR       	 */
 		vorrimm4s,                                              	/* 0x4F001400,	ORR       	 */
+	/*
+	 * Vector Shift Immediate
+	 * Please do not change or insert opcode between vshl16b and vushr2d.
+	 * Binary Encoder expects vshl16b - vushr2d appears contiguously in this order.
+	 */
+		vshl16b,                                                	/* 0x4F085400,	SHL       	 */
+		vshl8h,                                                 	/* 0x4F105400,	SHL       	 */
+		vshl4s,                                                 	/* 0x4F205400,	SHL       	 */
+		vshl2d,                                                 	/* 0x4F405400,	SHL       	 */
+		vsshr16b,                                               	/* 0x4F080400,	SSHR      	 */
+		vsshr8h,                                                	/* 0x4F100400,	SSHR      	 */
+		vsshr4s,                                                	/* 0x4F200400,	SSHR      	 */
+		vsshr2d,                                                	/* 0x4F400400,	SSHR      	 */
+		vushr16b,                                               	/* 0x6F080400,	USHR      	 */
+		vushr8h,                                                	/* 0x6F100400,	USHR      	 */
+		vushr4s,                                                	/* 0x6F200400,	USHR      	 */
+		vushr2d,                                                	/* 0x6F400400,	USHR      	 */
 	/* Vector Compare */
 		vcmeq16b,                                               	/* 0x6E208C00,	CMEQ      	 */
 		vcmeq8h,                                                	/* 0x6E608C00,	CMEQ      	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -725,7 +725,18 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6F001400,	/* BIC      	vbicimm4s */
 		0x4F009400,	/* ORR      	vorrimm8h */
 		0x4F001400,	/* ORR      	vorrimm4s */
-
+		0x4F085400,	/* SHL      	vshl16b  */
+		0x4F105400,	/* SHL      	vshl8h	 */
+		0x4F205400,	/* SHL      	vshl4s	 */
+		0x4F405400,	/* SHL      	vshl2d	 */
+		0x4F080400,	/* SSHR      	vsshr16b */
+		0x4F100400,	/* SSHR      	vsshr8h	 */
+		0x4F200400,	/* SSHR      	vsshr4s	 */
+		0x4F400400,	/* SSHR      	vsshr2d	 */
+		0x6F080400,	/* USHR      	vushr16b */
+		0x6F100400,	/* USHR      	vushr8h	 */
+		0x6F200400,	/* USHR      	vushr4s	 */
+		0x6F400400,	/* USHR      	vushr2d	 */
 	/* Vector Compare */
 		0x6E208C00,	/* CMEQ      	vcmeq16b */
 		0x6E608C00,	/* CMEQ      	vcmeq8b */

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -90,6 +90,17 @@ TEST_P(ARM64Trg1Src2EncodingTest, encode) {
     ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
 }
 
+class ARM64VectorShiftImmediateEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64VectorShiftImmediateEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+
+    auto instr = generateVectorShiftImmediateInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, std::get<3>(GetParam()));
+
+    ASSERT_EQ(std::get<4>(GetParam()), encodeInstruction(instr));
+}
+
 INSTANTIATE_TEST_CASE_P(MOV, ARM64Trg1ImmEncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0, "d2800003"),
     std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0xffff, "d29fffe3"),
@@ -882,4 +893,109 @@ INSTANTIATE_TEST_CASE_P(VectorFCMPZERO0, ARM64Trg1Src1EncodingTest, ::testing::V
     std::make_tuple(TR::InstOpCode::vfcmlt2d_zero, TR::RealRegister::v31, TR::RealRegister::v0, "4ee0e81f"),
     std::make_tuple(TR::InstOpCode::vfcmlt2d_zero, TR::RealRegister::v0, TR::RealRegister::v15, "4ee0e9e0"),
     std::make_tuple(TR::InstOpCode::vfcmlt2d_zero, TR::RealRegister::v0, TR::RealRegister::v31, "4ee0ebe0")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorShiftLeftImmediate, ARM64VectorShiftImmediateEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f09540f"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v15, TR::RealRegister::v0, 7, "4f0f540f"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f09541f"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v31, TR::RealRegister::v0, 7, "4f0f541f"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f0955e0"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v0, TR::RealRegister::v15, 7, "4f0f55e0"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f0957e0"),
+    std::make_tuple(TR::InstOpCode::vshl16b, TR::RealRegister::v0, TR::RealRegister::v31, 7, "4f0f57e0"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f11540f"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v15, TR::RealRegister::v0, 15, "4f1f540f"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f11541f"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v31, TR::RealRegister::v0, 15, "4f1f541f"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f1155e0"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v0, TR::RealRegister::v15, 15, "4f1f55e0"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f1157e0"),
+    std::make_tuple(TR::InstOpCode::vshl8h, TR::RealRegister::v0, TR::RealRegister::v31, 15, "4f1f57e0"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f21540f"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v15, TR::RealRegister::v0, 31, "4f3f540f"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f21541f"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v31, TR::RealRegister::v0, 31, "4f3f541f"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f2155e0"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v0, TR::RealRegister::v15, 31, "4f3f55e0"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f2157e0"),
+    std::make_tuple(TR::InstOpCode::vshl4s, TR::RealRegister::v0, TR::RealRegister::v31, 31, "4f3f57e0"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f41540f"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v15, TR::RealRegister::v0, 63, "4f7f540f"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f41541f"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v31, TR::RealRegister::v0, 63, "4f7f541f"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f4155e0"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v0, TR::RealRegister::v15, 63, "4f7f55e0"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f4157e0"),
+    std::make_tuple(TR::InstOpCode::vshl2d, TR::RealRegister::v0, TR::RealRegister::v31, 63, "4f7f57e0")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorSignedShiftRightImmediate, ARM64VectorShiftImmediateEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f0f040f"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v15, TR::RealRegister::v0, 7, "4f09040f"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f0f041f"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v31, TR::RealRegister::v0, 7, "4f09041f"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f0f05e0"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v0, TR::RealRegister::v15, 7, "4f0905e0"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f0f07e0"),
+    std::make_tuple(TR::InstOpCode::vsshr16b, TR::RealRegister::v0, TR::RealRegister::v31, 7, "4f0907e0"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f1f040f"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v15, TR::RealRegister::v0, 15, "4f11040f"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f1f041f"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v31, TR::RealRegister::v0, 15, "4f11041f"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f1f05e0"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v0, TR::RealRegister::v15, 15, "4f1105e0"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f1f07e0"),
+    std::make_tuple(TR::InstOpCode::vsshr8h, TR::RealRegister::v0, TR::RealRegister::v31, 15, "4f1107e0"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f3f040f"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v15, TR::RealRegister::v0, 31, "4f21040f"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f3f041f"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v31, TR::RealRegister::v0, 31, "4f21041f"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f3f05e0"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v0, TR::RealRegister::v15, 31, "4f2105e0"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f3f07e0"),
+    std::make_tuple(TR::InstOpCode::vsshr4s, TR::RealRegister::v0, TR::RealRegister::v31, 31, "4f2107e0"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4f7f040f"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v15, TR::RealRegister::v0, 63, "4f41040f"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4f7f041f"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v31, TR::RealRegister::v0, 63, "4f41041f"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4f7f05e0"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v0, TR::RealRegister::v15, 63, "4f4105e0"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4f7f07e0"),
+    std::make_tuple(TR::InstOpCode::vsshr2d, TR::RealRegister::v0, TR::RealRegister::v31, 63, "4f4107e0")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorUnsignedShiftRightImmediate, ARM64VectorShiftImmediateEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v15, TR::RealRegister::v0, 1, "6f0f040f"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v15, TR::RealRegister::v0, 7, "6f09040f"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v31, TR::RealRegister::v0, 1, "6f0f041f"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v31, TR::RealRegister::v0, 7, "6f09041f"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v0, TR::RealRegister::v15, 1, "6f0f05e0"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v0, TR::RealRegister::v15, 7, "6f0905e0"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v0, TR::RealRegister::v31, 1, "6f0f07e0"),
+    std::make_tuple(TR::InstOpCode::vushr16b, TR::RealRegister::v0, TR::RealRegister::v31, 7, "6f0907e0"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v15, TR::RealRegister::v0, 1, "6f1f040f"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v15, TR::RealRegister::v0, 15, "6f11040f"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v31, TR::RealRegister::v0, 1, "6f1f041f"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v31, TR::RealRegister::v0, 15, "6f11041f"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v0, TR::RealRegister::v15, 1, "6f1f05e0"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v0, TR::RealRegister::v15, 15, "6f1105e0"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v0, TR::RealRegister::v31, 1, "6f1f07e0"),
+    std::make_tuple(TR::InstOpCode::vushr8h, TR::RealRegister::v0, TR::RealRegister::v31, 15, "6f1107e0"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v15, TR::RealRegister::v0, 1, "6f3f040f"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v15, TR::RealRegister::v0, 31, "6f21040f"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v31, TR::RealRegister::v0, 1, "6f3f041f"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v31, TR::RealRegister::v0, 31, "6f21041f"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v0, TR::RealRegister::v15, 1, "6f3f05e0"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v0, TR::RealRegister::v15, 31, "6f2105e0"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v0, TR::RealRegister::v31, 1, "6f3f07e0"),
+    std::make_tuple(TR::InstOpCode::vushr4s, TR::RealRegister::v0, TR::RealRegister::v31, 31, "6f2107e0"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v15, TR::RealRegister::v0, 1, "6f7f040f"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v15, TR::RealRegister::v0, 63, "6f41040f"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v31, TR::RealRegister::v0, 1, "6f7f041f"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v31, TR::RealRegister::v0, 63, "6f41041f"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v0, TR::RealRegister::v15, 1, "6f7f05e0"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v0, TR::RealRegister::v15, 63, "6f4105e0"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v0, TR::RealRegister::v31, 1, "6f7f07e0"),
+    std::make_tuple(TR::InstOpCode::vushr2d, TR::RealRegister::v0, TR::RealRegister::v31, 63, "6f4107e0")
 ));


### PR DESCRIPTION
This commit vector shift immediate instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>