### PR TITLE
Add integer exponent code sample to JitBuilder

### DIFF
--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,6 +43,7 @@ create_jitbuilder_test(nestedloop      cpp/samples/NestedLoop.cpp)
 create_jitbuilder_test(pow2            cpp/samples/Pow2.cpp)
 create_jitbuilder_test(simple          cpp/samples/Simple.cpp)
 create_jitbuilder_test(worklist        cpp/samples/Worklist.cpp)
+create_jitbuilder_test(power           cpp/samples/Power.cpp)
 
 # Extended JitBuilder Tests: These may not run properly on all platforms
 # Opt in by setting OMR_JITBUILDER_TEST_EXTENDED

--- a/jitbuilder/release/cpp/samples/Power.cpp
+++ b/jitbuilder/release/cpp/samples/Power.cpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+#include "Power.hpp"
+#include "omrformatconsts.h"
+
+PowerMethod::PowerMethod(OMR::JitBuilder::TypeDictionary *types)
+   : OMR::JitBuilder::MethodBuilder(types)
+   {
+   DefineName("power");
+   DefineParameter("b", Int64);
+   DefineParameter("e", Int64);
+   DefineReturnType(Int64);
+   }
+
+bool
+PowerMethod::buildIL()
+   {
+   Store("a",
+      ConstInt64(1));
+
+   Store("i",
+      Load("e"));
+
+   Store("keepIterating",
+      GreaterThan(
+         Load("i"),
+         ConstInt64(-1)));
+
+   OMR::JitBuilder::IlBuilder *loopBody = NULL;
+   WhileDoLoop("keepIterating", &loopBody);
+
+   loopBody->Store("a",
+   loopBody->   Mul(
+   loopBody->      Load("a"),
+   loopBody->      Load("b")));
+
+   loopBody->Store("i",
+   loopBody->   Sub(
+   loopBody->      Load("i"),
+   loopBody->      ConstInt64(1)));
+
+   loopBody->Store("keepIterating",
+   loopBody->   GreaterThan(
+   loopBody->      Load("i"),
+   loopBody->      ConstInt64(0)));
+
+   Return(
+      Load("a"));
+
+   return true;
+   }
+
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define relevant types\n");
+   OMR::JitBuilder::TypeDictionary types;
+
+   printf("Step 3: compile method builder\n");
+   PowerMethod powerMethod(&types);
+   void *entry=0;
+   int32_t rc = compileMethodBuilder(&powerMethod, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: invoke compiled code\n");
+   PowerFunctionType *power = (PowerFunctionType *)entry;
+   int64_t r;
+   r = power((int64_t) 2, (int64_t) 5);
+
+   printf("2 power 5 is %" OMR_PRId64 "\n", r);
+
+   r = power((int64_t) 3, (int64_t) 4);
+
+   printf("3 power 4 is %" OMR_PRId64 "\n", r);
+
+   r = power((int64_t) 2, (int64_t) 10);
+
+   printf("2 power 10 is %" OMR_PRId64 "\n", r);
+
+   printf ("Step 5: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/cpp/samples/Power.hpp
+++ b/jitbuilder/release/cpp/samples/Power.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef POWER_INCL
+#define POWER_INCL
+
+#include "JitBuilder.hpp"
+
+typedef int64_t (PowerFunctionType)(int64_t, int64_t);
+
+class PowerMethod : public OMR::JitBuilder::MethodBuilder
+   {
+   public:
+   PowerMethod(OMR::JitBuilder::TypeDictionary *types);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(POWER_INCL)


### PR DESCRIPTION
Provide a new JitBuilder sample code that demonstrates how to compute power(a,n) using the DoWhileLoop construct to multiply a by itself n times (n is an integer). This code sample will be included in the set of default code samples that runs when OMR_JITBUILDERTEST is enabled in cmake builds.
