### PR TITLE
Correct usage of x86 directCallRequiresTrampoline() API

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2331,12 +2331,13 @@ void OMR::X86::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t * cursor
 // instruction or the disp32 to a trampoline that can reach the helper.
 //
 int32_t OMR::X86::CodeGenerator::branchDisplacementToHelperOrTrampoline(
-   uint8_t            *nextInstructionAddress,
+   uint8_t *branchInstructionAddress,
    TR::SymbolReference *helper)
    {
    intptr_t helperAddress = (intptr_t)helper->getMethodAddress();
+   uint8_t *nextInstructionAddress = branchInstructionAddress + 5;  // 5 == length of wide displacement direct call or jump instruction
 
-   if (self()->directCallRequiresTrampoline(helperAddress, (intptr_t)nextInstructionAddress))
+   if (self()->directCallRequiresTrampoline(helperAddress, (intptr_t)branchInstructionAddress))
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(helper->getReferenceNumber(), (void *)(nextInstructionAddress-4));
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -410,7 +410,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR::SymbolReference *getNanoTimeTemp();
 
-   int32_t branchDisplacementToHelperOrTrampoline(uint8_t *nextInstructionAddress, TR::SymbolReference *helper);
+   /**
+    * @brief Computes the 32-bit displacement between the given direct branch instruction
+    *        and either the target helper or a trampoline to reach the target helper
+    *
+    * @param[in] branchInstructionAddress : buffer address of the branch instruction
+    * @param[in] helper : \c TR::SymbolReference of the target helper
+    *
+    * @return The 32-bit displacement for the branch instruction
+    */
+   int32_t branchDisplacementToHelperOrTrampoline(uint8_t *branchInstructionAddress, TR::SymbolReference *helper);
 
    /**
     * \brief Reserve space in the code cache for a specified number of trampolines.

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -868,17 +868,6 @@ protected:
 
 }
 
-
-// Trampolines
-//
-
-#if defined(TR_TARGET_64BIT)
-#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->directCallRequiresTrampoline((intptr_t)target, (intptr_t)rip))
-#else
-// Give the C++ compiler a hand
-#define NEEDS_TRAMPOLINE(target, rip, cg) (0)
-#endif
-
 #define IS_32BIT_RIP(x,rip)  ((intptr_t)(x) == (intptr_t)(rip) + (int32_t)((intptr_t)(x) - (intptr_t)(rip)))
 
 class TR_X86ScratchRegisterManager: public TR_ScratchRegisterManager

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -124,9 +124,6 @@ extern int64_t getIntegralValue(TR::Node* node);
 #define LOWER_4_BYTES(x) (x)
 #endif
 
-// Multi Code Cache Routines for checking whether an entry point is within reach of a BASRL.
-#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->directCallRequiresTrampoline((intptr_t)target, (intptr_t)rip))
-
 #define TR_MAX_MVC_SIZE 256
 #define TR_MAX_CLC_SIZE 256
 #define TR_MIN_SS_DISP 0


### PR DESCRIPTION
* Correct usage of x86 directCallRequiresTrampoline() API
* Remove unused NEEDS_TRAMPOLINE macros