### PR TITLE
Add OMR Option to disable merging of OSR Guards

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1213,8 +1213,7 @@ OMR::CodeGenerator::isGlobalVRF(TR_GlobalRegisterNumber n)
 bool
 OMR::CodeGenerator::supportsMergingGuards()
    {
-   static bool enableMergingGuards = feGetEnv("TR_DisableMergingGuards") == NULL;
-   return enableMergingGuards &&
+   return !self()->comp()->getOption(TR_DisableOSRGuardMerging) &&
             self()->getSupportsVirtualGuardNOPing() &&
             self()->comp()->performVirtualGuardNOPing() &&
             !self()->comp()->compileRelocatableCode();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -472,6 +472,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableOSR",                         "O\tdisable support for on-stack replacement", SET_OPTION_BIT(TR_DisableOSR), "F"},
    {"disableOSRCallSiteRemat",            "O\tdisable use of the call stack remat table in on-stack replacement", SET_OPTION_BIT(TR_DisableOSRCallSiteRemat), "F"},
    {"disableOSRExceptionEdgeRemoval",     "O\tdon't trim away unused on-stack replacement points", TR::Options::disableOptimization, osrExceptionEdgeRemoval, 0, "P"},
+   {"disableOSRGuardMerging",             "O\tdisable Merging of OSR guards", SET_OPTION_BIT(TR_DisableOSRGuardMerging), "F"},
 #ifdef J9_PROJECT_SPECIFIC
    {"disableOSRGuardRemoval",             "O\tdisable OSR guard removal",                      TR::Options::disableOptimization, osrGuardRemoval, 0, "P"},
 #endif

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -547,7 +547,7 @@ enum TR_CompilationOptions
    TR_DoNotUsePersistentIprofiler                     = 0x00080000 + 15,
    TR_DoNotUseFastStackwalk                           = 0x00100000 + 15,
    TR_DisableOSRLiveRangeAnalysis                     = 0x00200000 + 15,
-   // Available                                       = 0x00400000 + 15,
+   TR_DisableOSRGuardMerging                         = 0x00400000 + 15,
    // Available                                       = 0x00800000 + 15,
    // Available                                       = 0x01000000 + 15,
    // Available                                       = 0x02000000 + 15,


### PR DESCRIPTION
Previously we had an environment option to disable merging of OSR guards
which was needed to allow VectorAPIExpansion to scalarize or vectorize
Vector API intrinsics on X and Z. Replacing an enviromentment option to
OMR Option to make it easier to set it for automated testing.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>