### PR TITLE
Don't emit rex prefix on 32-bit

### DIFF
--- a/compiler/x/codegen/OMRInstOpCode.cpp
+++ b/compiler/x/codegen/OMRInstOpCode.cpp
@@ -152,11 +152,15 @@ template <typename TBuffer> typename TBuffer::cursor_t OMR::X86::InstOpCode::OpC
          default:
             break;
          }
+
+#if defined(TR_TARGET_64BIT)
       // REX
       if (rex.value() || rexbits)
          {
          buffer.append(rex);
          }
+#endif
+
       // OpCode escape
       switch (escape)
          {


### PR DESCRIPTION
The rex prefix is illegal in 32-bit mode. However,
some VEX and EVEX encoded instructions use REX.W the bit
as an opcode extension bit. In 32-bit mode, if a SIMD
instruction is encoded as a legacy SSE instruction,
and the W bit is set, a rex prefix may be emitted. This
commit prevents that from happening.

Signed-off-by: BradleyWood <bradley.wood@ibm.com>