### PR TITLE
Add External Relocation Record TR_StaticDefaultValueInstance

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -465,6 +465,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_InlinedMethodPointer (108)",
    "TR_VMINLMethod (109)",
    "TR_ValidateJ2IThunkFromMethod (110)",
+   "TR_StaticDefaultValueInstance (111)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -444,6 +444,9 @@ public:
    inline void setDummyResolvedMethod();
    inline bool isDummyResolvedMethod();
 
+   inline void setStaticDefaultValueInstance();
+   inline bool isStaticDefaultValueInstance();
+
    /**
     * Enum values for _flags field.
     */
@@ -581,6 +584,10 @@ public:
        * and invokehandle bytecodes.
        */
       DummyResolvedMethod       = 0x00010000,
+      /**
+       * This flag is used to identify the value type default value instance slot address
+       */
+      StaticDefaultValueInstance = 0x00020000,
       };
 
 protected:

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -754,6 +754,19 @@ bool
 OMR::Symbol::isDummyResolvedMethod()
    {
    return _flags2.testAny(DummyResolvedMethod);
+   }
+
+void
+OMR::Symbol::setStaticDefaultValueInstance()
+   {
+   TR_ASSERT(self()->isStatic(), "Symbol must be static");
+   _flags2.set(StaticDefaultValueInstance);
+   }
+
+bool
+OMR::Symbol::isStaticDefaultValueInstance()
+   {
+   return self()->isStatic() && _flags2.testAny(StaticDefaultValueInstance);
    }
 
 TR::RegisterMappedSymbol *

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1240,7 +1240,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
 
    numSpaces = getNumSpacesAfterIndex( symRef->getReferenceNumber(), getIntLength(_comp->getSymRefTab()->baseArray.size()) );
 
-      symRefNum.appendf("#%d", symRef->getReferenceNumber());
+   symRefNum.appendf("#%d", symRef->getReferenceNumber());
 
    if (verbose)
       {
@@ -1966,6 +1966,18 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
 
       if (sym->isConst())
          return "<constant>";
+
+      // Value Type default value instance slot address
+      if (sym->isStaticDefaultValueInstance() && staticAddress)
+         {
+         if (_comp->getOption(TR_MaskAddresses))
+            return "*Masked*";
+
+         const uint8_t EXTRA_SPACE = 5;
+         char * name = (char *)_comp->trMemory()->allocateHeapMemory(TR::Compiler->debug.pointerPrintfMaxLenInChars()+EXTRA_SPACE);
+         sprintf(name, POINTER_PRINTF_FORMAT, staticAddress);
+         return name;
+         }
 
       return getOwningMethod(symRef)->staticName(symRef->getCPIndex(), comp()->trMemory());
       }

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -336,7 +336,8 @@ typedef enum
    TR_InlinedMethodPointer                = 108,
    TR_VMINLMethod                         = 109,
    TR_ValidateJ2IThunkFromMethod          = 110,
-   TR_NumExternalRelocationKinds          = 111,
+   TR_StaticDefaultValueInstance          = 111,
+   TR_NumExternalRelocationKinds          = 112,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -3576,6 +3576,8 @@ TR::AMD64RegImm64SymInstruction::autoSetReloKind()
    TR::Symbol *symbol = getSymbolReference()->getSymbol();
    if (symbol->isDebugCounter())
       setReloKind(TR_DebugCounter);
+   else if (symbol->isStaticDefaultValueInstance())
+      setReloKind(TR_StaticDefaultValueInstance);
    else if (symbol->isConst() || symbol->isConstantPoolAddress())
       setReloKind(TR_ConstantPool);
    else if (symbol->isStatic() && !getSymbolReference()->isUnresolved() && !symbol->isClassObject() && !symbol->isNotDataAddress())

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -2958,6 +2958,7 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             break;
 
          case TR_DataAddress:
+         case TR_StaticDefaultValueInstance:
             {
             if (cg()->needRelocationsForStatics())
                {


### PR DESCRIPTION
This relocation record is used to materialize value type default value instance slot address:
`&clazz->flattenedClassCache->defaultValue`

IL:
- Add `StaticDefaultValueInstance` flag to `Symbol` to indicate
if the symbol is for default value instance slot address

X86:
- Add relocation record in AMD64RegImm64SymInstruction for
`TR_StaticDefaultValueInstance` relocation type.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>