### PR TITLE
Restrict VP checkcast tenured alignment logic to loadaddr

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4182,10 +4182,10 @@ TR::Node *constrainCheckcast(OMR::ValuePropagation *vp, TR::Node *node)
          }
 
 #ifdef J9_PROJECT_SPECIFIC
-      if (definitionNode)
+      if (definitionNode && node->getSecondChild()->getOpCodeValue() == TR::loadaddr)
          {
          TR::SymbolReference * classSymRef = node->getSecondChild()->getSymbolReference();
-         if (classSymRef && !classSymRef->isUnresolved())
+         if (!classSymRef->isUnresolved())
             {
             TR::StaticSymbol * classSym = classSymRef->getSymbol()->getStaticSymbol();
             if (classSym)


### PR DESCRIPTION
If the type child of the `checkcast` node is a static load (rather than `loadaddr`), then the static address will be incorrectly interpreted as a class pointer.

This change is just a precaution. It's unlikely that it will be possible for a static load to appear in this position for some time, even for a `checkcast` node whose cast type is dynamic.