### PR TITLE
AArch64: Add more vector reduce add instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -968,6 +968,12 @@ static const char *opCodeToNameMap[] =
    "vaddv16b",
    "vaddv8h",
    "vaddv4s",
+   "vsaddlv8h",
+   "vsaddlv4s",
+   "vsaddlv2d",
+   "vuaddlv8h",
+   "vuaddlv4s",
+   "vuaddlv2d",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -962,6 +962,12 @@
 		vaddv16b,                                               	/* 0x4E31B800	ADDV    	 */
 		vaddv8h,                                                	/* 0x4E71B800	ADDV    	 */
 		vaddv4s,                                                	/* 0x4EB1B800	ADDV    	 */
+		vsaddlv8h,                                               	/* 0x4E303800	SADDLV  	 */
+		vsaddlv4s,                                               	/* 0x4E703800	SADDLV  	 */
+		vsaddlv2d,                                               	/* 0x4EB03800	SADDLV  	 */
+		vuaddlv8h,                                               	/* 0x6E303800	UADDLV  	 */
+		vuaddlv4s,                                               	/* 0x6E703800	UADDLV  	 */
+		vuaddlv2d,                                               	/* 0x6EB03800	UADDLV  	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -963,6 +963,12 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E31B800,	/* ADDV   	vaddv16b */
 		0x4E71B800,	/* ADDV   	vaddv8h */
 		0x4Eb1B800,	/* ADDV   	vaddv4s */
+		0x4E303800,	/* SADDLV 	vsaddlv8h */
+		0x4E703800,	/* SADDLV 	vsaddlv4s */
+		0x4EB03800,	/* SADDLV 	vsaddlv2d */
+		0x6E303800,	/* UADDLV 	vuaddlv8h */
+		0x6E703800,	/* UADDLV 	vuaddlv4s */
+		0x6EB03800,	/* UADDLV 	vuaddlv2d */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -1945,3 +1945,33 @@ INSTANTIATE_TEST_CASE_P(VectorADDV, ARM64Trg1Src1EncodingTest, ::testing::Values
     std::make_tuple(TR::InstOpCode::vaddv8h, TR::RealRegister::v31, TR::RealRegister::v0, "4e71b81f"),
     std::make_tuple(TR::InstOpCode::vaddv4s, TR::RealRegister::v31, TR::RealRegister::v0, "4eb1b81f")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorSADDLV, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vsaddlv8h, TR::RealRegister::v0, TR::RealRegister::v15, "4e3039e0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv4s, TR::RealRegister::v0, TR::RealRegister::v15, "4e7039e0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv2d, TR::RealRegister::v0, TR::RealRegister::v15, "4eb039e0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv8h, TR::RealRegister::v0, TR::RealRegister::v31, "4e303be0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv4s, TR::RealRegister::v0, TR::RealRegister::v31, "4e703be0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv2d, TR::RealRegister::v0, TR::RealRegister::v31, "4eb03be0"),
+    std::make_tuple(TR::InstOpCode::vsaddlv8h, TR::RealRegister::v15, TR::RealRegister::v0, "4e30380f"),
+    std::make_tuple(TR::InstOpCode::vsaddlv4s, TR::RealRegister::v15, TR::RealRegister::v0, "4e70380f"),
+    std::make_tuple(TR::InstOpCode::vsaddlv2d, TR::RealRegister::v15, TR::RealRegister::v0, "4eb0380f"),
+    std::make_tuple(TR::InstOpCode::vsaddlv8h, TR::RealRegister::v31, TR::RealRegister::v0, "4e30381f"),
+    std::make_tuple(TR::InstOpCode::vsaddlv4s, TR::RealRegister::v31, TR::RealRegister::v0, "4e70381f"),
+    std::make_tuple(TR::InstOpCode::vsaddlv2d, TR::RealRegister::v31, TR::RealRegister::v0, "4eb0381f")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorUADDLV, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vuaddlv8h, TR::RealRegister::v0, TR::RealRegister::v15, "6e3039e0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv4s, TR::RealRegister::v0, TR::RealRegister::v15, "6e7039e0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv2d, TR::RealRegister::v0, TR::RealRegister::v15, "6eb039e0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv8h, TR::RealRegister::v0, TR::RealRegister::v31, "6e303be0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv4s, TR::RealRegister::v0, TR::RealRegister::v31, "6e703be0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv2d, TR::RealRegister::v0, TR::RealRegister::v31, "6eb03be0"),
+    std::make_tuple(TR::InstOpCode::vuaddlv8h, TR::RealRegister::v15, TR::RealRegister::v0, "6e30380f"),
+    std::make_tuple(TR::InstOpCode::vuaddlv4s, TR::RealRegister::v15, TR::RealRegister::v0, "6e70380f"),
+    std::make_tuple(TR::InstOpCode::vuaddlv2d, TR::RealRegister::v15, TR::RealRegister::v0, "6eb0380f"),
+    std::make_tuple(TR::InstOpCode::vuaddlv8h, TR::RealRegister::v31, TR::RealRegister::v0, "6e30381f"),
+    std::make_tuple(TR::InstOpCode::vuaddlv4s, TR::RealRegister::v31, TR::RealRegister::v0, "6e70381f"),
+    std::make_tuple(TR::InstOpCode::vuaddlv2d, TR::RealRegister::v31, TR::RealRegister::v0, "6eb0381f")
+));


### PR DESCRIPTION
This commit adds `SADDLV` and `UADDLV` instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>