### PR TITLE
Implement new vector opcodes

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -615,24 +615,23 @@ int64_t OMR::ARM64::CodeGenerator::getSmallestPosConstThatMustBeMaterialized()
    }
 
 
-bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
+bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
-   if(length != TR::VectorLength128) return false;
-
    // implemented vector opcodes
 
-   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+   if (opcode.isVectorOpCode())
       {
       TR::DataType ot = opcode.getVectorResultDataType();
 
       if (ot.getVectorLength() != TR::VectorLength128) return false;
 
-      TR::DataType et = ot.getVectorElementType();
-
-      if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-         return true;
-      else
-         return false;
+      switch (opcode.getVectorOperation())
+         {
+         case OMR::vadd:
+            return true;
+         default:
+            return false;
+         }
       }
 
    switch (opcode.getOpCodeValue())

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -620,9 +620,23 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
    if(length != TR::VectorLength128) return false;
 
    // implemented vector opcodes
+
+   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+      {
+      TR::DataType ot = opcode.getVectorResultDataType();
+
+      if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+      TR::DataType et = ot.getVectorElementType();
+
+      if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         return true;
+      else
+         return false;
+      }
+
    switch (opcode.getOpCodeValue())
       {
-      case TR::vadd:
       case TR::vsub:
       case TR::vneg:
          if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -422,7 +422,7 @@ public:
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
    TR_GlobalRegisterNumber _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
 
    /**
     * @brief Answers whether a trampoline is required for a direct call instruction to

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1310,6 +1310,12 @@ OMR::ARM64::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg
    }
 
 TR::Register*
+OMR::ARM64::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
 OMR::ARM64::TreeEvaluator::vcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -602,6 +602,7 @@ public:
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1569,6 +1569,12 @@ OMR::ARM::TreeEvaluator::vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register*
 OMR::ARM::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
+OMR::ARM::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -312,6 +312,7 @@ public:
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -117,7 +117,7 @@ namespace TR { class RegisterDependencyConditions; }
 
 OMR::TreeEvaluatorFunctionPointerTable OMR::CodeGenerator::_nodeToInstrEvaluators;
 
-TR_TreeEvaluatorFunctionPointer
+OMR::TreeEvaluatorFunctionPointer
 OMR::TreeEvaluatorFunctionPointerTable::table[] =
    {
 #define OPCODE_MACRO(\

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -115,8 +115,10 @@
 namespace TR { class Optimizer; }
 namespace TR { class RegisterDependencyConditions; }
 
+OMR::TreeEvaluatorFunctionPointerTable OMR::CodeGenerator::_nodeToInstrEvaluators;
+
 TR_TreeEvaluatorFunctionPointer
-OMR::CodeGenerator::_nodeToInstrEvaluators[] =
+OMR::TreeEvaluatorFunctionPointerTable::table[] =
    {
 #define OPCODE_MACRO(\
    opcode, \
@@ -138,11 +140,35 @@ OMR::CodeGenerator::_nodeToInstrEvaluators[] =
 
 #include "il/Opcodes.enum"
 #undef OPCODE_MACRO
+
+#define VECTOR_OPERATION_MACRO(\
+   operation, \
+   name, \
+   prop1, \
+   prop2, \
+   prop3, \
+   prop4, \
+   dataType, \
+   typeProps, \
+   childProps, \
+   swapChildrenOpcode, \
+   reverseBranchOpcode, \
+   boolCompareOpcode, \
+   ifCompareOpcode, \
+   ...) TR::TreeEvaluator::operation ## Evaluator,
+
+#include "il/VectorOperations.enum"
+#undef VECTOR_OPERATION_MACRO
    };
 
-static_assert(TR::NumIlOps ==
-              (sizeof(OMR::CodeGenerator::_nodeToInstrEvaluators) / sizeof(OMR::CodeGenerator::_nodeToInstrEvaluators[0])),
-              "NodeToInstrEvaluators is not the correct size");
+
+void OMR::TreeEvaluatorFunctionPointerTable::checkTableSize()
+   {
+   static_assert((TR::NumScalarIlOps + OMR::NumVectorOperations) ==
+              (sizeof(table) / sizeof(table[0])),
+              "OMR::TreeEvaluatorFunctionPointerTable::table is not the correct size");
+   }
+
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1642,7 +1642,7 @@ public:
    bool getSupportsAutoSIMD() { return _flags4.testAny(SupportsAutoSIMD);}
    void setSupportsAutoSIMD() { _flags4.set(SupportsAutoSIMD);}
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength) { return false; }
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType) { return false; }
 
    bool removeRegisterHogsInLowerTreesWalk() { return _flags3.testAny(RemoveRegisterHogsInLowerTreesWalk);}
    void setRemoveRegisterHogsInLowerTreesWalk() { _flags3.set(RemoveRegisterHogsInLowerTreesWalk);}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -245,15 +245,17 @@ namespace TR
 namespace OMR
 {
 
+typedef TR::Register *(* TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *codeGen);
+
 class TreeEvaluatorFunctionPointerTable
    {
    private:
-   static TR_TreeEvaluatorFunctionPointer table[];
+   static TreeEvaluatorFunctionPointer table[];
 
    static void checkTableSize();
 
    public:
-   TR_TreeEvaluatorFunctionPointer& operator[] (TR::ILOpCode opcode)
+   TreeEvaluatorFunctionPointer& operator[] (TR::ILOpCode opcode)
       {
       return table[opcode.getTableIndex()];
       }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -245,6 +245,20 @@ namespace TR
 namespace OMR
 {
 
+class TreeEvaluatorFunctionPointerTable
+   {
+   private:
+   static TR_TreeEvaluatorFunctionPointer table[];
+
+   static void checkTableSize();
+
+   public:
+   TR_TreeEvaluatorFunctionPointer& operator[] (TR::ILOpCode opcode)
+      {
+      return table[opcode.getTableIndex()];
+      }
+   };
+
 class OMR_EXTENSIBLE CodeGenerator
    {
 
@@ -459,7 +473,7 @@ public:
    // --------------------------------------------------------------------------
    // Tree evaluation
    //
-   static TR_TreeEvaluatorFunctionPointer *getTreeEvaluatorTable() {return _nodeToInstrEvaluators;}
+   static TreeEvaluatorFunctionPointerTable getTreeEvaluatorTable() {return _nodeToInstrEvaluators;}
 
    int32_t getEvaluationPriority(TR::Node*node);
    int32_t whichNodeToEvaluate(TR::Node*first, TR::Node* second);      // Decide which of two nodes should be evaluated first.
@@ -2012,7 +2026,8 @@ public:
    flags16_t _enabledFlags;
 
    public:
-   static TR_TreeEvaluatorFunctionPointer _nodeToInstrEvaluators[];
+
+   static TreeEvaluatorFunctionPointerTable _nodeToInstrEvaluators;
 
    protected:
 

--- a/compiler/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,6 @@ namespace TR { class SymbolReference; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Register; }
 
-typedef TR::Register *(* TR_TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *codeGen);
 
 namespace OMR
 {
@@ -75,7 +74,7 @@ class OMR_EXTENSIBLE TreeEvaluator
    static bool instanceOfOrCheckCastNeedEqualityTest(TR::Node * castClassNode, TR::CodeGenerator *cg);
    static bool instanceOfOrCheckCastNeedSuperTest(TR::Node * castClassNode, TR::CodeGenerator *cg);
 
-   static TR_GlobalRegisterNumber getHighGlobalRegisterNumberIfAny(TR::Node *node, TR::CodeGenerator *cg); 
+   static TR_GlobalRegisterNumber getHighGlobalRegisterNumberIfAny(TR::Node *node, TR::CodeGenerator *cg);
 
    static int32_t classDepth(TR::Node * castClassNode, TR::CodeGenerator * cg);
    static int32_t checkNonNegativePowerOfTwo(int32_t value);

--- a/compiler/il/ILOpCodes.hpp
+++ b/compiler/il/ILOpCodes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@ namespace TR
      enum ILOpCodes
      {
      #include "il/ILOpCodesEnum.hpp"
-     NumIlOps
+     NumScalarIlOps
      };
    }
 

--- a/compiler/il/ILOpCodesEnum.hpp
+++ b/compiler/il/ILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,9 +22,9 @@
 #ifndef ILOPCODES_ENUM_INCL
 #define ILOPCODES_ENUM_INCL
 
-#include "compiler/il/OMRILOpCodesEnum.hpp" 
+#include "compiler/il/OMRILOpCodesEnum.hpp"
 
    FirstTROp = FirstOMROp,
-   LastTROp = LastOMROp,
+   LastTROp = LastScalarOMROp,
 
 #endif

--- a/compiler/il/ILOps.hpp
+++ b/compiler/il/ILOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ public:
    ILOpCode(TR::ILOpCodes opCode)
       : OMR::ILOpCode(opCode)
       {
-      TR_ASSERT(opCode <= TR::LastTROp, "assertion failure");
+      TR_ASSERT(opCode < NumAllIlOps, "assertion failure");
       }
 
    };

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -272,12 +272,28 @@ OMR::DataType::getName(TR::DataType dt)
       {
       // to avoid any race conditions, initialize all vector names once,
       // as soon as first one is requested
-      static bool staticallyInitialized = initVectorNames();
+       static bool staticallyInitialized = initVectorNames();
       TR_ASSERT_FATAL(staticallyInitialized && (OMRDataTypeNames[dt] != NULL), "Vector names should've been initialized");
       }
 
-   TR_ASSERT(dt < TR::NumAllTypes, "Name requested for unknown datatype");
+   TR_ASSERT(dt.isOMRDataType(), "Name requested for a non-OMR datatype\n");
    return OMRDataTypeNames[dt];
+   }
+
+TR::DataType
+OMR::DataType::getTypeFromName(const char *name)
+   {
+   for (int32_t i = 1 ; i < TR::NumAllTypes; i++)
+      {
+      TR::DataType dt = (TR::DataTypes)i;
+
+      if (!dt.isOMRDataType()) continue;
+
+      if (strcmp(name, getName(dt)) == 0)
+         return  dt;
+      }
+
+   return TR::NoType;
    }
 
 const char *

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -272,7 +272,7 @@ OMR::DataType::getName(TR::DataType dt)
       {
       // to avoid any race conditions, initialize all vector names once,
       // as soon as first one is requested
-       static bool staticallyInitialized = initVectorNames();
+      static bool staticallyInitialized = initVectorNames();
       TR_ASSERT_FATAL(staticallyInitialized && (OMRDataTypeNames[dt] != NULL), "Vector names should've been initialized");
       }
 

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -250,7 +250,8 @@ enum DataTypes
    // this space is reserved for vector types generated at runtime
    // the generated types can be used to index tables of size NumAllTypes as any other type
    //
-   NumAllTypes =  NumScalarTypes + NumVectorElementTypes * NumVectorLengths
+   NumVectorTypes = NumVectorElementTypes * NumVectorLengths,
+   NumAllTypes =  NumScalarTypes + NumVectorTypes
    };
 }
 
@@ -504,6 +505,8 @@ public:
    static TR::ILOpCodes getDataTypeBitConversion(TR::DataType t1, TR::DataType t2);
 
    static const char    * getName(TR::DataType dt);
+   static TR::DataType getTypeFromName(const char *name);
+
    static int32_t         getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);
 

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,5 +71,40 @@
 
 #include "il/Opcodes.enum"
 #undef OPCODE_MACRO
+
+
+#define VECTOR_OPERATION_MACRO(\
+   operation, \
+   name, \
+   prop1, \
+   prop2, \
+   prop3, \
+   prop4, \
+   dataType, \
+   typeProps, \
+   childProps, \
+   swapChildrenOpcode, \
+   reverseBranchOpcode, \
+   boolCompareOpcode, \
+   ifCompareOpcode, ...) \
+   \
+   { \
+   TR::BadILOp, \
+   name, \
+   prop1, \
+   prop2, \
+   prop3, \
+   prop4, \
+   dataType, \
+   typeProps, \
+   childProps, \
+   swapChildrenOpcode, \
+   reverseBranchOpcode, \
+   boolCompareOpcode, \
+   ifCompareOpcode, \
+   },
+
+#include "il/VectorOperations.enum"
+#undef VECTOR_OPERATION_MACRO
 
 #endif

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@
 
 #include "il/Opcodes.enum"
 
-   LastOMROp = Prefetch,
+   LastScalarOMROp = Prefetch,
 
 #undef OPCODE_MACRO
 

--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,10 +46,11 @@ OMR::OpCodeProperties OMR::ILOpCode::_opCodeProperties[] =
 #include "il/ILOpCodeProperties.hpp"
    };
 
+
 void
 OMR::ILOpCode::checkILOpArrayLengths()
    {
-   for (int i = TR::FirstOMROp; i < TR::NumIlOps; i++)
+   for (int i = TR::FirstOMROp; i < TR::NumScalarIlOps; i++)
       {
       TR::ILOpCodes opCode = (TR::ILOpCodes)i;
       TR::ILOpCode  op(opCode);
@@ -67,7 +68,7 @@ OMR::ILOpCode::setTarget()
    {
    if (TR::Compiler->target.is64Bit())
       {
-      for (int32_t i = 0; i < TR::NumIlOps; ++i)
+      for (int32_t i = 0; i < opCodePropertiesSize; ++i)
          {
          flags32_t *tp = (flags32_t*)(&_opCodeProperties[i].typeProperties); // so ugly
          if (tp->getValue() == ILTypeProp::Reference)
@@ -80,7 +81,7 @@ OMR::ILOpCode::setTarget()
       }
    else
       {
-      for (int32_t i = 0; i < TR::NumIlOps; ++i)
+      for (int32_t i = 0; i < opCodePropertiesSize; ++i)
          {
          flags32_t *tp = (flags32_t*)(&_opCodeProperties[i].typeProperties); // so ugly
          if (tp->getValue() == ILTypeProp::Reference)

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -78,9 +78,9 @@ class ILOpCode
 public:
 
    // The class is capable of storing "hidden" vector opcodes and provides an interface
-   // for creating and quiering them
-   // Vector operations that return a non-vector type(e.g. reduction) or for which result
-   // and source types are different(e.g. conversion) will be handled later
+   // for creating and querying them
+   // Vector operations that return a non-vector type (e.g. reduction) or for which result
+   // and source types are different (e.g. conversion) will be handled later
    static const int32_t NumAllIlOps = TR::NumScalarIlOps + NumVectorOperations*TR::NumVectorTypes;
 
    // Deprecate?
@@ -108,7 +108,7 @@ public:
    */
    static ILOpCode createVectorOpCode(VectorOperation operation, DataType resultVectorType)
       {
-      static_assert(NumAllIlOps < ((long long)1 << (sizeof(TR::ILOpCodes)*8)), "Number of scalar and vector opcodes does not fit into TR::ILOpCodes\n");
+      static_assert(NumAllIlOps < ((uint64_t)1 << (sizeof(TR::ILOpCodes)*8)), "Number of scalar and vector opcodes does not fit into TR::ILOpCodes\n");
 
       return (TR::ILOpCodes)(TR::NumScalarIlOps + operation*TR::NumVectorTypes + (resultVectorType - TR::NumScalarTypes));
       }
@@ -166,7 +166,7 @@ public:
    */
    static VectorOperation getVectorOperation(ILOpCode op)
       {
-      TR_ASSERT_FATAL(isVectorOpCode(op), "getVectOroperation() can only be called on vector opcode\n");
+      TR_ASSERT_FATAL(isVectorOpCode(op), "getVectorOperation() can only be called on vector opcode\n");
       return (VectorOperation)((op._opCode - TR::NumScalarIlOps) / TR::NumVectorTypes);
       }
 
@@ -1384,12 +1384,15 @@ public:
          case TR::dstorei:
             return TR::vstorei;
 
-         case TR::badd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int8,   vectorLength)).getOpCodeValue();
-         case TR::sadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int16,  vectorLength)).getOpCodeValue();
-         case TR::iadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int32,  vectorLength)).getOpCodeValue();
-         case TR::ladd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int64,  vectorLength)).getOpCodeValue();
-         case TR::fadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Float,  vectorLength)).getOpCodeValue();
-         case TR::dadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Double, vectorLength)).getOpCodeValue();
+         case TR::badd:
+         case TR::sadd:
+         case TR::iadd:
+         case TR::ladd:
+         case TR::fadd:
+         case TR::dadd:
+            return ILOpCode::createVectorOpCode(OMR::vadd,
+                                                TR::DataType::createVectorType(opcode.getDataType().getDataType(),
+                                                                               vectorLength)).getOpCodeValue();
 
          case TR::bsub:
          case TR::ssub:

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -35,6 +35,13 @@ namespace TR { class SymbolReference; }
 namespace OMR
 {
 
+enum VectorOperation
+   {
+   vadd,
+   vfma,
+   NumVectorOperations
+   };
+
 /**
  * Opcode properties.
  */
@@ -70,6 +77,12 @@ class ILOpCode
 
 public:
 
+   // The class is capable of storing "hidden" vector opcodes and provides an interface
+   // for creating and quiering them
+   // Vector operations that return a non-vector type(e.g. reduction) or for which result
+   // and source types are different(e.g. conversion) will be handled later
+   static const int32_t NumAllIlOps = TR::NumScalarIlOps + NumVectorOperations*TR::NumVectorTypes;
+
    // Deprecate?
    ILOpCode()
       : _opCode(TR::BadILOp)
@@ -78,45 +91,162 @@ public:
    ILOpCode(TR::ILOpCodes opCode)
       : _opCode(opCode)
       {
-      TR_ASSERT(opCode <= TR::LastTROp, "assertion failure");
+      TR_ASSERT(opCode < NumAllIlOps, "assertion failure");
       }
 
+  /** \brief
+   *     Creates vector opcode given vector operation and resulting vector type
+   *
+   *  \param operation
+   *     Vector operation
+   *
+   *  \param resultVectorType
+   *     Type of the vector created by the operation
+   *
+   *  \return
+   *     Vector opcode
+   */
+   static ILOpCode createVectorOpCode(VectorOperation operation, DataType resultVectorType)
+      {
+      static_assert(NumAllIlOps < ((long long)1 << (sizeof(TR::ILOpCodes)*8)), "Number of scalar and vector opcodes does not fit into TR::ILOpCodes\n");
+
+      return (TR::ILOpCodes)(TR::NumScalarIlOps + operation*TR::NumVectorTypes + (resultVectorType - TR::NumScalarTypes));
+      }
+
+  /** \brief
+   *     Checks if the opcode represents vector operation
+   *
+   *  \return
+   *     True if the opcode represents vector operation, false otherwise
+   */
+   bool isVectorOpCode() const { return _opCode >= TR::NumScalarIlOps; }
+
+  /** \brief
+   *     Checks if the opcode represents vector operation
+   *
+   *  \param op
+   *     Opcode
+   *
+   *  \return
+   *     True if the opcode represents vector operation, false otherwise
+   */
+   static bool isVectorOpCode(ILOpCode op) { return op._opCode >= TR::NumScalarIlOps; }
+
+  /** \brief
+   *     Checks if the opcode is an OMR opcode
+   *
+   *  \param op
+   *     Opcode
+   *
+   *  \return
+   *     True if the opcode is an OMR, false otherwise
+   */
+   static bool isOMROpCode(ILOpCode op) { return op._opCode <= TR::LastScalarOMROp || isVectorOpCode(op); }
+
+  /** \brief
+   *     Returns vector operation
+   *
+   *  \return
+   *     Vector operation
+   */
+   VectorOperation getVectorOperation() const
+      {
+      TR_ASSERT_FATAL(isVectorOpCode(), "getVectorOperation() can only be called on vector opcode\n");
+      return (VectorOperation)((_opCode - TR::NumScalarIlOps) / TR::NumVectorTypes);
+      }
+
+  /** \brief
+   *     Returns vector operation
+   *
+   *  \param op
+   *     Opcode
+   *
+   *  \return
+   *     Vector operation
+   */
+   static VectorOperation getVectorOperation(ILOpCode op)
+      {
+      TR_ASSERT_FATAL(isVectorOpCode(op), "getVectOroperation() can only be called on vector opcode\n");
+      return (VectorOperation)((op._opCode - TR::NumScalarIlOps) / TR::NumVectorTypes);
+      }
+
+  /** \brief
+   *     Returns vector result type
+   *
+   *  \return
+   *     Vector type
+   */
+   TR::DataType getVectorResultDataType() const
+      {
+      TR_ASSERT_FATAL(isVectorOpCode(), "getVectorResultDataType() can only be called on vector opcode\n");
+      return (TR::DataTypes)((_opCode - TR::NumScalarIlOps) % TR::NumVectorTypes + TR::NumScalarTypes);
+      }
+
+  /** \brief
+   *     Returns result vector type
+   *
+   *  \param op
+   *     Opcode
+   *
+   *  \return
+   *     Vector type
+   */
+   static TR::DataType getVectorResultDataType(ILOpCode op)
+      {
+      TR_ASSERT_FATAL(isVectorOpCode(op), "getVectorResultDataType() can only be called on vector opcode\n");
+      return (TR::DataTypes)((op._opCode - TR::NumScalarIlOps) % TR::NumVectorTypes + TR::NumScalarTypes);
+      }
+
+  /** \brief
+   *     Returns index into OMR opcode properties and handler tables. All OMR tables contain VectorOperation
+   *     entries following regular opcodes
+   *
+   *  \return
+   *     Index to OMR tables
+   */
+   int32_t getTableIndex() const { return isVectorOpCode() ? (TR::NumScalarIlOps + getVectorOperation()) : _opCode; }
+
    TR::ILOpCodes getOpCodeValue() const           { return (TR::ILOpCodes)_opCode; }
-   TR::ILOpCodes setOpCodeValue(TR::ILOpCodes op) { TR_ASSERT(op <= TR::LastTROp, "assertion failure"); return (TR::ILOpCodes) (_opCode = op); }
+   TR::ILOpCodes setOpCodeValue(TR::ILOpCodes op) { TR_ASSERT(op < NumAllIlOps, "assertion failure"); return (TR::ILOpCodes) (_opCode = op); }
 
    /// Get the opcode to be used if the children of this opcode are swapped.
    /// e.g. ificmplt --> ificmpgt
    TR::ILOpCodes getOpCodeForSwapChildren() const
-      { return _opCodeProperties[_opCode].swapChildrenOpCode; }
+      { return _opCodeProperties[getTableIndex()].swapChildrenOpCode; }
 
    /// Get the opcode to be used if the sense of this (compare) opcode is reversed.
    /// e.g. ificmplt --> ificmpge
    TR::ILOpCodes getOpCodeForReverseBranch() const
-      { return _opCodeProperties[_opCode].reverseBranchOpCode; }
+      { return _opCodeProperties[getTableIndex()].reverseBranchOpCode; }
 
    /// Get the boolean compare opcode that corresponds to this compare-and-branch
    /// opcode.
    /// e.g. ificmplt --> icmplt
    TR::ILOpCodes convertIfCmpToCmp()
-      { return _opCodeProperties[_opCode].booleanCompareOpCode; }
+      { return _opCodeProperties[getTableIndex()].booleanCompareOpCode; }
 
    /// Get the compare-and-branch opcode that corresponds to this boolean compare
    ///e.g. icmplt --> ificmplt
    TR::ILOpCodes convertCmpToIfCmp()
-      { return _opCodeProperties[_opCode].ifCompareOpCode; }
+      { return _opCodeProperties[getTableIndex()].ifCompareOpCode; }
 
-   TR::DataType getDataType() const                  { return _opCodeProperties[_opCode].dataType; }
-   static TR::DataType getDataType(TR::ILOpCodes op) { return _opCodeProperties[op].dataType; }
+   TR::DataType getDataType() const
+      { return isVectorOpCode() ? getVectorResultDataType() : _opCodeProperties[_opCode].dataType; }
+   static TR::DataType getDataType(TR::ILOpCodes op)
+         { return isVectorOpCode(op) ? getVectorResultDataType(op) : _opCodeProperties[op].dataType; }
 
-   TR::DataType getType() const                  { return _opCodeProperties[_opCode].dataType; }
-   static TR::DataType getType(TR::ILOpCodes op) { return _opCodeProperties[op].dataType; }
+   TR::DataType getType() const                  { return getDataType(); }
+   static TR::DataType getType(TR::ILOpCodes op) { return getDataType(op); }
 
-   const char *getName() const { return _opCodeProperties[_opCode].name; }
+   const char *getName() const { return _opCodeProperties[getTableIndex()].name; }
 
    // Query Functions
-
-   uint32_t getSize() const                  { return typeProperties().getValue(ILTypeProp::Size_Mask); }
-   static uint32_t getSize(TR::ILOpCodes op) { return ILOpCode(op).getSize(); }
+   uint32_t getSize() const
+         { return isVectorOpCode() ? OMR::DataType::getSize(getVectorResultDataType())
+                                   : typeProperties().getValue(ILTypeProp::Size_Mask); }
+   static uint32_t getSize(TR::ILOpCodes op)
+         { return isVectorOpCode(op) ? OMR::DataType::getSize(getVectorResultDataType(op))
+                                   : ILOpCode(op).getSize(); }
 
    /**
     * ILTypeProp
@@ -133,7 +263,7 @@ public:
    bool isUnsigned()                 const { return typeProperties().testAny(ILTypeProp::Unsigned); }
    bool isUnsignedConversion()       const { return isUnsigned() && isConversion(); }
    bool isFloatingPoint()            const { return typeProperties().testAny(ILTypeProp::Floating_Point); }
-   bool isVector()                   const { return typeProperties().testAny(ILTypeProp::Vector); }
+   bool isVector()                   const { return typeProperties().testAny(ILTypeProp::Vector) || isVectorOpCode(); }
    bool isIntegerOrAddress()         const { return typeProperties().testAny(ILTypeProp::Integer | ILTypeProp::Address); }
    bool is1Byte()                    const { return typeProperties().testAny(ILTypeProp::Size_1); }
    bool is2Byte()                    const { return typeProperties().testAny(ILTypeProp::Size_2); }
@@ -674,7 +804,7 @@ public:
 
    static TR::ILOpCodes addOpCode(TR::DataType type, bool is64Bit)
       {
-      if (type.isVector()) return TR::vadd;
+      if (type.isVector()) return createVectorOpCode(OMR::vadd, type).getOpCodeValue();
 
       switch(type)
          {
@@ -1218,7 +1348,7 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes convertScalarToVector(TR::ILOpCodes op)
+   static TR::ILOpCodes convertScalarToVector(TR::ILOpCodes op, TR::VectorLength vectorLength)
       {
       ILOpCode opcode;
       opcode.setOpCodeValue(op);
@@ -1253,13 +1383,14 @@ public:
          case TR::fstorei:
          case TR::dstorei:
             return TR::vstorei;
-         case TR::badd:
-         case TR::sadd:
-         case TR::iadd:
-         case TR::ladd:
-         case TR::fadd:
-         case TR::dadd:
-            return TR::vadd;
+
+         case TR::badd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int8,   vectorLength)).getOpCodeValue();
+         case TR::sadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int16,  vectorLength)).getOpCodeValue();
+         case TR::iadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int32,  vectorLength)).getOpCodeValue();
+         case TR::ladd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Int64,  vectorLength)).getOpCodeValue();
+         case TR::fadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Float,  vectorLength)).getOpCodeValue();
+         case TR::dadd: return ILOpCode::createVectorOpCode(OMR::vadd, TR::DataType::createVectorType(TR::Double, vectorLength)).getOpCodeValue();
+
          case TR::bsub:
          case TR::ssub:
          case TR::isub:
@@ -1361,14 +1492,15 @@ protected:
    TR::ILOpCodes _opCode;
 
    // Access properties words as flags.
-   flags32_t properties1()    const { return flags32_t(_opCodeProperties[_opCode].properties1); }
-   flags32_t properties2()    const { return flags32_t(_opCodeProperties[_opCode].properties2); }
-   flags32_t properties3()    const { return flags32_t(_opCodeProperties[_opCode].properties3); }
-   flags32_t properties4()    const { return flags32_t(_opCodeProperties[_opCode].properties4); }
-   flags32_t typeProperties() const { return flags32_t(_opCodeProperties[_opCode].typeProperties); }
-   TR::ILChildPropType childProperties() const { return _opCodeProperties[_opCode].childTypes; }
+   flags32_t properties1()    const { return flags32_t(_opCodeProperties[getTableIndex()].properties1); }
+   flags32_t properties2()    const { return flags32_t(_opCodeProperties[getTableIndex()].properties2); }
+   flags32_t properties3()    const { return flags32_t(_opCodeProperties[getTableIndex()].properties3); }
+   flags32_t properties4()    const { return flags32_t(_opCodeProperties[getTableIndex()].properties4); }
+   flags32_t typeProperties() const { return flags32_t(_opCodeProperties[getTableIndex()].typeProperties); }
+   TR::ILChildPropType childProperties() const { return _opCodeProperties[getTableIndex()].childTypes; }
 
-   static OpCodeProperties _opCodeProperties[TR::NumIlOps];
+   static const int32_t opCodePropertiesSize = TR::NumScalarIlOps + NumVectorOperations;
+   static OpCodeProperties _opCodeProperties[opCodePropertiesSize];
    };
 
 /**

--- a/compiler/il/OMROpcodes.enum
+++ b/compiler/il/OMROpcodes.enum
@@ -6580,22 +6580,6 @@ OPCODE_MACRO(\
    /* .description          =    vector negation */ \
 )
 OPCODE_MACRO(\
-   /* .opcode               = */ vadd, \
-   /* .name                 = */ "vadd", \
-   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Add, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector add */ \
-)
-OPCODE_MACRO(\
    /* .opcode               = */ vsub, \
    /* .name                 = */ "vsub", \
    /* .properties1          = */ ILProp1::Sub, \

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vadd, \
+   /* .name                 = */ "vadd", \
+   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Add, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector add */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .opcode               = */ vfma, \
+   /* .name                 = */ "vfma", \
+   /* .properties1          = */ 0, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector fused multiply and add */ \
+)

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -602,7 +602,7 @@ OMR::IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLo
    TR::ILOpCodes loadOp = comp()->il.opCodeForIndirectArrayLoad(primType);
    if (isVectorLoad)
       {
-      loadOp = TR::ILOpCode::convertScalarToVector(loadOp);
+      loadOp = TR::ILOpCode::convertScalarToVector(loadOp, TR::VectorLength128);
       baseType = _types->PrimitiveType(symRefType);
       }
 

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,12 +79,15 @@
 #include "optimizer/TransformUtil.hpp"
 #include "ras/Debug.hpp"
 
-extern const SimplifierPtr simplifierOpts[];
 
-static_assert(TR::NumIlOps ==
-              (sizeof(simplifierOpts) / sizeof(simplifierOpts[0])),
-              "simplifierOpts is not the correct size");
+extern const SimplifierPtrTable simplifierOpts;
 
+void SimplifierPtrTable::checkTableSize()
+   {
+   static_assert((TR::NumScalarIlOps + OMR::NumVectorOperations) ==
+              (sizeof(table) / sizeof(table[0])),
+              "SimplifierPtrTable::table is not the correct size");
+   }
 
 /*
  * Local helper functions

--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -80,13 +80,13 @@
 #include "ras/Debug.hpp"
 
 
-extern const SimplifierPtrTable simplifierOpts;
+extern const SimplifierPointerTable simplifierOpts;
 
-void SimplifierPtrTable::checkTableSize()
+void SimplifierPointerTable::checkTableSize()
    {
    static_assert((TR::NumScalarIlOps + OMR::NumVectorOperations) ==
               (sizeof(table) / sizeof(table[0])),
-              "SimplifierPtrTable::table is not the correct size");
+              "SimplifierPointerTable::table is not the correct size");
    }
 
 /*

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -268,7 +268,7 @@ TR::Node * removeArithmeticsUnderIntegralCompare(TR::Node* node,TR::Simplifier *
 
 typedef TR::Node *(* SimplifierPtr)(TR::Node *node, TR::Block *block, TR::Simplifier *s);
 
-class SimplifierPtrTable
+class SimplifierPointerTable
    {
    private:
    static const SimplifierPtr table[];
@@ -277,7 +277,7 @@ class SimplifierPtrTable
 
    public:
 
-   SimplifierPtrTable() {}; // some compilers require a default constructor for this class
+   SimplifierPointerTable() {}; // some compilers require a default constructor for this class
 
    SimplifierPtr operator[] (TR::ILOpCode opcode) const
       {

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -265,5 +265,24 @@ TR::Node * lowerTreeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
 TR::Node * arrayLengthSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 
 TR::Node * removeArithmeticsUnderIntegralCompare(TR::Node* node,TR::Simplifier * s);
+
+typedef TR::Node *(* SimplifierPtr)(TR::Node *node, TR::Block *block, TR::Simplifier *s);
+
+class SimplifierPtrTable
+   {
+   private:
+   static const SimplifierPtr table[];
+
+   static void checkTableSize();
+
+   public:
+
+   SimplifierPtrTable() {}; // some compilers require a default constructor for this class
+
+   SimplifierPtr operator[] (TR::ILOpCode opcode) const
+      {
+      return table[opcode.getTableIndex()];
+      }
+   };
 
 #endif

--- a/compiler/optimizer/OMRSimplifierTable.enum
+++ b/compiler/optimizer/OMRSimplifierTable.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -432,6 +432,7 @@
 #define vdcmpltSimplifierHandler normalizeCmpSimplifier
 #define vdcmpleSimplifierHandler normalizeCmpSimplifier
 #define vdsqrtSimplifierHandler dftSimplifier
+#define vfmaSimplifierHandler dftSimplifier
 #define vnegSimplifierHandler dftSimplifier
 #define vaddSimplifierHandler dftSimplifier
 #define vsubSimplifierHandler dftSimplifier
@@ -631,6 +632,26 @@
    BadILOpSimplifierHandler,
 
 #include "il/Opcodes.enum"
+
+#define VECTOR_OPERATION_MACRO(\
+   operation, \
+   name, \
+   prop1, \
+   prop2, \
+   prop3, \
+   prop4, \
+   dataType, \
+   typeProps, \
+   childProps, \
+   swapChildrenOpcode, \
+   reverseBranchOpcode, \
+   boolCompareOpcode, \
+   ifCompareOpcode, \
+   ...) operation ## SimplifierHandler,
+
+#include "il/VectorOperations.enum"
+
 #undef OPCODE_MACRO
+#undef VECTOR_OPERATION_MACRO
 
 #endif

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -76,7 +76,7 @@ template <class T> class TR_Stack;
 
 typedef TR::Node* (* ValuePropagationPtr)(OMR::ValuePropagation *, TR::Node *);
 
-class ValuePropagationPtrTable
+class ValuePropagationPointerTable
    {
    private:
    static const ValuePropagationPtr table[];
@@ -85,7 +85,7 @@ class ValuePropagationPtrTable
 
    public:
 
-   ValuePropagationPtrTable() {}; // some compilers require a default constructor for this class
+   ValuePropagationPointerTable() {}; // some compilers require a default constructor for this class
 
    ValuePropagationPtr operator[] (TR::ILOpCode opcode) const
       {
@@ -93,7 +93,7 @@ class ValuePropagationPtrTable
       }
    };
 
-extern const ValuePropagationPtrTable constraintHandlers;
+extern const ValuePropagationPointerTable constraintHandlers;
 
 typedef TR::typed_allocator<std::pair<TR::CFGEdge * const, TR_BitVector*>, TR::Region &> DefinedOnAllPathsMapAllocator;
 typedef std::map<TR::CFGEdge *, TR_BitVector *, std::less<TR::CFGEdge *>, DefinedOnAllPathsMapAllocator> DefinedOnAllPathsMap;

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -75,7 +75,25 @@ template <class T> class TR_Array;
 template <class T> class TR_Stack;
 
 typedef TR::Node* (* ValuePropagationPtr)(OMR::ValuePropagation *, TR::Node *);
-extern const ValuePropagationPtr constraintHandlers[];
+
+class ValuePropagationPtrTable
+   {
+   private:
+   static const ValuePropagationPtr table[];
+
+   static void checkTableSize();
+
+   public:
+
+   ValuePropagationPtrTable() {}; // some compilers require a default constructor for this class
+
+   ValuePropagationPtr operator[] (TR::ILOpCode opcode) const
+      {
+      return table[opcode.getTableIndex()];
+      }
+   };
+
+extern const ValuePropagationPtrTable constraintHandlers;
 
 typedef TR::typed_allocator<std::pair<TR::CFGEdge * const, TR_BitVector*>, TR::Region &> DefinedOnAllPathsMapAllocator;
 typedef std::map<TR::CFGEdge *, TR_BitVector *, std::less<TR::CFGEdge *>, DefinedOnAllPathsMapAllocator> DefinedOnAllPathsMap;

--- a/compiler/optimizer/SimplifierTable.hpp
+++ b/compiler/optimizer/SimplifierTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,9 +28,9 @@ namespace TR { class Simplifier; }
 
 #include "optimizer/OMRSimplifierHandlers.hpp"
 
-typedef TR::Node *(* SimplifierPtr)(TR::Node *node, TR::Block *block, TR::Simplifier *s);
+const SimplifierPtrTable simplifierOpts;
 
-const SimplifierPtr simplifierOpts[TR::NumIlOps] =
+const SimplifierPtr SimplifierPtrTable::table[] =
    {
    #include "optimizer/OMRSimplifierTable.enum"
    };

--- a/compiler/optimizer/SimplifierTable.hpp
+++ b/compiler/optimizer/SimplifierTable.hpp
@@ -28,9 +28,9 @@ namespace TR { class Simplifier; }
 
 #include "optimizer/OMRSimplifierHandlers.hpp"
 
-const SimplifierPtrTable simplifierOpts;
+const SimplifierPointerTable simplifierOpts;
 
-const SimplifierPtr SimplifierPtrTable::table[] =
+const SimplifierPtr SimplifierPointerTable::table[] =
    {
    #include "optimizer/OMRSimplifierTable.enum"
    };

--- a/compiler/optimizer/VPHandlersCommon.cpp
+++ b/compiler/optimizer/VPHandlersCommon.cpp
@@ -161,9 +161,9 @@ TR::Node *constrainVcall(OMR::ValuePropagation *vp, TR::Node *node)
 
 #include "optimizer/ValuePropagationTable.hpp" // IWYU pragma: keep
 
-void ValuePropagationPtrTable::checkTableSize()
+void ValuePropagationPointerTable::checkTableSize()
    {
    static_assert((TR::NumScalarIlOps + OMR::NumVectorOperations) ==
                  (sizeof(table) / sizeof(table[0])),
-                 "ValuePropagationPtrTable::table[] is not the correct size");
+                 "ValuePropagationPointerTable::table[] is not the correct size");
    }

--- a/compiler/optimizer/VPHandlersCommon.cpp
+++ b/compiler/optimizer/VPHandlersCommon.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -161,6 +161,9 @@ TR::Node *constrainVcall(OMR::ValuePropagation *vp, TR::Node *node)
 
 #include "optimizer/ValuePropagationTable.hpp" // IWYU pragma: keep
 
-static_assert(TR::NumIlOps ==
-              (sizeof(constraintHandlers) / sizeof(constraintHandlers[0])),
-              "constraintHandlers is not the correct size");
+void ValuePropagationPtrTable::checkTableSize()
+   {
+   static_assert((TR::NumScalarIlOps + OMR::NumVectorOperations) ==
+                 (sizeof(table) / sizeof(table[0])),
+                 "ValuePropagationPtrTable::table[] is not the correct size");
+   }

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -574,6 +574,7 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define vdcmpltVPHandler constrainCmp
 #define vdcmpleVPHandler constrainCmp
 #define vdsqrtVPHandler constrainChildren
+#define vfmaVPHandler constrainChildren
 #define vnegVPHandler constrainChildren
 #define vaddVPHandler constrainAdd
 #define vsubVPHandler constrainSubtract
@@ -852,7 +853,9 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define BCDCHKVPHandler constrainBCDCHK
 #endif
 
-const ValuePropagationPtr constraintHandlers[] =
+const ValuePropagationPtrTable constraintHandlers;
+
+const ValuePropagationPtr ValuePropagationPtrTable::table[] =
    {
 #define OPCODE_MACRO(\
    opcode, \
@@ -874,6 +877,25 @@ const ValuePropagationPtr constraintHandlers[] =
 
 #include "il/Opcodes.enum"
 #undef OPCODE_MACRO
+
+#define VECTOR_OPERATION_MACRO(\
+   operation, \
+   name, \
+   prop1, \
+   prop2, \
+   prop3, \
+   prop4, \
+   dataType, \
+   typeProps, \
+   childProps, \
+   swapChildrenOpcode, \
+   reverseBranchOpcode, \
+   boolCompareOpcode, \
+   ifCompareOpcode, \
+   ...) operation ## VPHandler,
+
+#include "il/VectorOperations.enum"
+#undef VECTOR_OPERATION_MACRO
 
    };
 

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -853,9 +853,9 @@ TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node);
 #define BCDCHKVPHandler constrainBCDCHK
 #endif
 
-const ValuePropagationPtrTable constraintHandlers;
+const ValuePropagationPointerTable constraintHandlers;
 
-const ValuePropagationPtr ValuePropagationPtrTable::table[] =
+const ValuePropagationPtr ValuePropagationPointerTable::table[] =
    {
 #define OPCODE_MACRO(\
    opcode, \

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1777,7 +1777,7 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
       TR::DataType et = ot.getVectorElementType();
 
       if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
-          opcode.getVectorOperation() == OMR::vadd && dt == TR::Int64)
+          opcode.getVectorOperation() == OMR::vadd && et == TR::Int64)
          return true;
 
       // implemented vector operations

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1770,15 +1770,38 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
        dt != TR::Int64)
       return false;
 
+   if (opcode.isVectorOpCode())
+      {
+      TR::DataType ot = opcode.getVectorResultDataType();
+
+      if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+      TR::DataType et = ot.getVectorElementType();
+
+      if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
+          opcode.getVectorOperation() == OMR::vadd && dt == TR::Int64)
+         return true;
+
+      // implemented vector operations
+      switch (opcode.getVectorOperation())
+         {
+         case OMR::vadd:
+            if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
+               return true;
+            else
+               return false;
+         }
+      return false;
+      }
+
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
-       (opcode.getOpCodeValue() == TR::vadd || opcode.getOpCodeValue() == TR::vsub || opcode.getOpCodeValue() == TR::vmul) &&
+       (opcode.getOpCodeValue() == TR::vsub || opcode.getOpCodeValue() == TR::vmul) &&
        dt == TR::Int64)
       return true;
 
    // implemented vector opcodes
    switch (opcode.getOpCodeValue())
       {
-      case TR::vadd:
       case TR::vsub:
       case TR::vmul:
          if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Float || dt == TR::Double)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1760,10 +1760,8 @@ OMR::Power::CodeGenerator::freeAndResetTransientLongs()
 
 
 
-bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
+bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
-   if(length != TR::VectorLength128) return false;
-
    // alignment issues
    if (!self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
        dt != TR::Double &&
@@ -1790,8 +1788,9 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
                return true;
             else
                return false;
+         default:
+            return false;
          }
-      return false;
       }
 
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -282,7 +282,7 @@ public:
       return false;
       }
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
 
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3848,6 +3848,11 @@ TR::Register *OMR::Power::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::Cod
     return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvsqrtdp);
     }
 
+TR::Register* OMR::Power::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
 TR::Register *OMR::Power::TreeEvaluator::vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg)
     {
     return TR::TreeEvaluator::inlineVectorUnaryOp(node, cg, TR::InstOpCode::xvcvsxddp);

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -664,6 +664,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineVectorUnaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
    static TR::Register *inlineVectorBinaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1704,6 +1704,12 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
       {
       output.appendf(" (%s)", getName(node->getDataType()));
       }
+   else if(node->getOpCode().isVectorOpCode())
+      {
+      // example of a vector opcode: vaddVector128Int32
+      output.appendf("%s", getName(node->getDataType()));
+      }
+
 
    if (node->getOpCode().isLoadConst())
       {

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1409,6 +1409,12 @@ OMR::RV::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
+OMR::RV::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
 OMR::RV::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
@@ -2271,7 +2277,7 @@ OMR::RV::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }
-   
+
 /**
  * \brief Extracts (hiBit,loBit) from 64bit value, starting at bit 'hiBit'. Lowest bit is bit 0,
  * highest bit is bit 63.

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -330,6 +330,7 @@ public:
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1620,6 +1620,12 @@ OMR::X86::AMD64::TreeEvaluator::vdcmpleEvaluator(TR::Node *node, TR::CodeGenerat
    }
 
 TR::Register*
+OMR::X86::AMD64::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
 OMR::X86::AMD64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEvaluator(node, cg);

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.hpp
@@ -313,6 +313,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::X86::TreeEvaluator
    static TR::Register *vdcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -986,28 +986,27 @@ bool OMR::X86::CodeGenerator::supportsAddressRematerialization()         { stati
 #undef CAN_REMATERIALIZE
 
 bool
-OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
+OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
-   if(length != TR::VectorLength128) return false;
-
    /*
     * Most of the vector evaluators for opcodes used in AutoSIMD have been implemented.
     * The cases that return false are placeholders that should be updated as support for more vector evaluators is added.
     */
    // implemented vector opcodes
 
-   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+   if (opcode.isVectorOpCode())
       {
       TR::DataType ot = opcode.getVectorResultDataType();
 
       if (ot.getVectorLength() != TR::VectorLength128) return false;
 
-      TR::DataType et = ot.getVectorElementType();
-
-      if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-         return true;
-      else
-         return false;
+      switch (opcode.getVectorOperation())
+         {
+         case OMR::vadd:
+            return true;
+         default:
+            return false;
+         }
       }
 
    switch (opcode.getOpCodeValue())

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -995,9 +995,23 @@ OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::D
     * The cases that return false are placeholders that should be updated as support for more vector evaluators is added.
     */
    // implemented vector opcodes
+
+   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+      {
+      TR::DataType ot = opcode.getVectorResultDataType();
+
+      if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+      TR::DataType et = ot.getVectorElementType();
+
+      if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         return true;
+      else
+         return false;
+      }
+
    switch (opcode.getOpCodeValue())
       {
-      case TR::vadd:
       case TR::vsub:
          if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
             return true;

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -358,7 +358,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool hasComplexAddressingMode() { return true; }
    bool getSupportsBitOpCodes() { return true; }
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
    bool getSupportsEncodeUtf16LittleWithSurrogateTest();
    bool getSupportsEncodeUtf16BigWithSurrogateTest();
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4151,12 +4151,21 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
          arithmetic = BinaryArithmeticXor;
          break;
       default:
-         if (OMR::ILOpCode::isVectorOpCode(opcode) && OMR::ILOpCode::getVectorOperation(opcode) == OMR::vadd)
+         if (OMR::ILOpCode::isVectorOpCode(opcode))
             {
-            arithmetic = BinaryArithmeticAdd;
-            break;
+            switch (OMR::ILOpCode::getVectorOperation(opcode))
+               {
+               case OMR::vadd:
+                  arithmetic = BinaryArithmeticAdd;
+                  break;
+               default:
+                  TR_ASSERT(false, "Unsupported OpCode");
+               }
             }
-         TR_ASSERT(false, "Unsupported OpCode");
+         else
+            {
+            TR_ASSERT(false, "Unsupported OpCode");
+            }
       }
 
    TR::Node* operandNode0 = node->getChild(0);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4118,12 +4118,12 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
                              "Only 128-bit vectors are supported right now\n");
 
    auto arithmetic = BinaryArithmeticInvalid;
+   TR::ILOpCodes opcode = node->getOpCodeValue();
 
-   switch (node->getOpCodeValue())
+   switch (opcode)
       {
       case TR::fadd:
       case TR::dadd:
-      case TR::vadd:
          arithmetic = BinaryArithmeticAdd;
          break;
       case TR::fsub:
@@ -4151,6 +4151,11 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
          arithmetic = BinaryArithmeticXor;
          break;
       default:
+         if (OMR::ILOpCode::isVectorOpCode(opcode) && OMR::ILOpCode::getVectorOperation(opcode) == OMR::vadd)
+            {
+            arithmetic = BinaryArithmeticAdd;
+            break;
+            }
          TR_ASSERT(false, "Unsupported OpCode");
       }
 

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -1705,6 +1705,12 @@ OMR::X86::I386::TreeEvaluator::vdcmpleEvaluator(TR::Node *node, TR::CodeGenerato
 
 
 TR::Register*
+OMR::X86::I386::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
 OMR::X86::I386::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEvaluator(node, cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
@@ -294,6 +294,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::X86::TreeEvaluator
    static TR::Register *vdcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vsubEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vmulEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4732,10 +4732,23 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
       return false;
       }
 
+   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+      {
+      TR::DataType ot = opcode.getVectorResultDataType();
+
+      if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+      TR::DataType et = opcode.getVectorResultDataType().getVectorElementType();
+
+      if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         return true;
+      else
+         return false;
+      }
+
    // implemented vector opcodes
    switch (opcode.getOpCodeValue())
       {
-      case TR::vadd:
       case TR::vsub:
       case TR::vmul:
       case TR::vdiv:

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4719,10 +4719,8 @@ bool OMR::Z::CodeGenerator::isDispInRange(int64_t disp)
    return (MINLONGDISP <= disp) && (disp <= MAXLONGDISP);
    }
 
-bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt, TR::VectorLength length)
+bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::DataType dt)
    {
-   if(length != TR::VectorLength128) return false;
-
    /*
     * Prior to z14, vector operations that operated on floating point numbers only supported
     * Doubles. On z14 and onward, Float type floating point numbers are supported as well.
@@ -4732,7 +4730,7 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
       return false;
       }
 
-   if (opcode.isVectorOpCode() && opcode.getVectorOperation() == OMR::vadd)
+   if (opcode.isVectorOpCode())
       {
       TR::DataType ot = opcode.getVectorResultDataType();
 
@@ -4740,10 +4738,16 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
 
       TR::DataType et = opcode.getVectorResultDataType().getVectorElementType();
 
-      if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-         return true;
-      else
-         return false;
+      switch(opcode.getVectorOperation())
+         {
+         case OMR::vadd:
+            if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+               return true;
+            else
+               return false;
+         default:
+            return false;
+         }
       }
 
    // implemented vector opcodes

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -749,7 +749,7 @@ public:
 
    virtual bool isDispInRange(int64_t disp);
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType, TR::VectorLength);
+   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType);
 
    TR::Instruction *_ccInstruction;
    TR::Instruction* ccInstruction() { return _ccInstruction; }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1292,6 +1292,12 @@ OMR::Z::TreeEvaluator::vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
+OMR::Z::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   }
+
+TR::Register*
 OMR::Z::TreeEvaluator::vloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::vloadEvaluator(node, cg);

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -281,6 +281,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vdcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vfmaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vcallEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -25,13 +25,13 @@
 class VectorTest : public TRTest::JitTest {};
 
 
-TEST_F(VectorTest, VDoubleAdd) { 
+TEST_F(VectorTest, VDoubleAdd) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
                      "     (vstorei type=VectorDouble offset=0                        "
                      "         (aload parm=0)                                         "
-                     "            (vadd                                               "
+                     "            (vaddVector128Double                                "
                      "                 (vloadi type=VectorDouble (aload parm=1))      "
                      "                 (vloadi type=VectorDouble (aload parm=2))))    "
                      "     (return)))                                                 ";
@@ -39,7 +39,7 @@ TEST_F(VectorTest, VDoubleAdd) {
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
-    //TODO: Re-enable this test on S390 after issue #1843 is resolved. 
+    //TODO: Re-enable this test on S390 after issue #1843 is resolved.
     SKIP_ON_S390(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_S390X(KnownBug) << "This test is currently disabled on Z platforms because not all Z platforms have vector support (issue #1843)";
     SKIP_ON_RISCV(MissingImplementation);
@@ -55,9 +55,9 @@ TEST_F(VectorTest, VDoubleAdd) {
     double inputA[] =  {1.0, 2.0};
     double inputB[] =  {1.0, 2.0};
 
-    entry_point(output,inputA,inputB); 
-    EXPECT_DOUBLE_EQ(inputA[0] + inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary? 
-    EXPECT_DOUBLE_EQ(inputA[1] + inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary? 
+    entry_point(output,inputA,inputB);
+    EXPECT_DOUBLE_EQ(inputA[0] + inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary?
+    EXPECT_DOUBLE_EQ(inputA[1] + inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary?
 }
 
 TEST_F(VectorTest, VInt8Add) {
@@ -66,7 +66,7 @@ TEST_F(VectorTest, VInt8Add) {
                      "  (block                                                        "
                      "     (vstorei type=VectorInt8 offset=0                          "
                      "         (aload parm=0)                                         "
-                     "            (vadd                                               "
+                     "            (vaddVector128Int8                                  "
                      "                 (vloadi type=VectorInt8 (aload parm=1))        "
                      "                 (vloadi type=VectorInt8 (aload parm=2))))      "
                      "     (return)))                                                 ";
@@ -104,7 +104,7 @@ TEST_F(VectorTest, VInt16Add) {
                      "  (block                                                        "
                      "     (vstorei type=VectorInt16 offset=0                         "
                      "         (aload parm=0)                                         "
-                     "            (vadd                                               "
+                     "            (vaddVector128Int16                                 "
                      "                 (vloadi type=VectorInt16 (aload parm=1))       "
                      "                 (vloadi type=VectorInt16 (aload parm=2))))     "
                      "     (return)))                                                 ";
@@ -142,7 +142,7 @@ TEST_F(VectorTest, VFloatAdd) {
                      "  (block                                                        "
                      "     (vstorei type=VectorFloat offset=0                         "
                      "         (aload parm=0)                                         "
-                     "            (vadd                                               "
+                     "            (vaddVector128Float                                 "
                      "                 (vloadi type=VectorFloat (aload parm=1))       "
                      "                 (vloadi type=VectorFloat (aload parm=2))))     "
                      "     (return)))                                                 ";
@@ -169,7 +169,7 @@ TEST_F(VectorTest, VFloatAdd) {
     entry_point(output,inputA,inputB);
 
     for (int i = 0; i < (sizeof(output) / sizeof(*output)); i++) {
-        EXPECT_FLOAT_EQ(inputA[i] + inputB[i], output[i]); // Epsilon = 4ULP -- is this necessary? 
+        EXPECT_FLOAT_EQ(inputA[i] + inputB[i], output[i]); // Epsilon = 4ULP -- is this necessary?
     }
 }
 


### PR DESCRIPTION
- introduce VectorOperations enum(vadd and vfma for now)
- the set of vector opcodes is a product of vector operations and vector types
- vector opcodes are generated at runtime and stored in IlOpCode class
- all OMR tables contain entries for vector operations following non-vector opcodes