### PR TITLE
Make fixUpTree a virtual method

### DIFF
--- a/compiler/optimizer/DeadTreesElimination.hpp
+++ b/compiler/optimizer/DeadTreesElimination.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,6 +86,12 @@ class DeadTreesElimination : public TR::Optimization
    virtual int32_t perform();
    virtual int32_t performOnBlock(TR::Block *);
    virtual void prePerformOnBlocks();
+   virtual bool fixUpTree(
+		TR::Node *node,
+		TR::TreeTop *treeTop,
+		TR::NodeChecklist &visited,
+		bool &highGlobalIndex,
+		vcount_t evaluatedVisitCount);
 
    virtual const char * optDetailString() const throw();
 


### PR DESCRIPTION
In DeadTreesElimination, fixUpTree() is a static function local to the cpp file for what appears to be historical reasons. To make this function available for downstream projects to override, make it a virtual method of the DeadTreesElimination class.