### PR TITLE
Remove duplicate and non-extended methods in Instruction

### DIFF
--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,12 +112,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
-
-   /**
-    * @brief Gets the opcode of the instruction
-    * @return opcode of the instruction
-    */
-   TR::InstOpCode& getOpCode() {return _opcode;}
 
    /**
     * @brief Answers if this instruction is a label or not

--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,10 +86,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    virtual Kind getKind() { return IsNotExtended; }
 
-   TR::InstOpCode& getOpCode()                       {return _opcode;}
-   TR::InstOpCode::Mnemonic getOpCodeValue()                  {return _opcode.getOpCodeValue();}
    TR::InstOpCode::Mnemonic getRecordFormOpCode()             {return _opcode.getRecordFormOpCodeValue();}
-   TR::InstOpCode::Mnemonic setOpCodeValue(TR::InstOpCode::Mnemonic op)  {return _opcode.setOpCodeValue(op);}
 
    void ARMNeedsGCMap(uint32_t mask);
 

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,10 +71,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    virtual uint8_t *generateBinaryEncoding();
 
-   TR::InstOpCode& getOpCode()                       {return _opcode;}
-   TR::InstOpCode::Mnemonic getOpCodeValue()                  {return _opcode.getOpCodeValue();}
    TR::InstOpCode::Mnemonic getRecordFormOpCode()             {return _opcode.getRecordFormOpCodeValue();}
-   TR::InstOpCode::Mnemonic setOpCodeValue(TR::InstOpCode::Mnemonic op)  {return _opcode.setOpCodeValue(op);}
 
    virtual TR::Register *getTrg1Register()                   {return NULL;}
 

--- a/compiler/riscv/codegen/OMRInstruction.hpp
+++ b/compiler/riscv/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -114,12 +114,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
-
-   /**
-    * @brief Gets the opcode of the instruction
-    * @return opcode of the instruction
-    */
-   TR::InstOpCode& getOpCode() {return _opcode;}
 
    /**
     * @brief Removes this instruction from instruction list

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -94,10 +94,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual char *description() { return "X86"; }
    virtual Kind getKind() { return IsNotExtended; }
 
-   TR::InstOpCode& getOpCode() { return _opcode; }
-   TR::InstOpCode::Mnemonic getOpCodeValue() { return _opcode.getOpCodeValue(); }
-   TR::InstOpCode::Mnemonic setOpCodeValue(TR::InstOpCode::Mnemonic op) { return _opcode.setOpCodeValue(op); }
-
    OMR::X86::Encoding getEncodingMethod() { return _encodingMethod; }
    void setEncodingMethod(OMR::X86::Encoding method) { _encodingMethod = method; }
 


### PR DESCRIPTION
  setOpCodeValue is void since most setters are void

Signed-off-by: Tao Guan <james_mango@yahoo.com>