### PR TITLE
Remove long disabled TR_ASSERTC macros

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2022,10 +2022,9 @@ OMR::CodeGenerator::processRelocations()
    while(iterator != _relocationList.end())
       {
       // Traverse the non-AOT/non-external labels first
-	  (*iterator)->apply(self());
+      (*iterator)->apply(self());
       ++iterator;
       }
-   //TR_ASSERTC(missedSite == -1, comp(), "Site %d is missing relocation\n", missedSite);
    }
 
 #if defined(TR_HOST_ARM)

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1456,17 +1456,6 @@ TR_OSRSlotSharingInfo::addSlotInfo(int32_t slot, int32_t symRefNum, int32_t symR
    for (auto i = 0U; i < slotInfos.size(); i++)
       {
       TR_SlotInfo& info = slotInfos[i];
-      if (info.symRefNum != -1)
-         {
-         if ((info.slot == slot) &&
-            (info.symRefNum != symRefNum) &&
-            (symRefTab->getSymRef(info.symRefNum)->getSymbol()->getDataType() == symRefTab->getSymRef(symRefNum)->getSymbol()->getDataType()))
-            {
-            //Two different variables sharing the same slot, can be live at a certain node (when there is a loop). So commenting the assertion out for now.
-            //TR_ASSERTC(0, comp, "ERROR: For slot %d symref #%d conflicts with symref#%d\n",
-            //    symRefNum, info.symRefNum, slot);
-            }
-         }
 
       if ((info.slot == slot) && (info.symRefNum == symRefNum))
          {

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1007,10 +1007,6 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
       assignedRegister->setState(TR::RealRegister::Free);
       assignedRegister = newAssignedRegister;
       }
-
-   // Make sure we only try to assign real regs to virt regs
-   //   TR_ASSERTC(comp, targetRegister->getRealRegister()==NULL,
-   //   "assignBestRegisterSingle: Trying to assign a real reg to a real reg in inst\n");
 
    // Have we already assigned a real register
    if (assignedRegister == NULL)
@@ -2706,7 +2702,7 @@ OMR::Z::Machine::spillRegister(TR::Instruction * currentInstruction, TR::Registe
             location->getMaxSpillDepth() != 2 )
          location->setMaxSpillDepth(3);
       }
-      
+
    best->setAssignedRegister(NULL);
    best->setState(TR::RealRegister::Free);
 
@@ -4195,14 +4191,7 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createCondForLiveAndSpilledG
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *virtReg = realReg->getAssignedRegister();
-            //if (!spilledRegisterList || !spilledRegisterList->find(virtReg))
-            //{
-                //TR_ASSERTC(comp, !spilledRegisterList || !spilledRegisterList->find(virtReg),
-                // "a register should not be in both an assigned state and in the spilled list\n");
             deps->addPostCondition(virtReg, realReg->getRegisterNumber());
-               //}
-
-            //virtReg->incTotalUseCount();
             virtReg->incFutureUseCount();
             }
          }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6469,7 +6469,6 @@ TR::Register *
 sloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempMR, bool isReversed)
    {
    TR::Compilation *comp = cg->comp();
-   //TR_ASSERTC( !isReversed,comp, "need to write logic for reverse load still");
 
    TR::Register * tempReg = cg->allocateRegister();
 
@@ -6569,8 +6568,6 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
 TR::Register *
 iloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempMR, bool isReversed)
    {
-   //TR_ASSERTC( !isReversed,cg->comp(), "need to write logic for reverse load still");
-
    TR::Register * tempReg = cg->allocateRegister();
 
    if (relativeLongLoadHelper(cg, node, tempReg))
@@ -11456,8 +11453,6 @@ OMR::Z::TreeEvaluator::arraycmpEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
       if (elemsExpr->getOpCode().isLoadConst())
          {
-         //TR_ASSERTC( elemsExpr->getSize() <=4,comp, "If this is not true why are we truncating?");
-         // remove the assertion for now
          int32_t elems = (int32_t) getIntegralValue(elemsExpr); //get number of elements (in bytes)
          bool    clobber = (comp->getOption(TR_DisableSSOpts) || elems>256 || elems==0 || node->isArrayCmpSign());
          if (!node->isArrayCmpSign())
@@ -12507,8 +12502,6 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
    //     baseReg = cg->gprClobberEvaluate(baseAddr);
 
    cg->decReferenceCount(elemsExpr);
-   //TR_ASSERTC( elemsExpr->getSize() <=4,comp, "If this is not true we should not be truncating");
-   //someone should investigate why this assertion is not being hit
 
    if (mvcCopy)
       {


### PR DESCRIPTION
The preprocessor macro does not even exist any longer.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>