### PR TITLE
Enable Vectorization for supported ops on Z

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1209,9 +1209,11 @@ OMR::CodeGenerator::isGlobalVRF(TR_GlobalRegisterNumber n)
 bool
 OMR::CodeGenerator::supportsMergingGuards()
    {
-   return self()->getSupportsVirtualGuardNOPing() &&
-          self()->comp()->performVirtualGuardNOPing() &&
-          !self()->comp()->compileRelocatableCode();
+   static bool enableMergingGuards = feGetEnv("TR_DisableMergingGuards") == NULL;
+   return enableMergingGuards &&
+            self()->getSupportsVirtualGuardNOPing() &&
+            self()->comp()->performVirtualGuardNOPing() &&
+            !self()->comp()->compileRelocatableCode();
    }
 
 bool

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4754,35 +4754,34 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR
 
    TR::DataType et = opcode.getVectorResultDataType().getVectorElementType();
 
+   TR_ASSERT_FATAL(et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double, "DataType %s is not supported for vectorization", et.toString());
+
    // implemented vector opcodes
    switch (opcode.getVectorOperation())
       {
       case OMR::vadd:
       case OMR::vsub:
-      case OMR::vmul:
-      case OMR::vdiv:
-      case OMR::vneg:
-         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-            return true;
-         else
-            return false;
       case OMR::vload:
       case OMR::vloadi:
       case OMR::vstore:
       case OMR::vstorei:
-         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+      case OMR::vneg:
+      case OMR::vsplats:
+         return true;
+      case OMR::vmul:
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
+            return true;
+         else
+            return false;
+      case OMR::vdiv:
+         if (et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
       case OMR::vxor:
       case OMR::vor:
       case OMR::vand:
-         if (et == TR::Int32 || et == TR::Int64)
-            return true;
-         else
-            return false;
-      case OMR::vsplats:
-         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
             return true;
          else
             return false;


### PR DESCRIPTION
This commit enables vectorization of following operations in Vector API
for different species.

1. Vector Load and Store for all species.
2. Binary Operations
   1. Add/Subtraction : Enabled for all species
   2. Multiplication : Enabled for all species except Long
   3. Division : Enabled for Float and Doubles only
   4. AND/OR/XOR : Enables for all integral types
3. NEG operation for all species
4. Broadcast operation for all species

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>