### PR TITLE
Use a wider type for local variables holding the cache line size

### DIFF
--- a/port/unix/omrcpu.c
+++ b/port/unix/omrcpu.c
@@ -98,7 +98,7 @@ void
 omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uintptr_t byteAmount)
 {
 #if defined(LINUXPPC) || defined(PPC) || defined(RS6000)
-	uint32_t cacheLineSize = PPG_mem_ppcCacheLineSize;
+	uintptr_t cacheLineSize = PPG_mem_ppcCacheLineSize;
 	unsigned char *addr = NULL;
 	unsigned char *limit = (unsigned char *)
 			(((uintptr_t)memoryPointer + byteAmount + (cacheLineSize - 1))

--- a/util/omrutil/j9memclr.cpp
+++ b/util/omrutil/j9memclr.cpp
@@ -74,12 +74,13 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 	}
 #endif /* defined(LINUXPPC) */
 
-	/* one-time-only calculation of cache line size */
-	if (0 == cacheLineSize) {
-		cacheLineSize = getCacheLineSize();
-	}
+	uintptr_t localCacheLineSize = cacheLineSize;
 
-	uint32_t localCacheLineSize = cacheLineSize;
+	/* one-time-only calculation of cache line size */
+	if (0 == localCacheLineSize) {
+		localCacheLineSize = getCacheLineSize();
+		cacheLineSize = localCacheLineSize;
+	}
 
 	/* Zeroing by dcbz is effective if requested length is at least twice larger then Data Cache Block size */
 	if (length < (2 * localCacheLineSize)) {


### PR DESCRIPTION
This allows the compiler to do the widening operation once, rather than repeatedly in loops, fixing a performance regression introduced in #6515.