### PR TITLE
Jb2 fixes

### DIFF
--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -393,6 +393,7 @@ compileMethodFromDetails(
                   );
                }
 
+            TR_VerboseLog::write("\n");
             trfflush(jitConfig->options.vLogFile);
             }
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -1105,17 +1105,17 @@ namespace TR
        */
       Metric Read(void) const { return _reading; }
 
-      static char* Name(bool csv = false)
+      static const char* Name(bool csv = false)
          {
          if (csv)
-            return const_cast<char *>("Allocs");
+            return "Allocs";
          else
-            return const_cast<char *>("Memory Usage (bytes)");
+            return "Memory Usage (bytes)";
          }
 
-      static char *UnitsText(bool alternativeFormat = false /* ignored */)
+      static const char *UnitsText(bool alternativeFormat = false /* ignored */)
          {
-            return const_cast<char *>("allocated (% total)  freed (% total)  maxLive (% total)");
+            return "allocated (% total)  freed (% total)  maxLive (% total)";
          }
 
       static uint32_t sprintf_part(char *line, uint64_t bytes, uint64_t total)

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,8 +29,8 @@ namespace TR
    class IlBuilder : public OMR::IlBuilder
       {
       public:
-         IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-            : OMR::IlBuilder(methodBuilder, types)
+         IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, int32_t bcIndex=-1)
+            : OMR::IlBuilder(methodBuilder, types, bcIndex)
             { }
 
          IlBuilder(TR::IlBuilder *source)

--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,9 +39,8 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
                                       int32_t bcIndex,
                                       char *name,
                                       int32_t bcLength)
-   : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary()),
+   : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary(), bcIndex),
    _fallThroughBuilder(0),
-   _bcIndex(bcIndex),
    _name(name),
    _bcLength(bcLength),
    _initialVMState(0),
@@ -51,19 +50,6 @@ OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
    initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
               methodBuilder->fe(), methodBuilder->symRefTab());
    initSequence();
-   }
-
-/**
- * Call this function at the top of your bytecode iteration loop so that all services called
- * while this bytecode builder is being translated will mark their IL nodes as having this
- * BytecodeBuilder's _bcIndex (very handy when looking at compiler logs).
- * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
- *       BytecodeBuilder's SetCurrentIlGenerator() is called.
- */
-void
-OMR::BytecodeBuilder::SetCurrentIlGenerator()
-   {
-   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
    }
 
 void

--- a/compiler/ilgen/OMRBytecodeBuilder.hpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,15 +39,6 @@ public:
    BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL, int32_t bcLength=-1);
 
    virtual bool isBytecodeBuilder() { return true; }
-
-   /**
-    * @brief bytecode index for this builder object
-    */
-   int32_t bcIndex() { return _bcIndex; }
-   virtual int32_t currentByteCodeIndex() { return _bcIndex; } // override from IlGenerator
-
-   /* @brief after calling this, all IL nodes created will have this BytecodeBuilder's _bcIndex */
-   void SetCurrentIlGenerator();
 
    /* The name for this BytecodeBuilder. This can be very helpful for debug output */
    char *name() { return _name; }
@@ -125,7 +116,6 @@ public:
 protected:
    TR::BytecodeBuilder       * _fallThroughBuilder;
    List<TR::BytecodeBuilder> * _successorBuilders;
-   int32_t                     _bcIndex;
    char                      * _name;
    int32_t                     _bcLength;
    TR::VirtualMachineState   * _initialVMState;

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -98,7 +98,9 @@ OMR::IlBuilder::IlBuilder(TR::IlBuilder *source)
    _count(-1),
    _partOfSequence(false),
    _connectedTrees(false),
-   _comesBack(true)
+   _comesBack(true),
+   _isHandler(source->_isHandler),
+   _bcIndex(source->_bcIndex)
    {
    }
 
@@ -205,6 +207,26 @@ OMR::IlBuilder::printBlock(TR::Block *block)
       tt = tt->getNextTreeTop();
       }
    comp()->getDebug()->print(comp()->getOutFile(), tt);
+   }
+
+TR::IlBuilder *
+OMR::IlBuilder::setBCIndex(int32_t bcIndex)
+   {
+   _bcIndex = bcIndex;
+   return static_cast<TR::IlBuilder *>(this);
+   }
+
+/*
+ * Call this function before calling services on this builder so they will
+ * mark their IL nodes as having this builder's _bcIndex (very handy when
+ * looking at compiler logs and ultimate used to track program locations).
+ * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
+ *       builder's SetCurrentIlGenerator() is called.
+ */
+void
+OMR::IlBuilder::SetCurrentIlGenerator()
+   {
+   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
    }
 
 TR::SymbolReference *

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corp. and others
+ * Copyright (c) 2016, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,7 +169,7 @@ public:
 
    friend class OMR::MethodBuilder;
 
-   IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
+   IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, int32_t bcIndex=-1)
       : TR::IlInjector(types),
       _client(0),
       _clientCallbackBuildIL(0),
@@ -182,7 +182,8 @@ public:
       _partOfSequence(false),
       _connectedTrees(false),
       _comesBack(true),
-      _isHandler(false)
+      _isHandler(false),
+      _bcIndex(bcIndex)
       {
       }
    IlBuilder(TR::IlBuilder *source);
@@ -203,6 +204,16 @@ public:
    virtual void setVMState(TR::VirtualMachineState *vmState) { }
 
    //char *getName();
+
+   /**
+    * @brief bytecode index for this builder object
+    */
+   int32_t bcIndex() { return _bcIndex; }
+   TR::IlBuilder * setBCIndex(int32_t bcIndex);
+   virtual int32_t currentByteCodeIndex() { return _bcIndex; } // override from IlGenerator
+
+   /* @brief after calling this, all IL nodes created will have this BytecodeBuilder's _bcIndex */
+   void SetCurrentIlGenerator();
 
    void print(const char *title, bool recurse=false);
    void printBlock(TR::Block *block);
@@ -724,6 +735,8 @@ protected:
     * @brief returns true if this IlBuilder object is a handler for an exception edge
     */
    bool                          _isHandler;
+
+   int32_t                       _bcIndex;
 
    virtual bool buildIL()
       {

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -223,15 +223,15 @@ OMR::StructType::AddField(const char *name, TR::IlType *typeInfo, size_t offset)
    if (_closed)
       return;
 
-   TR_ASSERT_FATAL(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
-
    OMR::FieldInfo *fieldInfo = new (PERSISTENT_NEW) OMR::FieldInfo(name, offset, typeInfo);
    if (0 != _lastField)
       _lastField->setNext(fieldInfo);
    else
       _firstField = fieldInfo;
    _lastField = fieldInfo;
-   _size = offset + typeInfo->getSize();
+   size_t newSize = offset + typeInfo->getSize();
+   if (newSize > _size)
+      _size = newSize;
    }
 
 void

--- a/fvtest/compilertest/ilgen/IlBuilder.hpp
+++ b/fvtest/compilertest/ilgen/IlBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,16 +29,16 @@ namespace TR
    class IlBuilder : public TestCompiler::IlBuilder
       {
       public:
-         IlBuilder(TR::MethodBuilder *methodBuilder, TypeDictionary *types)
-            : TestCompiler::IlBuilder(methodBuilder, types)
+         IlBuilder(TR::MethodBuilder *methodBuilder, TypeDictionary *types, int32_t bcIndex=-1)
+            : TestCompiler::IlBuilder(methodBuilder, types, bcIndex)
             { }
 
          IlBuilder(TR::IlBuilder *source)
             : TestCompiler::IlBuilder(source)
             { }
 
-         IlBuilder(TestCompiler::TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-            : TestCompiler::IlBuilder(test, methodBuilder, types)
+         IlBuilder(TestCompiler::TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, int32_t bcIndex=-1)
+            : TestCompiler::IlBuilder(test, methodBuilder, types, bcIndex)
             { }
       };
 

--- a/fvtest/compilertest/ilgen/TestIlBuilder.hpp
+++ b/fvtest/compilertest/ilgen/TestIlBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,16 +34,16 @@ class IlBuilder : public OMR::IlBuilder
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
-   IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-      : OMR::IlBuilder(methodBuilder, types)
+   IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, int32_t bcIndex)
+      : OMR::IlBuilder(methodBuilder, types, bcIndex)
       { }
 
    IlBuilder(TR::IlBuilder *source)
       : OMR::IlBuilder(source)
       { }
 
-   IlBuilder(TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-      : OMR::IlBuilder(methodBuilder, types)
+   IlBuilder(TestDriver *test, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, int32_t bcIndex)
+      : OMR::IlBuilder(methodBuilder, types, bcIndex)
       {
       // need to explicitly initialize TestCompiler::IlInjector layer because
       // it's hiding behind our OMR::IlBuilder base class

--- a/jitbuilder/compile/ResolvedMethod.cpp
+++ b/jitbuilder/compile/ResolvedMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corp. and others
+ * Copyright (c) 2014, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,7 @@ JitBuilder::ResolvedMethod::ResolvedMethod(TR_OpaqueMethodBlock *method)
    _signature = resolvedMethod->getSignature();
    _externalName = 0;
    _entryPoint = resolvedMethod->getEntryPoint();
-   strncpy(_signatureChars, resolvedMethod->signatureChars(), 62); // TODO: introduce concept of robustness
+   strncpy(_signatureChars, resolvedMethod->signatureChars(), MAX_SIGNATURE_LENGTH); // TODO: introduce concept of robustness
    }
 
 JitBuilder::ResolvedMethod::ResolvedMethod(TR::MethodBuilder *m)
@@ -119,7 +119,7 @@ JitBuilder::ResolvedMethod::computeSignatureChars()
       len += static_cast<uint32_t>(strlen(type->getSignatureName()));
       }
    len += static_cast<uint32_t>(strlen(_returnType->getSignatureName()));
-   TR_ASSERT(len < 64, "signature array may not be large enough"); // TODO: robustness
+   TR_ASSERT(len < MAX_SIGNATURE_LENGTH, "signature array may not be large enough"); // TODO: robustness
 
    int32_t s = 0;
    _signatureChars[s++] = '(';
@@ -127,13 +127,13 @@ JitBuilder::ResolvedMethod::computeSignatureChars()
       {
       name = _parmTypes[p]->getSignatureName();
       len = static_cast<uint32_t>(strlen(name));
-      strncpy(_signatureChars+s, name, len);
+      strncpy(_signatureChars+s, name, MAX_SIGNATURE_LENGTH-s);
       s += len;
       }
    _signatureChars[s++] = ')';
    name = _returnType->getSignatureName();
    len = static_cast<uint32_t>(strlen(name));
-   strncpy(_signatureChars+s, name, len);
+   strncpy(_signatureChars+s, name, MAX_SIGNATURE_LENGTH-s);
    s += len;
    _signatureChars[s++] = 0;
    }

--- a/jitbuilder/compile/ResolvedMethod.hpp
+++ b/jitbuilder/compile/ResolvedMethod.hpp
@@ -83,6 +83,8 @@ class ResolvedMethodBase : public TR_ResolvedMethod
       }
    };
 
+const int16_t MAX_SIGNATURE_LENGTH=128;
+
 class ResolvedMethod : public ResolvedMethodBase, public Method
    {
    public:
@@ -159,7 +161,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
 
    char *_name;
    char *_signature;
-   char  _signatureChars[64];
+   char  _signatureChars[MAX_SIGNATURE_LENGTH];
    char *_externalName;
 
    int32_t          _numParms;


### PR DESCRIPTION
Collection of improvements for JitBuilder.

Some are required (to fix warnings that break JitBuilder on newer compilers).

Some are useful for JitBuilder as it is (adding a newline so that verbose compile output isn't all displayed on a single line, improve the handling of Sub operations that involve an Address and and a Word).

Some facilitate JitBuilder 2.0 design (improve location tracking by bringing a bcIndex field to every IlBuilder object, allow structs to define fields that aren't only at the end of the struct).

JitBuilder 2.0 currently depends on all of these changes.