### PR TITLE
Add options to control the costs of collecting thread stack traces

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1280,7 +1280,28 @@ typedef struct J9ThreadWalkState {
 	intptr_t error;
 	uintptr_t error_detail;
 	const char *error_string;
+	uint32_t options;
 } J9ThreadWalkState;
+
+/*
+ * Possible options in J9ThreadWalkState.
+ */
+
+/*
+ * Don't resolve symbols in stack frames in introspect_threads_XXX();
+ * caller will use introspect_backtrace_symbols_ex() as necessary.
+ */
+#define OMR_INTROSPECT_NO_SYMBOLS 1
+
+/*
+ * Possible options in calls to introspect_backtrace_symbols_ex().
+ */
+
+/*
+ * Do only basic, low cost symbol resolution. Currently, this is only
+ * relevant on Linux where full symbol resolution can be costly.
+ */
+#define OMR_BACKTRACE_SYMBOLS_BASIC 1
 
 typedef struct J9PortSysInfoLoadData {
 	double oneMinuteAverage;
@@ -2397,6 +2418,8 @@ typedef struct OMRPortLibrary {
 	uintptr_t (*introspect_backtrace_thread)(struct OMRPortLibrary *portLibrary, J9PlatformThread *thread, J9Heap *heap, void *signalInfo) ;
 	/** see @ref omrintrospect.c::omrintrospect_backtrace_symbols "omrintrospect_backtrace_symbols"*/
 	uintptr_t (*introspect_backtrace_symbols)(struct OMRPortLibrary *portLibrary, J9PlatformThread *thread, J9Heap *heap) ;
+	/** see @ref omrintrospect.c::omrintrospect_backtrace_symbols_ex "omrintrospect_backtrace_symbols_ex"*/
+	uintptr_t (*introspect_backtrace_symbols_ex)(struct OMRPortLibrary *portLibrary, J9PlatformThread *thread, J9Heap *heap, uint32_t options);
 	/** see @ref omrsyslog.c::omrsyslog_query "omrsyslog_query"*/
 	uintptr_t (*syslog_query)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsyslog.c::omrsyslog_set "omrsyslog_set"*/
@@ -3021,7 +3044,8 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrintrospect_threads_startDo_with_signal(param1,param2,param3) privateOmrPortLibrary->introspect_threads_startDo_with_signal(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrintrospect_threads_nextDo(param1) privateOmrPortLibrary->introspect_threads_nextDo(param1)
 #define omrintrospect_backtrace_thread(param1,param2,param3) privateOmrPortLibrary->introspect_backtrace_thread(privateOmrPortLibrary, (param1), (param2), (param3))
-#define omrintrospect_backtrace_symbols(param1,param2) privateOmrPortLibrary->introspect_backtrace_symbols(privateOmrPortLibrary, (param1), (param2))
+#define omrintrospect_backtrace_symbols(param1,param2) privateOmrPortLibrary->introspect_backtrace_symbols_ex(privateOmrPortLibrary, (param1), (param2), 0)
+#define omrintrospect_backtrace_symbols_ex(param1,param2,param3) privateOmrPortLibrary->introspect_backtrace_symbols_ex(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsyslog_query() privateOmrPortLibrary->syslog_query(privateOmrPortLibrary)
 #define omrsyslog_set(param1) privateOmrPortLibrary->syslog_set(privateOmrPortLibrary, (param1))
 #define omrmem_walk_categories(param1) privateOmrPortLibrary->mem_walk_categories(privateOmrPortLibrary, (param1))

--- a/port/aix/omrosbacktrace_impl.c
+++ b/port/aix/omrosbacktrace_impl.c
@@ -166,11 +166,12 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
  * @param portLbirary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
-omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap)
+omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 	/* 32bit AIX needs 130 slots available for the base VM as of Java6sr7. This allows a little overhead for 3rd party jni libraries */
 	struct ld_info buffer[150];

--- a/port/common/omrosbacktrace_impl.c
+++ b/port/common/omrosbacktrace_impl.c
@@ -54,17 +54,17 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
  * If it isn't possible to determine any of the items in the string then they are omitted. If no heap is specified
  * then this function will use malloc to allocate the memory necessary for the symbols which must be freed by the caller.
  *
- * This function is called via the omrintrospect_backtrace_symbols function that provides signal protection
+ * This function is called via the omrintrospect_backtrace_symbols_ex function that provides signal protection
  *
  * @param portLbirary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
-omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap)
+omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 	return 0;
 }
-

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -347,6 +347,7 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrintrospect_threads_nextDo, /* introspect_threads_nextDo */
 	omrintrospect_backtrace_thread, /* introspect_backtrace_thread */
 	omrintrospect_backtrace_symbols, /* introspect_backtrace_symbols */
+	omrintrospect_backtrace_symbols_ex, /* introspect_backtrace_symbols_ex */
 	omrsyslog_query, /* syslog_query */
 	omrsyslog_set, /* syslog_set */
 	omrmem_walk_categories, /* mem_walk_categories */

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -955,6 +955,8 @@ extern J9_CFUNC uintptr_t
 omrintrospect_backtrace_thread(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, void *signalInfo);
 extern J9_CFUNC uintptr_t
 omrintrospect_backtrace_symbols(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap);
+extern J9_CFUNC uintptr_t
+omrintrospect_backtrace_symbols_ex(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options);
 
 /* omrcuda */
 #if defined(OMR_OPT_CUDA)

--- a/port/osx/omrosbacktrace_impl.c
+++ b/port/osx/omrosbacktrace_impl.c
@@ -361,11 +361,12 @@ omrintrospect_backtrace_thread_raw(OMRPortLibrary *portLibrary, J9PlatformThread
  * @param portLibrary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
-omrintrospect_backtrace_symbols_raw(OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap)
+omrintrospect_backtrace_symbols_raw(OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 #if defined(OMR_ARCH_X86)
 	J9PlatformStackFrame *frame = NULL;

--- a/port/win32/omrintrospect.c
+++ b/port/win32/omrintrospect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -322,7 +322,9 @@ setup_native_thread(J9ThreadWalkState *state, CONTEXT *sigContext)
 
 	/* assemble the callstack */
 	state->portLibrary->introspect_backtrace_thread(state->portLibrary, state->current_thread, state->heap, NULL);
-	state->portLibrary->introspect_backtrace_symbols(state->portLibrary, state->current_thread, state->heap);
+	if (OMR_ARE_NO_BITS_SET(state->options, OMR_INTROSPECT_NO_SYMBOLS)) {
+		state->portLibrary->introspect_backtrace_symbols_ex(state->portLibrary, state->current_thread, state->heap, 0);
+	}
 
 	if (state->current_thread->error != 0) {
 		RECORD_ERROR(state, state->current_thread->error, 1);

--- a/port/win32/omrosbacktrace_impl.c
+++ b/port/win32/omrosbacktrace_impl.c
@@ -391,11 +391,12 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
  * @param portLbirary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
-omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap)
+omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 	J9PlatformStackFrame *frame;
 	unsigned int i = 0;

--- a/port/zos390/omrosbacktrace_impl.c
+++ b/port/zos390/omrosbacktrace_impl.c
@@ -303,11 +303,12 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
  * @param portLbirary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
-omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap)
+omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 	uintptr_t frameNumber = 0;
 	J9PlatformStackFrame *frame;

--- a/port/ztpf/omrosbacktrace_impl.c
+++ b/port/ztpf/omrosbacktrace_impl.c
@@ -234,12 +234,13 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary,
  * @param portLbirary a pointer to an initialized port library
  * @param threadInfo a thread structure populated with a backtrace
  * @param heap a heap from which to allocate any necessary memory. If NULL malloc is used instead.
+ * @param options controls how much effort is expended trying to resolve symbols
  *
  * @return the number of frames for which a symbol was constructed.
  */
 uintptr_t
 omrintrospect_backtrace_symbols_raw(struct OMRPortLibrary *portLibrary,
-	J9PlatformThread *threadInfo, J9Heap *heap)
+		J9PlatformThread *threadInfo, J9Heap *heap, uint32_t options)
 {
 	J9PlatformStackFrame *frame;
 	int i;


### PR DESCRIPTION
Allow separation of symbol resolution from collecting stack traces. Don't call `introspect_backtrace_symbols()` if `OMR_INTROSPECT_NO_SYMBOLS` is specified in `J9ThreadWalkState.options` given to `omrintrospect_threads_*()`.

Add `introspect_backtrace_symbols_ex()` which accepts options, the first of which, `OMR_BACKTRACE_SYMBOLS_BASIC`, controls the cost of symbol resolution. Currently, this is only meaningful on Linux where full symbol resolution can be costly.