### PR TITLE
Fix message output in replacing virtual guard

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7728,7 +7728,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
       TR::Node* oldNode = cvg->_currentTree->getNode();
 
       // !oldNode means that the branch was already removed
-      if (!oldNode || !performTransformation(comp(), "%sReplacing the old guard %p with the shiny new overridden guard %p at treetop %p\n", oldNode, cvg->_newGuardNode, cvg->_currentTree))
+      if (!oldNode || !performTransformation(comp(), "%sReplacing the old guard %p with the shiny new overridden guard %p at treetop %p\n", OPT_DETAILS, oldNode, cvg->_newGuardNode, cvg->_currentTree))
          {
          continue;
          }


### PR DESCRIPTION
This commit fixes a mismatch between the format string and the arguments
for a message in OMR::ValuePropagation::doDelayedTransformations().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>