### PR TITLE
Run PR builds explicitly on cgroup.v1 and cgroup.v2 nodes

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -178,7 +178,7 @@ def SPECS = [
         'junitPublish' : true
     ],
     'linux_x86' : [
-        'label' : 'compile:xlinux',
+        'label' : 'compile:xlinux && cgroup.v1',
         'reference' : defaultReference,
         'environment' : [
             'PATH+CCACHE=/usr/lib/ccache/',
@@ -198,7 +198,7 @@ def SPECS = [
         'junitPublish' : true
     ],
     'linux_x86-64' : [
-        'label' : 'compile:xlinux',
+        'label' : 'compile:xlinux && cgroup.v2',
         'reference' : defaultReference,
         'environment' : [
             'PATH+CCACHE=/usr/lib/ccache/',


### PR DESCRIPTION
Ref-1: https://github.com/eclipse/omr/issues/6501#issuecomment-1140548746

As per Ref-1, OMR has six x64 machines labelled as cgroup.v1, and
another six x64 machines labelled as cgroup.v2.

To support https://github.com/eclipse/omr/issues/6468, the PR build for:
- linux_x86 will be explicitly run on cgroup.v1 nodes; and
- linux_x86-64 will be explicitly run on cgroup.v2 nodes.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>