### PR TITLE
Add option to limit trace file length

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1140,6 +1140,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceExitExtraction",              "L\ttrace extraction of structure nodes that unconditionally exit to outer regions", SET_OPTION_BIT(TR_TraceExitExtraction), "F"},
    {"traceExplicitNewInitialization",   "L\ttrace explicit new initialization",            TR::Options::traceOptimization, explicitNewInitialization, 0, "P"},
    {"traceFieldPrivatization",          "L\ttrace field privatization",                    TR::Options::traceOptimization, fieldPrivatization, 0, "P"},
+   {"traceFileLength=",    "L\ttrace file length in MB", TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_traceFileLength, 0, "F%d", NOT_IN_SUBSET},
    {"traceFull",                        "L\tturn on all trace options",                    SET_OPTION_BIT(TR_TraceAll), "P"},
    {"traceGeneralStoreSinking",         "L\ttrace general store sinking",                  TR::Options::traceOptimization, generalStoreSinking, 0, "P"},
    {"traceGlobalCopyPropagation",       "L\ttrace global copy propagation",                TR::Options::traceOptimization, globalCopyPropagation, 0, "P"},
@@ -1653,6 +1654,8 @@ int32_t       OMR::Options::_inlinerVeryLargeCompiledMethodAdjustFactor = 20;
 int32_t       OMR::Options::_numUsableCompilationThreads = -1; // -1 means not initialized
 
 int32_t       OMR::Options::_trampolineSpacePercentage = 0; // 0 means no change from default
+
+int32_t       OMR::Options::_traceFileLength = 0; // in MBs, 0 unlimited
 
 bool          OMR::Options::_countsAreProvidedByUser = false;
 TR_YesNoMaybe OMR::Options::_startupTimeMatters = TR_maybe;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1897,6 +1897,8 @@ public:
 
    static int32_t _trampolineSpacePercentage;
 
+   static int32_t _traceFileLength;
+
    static size_t _scratchSpaceLimit;
    static size_t _scratchSpaceLowerBound;
    static uint32_t _minBytesToLeaveAllocatedInSharedPool; // 0 to disable the feature and revert to old behavior

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -596,6 +596,12 @@ TR_Debug::vtrace(const char * format, va_list args)
    if (_file != NULL)
       {
       char buffer[256];
+      if(TR::Options::_traceFileLength && TR::IO::ftell(_file) > (TR::Options::_traceFileLength * (1 << 20)))
+         {
+         TR::IO::fseek(_file, 0, SEEK_SET); // rewind the trace file
+         sprintf(buffer, "Rewind trace file ...\n\n\n");
+         TR::IO::vfprintf(_file, buffer, args);
+         }
       TR::IO::vfprintf(_file, getDiagnosticFormat(format, buffer, sizeof(buffer)), args);
       trfflush(_file);
       }


### PR DESCRIPTION
Add a new option to limit the trace file size: default is unlimited as before, when any value set, check trace file size and rewind trace file when hit limit.

Signed-off-by: Tao Guan <james_mango@yahoo.com>