### PR TITLE
AArch64: Add Vector Add across Vector instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -965,6 +965,9 @@ static const char *opCodeToNameMap[] =
    "vumull2_8h",
    "vumull2_4s",
    "vumull2_2d",
+   "vaddv16b",
+   "vaddv8h",
+   "vaddv4s",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -958,6 +958,10 @@
 		vumull2_8h,                                              	/* 0x6E20C000	UMULL2   	 */
 		vumull2_4s,                                              	/* 0x6E60C000	UMULL2   	 */
 		vumull2_2d,                                              	/* 0x6EA0C000	UMULL2   	 */
+	/* Vector reduce instructions */
+		vaddv16b,                                               	/* 0x4E31B800	ADDV    	 */
+		vaddv8h,                                                	/* 0x4E71B800	ADDV    	 */
+		vaddv4s,                                                	/* 0x4EB1B800	ADDV    	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -959,6 +959,10 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6E20C000,	/* UMULL2  	vumull2_8h */
 		0x6E60C000,	/* UMULL2  	vumull2_4s */
 		0x6EA0C000,	/* UMULL2  	vumull2_2d */
+	/* Vector reduce instructions */
+		0x4E31B800,	/* ADDV   	vaddv16b */
+		0x4E71B800,	/* ADDV   	vaddv8h */
+		0x4Eb1B800,	/* ADDV   	vaddv4s */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -1930,3 +1930,18 @@ INSTANTIATE_TEST_CASE_P(INS2, ARM64MovVectorElementEncodingTest, ::testing::Valu
     std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 0, 1, "6e08441f"),
     std::make_tuple(TR::InstOpCode::vinsed, TR::RealRegister::v31, TR::RealRegister::v0, 1, 1, "6e18441f")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorADDV, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vaddv16b, TR::RealRegister::v0, TR::RealRegister::v15, "4e31b9e0"),
+    std::make_tuple(TR::InstOpCode::vaddv8h, TR::RealRegister::v0, TR::RealRegister::v15, "4e71b9e0"),
+    std::make_tuple(TR::InstOpCode::vaddv4s, TR::RealRegister::v0, TR::RealRegister::v15, "4eb1b9e0"),
+    std::make_tuple(TR::InstOpCode::vaddv16b, TR::RealRegister::v0, TR::RealRegister::v31, "4e31bbe0"),
+    std::make_tuple(TR::InstOpCode::vaddv8h, TR::RealRegister::v0, TR::RealRegister::v31, "4e71bbe0"),
+    std::make_tuple(TR::InstOpCode::vaddv4s, TR::RealRegister::v0, TR::RealRegister::v31, "4eb1bbe0"),
+    std::make_tuple(TR::InstOpCode::vaddv16b, TR::RealRegister::v15, TR::RealRegister::v0, "4e31b80f"),
+    std::make_tuple(TR::InstOpCode::vaddv8h, TR::RealRegister::v15, TR::RealRegister::v0, "4e71b80f"),
+    std::make_tuple(TR::InstOpCode::vaddv4s, TR::RealRegister::v15, TR::RealRegister::v0, "4eb1b80f"),
+    std::make_tuple(TR::InstOpCode::vaddv16b, TR::RealRegister::v31, TR::RealRegister::v0, "4e31b81f"),
+    std::make_tuple(TR::InstOpCode::vaddv8h, TR::RealRegister::v31, TR::RealRegister::v0, "4e71b81f"),
+    std::make_tuple(TR::InstOpCode::vaddv4s, TR::RealRegister::v31, TR::RealRegister::v0, "4eb1b81f")
+));


### PR DESCRIPTION
This commit adds vector add across vector (reduce add) instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>