### PR TITLE
Make TR_Uncopyable more widely available as TR::Uncopyable

### DIFF
--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,7 @@
 #include "il/ILOpCodes.hpp"
 #include "il/ILOps.hpp"
 #include "runtime/Runtime.hpp"
+#include "infra/Uncopyable.hpp"
 
 class TR_Debug;
 class TR_FrontEnd;
@@ -98,18 +99,8 @@ struct TR_BinaryEncodingData
    {
    };
 
-class TR_Uncopyable
-   {
-   public:
-   TR_Uncopyable() {}
-   ~TR_Uncopyable() {}
-   private:
-   TR_Uncopyable(const TR_Uncopyable &);            // = delete;
-   TR_Uncopyable& operator=(const TR_Uncopyable &); // = delete;
-   };
 
-
-class TR_FrontEnd : public TR_Uncopyable
+class TR_FrontEnd : private TR::Uncopyable
    {
 public:
    TR_FrontEnd() {}

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -450,14 +450,6 @@ OMR::TypeDictionary::MemoryManager::~MemoryManager()
    ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
    }
 
-// Copy constructor is private but it must be defined
-// to avoid undefined behavior, since we can't use `delete`
-OMR::TypeDictionary::TypeDictionary(const TypeDictionary &src) :
-   _client(0),
-   _structsByName(str_comparator, trMemory()->heapMemoryRegion()),
-   _unionsByName(str_comparator, trMemory()->heapMemoryRegion())
-   {}
-
 OMR::TypeDictionary::TypeDictionary() :
    _client(0),
    _structsByName(str_comparator, trMemory()->heapMemoryRegion()),

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -26,6 +26,7 @@
 #include "map"
 #include "ilgen/IlBuilder.hpp"
 #include "env/TypedAllocator.hpp"
+#include "infra/Uncopyable.hpp"
 
 class TR_Memory;
 
@@ -43,9 +44,8 @@ typedef void * (*ImplGetter)(void *client);
 namespace OMR
 {
 
-class TypeDictionary
+class TypeDictionary : private TR::Uncopyable
    {
-   TypeDictionary(const TypeDictionary &src); // = delete;
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 

--- a/compiler/infra/String.hpp
+++ b/compiler/infra/String.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2021 IBM Corp. and others
+ * Copyright (c) 2021, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 #include <stddef.h>
 #include "env/defines.h"
 #include "env/TRMemory.hpp"
+#include "infra/Uncopyable.hpp"
 
 #if HOST_COMPILER == COMPILER_GCC || HOST_COMPILER == COMPILER_CLANG
 #define TR_PRINTF_FORMAT_ATTR(fmtIndex, argsIndex) \
@@ -55,7 +56,7 @@ int vsnprintfNoTrunc(char *buf, size_t size, const char *fmt, va_list args);
 int snprintfNoTrunc(char *buf, size_t size, const char *fmt, ...)
    TR_PRINTF_FORMAT_ATTR(3, 4);
 
-class StringBuf
+class StringBuf : private TR::Uncopyable
    {
    TR::Region &_region;
    size_t _cap;
@@ -100,11 +101,6 @@ class StringBuf
    void appendf(const char *fmt, ...) TR_PRINTF_FORMAT_ATTR(2, 3);
 
    private:
-
-   // Non-copyable. These are undefined and will cause a link error if anything
-   // attempts to use them accidentally.
-   StringBuf(const StringBuf &);
-   StringBuf &operator=(const StringBuf &);
 
    void ensureCapacity(size_t newLen);
    };

--- a/compiler/infra/Uncopyable.hpp
+++ b/compiler/infra/Uncopyable.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_UNCOPYABLE_INCL
+#define TR_UNCOPYABLE_INCL
+
+namespace TR {
+
+/**
+ * A utility class that prevents its subtypes from implicitly defining a
+ * default copy constructor and copy assignment operator.
+ *
+ * To prevent a type from being copied, simply make it inherit from
+ * TR::Uncopyable. Private inheritance is recommended because the subtyping
+ * relationship is irrelevant to consumers of the subtype. Example:
+ *
+ * \code
+ * class Foo : private TR::Uncopyable { ... };
+ * ...
+ * Foo x(otherFoo); // compile error
+ * existingFoo = otherFoo; // compile error
+ * \endcode
+ *
+ * Note that such inheritance does not prevent subtypes from defining their own
+ * copy constructors or copy assignment operators explicitly, though to do so
+ * would be confusing.
+ */
+class Uncopyable
+   {
+   protected:
+   Uncopyable() {}
+   ~Uncopyable() {}
+
+   // The default copy constructor and copy assignment operator implementations
+   // for any subtype require access to the corresponding two methods below.
+   // Because they're private, those default definitions are disallowed, so the
+   // methods are deleted in the subtype instead.
+   //
+   // Because explicitly deleted methods are not supported on all build
+   // compilers, these methods are deliberately left undefined to ensure that
+   // there are no uses of them. If somehow such a use is accidentally
+   // introduced (within this class), it will result in an undefined symbol
+   // error at link time.
+   //
+   private:
+   Uncopyable(const Uncopyable &);            // = delete;
+   Uncopyable& operator=(const Uncopyable &); // = delete;
+   };
+
+}
+
+#endif


### PR DESCRIPTION
`TR_Uncopyable` provides highly general functionality that should be available without including FrontEnd.hpp. This commit moves it into its own header, where it will be more widely available.

Additionally:

- It is moved into the `TR` namespace.

- The constructor and destructor are declared `protected` rather than `public`. Only subclasses need access to those.

- The only existing point of use (`TR_FrontEnd`) is changed to use `private` rather than `public` inheritance, since the fact that inheritance is used to get the desired effect is an implementation detail.

- A couple of types are changed to use `TR::Uncopyable`.