### PR TITLE
Make LocalDeadStoreElimination members/methods protected

### DIFF
--- a/compiler/optimizer/LocalDeadStoreElimination.hpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,6 @@ class LocalDeadStoreElimination : public TR::Optimization
 
    virtual bool isNonRemovableStore(TR::Node *storeNode, bool &seenIdentityStore);
 
-   private:
    typedef TR::Node *StoreNode;
 
    typedef TR::deque<StoreNode, TR::Region&> StoreNodeTable;
@@ -104,7 +103,6 @@ class LocalDeadStoreElimination : public TR::Optimization
 
    TR::TreeTop                      *_curTree;
 
-   private:
    StoreNodeTable                   *_storeNodes;
 
    bool                              _blockContainsReturn;


### PR DESCRIPTION
Replace private access with protected to allow downstream projects to make use of derived classes to extend/specialize the functionality of LocalDeadStoreElimination.