### PR TITLE
Transform old vector opcodes into new ones

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -619,46 +619,42 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
    {
    // implemented vector opcodes
 
-   if (opcode.isVectorOpCode())
+   if (!opcode.isVectorOpCode())
+      return false;
+
+   TR::DataType ot = opcode.getVectorResultDataType();
+
+   if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+   TR::DataType et = ot.getVectorElementType();
+
+   TR_ASSERT_FATAL(et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double,
+                   "Unexpected vector element type\n");
+
+   switch (opcode.getVectorOperation())
       {
-      TR::DataType ot = opcode.getVectorResultDataType();
-
-      if (ot.getVectorLength() != TR::VectorLength128) return false;
-
-      TR::DataType et = ot.getVectorElementType();
-
-      switch (opcode.getVectorOperation())
-         {
-         case OMR::vadd:
-            return true;
-         case OMR::vfma:
-            return (et == TR::Float || et == TR::Double);
-         default:
-            return false;
-         }
-      }
-
-   switch (opcode.getOpCodeValue())
-      {
-      case TR::vsub:
-      case TR::vneg:
-      case TR::vmul:
-      case TR::vdiv:
+      case OMR::vadd:
+      case OMR::vsub:
+      case OMR::vneg:
+      case OMR::vmul:
+      case OMR::vdiv:
          return true;
-      case TR::vand:
-      case TR::vor:
-      case TR::vxor:
-      case TR::vnot:
-         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64)
+      case OMR::vand:
+      case OMR::vor:
+      case OMR::vxor:
+      case OMR::vnot:
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
             return true;
          else
             return false; // Float/ Double are not supported
-      case TR::vload:
-      case TR::vloadi:
-      case TR::vstore:
-      case TR::vstorei:
-      case TR::vsplats:
+      case OMR::vload:
+      case OMR::vloadi:
+      case OMR::vstore:
+      case OMR::vstorei:
+      case OMR::vsplats:
          return true;
+      case OMR::vfma:
+         return (et == TR::Float || dt == TR::Double);
       default:
          return false;
       }

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -691,7 +691,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().vectorToScalar()));
             }
          // the other way around
-         if (_symbol->isArrayShadowSymbol() && !_symbol->getDataType().isVector())
+         if (_symbol->isArrayShadowSymbol() && _symbol->getDataType().isVectorElement())
             {
             if (!aliases)
                aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -117,10 +117,7 @@ OMR::DataType::scalarToVector(TR::VectorLength length)
    {
    TR::DataTypes type = self()->getDataType();
 
-   if (type > TR::NoType && type <= TR::NumVectorElementTypes)
-      return createVectorType(type, length);
-   else
-      return TR::NoType;
+   return createVectorType(type, length);
    }
 
 TR::DataType

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -402,6 +402,8 @@ public:
 
    inline bool isFloatingPoint();
    inline bool isVector();
+   inline bool isVectorElement();
+
    inline bool isBFPorHFP();
    inline bool isDouble();
    inline bool isFloat();

--- a/compiler/il/OMRDataTypes_inlines.hpp
+++ b/compiler/il/OMRDataTypes_inlines.hpp
@@ -85,6 +85,12 @@ OMR::DataType::isVector()
    }
 
 bool
+OMR::DataType::isVectorElement()
+   {
+   return (_type > TR::NoType) && (_type <= TR::NumVectorElementTypes);
+   }
+
+bool
 OMR::DataType::isBFPorHFP()
    {
    return self()->getDataType() == TR::Float || self()->getDataType() == TR::Double;

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -368,6 +368,12 @@ TR::ILOpCodes OMR::IL::opCodesForSelect [] =
 TR::ILOpCodes
 OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
    {
+   if (TR::ILOpCode::isVectorOpCode(loadOpCode))
+      {
+      if (TR::ILOpCode::getVectorOperation(loadOpCode) == OMR::vloadi)
+         return TR::ILOpCode::createVectorOpCode(OMR::vstorei, TR::ILOpCode::getVectorResultDataType(loadOpCode));
+      }
+
    switch (loadOpCode)
       {
       case TR::bloadi: return TR::bstorei;
@@ -377,7 +383,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::floadi: return TR::fstorei;
       case TR::dloadi: return TR::dstorei;
       case TR::aloadi: return TR::astorei;
-      case TR::vloadi: return TR::vstorei;
       case TR::brdbari:
       case TR::srdbari:
       case TR::irdbari:
@@ -400,6 +405,11 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
 TR::ILOpCodes
 OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
    {
+   if (TR::ILOpCode::isVectorOpCode(storeOpCode))
+      {
+      if (TR::ILOpCode::getVectorOperation(storeOpCode) == OMR::vstorei)
+         return TR::ILOpCode::createVectorOpCode(OMR::vloadi, TR::ILOpCode::getVectorResultDataType(storeOpCode));
+      }
 
    switch (storeOpCode)
       {
@@ -411,7 +421,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::dstorei:  return TR::dloadi;
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
-      case TR::vstorei:  return TR::vloadi;
       case TR::bwrtbari:
       case TR::swrtbari:
       case TR::iwrtbari:
@@ -457,6 +466,12 @@ OMR::IL::opCodeForCorrespondingLoadOrStore(TR::ILOpCodes opCodes)
 TR::ILOpCodes
 OMR::IL::opCodeForCorrespondingDirectLoad(TR::ILOpCodes loadOpCode)
    {
+   if (TR::ILOpCode::isVectorOpCode(loadOpCode))
+      {
+      if (TR::ILOpCode::getVectorOperation(loadOpCode) == OMR::vload)
+         return TR::ILOpCode::createVectorOpCode(OMR::vstore, TR::ILOpCode::getVectorResultDataType(loadOpCode));
+      }
+
    switch (loadOpCode)
       {
       case TR::bload: return TR::bstore;
@@ -466,7 +481,6 @@ OMR::IL::opCodeForCorrespondingDirectLoad(TR::ILOpCodes loadOpCode)
       case TR::fload: return TR::fstore;
       case TR::dload: return TR::dstore;
       case TR::aload: return TR::astore;
-      case TR::vload: return TR::vstore;
       case TR::brdbar:
       case TR::srdbar:
       case TR::irdbar:
@@ -489,6 +503,12 @@ OMR::IL::opCodeForCorrespondingDirectLoad(TR::ILOpCodes loadOpCode)
 TR::ILOpCodes
 OMR::IL::opCodeForCorrespondingDirectStore(TR::ILOpCodes storeOpCode)
    {
+   if (TR::ILOpCode::isVectorOpCode(storeOpCode))
+      {
+      if (TR::ILOpCode::getVectorOperation(storeOpCode) == OMR::vstore)
+         return TR::ILOpCode::createVectorOpCode(OMR::vload, TR::ILOpCode::getVectorResultDataType(storeOpCode));
+      }
+
    switch (storeOpCode)
       {
       case TR::bstore:  return TR::bload;
@@ -499,7 +519,6 @@ OMR::IL::opCodeForCorrespondingDirectStore(TR::ILOpCodes storeOpCode)
       case TR::dstore:  return TR::dload;
       case TR::astore:  return TR::aload;
       case TR::awrtbar: return TR::aload;
-      case TR::vstore:  return TR::vload;
       case TR::bwrtbar:
       case TR::swrtbar:
       case TR::iwrtbar:
@@ -550,7 +569,7 @@ OMR::IL::opCodeForDirectLoad(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectLoad) / sizeof(OMR::IL::opCodesForDirectLoad[0])),
               "OMR::IL::opCodesForDirectLoad is not the correct size");
 
-   if (dt.isVector()) return TR::vload;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vload, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -576,7 +595,7 @@ OMR::IL::opCodeForDirectStore(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectStore) / sizeof(OMR::IL::opCodesForDirectStore[0])),
               "OMR::IL::opCodesForDirectStore is not the correct size");
 
-   if (dt.isVector()) return TR::vstore;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vstore, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -603,7 +622,7 @@ OMR::IL::opCodeForIndirectLoad(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectLoad) / sizeof(OMR::IL::opCodesForIndirectLoad[0])),
               "OMR::IL::opCodesForIndirectLoad is not the correct size");
 
-   if (dt.isVector()) return TR::vloadi;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vloadi, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -629,7 +648,7 @@ OMR::IL::opCodeForIndirectStore(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectStore) / sizeof(OMR::IL::opCodesForIndirectStore[0])),
               "OMR::IL::opCodesForIndirectStore is not the correct size");
 
-   if (dt.isVector()) return TR::vstorei;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vstorei, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -655,7 +674,7 @@ OMR::IL::opCodeForIndirectArrayLoad(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayLoad) / sizeof(OMR::IL::opCodesForIndirectArrayLoad[0])),
               "OMR::IL::opCodesForIndirectArrayLoad is not the correct size");
 
-   if (dt.isVector()) return TR::vloadi;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vloadi, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -668,7 +687,7 @@ OMR::IL::opCodeForIndirectArrayStore(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectArrayStore) / sizeof(OMR::IL::opCodesForIndirectArrayStore[0])),
               "OMR::IL::opCodesForIndirectArrayStore is not the correct size");
 
-   if (dt.isVector()) return TR::vstorei;
+   if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(OMR::vstorei, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5261,9 +5261,6 @@ OMR::Node::computeDataType()
             _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getVectorIntegralType().getDataType();
          else if (_opCode.isVectorReduction())
             _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getVectorElementType().getDataType();
-         else if (_opCode.getOpCodeValue() == TR::vsplats)
-            // TODO: convert vsplats into 'true' vector opcode that has proper element type and length
-            _unionPropertyA._dataType = self()->getFirstChild()->getDataType().scalarToVector(TR::VectorLength128).getDataType();
          else
             _unionPropertyA._dataType = self()->getFirstChild()->getDataType().getDataType();
 

--- a/compiler/il/OMROpcodes.enum
+++ b/compiler/il/OMROpcodes.enum
@@ -6276,22 +6276,6 @@ OPCODE_MACRO(\
    /* .description          =    vector integer compare less equal */ \
 )
 OPCODE_MACRO(\
-   /* .opcode               = */ vnot, \
-   /* .name                 = */ "vnot", \
-   /* .properties1          = */ 0, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::HasNoDataType | ILTypeProp::Vector, \
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector boolean not */ \
-)
-OPCODE_MACRO(\
    /* .opcode               = */ vbitselect, \
    /* .name                 = */ "vbitselect", \
    /* .properties1          = */ 0, \
@@ -6322,22 +6306,6 @@ OPCODE_MACRO(\
    /* .booleanCompareOpCode = */ TR::BadILOp, \
    /* .ifCompareOpCode      = */ TR::BadILOp, \
    /* .description          =    vector permute */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vsplats, \
-   /* .name                 = */ "vsplats", \
-   /* .properties1          = */ 0, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ ILChildProp::Unspecified, \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector splats */ \
 )
 OPCODE_MACRO(\
    /* .opcode               = */ vdmergel, \
@@ -6564,118 +6532,6 @@ OPCODE_MACRO(\
    /* .description          =    vector double square root */ \
 )
 OPCODE_MACRO(\
-   /* .opcode               = */ vneg, \
-   /* .name                 = */ "vneg", \
-   /* .properties1          = */ ILProp1::Neg, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ ILProp3::LikeUse, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector negation */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vsub, \
-   /* .name                 = */ "vsub", \
-   /* .properties1          = */ ILProp1::Sub, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector subtract */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vmul, \
-   /* .name                 = */ "vmul", \
-   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Mul, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector multiply */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vdiv, \
-   /* .name                 = */ "vdiv", \
-   /* .properties1          = */ ILProp1::Div, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector divide */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vand, \
-   /* .name                 = */ "vand", \
-   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::And, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector logical AND */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vor, \
-   /* .name                 = */ "vor", \
-   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Or, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector logical OR */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vxor, \
-   /* .name                 = */ "vxor", \
-   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Xor, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3          = */ 0, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    vector exclusive OR integer */ \
-)
-OPCODE_MACRO(\
    /* .opcode               = */ vcmpeq, \
    /* .name                 = */ "vcmpeq", \
    /* .properties1          = */ ILProp1::BooleanCompare, \
@@ -6770,70 +6626,6 @@ OPCODE_MACRO(\
    /* .booleanCompareOpCode = */ TR::BadILOp, \
    /* .ifCompareOpCode      = */ TR::BadILOp, \
    /* .description          =    vector compare greater or equal */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vload, \
-   /* .name                 = */ "vload", \
-   /* .properties1          = */ ILProp1::LoadVar | ILProp1::HasSymbolRef, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE| ILProp2::MayUseSystemStack, \
-   /* .properties3          = */ ILProp3::LikeUse, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ ILChildProp::NoChildren, \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    load vector */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vloadi, \
-   /* .name                 = */ "vloadi", \
-   /* .properties1          = */ ILProp1::LoadVar | ILProp1::Indirect | ILProp1::HasSymbolRef, \
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE| ILProp2::MayUseSystemStack, \
-   /* .properties3          = */ ILProp3::LikeUse, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    load indirect vector */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vstore, \
-   /* .name                 = */ "vstore", \
-   /* .properties1          = */ ILProp1::Store | ILProp1::TreeTop | ILProp1::HasSymbolRef, \
-   /* .properties2          = */ ILProp2::MayUseSystemStack, \
-   /* .properties3          = */ ILProp3::LikeDef, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    store vector */ \
-)
-OPCODE_MACRO(\
-   /* .opcode               = */ vstorei, \
-   /* .name                 = */ "vstorei", \
-   /* .properties1          = */ ILProp1::Store | ILProp1::Indirect | ILProp1::TreeTop | ILProp1::HasSymbolRef, \
-   /* .properties2          = */ ILProp2::MayUseSystemStack, \
-   /* .properties3          = */ ILProp3::LikeDef, \
-   /* .properties4          = */ 0, \
-   /* .dataType             = */ TR::NoType, \
-   /* .typeProperties       = */ ILTypeProp::Size_16 | ILTypeProp::Vector | ILTypeProp::HasNoDataType, \
-   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOpCode   = */ TR::BadILOp, \
-   /* .reverseBranchOpCode  = */ TR::BadILOp, \
-   /* .booleanCompareOpCode = */ TR::BadILOp, \
-   /* .ifCompareOpCode      = */ TR::BadILOp, \
-   /* .description          =    store indirect vector */ \
 )
 OPCODE_MACRO(\
    /* .opcode               = */ vreturn, \

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -20,6 +20,102 @@
  *******************************************************************************/
 
 VECTOR_OPERATION_MACRO(\
+   /* .opcode               = */ vload, \
+   /* .name                 = */ "vload", \
+   /* .properties1          = */ ILProp1::LoadVar | ILProp1::HasSymbolRef, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE| ILProp2::MayUseSystemStack, \
+   /* .properties3          = */ ILProp3::LikeUse, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ILChildProp::NoChildren, \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    load vector */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .opcode               = */ vloadi, \
+   /* .name                 = */ "vloadi", \
+   /* .properties1          = */ ILProp1::LoadVar | ILProp1::Indirect | ILProp1::HasSymbolRef, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE| ILProp2::MayUseSystemStack, \
+   /* .properties3          = */ ILProp3::LikeUse, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    load indirect vector */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vstore, \
+   /* .name                 = */ "vstore", \
+   /* .properties1          = */ ILProp1::Store | ILProp1::TreeTop | ILProp1::HasSymbolRef, \
+   /* .properties2          = */ ILProp2::MayUseSystemStack, \
+   /* .properties3          = */ ILProp3::LikeDef, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    store vector */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vstorei, \
+   /* .name                 = */ "vstorei", \
+   /* .properties1          = */ ILProp1::Store | ILProp1::Indirect | ILProp1::TreeTop | ILProp1::HasSymbolRef, \
+   /* .properties2          = */ ILProp2::MayUseSystemStack, \
+   /* .properties3          = */ ILProp3::LikeDef, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    store indirect vector */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vnot, \
+   /* .name                 = */ "vnot", \
+   /* .properties1          = */ 0, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector boolean not */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vneg, \
+   /* .name                 = */ "vneg", \
+   /* .properties1          = */ ILProp1::Neg, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ ILProp3::LikeUse, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector negation */ \
+)
+VECTOR_OPERATION_MACRO(\
    /* .operation            = */ vadd, \
    /* .name                 = */ "vadd", \
    /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Add, \
@@ -36,7 +132,103 @@ VECTOR_OPERATION_MACRO(\
    /* .description          =    vector add */ \
 )
 VECTOR_OPERATION_MACRO(\
-   /* .opcode               = */ vfma, \
+   /* .operation            = */ vsub, \
+   /* .name                 = */ "vsub", \
+   /* .properties1          = */ ILProp1::Sub, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector subtract */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation             = */ vmul, \
+   /* .name                 = */ "vmul", \
+   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Mul, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector multiply */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vdiv, \
+   /* .name                 = */ "vdiv", \
+   /* .properties1          = */ ILProp1::Div, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector divide */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vand, \
+   /* .name                 = */ "vand", \
+   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::And, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector logical AND */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vor, \
+   /* .name                 = */ "vor", \
+   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Or, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector logical OR */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vxor, \
+   /* .name                 = */ "vxor", \
+   /* .properties1          = */ ILProp1::Commutative | ILProp1::Associative | ILProp1::Xor, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector exclusive OR integer */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vfma, \
    /* .name                 = */ "vfma", \
    /* .properties1          = */ 0, \
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
@@ -50,4 +242,20 @@ VECTOR_OPERATION_MACRO(\
    /* .booleanCompareOpCode = */ TR::BadILOp, \
    /* .ifCompareOpCode      = */ TR::BadILOp, \
    /* .description          =    vector fused multiply and add */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation            = */ vsplats, \
+   /* .name                 = */ "vsplats", \
+   /* .properties1          = */ 0, \
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3          = */ 0, \
+   /* .properties4          = */ 0, \
+   /* .dataType             = */ TR::NoType, \
+   /* .typeProperties       = */ ILTypeProp::Vector, \
+   /* .childProperties      = */ ILChildProp::Unspecified, \
+   /* .swapChildrenOpCode   = */ TR::BadILOp, \
+   /* .reverseBranchOpCode  = */ TR::BadILOp, \
+   /* .booleanCompareOpCode = */ TR::BadILOp, \
+   /* .ifCompareOpCode      = */ TR::BadILOp, \
+   /* .description          =    vector splats */ \
 )

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -677,8 +677,8 @@ OMR::IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    TR::DataType dt = valueNode->getDataType();
    if (!dt.isVector())
       {
-      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
       dt = dt.scalarToVector(TR::VectorLength128);
+      valueNode = TR::Node::create(TR::ILOpCode::createVectorOpCode(OMR::vsplats, dt), 1, valueNode);
       }
 
    if (!_methodBuilder->symbolDefined(varName))
@@ -717,9 +717,13 @@ OMR::IlBuilder::VectorStoreAt(TR::IlValue *address, TR::IlValue *value)
    TraceIL("IlBuilder[ %p ]::VectorStoreAt address %d gets %d\n", this, address->getID(), value->getID());
 
    TR::Node *valueNode = loadValue(value);
+   TR::DataType dt = valueNode->getDataType();
 
-   if (!valueNode->getDataType().isVector())
-      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
+   if (!dt.isVector())
+      {
+      dt = dt.scalarToVector(TR::VectorLength128);
+      valueNode = TR::Node::create(TR::ILOpCode::createVectorOpCode(OMR::vsplats, dt), 1, valueNode);
+      }
 
    indirectStoreNode(loadValue(address), valueNode);
    }
@@ -1101,10 +1105,10 @@ OMR::IlBuilder::doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr)
    TR::DataType rType = right->getDataType();
 
    if (lType.isVector() && !rType.isVector())
-      *rightPtr = TR::Node::create(TR::vsplats, 1, right);
+      *rightPtr = TR::Node::create(TR::ILOpCode::createVectorOpCode(OMR::vsplats, lType), 1, right);
 
    if (!lType.isVector() && rType.isVector())
-      *leftPtr = TR::Node::create(TR::vsplats, 1, left);
+      *leftPtr = TR::Node::create(TR::ILOpCode::createVectorOpCode(OMR::vsplats, rType), 1, left);
    }
 
 TR::IlValue *

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1768,81 +1768,74 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
        dt != TR::Int64)
       return false;
 
-   if (opcode.isVectorOpCode())
+   if (!opcode.isVectorOpCode())
       {
-      TR::DataType ot = opcode.getVectorResultDataType();
-
-      if (ot.getVectorLength() != TR::VectorLength128) return false;
-
-      TR::DataType et = ot.getVectorElementType();
-
-      if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
-          opcode.getVectorOperation() == OMR::vadd && et == TR::Int64)
-         return true;
-
-      // implemented vector operations
-      switch (opcode.getVectorOperation())
+      // Will be transformed into new vector opcodes soon
+      switch (opcode.getOpCodeValue())
          {
-         case OMR::vadd:
-            if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
+         case TR::getvelem:
+            if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
                return true;
             else
                return false;
-         case OMR::vfma:
-            if (et == TR::Float || et == TR::Double)
-               return true;
-            else
-               return false;
+         case TR::vl2vd:
+            return true;
          default:
             return false;
          }
       }
 
+   TR::DataType ot = opcode.getVectorResultDataType();
+
+   if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+   TR::DataType et = ot.getVectorElementType();
+
    if (self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8) &&
-       (opcode.getOpCodeValue() == TR::vsub || opcode.getOpCodeValue() == TR::vmul) &&
-       dt == TR::Int64)
+       (opcode.getVectorOperation() == OMR::vadd || opcode.getVectorOperation() == OMR::vsub || opcode.getVectorOperation() == OMR::vmul) &&
+       et == TR::Int64)
       return true;
 
    // implemented vector opcodes
-   switch (opcode.getOpCodeValue())
+   switch (opcode.getVectorOperation())
       {
-      case TR::vsub:
-      case TR::vmul:
-         if (dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Float || dt == TR::Double)
+      case OMR::vadd:
+      case OMR::vsub:
+      case OMR::vmul:
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vdiv:
-      case TR::vneg:
-         if (dt == TR::Int32 || dt == TR::Float || dt == TR::Double)
+      case OMR::vdiv:
+      case OMR::vneg:
+         if (et == TR::Int32 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vload:
-      case TR::vloadi:
-      case TR::vstore:
-      case TR::vstorei:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+      case OMR::vload:
+      case OMR::vloadi:
+      case OMR::vstore:
+      case OMR::vstorei:
+         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vxor:
-      case TR::vor:
-      case TR::vand:
-         if (dt == TR::Int32 || dt == TR::Int64)
+      case OMR::vxor:
+      case OMR::vor:
+      case OMR::vand:
+         if (et == TR::Int32 || et == TR::Int64)
             return true;
          else
             return false;
-      case TR::vsplats:
-         if ((dt == TR::Int8 || dt == TR::Int16 || dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double))
+      case OMR::vsplats:
+         if ((et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double))
             return true;
-      case TR::getvelem:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+
+      case OMR::vfma:
+         if (et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vl2vd:
-         return true;
       default:
          return false;
       }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4128,27 +4128,15 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
          break;
       case TR::fsub:
       case TR::dsub:
-      case TR::vsub:
          arithmetic = BinaryArithmeticSub;
          break;
       case TR::fmul:
       case TR::dmul:
-      case TR::vmul:
          arithmetic = BinaryArithmeticMul;
          break;
       case TR::fdiv:
       case TR::ddiv:
-      case TR::vdiv:
          arithmetic = BinaryArithmeticDiv;
-         break;
-      case TR::vand:
-         arithmetic = BinaryArithmeticAnd;
-         break;
-      case TR::vor:
-         arithmetic = BinaryArithmeticOr;
-         break;
-      case TR::vxor:
-         arithmetic = BinaryArithmeticXor;
          break;
       default:
          if (OMR::ILOpCode::isVectorOpCode(opcode))
@@ -4158,6 +4146,25 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
                case OMR::vadd:
                   arithmetic = BinaryArithmeticAdd;
                   break;
+               case OMR::vsub:
+                  arithmetic = BinaryArithmeticSub;
+                  break;
+               case OMR::vmul:
+                  arithmetic = BinaryArithmeticMul;
+                  break;
+               case OMR::vdiv:
+                  arithmetic = BinaryArithmeticDiv;
+                  break;
+               case OMR::vand:
+                  arithmetic = BinaryArithmeticAnd;
+                  break;
+               case OMR::vor:
+                  arithmetic = BinaryArithmeticOr;
+                  break;
+               case OMR::vxor:
+                  arithmetic = BinaryArithmeticXor;
+                  break;
+
                default:
                   TR_ASSERT(false, "Unsupported OpCode");
                }
@@ -4178,7 +4185,7 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
       {
       if (operandNode1->getRegister()                               ||
           operandNode1->getReferenceCount() != 1                    ||
-          operandNode1->getOpCodeValue() != (type.isVector() ? TR::vload : MemoryLoadOpCodes[type]) ||
+          operandNode1->getOpCodeValue() != (type.isVector() ? TR::ILOpCode::createVectorOpCode(OMR::vload, type) : MemoryLoadOpCodes[type]) ||
           (type.isVector() ? VectorBinaryArithmeticOpCodesForMem[type.getVectorElementType() - 1][arithmetic]
                            : BinaryArithmeticOpCodesForMem[type][arithmetic]) == TR::InstOpCode::bad)
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4730,61 +4730,62 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
       return false;
       }
 
-   if (opcode.isVectorOpCode())
+   if (!opcode.isVectorOpCode())
       {
-      TR::DataType ot = opcode.getVectorResultDataType();
-
-      if (ot.getVectorLength() != TR::VectorLength128) return false;
-
-      TR::DataType et = opcode.getVectorResultDataType().getVectorElementType();
-
-      switch(opcode.getVectorOperation())
+      // Will be transformed into new vector opcodes soon
+      switch (opcode.getOpCodeValue())
          {
-         case OMR::vadd:
-            if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         case TR::getvelem:
+         case TR::vsetelem:
+            if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
                return true;
-            else
+           else
                return false;
+         case TR::vl2vd:
+            return true;
          default:
             return false;
          }
       }
 
+   TR::DataType ot = opcode.getVectorResultDataType();
+
+   if (ot.getVectorLength() != TR::VectorLength128) return false;
+
+   TR::DataType et = opcode.getVectorResultDataType().getVectorElementType();
+
    // implemented vector opcodes
-   switch (opcode.getOpCodeValue())
+   switch (opcode.getVectorOperation())
       {
-      case TR::vsub:
-      case TR::vmul:
-      case TR::vdiv:
-      case TR::vneg:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+      case OMR::vadd:
+      case OMR::vsub:
+      case OMR::vmul:
+      case OMR::vdiv:
+      case OMR::vneg:
+         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vload:
-      case TR::vloadi:
-      case TR::vstore:
-      case TR::vstorei:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+      case OMR::vload:
+      case OMR::vloadi:
+      case OMR::vstore:
+      case OMR::vstorei:
+         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vxor:
-      case TR::vor:
-      case TR::vand:
-         if (dt == TR::Int32 || dt == TR::Int64)
+      case OMR::vxor:
+      case OMR::vor:
+      case OMR::vand:
+         if (et == TR::Int32 || et == TR::Int64)
             return true;
          else
             return false;
-      case TR::vsplats:
-      case TR::getvelem:
-      case TR::vsetelem:
-         if (dt == TR::Int32 || dt == TR::Int64 || dt == TR::Float || dt == TR::Double)
+      case OMR::vsplats:
+         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
-      case TR::vl2vd:
-         return true;
       default:
         return false;
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14663,8 +14663,8 @@ OMR::Z::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::bad;
 
-   if (node->getOpCodeValue() == TR::vload ||
-       node->getOpCodeValue() == TR::vloadi)
+   if (node->getOpCode().getVectorOperation() == OMR::vload ||
+       node->getOpCode().getVectorOperation() == OMR::vloadi)
       {
       opcode = TR::InstOpCode::VL;
       }
@@ -14722,8 +14722,8 @@ OMR::Z::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::bad;
 
-   if (node->getOpCodeValue() == TR::vstore ||
-       node->getOpCodeValue() == TR::vstorei)
+   if (node->getOpCode().getVectorOperation() == OMR::vstore ||
+       node->getOpCode().getVectorOperation() == OMR::vstorei)
       {
       opcode = TR::InstOpCode::VST;
       }

--- a/doc/compiler/tril/TrilLanguageReference.md
+++ b/doc/compiler/tril/TrilLanguageReference.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2017, 2017 IBM Corp. and others
+Copyright (c) 2017, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -10,7 +10,7 @@ is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following
 Secondary Licenses when the conditions for such availability set
 forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-General Public License, version 2 with the GNU Classpath 
+General Public License, version 2 with the GNU Classpath
 Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
@@ -23,27 +23,27 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 # Tril Language Reference
 
 In many ways, the Tril language mirrors the Testarossa Intermediate Language,
-_Trees_. 
+_Trees_.
 
 This language reference intends to document the places where special behaviour
-has been created in Tril to make writing test cases easier. 
+has been created in Tril to make writing test cases easier.
 
 # Basics
 
-Tril is built out of two main components: 
+Tril is built out of two main components:
 
 1. A very permissive S-expression parser.
 2. An IlGenerator that walks the AST produced by said parser, and generates
-   Trees. 
+   Trees.
 
 # Syntax
 
 Tril represents Trees using S-expressions, with key-value properties to augment
-a particular node with more information. 
+a particular node with more information.
 
 * `(x (y) (z))` represents some `x` with `y` and `z` as children.
 * `(x foo=bar baz=braz (y) (z)` is the same tree as above, but where the node
-  for `x` is augmented with two properties with values. 
+  for `x` is augmented with two properties with values.
 
   Anything may be provided as a property for a node, however, unknown
   properties will be silently ignored.
@@ -51,23 +51,23 @@ a particular node with more information.
 ## Literals
 
 * Signed integer literals can be input directly, and will always be treated internally
-  as a 64-bit integer.  
+  as a 64-bit integer.
 * Hexadecimal integer literals are supported as well, and are treated as
-  64-bit integers. Use a leading `0x`. 
-* Floating point numbers can be input by including a decimal point.  
+  64-bit integers. Use a leading `0x`.
+* Floating point numbers can be input by including a decimal point.
 
-## Comments 
+## Comments
 
-`;` starts a comment in Tril, and the comment proceeds to the end of a line. 
+`;` starts a comment in Tril, and the comment proceeds to the end of a line.
 
-## Special Forms: 
+## Special Forms:
 
 The key to Tril is the unlocking of extra behaviour using 'special forms', or
-atoms that represent certain behaviours in Testarossa. 
+atoms that represent certain behaviours in Testarossa.
 
 ### Types
 
-The Testarossa IL, and therefore Tril, deals with the following data types. 
+The Testarossa IL, and therefore Tril, deals with the following data types.
 
 * `Int8`
 * `Int16`
@@ -76,64 +76,61 @@ The Testarossa IL, and therefore Tril, deals with the following data types.
 * `Address`
 * `Float`
 * `Double`
-* `VectorInt8`
-* `VectorInt16`
-* `VectorInt32`
-* `VectorInt64`
-* `VectorFloat`
-* `VectorDouble`
 * `NoType`
 
 Signedness is a property of operations, not the data itself.
 
+In addition, there are vector types that are generated on demand. For example Vector128Int8 or
+Vector128Float can be generated during method compilation.
+
 ### Methods
 
-A whole method in Tril is wrapped in a `method` expression. 
+A whole method in Tril is wrapped in a `method` expression.
 
-#### Properties 
+#### Properties
 
-* `return` _Mandatory_ is the return type of the method. 
+* `return` _Mandatory_ is the return type of the method.
 * `args` _Optional_ is a square-bracketed list of arguments representing the
-  types of the parameters, and the order in which they appear. 
+  types of the parameters, and the order in which they appear.
 
   eg. `args=[Int32,Double,Float]`
-    
+
 ### Block
 
-In the Testarossa IL, all trees exist within the context of a basic block. In 
+In the Testarossa IL, all trees exist within the context of a basic block. In
 Tril, blocks must be children of a `method`, or they will not be recognized.
 
 #### Properties
 
-* `name` _Optional_ Blocks can be named in order to target them with branches. 
+* `name` _Optional_ Blocks can be named in order to target them with branches.
 
 ### Stores and loads
 
 Currently the creation of new symbol references in Tril is not supported.
 However, store and load opcodes provide two options for where the store / load
-can come from, which can be specified with one of the following two properties: 
+can come from, which can be specified with one of the following two properties:
 
-* `parm` can specify the parameter from which a load can come. Parameters are 
+* `parm` can specify the parameter from which a load can come. Parameters are
   counted from zero.  eg. `(iload parm=2)` loads the third parameter from the
-  signature. 
+  signature.
 * `temp` Stores to temps create new temporary variables that can later be
   referenced. eg. `(istore temp="x" ...)`
 
-### Branches 
+### Branches
 
 Branches evaluate a condition then either jump to a target, or falls through to
 the next block. The fallthrough block can be eiher implied, in which case it
-will be the next block textually, or it can be specified manually with the 
-`fallthrough` property. 
+will be the next block textually, or it can be specified manually with the
+`fallthrough` property.
 
 #### Properties
 
 * `target` _Mandatory_ The `name` of the block a successful computation of the
-  condition will continue executing in. 
+  condition will continue executing in.
 * `fallthrough` _Optional_ In some circumstances it is necessary to explicitly
   list the `name` of the fallthrough block of a branch to ensure the desired CFG is
   constructed. In addition to a block `name`, there are two special values that
-  may be used here: 
+  may be used here:
    * `@none` indicates no fallthrough edge need be generated: this can be the
      case for certain opcodes, ie
 
@@ -147,46 +144,42 @@ will be the next block textually, or it can be specified manually with the
 ```
 (method ...
    (block fallthrough="sub" name="start"
-      (ificmpge target="add"                 
+      (ificmpge target="add"
         ...) )
    (block name="sub"
       (ireturn
          ...) )
    (block name="add"
-      (ireturn                               
+      (ireturn
         ... ) )
 ```
-   
-### Commoning 
+
+### Commoning
 
 Nodes can be given identifiers to allow creating commoned subtrees. To common a
 reference, on first computation annotate the node with the `id="<some name>"`
 property. Then, where commoning is desired, replace the node with `(@id "<some
-name>")` 
+name>")`
 
 ```
 (imul id="multiplyResult"
-    ...) 
+    ...)
 (iadd
   (@id "multiplyResult")
   (@id "multiplyResult")
 ```
 
-### Vectors 
+### Vectors
 
-Vector support in Tril is very preliminary, but present. One of the most
-important pieces is the ability to annotate indirect vector loads and stores
-with the data type of the load. 
+Vector support in Tril is very preliminary, but present. Vector opcodes are formed
+by concatinating vector operation (such as vloadi) with any vector type, for example
+Vector128Double:
 
-This is required because the vector support in Testarossa infers the vector
-types from certain roots, as opposed to expressing the data types in the
-opcodes directly like other opcodes in Testarossa. 
+    (vloadiVector128Double (aload parm=0))
 
-    (vloadi type=VectorDouble (aload parm=0))
-    
 ####Properties
 
-* `type` _Mandatory_ The data type being loaded or stored. 
+* `type` _Mandatory_ The data type being loaded or stored.
 
 
 
@@ -195,17 +188,17 @@ opcodes directly like other opcodes in Testarossa.
 Call opcodes are supported with in Tril by providing extra annotation of the
 argument types and the function pointer to be invoked.
 
-    (icall address=0x1234 args=[Int32] ...) 
+    (icall address=0x1234 args=[Int32] ...)
 
 ####Properties
 
 * `address` _Mandatory_ The address of the function to be invoked by the call opcode
-* `args` _Optional_ The list of argument types passed to the call. 
+* `args` _Optional_ The list of argument types passed to the call.
 
 
-# Examples 
+# Examples
 
-## Incordec 
+## Incordec
 
 Checked in as `fvtest/tril/examples/incordec/incordec.tril`
 
@@ -220,7 +213,7 @@ Checked in as `fvtest/tril/examples/incordec/incordec.tril`
 ; int incordec(int* parm0) {
 ;    if (*parm0 < 0) {
 ;     return *parm0 - (int)1.0;
-;    } else { 
+;    } else {
 ;      int x = 1;
 ;      return *parm0 + x;
 ;    }
@@ -244,18 +237,18 @@ Checked in as `fvtest/tril/examples/incordec/incordec.tril`
             (iload temp="x") ) ) ) )
 ```
 
-## Vector Support: 
+## Vector Support:
 
 Vector addition of two input double vectors into a third output double vector.
 Hooked up as a test case in `fvtest/compilertriltest/VectorTest.cpp`.
 
 ```
-(method return= NoType args=[Address,Address,Address]          
-  (block                                                       
-     (vstorei type=VectorDouble offset=0                       
-         (aload parm=0)                                        
-            (vadd                                              
-                 (vloadi type=VectorDouble (aload parm=1))     
-                 (vloadi type=VectorDouble (aload parm=2))))   
-     (return)))                                                
+(method return= NoType args=[Address,Address,Address]
+  (block
+     (vstoreiVector128Double offset=0
+         (aload parm=0)
+            (vaddVector128Double
+                 (vloadiVector128Double (aload parm=1))
+                 (vloadiVector128Double (aload parm=2))))
+     (return)))
 ```

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -29,11 +29,11 @@ TEST_F(VectorTest, VDoubleAdd) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorDouble offset=0                        "
+                     "     (vstoreiVector128Double  offset=0                          "
                      "         (aload parm=0)                                         "
                      "            (vaddVector128Double                                "
-                     "                 (vloadi type=VectorDouble (aload parm=1))      "
-                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "                 (vloadiVector128Double (aload parm=1))         "
+                     "                 (vloadiVector128Double (aload parm=2))))       "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -64,11 +64,11 @@ TEST_F(VectorTest, VInt8Add) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
                      "            (vaddVector128Int8                                  "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -102,11 +102,11 @@ TEST_F(VectorTest, VInt16Add) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt16 offset=0                         "
+                     "     (vstoreiVector128Int16 offset=0                            "
                      "         (aload parm=0)                                         "
                      "            (vaddVector128Int16                                 "
-                     "                 (vloadi type=VectorInt16 (aload parm=1))       "
-                     "                 (vloadi type=VectorInt16 (aload parm=2))))     "
+                     "                 (vloadiVector128Int16 (aload parm=1))          "
+                     "                 (vloadiVector128Int16 (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -140,11 +140,11 @@ TEST_F(VectorTest, VFloatAdd) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorFloat offset=0                         "
+                     "     (vstoreiVector128Float offset=0                            "
                      "         (aload parm=0)                                         "
                      "            (vaddVector128Float                                 "
-                     "                 (vloadi type=VectorFloat (aload parm=1))       "
-                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "                 (vloadiVector128Float (aload parm=1))          "
+                     "                 (vloadiVector128Float (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -177,11 +177,11 @@ TEST_F(VectorTest, VInt8Sub) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vsub                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "            (vsubVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -215,11 +215,11 @@ TEST_F(VectorTest, VInt16Sub) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt16 offset=0                         "
+                     "     (vstoreiVector128Int16 offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vsub                                               "
-                     "                 (vloadi type=VectorInt16 (aload parm=1))       "
-                     "                 (vloadi type=VectorInt16 (aload parm=2))))     "
+                     "            (vsubVector128Int16                                 "
+                     "                 (vloadiVector128Int16 (aload parm=1))          "
+                     "                 (vloadiVector128Int16 (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -253,11 +253,11 @@ TEST_F(VectorTest, VFloatSub) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorFloat offset=0                         "
+                     "     (vstoreiVector128Float offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vsub                                               "
-                     "                 (vloadi type=VectorFloat (aload parm=1))       "
-                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "            (vsubVector128Float                                 "
+                     "                 (vloadiVector128Float (aload parm=1))          "
+                     "                 (vloadiVector128Float (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -290,11 +290,11 @@ TEST_F(VectorTest, VDoubleSub) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorDouble offset=0                        "
+                     "     (vstoreiVector128Double offset=0                           "
                      "         (aload parm=0)                                         "
-                     "            (vsub                                               "
-                     "                 (vloadi type=VectorDouble (aload parm=1))      "
-                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "            (vsubVector128Double                                "
+                     "                 (vloadiVector128Double (aload parm=1))         "
+                     "                 (vloadiVector128Double (aload parm=2))))       "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -325,11 +325,11 @@ TEST_F(VectorTest, VInt8Mul) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vmul                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "            (vmulVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -365,11 +365,11 @@ TEST_F(VectorTest, VInt16Mul) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt16 offset=0                         "
+                     "     (vstoreiVector128Int16 offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vmul                                               "
-                     "                 (vloadi type=VectorInt16 (aload parm=1))       "
-                     "                 (vloadi type=VectorInt16 (aload parm=2))))     "
+                     "            (vmulVector128Int16                                 "
+                     "                 (vloadiVector128Int16 (aload parm=1))          "
+                     "                 (vloadiVector128Int16 (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -403,11 +403,11 @@ TEST_F(VectorTest, VFloatMul) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorFloat offset=0                         "
+                     "     (vstoreiVector128Float offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vmul                                               "
-                     "                 (vloadi type=VectorFloat (aload parm=1))       "
-                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "            (vmulVector128Float                                 "
+                     "                 (vloadiVector128Float (aload parm=1))          "
+                     "                 (vloadiVector128Float (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -440,11 +440,11 @@ TEST_F(VectorTest, VDoubleMul) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorDouble offset=0                        "
+                     "     (vstoreiVector128Double offset=0                           "
                      "         (aload parm=0)                                         "
-                     "            (vmul                                               "
-                     "                 (vloadi type=VectorDouble (aload parm=1))      "
-                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "            (vmulVector128Double                                "
+                     "                 (vloadiVector128Double (aload parm=1))         "
+                     "                 (vloadiVector128Double (aload parm=2))))       "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -636,11 +636,11 @@ TEST_F(VectorTest, VFloatDiv) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorFloat offset=0                         "
+                     "     (vstoreiVector128Float offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vdiv                                               "
-                     "                 (vloadi type=VectorFloat (aload parm=1))       "
-                     "                 (vloadi type=VectorFloat (aload parm=2))))     "
+                     "            (vdivVector128Float                                 "
+                     "                 (vloadiVector128Float (aload parm=1))          "
+                     "                 (vloadiVector128Float (aload parm=2))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -673,11 +673,11 @@ TEST_F(VectorTest, VDoubleDiv) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorDouble offset=0                        "
+                     "     (vstoreiVector128Double offset=0                           "
                      "         (aload parm=0)                                         "
-                     "            (vdiv                                               "
-                     "                 (vloadi type=VectorDouble (aload parm=1))      "
-                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "            (vdivVector128Double                                "
+                     "                 (vloadiVector128Double (aload parm=1))         "
+                     "                 (vloadiVector128Double (aload parm=2))))       "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -708,11 +708,11 @@ TEST_F(VectorTest, VInt8And) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vand                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "            (vandVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -748,11 +748,11 @@ TEST_F(VectorTest, VInt8Or) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vor                                                "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "            (vorVector128Int8                                   "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -788,11 +788,11 @@ TEST_F(VectorTest, VInt8Xor) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vxor                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))        "
-                     "                 (vloadi type=VectorInt8 (aload parm=2))))      "
+                     "            (vxorVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))           "
+                     "                 (vloadiVector128Int8 (aload parm=2))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -828,10 +828,10 @@ TEST_F(VectorTest, VInt8Neg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))))      "
+                     "            (vnegVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -864,10 +864,10 @@ TEST_F(VectorTest, VInt16Neg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt16 offset=0                         "
+                     "     (vstoreiVector128Int16 offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorInt16 (aload parm=1))))     "
+                     "            (vnegVector128Int16                                 "
+                     "                 (vloadiVector128Int16 (aload parm=1))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -900,10 +900,10 @@ TEST_F(VectorTest, VInt32Neg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt32 offset=0                         "
+                     "     (vstoreiVector128Int32 offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorInt32 (aload parm=1))))     "
+                     "            (vnegVector128Int32                                 "
+                     "                 (vloadiVector128Int32 (aload parm=1))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -936,10 +936,10 @@ TEST_F(VectorTest, VInt64Neg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt64 offset=0                         "
+                     "     (vstoreiVector128Int64 offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorInt64 (aload parm=1))))     "
+                     "            (vnegVector128Int64                                 "
+                     "                 (vloadiVector128Int64 (aload parm=1))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -972,10 +972,10 @@ TEST_F(VectorTest, VFloatNeg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorFloat offset=0                         "
+                     "     (vstoreiVector128Float offset=0                            "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorFloat (aload parm=1))))     "
+                     "            (vnegVector128Float                                 "
+                     "                 (vloadiVector128Float (aload parm=1))))        "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -1007,10 +1007,10 @@ TEST_F(VectorTest, VDoubleNeg) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorDouble offset=0                        "
+                     "     (vstoreiVector128Double offset=0                           "
                      "         (aload parm=0)                                         "
-                     "            (vneg                                               "
-                     "                 (vloadi type=VectorDouble (aload parm=1))))    "
+                     "            (vnegVector128Double                                "
+                     "                 (vloadiVector128Double (aload parm=1))))       "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -1040,10 +1040,10 @@ TEST_F(VectorTest, VDoubleSQRT) {
 
     auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                       "  (block                                                        "
-                      "     (vstorei type=VectorDouble offset=0                        "
+                      "     (vstoreiVector128Double offset=0                           "
                       "         (aload parm=0)                                         "
                       "            (vdsqrt                                             "
-                      "                 (vloadi type=VectorDouble (aload parm=1))))    "
+                      "                 (vloadiVector128Double (aload parm=1))))       "
                       "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);
@@ -1074,10 +1074,10 @@ TEST_F(VectorTest, VInt8Not) {
 
    auto inputTrees = "(method return= NoType args=[Address,Address]                   "
                      "  (block                                                        "
-                     "     (vstorei type=VectorInt8 offset=0                          "
+                     "     (vstoreiVector128Int8 offset=0                             "
                      "         (aload parm=0)                                         "
-                     "            (vnot                                               "
-                     "                 (vloadi type=VectorInt8 (aload parm=1))))      "
+                     "            (vnotVector128Int8                                  "
+                     "                 (vloadiVector128Int8 (aload parm=1))))         "
                      "     (return)))                                                 ";
 
     auto trees = parseString(inputTrees);

--- a/fvtest/tril/tril/GenericNodeConverter.cpp
+++ b/fvtest/tril/tril/GenericNodeConverter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,7 +145,7 @@ TR::Node* GenericNodeConverter::impl(const ASTNode* tree, IlGenState* state) {
         const auto name = tree->getName();
         auto compilation = TR::comp();
         TR::DataType type;
-        if (opcode.isVector()) {
+        if (opcode.isVector() && !opcode.isVectorOpCode()) {
             // Vector types in TR IL are "typeless", insofar as they are
             // supposed to infer the vector type depending on the children.
             // Loads determine their data type based on the symref. However,

--- a/fvtest/tril/tril/ilgen.hpp
+++ b/fvtest/tril/tril/ilgen.hpp
@@ -89,7 +89,7 @@ class OpCodeTable : public TR::ILOpCode {
 
             if (vectorType == TR::NoType) return TR::BadILOp;
 
-            TR::ILOpCodes opcode = TR::ILOpCode::createVectorOpCode(vop, vectorType).getOpCodeValue();
+            TR::ILOpCodes opcode = TR::ILOpCode::createVectorOpCode(vop, vectorType);
             _opcodeNameMap[name] = opcode;
             return opcode;
          }


### PR DESCRIPTION
- transform opcodes for which source and result types are the same:
  vload/vstore, vloadi/vstorei, vnot, vneg, vsub, vmul, vdiv, vand, vor, vxor, vsplats