### PR TITLE
Remove the --gtest_filter=${porttest_filter} option for porttest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,24 @@
+###############################################################################
+# Copyright (c) 2020, 2022 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
 trigger:
   - master
 pr:
@@ -116,6 +137,7 @@ jobs:
       vmImage: 'ubuntu-18.04'
     variables:
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
+      GTEST_FILTER: -*dump_test_create_dump_*
     steps:
       - script: |
           sudo apt-get install -y ccache libelf-dev libdwarf-dev

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,13 +165,13 @@ endif()
 if (NOT (OMR_OS_AIX OR OMR_OS_ZOS OR CMAKE_CROSSCOMPILING))
 	omr_add_test(
 		NAME porttest
-		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter=${porttest_filter}
+		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml
 	)
 endif()
 
 if(OMR_OPT_CUDA)
 	omr_add_test(
 		NAME cuda_porttest
-		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter="Cuda*" -earlyExit
+		COMMAND $<TARGET_FILE:omrporttest> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter=*Cuda* -earlyExit
 	)
 endif()


### PR DESCRIPTION
1. Remove the `--gtest_filter=${porttest_filter}` option for porttest

    When `${porttest_filter}` is an empty string, no tests from `porttest` are
run. `${porttest_filter}` is never set in OMR so it will always be an
empty string. Also, `--gtest_filter=${porttest_filter}` conflicts with
the `GTEST_FILTER` environment variable used by `omrbuild.groovy`. To avoid
the conflict and correctly run `porttest`, the `--gtest_filter=${porttest_filter}`
option is removed. `porttest` should consistently rely upon the `GTEST_FILTER`
environment variable.

   Changed `--gtest_filter="Cuda*"` to `--gtest_filter=*Cuda*`. 0 tests are run.
This allows `cuda_porttest` to work correctly.

2. Disable `*_create_dump_*` tests for the "x86-64 Linux" job in Azure

    These tests are disabled because core files cannot be generated on Linux
in the Azure pipeline.

Fixes: https://github.com/eclipse/omr/issues/6486

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>