### PR TITLE
Implement evaluators for different Vector Opcodes

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4753,6 +4753,7 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode)
       case TR::vstorei:
       case TR::vneg:
       case TR::vsplats:
+      case TR::vabs:
          return true;
       case TR::vmul:
          if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
@@ -4760,6 +4761,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode)
          else
             return false;
       case TR::vdiv:
+      case TR::vfma:
+      case TR::vsqrt:
          if (et == TR::Float || et == TR::Double)
             return true;
          else


### PR DESCRIPTION
Implement evaluators for following different opcodes on Z to vectorize
the operation when platform support is available.
1. VFMA
2. VSQRT
3. VABS

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>