### PR TITLE
AArch64: Implement vbitselect evaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -647,6 +647,7 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vreductionAnd:
       case TR::vreductionOr:
       case TR::vreductionXor:
+      case TR::vbitselect:
          // Float/ Double are not supported
          return (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64);
       case TR::vload:


### PR DESCRIPTION
This commit implements vbitselect evaluator and adds a unit test.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>