### PR TITLE
Fix an assert in OMR::Power::TreeEvaluator::s2iEvaluator()

### DIFF
--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -278,7 +278,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
    TR::Node *child  = node->getFirstChild();
    TR::Register *trgReg = cg->allocateRegister();
 
-   if (child->getOpCode().isLoad() && !child->getRegister() && child->getReferenceCount() == 1)
+   if (child->getOpCode().isLoadVar() && !child->getRegister() && child->getReferenceCount() == 1)
       {
       TR::LoadStoreHandler::generateLoadNodeSequence(cg, trgReg, child, TR::InstOpCode::lha, 2);
       }


### PR DESCRIPTION
The s2iEvaluator uses a isLoad() test when deciding between a simple
sign extend or generating a load sequence. The isLoad() test returns
true for both LoadVar and LoadConst cases and therefore we can get
into the load sequence when handling a sconst node child which results
in an assert. This PR will change isLoad() to isLoadVar() so that
the sconst case will use the simple sign extend path.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>