### PR TITLE
Defend removed nodes during delayed transformations

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3335,6 +3335,10 @@ const char* transformedTargetName (TR::RecognizedMethod rm)
    }
 
 #ifdef J9_PROJECT_SPECIFIC
+/**
+ * Can be called from doDelayedTransformations when nodes may have been removed from the tree. Issue 6623
+ * https://github.com/eclipse/omr/issues/6623
+ */
 void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR::ValuePropagation::ObjCloneInfo *cloneInfo)
    {
    TR_OpaqueClassBlock *j9class = cloneInfo->_clazz;
@@ -3344,6 +3348,12 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
 
    TR::Node *callNode = callTree->getNode()->getFirstChild();
    TR::Node *objNode = callNode->getFirstChild();
+
+   // Check that the node hasn't been removed (issue 6623)
+   if (callNode->getReferenceCount() < 1)
+      {
+      return;
+      }
 
    TR::SymbolReference * symRef = callNode->getSymbolReference();
    TR::ResolvedMethodSymbol *method = symRef->getSymbol()->getResolvedMethodSymbol();
@@ -3433,6 +3443,10 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
    return;
    }
 
+/**
+ * Can be called from doDelayedTransformations when nodes may have been removed from the tree. Issue 6623
+ * https://github.com/eclipse/omr/issues/6623
+ */
 void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::ValuePropagation::ArrayCloneInfo *cloneInfo)
    {
    static char *disableArrayCloneOpt = feGetEnv("TR_disableFastArrayClone");
@@ -3440,6 +3454,13 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::
       return;
 
    TR::Node *callNode = callTree->getNode()->getFirstChild();
+
+   // Check that the node hasn't been removed (issue 6623)
+   if (callNode->getReferenceCount() < 1)
+      {
+      return;
+      }
+
    TR::Node *objNode = callNode->getFirstChild();
 
    TR::SymbolReference * symRef = callNode->getSymbolReference();


### PR DESCRIPTION
During globalVP nodes that are added to lists for later processing
may be removed from the trees before doDelayedTransformations is called.
If such nodes are processed the trees can be corrupted and will likely
cause a crash during compilation.

The problem was originally seen with the transformArrayCloneCall, and
has also been demonstrated with transformObjectCloneCall. This PR avoids
the issue for these two functions by testing the reference count of the
call node.

It is likely that other transformations called from doDelayedTransformations
will need similar treatment.

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>