### PR TITLE
Add AVX2 to enabled CPU features on x86

### DIFF
--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -40,9 +40,9 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
                                         OMR_FEATURE_X86_MMX, OMR_FEATURE_X86_SSE, OMR_FEATURE_X86_SSE2,
                                         OMR_FEATURE_X86_SSSE3, OMR_FEATURE_X86_SSE4_1, OMR_FEATURE_X86_POPCNT,
                                         OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_OSXSAVE, OMR_FEATURE_X86_AVX,
-                                        OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM,
-                                        OMR_FEATURE_X86_AVX512F, OMR_FEATURE_X86_AVX512VL, OMR_FEATURE_X86_AVX512BW,
-                                        OMR_FEATURE_X86_AVX512DQ
+                                        OMR_FEATURE_X86_AVX2, OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE,
+                                        OMR_FEATURE_X86_RTM, OMR_FEATURE_X86_AVX512F, OMR_FEATURE_X86_AVX512VL,
+                                        OMR_FEATURE_X86_AVX512BW, OMR_FEATURE_X86_AVX512DQ
                                         };
 
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);


### PR DESCRIPTION
Signed-off-by: BradleyWood <bradley.wood@ibm.com>