### PR TITLE
AArch64: Add vector reverse elements instrucitons

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -888,6 +888,12 @@ static const char *opCodeToNameMap[] =
    "vabs2d",
    "vfabs4s",
    "vfabs2d",
+   "vrev16_16b",
+   "vrev32_16b",
+   "vrev32_8h",
+   "vrev64_16b",
+   "vrev64_8h",
+   "vrev64_4s",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -873,6 +873,12 @@
 		vabs2d,                                                  	/* 0x4EE0B800	ABS      	 */
 		vfabs4s,                                                 	/* 0x4EA0F800	FABS     	 */
 		vfabs2d,                                                 	/* 0x4EE0F800	FABS     	 */
+		vrev16_16b,                                              	/* 0x4E201800	REV16    	 */
+		vrev32_16b,                                              	/* 0x6E200800	REV32    	 */
+		vrev32_8h,                                               	/* 0x6E600800	REV32    	 */
+		vrev64_16b,                                              	/* 0x4E200800	REV64    	 */
+		vrev64_8h,                                               	/* 0x4E600800	REV64    	 */
+		vrev64_4s,                                               	/* 0x4EA00800	REV64    	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -874,6 +874,12 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4EE0B800,	/* ABS     	vabs2d   */
 		0x4EA0F800,	/* ABS     	vfabs4s  */
 		0x4EE0F800,	/* ABS     	vfabs2d  */
+		0x4E201800,	/* REV16   	vrev16_16b */
+		0x6E200800,	/* REV32   	vrev32_16b */
+		0x6E600800,	/* REV32   	vrev32_8h */
+		0x4E200800,	/* REV64   	vrev64_16b */
+		0x4E600800,	/* REV64   	vrev64_8h */
+		0x4EA00800,	/* REV64   	vrev64_4s */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -1074,3 +1074,30 @@ INSTANTIATE_TEST_CASE_P(VectorBitwise, ARM64Trg1Src2EncodingTest, ::testing::Val
     std::make_tuple(TR::InstOpCode::vbsl16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e6f1c00"),
     std::make_tuple(TR::InstOpCode::vbsl16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e7f1c00")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorRev, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vrev16_16b, TR::RealRegister::v15, TR::RealRegister::v0, "4e20180f"),
+    std::make_tuple(TR::InstOpCode::vrev16_16b, TR::RealRegister::v31, TR::RealRegister::v0, "4e20181f"),
+    std::make_tuple(TR::InstOpCode::vrev16_16b, TR::RealRegister::v0, TR::RealRegister::v15, "4e2019e0"),
+    std::make_tuple(TR::InstOpCode::vrev16_16b, TR::RealRegister::v0, TR::RealRegister::v31, "4e201be0"),
+    std::make_tuple(TR::InstOpCode::vrev32_16b, TR::RealRegister::v15, TR::RealRegister::v0, "6e20080f"),
+    std::make_tuple(TR::InstOpCode::vrev32_16b, TR::RealRegister::v31, TR::RealRegister::v0, "6e20081f"),
+    std::make_tuple(TR::InstOpCode::vrev32_16b, TR::RealRegister::v0, TR::RealRegister::v15, "6e2009e0"),
+    std::make_tuple(TR::InstOpCode::vrev32_16b, TR::RealRegister::v0, TR::RealRegister::v31, "6e200be0"),
+    std::make_tuple(TR::InstOpCode::vrev32_8h, TR::RealRegister::v15, TR::RealRegister::v0, "6e60080f"),
+    std::make_tuple(TR::InstOpCode::vrev32_8h, TR::RealRegister::v31, TR::RealRegister::v0, "6e60081f"),
+    std::make_tuple(TR::InstOpCode::vrev32_8h, TR::RealRegister::v0, TR::RealRegister::v15, "6e6009e0"),
+    std::make_tuple(TR::InstOpCode::vrev32_8h, TR::RealRegister::v0, TR::RealRegister::v31, "6e600be0"),
+    std::make_tuple(TR::InstOpCode::vrev64_16b, TR::RealRegister::v15, TR::RealRegister::v0, "4e20080f"),
+    std::make_tuple(TR::InstOpCode::vrev64_16b, TR::RealRegister::v31, TR::RealRegister::v0, "4e20081f"),
+    std::make_tuple(TR::InstOpCode::vrev64_16b, TR::RealRegister::v0, TR::RealRegister::v15, "4e2009e0"),
+    std::make_tuple(TR::InstOpCode::vrev64_16b, TR::RealRegister::v0, TR::RealRegister::v31, "4e200be0"),
+    std::make_tuple(TR::InstOpCode::vrev64_8h, TR::RealRegister::v15, TR::RealRegister::v0, "4e60080f"),
+    std::make_tuple(TR::InstOpCode::vrev64_8h, TR::RealRegister::v31, TR::RealRegister::v0, "4e60081f"),
+    std::make_tuple(TR::InstOpCode::vrev64_8h, TR::RealRegister::v0, TR::RealRegister::v15, "4e6009e0"),
+    std::make_tuple(TR::InstOpCode::vrev64_8h, TR::RealRegister::v0, TR::RealRegister::v31, "4e600be0"),
+    std::make_tuple(TR::InstOpCode::vrev64_4s, TR::RealRegister::v15, TR::RealRegister::v0, "4ea0080f"),
+    std::make_tuple(TR::InstOpCode::vrev64_4s, TR::RealRegister::v31, TR::RealRegister::v0, "4ea0081f"),
+    std::make_tuple(TR::InstOpCode::vrev64_4s, TR::RealRegister::v0, TR::RealRegister::v15, "4ea009e0"),
+    std::make_tuple(TR::InstOpCode::vrev64_4s, TR::RealRegister::v0, TR::RealRegister::v31, "4ea00be0")
+));


### PR DESCRIPTION
This commits adds vector reverse elements instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>