### PR TITLE
Check for bit length of constant before addConstantToInteger

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2506,7 +2506,7 @@ TR::Register *intEqualityEvaluator(TR::Node *node, bool flipResult, TR::DataType
 
          if (src2Value != 0)
             {
-            if (type == TR::Int64)
+            if (type == TR::Int64 || (type == TR::Address && cg->comp()->target().is64Bit()))
                addConstantToLong(node, src1Reg, -src2Value, trgReg, cg);
             else
                addConstantToInteger(node, trgReg, src1Reg, -src2Value, cg);


### PR DESCRIPTION
Issue was while calling addConstantToInteger a 64 bit value was used
and passed as 32bit in the function call. Code generated to load the 
constant was losing higher bits and thus caused issues.

Fixes #6511

Signed-off-by: Bhavani S N <bhavani.sn@ibm.com>