### PR TITLE
Flush Ownable Synchronizer Buffers For Each Concurrent Scavenge Phase

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1551,15 +1551,6 @@ MM_ParallelGlobalGC::completeExternalConcurrentCycle(MM_EnvironmentBase *env)
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		/* ParallelGlobalGC or ConcurrentGC (STW phase) cannot start before Concurrent Scavenger cycle is in progress */
 		_extensions->scavenger->completeConcurrentCycle(env);
-
-		/* Push thread local buffers to the global list.
-		 * This is important to do because some threads can miss to flush their Ownable buffers. The scheduler may dispatch different threads for different phases of CS,
-		 * Ownable buffers are only flushed during final phase. Hence, threads that don't participate in the final phase (but built lists in prior phases) may still have buffers which need to
-		 * be flushed. Typically, this isn't an issue because all thread local buffers will be flushed when we acquire exclusive for global. However, we're already past that point now.
-		 *
-		 * TODO: This is a temporary workaround, it is Scavengers responsibility to ensure all buffers are flushed by the time we complete a cycle.
-		 */
-		GC_OMRVMInterface::flushNonAllocationCaches(env);
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 }

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -5585,6 +5585,7 @@ MM_Scavenger::workThreadProcessRoots(MM_EnvironmentStandard *env)
 	 * we don't know which threads Scheduler will not use, so we do it for every thread.
 	 */
 	threadReleaseCaches(env, env, true, true);
+	rootScanner.flush(env);
 
 	mergeThreadGCStats(env);
 }
@@ -5606,6 +5607,7 @@ MM_Scavenger::workThreadScan(MM_EnvironmentStandard *env)
 	 * but this is not 100% guarantied (the control of what threads are inolved is in Dispatcher's domain).
 	 */
 	threadReleaseCaches(env, env, true, true);
+	rootScanner.flush(env);
 
 	mergeThreadGCStats(env);
 }


### PR DESCRIPTION
Relates to https://github.com/eclipse/omr/pull/6633

Currently, we rely on the global collector to flush ownable sync. buffers when completing an external concurrent scavenge cycle during a global collection. This not optimal as it requires all the threads to be iterated and flushed. Furthermore, it is Scavenger's responsibility to flush buffers for the participating GC threads.

Signed-off-by: Salman Rana <salman.rana@ibm.com>