### PR TITLE
TLH Alignment for Spanning Sweep Chunks

### DIFF
--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2010, 2020 IBM Corp. and others
+Copyright (c) 2010, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1149,6 +1149,18 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
 		<data type="uintptr_t" name="succeeded" description="was the allocation successful TRUE/FALSE" />
 		<data type="uintptr_t" name="bytesRequested" description="bytes requested for the allocation" />
+	</event>
+
+	<event>
+		<name>J9HOOK_MM_PRIVATE_CONCURRENT_SATB_TOGGLED</name>
+		<description>
+			Triggered when the SATB barrier is enabled or disabled.
+		</description>
+		<struct>MM_ConcurrentSATBEvent</struct>
+		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
+		<data type="uint64_t" name="timestamp" description="time of event" />
+		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
+		<data type="bool" name="satbEnabled" description="True if SATB is active" />
 	</event>
 
 </interface>

--- a/gc/base/standard/ConcurrentGCSATB.hpp
+++ b/gc/base/standard/ConcurrentGCSATB.hpp
@@ -84,6 +84,8 @@ protected:
 		return env->acquireExclusiveVMAccessForGC(this, true, true);
 	}
 
+	void enableSATB(MM_EnvironmentBase *env);
+	void disableSATB(MM_EnvironmentBase *env);
 public:
 	virtual uintptr_t getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_CONCURRENTGC; };
 	static MM_ConcurrentGCSATB *newInstance(MM_EnvironmentBase *env);


### PR DESCRIPTION
Normally, a TLH can span multiple sweep chunks without any issues. However, a batch marked TLH (for SATB) is required to be contained within a single sweep chunk. Otherwise, this is problematic for sweep as sweep must determine the last obj in a chunk. With a batch marked TLH spanning multiple chunks, the TLH in the fist chunk will only be partially contained. As a result, all mark bits will be set to the end of the chunk resulting in the last live obj in chunk being undiscoverable. Hence, we must align the TLHs to sweep chunk boundaries when a pool freeEntry spans multiple chunks during TLH allocation.

To do so, we first determine the chunk boundaries containing the freeEntry baseAddr. If freeEntry topAddr is past the chunk top boundary
(the freeEntry spans multiple chunks) then we clip part of the freeEntry which overflows into next chunk.

Signed-off-by: Salman Rana <salman.rana@ibm.com>