### PR TITLE
Revert back to compare_and_swaplp() for 32-bit compilation for xlC on Linux

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -33,7 +33,7 @@
 #include <tpf/cmpswp.h>
 #endif
 
-#if defined(__xlC__)
+#if defined(__xlC__) && defined(AIXPPC)
 #include <sys/atomic_op.h>
 #endif
 
@@ -417,10 +417,10 @@ public:
 		csg((csg_t *)&oldValue, (csg_t *)address, (csg_t)newValue);
 		return oldValue;
 #elif defined(__xlC__) /* defined(OMRZTPF) */
-#if defined(__64BIT__)
+#if defined(__64BIT__) || !defined(AIXPPC)
 		__compare_and_swaplp((volatile long*)address, (long*)&oldValue, (long)newValue);
 #else /* defined(__64BIT__) */
-		/* __compare_and_swaplp is valid only in 64-bit mode. */
+		/* On AIX __compare_and_swaplp is valid only in 64-bit mode. */
 		compare_and_swaplp((atomic_l)address, (long*)&oldValue, (long)newValue);
 #endif /* defined(__64BIT__) */
 		return oldValue;


### PR DESCRIPTION
Pull request #6400 changed the atomic support using xlC to use compare_and_swaplp for 32-bit compilation, to allow compilation on AIX. Unfortunately this API isn't available for xlC on Linux.

The documentation for Linux doesn't state that __compare_and_swaplp is unavailable for 32-bit compilation, so revert to only using compare_and_swaplp on AIX.

Signed-off-by: David McCann mccannd@uk.ibm.com