### PR TITLE
AArch64 macOS: Include pthread.h explicitly

### DIFF
--- a/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
@@ -26,6 +26,10 @@
 #include "env/jittypes.h"
 #include <infra/Assert.hpp>
 
+#if defined(OSX)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 extern void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
 
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -112,6 +112,10 @@
 #include "stdarg.h"
 #include "OMR/Bytes.hpp"
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 namespace TR { class Optimizer; }
 namespace TR { class RegisterDependencyConditions; }
 

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -50,6 +50,10 @@
 #include <unistd.h>
 #endif
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 namespace TR { class CodeGenerator; }
 
 /*****************************************************************************

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -54,6 +54,10 @@ TR::CodeCacheSymbolContainer * OMR::CodeCacheManager::_symbolContainer = NULL;
 
 #endif //HOST_OS == OMR_LINUX
 
+#if defined(OSX) && defined(AARCH64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
+
 OMR::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator) :
    _rawAllocator(rawAllocator),
    _initialized(false),


### PR DESCRIPTION
This commit adds "#include <pthread.h>" to the files that call
pthread_jit_write_protect_np() on AArch64 macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>