### PR TITLE
Remove long disabled AOT code generator diagnostics

### DIFF
--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,7 +64,6 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             symbolKind = TR::SymbolType::typeMethod;
             // intentional fall through
          case TR_ClassPointer:
-            AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
                TR_ASSERT_FATAL(getData<uint8_t *>(), "Static Sym can not be NULL");

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,38 +70,33 @@ void TR::LabelRelocation::assertLabelDefined()
 
 void TR::LabelRelative8BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative8BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    assertLabelDefined();
    codeGen->apply8BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
 void TR::LabelRelative12BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative12BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    assertLabelDefined();
    codeGen->apply12BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), isCheckDisp());
    }
 
 void TR::LabelRelative16BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative16BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    assertLabelDefined();
-   if(getAddressDifferenceDivisor() == 1)
-   codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
+   if (getAddressDifferenceDivisor() == 1)
+      codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    else
-     codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), getAddressDifferenceDivisor(), isInstructionOffset());
+      codeGen->apply16BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel(), getAddressDifferenceDivisor(), isInstructionOffset());
    }
 
 void TR::LabelRelative24BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative24BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    assertLabelDefined();
    codeGen->apply24BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
 
 void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag2(codeGen->comp(), "TR::LabelRelative32BitRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", getUpdateLocation(), getLabel());
    assertLabelDefined();
    codeGen->apply32BitLabelRelativeRelocation((int32_t *)getUpdateLocation(), getLabel());
    }
@@ -109,7 +104,6 @@ void TR::LabelRelative32BitRelocation::apply(TR::CodeGenerator *codeGen)
 void TR::LabelAbsoluteRelocation::apply(TR::CodeGenerator *codeGen)
    {
    intptr_t *cursor = (intptr_t *)getUpdateLocation();
-   AOTcgDiag2(codeGen->comp(), "TR::LabelAbsoluteRelocation::apply cursor=" POINTER_PRINTF_FORMAT " label=" POINTER_PRINTF_FORMAT "\n", cursor, getLabel());
    assertLabelDefined();
    *cursor = (intptr_t)getLabel()->getCodeLocation();
    }
@@ -182,7 +176,6 @@ uint8_t TR::ExternalRelocation::collectModifier()
 
    int32_t distanceFromStartOfBuffer = static_cast<int32_t>(updateLocation - relocatableMethodCodeStart);
    int32_t distanceFromStartOfMethod = static_cast<int32_t>(updateLocation - comp->cg()->getCodeStart());
-   AOTcgDiag2(comp, "TR::ExternalRelocation::collectModifier distance from start of buffer=%x, from start of method=%x\n", distanceFromStartOfBuffer, distanceFromStartOfMethod);
 
    if (distanceFromStartOfBuffer < MIN_SHORT_OFFSET || distanceFromStartOfBuffer > MAX_SHORT_OFFSET)
       return RELOCATION_TYPE_WIDE_OFFSET;
@@ -194,30 +187,16 @@ void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *codeGen)
    {
    TR::AheadOfTimeCompile::interceptAOTRelocation(this);
 
-   TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag0(comp, "TR::ExternalRelocation::addExternalRelocation\n");
-
    TR_LinkHead<TR::IteratedExternalRelocation>& aot = codeGen->getAheadOfTimeCompile()->getAOTRelocationTargets();
    uint32_t narrowSize = getNarrowSize();
    uint32_t wideSize = getWideSize();
    flags8_t modifier(collectModifier());
    TR::IteratedExternalRelocation *r;
 
-   AOTcgDiag1(comp, "target=" POINTER_PRINTF_FORMAT "\n", _targetAddress);
-   if (_targetAddress2)
-      AOTcgDiag1(comp, "target2=" POINTER_PRINTF_FORMAT "\n", _targetAddress2);
    for (r = aot.getFirst();
         r != 0;
         r = r->getNext())
       {
-      if (r->getTargetAddress2())
-         AOTcgDiag6(comp, "r=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " target2=" POINTER_PRINTF_FORMAT ", kind=%x modifier=%x\n",
-            r, r->full(), r->getTargetAddress(), r->getTargetAddress2(), r->getTargetKind(), r->getModifierValue());
-      else
-         AOTcgDiag5(comp, "r=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-            r, r->full(), r->getTargetAddress(), r->getTargetKind(), r->getModifierValue());
-      AOTcgDiag2(comp, "#sites=%x size=%x\n", r->getNumberOfRelocationSites(), r->getSizeOfRelocationData());
-
       if (r->full() == false                        &&
           r->getTargetAddress()  == _targetAddress  &&
           r->getTargetAddress2() == _targetAddress2 &&
@@ -246,46 +225,26 @@ void TR::ExternalRelocation::addExternalRelocation(TR::CodeGenerator *codeGen)
          r->setSizeOfRelocationData(r->getSizeOfRelocationData() +
                             (r->needsWideOffsets()?wideSize:narrowSize));
          _relocationRecord = r;
-         if (r->getTargetAddress2())
-            AOTcgDiag6(comp, "r=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " target2=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-               r, r->full(), r->getTargetAddress(), r->getTargetAddress2(), r->getTargetKind(), r->getModifierValue());
-         else
-            AOTcgDiag5(comp, "r=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-               r, r->full(), r->getTargetAddress(), r->getTargetKind(), r->getModifierValue());
-         AOTcgDiag2(comp, "#sites=%x size=%x\n", r->getNumberOfRelocationSites(), r->getSizeOfRelocationData());
+
          return;
          }
       }
+
    TR::IteratedExternalRelocation *temp =   _targetAddress2 ?
       new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _targetAddress2, _kind, modifier, codeGen) :
       new (codeGen->trHeapMemory()) TR::IteratedExternalRelocation(_targetAddress, _kind, modifier, codeGen);
 
    aot.add(temp);
-   if (_targetAddress2)
-      AOTcgDiag6(comp, "temp=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " target2=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-         temp, temp->full(), temp->getTargetAddress(), temp->getTargetAddress2(), temp->getTargetKind(), temp->getModifierValue());
-   else
-      AOTcgDiag5(comp, "temp=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-         temp, temp->full(), temp->getTargetAddress(), temp->getTargetKind(), temp->getModifierValue());
-   AOTcgDiag2(comp, "#sites=%x size=%x\n", temp->getNumberOfRelocationSites(), temp->getSizeOfRelocationData());
+
    temp->setNumberOfRelocationSites(temp->getNumberOfRelocationSites()+1);
    temp->setSizeOfRelocationData(temp->getSizeOfRelocationData() +
                           (temp->needsWideOffsets()?wideSize:narrowSize));
    _relocationRecord = temp;
-   if (_targetAddress2)
-      AOTcgDiag6(comp, "temp=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " target2=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-         temp, temp->full(), temp->getTargetAddress(), temp->getTargetAddress2(), temp->getTargetKind(), temp->getModifierValue());
-   else
-      AOTcgDiag5(comp, "temp=" POINTER_PRINTF_FORMAT " full=%x target=" POINTER_PRINTF_FORMAT " kind=%x modifier=%x\n",
-         temp, temp->full(), temp->getTargetAddress(), temp->getTargetKind(), temp->getModifierValue());
-   AOTcgDiag2(comp, "#sites=%x size=%x\n", temp->getNumberOfRelocationSites(), temp->getSizeOfRelocationData());
-
    }
 
 void TR::ExternalRelocation::apply(TR::CodeGenerator *codeGen)
    {
    TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag1(comp, "TR::ExternalRelocation::apply updateLocation=" POINTER_PRINTF_FORMAT " \n", getUpdateLocation());
    uint8_t * relocatableMethodCodeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
    getRelocationRecord()->addRelocationEntry((uint32_t)(getUpdateLocation() - relocatableMethodCodeStart));
    }
@@ -330,7 +289,6 @@ TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation(
                  TR::CodeGenerator                *codeGen) :
    TR::ExternalRelocation(), _update2Location(location2)
    {
-   AOTcgDiag0(codeGen->comp(), "TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation\n");
    setUpdateLocation(location1);
    setTargetAddress(target);
    setTargetKind(k);
@@ -362,7 +320,7 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
 
    int32_t iLoc = static_cast<int32_t>(updateLocation - relocatableMethodCodeStart);
    int32_t iLoc2 = static_cast<int32_t>(updateLocation2 - relocatableMethodCodeStart);
-   AOTcgDiag0(comp, "TR::ExternalOrderedPair32BitRelocation::collectModifier\n");
+
    if ( (iLoc < MIN_SHORT_OFFSET  || iLoc > MAX_SHORT_OFFSET ) || (iLoc2 < MIN_SHORT_OFFSET || iLoc2 > MAX_SHORT_OFFSET ) )
       return RELOCATION_TYPE_WIDE_OFFSET | RELOCATION_TYPE_ORDERED_PAIR;
 
@@ -373,7 +331,6 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
 void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
    {
    TR::Compilation *comp = codeGen->comp();
-   AOTcgDiag0(comp, "TR::ExternalOrderedPair32BitRelocation::apply\n");
 
    TR::IteratedExternalRelocation *rec = getRelocationRecord();
    uint8_t *codeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
@@ -546,7 +503,6 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, TR_E
         _full(false),
         _kind(k)
       {
-      AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
 TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen)
@@ -562,19 +518,16 @@ TR::IteratedExternalRelocation::IteratedExternalRelocation(uint8_t *target, uint
         _full(false),
         _kind(k)
       {
-      AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::IteratedExternalRelocation\n");
       }
 
 void TR::IteratedExternalRelocation::initializeRelocation(TR::CodeGenerator *codeGen)
    {
-   AOTcgDiag0(TR::comp(), "TR::IteratedExternalRelocation::initializeRelocation\n");
    _relocationDataCursor = codeGen->getAheadOfTimeCompile()->initializeAOTRelocationHeader(this);
    }
 
 void TR::IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
    {
    TR::Compilation *comp = TR::comp();
-   AOTcgDiag2(comp, "TR::IteratedExternalRelocation::addRelocationEntry _relocationDataCursor=" POINTER_PRINTF_FORMAT ", locationOffset=%x\n", _relocationDataCursor, locationOffset);
    if (!needsWideOffsets())
       {
       *(uint16_t *)_relocationDataCursor = (uint16_t)locationOffset;

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -93,7 +93,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_ClassAddress:
       case TR_ClassObject:
          {
-         AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
          TR::SymbolReference *reloSymRef= (reloType==TR_ClassAddress)?getNode()->getSymbolReference():getSymbolReference();
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
@@ -121,7 +120,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          break;
       case TR_MethodObject:
          {
-         AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
          TR::SymbolReference *reloSymRef= (reloType==TR_ClassAddress)?getNode()->getSymbolReference():getSymbolReference();
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) reloSymRef,
                                                                                 getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
@@ -134,8 +132,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_JNISpecialTargetAddress:
       case TR_JNIVirtualTargetAddress:
          {
-         AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
-
          TR_RelocationRecordInformation *info = new (comp->trHeapMemory()) TR_RelocationRecordInformation();
          info->data1 = 0;
          info->data2 = reinterpret_cast<uintptr_t>(getNode()->getSymbolReference());
@@ -156,7 +152,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          {
          if (cg()->needRelocationsForStatics())
             {
-            AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(),
                                      getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                    (TR_ExternalRelocationTargetKind) reloType, cg()),
@@ -166,14 +161,12 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          break;
 
       case TR_ArrayCopyHelper:
-         AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getSymbolReference(),
                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
                                 __FILE__, __LINE__, getNode());
          break;
 
       case TR_HelperAddress:
-         AOTcgDiag1(comp, "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
          if (cg()->comp()->target().is64Bit())
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_AbsoluteHelperAddress, cg()),
@@ -188,7 +181,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_AbsoluteMethodAddress:
       case TR_BodyInfoAddress:
-         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
          if (cg()->comp()->target().is64Bit())
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor),
@@ -204,7 +196,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          break;
 
       case TR_GlobalValue:
-         AOTcgDiag2(comp, "add TR_GlobalValue (countForRecompile) cursor=%x\n", reloType, cursor);
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile,
                                                                                 TR_GlobalValue, cg()),
                                   __FILE__, __LINE__, getNode());
@@ -215,7 +206,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          symbolKind = TR::SymbolType::typeMethod;
          // intentional fall through
       case TR_ClassPointer:
-         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             TR_ASSERT_FATAL(getDataAs8Bytes(), "Static Sym can not be NULL");
@@ -253,7 +243,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             cg()->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::X86::MemoryReference::addMetaDataForCodeAddress\n");
             }
-         AOTcgDiag3(comp, "add relocation (%d) cursor=%x counter=%x\n", reloType, cursor, counter);
+
          TR::DebugCounter::generateRelocation(cg()->comp(),
                                               cursor,
                                               getNode(),
@@ -263,7 +253,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_BlockFrequency:
          {
-         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
          TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data1 = (uintptr_t)getNode()->getSymbolReference();
          recordInfo->data2 = 0; // seqKind
@@ -274,7 +263,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_RecompQueuedFlag:
          {
-         AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
          TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
          cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
          }
@@ -339,13 +327,10 @@ TR::S390ConstantDataSnippet::emitSnippetBody()
    uint8_t * cursor = cg()->getBinaryBufferCursor();
    TR::Compilation *comp = cg()->comp();
 
-   AOTcgDiag1(comp, "TR::S390ConstantDataSnippet::emitSnippetBody cursor=%x\n", cursor);
    getSnippetLabel()->setCodeLocation(cursor);
    memcpy(cursor, &_value, _length);
 
    uint32_t reloType = getReloType();
-
-   AOTcgDiag6(comp, "this=%p cursor=%p node=%p value=%p length=%x reloType=%x\n", this, cursor, getNode(), *((int*)cursor), _length, reloType);
 
    switch (reloType)
       {

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2167,8 +2167,6 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
       imm = (uintptr_t) callSymRef->getMethodAddress();
       }
 
-   AOTcgDiag2(comp, "\nimm=%x isHelper=%x\n", imm, isHelper);
-
    // Since N3 generate TR::InstOpCode::BRASL -- only need 1 instruction, and no worry
    // about the displacement
    // Calling myself
@@ -2222,7 +2220,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
                tempInst->setSymbolReference(callSymRef);
             }
 #endif
-         AOTcgDiag1(comp, "\ntempInst=%x\n", tempInst);
+
          return tempInst;
          }
 #if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
@@ -2450,7 +2448,6 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
 
       targetSnippet->setSymbolReference(new (INSN_HEAP) TR::SymbolReference(comp->getSymRefTab()));
       targetSnippet->setReloType(reloType);
-      AOTcgDiag4(comp, "generateRegLitRefInstruction constantDataSnippet=%x symbolReference=%x symbol=%x reloType=%x\n", targetSnippet, targetSnippet->getSymbolReference(), targetSnippet->getSymbolReference()->getSymbol(), reloType);
 
       cursor = (TR::S390RILInstruction *) generateRILInstruction(cg, (op == TR::InstOpCode::LG)?TR::InstOpCode::LGRL:TR::InstOpCode::LRL, node, treg, targetSnippet, preced);
       return cursor;
@@ -2480,9 +2477,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       {
       dataref = generateS390MemoryReference((int32_t)imm, TR::Int32, cg, base, node);
       }
-   AOTcgDiag5(comp, "generateRegLitRefInstruction dataref=%x constantDataSnippet=%x symbolReference=%x symbol=%x reloType=%x\n",
-      dataref, dataref->getConstantDataSnippet(), dataref->getSymbolReference(),
-      dataref->getSymbolReference()->getSymbol(), reloType);
+
    dataref->getConstantDataSnippet()->setSymbolReference(dataref->getSymbolReference());
    dataref->getConstantDataSnippet()->setReloType(reloType);
    cursor = generateRXInstruction(cg, op, node, treg, dataref);

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ TR::S390HelperCallSnippet::emitSnippetBody()
    this->setSnippetDestAddr(destAddr);
 
    *(int32_t *) cursor = (int32_t)((destAddr - branchInstructionStartAddress) / 2);
-   AOTcgDiag1(cg()->comp(), "add TR_HelperAddress cursor=%x\n", cursor);
+
    cg()->addProjectSpecializedRelocation(cursor, (uint8_t*) helperSymRef, NULL, TR_HelperAddress,
                              __FILE__, __LINE__, getNode());
    cursor += sizeof(int32_t);

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -273,7 +273,6 @@ TR::S390LabelInstruction::generateBinaryEncoding()
 
    if (getOpCode().getOpCodeValue() == TR::InstOpCode::dd)
       {
-      AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
       cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
       cg()->addProjectSpecializedRelocation(cursor, NULL, NULL, TR_AbsoluteMethodAddress,
                              __FILE__, __LINE__, getNode());
@@ -633,7 +632,6 @@ TR::S390BranchInstruction::generateBinaryEncoding()
          }
       else
          {
-         AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", cursor);
          cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
          cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                 __FILE__, __LINE__, getNode());
@@ -773,7 +771,6 @@ TR::S390BranchOnCountInstruction::generateBinaryEncoding()
             }
          else
             {
-            AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", relocationPoint);
             cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
             cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                    __FILE__, __LINE__, getNode());
@@ -889,8 +886,6 @@ TR::S390BranchOnIndexInstruction::generateBinaryEncoding()
          }
       else
          {
-         AOTcgDiag1(cg()->comp(), "add TR_AbsoluteMethodAddress cursor=%x\n", relocationPoint);
-
          cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(relocationPoint, label));
          cg()->addProjectSpecializedRelocation(relocationPoint, NULL, NULL, TR_AbsoluteMethodAddress,
                                 __FILE__, __LINE__, getNode());
@@ -2141,7 +2136,6 @@ TR::S390RILInstruction::generateBinaryEncoding()
 #endif
             if (isHelper)
                {
-               AOTcgDiag2(comp, "add TR_HelperAddress cursor=%p i2=%p\n", cursor, i2);
                cg()->addProjectSpecializedRelocation(cursor+2, (uint8_t*) getSymbolReference(), NULL, TR_HelperAddress,
                                          __FILE__, __LINE__, getNode());
                }
@@ -2282,7 +2276,6 @@ TR::S390RILInstruction::generateBinaryEncoding()
             TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : NULL;
             if (sym && (sym->castToMethodSymbol()->isHelper() || cg()->callUsesHelperImplementation(sym)))
                {
-               AOTcgDiag1(comp, "add TR_HelperAddress cursor=%x\n", cursor);
                cg()->addProjectSpecializedRelocation(cursor+2, (uint8_t*) getSymbolReference(), NULL, TR_HelperAddress,
                      __FILE__, __LINE__, getNode());
                }
@@ -5378,7 +5371,6 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
 
       //bool brcRangeExceeded = (distance<MIN_IMMEDIATE_VAL || distance>MAX_IMMEDIATE_VAL);
 
-      AOTcgDiag1(comp, "add TR_AbsoluteMethodAddress cursor=%x\n", (uint8_t *) (&_site->getDestination()));
       cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
 
       doRelocation = true;

--- a/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.cpp
+++ b/compiler/z/objectfmt/OMRJitCodeRWXObjectFormat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,10 +52,10 @@ OMR::Z::JitCodeRWXObjectFormat::emitFunctionCall(TR::FunctionCallData &data)
    TR_ASSERT_FATAL_WITH_NODE(callNode, targetAddress != NULL, "Unable to make a call as targetAddress for the Call is not found.");
 
 
-   // Now as we are going to make call, we need Return Address register. 
+   // Now as we are going to make call, we need Return Address register.
    TR_ASSERT_FATAL_WITH_NODE(callNode, data.returnAddressReg != NULL, "returnAddressReg should be set to make a function call.");
 
-   
+
    // We do not need to check if the address is addressible using RIL type
    // instruction, as the instruction API will check for it and generate
    // trampolines if needed.
@@ -105,13 +105,13 @@ OMR::Z::JitCodeRWXObjectFormat::encodeFunctionCall(TR::FunctionCallData &data)
 
       *reinterpret_cast<int16_t *>(cursor) = cg->comp()->target().is64Bit() ? 0x0004 : 0x0014;
       cursor += sizeof(int16_t);
-      
+
 		// BCR   rEP
       *reinterpret_cast<int16_t *>(cursor) = 0x07F0 + static_cast<int16_t>(cg->getEntryPointRegister() - 1);
       cursor += sizeof(int16_t);
 
       // Now updating the offset in LARL instruction
-      *reinterpret_cast<int32_t *>(larlOffsetAddress) = static_cast<int32_t>(((uintptr_t)cursor + data.snippet->getPadBytes() - larlInstructionAddress ) / 2); 
+      *reinterpret_cast<int32_t *>(larlOffsetAddress) = static_cast<int32_t>(((uintptr_t)cursor + data.snippet->getPadBytes() - larlInstructionAddress ) / 2);
       }
    else
       {
@@ -121,7 +121,6 @@ OMR::Z::JitCodeRWXObjectFormat::encodeFunctionCall(TR::FunctionCallData &data)
       *reinterpret_cast<int32_t *>(cursor) = TR::S390CallSnippet::adjustCallOffsetWithTrampoline(targetAddress, instrAddr, callSymRef, data.snippet);
       // TODO: We should be able to use reloKind field from the FunctionCallData to add relocation.
       // Probably only change apart from the hardcoded TR_HelperAddress is to get the correct Diagnostic message for AOT.
-      AOTcgDiag1(cg->comp(), "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
       cg->addProjectSpecializedRelocation(cursor, (uint8_t*) callSymRef, NULL, TR_HelperAddress,
                                     __FILE__, __LINE__, callNode);
       cursor += sizeof(int32_t);


### PR DESCRIPTION
The diagnostic information has been disabled in the code base for over 15 years,
and in fact the diagnostic macros are simply stubs.

Remove it to improve code readability.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>