### PR TITLE
Indirect SignalThreadsForWB step1

### DIFF
--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -392,6 +392,9 @@ public:
 	virtual void abortCollection(MM_EnvironmentBase *env, CollectionAbortReason reason);
 	
 	static void signalThreadsToActivateWriteBarrierAsyncEventHandler(OMR_VMThread *omrVMThread, void *userData);
+	void acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env) {
+		signalThreadsToActivateWriteBarrier(env);
+	}
 	
 	virtual void prepareHeapForWalk(MM_EnvironmentBase *env);
 


### PR DESCRIPTION
Introduce a temp public wrapper
acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier around
existing protected signalThreadsToActivateWriteBarrier, to help with
downstream project (J9) being able to access the method.

The wrapper will be become a full new method in step2 change after the
downstream project changes are complete.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>