### PR TITLE
Revert "Implement 256 and 512-bit vload/vstore on x86"

### DIFF
--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -225,11 +225,7 @@ enum VectorLength
    VectorLength64,
    // TODO: Redefine, preferably based on platform, when some platform starts supporting other than 128-bit
    // Defining per platform is not necessary for functional correctness but for reducing NumAllTypes
-#if defined(TR_TARGET_X86)
-   NumVectorLengths = VectorLength512
-#else
    NumVectorLengths = VectorLength128
-#endif
    };
 
 /**

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1028,6 +1028,9 @@ OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::D
       }
 
    TR::DataType ot = opcode.getVectorResultDataType();
+
+   if (ot.getVectorLength() != TR::VectorLength128) return false;
+
    TR::DataType et = ot.getVectorElementType();
 
    switch (opcode.getVectorOperation())
@@ -1035,51 +1038,39 @@ OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::D
       case OMR::vadd:
       case OMR::vsub:
          if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-            return ot.getVectorLength() == TR::VectorLength128;
+            return true;
          else
             return false;
       case OMR::vmul:
          TR_ASSERT_FATAL(self()->comp()->compileRelocatableCode() || self()->comp()->isOutOfProcessCompilation() || self()->comp()->compilePortableCode() || self()->getX86ProcessorInfo().supportsSSE4_1() == self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1), "supportsSSE4_1() failed\n");
          if (et == TR::Float || et == TR::Double || (et == TR::Int32 && self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1)))
-            return ot.getVectorLength() == TR::VectorLength128;
+            return true;
          else
             return false;
       case OMR::vdiv:
          if (et == TR::Float || et == TR::Double)
-            return ot.getVectorLength() == TR::VectorLength128;
+            return true;
          else
             return false;
       case OMR::vneg:
-         return ot.getVectorLength() == TR::VectorLength128;
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+            return true;
+         else
+            return false;
       case OMR::vxor:
       case OMR::vor:
       case OMR::vand:
          if (et == TR::Int32 || et == TR::Int64)
-            return ot.getVectorLength() == TR::VectorLength128;
+            return true;
          else
             return false;
       case OMR::vload:
       case OMR::vloadi:
       case OMR::vstore:
       case OMR::vstorei:
-         switch (ot.getVectorLength())
-            {
-            case TR::VectorLength512:
-               if (!self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F))
-                  return false;
-               return true;
-            case TR::VectorLength256:
-               if (!self()->comp()->target().cpu.supportsAVX())
-                  return false;
-               return true;
-            case TR::VectorLength128:
-               return true;
-            default:
-                return false;
-            }
       case OMR::vsplats:
          if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
-            return ot.getVectorLength() == TR::VectorLength128;
+            return true;
          else
             return false;
       default:

--- a/compiler/x/codegen/SIMDTreeEvaluator.cpp
+++ b/compiler/x/codegen/SIMDTreeEvaluator.cpp
@@ -75,31 +75,20 @@ TR::Register* OMR::X86::TreeEvaluator::SIMDloadEvaluator(TR::Node* node, TR::Cod
    tempMR = ConvertToPatchableMemoryReference(tempMR, node, cg);
    TR::Register* resultReg = cg->allocateRegister(TR_VRF);
 
-   TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::MOVDQURegMem;
-   OMR::X86::Encoding encoding = Legacy;
-
+   TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
    switch (node->getSize())
       {
       case 16:
-         if (cg->comp()->target().cpu.supportsAVX())
-            encoding = VEX_L128;
-         break;
-      case 32:
-         TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsAVX(), "256-bit vload requires AVX");
-         encoding = VEX_L256;
-         break;
-      case 64:
-         TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F), "512-bit vload requires AVX-512");
-         encoding = EVEX_L512;
+         opCode = TR::InstOpCode::MOVDQURegMem;
          break;
       default:
          if (cg->comp()->getOption(TR_TraceCG))
             traceMsg(cg->comp(), "Unsupported fill size: Node = %p\n", node);
-         TR_ASSERT_FATAL(false, "Unsupported fill size");
+         TR_ASSERT(false, "Unsupported fill size");
          break;
       }
 
-   TR::Instruction* instr = generateRegMemInstruction(opCode, node, resultReg, tempMR, cg, encoding);
+   TR::Instruction* instr = generateRegMemInstruction(opCode, node, resultReg, tempMR, cg);
    if (node->getOpCode().isIndirect())
       cg->setImplicitExceptionPoint(instr);
    node->setRegister(resultReg);
@@ -114,31 +103,20 @@ TR::Register* OMR::X86::TreeEvaluator::SIMDstoreEvaluator(TR::Node* node, TR::Co
    tempMR = ConvertToPatchableMemoryReference(tempMR, node, cg);
    TR::Register* valueReg = cg->evaluate(valueNode);
 
-   TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::MOVDQUMemReg;
-   OMR::X86::Encoding encoding = Legacy;
-
+   TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
    switch (node->getSize())
       {
       case 16:
-         if (cg->comp()->target().cpu.supportsAVX())
-            encoding = VEX_L128;
-         break;
-      case 32:
-         TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsAVX(), "256-bit vstore requires AVX");
-         encoding = VEX_L256;
-         break;
-      case 64:
-          TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F), "512-bit vstore requires AVX-512");
-         encoding = EVEX_L512;
+         opCode = TR::InstOpCode::MOVDQUMemReg;
          break;
       default:
          if (cg->comp()->getOption(TR_TraceCG))
             traceMsg(cg->comp(), "Unsupported fill size: Node = %p\n", node);
-         TR_ASSERT_FATAL(false, "Unsupported fill size");
+         TR_ASSERT(false, "Unsupported fill size");
          break;
       }
 
-   TR::Instruction* instr = generateMemRegInstruction(opCode, node, tempMR, valueReg, cg, encoding);
+   TR::Instruction* instr = generateMemRegInstruction(opCode, node, tempMR, valueReg, cg);
 
    cg->decReferenceCount(valueNode);
    tempMR->decNodeReferenceCounts(cg);


### PR DESCRIPTION
Reverts eclipse/omr#6509

See https://github.com/eclipse/omr/pull/6509#issuecomment-1129396524