### PR TITLE
Create TR::StackMemoryRegion for each CodeGenerator phase

### DIFF
--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "env/StackMemoryRegion.hpp"
 #include "codegen/BackingStore.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,7 @@
 #include "env/IO.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/RegionProfiler.hpp"
+#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "il/Block.hpp"
 #include "il/Node.hpp"
@@ -126,13 +127,14 @@ OMR::CodeGenPhase::_phaseToFunctionTable[] =
 void
 OMR::CodeGenPhase::performAll()
    {
-   int i = 0;
-
-   for(; i < TR::CodeGenPhase::getListSize(); i++)
+   for(int32_t i = 0; i < TR::CodeGenPhase::getListSize(); i++)
       {
       PhaseValue phaseToDo = PhaseList[i];
+
+      TR::StackMemoryRegion stackMemoryRegion(*_cg->trMemory());
       TR::RegionProfiler rp(_cg->comp()->trMemory()->heapMemoryRegion(), *_cg->comp(), "codegen/%s/%s",
          _cg->comp()->getHotnessName(_cg->comp()->getMethodHotness()), self()->getName(phaseToDo));
+
       _phaseToFunctionTable[phaseToDo](_cg, self());
       }
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -68,7 +68,6 @@
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
 #include "env/PersistentInfo.hpp"
-#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 #include "il/AliasSetInterface.hpp"
@@ -643,9 +642,6 @@ OMR::CodeGenerator::doInstructionSelection()
 
    self()->beginInstructionSelection();
 
-   {
-   TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
-
    TR_BitVector *liveLocals = self()->getLiveLocals();
    TR_BitVector nodeChecklistBeforeDump(comp->getNodeCount(), self()->trMemory(), stackAlloc, growable);
 
@@ -821,7 +817,6 @@ OMR::CodeGenerator::doInstructionSelection()
    //
    self()->insertInstructionPrefetches();
 #endif
-   } // scope of the stack memory region
 
    if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
       {

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "env/CompilerEnv.hpp"
+#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 #include "il/AliasSetInterface.hpp"

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -23,7 +23,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "env/StackMemoryRegion.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "env/FrontEnd.hpp"
 #include "codegen/GCStackAtlas.hpp"
@@ -99,9 +98,6 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
    uint32_t origSize = 0;
    bool     isFirst  = false;
 #endif
-
-   {
-   TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
 
    int32_t *colourToOffsetMap =
       (int32_t *) self()->trMemory()->allocateStackMemory(self()->cg()->getLocalsIG()->getNumberOfColoursUsedToColour() * sizeof(int32_t));
@@ -301,8 +297,6 @@ void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
 
    atlas->setLocalBaseOffset(lowGCOffset);
    atlas->setParmBaseOffset(atlas->getParmBaseOffset() + offsetToFirstParm);
-
-   } // scope of the stack memory region
 
    if (debug("reportCL"))
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,7 +78,6 @@
 #include "env/CompilerEnv.hpp"
 #include "env/IO.hpp"
 #include "env/Processors.hpp"
-#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 #include "il/AliasSetInterface.hpp"

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,6 @@
 #include "env/CompilerEnv.hpp"
 #include "env/ObjectModel.hpp"
 #include "env/PersistentInfo.hpp"
-#include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
 #include "env/defines.h"
 #include "env/jittypes.h"


### PR DESCRIPTION
Allocate `TR::StackMemoryRegion` consistently before each phase.

Remove redundant `TR::StackMemoryRegions` within CodeGenerator phases.

Issue: #6382

Signed-off-by: Daryl Maier <maier@ca.ibm.com>