### PR TITLE
AArch64: Add vector add pairwise instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -990,6 +990,11 @@ static const char *opCodeToNameMap[] =
    "vuminv16b",
    "vuminv8h",
    "vuminv4s",
+   "vaddp16b",
+   "vaddp8h",
+   "vaddp4s",
+   "vaddp2d",
+   "addp2d",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -984,6 +984,12 @@
 		vuminv16b,                                               	/* 0x6E31A800	UMINV   	 */
 		vuminv8h,                                                	/* 0x6E71A800	UMINV   	 */
 		vuminv4s,                                                	/* 0x6EB1A800	UMINV   	 */
+	/* Vector pairwise instructions */
+		vaddp16b,                                               	/* 0x4E20BC00	ADDP         	 */
+		vaddp8h,                                                	/* 0x4E60BC00	ADDP         	 */
+		vaddp4s,                                                	/* 0x4EA0BC00	ADDP         	 */
+		vaddp2d,                                                	/* 0x4EE0BC00	ADDP         	 */
+		addp2d,                                                 	/* 0x5EF1B800	ADDP (scalar)	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -985,6 +985,12 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6E31A800,	/* UMINV  	vuminv16b */
 		0x6E71A800,	/* UMINV  	vuminv8h */
 		0x6EB1A800,	/* UMINV  	vuminv4s */
+	/* Vector pairwise instructions */
+		0x4E20BC00,	/* ADDP   	vaddp16b */
+		0x4E60BC00,	/* ADDP   	vaddp8h */
+		0x4EA0BC00,	/* ADDP   	vaddp4s */
+		0x4EE0BC00,	/* ADDP   	vaddp2d */
+		0x5EF1B800,	/* ADDP (scalar) addp2d */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -2048,3 +2048,37 @@ INSTANTIATE_TEST_CASE_P(VectorUnsignedReduceMINMAX, ARM64Trg1Src1EncodingTest, :
     std::make_tuple(TR::InstOpCode::vuminv8h, TR::RealRegister::v31, TR::RealRegister::v0, "6e71a81f"),
     std::make_tuple(TR::InstOpCode::vuminv4s, TR::RealRegister::v31, TR::RealRegister::v0, "6eb1a81f")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorAddp, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e20bc0f"),
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e20bc1f"),
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e20bde0"),
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e20bfe0"),
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e2fbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e3fbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e60bc0f"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e60bc1f"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e60bde0"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e60bfe0"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e6fbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e7fbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4ea0bc0f"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4ea0bc1f"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4ea0bde0"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4ea0bfe0"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eafbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4ebfbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4ee0bc0f"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4ee0bc1f"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4ee0bde0"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4ee0bfe0"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eefbc00"),
+    std::make_tuple(TR::InstOpCode::vaddp2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4effbc00")
+));
+
+INSTANTIATE_TEST_CASE_P(ScalarAddp, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v0, TR::RealRegister::v15, "5ef1b9e0"),
+    std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v0, TR::RealRegister::v31, "5ef1bbe0"),
+    std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v15, TR::RealRegister::v0, "5ef1b80f"),
+    std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v31, TR::RealRegister::v0, "5ef1b81f")
+));


### PR DESCRIPTION
This commit adds vector add pairwise instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>