### PR TITLE
Add Heap Fixup GC Logging and J9MM Tracepoints

### DIFF
--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1002,3 +1002,6 @@ TraceEvent=Trc_MM_SparseAddressOrderedFixedSizeDataPool_returnFreeListEntry_succ
 
 TraceEntry=Trc_MM_getSparseAddressAndDecommitLeaves_Entry Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::getSparseAddressAndDecommitLeaves_Entry: inHeapObjectPointer (spine): %p, bytesToAllocate: %p, arrayletLeafCount: %zu, arrayletLeafSize: %p"
 TraceExit=Trc_MM_getSparseAddressAndDecommitLeaves_Exit Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::getSparseAddressAndDecommitLeaves_Exit: inHeapObjectPointer (spine): %p, bytesStillRemainingToAllocate (should be zero if allocated successfully to sparse heap): %zu"
+
+TraceEntry=Trc_MM_DoFixHeapForCompact_Entry Overhead=1 Level=1 Template="Trc_MM_DoFixHeapForCompact Entry with walkflags: %zx and walkReason: %zx"
+TraceExit=Trc_MM_DoFixHeapForCompact_Exit Overhead=1 Level=1 Template="Trc_MM_DoFixHeapForCompact Exit after fixing up %zu objects"

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -312,7 +312,7 @@ public:
 	virtual void compact(MM_EnvironmentBase *env, bool rebuildMarkBits, bool aggressive);
 	omrobjectptr_t getForwardingPtr(omrobjectptr_t objectPtr) const;
 	void flushPool(MM_EnvironmentStandard *env, MM_CompactMemoryPoolState *freeListState);
-	void fixHeapForWalk(MM_EnvironmentBase *env);
+	void fixHeapForWalk(MM_EnvironmentBase *env, uintptr_t walkFlags, uintptr_t walkReason);
 	void parallelFixHeapForWalk(MM_EnvironmentBase *env);
 
 	/**

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -506,11 +506,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 		if (!_fixHeapForWalkCompleted) {
 #if defined(OMR_GC_MODRON_COMPACTION)
 			if (compactedThisCycle) {
-				OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
-				U_64 startTime = omrtime_hires_clock();
-				getCompactScheme(env)->fixHeapForWalk(env);
-				_extensions->globalGCStats.fixHeapForWalkTime = omrtime_hires_delta(startTime, omrtime_hires_clock(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-				_extensions->globalGCStats.fixHeapForWalkReason = FIXUP_DEBUG_TOOLING;
+				getCompactScheme(env)->fixHeapForWalk(env, MEMORY_TYPE_RAM, FIXUP_DEBUG_TOOLING);
 			} else
 #endif /* OMR_GC_MODRON_COMPACTION */
 			{

--- a/gc/stats/GlobalGCStats.hpp
+++ b/gc/stats/GlobalGCStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,12 +50,11 @@ public:
 
 	uintptr_t fixHeapForWalkReason;
 	uint64_t fixHeapForWalkTime;
+	uint64_t fixHeapForWalkObjectCount;
 
 	MM_MarkStats markStats;
 	MM_ClassUnloadStats classUnloadStats;
 	MM_MetronomeStats metronomeStats; /**< Stats collected during one GC increment (quantum) */
-
-	uintptr_t finalizableCount; /**< count of objects pushed for finalization during one GC cycle */
 
 	MMINLINE void clear()
 	{
@@ -69,12 +68,11 @@ public:
 
 		fixHeapForWalkReason = FIXUP_NONE;
 		fixHeapForWalkTime = 0;
+		fixHeapForWalkObjectCount = 0;
 
 		markStats.clear();
 		classUnloadStats.clear();
 		metronomeStats.clearStart();
-
-		finalizableCount = 0;
 	};
 
 	/**
@@ -87,19 +85,20 @@ public:
 		return markStats.getStallTime() + workPacketStats.getStallTime() + sweepStats.idleTime;
 	}
 
-	MM_GlobalGCStats()
-		: gcCount(0)
-		, workPacketStats()
-		, sweepStats()
+	MM_GlobalGCStats() :
+		gcCount(0),
+		workPacketStats(),
+		sweepStats(),
 #if defined(OMR_GC_MODRON_COMPACTION)
-		, compactStats()
+		compactStats(),
 #endif /* OMR_GC_MODRON_COMPACTION */
-		, fixHeapForWalkReason(FIXUP_NONE)
-		, fixHeapForWalkTime(0)
-		, markStats()
-		, classUnloadStats()
-		, metronomeStats()
-		, finalizableCount(0) {};
+		fixHeapForWalkReason(FIXUP_NONE),
+		fixHeapForWalkTime(0),
+		fixHeapForWalkObjectCount(0),
+		markStats(),
+		classUnloadStats(),
+		metronomeStats()
+	{}
 };
 
 #endif /* GLOBALGCSTATS_HPP_ */

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -382,6 +382,13 @@ public:
 	 * @return string representing the reason for termination
 	 */ 
 	virtual const char *getConcurrentTerminationReason(MM_ConcurrentPhaseStatsBase *stats);
+
+	/**
+	 * Answer a string representation of a given heap fixup reason.
+	 * @param[IN] heap fixup reason
+	 * @return string representing the readable "reason" of heap fixup.
+	 */
+	const char *getHeapFixupReasonString(uintptr_t type);
 
 	/**
 	 * Handle any output or data tracking for the initialized phase of verbose GC.


### PR DESCRIPTION
Add heap fixup verbose GC logging and J9mm tracepoints
for heap fixups that also include the reason for the heap fixup.

Signed-off-by: Jonathan Oommen jon.oommen@gmail.com