### PR TITLE
Skip enum NumOMRTypes in for loop

### DIFF
--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -579,6 +579,10 @@ bool decodeConversionOpcode(TR::ILOpCode op, TR::DataType nodeDataType, TR::Data
       TR::ILOpCodes opValue = op.getOpCodeValue();
       for (int i = 0; i < TR::NumAllTypes; i++)
           {
+          if (TR::NumOMRTypes == i)
+             {
+             continue;
+             }
           sourceDataType = (TR::DataTypes)i;
           if (opValue == TR::ILOpCode::getProperConversion(sourceDataType, targetDataType, false /*!wantZeroExtension*/))
              {


### PR DESCRIPTION
  in the for loop when DataType greater than Aggregate and still no conversion found, this will avoid assertion failure in [OMRDataTypes](https://github.com/eclipse/omr/blob/master/compiler/il/OMRDataTypes.cpp#L155)

Signed-off-by: Tao Guan <james_mango@yahoo.com>