### PR TITLE
Update ResolvedMethod API for getResolvedDynamic/HandleMethod

### DIFF
--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -491,8 +491,8 @@ void TR_ResolvedMethod::setOwningMethod(TR_ResolvedMethod*)                     
 TR_ResolvedMethod * TR_ResolvedMethod::getResolvedStaticMethod (TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
 TR_ResolvedMethod * TR_ResolvedMethod::getResolvedSpecialMethod(TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
 TR_ResolvedMethod * TR_ResolvedMethod::getResolvedVirtualMethod(TR::Compilation *, int32_t, bool, bool *)     { TR_UNIMPLEMENTED(); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedDynamicMethod(TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethod (TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedDynamicMethod(TR::Compilation *, int32_t, bool *, bool *)   { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethod (TR::Compilation *, int32_t, bool *, bool *)   { TR_UNIMPLEMENTED(); return 0; }
 TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethodWithSignature(TR::Compilation *, int32_t, char *) { TR_UNIMPLEMENTED(); return 0; }
 
 uint32_t

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -224,8 +224,8 @@ public:
 
    virtual TR_ResolvedMethod *getResolvedStaticMethod (TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0);
    virtual TR_ResolvedMethod *getResolvedSpecialMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0);
-   virtual TR_ResolvedMethod *getResolvedDynamicMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0);
-   virtual TR_ResolvedMethod *getResolvedHandleMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0);
+   virtual TR_ResolvedMethod *getResolvedDynamicMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0, bool * isInvokeCacheAppendixNull = 0);
+   virtual TR_ResolvedMethod *getResolvedHandleMethod(TR::Compilation *, int32_t cpIndex, bool * unresolvedInCP = 0, bool * isInvokeCacheAppendixNull = 0);
    virtual TR_ResolvedMethod *getResolvedHandleMethodWithSignature(TR::Compilation *, int32_t cpIndex, char *signature);
    virtual TR_ResolvedMethod *getResolvedVirtualMethod(TR::Compilation *, int32_t cpIndex, bool ignoreReResolve = true, bool * unresolvedInCP = 0);
 


### PR DESCRIPTION
This change is needed to facilitate the callers of this method
with the ability to check whether objects found at the specified
CP entry are valid, which can affect how the call for the
ResolvedMethod returned by this method is set up.

Merging this PR will need to be coordinated with
eclipse-openj9/openj9#14769

Signed-off-by: Nazim Bhuiyan <nubhuiyan@ibm.com>