### PR TITLE
Add defaultValueSymbol for value type class

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -399,7 +399,12 @@
     */
    J9JNIMethodIDvTableIndexFieldSymbol,
 
-   OMRlastPrintableCommonNonhelperSymbol = J9JNIMethodIDvTableIndexFieldSymbol,
+   /** \brief
+    * This symbol is used to access the default instance associated with a class, if any exists
+    */
+   defaultValueSymbol,
+
+   OMRlastPrintableCommonNonhelperSymbol = defaultValueSymbol,
 
    firstPerCodeCacheHelperSymbol,
    lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -476,7 +476,12 @@ class SymbolReferenceTable
        */
       J9JNIMethodIDvTableIndexFieldSymbol,
 
-      OMRlastPrintableCommonNonhelperSymbol = J9JNIMethodIDvTableIndexFieldSymbol,
+      /** \brief
+       * This symbol is used to access the default instance associated with a class, if any exists
+       */
+      defaultValueSymbol,
+
+      OMRlastPrintableCommonNonhelperSymbol = defaultValueSymbol,
 
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1626,6 +1626,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<nonNullableArrayNullStoreCheck>";
          case TR::SymbolReferenceTable::J9JNIMethodIDvTableIndexFieldSymbol:
              return "<J9JNIMethodIDvTableIndexFieldSymbol>";
+         case TR::SymbolReferenceTable::defaultValueSymbol:
+             return "<defaultValue>";
          }
       }
 
@@ -2090,7 +2092,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<j9VMThreadTempSlotField>",
    "<computedStaticCallSymbol>",
    "<j9VMThreadFloatTemp1>",
-   "<J9JNIMethodIDvTableIndexFieldSymbol>"
+   "<J9JNIMethodIDvTableIndexFieldSymbol>",
+   "<defaultValue>"
    };
 
 const char *


### PR DESCRIPTION
`defaultValueSymbol` symbol represents the `defaultValue` field in J9Class.flattenedClassCache.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>