### PR TITLE
Ensure calls to feGetEnv are cached

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -7171,7 +7171,7 @@ TR_InductionVariableAnalysis::findEntryValueForSymRef(TR_RegionStructure *loop,
 
 static int32_t getEntryValueMaxDepth()
    {
-   char * ivaMaxDepthString = feGetEnv("TR_IVAEntryValueMaxDepth");
+   static const char * ivaMaxDepthString = feGetEnv("TR_IVAEntryValueMaxDepth");
    if (ivaMaxDepthString)
       return atoi(ivaMaxDepthString);
    return 500;

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -2639,7 +2639,7 @@ int32_t *computeCallsiteCounts(TR_ScratchList<TR::Block> *loopBlocks, TR::Compil
 
 bool TR_LoopVersioner::checkProfiledGuardSuitability(TR_ScratchList<TR::Block> *loopBlocks, TR::Node *guardNode, TR::SymbolReference *callSymRef, TR::Compilation *comp)
    {
-   bool disableLoopCodeRatioCheck = feGetEnv("TR_DisableLoopCodeRatioCheck") != NULL;
+   static const bool disableLoopCodeRatioCheck = feGetEnv("TR_DisableLoopCodeRatioCheck") != NULL;
    bool risky = false;
    if (comp->getMethodHotness() >= hot && callSymRef)
       {

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -62,7 +62,8 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
 
    if (TRUE == omrsysinfo_processor_has_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE))
       {
-      if (((6 & _xgetbv(0)) != 6) || feGetEnv("TR_DisableAVX")) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
+      static const bool disableAVX = feGetEnv("TR_DisableAVX") != NULL;
+      if (((6 & _xgetbv(0)) != 6) || disableAVX) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
          {
          // Unset OSXSAVE if not enabled via CR0
          omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_X86_OSXSAVE, FALSE);

--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,8 @@ inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
       // Check for XSAVE
       if(pBuffer->_featureFlags2 & TR_OSXSAVE)
          {
-         if(((6 & _xgetbv(0)) != 6) || feGetEnv("TR_DisableAVX")) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
+         static const bool disableAVX = feGetEnv("TR_DisableAVX") != NULL;
+         if(((6 & _xgetbv(0)) != 6) || disableAVX) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
             {
             // Unset OSXSAVE if not enabled via CR0
             pBuffer->_featureFlags2 &= ~TR_OSXSAVE;


### PR DESCRIPTION
Calls to feGetEnv are usually cached in static variables. This
PR catches a few instances that were not.

Personal build 29921 passed