### PR TITLE
Fix computation of cache-line size on Power

### DIFF
--- a/include_core/omrutil.h
+++ b/include_core/omrutil.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -330,9 +330,9 @@ getPageTypeStringWithLeadingSpace(uintptr_t pageFlags);
 /**
 * @brief
 * @param void
-* @return uintptr_t
+* @return uint32_t
 */
-uintptr_t getCacheLineSize(void);
+uint32_t getCacheLineSize(void);
 
 
 /**

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -95,7 +95,7 @@ typedef struct OMRPortPlatformGlobals {
 	BOOLEAN globalConverterEnabled;
 	char *si_executableName;
 #if defined(RS6000) || defined (LINUXPPC) || defined (PPC)
-	int32_t mem_ppcCacheLineSize;
+	uint32_t mem_ppcCacheLineSize;
 #endif
 #if defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL)
 	int32_t introspect_threadSuspendSignal;


### PR DESCRIPTION
We need to inform the compiler that our uses of `dcbz` clobber memory, otherwise the optimizer can reasonably assume, e.g. in `omrcpu_startup(),` that `buf[0] == 255` at the beginning of the for loop.