### PR TITLE
Correct the OMR_InlinerPolicy::suitableForRemat() doc comment

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -6215,10 +6215,11 @@ OMR_InlinerPolicy::checkIfTargetInlineable(TR_CallTarget* target, TR_CallSite* c
    }
 
 /**
- * Do not perform privated inliner argument rematerialization on high probability profiled
- * guards when distrusted
+ * Determine whether to perform privatized inliner argument rematerialization
+ * on the given profiled guard.
  *
- * @return true if privatized inliner argumetn rematerialization should be suppressed
+ * @return true if privatized inliner argument rematerialization should be
+ *         performed, false otherwise
  */
 bool
 OMR_InlinerPolicy::suitableForRemat(TR::Compilation *comp, TR::Node *node, TR_VirtualGuardSelection *guard)


### PR DESCRIPTION
Now the meaning of the comment matches both the method name and the apparent use of the method.