### PR TITLE
Remove duplicate _opcode at arm and x level

### DIFF
--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -210,7 +210,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
 
    private:
-      TR::InstOpCode   _opcode;
       TR_ARMConditionCode                  _conditionCode;
       TR::RegisterDependencyConditions *_conditions;
       bool        _asyncBranch;

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -176,7 +176,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    private:
 
-   TR::InstOpCode _opcode;
    TR::RegisterDependencyConditions *_conditions;
    void assumeValidInstruction();
 


### PR DESCRIPTION
  the member not found in other platforms: aarch64, p, riscv, z
  the member is currently at OMR::Instruction level with protected attribution

Signed-off-by: Tao Guan <james_mango@yahoo.com>