### PR TITLE
AArch64: vector floating point add pairwise instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -995,6 +995,10 @@ static const char *opCodeToNameMap[] =
    "vaddp4s",
    "vaddp2d",
    "addp2d",
+   "vfaddp4s",
+   "vfaddp2d",
+   "faddp2s",
+   "faddp2d",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -990,6 +990,10 @@
 		vaddp4s,                                                	/* 0x4EA0BC00	ADDP         	 */
 		vaddp2d,                                                	/* 0x4EE0BC00	ADDP         	 */
 		addp2d,                                                 	/* 0x5EF1B800	ADDP (scalar)	 */
+		vfaddp4s,                                               	/* 0x6E20D400	FADDP        	 */
+		vfaddp2d,                                               	/* 0x6E60D400	FADDP        	 */
+		faddp2s,                                                	/* 0x7E30D800	FADDP(scalar)	 */
+		faddp2d,                                                	/* 0x7E70D800	FADDP(scalar)	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -991,6 +991,10 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4EA0BC00,	/* ADDP   	vaddp4s */
 		0x4EE0BC00,	/* ADDP   	vaddp2d */
 		0x5EF1B800,	/* ADDP (scalar) addp2d */
+		0x6E20D400,	/* FADDP  	vfaddp4s */
+		0x6E60D400,	/* FADDP  	vfaddp2d */
+		0x7E30D800,	/* FADDP(scalar) faddp2s */
+		0x7E70D800,	/* FADDP(scalar) faddp2d */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -2082,3 +2082,29 @@ INSTANTIATE_TEST_CASE_P(ScalarAddp, ARM64Trg1Src1EncodingTest, ::testing::Values
     std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v15, TR::RealRegister::v0, "5ef1b80f"),
     std::make_tuple(TR::InstOpCode::addp2d, TR::RealRegister::v31, TR::RealRegister::v0, "5ef1b81f")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorFAddp, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "6e20d40f"),
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e20d41f"),
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e20d5e0"),
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e20d7e0"),
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e2fd400"),
+    std::make_tuple(TR::InstOpCode::vfaddp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e3fd400"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "6e60d40f"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e60d41f"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e60d5e0"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e60d7e0"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e6fd400"),
+    std::make_tuple(TR::InstOpCode::vfaddp2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e7fd400")
+));
+
+INSTANTIATE_TEST_CASE_P(ScalarFAddp, ARM64Trg1Src1EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::faddp2s, TR::RealRegister::v0, TR::RealRegister::v15, "7e30d9e0"),
+    std::make_tuple(TR::InstOpCode::faddp2s, TR::RealRegister::v0, TR::RealRegister::v31, "7e30dbe0"),
+    std::make_tuple(TR::InstOpCode::faddp2s, TR::RealRegister::v15, TR::RealRegister::v0, "7e30d80f"),
+    std::make_tuple(TR::InstOpCode::faddp2s, TR::RealRegister::v31, TR::RealRegister::v0, "7e30d81f"),
+    std::make_tuple(TR::InstOpCode::faddp2d, TR::RealRegister::v0, TR::RealRegister::v15, "7e70d9e0"),
+    std::make_tuple(TR::InstOpCode::faddp2d, TR::RealRegister::v0, TR::RealRegister::v31, "7e70dbe0"),
+    std::make_tuple(TR::InstOpCode::faddp2d, TR::RealRegister::v15, TR::RealRegister::v0, "7e70d80f"),
+    std::make_tuple(TR::InstOpCode::faddp2d, TR::RealRegister::v31, TR::RealRegister::v0, "7e70d81f")
+));


### PR DESCRIPTION
This commit adds vector floating point add pairwise instructions
and binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>