### PR TITLE
Split analysis from constructor of LiveVariableInfo and Liveness

### DIFF
--- a/compiler/optimizer/CompactLocals.cpp
+++ b/compiler/optimizer/CompactLocals.cpp
@@ -147,6 +147,7 @@ int32_t TR_CompactLocals::perform()
    // Perform liveness analysis
    //
    TR_Liveness liveLocals(comp(), optimizer(), comp()->getFlowGraph()->getStructure());
+   liveLocals.perform(comp()->getFlowGraph()->getStructure());
 
    TR_BitVector *referenceLocals;
    TR_BitVector *nonReferenceLocals;

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -749,6 +749,8 @@ class TR_LiveVariableInformation
                               bool includeParms = false,
                               bool ignoreOSRUses = false);
 
+   virtual void collectLiveVariableInformation();
+
    bool traceLiveVarInfo()           { return _traceLiveVariableInfo; }
 
    TR::Compilation *comp()            { return _compilation; }
@@ -778,14 +780,16 @@ class TR_LiveVariableInformation
                                          TR_BitVector *genSetInfo, TR_BitVector *killSetInfo,
                                          TR_BitVector *commonedLoads, vcount_t visitCount);
 
-   protected:
-   virtual void findUseOfLocal(TR::Node *node, int32_t blockNum,
-                       TR_BitVector **genSetInfo, TR_BitVector **killSetInfo,
-                       TR_BitVector *commonedLoads, bool movingForwardThroughTrees, vcount_t visitCount);
    private:
    void visitTreeForLocals(TR::Node *node, TR_BitVector **blockGenSetInfo, TR_BitVector *blockKillSetInfo,
                            bool movingForwardThroughTrees, bool visitEntireTree, vcount_t visitCount,
                            TR_BitVector *commonedLoads, bool belowCommonedNode);
+
+   protected:
+   virtual void findUseOfLocal(TR::Node *node, int32_t blockNum,
+                       TR_BitVector **genSetInfo, TR_BitVector **killSetInfo,
+                       TR_BitVector *commonedLoads, bool movingForwardThroughTrees, vcount_t visitCount);
+
 
    TR::Compilation *_compilation;
    TR_Memory *     _trMemory;
@@ -863,7 +867,7 @@ class TR_Liveness : public TR_BackwardUnionBitVectorAnalysis
    *
    * @return none
    */
-   virtual void perform(TR_Structure *rootStructure) {}
+   virtual void perform(TR_Structure *rootStructure);
 
    bool traceLiveness() { return _traceLiveness; }
 
@@ -875,7 +879,7 @@ class TR_Liveness : public TR_BackwardUnionBitVectorAnalysis
    virtual void analyzeTreeTopsInBlockStructure(TR_BlockStructure *);
    virtual bool postInitializationProcessing();
 
-   private:
+   protected:
 
    TR_LiveVariableInformation *_liveVariableInfo;
 

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -373,6 +373,9 @@ TR_GlobalRegisterAllocator::perform()
             //
             TR_Liveness liveLocals(comp(), optimizer(), comp()->getFlowGraph()->getStructure(),
                false, NULL, false, comp()->getOption(TR_EnableAggressiveLiveness));
+
+            liveLocals.perform(comp()->getFlowGraph()->getStructure());
+
             if (comp()->getVisitCount() > HIGH_VISIT_COUNT)
                {
                comp()->resetVisitCounts(1);
@@ -3880,6 +3883,9 @@ void TR_LiveRangeSplitter::splitLiveRanges()
          // Perform liveness analysis
          //
          TR_Liveness liveLocals(comp(), optimizer(), comp()->getFlowGraph()->getStructure());
+
+         liveLocals.perform(comp()->getFlowGraph()->getStructure());
+
          if (comp()->getVisitCount() > HIGH_VISIT_COUNT)
             {
             comp()->resetVisitCounts(1);

--- a/compiler/optimizer/LiveOnAllPaths.cpp
+++ b/compiler/optimizer/LiveOnAllPaths.cpp
@@ -76,7 +76,10 @@ TR_LiveOnAllPaths::TR_LiveOnAllPaths(TR::Compilation *comp,
       comp->resetVisitCounts(1);
 
    if (liveVariableInfo == NULL)
+      {
       _liveVariableInfo = new (trStackMemory()) TR_LiveVariableInformation(comp, optimizer, rootStructure, splitLongs, includeParms);
+      _liveVariableInfo->collectLiveVariableInformation();
+      }
    else
       _liveVariableInfo = liveVariableInfo;
 

--- a/compiler/optimizer/LiveVariableInformation.cpp
+++ b/compiler/optimizer/LiveVariableInformation.cpp
@@ -64,16 +64,27 @@ TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
    {
    _traceLiveVariableInfo = comp()->getOption(TR_TraceLiveness);
 
-   if (traceLiveVarInfo())
-      traceMsg(comp(), "Collecting live variable information\n");
-
    // Find the number of locals and assign an index to each
    //
    _numLocals = 0;
    _includeParms = includeParms;
    _splitLongs = splitLongs;
 
-   if (includeParms)
+   _localObjects = NULL;
+   _cachedRegularGenSetInfo = NULL;
+   _cachedRegularKillSetInfo = NULL;
+   _cachedExceptionGenSetInfo = NULL;
+   _cachedExceptionKillSetInfo = NULL;
+
+   _haveCachedGenAndKillSets = false;
+   _liveCommonedLoads = NULL;
+   }
+
+void TR_LiveVariableInformation::collectLiveVariableInformation()
+   {
+   if (traceLiveVarInfo())
+      traceMsg(comp(), "Collecting live variable information\n");
+   if (_includeParms)
       {
       TR::ParameterSymbol *p;
       ListIterator<TR::ParameterSymbol> parms(&comp()->getMethodSymbol()->getParameterList());
@@ -82,7 +93,7 @@ TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
          if (traceLiveVarInfo())
             traceMsg(comp(), "#%2d : is a parm symbol at %p\n", _numLocals, p);
 
-         if (p->getType().isInt64() && splitLongs)
+         if (p->getType().isInt64() && _splitLongs)
             {
             p->setLiveLocalIndex(_numLocals, comp()->fe());
             _numLocals += 2;
@@ -99,7 +110,7 @@ TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
       if (traceLiveVarInfo())
          traceMsg(comp(), "Local #%2d is symbol at %p\n",_numLocals,p);
 
-      if (p->getType().isInt64() && splitLongs)
+      if (p->getType().isInt64() && _splitLongs)
          {
          p->setLiveLocalIndex(_numLocals, comp()->fe());
          _numLocals += 2;
@@ -108,7 +119,7 @@ TR_LiveVariableInformation::TR_LiveVariableInformation(TR::Compilation   *c,
          p->setLiveLocalIndex(_numLocals++, comp()->fe());
       }
 
-    if (traceLiveVarInfo())
+   if (traceLiveVarInfo())
       traceMsg(comp(), "Finished collecting live variable information: %d locals found\n", _numLocals);
 
    _localObjects = NULL;

--- a/compiler/optimizer/Liveness.cpp
+++ b/compiler/optimizer/Liveness.cpp
@@ -70,21 +70,26 @@ TR_Liveness::TR_Liveness(TR::Compilation           *comp,
      _liveVariableInfo(liveVariableInfo)
    {
    _traceLiveness = comp->getOption(TR_TraceLiveness);
-   if (traceLiveness())
-      traceMsg(comp, "Starting Liveness analysis\n");
 
    if (liveVariableInfo == NULL)
+      {
       // can be re-used by the caller because it's allocated in caller's stack
       _liveVariableInfo = new (trStackMemory()) TR_LiveVariableInformation(comp, optimizer, rootStructure, splitLongs, includeParms,
                                                                            ignoreOSRUses);
-   else
-      _liveVariableInfo = liveVariableInfo;
+      _liveVariableInfo->collectLiveVariableInformation();
+      }
+   }
+
+void TR_Liveness::perform(TR_Structure *rootStructure)
+   {
+   if (traceLiveness())
+      traceMsg(comp(), "Starting Liveness analysis\n");
 
    if (_liveVariableInfo->numLocals() == 0)
       return; // Nothing to do if there are no locals
 
-   if (comp->getVisitCount() > 8000)
-      comp->resetVisitCounts(1);
+   if (comp()->getVisitCount() > 8000)
+      comp()->resetVisitCounts(1);
 
    // Allocate the block info before setting the stack mark - it will be used by
    // the caller
@@ -102,11 +107,11 @@ TR_Liveness::TR_Liveness(TR::Compilation           *comp,
          {
          if (_blockAnalysisInfo[i])
             {
-            traceMsg(comp, "\nLive variables for block_%d: ",i);
-            _blockAnalysisInfo[i]->print(comp);
+            traceMsg(comp(), "\nLive variables for block_%d: ",i);
+            _blockAnalysisInfo[i]->print(comp());
             }
          }
-      traceMsg(comp, "\nEnding Liveness analysis\n");
+      traceMsg(comp(), "\nEnding Liveness analysis\n");
       }
    } // scope of the stack memory region
 

--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1309,6 +1309,7 @@ int32_t TR_OSRLiveRangeAnalysis::fullAnalysis(bool includeParms, bool containsPe
    bool ignoreOSRuses = true;
    bool includeParms = true;
    TR_Liveness liveLocals(comp(), optimizer(), comp()->getFlowGraph()->getStructure(), ignoreOSRuses, NULL, false, includeParms);
+   liveLocals.perform(comp()->getFlowGraph()->getStructure());
    _liveVars = new (trStackMemory()) TR_BitVector(liveLocals.getNumberOfBits(), trMemory(), stackAlloc);
 
    //set the structure to NULL so that the inliner (which is applied very soon after) doesn't need

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -563,6 +563,8 @@ int32_t TR_SinkStores::performStoreSinking()
                                                                    true,  /* includeParms */
                                                                    false);
 
+   _liveVarInfo->collectLiveVariableInformation();
+
    if (_liveVarInfo->numLocals() == 0)
       {
       return 1;
@@ -574,6 +576,8 @@ int32_t TR_SinkStores::performStoreSinking()
    if (usesDataFlowAnalysis())
       {
       _liveOnSomePaths     = new (comp()->allocator()) TR_Liveness(comp(), optimizer(), rootStructure, false, _liveVarInfo, false, true);
+      _liveOnSomePaths->perform(rootStructure);
+
       _liveOnAllPaths      = new (comp()->allocator()) TR_LiveOnAllPaths(comp(), optimizer(), rootStructure, _liveVarInfo, false, true);
       _liveOnNotAllPaths   = new (comp()->allocator()) TR_LiveOnNotAllPaths(comp(), _liveOnSomePaths, _liveOnAllPaths);
 


### PR DESCRIPTION
Allow downstream projects to extend TR_LiveVariableInformation and TR_Liveness through project-level derived classes by splitting the analysis each performs out of its constructor into a separate function that can be called after all constructors have executed, and by making members of these classes protected.