### PR TITLE
Add safeguard check for SIMD ops support

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4736,7 +4736,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode)
     * Prior to z14, vector operations that operated on floating point numbers only supported
     * Doubles. On z14 and onward, Float type floating point numbers are supported as well.
     */
-   if (et == TR::Float && !self()->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z14))
+   if (!self()->getSupportsVectorRegisters() ||
+         (et == TR::Float && !self()->comp()->target().cpu.getSupportsVectorFacilityEnhancement1()))
       {
       return false;
       }


### PR DESCRIPTION
This commit adds a check to getSupportsOpCodeForAutoSIMD to make sure
that SIMD opcode is supported only when we have support for Vector
instructions.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>