### PR TITLE
AArch64: Add SIMD copy instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -890,12 +890,6 @@ static const char *opCodeToNameMap[] =
    "vfneg4s",
    "vfneg2d",
    "vnot16b",
-   "vdup16b",
-   "vdup8h",
-   "vdup4s",
-   "vdup2d",
-   "vfdup4s",
-   "vfdup2d",
    "vfsqrt4s",
    "vfsqrt2d",
    "vabs16b",
@@ -910,6 +904,31 @@ static const char *opCodeToNameMap[] =
    "vrev64_16b",
    "vrev64_8h",
    "vrev64_4s",
+   "vdup16b",
+   "vdup8h",
+   "vdup4s",
+   "vdup2d",
+   "vdupe16b",
+   "vdupe8h",
+   "vdupe4s",
+   "vdupe2d",
+   "smovwb",
+   "smovwh",
+   "smovxb",
+   "smovxh",
+   "smovxs",
+   "umovwb",
+   "umovwh",
+   "umovws",
+   "umovxd",
+   "vinsb",
+   "vinsh",
+   "vinss",
+   "vinsd",
+   "vinseb",
+   "vinseh",
+   "vinses",
+   "vinsed",
    "vumlal_8h",
    "vumlal_4s",
    "vumlal_2d",
@@ -1761,6 +1780,49 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
       print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
       print(pOutFile, instr->getSource1Register(), TR_WordReg);
       trfprintf(pOutFile, ", %d", shiftAmount);
+      }
+   else if ((op >= TR::InstOpCode::vdupe16b) && (op <= TR::InstOpCode::umovxd))
+      {
+      done = true;
+      const uint32_t elementSizeShift = (op <= TR::InstOpCode::vdupe2d) ? (op - TR::InstOpCode::vdupe16b) :
+                                        ((op <= TR::InstOpCode::smovwh) ? (op - TR::InstOpCode::smovwb) :
+                                        ((op <= TR::InstOpCode::smovxh) ? (op - TR::InstOpCode::smovxb) : (op - TR::InstOpCode::umovwb)));
+
+      const uint32_t imm5 = instr->getSourceImmediate() & 0x1f;
+      const uint32_t index = imm5 >> (elementSizeShift + 1);
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ".[%d]", index);
+      }
+   else if ((op >= TR::InstOpCode::vinswb) && (op <= TR::InstOpCode::vinsxd))
+      {
+      done = true;
+      const uint32_t elementSizeShift = op - TR::InstOpCode::vinswb;
+      const uint32_t imm5 = instr->getSourceImmediate() & 0x1f;
+      const uint32_t index = imm5 >> (elementSizeShift + 1);
+
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+      trfprintf(pOutFile, ".[%d]", index);
+      trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      }
+   else if ((op >= TR::InstOpCode::vinseb) && (op <= TR::InstOpCode::vinsed))
+      {
+      done = true;
+      const uint32_t elementSizeShift = op - TR::InstOpCode::vinseb;
+      const uint32_t imm5 = (instr->getSourceImmediate() >> 5) & 0x1f;
+      const uint32_t imm4 = instr->getSourceImmediate() & 0xf;
+      const uint32_t dstIndex = imm5 >> (elementSizeShift + 1);
+      const uint32_t srcIndex = imm4 >> elementSizeShift;
+
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+      trfprintf(pOutFile, ".[%d]", dstIndex);
+      trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSource1Register(), TR_WordReg);
+      trfprintf(pOutFile, ".[%d]", srcIndex);
       }
 
    if (!done)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2322,6 +2322,14 @@ class ARM64Trg1Src1ImmInstruction : public ARM64Trg1Src1Instruction
          {
          *instruction |= ((_source1Immediate & 0x7f) << 16); /* immh:immb */
          }
+      else if ((op >= TR::InstOpCode::vdupe16b) && (op <= TR::InstOpCode::vinsxd))
+         {
+         *instruction |= ((_source1Immediate & 0x1f) << 16); /* imm5 */
+         }
+      else if ((op >= TR::InstOpCode::vinseb) && (op <= TR::InstOpCode::vinsed))
+         {
+         *instruction |= ((_source1Immediate & 0x3ff) << 11); /* imm5 and imm4 */
+         }
       else
          {
          *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1111,7 +1111,7 @@ TR::Instruction *generateUBFIZInstruction(
  * @param[in] treg        : target register
  * @param[in] sreg        : source register
  * @param[in] shiftAmount : shift amount
- * @param[in] preced  : preceding instruction
+ * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
 TR::Instruction *generateVectorShiftImmediateInstruction(
@@ -1121,6 +1121,93 @@ TR::Instruction *generateVectorShiftImmediateInstruction(
                   TR::Register *treg,
                   TR::Register *sreg,
                   uint32_t shiftAmount,
+                  TR::Instruction *preced = NULL);
+
+/**
+ * @brief Generates duplicate vector element instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] op          : opcode
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] srcIndex    : source element index
+ * @param[in] preced      : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateVectorDupElementInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t srcIndex,
+                  TR::Instruction *preced = NULL);
+
+/**
+ * @brief Generates signed or unsigned move vector element to general purpose register instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] op          : opcode
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] srcIndex    : source element index
+ * @param[in] preced      : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMovVectorElementToGPRInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t srcIndex,
+                  TR::Instruction *preced = NULL);
+
+/**
+ * @brief Generates move general purpose register to vector element instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] op          : opcode
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] trgIndex    : target element index
+ * @param[in] preced      : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMovGPRToVectorElementInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t trgIndex,
+                  TR::Instruction *preced = NULL);
+
+
+/**
+ * @brief Generates move vector element instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] op          : opcode
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] trgIndex    : target element index
+ * @param[in] srcIndex    : source element index
+ * @param[in] preced      : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMovVectorElementInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  uint32_t trgIndex,
+                  uint32_t srcIndex,
                   TR::Instruction *preced = NULL);
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -875,12 +875,6 @@
 		vfneg4s,                                                  	/* 0x6EA0F800	FNEG      	 */
 		vfneg2d,                                                  	/* 0x6EE0F800	FNEG      	 */
 		vnot16b,                                                  	/* 0x6E205800	NOT      	 */
-		vdup16b,                                               		/* 0x4E010C00	DUP      	 */
-		vdup8h,                                                  	/* 0x4E020C00	DUP      	 */
-		vdup4s,                                               		/* 0x4E040C00	DUP      	 */
-		vdup2d,                                               		/* 0x4E080C00	DUP      	 */
-		vfdup4s,                                                  	/* 0x4E040400	DUP      	 */
-		vfdup2d,                                                  	/* 0x4E080400	DUP      	 */
 		vfsqrt4s,                                                	/* 0x6EA1F800	FSQRT    	 */
 		vfsqrt2d,                                                	/* 0x6EE1F800	FSQRT    	 */
 		vabs16b,                                                 	/* 0x4E20B800	ABS      	 */
@@ -895,6 +889,38 @@
 		vrev64_16b,                                              	/* 0x4E200800	REV64    	 */
 		vrev64_8h,                                               	/* 0x4E600800	REV64    	 */
 		vrev64_4s,                                               	/* 0x4EA00800	REV64    	 */
+	/* Vector Copy */
+		/* DUP (general) */
+		vdup16b,                                               		/* 0x4E010C00	DUP      	 */
+		vdup8h,                                                  	/* 0x4E020C00	DUP      	 */
+		vdup4s,                                               		/* 0x4E040C00	DUP      	 */
+		vdup2d,                                               		/* 0x4E080C00	DUP      	 */
+		/* DUP (element) */
+		vdupe16b,                                                	/* 0x4E010400	DUP      	 */
+		vdupe8h,                                                 	/* 0x4E020400	DUP      	 */
+		vdupe4s,                                                 	/* 0x4E040400	DUP      	 */
+		vdupe2d,                                                 	/* 0x4E080400	DUP      	 */
+		/* SMOV */
+		smovwb,                                                  	/* 0x0E012C00	SMOV     	 */
+		smovwh,                                                  	/* 0x0E022C00	SMOV     	 */
+		smovxb,                                                  	/* 0x4E012C00	SMOV     	 */
+		smovxh,                                                  	/* 0x4E022C00	SMOV     	 */
+		smovxs,                                                  	/* 0x4E042C00	SMOV     	 */
+		/* UMOV */
+		umovwb,                                                  	/* 0x0E013C00	UMOV     	 */
+		umovwh,                                                  	/* 0x0E023C00	UMOV     	 */
+		umovws,                                                  	/* 0x0E043C00	UMOV     	 */
+		umovxd,                                                  	/* 0x4E083C00	UMOV     	 */
+		/* INS (general) */
+		vinswb,                                                   	/* 0x4E011C00	INS      	 */
+		vinswh,                                                   	/* 0x4E021C00	INS      	 */
+		vinsws,                                                   	/* 0x4E041C00	INS      	 */
+		vinsxd,                                                   	/* 0x4E081C00	INS      	 */
+		/* INS (element) */
+		vinseb,                                                  	/* 0x6E010400	INS      	 */
+		vinseh,                                                  	/* 0x6E020400	INS      	 */
+		vinses,                                                  	/* 0x6E040400	INS      	 */
+		vinsed,                                                  	/* 0x6E080400	INS      	 */
 	/* Vector widening and narrowing arithmetics */
 		vumlal_8h,                                               	/* 0x2E208000	UMLAL    	 */
 		vumlal_4s,                                               	/* 0x2E608000	UMLAL    	 */

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1472,11 +1472,11 @@ OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *c
             break;
          case TR::Float:
             TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
-            op = TR::InstOpCode::vfdup4s;
+            op = TR::InstOpCode::vdupe4s;
             break;
          case TR::Double:
             TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
-            op = TR::InstOpCode::vfdup2d;
+            op = TR::InstOpCode::vdupe2d;
             break;
          default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -876,12 +876,6 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6EA0F800,	/* FNEG      	vfneg4s	 */
 		0x6EE0F800,	/* FNEG      	vfneg2d	 */
 		0x6E205800,	/* NOT      	vnot16b	 */
-		0x4E010C00,	/* DUP      	vdup16b  */
-		0x4E020C00,	/* DUP      	vdup8h   */
-		0x4E040C00,	/* DUP      	vdup4s   */
-		0x4E080C00,	/* DUP      	vdup2d   */
-		0x4E040400,	/* DUP      	vfdup4s  */
-		0x4E080400,	/* DUP      	vfdup2d  */
 		0x6EA1F800,	/* FSQRT   	vfsqrt4s */
 		0x6EE1F800,	/* FSQRT   	vfsqrt2d */
 		0x4E20B800,	/* ABS     	vabs16b  */
@@ -896,6 +890,38 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E200800,	/* REV64   	vrev64_16b */
 		0x4E600800,	/* REV64   	vrev64_8h */
 		0x4EA00800,	/* REV64   	vrev64_4s */
+	/* Vector Copy */
+		/* DUP (general) */
+		0x4E010C00,	/* DUP   	vdup16b */
+		0x4E020C00,	/* DUP   	vdup8h */
+		0x4E040C00,	/* DUP   	vdup4s */
+		0x4E080C00,	/* DUP   	vdup2d */
+		/* DUP (element) */
+		0x4E010400,	/* DUP   	vdupe16b */
+		0x4E020400,	/* DUP   	vdupe8h */
+		0x4E040400,	/* DUP   	vdupe4s */
+		0x4E080400,	/* DUP   	vdupe2d */
+		/* SMOV */
+		0x0E012C00,	/* SMOV  	smovwb */
+		0x0E022C00,	/* SMOV  	smovwh */
+		0x4E012C00,	/* SMOV  	smovxb */
+		0x4E022C00,	/* SMOV  	smovxh */
+		0x4E042C00,	/* SMOV  	smovxs */
+		/* UMOV */
+		0x0E013C00,	/* UMOV  	umovwb */
+		0x0E023C00,	/* UMOV  	umovwh */
+		0x0E043C00,	/* UMOV  	umovws */
+		0x4E083C00,	/* UMOV  	umovxd */
+		/* INS (general) */
+		0x4E011C00,	/* INS  	vinswb  */
+		0x4E021C00,	/* INS  	vinswh  */
+		0x4E041C00,	/* INS  	vinsws  */
+		0x4E081C00,	/* INS  	vinsxd  */
+		/* INS (element) */
+		0x6E010400,	/* INS  	vinseb  */
+		0x6E020400,	/* INS  	vinseh  */
+		0x6E040400,	/* INS  	vinses  */
+		0x6E080400,	/* INS  	vinsed  */
 	/* Vector widening and narrowing arithmetics */
 		0x2E208000,	/* UMLAL   	vumlal_8h */
 		0x2E608000,	/* UMLAL   	vumlal_4s */

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -121,6 +121,59 @@ TEST_P(ARM64VectorSplatsImmediateEncodingTest, encode) {
     }
 }
 
+class ARM64VectorDupElementEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64VectorDupElementEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto srcIndex = std::get<3>(GetParam());
+
+    auto instr = generateVectorDupElementInstruction(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
+
+    ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
+}
+
+class ARM64MovVectorElementToGPREncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64MovVectorElementToGPREncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto srcIndex = std::get<3>(GetParam());
+
+    auto instr = generateMovVectorElementToGPRInstruction(cg(), op, fakeNode, trgReg, srcReg, srcIndex);
+
+    ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
+}
+
+class ARM64MovGPRToVectorElementEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64MovGPRToVectorElementEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto trgIndex = std::get<3>(GetParam());
+
+    auto instr = generateMovGPRToVectorElementInstruction(cg(), op, fakeNode, trgReg, srcReg, trgIndex);
+
+    ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
+}
+
+class ARM64MovVectorElementEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64MovVectorElementEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto trgIndex = std::get<3>(GetParam());
+    auto srcIndex = std::get<4>(GetParam());
+
+    auto instr = generateMovVectorElementInstruction(cg(), op, fakeNode, trgReg, srcReg, trgIndex, srcIndex);
+
+    ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
+}
+
 INSTANTIATE_TEST_CASE_P(MOV, ARM64Trg1ImmEncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0, "d2800003"),
     std::make_tuple(TR::InstOpCode::movzx,  TR::RealRegister::x3, 0xffff, "d29fffe3"),
@@ -1482,4 +1535,269 @@ INSTANTIATE_TEST_CASE_P(VectorSplatsImm4, ARM64VectorSplatsImmediateEncodingTest
     std::make_tuple(TR::InstOpCode::bad,  TR::RealRegister::v0, TR::Int64,           0x55000000000000LL, ""),
     std::make_tuple(TR::InstOpCode::bad,  TR::RealRegister::v0, TR::Int64,          0x1ff000000000000LL, ""),
     std::make_tuple(TR::InstOpCode::bad,  TR::RealRegister::v0, TR::Int64,         0x5500000000000000LL, "")
+));
+
+INSTANTIATE_TEST_CASE_P(DUP, ARM64VectorDupElementEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v15, 0, "4e0105e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4e0305e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v15, 15, "4e1f05e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v31, 0, "4e0107e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4e0307e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v0, TR::RealRegister::v31, 15, "4e1f07e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v15, 0, "4e0205e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4e0605e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v15, 7, "4e1e05e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v31, 0, "4e0207e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4e0607e0"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v0, TR::RealRegister::v31, 7, "4e1e07e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v15, 0, "4e0405e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4e0c05e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v15, 3, "4e1c05e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v31, 0, "4e0407e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4e0c07e0"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v0, TR::RealRegister::v31, 3, "4e1c07e0"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v0, TR::RealRegister::v15, 0, "4e0805e0"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v0, TR::RealRegister::v15, 1, "4e1805e0"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v0, TR::RealRegister::v31, 0, "4e0807e0"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4e1807e0"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v15, TR::RealRegister::v0, 0, "4e01040f"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4e03040f"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v15, TR::RealRegister::v0, 15, "4e1f040f"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v31, TR::RealRegister::v0, 0, "4e01041f"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4e03041f"),
+    std::make_tuple(TR::InstOpCode::vdupe16b, TR::RealRegister::v31, TR::RealRegister::v0, 15, "4e1f041f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v15, TR::RealRegister::v0, 0, "4e02040f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4e06040f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v15, TR::RealRegister::v0, 7, "4e1e040f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v31, TR::RealRegister::v0, 0, "4e02041f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4e06041f"),
+    std::make_tuple(TR::InstOpCode::vdupe8h, TR::RealRegister::v31, TR::RealRegister::v0, 7, "4e1e041f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v15, TR::RealRegister::v0, 0, "4e04040f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4e0c040f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v15, TR::RealRegister::v0, 3, "4e1c040f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v31, TR::RealRegister::v0, 0, "4e04041f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4e0c041f"),
+    std::make_tuple(TR::InstOpCode::vdupe4s, TR::RealRegister::v31, TR::RealRegister::v0, 3, "4e1c041f"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v15, TR::RealRegister::v0, 0, "4e08040f"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v15, TR::RealRegister::v0, 1, "4e18040f"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v31, TR::RealRegister::v0, 0, "4e08041f"),
+    std::make_tuple(TR::InstOpCode::vdupe2d, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4e18041f")
+));
+
+INSTANTIATE_TEST_CASE_P(SMOV1, ARM64MovVectorElementToGPREncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v15, 0, "0e012de0"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v15, 1, "0e032de0"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v15, 15, "0e1f2de0"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v31, 0, "0e012fe0"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v31, 1, "0e032fe0"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x0, TR::RealRegister::v31, 15, "0e1f2fe0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v15, 0, "0e022de0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v15, 1, "0e062de0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v15, 7, "0e1e2de0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v31, 0, "0e022fe0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v31, 1, "0e062fe0"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x0, TR::RealRegister::v31, 7, "0e1e2fe0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v15, 0, "4e012de0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v15, 1, "4e032de0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v15, 15, "4e1f2de0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v31, 0, "4e012fe0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v31, 1, "4e032fe0"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x0, TR::RealRegister::v31, 15, "4e1f2fe0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v15, 0, "4e022de0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v15, 1, "4e062de0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v15, 7, "4e1e2de0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v31, 0, "4e022fe0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v31, 1, "4e062fe0"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x0, TR::RealRegister::v31, 7, "4e1e2fe0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v15, 0, "4e042de0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v15, 1, "4e0c2de0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v15, 3, "4e1c2de0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v31, 0, "4e042fe0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v31, 1, "4e0c2fe0"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x0, TR::RealRegister::v31, 3, "4e1c2fe0")
+));
+
+INSTANTIATE_TEST_CASE_P(SMOV2, ARM64MovVectorElementToGPREncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x3, TR::RealRegister::v0, 0, "0e012c03"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x3, TR::RealRegister::v0, 1, "0e032c03"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x3, TR::RealRegister::v0, 15, "0e1f2c03"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x28, TR::RealRegister::v0, 0, "0e012c1c"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x28, TR::RealRegister::v0, 1, "0e032c1c"),
+    std::make_tuple(TR::InstOpCode::smovwb, TR::RealRegister::x28, TR::RealRegister::v0, 15, "0e1f2c1c"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x3, TR::RealRegister::v0, 0, "0e022c03"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x3, TR::RealRegister::v0, 1, "0e062c03"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x3, TR::RealRegister::v0, 7, "0e1e2c03"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x28, TR::RealRegister::v0, 0, "0e022c1c"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x28, TR::RealRegister::v0, 1, "0e062c1c"),
+    std::make_tuple(TR::InstOpCode::smovwh, TR::RealRegister::x28, TR::RealRegister::v0, 7, "0e1e2c1c"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x3, TR::RealRegister::v0, 0, "4e012c03"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x3, TR::RealRegister::v0, 1, "4e032c03"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x3, TR::RealRegister::v0, 15, "4e1f2c03"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x15, TR::RealRegister::v0, 0, "4e012c0f"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x15, TR::RealRegister::v0, 1, "4e032c0f"),
+    std::make_tuple(TR::InstOpCode::smovxb, TR::RealRegister::x15, TR::RealRegister::v0, 15, "4e1f2c0f"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x3, TR::RealRegister::v0, 0, "4e022c03"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x3, TR::RealRegister::v0, 1, "4e062c03"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x3, TR::RealRegister::v0, 7, "4e1e2c03"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x15, TR::RealRegister::v0, 0, "4e022c0f"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x15, TR::RealRegister::v0, 1, "4e062c0f"),
+    std::make_tuple(TR::InstOpCode::smovxh, TR::RealRegister::x15, TR::RealRegister::v0, 7, "4e1e2c0f"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x3, TR::RealRegister::v0, 0, "4e042c03"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x3, TR::RealRegister::v0, 1, "4e0c2c03"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x3, TR::RealRegister::v0, 3, "4e1c2c03"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x15, TR::RealRegister::v0, 0, "4e042c0f"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x15, TR::RealRegister::v0, 1, "4e0c2c0f"),
+    std::make_tuple(TR::InstOpCode::smovxs, TR::RealRegister::x15, TR::RealRegister::v0, 3, "4e1c2c0f")
+));
+
+INSTANTIATE_TEST_CASE_P(UMOV, ARM64MovVectorElementToGPREncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v15, 0, "0e013de0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v15, 1, "0e033de0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v15, 15, "0e1f3de0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v31, 0, "0e013fe0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v31, 1, "0e033fe0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x0, TR::RealRegister::v31, 15, "0e1f3fe0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v15, 0, "0e023de0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v15, 1, "0e063de0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v15, 7, "0e1e3de0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v31, 0, "0e023fe0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v31, 1, "0e063fe0"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x0, TR::RealRegister::v31, 7, "0e1e3fe0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v15, 0, "0e043de0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v15, 1, "0e0c3de0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v15, 3, "0e1c3de0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v31, 0, "0e043fe0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v31, 1, "0e0c3fe0"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x0, TR::RealRegister::v31, 3, "0e1c3fe0"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x0, TR::RealRegister::v15, 0, "4e083de0"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x0, TR::RealRegister::v15, 1, "4e183de0"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x0, TR::RealRegister::v31, 0, "4e083fe0"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x0, TR::RealRegister::v31, 1, "4e183fe0"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x3, TR::RealRegister::v0, 0, "0e013c03"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x3, TR::RealRegister::v0, 1, "0e033c03"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x3, TR::RealRegister::v0, 15, "0e1f3c03"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x28, TR::RealRegister::v0, 0, "0e013c1c"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x28, TR::RealRegister::v0, 1, "0e033c1c"),
+    std::make_tuple(TR::InstOpCode::umovwb, TR::RealRegister::x28, TR::RealRegister::v0, 15, "0e1f3c1c"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x3, TR::RealRegister::v0, 0, "0e023c03"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x3, TR::RealRegister::v0, 1, "0e063c03"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x3, TR::RealRegister::v0, 7, "0e1e3c03"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x28, TR::RealRegister::v0, 0, "0e023c1c"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x28, TR::RealRegister::v0, 1, "0e063c1c"),
+    std::make_tuple(TR::InstOpCode::umovwh, TR::RealRegister::x28, TR::RealRegister::v0, 7, "0e1e3c1c"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x3, TR::RealRegister::v0, 0, "0e043c03"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x3, TR::RealRegister::v0, 1, "0e0c3c03"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x3, TR::RealRegister::v0, 3, "0e1c3c03"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x15, TR::RealRegister::v0, 0, "0e043c0f"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x15, TR::RealRegister::v0, 1, "0e0c3c0f"),
+    std::make_tuple(TR::InstOpCode::umovws, TR::RealRegister::x15, TR::RealRegister::v0, 3, "0e1c3c0f"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x3, TR::RealRegister::v0, 0, "4e083c03"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x3, TR::RealRegister::v0, 1, "4e183c03"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x15, TR::RealRegister::v0, 0, "4e083c0f"),
+    std::make_tuple(TR::InstOpCode::umovxd, TR::RealRegister::x15, TR::RealRegister::v0, 1, "4e183c0f")
+));
+
+INSTANTIATE_TEST_CASE_P(INS, ARM64MovGPRToVectorElementEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x3, 0, "4e011c60"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x3, 1, "4e031c60"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x3, 15, "4e1f1c60"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x28, 0, "4e011f80"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x28, 1, "4e031f80"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v0, TR::RealRegister::x28, 15, "4e1f1f80"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x3, 0, "4e021c60"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x3, 1, "4e061c60"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x3, 7, "4e1e1c60"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x28, 0, "4e021f80"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x28, 1, "4e061f80"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v0, TR::RealRegister::x28, 7, "4e1e1f80"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x3, 0, "4e041c60"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x3, 1, "4e0c1c60"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x3, 3, "4e1c1c60"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x15, 0, "4e041de0"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x15, 1, "4e0c1de0"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v0, TR::RealRegister::x15, 3, "4e1c1de0"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v0, TR::RealRegister::x3, 0, "4e081c60"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v0, TR::RealRegister::x3, 1, "4e181c60"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v0, TR::RealRegister::x15, 0, "4e081de0"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v0, TR::RealRegister::x15, 1, "4e181de0"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v15, TR::RealRegister::x0, 0, "4e011c0f"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v15, TR::RealRegister::x0, 1, "4e031c0f"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v15, TR::RealRegister::x0, 15, "4e1f1c0f"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v31, TR::RealRegister::x0, 0, "4e011c1f"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v31, TR::RealRegister::x0, 1, "4e031c1f"),
+    std::make_tuple(TR::InstOpCode::vinswb, TR::RealRegister::v31, TR::RealRegister::x0, 15, "4e1f1c1f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v15, TR::RealRegister::x0, 0, "4e021c0f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v15, TR::RealRegister::x0, 1, "4e061c0f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v15, TR::RealRegister::x0, 7, "4e1e1c0f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v31, TR::RealRegister::x0, 0, "4e021c1f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v31, TR::RealRegister::x0, 1, "4e061c1f"),
+    std::make_tuple(TR::InstOpCode::vinswh, TR::RealRegister::v31, TR::RealRegister::x0, 7, "4e1e1c1f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v15, TR::RealRegister::x0, 0, "4e041c0f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v15, TR::RealRegister::x0, 1, "4e0c1c0f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v15, TR::RealRegister::x0, 3, "4e1c1c0f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v31, TR::RealRegister::x0, 0, "4e041c1f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v31, TR::RealRegister::x0, 1, "4e0c1c1f"),
+    std::make_tuple(TR::InstOpCode::vinsws, TR::RealRegister::v31, TR::RealRegister::x0, 3, "4e1c1c1f"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v15, TR::RealRegister::x0, 0, "4e081c0f"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v15, TR::RealRegister::x0, 1, "4e181c0f"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v31, TR::RealRegister::x0, 0, "4e081c1f"),
+    std::make_tuple(TR::InstOpCode::vinsxd, TR::RealRegister::v31, TR::RealRegister::x0, 1, "4e181c1f")
+));
+
+INSTANTIATE_TEST_CASE_P(INS1, ARM64MovVectorElementEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v15, 0, 1, "6e010de0"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v15, 1, 15, "6e037de0"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v15, 15, 0, "6e1f05e0"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v31, 0, 1, "6e010fe0"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v31, 1, 15, "6e037fe0"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v0, TR::RealRegister::v31, 15, 0, "6e1f07e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v15, 0, 1, "6e0215e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v15, 1, 7, "6e0675e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v15, 7, 0, "6e1e05e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v31, 0, 1, "6e0217e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v31, 1, 7, "6e0677e0"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v0, TR::RealRegister::v31, 7, 0, "6e1e07e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v15, 0, 1, "6e0425e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v15, 1, 3, "6e0c65e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v15, 3, 0, "6e1c05e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v31, 0, 1, "6e0427e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v31, 1, 3, "6e0c67e0"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v0, TR::RealRegister::v31, 3, 0, "6e1c07e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v15, 0, 0, "6e0805e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v15, 1, 0, "6e1805e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v15, 0, 1, "6e0845e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v15, 1, 1, "6e1845e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v31, 0, 0, "6e0807e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v31, 1, 0, "6e1807e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v31, 0, 1, "6e0847e0"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v0, TR::RealRegister::v31, 1, 1, "6e1847e0")
+));
+
+INSTANTIATE_TEST_CASE_P(INS2, ARM64MovVectorElementEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v15, TR::RealRegister::v0, 0, 1, "6e010c0f"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v15, TR::RealRegister::v0, 1, 15, "6e037c0f"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v15, TR::RealRegister::v0, 15, 0, "6e1f040f"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v31, TR::RealRegister::v0, 0, 1, "6e010c1f"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v31, TR::RealRegister::v0, 1, 15, "6e037c1f"),
+    std::make_tuple(TR::InstOpCode::vinseb, TR::RealRegister::v31, TR::RealRegister::v0, 15, 0, "6e1f041f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v15, TR::RealRegister::v0, 0, 1, "6e02140f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v15, TR::RealRegister::v0, 1, 7, "6e06740f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v15, TR::RealRegister::v0, 7, 0, "6e1e040f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v31, TR::RealRegister::v0, 0, 1, "6e02141f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v31, TR::RealRegister::v0, 1, 7, "6e06741f"),
+    std::make_tuple(TR::InstOpCode::vinseh, TR::RealRegister::v31, TR::RealRegister::v0, 7, 0, "6e1e041f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v15, TR::RealRegister::v0, 0, 1, "6e04240f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v15, TR::RealRegister::v0, 1, 3, "6e0c640f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v15, TR::RealRegister::v0, 3, 0, "6e1c040f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v31, TR::RealRegister::v0, 0, 1, "6e04241f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v31, TR::RealRegister::v0, 1, 3, "6e0c641f"),
+    std::make_tuple(TR::InstOpCode::vinses, TR::RealRegister::v31, TR::RealRegister::v0, 3, 0, "6e1c041f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v15, TR::RealRegister::v0, 0, 0, "6e08040f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v15, TR::RealRegister::v0, 1, 0, "6e18040f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v15, TR::RealRegister::v0, 0, 1, "6e08440f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v15, TR::RealRegister::v0, 1, 1, "6e18440f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 0, 0, "6e08041f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 1, 0, "6e18041f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 0, 1, "6e08441f"),
+    std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 1, 1, "6e18441f")
 ));


### PR DESCRIPTION
This commit adds SIMD copy instructions, helper functions for generating
those instructions and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>