### PR TITLE
x86: Implement vector reduction opcodes

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1460,6 +1460,42 @@ public:
       return TR::BadILOp;
       }
 
+   static TR::ILOpCodes reductionToVerticalOpcode(TR::ILOpCodes op, TR::VectorLength vectorLength)
+      {
+      ILOpCode opcode;
+      opcode.setOpCodeValue(op);
+      TR::VectorOperation operation;
+
+      switch (opcode.getVectorOperation())
+         {
+         case TR::vreductionAdd:
+            operation = TR::vadd;
+            break;
+         case TR::vreductionMul:
+            operation = TR::vmul;
+            break;
+         case TR::vreductionAnd:
+            operation = TR::vand;
+            break;
+         case TR::vreductionOr:
+            operation = TR::vor;
+            break;
+         case TR::vreductionXor:
+            operation = TR::vxor;
+            break;
+         case TR::vreductionMin:
+            operation = TR::vmin;
+            break;
+         case TR::vreductionMax:
+            operation = TR::vmax;
+            break;
+         default:
+            return TR::BadILOp;
+         }
+
+      return ILOpCode::createVectorOpCode(operation, TR::DataType::createVectorType(opcode.getDataType().getDataType(), vectorLength));
+      }
+
    static TR::ILOpCodes convertScalarToVector(TR::ILOpCodes op, TR::VectorLength vectorLength)
       {
       ILOpCode opcode;

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -391,7 +391,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionAdd", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -407,7 +407,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionAnd", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -423,7 +423,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionFirstNonZero", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -439,7 +439,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionMax", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -455,7 +455,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionMin", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -471,7 +471,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionMul", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -487,7 +487,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionOr", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -503,7 +503,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionOrUnchecked", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \
@@ -519,7 +519,7 @@ VECTOR_OPERATION_MACRO(\
    /* .name                    = */ "vreductionXor", \
    /* .properties1             = */ ILProp1::Commutative | ILProp1::Associative, \
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
+   /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
    /* .typeProperties          = */ TR::NoType, \

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -303,6 +303,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    // SIMD evaluators
    static TR::Register *SIMDRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *SIMDRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *SIMDreductionEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *SIMDloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *SIMDstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *SIMDsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Goals:
 - Support reduction operations for all supported vertical operations
 - Support 128, 256, 512-bit vector lengths
 - Support all element types

