### PR TITLE
Get opendir to use the cwd if the corepath is blank

### DIFF
--- a/port/unix/omrosdump.c
+++ b/port/unix/omrosdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -238,6 +238,9 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 		}
 
 		/* Apply suggested name */
+#if defined(DUMP_DBG)
+		portLibrary->tty_err_printf(portLibrary, "Attempting to rename \"%s\" to \"%s\"\n", corepath, filename);
+#endif /* defined(DUMP_DBG) */
 		if (rename(corepath, filename)) {
 			portLibrary->str_printf(portLibrary, filename, EsMaxPath, "cannot find core file: \"%s\". check \"ulimit -Hc\" is set high enough", strerror(errno));
 			return 1;


### PR DESCRIPTION
On AIX, if the corepath provided to appendCoreName() is blank, then opendir() will fail. However the core may have been written to the current working directory and it will be missed. If corepath is blank, provide "." to opendir().

Also add some extra messages that will come out when DUMP_DEBUG is defined, and fix a typo.

Signed-off-by: David McCann mccannd@uk.ibm.com