### PR TITLE
Fix usage of pTOC with portableSCC code run in P10 container

### DIFF
--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1435,7 +1435,8 @@ void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
             {
             //For Little Endian, load target's Global Entry Point into r12, TOC will be restored at branch target.
             TR::Register *geReg = dependencies->searchPreConditionRegister(TR::RealRegister::gr12);
-            if (!cg()->comp()->getOption(TR_DisableTOC))
+
+            if (!cg()->comp()->getOption(TR_DisableTOC) && !cg()->comp()->compilePortableCode())
                generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, geReg,
                   TR::MemoryReference::createWithDisplacement(cg(), cg()->getTOCBaseRegister(),
                        (refNum-1)*TR::Compiler->om.sizeofReferenceAddress(),


### PR DESCRIPTION
This fixes an issue with the code generated for containers with
-XX:+PortableSharedCache option. AOT code generated on P8 uses
pTOC and if the same container is used on P10 environment causes
a crash as pTOC is not there on P10. The fix will generate
materialize sequence of instructions when -XX:+PortableSharedCache
option is enabled and not pTOC.

Signed-off-by: Bhavani SN <bhavani.sn@ibm.com>