### PR TITLE
Set Vector Support in OMR

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -426,6 +426,18 @@ OMR::Z::CodeGenerator::initialize()
 
    _cgFlags = 0;
 
+   bool supportsAutoSIMD = !comp->getOption(TR_DisableSIMD) && comp->target().cpu.supportsFeature(OMR_FEATURE_S390_VECTOR_FACILITY);
+
+   if(supportsAutoSIMD)
+      {
+      cg->setSupportsVectorRegisters();
+      cg->setSupportsAutoSIMD();
+      }
+   else
+      {
+      comp->setOption(TR_DisableSIMD);
+      }
+
    // Initialize Linkage for Code Generator
    cg->initializeLinkage();
 


### PR DESCRIPTION
While constructing a code generator object, check for vector facility
and set appropriate options. This check was done previously in
S390PrivateLinkage in OpenJ9, which would be incorrect place to do so.

Fixes: #6572

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>