### PR TITLE
AArch64: Use MOVI for broadcasting immediate value into vector registers

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1384,7 +1384,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1ImmInstruction *instr)
          {
          if ((imm8 & (1 << i)) != 0)
             {
-            imm |= 0xff << (i * 8);
+            imm |= static_cast<uint64_t>(0xff) << (i * 8);
             }
          }
       trfprintf(pOutFile, ", 0x%08llx", imm);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -687,6 +687,19 @@ public:
       {
       // do nothing
       }
+
+   /**
+    * @brief Helper for generating SIMD move immediate instruction for vsplats node.
+    *
+    * @param[in] node: node
+    * @param[in] cg: CodeGenerator
+    * @param[in] firstChild: first child node
+    * @param[in] elementType: element type of the vector
+    * @param[in] treg: target register
+    *
+    * @return instruction cursor if move instuction is successfully generated and otherwise returns NULL
+    */
+   static TR::Instruction *vsplatsImmediateHelper(TR::Node *node, TR::CodeGenerator *cg, TR::Node *firstChild, TR::DataType elementType, TR::Register *treg);
    };
 
 } // ARM64


### PR DESCRIPTION
Use MOVI and MVNI instructions for broadcasting immediate value
into vector registers.
Fix ARM64Debug.cpp to correctly print 64-bit constant value for `vmovi2d` instruction.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>