### PR TITLE
AArch64: Expand instructions to address too large displacement of MemoryReference

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -363,6 +363,23 @@ uint8_t *TR::ARM64RegBranchInstruction::generateBinaryEncoding()
    return cursor;
    }
 
+TR::Instruction *TR::ARM64AdminInstruction::expandInstruction()
+   {
+   TR::InstOpCode::Mnemonic op = getOpCodeValue();
+
+   if (op == TR::InstOpCode::retn)
+      {
+      /*
+       * Generates instructions for epilogue after retn pseudo instruction.
+       * We need to call expandInstruction on those instructions because
+       * memory instrutions are included.
+       */
+      cg()->getLinkage()->createEpilogue(self());
+      }
+
+   return self();
+   }
+
 uint8_t *TR::ARM64AdminInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
@@ -682,6 +699,11 @@ uint8_t *TR::ARM64Trg1Src3Instruction::generateBinaryEncoding()
    return cursor;
    }
 
+TR::Instruction *TR::ARM64Trg1MemInstruction::expandInstruction()
+   {
+   return getMemoryReference()->expandInstruction(self(), cg());
+   }
+
 uint8_t *TR::ARM64Trg1MemInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
@@ -699,6 +721,11 @@ int32_t TR::ARM64Trg1MemInstruction::estimateBinaryLength(int32_t currentEstimat
    {
    setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
    return currentEstimate + getEstimatedBinaryLength();
+   }
+
+TR::Instruction *TR::ARM64MemInstruction::expandInstruction()
+   {
+   return getMemoryReference()->expandInstruction(self(), cg());
    }
 
 uint8_t *TR::ARM64MemInstruction::generateBinaryEncoding()

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1324,6 +1324,14 @@ class ARM64AdminInstruction : public TR::Instruction
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
    /**
+    * @brief Expand this instruction prior to binary encoding.
+    *
+    * @returns the last instruction in the expansion or this instruction if no expansion was
+    *          performed.
+    */
+   virtual TR::Instruction *expandInstruction();
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */
@@ -3206,6 +3214,14 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
    /**
+    * @brief Expand this instruction prior to binary encoding.
+    *
+    * @returns the last instruction in the expansion or this instruction if no expansion was
+    *          performed.
+    */
+   virtual TR::Instruction *expandInstruction();
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */
@@ -3314,6 +3330,15 @@ class ARM64MemInstruction : public TR::Instruction
     * @param[in] kindToBeAssigned : register kind
     */
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
+    * @brief Expand this instruction prior to binary encoding.
+    *
+    * @returns the last instruction in the expansion or this instruction if no expansion was
+    *          performed.
+    */
+   virtual TR::Instruction *expandInstruction();
+
    /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor


### PR DESCRIPTION
There are certain cases where the displacement of MemoryReference cannot be determined
until stack mapping is done. Currently, aarch64 codegen cannot perform binary encoding
phase if the displacement becomes too huge as a result of stack mapping.
To address this problem, this commit introduces `expandInstruction` member function
to MemoryReference related instruction classes and MemoryReference class,
and updates MemoryReference to generate necessary instructions in `expandInstruction`
rather than generating binary for multple instructions in `generateBinaryEncoding`.
Unlike power codegen, we do instruction expansion in the loop for estimating byte length
in binary encoding phase.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>