### PR TITLE
Avoid invalidating use/def info in modifying tree for redundant rem

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -3985,6 +3985,16 @@ int32_t TR::GlobalValuePropagation::perform()
    if (checksWereRemoved())
       requestOpt(OMR::catchBlockRemoval);
 
+   // A reference to use/def info is cached by Global VP, but use/def info can be
+   // deleted in the optimizer if a TR::Node is discarded, unless use/def info
+   // is explicitly requested to be preserved.  This is just a safety check that
+   // the use/def info has been preserved throughout the processing of Global VP.
+   //
+   if (_useDefInfo != NULL)
+      {
+      TR_ASSERT_FATAL(optimizer()->getUseDefInfo() == _useDefInfo, "Use/def info was unexpectedly destroyed during Global Value Propagation\n");
+      }
+
    // Perform transformations that were delayed until the end of the analysis
    //
    doDelayedTransformations();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -6701,7 +6701,14 @@ TR::Node *removeRedundantREM(OMR::ValuePropagation *vp, TR::Node *node, TR::VPCo
          // this doesn't work for unsigned (iurem) as these ops treat the operands as unsigned so, for example, a prec=1 dividend that is negative
          // when interpreted as unsigned will actually have 10 digits of precision (-1 would be 0xFFffFFff = 4,294,967,295)
          //
-         return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+
+         // Safely replace irem/lrem with first operand, using VP removeNode that ensures
+         // use/def info is preserved.
+         //
+         TR::Node *firstOperand = node->getFirstChild();
+         firstOperand->incReferenceCount();
+         vp->removeNode(node);
+         return firstOperand;
          }
       }
 


### PR DESCRIPTION
In the process of replacing an `irem`/`lrem` node with its first operand, `removedRedundantRem` used `replaceNode`, which can result in the use/def info held by the `TR::Optimizer` being deleted.  As GlobalValuePropagation has a cached reference to the use/def info, it might continue to use that use/def info after it has been deleted.

This change uses VP's `removeNode` method to ensure deletion of use/def info will be deferred.

This change fixes eclipse-openj9/openj9#15364