### PR TITLE
AArch64: Enable vector bitwise logical operations for all integer types

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -678,6 +678,9 @@ OMR::ARM64::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    switch(node->getDataType().getVectorElementType())
       {
       case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
+      case TR::Int64:
          andOp = TR::InstOpCode::vand16b;
          break;
       default:
@@ -697,6 +700,9 @@ OMR::ARM64::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    switch(node->getDataType().getVectorElementType())
       {
       case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
+      case TR::Int64:
          orrOp = TR::InstOpCode::vorr16b;
          break;
       default:
@@ -716,6 +722,9 @@ OMR::ARM64::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    switch(node->getDataType().getVectorElementType())
       {
       case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
+      case TR::Int64:
          xorOp = TR::InstOpCode::veor16b;
          break;
       default:

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -643,10 +643,10 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
       case TR::vor:
       case TR::vxor:
       case TR::vnot:
-         if (dt == TR::Int8)
+         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64)
             return true;
          else
-            return false; // Int16/ Int32/ Int64/ Float/ Double are not supported
+            return false; // Float/ Double are not supported
       case TR::vload:
       case TR::vloadi:
       case TR::vstore:

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -172,6 +172,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeG
    switch(node->getDataType().getVectorElementType())
       {
       case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
+      case TR::Int64:
          notOp = TR::InstOpCode::vnot16b;
          break;
       default:


### PR DESCRIPTION
Enable vector bitwise logical operations for vectors whose element
type is an integer.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>