### PR TITLE
Fix format specifier in s390 VGNOP trace

### DIFF
--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -5377,7 +5377,7 @@ TR::S390VirtualGuardNOPInstruction::generateBinaryEncoding()
 #ifdef DEBUG
       if (debug("traceVGNOP"))
          {
-         printf("####> virtual location(est) = %p+%d, label (relocation) = %p\n", cursor, distance, label);
+         printf("####> virtual location(est) = %p+%" OMR_PRIdPTR ", label (relocation) = %p\n", cursor, distance, label);
          }
 #endif
       }


### PR DESCRIPTION
Internal debug build on z/Linux failed with
```
/.../omr/compiler/z/codegen/S390Instruction.cpp:5380:106: error: format '%d' expects argument of type 'int', but argument 3 has type 'intptr_t {aka long int}' [-Werror=format=]
          printf("####> virtual location(est) = %p+%d, label (relocation) = %p\n", cursor, distance, label);
                                                                                                          ^
```
This patch puts the correct format specifier for `intptr_t`