### PR TITLE
Rename memory TR::Region fields in Structure to improve code clarity

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1624,9 +1624,9 @@ OMR::Block::split(TR::TreeTop * startOfNewBlock, TR::CFG * cfg, bool fixupCommon
       TR_BlockStructure *thisBlockStructure = self()->getStructureOf();
       if (thisBlockStructure)
          {
-         TR_BlockStructure *blockStructure2 = new (cfg->structureRegion()) TR_BlockStructure(comp, block2->getNumber(), block2);
+         TR_BlockStructure *blockStructure2 = new (cfg->structureMemoryRegion()) TR_BlockStructure(comp, block2->getNumber(), block2);
          TR_RegionStructure *parentStructure = thisBlockStructure->getParent()->asRegion();
-         TR_StructureSubGraphNode *blockStructureNode2 = new (cfg->structureRegion()) TR_StructureSubGraphNode(blockStructure2);
+         TR_StructureSubGraphNode *blockStructureNode2 = new (cfg->structureMemoryRegion()) TR_StructureSubGraphNode(blockStructure2);
          TR_StructureSubGraphNode *subNode;
          TR_RegionStructure::Cursor si(*parentStructure);
          for (subNode = si.getCurrent(); subNode != NULL; subNode = si.getNext())

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -95,7 +95,7 @@ OMR::Block::Block(TR_Memory * m) :
    }
 
 OMR::Block::Block(TR::CFG &cfg) :
-   TR::CFGNode(cfg.getInternalRegion())
+   TR::CFGNode(cfg.getInternalMemoryRegion())
    {
    self()->init(NULL, NULL);
    self()->setFrequency(-1);
@@ -113,7 +113,7 @@ OMR::Block::Block(TR::TreeTop *entry, TR::TreeTop *exit, TR_Memory * m) :
    }
 
 OMR::Block::Block(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg) :
-   TR::CFGNode(cfg.getInternalRegion())
+   TR::CFGNode(cfg.getInternalMemoryRegion())
    {
    self()->init(entry, exit);
    self()->setFrequency(-1);
@@ -142,7 +142,7 @@ OMR::Block::init(TR::TreeTop *entry, TR::TreeTop *exit)
 TR::Block*
 OMR::Block::createBlock(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg)
    {
-   return new (cfg.getInternalRegion()) TR::Block(entry, exit, cfg);
+   return new (cfg.getInternalMemoryRegion()) TR::Block(entry, exit, cfg);
    }
 
 /// Copy constructor

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -365,7 +365,7 @@ bool OMR::alwaysTrue(TR::CFGEdge * e)
    }
 
 
-TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingRegion)
+TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingMemoryRegion)
    {
    if (tryBlock->getExceptionSuccessors().empty())
       _dim = 0;
@@ -382,7 +382,7 @@ TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block
          }
 
       _dim = handlerDim * inlineDim;
-      _handlers = (TR::Block **)workingRegion.allocate(_dim*sizeof(TR::Block *));
+      _handlers = (TR::Block **)workingMemoryRegion.allocate(_dim*sizeof(TR::Block *));
       memset(_handlers, 0, _dim*sizeof(TR::Block *));
 
       for (auto e = tryBlock->getExceptionSuccessors().begin(); e != tryBlock->getExceptionSuccessors().end(); ++e)

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,7 @@ OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInPare
          TR_BlockStructure *blockStructure = block->getStructureOf();
          TR_StructureSubGraphNode *blockNode = NULL;
          if (!blockStructure)
-            blockStructure = new (structureRegion()) TR_BlockStructure(comp(), block->getNumber(), block);
+            blockStructure = new (structureMemoryRegion()) TR_BlockStructure(comp(), block->getNumber(), block);
          else
             {
             TR_StructureSubGraphNode *node;
@@ -101,7 +101,7 @@ OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInPare
 
          if (!blockNode)
             {
-            blockNode = new (structureRegion()) TR_StructureSubGraphNode(blockStructure);
+            blockNode = new (structureMemoryRegion()) TR_StructureSubGraphNode(blockStructure);
             if (!isEntryInParent)
                {
                parent->addSubNode(blockNode);
@@ -342,7 +342,7 @@ TR_Structure *
 OMR::CFG::invalidateStructure()
    {
    setStructure(NULL);
-   TR::Region::reset(_structureRegion, comp()->trMemory()->heapMemoryRegion());
+   TR::Region::reset(_structureMemoryRegion, comp()->trMemory()->heapMemoryRegion());
    return getStructure();
    }
 
@@ -1770,7 +1770,7 @@ OMR::CFG::clone()
    //
    setStructure(0);
 
-   TR_BlockCloner *cloner = new (structureRegion()) TR_BlockCloner(self(), false, true);
+   TR_BlockCloner *cloner = new (structureMemoryRegion()) TR_BlockCloner(self(), false, true);
    TR::Block *clonedBlock = cloner->cloneBlocks(comp()->getStartTree()->getNode()->getBlock(), lastTreeTop->getNode()->getBlock());
    lastTreeTop->join(clonedBlock->getEntry());
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -156,7 +156,7 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t)
 
    TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
 
-   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, _internalRegion);
+   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, _internalMemoryRegion);
    addEdge(e);
    return e;
    }
@@ -225,7 +225,7 @@ OMR::CFG::addExceptionEdgeUnchecked(
 
    TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
 
-   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, _internalRegion);
+   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, _internalMemoryRegion);
    _numEdges++;
 
    // Tell the control tree to modify the structures containing this edge
@@ -3271,7 +3271,7 @@ OMR::CFG::findReachableBlocks(TR_BitVector *result)
    }
 
 TR::Region&
-OMR::CFG::getInternalRegion()
+OMR::CFG::getInternalMemoryRegion()
    {
-   return self()->_internalRegion;
+   return self()->_internalMemoryRegion;
    }

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -98,14 +98,14 @@ class CFG
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
       _structureMemoryRegion(c->trMemory()->heapMemoryRegion()),
-      _internalRegion(c->trMemory()->heapMemoryRegion())
+      _internalMemoryRegion(c->trMemory()->heapMemoryRegion())
       {
          init(c, m);
       }
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region &r) :
       _structureMemoryRegion(c->trMemory()->heapMemoryRegion()),
-      _internalRegion(r)
+      _internalMemoryRegion(r)
       {
          init(c, m);
       }
@@ -344,7 +344,7 @@ class CFG
    //
    void getBranchCountersFromProfilingData(TR::Node *node, TR::Block *block, int32_t *taken, int32_t *notTaken) { return; }
 
-   TR::Region& getInternalRegion();
+   TR::Region& getInternalMemoryRegion();
 
 protected:
    TR::Compilation *_compilation;
@@ -353,7 +353,7 @@ protected:
    TR::CFGNode *_pStart;
    TR::CFGNode *_pEnd;
    TR::Region _structureMemoryRegion;
-   TR::Region _internalRegion;
+   TR::Region _internalMemoryRegion;
    TR_Structure *_rootStructure;
 
    TR_LinkHead1<TR::CFGNode> _nodes;

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -97,14 +97,14 @@ class CFG
    TR_ALLOC(TR_Memory::CFG)
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
-      _structureRegion(c->trMemory()->heapMemoryRegion()),
+      _structureMemoryRegion(c->trMemory()->heapMemoryRegion()),
       _internalRegion(c->trMemory()->heapMemoryRegion())
       {
          init(c, m);
       }
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region &r) :
-      _structureRegion(c->trMemory()->heapMemoryRegion()),
+      _structureMemoryRegion(c->trMemory()->heapMemoryRegion()),
       _internalRegion(r)
       {
          init(c, m);
@@ -146,7 +146,8 @@ class CFG
    TR_Memory *trMemory() { return comp()->trMemory(); }
    TR_HeapMemory trHeapMemory() { return trMemory(); }
    TR_StackMemory trStackMemory() { return trMemory(); }
-   TR::Region &structureRegion() { return _structureRegion; }
+   TR::Region &structureMemoryRegion() { return _structureMemoryRegion; }
+   TR::Region &structureRegion() { return _structureMemoryRegion; }
 
    void setStartAndEnd(TR::CFGNode * s, TR::CFGNode * e) { addNode(s); addNode(e); setStart(s); setEnd(e); }
 
@@ -181,7 +182,7 @@ class CFG
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
 
    /**
-    * Create and store exception edge from CFGNode f to CFGNode t 
+    * Create and store exception edge from CFGNode f to CFGNode t
     *
     * The new edge will not be added if there is an existing exception edge
     * from the "from" node to an existing block which catches the same
@@ -351,7 +352,7 @@ protected:
 
    TR::CFGNode *_pStart;
    TR::CFGNode *_pEnd;
-   TR::Region _structureRegion;
+   TR::Region _structureMemoryRegion;
    TR::Region _internalRegion;
    TR_Structure *_rootStructure;
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -484,7 +484,7 @@ class TR_OrderedExceptionHandlerIterator
 public:
    TR_ALLOC(TR_Memory::OrderedExceptionHandlerIterator)
 
-   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingRegion);
+   TR_OrderedExceptionHandlerIterator(TR::Block * tryBlock, TR::Region &workingMemoryRegion);
 
    TR::Block * getFirst();
 

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -239,7 +239,7 @@ void TR_LoopUnroller::unrollLoopOnce(TR_RegionStructure *loop, TR_StructureSubGr
       //Clone all the substructures
       TR_Structure *subStruct = subNode->getStructure();
       TR_Structure *clonedSubStruct = cloneStructure(subStruct);
-      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedSubStruct);
+      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(clonedSubStruct);
 
       //Memorize the mapping between subNode and clonedSubNode
       SET_CLONE_NODE(subNode, clonedSubNode);
@@ -470,8 +470,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
       comp()->setStartTree(newBlock->getEntry());
 
       _cfg->addNode(newBlock);
-      TR_BlockStructure *newBlockStr = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-      TR_StructureSubGraphNode *newNode  = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStr);
+      TR_BlockStructure *newBlockStr = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+      TR_StructureSubGraphNode *newNode  = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newBlockStr);
 
       parent->addSubNode(newNode);
 
@@ -629,8 +629,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
 
          _cfg->addNode(newBlock);
 
-         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          TR::CFGEdge *edgeToRemove = pBlock->getSuccessors().front();
@@ -780,8 +780,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
          pBlock->getExit()->join(newBlock->getEntry());
 
          _cfg->addNode(newBlock);
-         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          TR::CFGEdge *edgeToRemove = NULL;
@@ -813,8 +813,8 @@ void TR_LoopUnroller::modifyBranchTree(TR_RegionStructure *loop,
          TR::Block *newBlock = pBlock->split(lastTree, _cfg);
          pBlock->append(iterGuard);
 
-         TR_BlockStructure *newBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
-         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBlockStructure);
+         TR_BlockStructure *newBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newBlock->getNumber(), newBlock);
+         TR_StructureSubGraphNode *newSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newBlockStructure);
          parent->addSubNode(newSubNode);
 
          _cfg->addEdge(TR::CFGEdge::createEdge(pBlock,  spillBlock, trMemory()));
@@ -1164,8 +1164,8 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
 
             newIfBlock->append(newIfTree);
             _cfg->addNode(newIfBlock);
-            newIfBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
-            newIfSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newIfBlockStructure);
+            newIfBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newIfBlock->getNumber(), newIfBlock);
+            newIfSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newIfBlockStructure);
             parent->addSubNode(newIfSubNode);
 
             TR::Node *gotoNode  = TR::Node::create(newIfTree->getNode(), TR::Goto);
@@ -1175,8 +1175,8 @@ void TR_LoopUnroller::modifyOriginalLoop(TR_RegionStructure *loop, TR_StructureS
             _cfg->addNode(gotoBlock);
             _cfg->addEdge(TR::CFGEdge::createEdge(gotoBlock, spillLoop->getEntryBlock(), trMemory()));
 
-            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode
-               (new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
+            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode
+               (new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(), gotoBlock));
             parent->addSubNode(gotoSubNode);
 
             if (spillLoop->contains(branchDestination->getStructureOf(), parent))
@@ -1870,7 +1870,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    cloneBlocksInRegion(loop, true); // isSpillLoop = true
 
    TR_RegionStructure *spillLoop = cloneStructure(loop)->asRegion();
-   TR_StructureSubGraphNode *spillNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(spillLoop);
+   TR_StructureSubGraphNode *spillNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(spillLoop);
    fixExitEdges(loop, spillLoop, branchNode);
 
    spillLoop->getEntryBlock()->getStructureOf()->setIsEntryOfShortRunningLoop();
@@ -1913,7 +1913,7 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    //clone the loop
    cloneBlocksInRegion(loop);
    TR_RegionStructure *spillLoop = cloneStructure(loop)->asRegion();
-   TR_StructureSubGraphNode *spillNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(spillLoop);
+   TR_StructureSubGraphNode *spillNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(spillLoop);
    fixExitEdges(loop, spillLoop, branchNode);
 
    TR_StructureSubGraphNode *clonedBranchNode = GET_CLONE_NODE(branchNode);
@@ -1932,9 +1932,9 @@ void TR_LoopUnroller::generateSpillLoop(TR_RegionStructure *loop,
    _cfg->addNode(newBranchBlock);
 
    //create the structure
-   TR_BlockStructure *newBranchStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newBranchBlock->getNumber(),
+   TR_BlockStructure *newBranchStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newBranchBlock->getNumber(),
                                                                  newBranchBlock);
-   TR_StructureSubGraphNode *newBranchNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newBranchStructure);
+   TR_StructureSubGraphNode *newBranchNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newBranchStructure);
    spillLoop->addSubNode(newBranchNode);
 
    //make newBranchNode the entryNode
@@ -2221,9 +2221,9 @@ void TR_LoopUnroller::addEdgeForSpillLoop(TR_RegionStructure *region,
                }
 
             //create the structures
-            TR_BlockStructure *gotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
+            TR_BlockStructure *gotoStruct = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
                                                                   gotoBlock);
-            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(gotoStruct);
+            TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(gotoStruct);
             region->addSubNode(gotoSubNode);
 
             //create the cfg edges
@@ -2356,9 +2356,9 @@ void TR_LoopUnroller::addExitEdgeAndFixEverything(TR_RegionStructure *region,
                      gotoBlock->getExit()->setNextTreeTop(NULL);
 
                   //create the structures
-                  TR_BlockStructure *gotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
+                  TR_BlockStructure *gotoStruct = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), gotoBlock->getNumber(),
                                                                         gotoBlock);
-                  TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(gotoStruct);
+                  TR_StructureSubGraphNode *gotoSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(gotoStruct);
                   region->addSubNode(gotoSubNode);
 
                   //create the cfg edges
@@ -2638,7 +2638,7 @@ TR_Structure *TR_LoopUnroller::cloneBlockStructure(TR_BlockStructure *blockStruc
    TR::Block *block = blockStructure->getBlock();
    TR::Block *clonedBlock = GET_CLONE_BLOCK(block);
    TR_BlockStructure *clonedBlockStructure =
-      new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedBlock->getNumber(), clonedBlock);
+      new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), clonedBlock->getNumber(), clonedBlock);
    clonedBlockStructure->setAsLoopInvariantBlock(blockStructure->isLoopInvariantBlock());
    clonedBlockStructure->setNestingDepth(blockStructure->getNestingDepth());
    clonedBlockStructure->setMaxNestingDepth(blockStructure->getMaxNestingDepth());
@@ -2647,7 +2647,7 @@ TR_Structure *TR_LoopUnroller::cloneBlockStructure(TR_BlockStructure *blockStruc
 
 TR_Structure *TR_LoopUnroller::cloneRegionStructure(TR_RegionStructure *region)
    {
-   TR_RegionStructure *clonedRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), 0xDeadF00d); //for now
+   TR_RegionStructure *clonedRegion = new (_cfg->structureMemoryRegion()) TR_RegionStructure(comp(), 0xDeadF00d); //for now
    clonedRegion->setAsCanonicalizedLoop(region->isCanonicalizedLoop());
    clonedRegion->setContainsInternalCycles(region->containsInternalCycles());
 
@@ -2659,7 +2659,7 @@ TR_Structure *TR_LoopUnroller::cloneRegionStructure(TR_RegionStructure *region)
       {
       subStruct = subNode->getStructure();
       TR_Structure *clonedSubStruct = cloneStructure(subStruct);
-      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedSubStruct);
+      TR_StructureSubGraphNode *clonedSubNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(clonedSubStruct);
       SET_CLONE_NODE(subNode, clonedSubNode);
       clonedRegion->addSubNode(clonedSubNode);
       if (subNode == region->getEntry())

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1412,14 +1412,14 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    // new region replaces the original natural loop in its parent.
    //
    TR_Structure *parentStructure = whileLoop->getParent();
-   TR_RegionStructure *properRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), loopHeader->getNumber());
+   TR_RegionStructure *properRegion = new (_cfg->structureMemoryRegion()) TR_RegionStructure(comp(), loopHeader->getNumber());
    properRegion->setAsCanonicalizedLoop(true);
    parentStructure->replacePart(whileLoop, properRegion);
    whileLoop->setParent(properRegion);
 
    whileLoop->setEntry(bodyNode);
    whileLoop->setNumber(loopBody->getNumber());
-   TR_BlockStructure *clonedHdrBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedHeader->getNumber(), clonedHeader);
+   TR_BlockStructure *clonedHdrBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), clonedHeader->getNumber(), clonedHeader);
    if (needToSetFlag)
      {
      //clonedHdrBlockStructure->setIsEntryOfShortRunningLoop();
@@ -1438,21 +1438,21 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    clonedHdrBlockStructure->setWasHeaderOfCanonicalizedLoop(true);
    whileLoop->replacePart(entryGraphNode->getStructure(), clonedHdrBlockStructure);
 
-   TR_StructureSubGraphNode *hdrNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(loopHeader->getStructureOf());
+   TR_StructureSubGraphNode *hdrNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(loopHeader->getStructureOf());
    properRegion->addSubNode(hdrNode);
    properRegion->setEntry(hdrNode);
 
-   TR_StructureSubGraphNode *node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(new (_cfg->structureRegion()) TR_BlockStructure(comp(), splitter2->getNumber(), splitter2));
+   TR_StructureSubGraphNode *node = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), splitter2->getNumber(), splitter2));
    node->getStructure()->asBlock()->setAsLoopInvariantBlock(true);
    _invariantBlocks.add(splitter2);
    properRegion->addSubNode(node);
    TR::CFGEdge::createEdge(hdrNode, node, trMemory());
 
-   TR_StructureSubGraphNode *loopNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(whileLoop);
+   TR_StructureSubGraphNode *loopNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(whileLoop);
    properRegion->addSubNode(loopNode);
    TR::CFGEdge::createEdge(node, loopNode, trMemory());
 
-   node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(new (_cfg->structureRegion()) TR_BlockStructure(comp(), splitter1->getNumber(), splitter1));
+   node = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), splitter1->getNumber(), splitter1));
    properRegion->addSubNode(node);
    TR::CFGEdge::createEdge(hdrNode, node, trMemory());
 
@@ -1484,8 +1484,8 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
    if (reversedBranch)
       {
       bool naturalLoopStillExitsToJoinNode = false;
-      TR_BlockStructure *extraGotoStruct = new (_cfg->structureRegion()) TR_BlockStructure(comp(), extraGoto->getNumber(), extraGoto);
-      node = new (_cfg->structureRegion()) TR_StructureSubGraphNode(extraGotoStruct);
+      TR_BlockStructure *extraGotoStruct = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), extraGoto->getNumber(), extraGoto);
+      node = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(extraGotoStruct);
       properRegion->addSubNode(node);
       TR::CFGEdge::createEdge(loopNode, node, trMemory());
 
@@ -1503,7 +1503,7 @@ void TR_LoopCanonicalizer::canonicalizeNaturalLoop(TR_RegionStructure *whileLoop
             {
             if (fromNode->getStructure() == clonedHdrBlockStructure)
                {
-               edge->setTo(TR_StructureSubGraphNode::create(node->getNumber(), whileLoop));     //new (_cfg->structureRegion()) TR_StructureSubGraphNode(node->getNumber()));
+               edge->setTo(TR_StructureSubGraphNode::create(node->getNumber(), whileLoop));
                }
             else
                naturalLoopStillExitsToJoinNode = true;
@@ -1709,7 +1709,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
       newExit->join(blockHeadTreeTop);
       }
 
-   TR_BlockStructure *invariantBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), loopInvariantBlock->getNumber(), loopInvariantBlock);
+   TR_BlockStructure *invariantBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), loopInvariantBlock->getNumber(), loopInvariantBlock);
    invariantBlockStructure->setAsLoopInvariantBlock(true);
 
    TR::Block *dummyEntryBlock = NULL;
@@ -1736,7 +1736,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
          dummyExit->join(newEntry);
          }
 
-      dummyEntryBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), dummyEntryBlock->getNumber(), dummyEntryBlock);
+      dummyEntryBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), dummyEntryBlock->getNumber(), dummyEntryBlock);
       targetBlock = dummyEntryBlock;
       }
    else
@@ -1772,7 +1772,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
 
    _cfg->setStructure(_rootStructure);
 
-   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
+   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
    parentStructure->addSubNode(invariantNode);
 
    TR::CFGEdge::createEdge(invariantNode,  doWhileNode, trMemory());
@@ -1781,7 +1781,7 @@ void TR_LoopCanonicalizer::canonicalizeDoWhileLoop(TR_RegionStructure *doWhileLo
    TR_Structure *targetStructure = NULL;
    if (isEntry)
       {
-      TR_StructureSubGraphNode *dummyEntryNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(dummyEntryBlockStructure);
+      TR_StructureSubGraphNode *dummyEntryNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(dummyEntryBlockStructure);
       parentStructure->addSubNode(dummyEntryNode);
 
       TR::CFGEdge::createEdge(dummyEntryNode,  invariantNode, trMemory());

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3594,7 +3594,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
                      }
                   }
 
-               TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
+               TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
                newGotoBlockStructure->setCreatedByVersioning(true);
                if (!_neitherLoopCold)
                   {
@@ -4474,7 +4474,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          endTree = gotoBlockExitTree;
          //_cfg->addEdge(TR::CFGEdge::createEdge(comparisonBlock,  newGotoBlock, trMemory()));
          //_cfg->addEdge(TR::CFGEdge::createEdge(newGotoBlock,  clonedLoopInvariantBlock, trMemory()));
-         TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
+         TR_BlockStructure *newGotoBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), newGotoBlock->getNumber(), newGotoBlock);
          newGotoBlockStructure->setCreatedByVersioning(true);
          if (!_neitherLoopCold)
             {
@@ -4653,20 +4653,20 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    whileLoop->setVersionedLoop(clonedWhileLoop);
 
    TR_BlockStructure *invariantBlockStructure = invariantBlock->getStructureOf();
-   TR_BlockStructure *clonedInvariantBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), clonedLoopInvariantBlock->getNumber(), clonedLoopInvariantBlock);
+   TR_BlockStructure *clonedInvariantBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), clonedLoopInvariantBlock->getNumber(), clonedLoopInvariantBlock);
    clonedInvariantBlockStructure->setCreatedByVersioning(true);
 
    if (!_neitherLoopCold)
       clonedInnerWhileLoops->deleteAll();
    clonedInvariantBlockStructure->setAsLoopInvariantBlock(true);
    TR_RegionStructure *parentStructure = whileLoop->getParent()->asRegion();
-   TR_RegionStructure *properRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), chooserBlock->getNumber());
+   TR_RegionStructure *properRegion = new (_cfg->structureMemoryRegion()) TR_RegionStructure(comp(), chooserBlock->getNumber());
    parentStructure->replacePart(invariantBlockStructure, properRegion);
 
-   TR_StructureSubGraphNode *clonedWhileNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedWhileLoop);
-   TR_StructureSubGraphNode *whileNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(whileLoop);
-   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
-   TR_StructureSubGraphNode *clonedInvariantNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(clonedInvariantBlockStructure);
+   TR_StructureSubGraphNode *clonedWhileNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(clonedWhileLoop);
+   TR_StructureSubGraphNode *whileNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(whileLoop);
+   TR_StructureSubGraphNode *invariantNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(invariantBlockStructure);
+   TR_StructureSubGraphNode *clonedInvariantNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(clonedInvariantBlockStructure);
 
    properRegion->addSubNode(whileNode);
    properRegion->addSubNode(clonedWhileNode);
@@ -4689,9 +4689,9 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
       bool isTest =
          !actualComparisonBlock->getLastRealTreeTop()->getNode()->getOpCode().isStore();
 
-      TR_BlockStructure *comparisonBlockStructure = new (_cfg->structureRegion()) TR_BlockStructure(comp(), actualComparisonBlock->getNumber(), actualComparisonBlock);
+      TR_BlockStructure *comparisonBlockStructure = new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), actualComparisonBlock->getNumber(), actualComparisonBlock);
       comparisonBlockStructure->setCreatedByVersioning(true);
-      TR_StructureSubGraphNode *comparisonNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(comparisonBlockStructure);
+      TR_StructureSubGraphNode *comparisonNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(comparisonBlockStructure);
       properRegion->addSubNode(comparisonNode);
 
       if (prevComparisonNode)
@@ -4710,7 +4710,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          {
          if (currCriticalEdgeBlock != NULL)
             {
-            TR_StructureSubGraphNode *criticalEdgeNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(currCriticalEdgeBlock->getData()->getStructureOf());
+            TR_StructureSubGraphNode *criticalEdgeNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(currCriticalEdgeBlock->getData()->getStructureOf());
             properRegion->addSubNode(criticalEdgeNode);
             TR::CFGEdge::createEdge(prevComparisonNode,  criticalEdgeNode, trMemory());
             TR::CFGEdge::createEdge(criticalEdgeNode,  clonedInvariantNode, trMemory());
@@ -4818,7 +4818,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    TR_BlockStructure *newGotoBlockStructure;
    for (newGotoBlockStructure = newGotoBlockStructuresIt.getCurrent(); newGotoBlockStructure; newGotoBlockStructure = newGotoBlockStructuresIt.getNext())
       {
-      TR_StructureSubGraphNode *newGotoBlockNode = new (_cfg->structureRegion()) TR_StructureSubGraphNode(newGotoBlockStructure);
+      TR_StructureSubGraphNode *newGotoBlockNode = new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode(newGotoBlockStructure);
       properRegion->addSubNode(newGotoBlockNode);
       TR::CFGEdge::createEdge(clonedWhileNode,  newGotoBlockNode, trMemory());
       }

--- a/compiler/optimizer/StructuralAnalysis.cpp
+++ b/compiler/optimizer/StructuralAnalysis.cpp
@@ -116,7 +116,7 @@ void TR_RegionAnalysis::createLeafStructures(TR::CFG *cfg, TR::Region &region)
 
    _totalNumberOfNodes = 0;
 
-   _infoTable = (StructInfo**) _workingRegion.allocate((cfg->getNumberOfNodes()+1)*sizeof(StructInfo*));
+   _infoTable = (StructInfo**) _workingMemoryRegion.allocate((cfg->getNumberOfNodes()+1)*sizeof(StructInfo*));
 
    // We need two passes to initialize the array of StructInfo objects
    // because the order of nodes is not necessarily sequential.

--- a/compiler/optimizer/StructuralAnalysis.cpp
+++ b/compiler/optimizer/StructuralAnalysis.cpp
@@ -373,7 +373,7 @@ TR_RegionStructure *TR_RegionAnalysis::findNaturalLoop(StructInfo &node,
    if (numBackEdges == 0)
       return NULL;
 
-   TR_RegionStructure *region = new (_structureRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
+   TR_RegionStructure *region = new (_structureMemoryRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
    if (cyclesFound)
       {
       if (trace())
@@ -526,7 +526,7 @@ TR_RegionStructure *TR_RegionAnalysis::findRegion(StructInfo &node,
          return NULL;
       }
 
-   TR_RegionStructure *region = new (_structureRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
+   TR_RegionStructure *region = new (_structureMemoryRegion) TR_RegionStructure(_compilation, node._structure->getNumber() /* node._nodeIndex */);
    if (cyclesFound)
       {
       if (trace())
@@ -671,7 +671,7 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
       StructInfo &fromNode = getInfo(fromIndex);
 
       if (cfgNodes[fromIndex] == NULL)
-         cfgNodes[fromIndex] = new (_structureRegion) TR_StructureSubGraphNode(fromNode._structure);
+         cfgNodes[fromIndex] = new (_structureMemoryRegion) TR_StructureSubGraphNode(fromNode._structure);
       from = cfgNodes[fromIndex];
       region->addSubNode(from);
 
@@ -683,12 +683,12 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
          if (cfgNodes[toIndex] == NULL)
             {
             if (regionNodes.get(toIndex))
-               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure);
+               cfgNodes[toIndex] = new (_structureMemoryRegion) TR_StructureSubGraphNode(toNode._structure);
             else
-               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureRegion);
+               cfgNodes[toIndex] = new (_structureMemoryRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureMemoryRegion);
             }
          to = cfgNodes[toIndex];
-         edge = TR::CFGEdge::createEdge(from,  to, _structureRegion);
+         edge = TR::CFGEdge::createEdge(from,  to, _structureMemoryRegion);
          if (regionNodes.get(toIndex))
             {
             toNode._pred.reset(fromIndex);
@@ -718,12 +718,12 @@ void TR_RegionAnalysis::buildRegionSubGraph(TR_RegionStructure *region,
          if (cfgNodes[toIndex] == NULL)
             {
             if (regionNodes.get(toIndex))
-               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure);
+               cfgNodes[toIndex] = new (_structureMemoryRegion) TR_StructureSubGraphNode(toNode._structure);
             else
-               cfgNodes[toIndex] = new (_structureRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureRegion);
+               cfgNodes[toIndex] = new (_structureMemoryRegion) TR_StructureSubGraphNode(toNode._structure->getNumber(), _structureMemoryRegion);
             }
          to = cfgNodes[toIndex];
-         edge = TR::CFGEdge::createExceptionEdge(from, to, _structureRegion);
+         edge = TR::CFGEdge::createExceptionEdge(from, to, _structureMemoryRegion);
          if (regionNodes.get(toIndex))
             {
             toNode._exceptionPred.reset(fromIndex);

--- a/compiler/optimizer/StructuralAnalysis.cpp
+++ b/compiler/optimizer/StructuralAnalysis.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,7 +96,7 @@ void TR_RegionAnalysis::simpleIterator (TR_Stack<int32_t>& workStack,
 
 void TR_RegionAnalysis::StructInfo::initialize(TR::Compilation * comp, int32_t index, TR::Block *block)
    {
-   _structure       = new (comp->getFlowGraph()->structureRegion()) TR_BlockStructure(comp, block->getNumber(), block);
+   _structure       = new (comp->getFlowGraph()->structureMemoryRegion()) TR_BlockStructure(comp, block->getNumber(), block);
    _originalBlock   = block;
    _nodeIndex       = index;
    }

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -92,7 +92,7 @@ class TR_RegionAnalysis
 
    TR_RegionAnalysis(TR::Compilation *comp, TR_Dominators &dominators, TR::CFG * cfg, TR::Region &workingRegion) :
       _workingRegion(workingRegion),
-      _structureRegion(comp->getFlowGraph()->structureMemoryRegion()),
+      _structureMemoryRegion(comp->getFlowGraph()->structureMemoryRegion()),
       _compilation(comp),
       _infoTable(NULL),
       _dominators(dominators),
@@ -100,7 +100,7 @@ class TR_RegionAnalysis
       {
       }
    TR::Region &_workingRegion;
-   TR::Region &_structureRegion;
+   TR::Region &_structureMemoryRegion;
    TR::Compilation *_compilation;
 
    /** The StructInfoTable is 1-based */

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ class TR_RegionAnalysis
 
    TR_RegionAnalysis(TR::Compilation *comp, TR_Dominators &dominators, TR::CFG * cfg, TR::Region &workingRegion) :
       _workingRegion(workingRegion),
-      _structureRegion(comp->getFlowGraph()->structureRegion()),
+      _structureRegion(comp->getFlowGraph()->structureMemoryRegion()),
       _compilation(comp),
       _infoTable(NULL),
       _dominators(dominators),

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -90,8 +90,8 @@ class TR_RegionAnalysis
       int32_t getNumber() { return _originalBlock ? _originalBlock->getNumber() : -1; }
       };
 
-   TR_RegionAnalysis(TR::Compilation *comp, TR_Dominators &dominators, TR::CFG * cfg, TR::Region &workingRegion) :
-      _workingRegion(workingRegion),
+   TR_RegionAnalysis(TR::Compilation *comp, TR_Dominators &dominators, TR::CFG * cfg, TR::Region &workingMemoryRegion) :
+      _workingMemoryRegion(workingMemoryRegion),
       _structureMemoryRegion(comp->getFlowGraph()->structureMemoryRegion()),
       _compilation(comp),
       _infoTable(NULL),
@@ -99,7 +99,7 @@ class TR_RegionAnalysis
       _cfg(cfg)
       {
       }
-   TR::Region &_workingRegion;
+   TR::Region &_workingMemoryRegion;
    TR::Region &_structureMemoryRegion;
    TR::Compilation *_compilation;
 

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -195,7 +195,7 @@ class TR_RegionStructure::ExitExtraction
       , _cfg(_comp->getFlowGraph())
       , _trace(_comp->getOption(TR_TraceExitExtraction))
       , _memRegion(memRegion)
-      , _structureRegion(_cfg->structureMemoryRegion())
+      , _structureMemoryRegion(_cfg->structureMemoryRegion())
       , _workStack(_memRegion)
       , _queued(std::less<TR_Structure*>(), _memRegion)
       , _regionContents(RcCmp(), _memRegion)
@@ -234,7 +234,7 @@ class TR_RegionStructure::ExitExtraction
    const bool _trace;
 
    TR::Region &_memRegion;
-   TR::Region &_structureRegion;
+   TR::Region &_structureMemoryRegion;
    StructureVec _workStack;
    StructureSet _queued;
    RegionContents _regionContents;
@@ -792,9 +792,9 @@ void TR_RegionStructure::ExitExtraction::moveNodeIntoParent(
    // Parent needs an edge from region to node
    auto * const regionNode = parent->subNodeFromStructure(region);
    if (nodeIsHandler)
-      TR::CFGEdge::createExceptionEdge(regionNode, node, _structureRegion);
+      TR::CFGEdge::createExceptionEdge(regionNode, node, _structureMemoryRegion);
    else
-      TR::CFGEdge::createEdge(regionNode, node, _structureRegion);
+      TR::CFGEdge::createEdge(regionNode, node, _structureMemoryRegion);
 
    if (_trace)
       {
@@ -955,9 +955,9 @@ void TR_RegionStructure::ExitExtraction::moveOutgoingEdgeToParent(
    else
       {
       if (isExceptionEdge)
-         TR::CFGEdge::createExceptionEdge(node, redirect, _structureRegion);
+         TR::CFGEdge::createExceptionEdge(node, redirect, _structureMemoryRegion);
       else
-         TR::CFGEdge::createEdge(node, redirect, _structureRegion);
+         TR::CFGEdge::createEdge(node, redirect, _structureMemoryRegion);
 
       if (_trace)
          {
@@ -1741,8 +1741,8 @@ TR_Structure *TR_BlockStructure::cloneStructure(TR::Block **correspondingBlocks,
 
 TR_Structure *TR_RegionStructure::cloneStructure(TR::Block **correspondingBlocks, TR_StructureSubGraphNode **correspondingSubNodes, List<TR_Structure> *whileLoops, List<TR_Structure> *correspondingWhileLoops)
    {
-   TR::Region &structureRegion = cfg()->structureMemoryRegion();
-   TR_RegionStructure *clonedRegionStructure = new (structureRegion) TR_RegionStructure(comp(), correspondingBlocks[getNumber()]->getNumber());
+   TR::Region &structureMemoryRegion = cfg()->structureMemoryRegion();
+   TR_RegionStructure *clonedRegionStructure = new (structureMemoryRegion) TR_RegionStructure(comp(), correspondingBlocks[getNumber()]->getNumber());
    clonedRegionStructure->setAsCanonicalizedLoop(isCanonicalizedLoop());
    clonedRegionStructure->setContainsInternalCycles(containsInternalCycles());
 
@@ -1753,7 +1753,7 @@ TR_Structure *TR_RegionStructure::cloneStructure(TR::Block **correspondingBlocks
       {
       subStruct = subNode->getStructure();
       TR_Structure *clonedSubStruct = subStruct->cloneStructure(correspondingBlocks, correspondingSubNodes, whileLoops, correspondingWhileLoops);
-      TR_StructureSubGraphNode *clonedSubNode = new (structureRegion) TR_StructureSubGraphNode(clonedSubStruct);
+      TR_StructureSubGraphNode *clonedSubNode = new (structureMemoryRegion) TR_StructureSubGraphNode(clonedSubStruct);
       clonedRegionStructure->addSubNode(clonedSubNode);
       if (subNode == getEntry())
          clonedRegionStructure->setEntry(clonedSubNode);
@@ -1807,7 +1807,7 @@ TR_Structure *TR_RegionStructure::cloneStructure(TR::Block **correspondingBlocks
    TR_InductionVariable *prevClonedInductionVariable = NULL;
    while (currInductionVariable)
       {
-      TR_InductionVariable *currClonedInductionVariable = new (structureRegion) TR_InductionVariable();
+      TR_InductionVariable *currClonedInductionVariable = new (structureMemoryRegion) TR_InductionVariable();
       memcpy(currClonedInductionVariable, currInductionVariable, sizeof(TR_InductionVariable));
       if (!prevClonedInductionVariable)
          clonedRegionStructure->addInductionVariable(currClonedInductionVariable);
@@ -1963,7 +1963,7 @@ void TR_RegionStructure::addEdge(TR::CFGEdge *edge, bool isExceptionEdge)
       fromStruct->addExternalEdge(from->getStructureOf(), to->getNumber(), isExceptionEdge);
       }
 
-   TR::Region &structureRegion = cfg()->structureMemoryRegion();
+   TR::Region &structureMemoryRegion = cfg()->structureMemoryRegion();
    // Find the subgraph node for the to block
    //
    TR_StructureSubGraphNode *toNode;
@@ -1985,9 +1985,9 @@ void TR_RegionStructure::addEdge(TR::CFGEdge *edge, bool isExceptionEdge)
             {
             toStruct = to->getStructureOf();
             if (!toStruct)
-               toStruct = new ((structureRegion)) TR_BlockStructure(comp(), to->getNumber(), to);
+               toStruct = new ((structureMemoryRegion)) TR_BlockStructure(comp(), to->getNumber(), to);
             toStruct->setNumber(to->getNumber());
-            toNode = new (structureRegion) TR_StructureSubGraphNode(toStruct);
+            toNode = new (structureMemoryRegion) TR_StructureSubGraphNode(toStruct);
             addSubNode(toNode);
             toNode->setNumber(to->getNumber());
             }

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,7 +195,7 @@ class TR_RegionStructure::ExitExtraction
       , _cfg(_comp->getFlowGraph())
       , _trace(_comp->getOption(TR_TraceExitExtraction))
       , _memRegion(memRegion)
-      , _structureRegion(_cfg->structureRegion())
+      , _structureRegion(_cfg->structureMemoryRegion())
       , _workStack(_memRegion)
       , _queued(std::less<TR_Structure*>(), _memRegion)
       , _regionContents(RcCmp(), _memRegion)
@@ -1729,7 +1729,7 @@ bool TR_RegionStructure::containsOnlyAcyclicRegions()
 TR_Structure *TR_BlockStructure::cloneStructure(TR::Block **correspondingBlocks, TR_StructureSubGraphNode **correspodingSubNodes, List<TR_Structure> *whileLoops, List<TR_Structure> *correspondingWhileLoops)
    {
    TR::Block *correspondingBlock = correspondingBlocks[getNumber()];
-   TR_BlockStructure *clonedBlockStructure = new (cfg()->structureRegion()) TR_BlockStructure(comp(), correspondingBlock->getNumber(), correspondingBlock);
+   TR_BlockStructure *clonedBlockStructure = new (cfg()->structureMemoryRegion()) TR_BlockStructure(comp(), correspondingBlock->getNumber(), correspondingBlock);
    clonedBlockStructure->setNestingDepth(getNestingDepth());
    clonedBlockStructure->setMaxNestingDepth(getMaxNestingDepth());
    clonedBlockStructure->setDuplicatedBlock(this);
@@ -1741,7 +1741,7 @@ TR_Structure *TR_BlockStructure::cloneStructure(TR::Block **correspondingBlocks,
 
 TR_Structure *TR_RegionStructure::cloneStructure(TR::Block **correspondingBlocks, TR_StructureSubGraphNode **correspondingSubNodes, List<TR_Structure> *whileLoops, List<TR_Structure> *correspondingWhileLoops)
    {
-   TR::Region &structureRegion = cfg()->structureRegion();
+   TR::Region &structureRegion = cfg()->structureMemoryRegion();
    TR_RegionStructure *clonedRegionStructure = new (structureRegion) TR_RegionStructure(comp(), correspondingBlocks[getNumber()]->getNumber());
    clonedRegionStructure->setAsCanonicalizedLoop(isCanonicalizedLoop());
    clonedRegionStructure->setContainsInternalCycles(containsInternalCycles());
@@ -1963,7 +1963,7 @@ void TR_RegionStructure::addEdge(TR::CFGEdge *edge, bool isExceptionEdge)
       fromStruct->addExternalEdge(from->getStructureOf(), to->getNumber(), isExceptionEdge);
       }
 
-   TR::Region &structureRegion = cfg()->structureRegion();
+   TR::Region &structureRegion = cfg()->structureMemoryRegion();
    // Find the subgraph node for the to block
    //
    TR_StructureSubGraphNode *toNode;
@@ -2297,7 +2297,7 @@ TR_RegionStructure::addExitEdge(TR_StructureSubGraphNode *from, int32_t to, bool
       }
 
    TR::CFGEdge *edge;
-   TR::CFGNode *toNode = cursor ? cursor->getTo() : new (cfg()->structureRegion()) TR_StructureSubGraphNode(to, cfg()->structureRegion());
+   TR::CFGNode *toNode = cursor ? cursor->getTo() : new (cfg()->structureMemoryRegion()) TR_StructureSubGraphNode(to, cfg()->structureMemoryRegion());
 
    if (origEdge)
       {
@@ -2330,7 +2330,7 @@ TR_StructureSubGraphNode::create(int32_t num, TR_RegionStructure *region)
    if (edge)
       return edge->getTo()->asStructureSubGraphNode();
 
-   return new (region->cfg()->structureRegion()) TR_StructureSubGraphNode(num, region->cfg()->structureRegion());
+   return new (region->cfg()->structureMemoryRegion()) TR_StructureSubGraphNode(num, region->cfg()->structureMemoryRegion());
    }
 
 TR_StructureSubGraphNode *TR_StructureSubGraphNode::asStructureSubGraphNode() {return this;}

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -280,7 +280,7 @@ class TR_StructureSubGraphNode : public TR::CFGNode
    // Create a node for a concrete structure
    //
    TR_StructureSubGraphNode(TR_Structure *s)
-      : TR::CFGNode(s->getNumber(), s->cfg()->structureRegion()), _structure(s)  {s->setSubGraphNode(this);}
+      : TR::CFGNode(s->getNumber(), s->cfg()->structureMemoryRegion()), _structure(s)  {s->setSubGraphNode(this);}
 
    TR_StructureSubGraphNode(int32_t n, TR::Region &region)
       : TR::CFGNode(n, region), _structure(0) {}
@@ -420,8 +420,8 @@ class TR_RegionStructure : public TR_Structure
 
    TR_RegionStructure(TR::Compilation * c, int32_t index)
       : TR_Structure(c, index), _invariantSymbols(NULL), _blocksAtSameNestingLevel(NULL), _piv(NULL),
-        _basicIVs(c->getFlowGraph()->structureRegion()), _exitEdges(c->getFlowGraph()->structureRegion()),
-         _subNodes(c->getFlowGraph()->structureRegion()), _invariantExpressions(NULL)
+        _basicIVs(c->getFlowGraph()->structureMemoryRegion()), _exitEdges(c->getFlowGraph()->structureMemoryRegion()),
+        _subNodes(c->getFlowGraph()->structureMemoryRegion()), _invariantExpressions(NULL)
       {
       }
 

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -415,8 +415,8 @@ void TR_VirtualGuardTailSplitter::transformLinear(TR::Block *first, TR::Block *l
       if (_cfg->getStructure())
          {
          next->getStructureOf()->getParent()->asRegion()->
-            addSubNode(new (_cfg->structureRegion()) TR_StructureSubGraphNode
-                       (new (_cfg->structureRegion()) TR_BlockStructure(comp(), clone->getNumber(), clone)));
+            addSubNode(new (_cfg->structureMemoryRegion()) TR_StructureSubGraphNode
+                       (new (_cfg->structureMemoryRegion()) TR_BlockStructure(comp(), clone->getNumber(), clone)));
          }
 
       if (trace())


### PR DESCRIPTION
The term 'region' is overloaded when building method structure for both a structural component and for the allocator to satisfy memory requests.

In these contexts, rename fields that refer to `TR::Region`s to make it clear that they are memory regions.