### PR TITLE
Add verbose option for interpreter profiling persistence

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4833,7 +4833,8 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "JITServer",
    "aotcompression",
    "JITServerConns",
-   "vectorAPI"
+   "vectorAPI",
+   "iprofilerPersistence"
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1069,6 +1069,7 @@ enum TR_VerboseFlags
    TR_VerboseAOTCompression,
    TR_VerboseJITServerConns,
    TR_VerboseVectorAPI,
+   TR_VerboseIProfilerPersistence,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };


### PR DESCRIPTION
The new verbose option is called `iprofilerPersistence`.
This will be used in a downstream project (openj9)

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>