### PR TITLE
Add genLoadProfiledClassAddressConstant helper in Z codegen

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -2223,6 +2223,16 @@ genLoadAddressConstantInSnippet(TR::CodeGenerator * cg, TR::Node * node, uintptr
    return generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister, value, cond, NULL, base, isPICCandidate);
    }
 
+TR::Instruction *
+genLoadProfiledClassAddressConstant(TR::CodeGenerator * cg, TR::Node * node, TR_OpaqueClassBlock * clazz, TR::Register * targetRegister,
+   TR::Instruction * cursor, TR::RegisterDependencyConditions * cond, TR::Register * base)
+   {
+   uintptr_t value = reinterpret_cast<uintptr_t>(clazz);
+   TR::Node * dummy_node = TR::Node::aconst(node, value);
+   dummy_node->setIsClassPointerConstant(true);
+   return genLoadAddressConstant(cg, dummy_node, value, targetRegister, cursor, cond, base);
+   }
+
 static TR::Register *
 generateLoad32BitConstant(TR::CodeGenerator * cg, TR::Node * constExpr)
    {

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -127,6 +127,7 @@ TR::Instruction* generateLoad32BitConstant(TR::CodeGenerator* cg, TR::Node* node
 TR::Instruction * genLoadLongConstant(TR::CodeGenerator *cg, TR::Node *node, int64_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
 TR::Instruction * genLoadAddressConstant(TR::CodeGenerator *cg, TR::Node *node, uintptr_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
 TR::Instruction * genLoadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, uintptr_t value, TR::Register *targetRegister, TR::Instruction *cursor=NULL,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0, bool isPICCandidate=false);
+TR::Instruction * genLoadProfiledClassAddressConstant(TR::CodeGenerator *cg, TR::Node *node, TR_OpaqueClassBlock *clazz, TR::Register *targetRegister, TR::Instruction *cursor = 0,TR::RegisterDependencyConditions *cond = 0, TR::Register *base = 0);
 
 TR::MemoryReference * sstoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed=false);
 TR::MemoryReference * istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed=false);


### PR DESCRIPTION
`genLoadAddressConstant` only adds instructions from `aconst` and `aloadi` nodes to the `staticPICSites` lists. Profiled class address constants are not found in `aconst` or `aloadi` nodes, but need to be treated as `aconst` nodes. This commit adds the `genLoadProfiledClassAddressConstant` helper to wrap the class address constant value in a dummy `aconst` node before passing it to genLoadAddressConstant.

See the [OpenJ9 PR](https://github.com/eclipse-openj9/openj9/pull/14932) for where this is used

[Related OpenJ9 issue](https://github.com/eclipse-openj9/openj9/issues/14775)