### PR TITLE
Check if two addresses are equal in arraycmp

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1190,6 +1190,8 @@ TR::Register *OMR::X86::TreeEvaluator::SSE2ArraycmpEvaluator(TR::Node *node, TR:
    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, deltaReg, s1Reg, cg);
    generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, deltaReg, s2Reg, cg); // delta = s1 - s2
+   // If s1 and s2 are the same address, jump to equalLabel
+   generateLabelInstruction(TR::InstOpCode::JE4, node, equalLabel, cg);
    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, qwordCounterReg, strLenReg, cg);
    generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, qwordCounterReg, 4, cg);
    generateLabelInstruction(TR::InstOpCode::JE4,node, byteStart, cg);


### PR DESCRIPTION
If s1 and s2 points to the same address, jmp directly to
equalLabel.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>