### PR TITLE
Fix: Heap Corruption from Ownable Synchronizers Lists with Concurrent Scavenger 

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1551,6 +1551,15 @@ MM_ParallelGlobalGC::completeExternalConcurrentCycle(MM_EnvironmentBase *env)
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		/* ParallelGlobalGC or ConcurrentGC (STW phase) cannot start before Concurrent Scavenger cycle is in progress */
 		_extensions->scavenger->completeConcurrentCycle(env);
+
+		/* Push thread local buffers to the global list.
+		 * This is important to do because some threads can miss to flush their Ownable buffers. The scheduler may dispatch different threads for different phases of CS,
+		 * Ownable buffers are only flushed during final phase. Hence, threads that don't participate in the final phase (but built lists in prior phases) may still have buffers which need to
+		 * be flushed. Typically, this isn't an issue because all thread local buffers will be flushed when we acquire exclusive for global. However, we're already past that point now.
+		 *
+		 * TODO: This is a temporary workaround, it is Scavengers responsibility to ensure all buffers are flushed by the time we complete a cycle.
+		 */
+		GC_OMRVMInterface::flushNonAllocationCaches(env);
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 }


### PR DESCRIPTION
With Concurrent Scavenger, we may end up with unflushed Ownabele Sync. buffers which can eventually lead to a heap corruption. Multiple crashes and assertion have been reported as a result of this, for instance:

```
  j9mm.141    *   ** ASSERTION FAILED ** at
./OwnableSynchronizerObjectBuffer.cpp:100: ((false))
```

```
** ASSERTION FAILED ** at ./Scavenger.cpp:1659: ((false))
```

```
Corruption in Evacuate at 0000005020E395F8: calculated object size
344152650780 larger then available 3172872, Forwarded Header at
00000050322FE8A8
```

```
*   ** ASSERTION FAILED ** at ../../../gc_glue_java/MarkingDelegate.hpp:123: ((false && ((UDATA)0x99669966 == clazz->eyecatcher)))
```

For Concurrent Scavenger, the Ownable buffers are flushed:
1. At the start of a global cycle when we acquire exclusive access. https://github.com/eclipse/omr/blob/e70cf35e07900aa3dcf6f5c68f895094faadaca1/gc/base/standard/ConcurrentGC.hpp#L379


2. Scavenger will flush Ownable buffers for participating threads, as
threads complete a cycle,   `scavengerRootScanner.flush(env);` .
https://github.com/eclipse/omr/blob/e70cf35e07900aa3dcf6f5c68f895094faadaca1/gc/base/standard/Scavenger.cpp#L5634

In terms of #&#x2060;2, the scheduler may dispatch different threads for different phases of CS; Ownable lists are built during scan phase, however buffers are only flushed during the final phase. Hence, threads that don't participate in the last phase (but participated in prior phases) may still have buffers which need to be flushed. Typically, this isn't an issue because all buffers will be flushed as we acquire exclusive for global (#&#x2060;1).


The problem arises because there's still a possibility to miss flushing the buffers: when we complete a CS cycle as part of a global cycle (i.e CS cycle in STW through `MM_ParallelGlobalGC::completeExternalConcurrentCycle`). In which case, we're already past acquiring exlusive (#&#x2060;1) and scavenger (#&#x2060;2) will miss to flush threads that don't participate in the final phase of CS (but built lists in prior phases).

A simple workaround is to invoke `GC_OMRVMInterface::flushNonAllocationCaches(env);` in this specific
case. This will ensure all thread buffers are flushed. This should be revisited and a better solution should be adopted for Scavenger to handle this.

Signed-off-by: Salman Rana <salman.rana@ibm.com>