### PR TITLE
RISC-V: add variant of instruction encoding utilities taking RegNum

### DIFF
--- a/compiler/riscv/codegen/OMRRealRegister.hpp
+++ b/compiler/riscv/codegen/OMRRealRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,12 +70,25 @@ class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
    public:
 
    /**
+    * @brief Return binary encoding of given @param reg.
+    *
+    * @param reg register to encode
+    * @return register binary encoding
+    */
+   static
+   uint32_t binaryRegCode(RegNum reg)
+      {
+      return (uint32_t)fullRegBinaryEncodings[reg];
+      }
+
+
+   /**
     * @brief Return binary encoding of the register
     * @return: register binary encoding
     */
    uint32_t binaryRegCode()
       {
-      return (uint32_t)fullRegBinaryEncodings[_registerNumber];
+      return binaryRegCode(_registerNumber);
       }
 
    private:

--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,106 +22,17 @@
 #ifndef RVINSTRUCTION_INCL
 #define RVINSTRUCTION_INCL
 
-#include <stddef.h>
-#include <stdint.h>
-#include <riscv.h>
+
 
 #include "codegen/CodeGenerator.hpp"
-#include "codegen/Register.hpp"
-#include "codegen/InstOpCode.hpp"
 #include "codegen/Instruction.hpp"
+#include "codegen/RVInstructionUtils.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "il/LabelSymbol.hpp"
 #include "infra/Assert.hpp"
 
 class TR_VirtualGuardSite;
 namespace TR { class SymbolReference; }
-
-#define RISCV_INSTRUCTION_LENGTH 4
-
-static inline uint32_t
-TR_RISCV_RTYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t rs2)
-   {
-   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2));
-   }
-
-static inline uint32_t
-TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, TR::Register *rs2)
-   {
-   return TR_RISCV_RTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode());
-   }
-
-
-static inline uint32_t
-TR_RISCV_ITYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t imm)
-   {
-   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ENCODE_ITYPE_IMM(imm));
-   }
-
-static inline uint32_t
-TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, uint32_t imm)
-   {
-   return TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), imm);
-   }
-
-
-static inline uint32_t
-TR_RISCV_STYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
-   {
-   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_STYPE_IMM(imm));
-   }
-
-static inline uint32_t
-TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
-   {
-   return TR_RISCV_STYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
-   }
-
-
-static inline uint32_t
-TR_RISCV_SBTYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
-   {
-   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_SBTYPE_IMM(imm));
-   }
-
-static inline uint32_t
-TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
-   {
-   return TR_RISCV_SBTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
-   }
-
-
-static inline uint32_t
-TR_RISCV_UTYPE(uint32_t insn, uint32_t rd, uint32_t bigimm)
-   {
-   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UTYPE_IMM(bigimm));
-   }
-
-static inline uint32_t
-TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t bigimm)
-   {
-   return TR_RISCV_UTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), bigimm);
-   }
-
-
-static inline uint32_t
-TR_RISCV_UJTYPE(uint32_t insn, uint32_t rd, uint32_t target)
-   {
-   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UJTYPE_IMM(target));
-   }
-
-static inline uint32_t
-TR_RISCV_UJTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t target)
-   {
-   return TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), target);
-   }
-
-static inline uint32_t
-TR_RISCV_UJTYPE(TR::InstOpCode &insn, TR::Register *rd, uint32_t target)
-   {
-   return TR_RISCV_UJTYPE(insn.getMnemonic(), rd, target);
-   }
-
 
 namespace TR
 {

--- a/compiler/riscv/codegen/RVInstructionUtils.hpp
+++ b/compiler/riscv/codegen/RVInstructionUtils.hpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef RVINSTRUCTIONUTILS_INCL
+#define RVINSTRUCTIONUTILS_INCL
+
+#include <stddef.h>
+#include <stdint.h>
+#include <riscv.h>
+
+#include "codegen/Register.hpp"
+#include "codegen/RealRegister.hpp"
+#include "codegen/InstOpCode.hpp"
+
+#define RISCV_INSTRUCTION_LENGTH 4
+
+static inline uint32_t
+TR_RISCV_RTYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t rs2)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2));
+   }
+
+static inline uint32_t
+TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, TR::Register *rs2)
+   {
+   return TR_RISCV_RTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode());
+   }
+
+
+static inline uint32_t
+TR_RISCV_ITYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t imm)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ((rs1) << OP_SH_RS1) | ENCODE_ITYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, uint32_t imm)
+   {
+   return TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_STYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
+   {
+   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_STYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_STYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_SBTYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
+   {
+   return ((insn) | ((rs1) << OP_SH_RS1) | ((rs2) << OP_SH_RS2) | ENCODE_SBTYPE_IMM(imm));
+   }
+
+static inline uint32_t
+TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_SBTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_UTYPE(uint32_t insn, uint32_t rd, uint32_t bigimm)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UTYPE_IMM(bigimm));
+   }
+
+static inline uint32_t
+TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t bigimm)
+   {
+   return TR_RISCV_UTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), bigimm);
+   }
+
+
+static inline uint32_t
+TR_RISCV_UJTYPE(uint32_t insn, uint32_t rd, uint32_t target)
+   {
+   return ((insn) | ((rd) << OP_SH_RD) | ENCODE_UJTYPE_IMM(target));
+   }
+
+static inline uint32_t
+TR_RISCV_UJTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t target)
+   {
+   return TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), target);
+   }
+
+static inline uint32_t
+TR_RISCV_UJTYPE(TR::InstOpCode &insn, TR::Register *rd, uint32_t target)
+   {
+   return TR_RISCV_UJTYPE(insn.getMnemonic(), rd, target);
+   }
+
+#endif // RVINSTRUCTIONUTILS_INCL

--- a/compiler/riscv/codegen/RVInstructionUtils.hpp
+++ b/compiler/riscv/codegen/RVInstructionUtils.hpp
@@ -32,6 +32,10 @@
 
 #define RISCV_INSTRUCTION_LENGTH 4
 
+/**
+ * ==== R-type ====
+ */
+
 static inline uint32_t
 TR_RISCV_RTYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t rs2)
    {
@@ -39,11 +43,20 @@ TR_RISCV_RTYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t rs2)
    }
 
 static inline uint32_t
-TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, TR::Register *rs2)
+TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rd, TR::RealRegister::RegNum rs1, TR::RealRegister::RegNum rs2)
    {
-   return TR_RISCV_RTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode());
+   return TR_RISCV_RTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rd), TR::RealRegister::binaryRegCode(rs1), TR::RealRegister::binaryRegCode(rs2));
    }
 
+static inline uint32_t
+TR_RISCV_RTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, TR::Register *rs2)
+   {
+   return TR_RISCV_RTYPE(insn, toRealRegister(rd)->getRegisterNumber(), toRealRegister(rs1)->getRegisterNumber(), toRealRegister(rs2)->getRegisterNumber());
+   }
+
+/**
+ * ==== I-type ====
+ */
 
 static inline uint32_t
 TR_RISCV_ITYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t imm)
@@ -52,11 +65,20 @@ TR_RISCV_ITYPE(uint32_t insn, uint32_t rd, uint32_t rs1, uint32_t imm)
    }
 
 static inline uint32_t
-TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, uint32_t imm)
+TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rd, TR::RealRegister::RegNum rs1, uint32_t imm)
    {
-   return TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), toRealRegister(rs1)->binaryRegCode(), imm);
+   return TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rd), TR::RealRegister::binaryRegCode(rs1), imm);
    }
 
+static inline uint32_t
+TR_RISCV_ITYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, TR::Register *rs1, uint32_t imm)
+   {
+   return TR_RISCV_ITYPE(insn, toRealRegister(rd)->getRegisterNumber(), toRealRegister(rs1)->getRegisterNumber(), imm);
+   }
+
+/**
+ * ==== S-type ====
+ */
 
 static inline uint32_t
 TR_RISCV_STYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
@@ -65,11 +87,20 @@ TR_RISCV_STYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
    }
 
 static inline uint32_t
-TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rs1, TR::RealRegister::RegNum rs2, uint32_t imm)
    {
-   return TR_RISCV_STYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   return TR_RISCV_STYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rs1), TR::RealRegister::binaryRegCode(rs2), imm);
    }
 
+static inline uint32_t
+TR_RISCV_STYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_STYPE(insn, toRealRegister(rs1)->getRegisterNumber(), toRealRegister(rs2)->getRegisterNumber(), imm);
+   }
+
+/**
+ * ==== B-type ====
+ */
 
 static inline uint32_t
 TR_RISCV_SBTYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
@@ -78,11 +109,20 @@ TR_RISCV_SBTYPE(uint32_t insn, uint32_t rs1, uint32_t rs2, uint32_t imm)
    }
 
 static inline uint32_t
-TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rs1, TR::RealRegister::RegNum rs2, uint32_t imm)
    {
-   return TR_RISCV_SBTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rs1)->binaryRegCode(), toRealRegister(rs2)->binaryRegCode(), imm);
+   return TR_RISCV_SBTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rs1), TR::RealRegister::binaryRegCode(rs2), imm);
    }
 
+static inline uint32_t
+TR_RISCV_SBTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rs1, TR::Register *rs2, uint32_t imm)
+   {
+   return TR_RISCV_SBTYPE(insn, toRealRegister(rs1)->getRegisterNumber(), toRealRegister(rs2)->getRegisterNumber(), imm);
+   }
+
+/**
+ * ==== U-type ====
+ */
 
 static inline uint32_t
 TR_RISCV_UTYPE(uint32_t insn, uint32_t rd, uint32_t bigimm)
@@ -91,11 +131,20 @@ TR_RISCV_UTYPE(uint32_t insn, uint32_t rd, uint32_t bigimm)
    }
 
 static inline uint32_t
-TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t bigimm)
+TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rd, uint32_t bigimm)
    {
-   return TR_RISCV_UTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), bigimm);
+   return TR_RISCV_UTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rd), bigimm);
    }
 
+static inline uint32_t
+TR_RISCV_UTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t bigimm)
+   {
+   return TR_RISCV_UTYPE(insn, toRealRegister(rd)->getRegisterNumber(), bigimm);
+   }
+
+/**
+ * ==== J-type ====
+ */
 
 static inline uint32_t
 TR_RISCV_UJTYPE(uint32_t insn, uint32_t rd, uint32_t target)
@@ -104,9 +153,15 @@ TR_RISCV_UJTYPE(uint32_t insn, uint32_t rd, uint32_t target)
    }
 
 static inline uint32_t
+TR_RISCV_UJTYPE(TR::InstOpCode::Mnemonic insn, TR::RealRegister::RegNum rd, uint32_t bigimm)
+   {
+   return TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), TR::RealRegister::binaryRegCode(rd), bigimm);
+   }
+
+static inline uint32_t
 TR_RISCV_UJTYPE(TR::InstOpCode::Mnemonic insn, TR::Register *rd, uint32_t target)
    {
-   return TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(insn), toRealRegister(rd)->binaryRegCode(), target);
+   return TR_RISCV_UJTYPE(insn, toRealRegister(rd)->getRegisterNumber(), target);
    }
 
 static inline uint32_t

--- a/compiler/riscv/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/riscv/runtime/VirtualGuardRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corp. and others
+ * Copyright (c) 2021, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include "codegen/RVInstruction.hpp"
+#include "codegen/RealRegister.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/jittypes.h"
@@ -31,6 +32,6 @@
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
    int64_t distance = (int64_t)destinationAddr - (int64_t)locationAddr;
-   *(uint32_t *)locationAddr = TR_RISCV_UJTYPE(TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::_jal), 0, distance);
+   *(uint32_t *)locationAddr = TR_RISCV_UJTYPE(TR::InstOpCode::_jal, TR::RealRegister::zero, distance);
    riscvCodeSync(locationAddr, RISCV_INSTRUCTION_LENGTH);
    }


### PR DESCRIPTION
These variants are useful when generating "hand-written" code such as snippets,
trampolines and thunks.