### PR TITLE
Prevent loading mark bits prematurely during final card cleaning

### DIFF
--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -1079,6 +1079,9 @@ MM_ConcurrentCardTable::finalCleanCards(MM_EnvironmentBase *env, uintptr_t *byte
 		/* ..and address of last slot N.B Range is EXCLUSIVE */
 		uintptr_t *heapTop = (uintptr_t *)((uint8_t *)heapBase + CARD_SIZE);
 
+		/* prevent loading mark bits prematurely */
+		MM_AtomicOperations::readBarrier();
+
 		/* Then iterate over all marked objects in the heap between the two addresses */
 		MM_HeapMapIterator markedObjectIterator(_extensions, markMap, heapBase, heapTop);
 		while (NULL != (objectPtr = markedObjectIterator.nextObject())) {


### PR DESCRIPTION
On ARM M1 processor, we may end up marking an object on one thread/core
that happens to be in an already dirty card, hence skipping to scan it,
while the other thread/core racing to clean the card does not see the
object being marked and skips scanning it. Altogether, we miss to scan
the object.

Normally not possible, but due to some kind of store or load reordering
the latter core sees a stale mark bit.

A fix that appears to work is to prevent the loading of mark bits too
early. It's not completely clear what other loading operation this can
be reorder with... Loading of mark bits is conditional to prior reading
a card, and only proceeding with reading mark bits, if the card is
dirty. Hence, first load operation of card reading is expected to
complete before reading mark bits.

This problem has to be studied more, but for now, this is a
simple fix, relatively non-intrusive, that is tested and works.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>