### PR TITLE
Provide a way to mark cold the taken side of a profiled guard

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1894,7 +1894,8 @@ TR_InlinerBase::addGuardForVirtual(
 
    getUtil()->refineInlineGuard(callNode, block1, block2, appendTestToBlock1, callerSymbol, cursorTree, virtualGuard, block4);
 
-   if ((guard->_kind == TR_ProfiledGuard) || (guard->_kind == TR_InnerGuard))
+   if ((guard->_kind == TR_ProfiledGuard || guard->_kind == TR_InnerGuard)
+       && !guard->_forceTakenSideCold)
       {
       if (block1->getFrequency() < 0)
          block4->setFrequency(block1->getFrequency());

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -229,7 +229,13 @@ struct TR_VirtualGuardSelection
 
    TR_VirtualGuardSelection
    (TR_VirtualGuardKind kind, TR_VirtualGuardTestType type = TR_NonoverriddenTest, TR_OpaqueClassBlock *thisClass= 0)
-      : _kind(kind), _type(type), _thisClass(thisClass), _highProbabilityProfiledGuard(false) {}
+      : _kind(kind)
+      , _type(type)
+      , _thisClass(thisClass)
+      , _highProbabilityProfiledGuard(false)
+      , _forceTakenSideCold(false)
+      {}
+
    TR_VirtualGuardKind  _kind;
    TR_VirtualGuardTestType  _type;
 
@@ -245,6 +251,13 @@ struct TR_VirtualGuardSelection
    // the slow path as cold so optimizations like escape analysis can
    // work on the fast path.
    bool _highProbabilityProfiledGuard;
+
+   // Force the taken side to be cold (even for guard kinds, e.g. profiled
+   // guard, that usually don't mark the taken side cold). This is for use in
+   // cases where where we have reason to believe that the guard will always
+   // pass as a practical matter, but where for correctness in some absurd
+   // corner cases it's not possible to generate a nop guard.
+   bool _forceTakenSideCold;
 
    void setIsHighProbablityProfiledGuard(bool b=true)
       {


### PR DESCRIPTION
There can be circumstances under which it is technically necessary to generate a run-time test, but where the failure of that run-time test is known in advance to be an exceedingly rare corner case. In such a circumstance, the taken side should be marked cold, which can now be arranged by setting `_forceTakenSideCold` to true.