### PR TITLE
AArch64: Implement vector compare evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -651,6 +651,12 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vreductionMul:
       case TR::vreductionMax:
       case TR::vreductionMin:
+      case TR::vcmpeq:
+      case TR::vcmpge:
+      case TR::vcmpgt:
+      case TR::vcmple:
+      case TR::vcmplt:
+      case TR::vcmpne:
          return true;
       case TR::vand:
       case TR::vor:


### PR DESCRIPTION
This commit implements vector compare evaluators.
These evaluators return a vector register containing the mask result.
The mask result is all ones for the lane where the test passes,
and all zeroes for the lane where the test fails.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>