### PR TITLE
Restrict checkcast and profiled guard coalescer cold merge special case

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7756,11 +7756,16 @@ int32_t TR_CheckcastAndProfiledGuardCoalescer::perform()
                "catch block_%d has a non-exception predecessor",
                curBlock->getNumber());
 
+            // The predecessor is necessarily the textually previous block.
+            // Otherwise, the previous block would end with control flow that
+            // does not fall through, and checkcastTree would have been unset.
+            //
             // This is basically like being in an extended block, except that
             // there won't be any commoning, i.e. there won't be any more
             // occurrences of castObj. However, if castObjAuto is set, it's
             // still possible to find loads that match. Without castObjAuto,
             // it's pointless, so give up.
+            //
             if (castObjAuto == NULL)
                {
                checkcastTree = NULL;

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -8000,7 +8000,29 @@ int32_t TR_CheckcastAndProfiledGuardCoalescer::perform()
                      if (nDest == slowPathBlock
                          && slowPathBlock->getPredecessors().size() == 2)
                         {
-                        ifNode = n;
+                        // Check for an indirect load that will be evaluated in
+                        // the hot conditional tree. If there is one, then the
+                        // transformation would move checkcast across it too.
+                        //
+                        // It's safe to processSubtree() here because between
+                        // tt and n there is only a BBEnd and a BBStart. When
+                        // the tt loop reaches this conditional tree, the
+                        // redundant processSubtree() call will just do nothing
+                        // and return false. The false result will be fine
+                        // (even if the result is true here) because there
+                        // won't be a candidate checkcast anymore.
+                        //
+                        if (processSubtree(visited, fresh, freshByAuto, n))
+                           {
+                           // leave ifNode unset
+                           traceCannotTransform(
+                              node,
+                              "(hot conditional) will evaluate an indirect load");
+                           }
+                        else
+                           {
+                           ifNode = n;
+                           }
                         }
                      }
                   }


### PR DESCRIPTION
...to instances where the conditional on the passing side of the guard does not evaluate any indirect loads. If the conditional does evaluate an indirect load, the transformation must be abandoned just as though an indirect load were found in an earlier tree.

The failure mode against which this PR protects is theoretical and has not been observed. It's unclear whether it's even possible to cause an indirect load to appear in such a position. Nonetheless, it's prudent to check.

Also elaborate a bit on one of the comments in the pass.