### PR TITLE
Add VPHandler constrainNewvalue

### DIFF
--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,6 +107,7 @@ public:
    bool isClassFinal(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
    bool hasFinalizer(TR::Compilation *comp, TR_OpaqueClassBlock *classPointer) { return false; }
    bool isClassInitialized(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
+   bool isClassVisible(TR::Compilation *comp, TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) { return false; }
    bool hasFinalFieldsInClass(TR::Compilation *comp, TR_OpaqueClassBlock *classPointer) { return false; }
    bool sameClassLoaders(TR::Compilation *comp, TR_OpaqueClassBlock *, TR_OpaqueClassBlock *) { return false; }
    bool isString(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) { return false; }

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1927,30 +1927,30 @@ OMR::Block::createConditionalBlocksBeforeTree(TR::TreeTop * tree,
 OMR::Block::StandardException OMR::Block::_standardExceptions[] =
    {
 #define MIN_EXCEPTION_NAME_SIZE 5
-   { 5, "Error", CanCatchNew | CanCatchArrayNew },
+   { 5, "Error", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
    { 9, "Exception", CanCatchNullCheck | CanCatchDivCheck | CanCatchBoundCheck |
                      CanCatchArrayStoreCheck | CanCatchArrayNew |
                      CanCatchCheckCast | CanCatchMonitorExit },
    { 9, "Throwable", CanCatchEverything },
-   {12, "UnknownError", CanCatchNew | CanCatchArrayNew },
-   {13, "InternalError", CanCatchNew | CanCatchArrayNew },
-   {16, "OutOfMemoryError", CanCatchNew | CanCatchArrayNew },
+   {12, "UnknownError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
+   {13, "InternalError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
+   {16, "OutOfMemoryError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
    {16, "RuntimeException", CanCatchNullCheck | CanCatchDivCheck |
                             CanCatchBoundCheck | CanCatchArrayStoreCheck |
                             CanCatchArrayNew | CanCatchCheckCast |
                             CanCatchMonitorExit },
    {18, "ClassCastException", CanCatchCheckCast },
-   {18, "IllegalAccessError", CanCatchArrayNew },
-   {18, "InstantiationError", CanCatchNew },
-   {18, "StackOverflowError", CanCatchNew | CanCatchArrayNew },
+   {18, "IllegalAccessError", CanCatchArrayNew | CanCatchNewvalue},
+   {18, "InstantiationError", CanCatchNew | CanCatchNewvalue },
+   {18, "StackOverflowError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
    {19, "ArithmeticException", CanCatchDivCheck },
    {19, "ArrayStoreException", CanCatchArrayStoreCheck },
-   {19, "VirtualMachineError", CanCatchNew | CanCatchArrayNew },
+   {19, "VirtualMachineError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
    {20, "NullPointerException", CanCatchNullCheck },
    {25, "IndexOutOfBoundsException", CanCatchBoundCheck },
    {26, "NegativeArraySizeException", CanCatchArrayNew },
    {28, "IllegalMonitorStateException", CanCatchMonitorExit },
-   {28, "IncompatibleClassChangeError", CanCatchNew | CanCatchArrayNew },
+   {28, "IncompatibleClassChangeError", CanCatchNew | CanCatchArrayNew | CanCatchNewvalue },
    {30, "ArrayIndexOutOfBoundsException", CanCatchBoundCheck },
 #define MAX_EXCEPTION_NAME_SIZE 30
    {99, "", 0 }

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -161,9 +161,9 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    TR::TreeTop * prepend(TR::TreeTop * tt);
 
    TR::Block * split(TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL);
-   
+
    TR::Block * splitPostGRA(TR::TreeTop *startOfNewBlock, TR::CFG *cfg, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL);
-   
+
 
    TR::Block * splitWithGivenMethodSymbol(TR::ResolvedMethodSymbol *methodSymbol, TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true);
 
@@ -233,7 +233,8 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       CanCatchUserThrows          = 0x00000200,
       CanCatchOSR                 = 0x00000400,
       CanCatchOverflowCheck       = 0x00000800,
-      CanCatchEverything          = 0x000007FF, // Mask for all of the above
+      CanCatchNewvalue            = 0x00001000,
+      CanCatchEverything          = 0x00001FFF, // Mask for all of the above
       };
 
    bool     canCatchExceptions(uint32_t flags); // uses the above enum

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3680,6 +3680,9 @@ OMR::Node::exceptionsRaised()
       case TR::New:
          possibleExceptions |= TR::Block:: CanCatchNew;
          break;
+      case TR::newvalue:
+         possibleExceptions |= TR::Block:: CanCatchNewvalue;
+         break;
       case TR::newarray:
       case TR::anewarray:
       case TR::multianewarray:
@@ -8078,8 +8081,8 @@ OMR::Node::setHasMonitorClassInNode(bool v)
 bool
 OMR::Node::markedAllocationCanBeRemoved()
    {
-   TR_ASSERT(self()->getOpCodeValue() == TR::New || self()->getOpCodeValue() == TR::newarray || self()->getOpCodeValue() == TR::anewarray,
-             "Opcode must be newarray or anewarray");
+   TR_ASSERT(self()->getOpCodeValue() == TR::New || self()->getOpCodeValue() == TR::newarray ||
+             self()->getOpCodeValue() == TR::anewarray || self()->getOpCodeValue() == TR::newvalue, "Opcode must be new, newarray, anewarray, or newvalue");
    return _flags.testAny(allocationCanBeRemoved);
    }
 
@@ -8087,7 +8090,8 @@ void
 OMR::Node::setAllocationCanBeRemoved(bool v)
    {
    TR::Compilation * c = TR::comp();
-   TR_ASSERT(self()->getOpCodeValue() == TR::New || self()->getOpCodeValue() == TR::newarray || self()->getOpCodeValue() == TR::anewarray, "Opcode must be newarray or anewarray");
+   TR_ASSERT(self()->getOpCodeValue() == TR::New || self()->getOpCodeValue() == TR::newarray ||
+             self()->getOpCodeValue() == TR::anewarray || self()->getOpCodeValue() == TR::newvalue, "Opcode must be new, newarray, anewarray, or newvalue");
    if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting allocationCanBeRemoved flag on node %p to %d\n", self(), v))
       _flags.set(allocationCanBeRemoved, v);
    }
@@ -8095,7 +8099,11 @@ OMR::Node::setAllocationCanBeRemoved(bool v)
 bool
 OMR::Node::chkAllocationCanBeRemoved()
    {
-   return ((self()->getOpCodeValue() == TR::New || self()->getOpCodeValue() == TR::newarray || self()->getOpCodeValue() == TR::anewarray) && _flags.testAny(allocationCanBeRemoved));
+   return ((self()->getOpCodeValue() == TR::New ||
+            self()->getOpCodeValue() == TR::newarray ||
+            self()->getOpCodeValue() == TR::anewarray ||
+            self()->getOpCodeValue() == TR::newvalue)
+           && _flags.testAny(allocationCanBeRemoved));
    }
 
 const char *

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,6 +120,7 @@ TR::Node *constrainNarrowToChar(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainNarrowToInt(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainNarrowToShort(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainNew(OMR::ValuePropagation *vp, TR::Node *node);
+TR::Node *constrainNewvalue(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainNewArray(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainNullChk(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainZeroChk(OMR::ValuePropagation *vp, TR::Node *node);
@@ -631,7 +632,7 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define checkcastVPHandler constrainCheckcast
 #define checkcastAndNULLCHKVPHandler constrainCheckcastNullChk
 #define NewVPHandler constrainNew
-#define newvalueVPHandler constrainChildren
+#define newvalueVPHandler constrainNewvalue
 #define newarrayVPHandler constrainNewArray
 #define anewarrayVPHandler constrainANewArray
 #define variableNewVPHandler constrainVariableNew


### PR DESCRIPTION
- Add a handler to type propagate fixed class constraint on `newvalue`
- Fix `constrainNew` where `setAllocationCanBeRemoved` should not be true if the class is an abstract class or an interface

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>