### PR TITLE
Improve VP's handling of guards with method tests

### DIFF
--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,7 +51,13 @@ OMR::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClass
 intptr_t
 OMR::ClassEnv::getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset)
    {
-   return *(intptr_t*) (((uint8_t *)clazz) + offset);
+   // There is no project-agnostic way to determine whether or not offset is a
+   // valid VFT offset for clazz, so return 0 to be safe. If offset were valid,
+   // the result would be:
+   //
+   //    *(intptr_t*) (((uint8_t *)clazz) + offset)
+   //
+   return 0;
    }
 
 bool

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -165,7 +165,9 @@ public:
     *
     * @param clazz The RAM class pointer to read from
     * @param offset An offset into the virtual function table (VFT) of clazz
-    * @return The entry point of the method at the given offset
+    * @return The method at the given offset, or (depending on offset) its
+    * entry point, or 0 if offset is out of bounds or the result is otherwise
+    * unavailable.
     */
    intptr_t getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset);
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -7448,6 +7448,39 @@ OMR::Node::isNopableInlineGuard()
    }
 
 bool
+OMR::Node::vftEntryIsInBounds()
+   {
+   TR_ASSERT_FATAL_WITH_NODE(
+      self(),
+      self()->isTheVirtualGuardForAGuardedInlinedCall(),
+      "vftEntryIsInBounds can only be queried on guards");
+
+   return _flags.testAny(vftEntryIsInBoundsFlag);
+   }
+
+void
+OMR::Node::setVFTEntryIsInBounds(bool inBounds)
+   {
+   TR_ASSERT_FATAL_WITH_NODE(
+      self(),
+      self()->isTheVirtualGuardForAGuardedInlinedCall(),
+      "vftEntryIsInBounds can only be set on guards");
+
+   _flags.set(vftEntryIsInBoundsFlag, inBounds);
+   }
+
+const char *
+OMR::Node::printVFTEntryIsInBounds()
+   {
+   bool show =
+      self()->isTheVirtualGuardForAGuardedInlinedCall()
+      && self()->vftEntryIsInBounds();
+
+   return show ? "vftEntryIsInBounds " : "";
+   }
+
+
+bool
 OMR::Node::isMutableCallSiteTargetGuard()
    {
    return _flags.testValue(inlineGuardMask, mutableCallSiteTargetGuard) && self()->getOpCode().isIf();
@@ -8592,6 +8625,9 @@ resetFlagsAndPropertiesForCodeMotionHelper(TR::Node *node, TR::NodeChecklist &vi
 
    if (node->hasKnownObjectIndex())
       node->setKnownObjectIndex(TR::KnownObjectTable::UNKNOWN);
+
+   if (node->isTheVirtualGuardForAGuardedInlinedCall())
+      node->setVFTEntryIsInBounds(false);
    }
 
 // Clear out relevant flags set on the node; this will ensure

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1410,6 +1410,10 @@ public:
    void resetIsTheVirtualGuardForAGuardedInlinedCall();
    bool isNopableInlineGuard();
 
+   bool vftEntryIsInBounds();
+   void setVFTEntryIsInBounds(bool inBounds);
+   const char * printVFTEntryIsInBounds();
+
    bool isMutableCallSiteTargetGuard();
    void setIsMutableCallSiteTargetGuard();
    const char * printIsMutableCallSiteTargetGuard();
@@ -2048,6 +2052,7 @@ protected:
       swappedChildren                       = 0x00020000,
       versionIfWithMaxExpr                  = 0x00010000,
       versionIfWithMinExpr                  = 0x00040000,
+      vftEntryIsInBoundsFlag                = 0x00080000, ///< For guards with method test
 
       // Can be set on int loads and arithmetic operations
       IsPowerOfTwo                          = 0x10000000,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -986,6 +986,7 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    output.appendf(format, node->printIsOSRGuard()          );
    output.appendf(format, node->printIsBreakpointGuard()          );
    output.appendf(format, node->printIsMutableCallSiteTargetGuard() );
+   output.appendf(format, node->printVFTEntryIsInBounds());
    output.appendf(format, node->printIsByteToByteTranslate());
    output.appendf(format, node->printIsByteToCharTranslate());
    output.appendf(format, node->printIsCharToByteTranslate());


### PR DESCRIPTION
VP would already fold the guard when there was a fixed-type bound for the receiver. Now it will also:

- Fold the guard (to unconditionally go to the cold side) when there is a type bound *C* for the receiver, and instances of *C* cannot possibly be instances of the defining class of the inlined method.

- Fold the guard (to unconditionally go to the hot side) when there is a type bound *C* for the receiver, and *C* has the expected method, and the expected method is final.

- Flag the guard to indicate that its load of the VFT entry is known to be in bounds when there is a type bound *C* for the receiver, and *C* has a large enough VFT. If the guard is not noppable, it might usually require a run-time bounds test, and if it does, this flag will allow that test to be skipped. This is done regardless of whether the guard can be folded, but it only matters when the guard is not folded.

- Derive a type bound for the receiver on the hot side of the guard when the guard is not folded. Only instances of the defining class of the inlined method can pass the guard. There was already code that looked like it was trying to do this, but it was dead because it required the VFT entry load to also be a load of `<vft-symbol>`. Instead of special handling for this case at the end of the VP handler, we now make use of `instanceofObjectRef` in the same way as for VFT tests.

----

There are a few additional commits in the series to prepare for this main change:
- Remove dead logic in VP `ifxcmpeq`/`ne` handler
- Extract type propagation logic from VP's VFT test path
- Restrict VP's VFT and method test guard handling to `ifacmpne`