### PR TITLE
x86: Fix codegen traces for xmm registers

### DIFF
--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -1857,6 +1857,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::RealRegister * reg, TR_RegisterSizes siz
       case TR_DoubleReg:
          trfprintf(pOutFile, "%s", getName(reg));
          break;
+      case TR_VectorReg128:
       case TR_VectorReg256:
       case TR_VectorReg512:
       case TR_QuadWordReg:


### PR DESCRIPTION
Signed-off-by: BradleyWood <bradley.wood@ibm.com>