### PR TITLE
Version profiled guards with cold targets regardless of profiling

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -2712,7 +2712,8 @@ bool TR_LoopVersioner::isBranchSuitableToVersion(TR_ScratchList<TR::Block> *loop
       }
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (node->isProfiledGuard())
+   if (node->isProfiledGuard()
+       && !node->getBranchDestination()->getNode()->getBlock()->isCold())
        {
        bool isGetFieldCacheCounts = !strncmp(comp->signature(),"org/apache/solr/request/SimpleFacets.getFieldCacheCounts(Lorg/apache/solr/search/SolrIndexSearcher;Lorg/apache/solr/search/DocSet;Ljava/lang/String;IIIZLjava/lang/String;Ljava/lang/String;)Lorg/apache/solr/common/util/NamedList;",60);
 


### PR DESCRIPTION
The target block is only marked cold when the guard branch is strongly expected to fall through. This might be the case for a profiled guard even when the top profiled receiver type is not overwhelmingly likely, e.g. if the guard uses a method test and all profiled receivers inherit the same method.

It's possible to look specifically for such situations, but for the moment, just don't second-guess the cold marking on the target block.