### PR TITLE
Correct the comment describing the allocated ranges of node flag bits

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1873,16 +1873,17 @@ private:
 protected:
    enum
       {
-      // Here's map of how the flag bits have been allocated
+      // Flag bits allocation map (inclusive ranges):
       //
-      // 0x00000000 - 0x00000400 are general node flags (6 bits)
-      // 0x00000400 - 0x00008000 are node specific flags (10 bits)
-      // 0x00001000 - 0x10000000 are unallocated (13 bits)
-      // 0x20000000 - 0x80000000 are frontend specific general node flags (3 bits)
+      // 0x00000001 - 0x00000200 are general node flags (10 bits)
+      // 0x00000400 - 0x00400000 are node specific flags (13 bits)
+      // 0x00800000 - 0x40000000 are unallocated (8 bits)
+      // 0x80000000 - 0x80000000 are frontend specific general node flags (1 bit)
       //
 
       //---------------------------------------- general flags ---------------------------------------
 
+      // available                          = 0x00000001,
       nodeIsZero                            = 0x00000002,
       nodeIsNonZero                         = 0x00000004,
       nodeIsNull                            = 0x00000002,

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1439,10 +1439,6 @@ public:
    bool isVersionableIfWithMinExpr();
    void setIsVersionableIfWithMinExpr(TR::Compilation * c);
 
-   // Can be set on int loads and arithmetic operations
-   bool isPowerOfTwo()          { return _flags.testAny(IsPowerOfTwo); }
-   void setIsPowerOfTwo(bool b) { _flags.set(IsPowerOfTwo, b); }
-
    // Flags used by indirect stores and wrtbars for references
    bool isStoreAlreadyEvaluated();
    void setStoreAlreadyEvaluated(bool b);
@@ -2048,9 +2044,6 @@ protected:
       swappedChildren                       = 0x00020000,
       versionIfWithMaxExpr                  = 0x00010000,
       versionIfWithMinExpr                  = 0x00040000,
-
-      // Can be set on int loads and arithmetic operations
-      IsPowerOfTwo                          = 0x10000000,
 
       // Flags used by indirect stores & wrtbars for references
       storeAlreadyEvaluated                 = 0x00001000,

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2691,9 +2691,6 @@ int32_t TR_SimplifyAnds::performOnBlock(TR::Block *block)
 
 bool isPowerOfTwo(TR::Compilation *comp, TR::Node *node)
    {
-   if (node->isPowerOfTwo())
-     return true;
-
    if (node->getOpCode().isLoadConst() &&
        isNonNegativePowerOf2(node->get64bitIntegralValue()))
       return true;


### PR DESCRIPTION
Also remove an unused flag that would have complicated the description.