### PR TITLE
Add support for DDR on AArch64 Linux cross build

### DIFF
--- a/configure
+++ b/configure
@@ -6742,9 +6742,7 @@ fi
   *) :
 
 			# other host types: look for DWARF support
-			if test "x$OMR_CROSS_CONFIGURE" != "xyes"
-			then
-				for ac_header in dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h
+			for ac_header in dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -6757,7 +6755,7 @@ fi
 
 done
 
-				{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
 $as_echo_n "checking for library containing dwarf_init... " >&6; }
 if ${ac_cv_search_dwarf_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6813,7 +6811,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-				{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
 $as_echo_n "checking for library containing dwarf_init... " >&6; }
 if ${ac_cv_search_dwarf_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6869,7 +6867,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-				{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing elf_begin" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing elf_begin" >&5
 $as_echo_n "checking for library containing elf_begin... " >&6; }
 if ${ac_cv_search_elf_begin+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6925,19 +6923,17 @@ if test "$ac_res" != no; then :
 
 fi
 
-			else
-				# Can't run AC_CHECK_HEADERS when cross-configuring.
-				# If DDR is enabled set these flags and hope for the best,
-				# otherwise the build will fail even if the headers are available.
-				$as_echo "#define HAVE_DWARF_H 1" >>confdefs.h
-
-				$as_echo "#define HAVE_LIBDWARF_H 1" >>confdefs.h
-
-			fi
-
 	 ;;
 esac
 
+fi
+
+if test "$enable_DDR" = "yes" && test "$OMR_HOST_OS" = "linux" && test "$OMR_CROSS_CONFIGURE" = "yes"; then :
+	# Can't run AC_CHECK_HEADERS when cross-configuring.
+	# If DDR is enabled set these flags and hope for the best,
+	# otherwise the build will fail even if the headers are available.
+	$as_echo "#define HAVE_LIBDWARF_DWARF_H 1" >>confdefs.h
+	$as_echo "#define HAVE_LIBDWARF_LIBDWARF_H 1" >>confdefs.h
 fi
 
 # Check whether --enable-OMR_GC_IDLE_HEAP_MANAGER was given.

--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corp. and others
+# Copyright (c) 2016, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,12 @@ ifeq (linux,$(OMR_HOST_OS))
   endif
   ifeq (s390,$(OMR_HOST_ARCH))
     MODULE_SHARED_LIBS += elf z
+  endif
+  ifeq (aarch64,$(OMR_HOST_ARCH))
+    ifeq (1,$(OMR_CROSS_COMPILE))
+      MODULE_SHARED_LIBS += elf z
+      MODULE_LDFLAGS += -static
+    endif
   endif
 endif
 


### PR DESCRIPTION
This commit adds support for DDR on AArch64 Linux cross build by:
- Define symbols for DWARF header files
- Add libelf and libz for building ddrgen statically

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>