### PR TITLE
Add test for cgroup subsystem iterator functions

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -6796,7 +6796,7 @@ _end:
 int32_t
 omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement)
 {
-	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
+	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 #if defined(LINUX) && !defined(OMRZTPF)
 	struct OMRCgroupMetricInfoElement *currentElement = NULL;
 	const struct OMRCgroupSubsystemMetricMap *subsystemMetricMap = NULL;


### PR DESCRIPTION
* Add testing for omrsysinfo_cgroup_subsystem_iterator_* functions; checks
a few key metrics and that iterating doesn't fail.
* Change default return value from OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE
to OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM to keep consistency
between Unix and non-Unix.

Issue: https://github.com/eclipse/omr/issues/1281
Signed-off-by: Eric Yang <eric.yang@ibm.com>