### PR TITLE
Indirect SignalThreadsForWB step2

### DIFF
--- a/example/glue/ConcurrentMarkingDelegate.hpp
+++ b/example/glue/ConcurrentMarkingDelegate.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,6 +205,11 @@ public:
 	{
 		return true;
 	}
+
+	/**
+	 * Firstly acquire exclusive VM access, and then signal threads to activate WB.
+	 */
+	void acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env) {}
 
 	/**
 	 * This can be used to optimize the concurrent write barrier(s) by conditioning threads to stop

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -380,7 +380,7 @@ MM_ConcurrentGC::signalThreadsToActivateWriteBarrierAsyncEventHandler(OMR_VMThre
 	MM_ConcurrentGC *collector  = (MM_ConcurrentGC *)userData;
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 
-	collector->signalThreadsToActivateWriteBarrier(env);
+	collector->_concurrentDelegate.acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(env);
 }
 
 /**
@@ -1487,7 +1487,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 			case CONCURRENT_INIT_COMPLETE:
 				if (_extensions->optimizeConcurrentWB) {
 					if (threadAtSafePoint) {
-						signalThreadsToActivateWriteBarrier(env);
+						_concurrentDelegate.acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(env);
 					} else {
 						/* Register for this thread to get called back at safe point */
 						_callback->requestCallback(env);
@@ -1573,7 +1573,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 }
 
 void
-MM_ConcurrentGC::signalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env)
+MM_ConcurrentGC::acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env)
 {
 	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
 

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -297,8 +297,6 @@ protected:
 	virtual uintptr_t doConcurrentTrace(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t sizeToTrace, MM_MemorySubSpace *subspace, bool tlhAllocation) = 0;
 	void concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace,  MM_AllocateDescription *allocDescription);
 
-	void signalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env);
-
 	uintptr_t calculateInitSize(MM_EnvironmentBase *env, uintptr_t allocationSize);
 	uintptr_t calculateTraceSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 
@@ -392,9 +390,7 @@ public:
 	virtual void abortCollection(MM_EnvironmentBase *env, CollectionAbortReason reason);
 	
 	static void signalThreadsToActivateWriteBarrierAsyncEventHandler(OMR_VMThread *omrVMThread, void *userData);
-	void acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env) {
-		signalThreadsToActivateWriteBarrier(env);
-	}
+	void acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env);
 	
 	virtual void prepareHeapForWalk(MM_EnvironmentBase *env);
 


### PR DESCRIPTION
When starting Concurrent Global Mark we call
MM_ConcurrentGC::signalThreadsForWriteBarrier, that will acquire
exlusive VM access and then iterate over threads to set their enable-WB
flag.

A language specific pre/post processing may be need to performed
before/after exclusive acquire/release, so we will now introduce a level
of indirection so that language specific API is called instead, which
will perform extra processing and meanwhile call back the original OMR's
MM_ConcurrentGC::signalThreadsForWriteBarrier

There is also a rename of some of methods signalThreadsForWriteBarrier
-> acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier to
distinguish them from those that only do the iteration/signalling without
dealing with exclusive VM access.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>