### PR TITLE
Remove dummy opcode value setting in Instruction constructor

### DIFF
--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -80,15 +80,13 @@ OMR::ARM::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemon
 OMR::ARM::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
    : OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
    {
-   self()->setOpCodeValue(TR::InstOpCode::bad);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(NULL);
    }
 
 OMR::ARM::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
-   : OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
+   : OMR::InstructionConnector(cg, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(NULL);
    }
@@ -97,9 +95,8 @@ OMR::ARM::Instruction::Instruction(TR::Instruction   *precedingInstruction,
             TR::InstOpCode::Mnemonic     op,
             TR::Node          *node,
             TR::CodeGenerator *cg)
-   : OMR::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad, node)
+   : OMR::InstructionConnector(cg, precedingInstruction, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(NULL);
    }
@@ -108,9 +105,8 @@ OMR::ARM::Instruction::Instruction(TR::InstOpCode::Mnemonic                     
             TR::Node                            *node,
             TR::RegisterDependencyConditions    *cond,
             TR::CodeGenerator                   *cg)
-   : OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
+   : OMR::InstructionConnector(cg, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(cond);
    if (cond)
@@ -122,9 +118,8 @@ OMR::ARM::Instruction::Instruction(TR::Instruction                     *precedin
             TR::Node                            *node,
             TR::RegisterDependencyConditions    *cond,
             TR::CodeGenerator                   *cg)
-   : OMR::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad, node)
+   : OMR::InstructionConnector(cg, precedingInstruction, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setConditionCode(ARMConditionCodeAL);
    self()->setDependencyConditions(cond);
    if (cond)

--- a/compiler/x/codegen/Instruction.hpp
+++ b/compiler/x/codegen/Instruction.hpp
@@ -56,34 +56,30 @@ class OMR_EXTENSIBLE Instruction : public OMR::InstructionConnector
 #include "codegen/OMRInstruction_inlines.hpp"
 
 TR::Instruction::Instruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg, OMR::X86::Encoding encoding) :
-   OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
+   OMR::InstructionConnector(cg, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setEncodingMethod(encoding);
    self()->initialize();
    }
 
 TR::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, OMR::X86::Encoding encoding) :
-   OMR::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
+   OMR::InstructionConnector(cg, precedingInstruction, op)
    {
-   self()->setOpCodeValue(op);
    self()->setEncodingMethod(encoding);
    self()->initialize();
    }
 
 TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg, OMR::X86::Encoding encoding) :
-   OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
+   OMR::InstructionConnector(cg, op, node)
    {
-   self()->setOpCodeValue(op);
    self()->setDependencyConditions(cond);
    self()->setEncodingMethod(encoding);
    self()->initialize(cg, cond, op, true);
    }
 
 TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, OMR::X86::Encoding encoding) :
-   OMR::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
+   OMR::InstructionConnector(cg, precedingInstruction, op)
    {
-   self()->setOpCodeValue(op);
    self()->setDependencyConditions(cond);
    self()->setEncodingMethod(encoding);
    self()->initialize(cg, cond, op);


### PR DESCRIPTION
This should be part of #6640 since there were duplicate **_opcode** member at top level and extended platform level, now no need to enforce such TR::InstOpCode::bad at OMR::Instruction level and set it at platform level.

Signed-off-by: Tao Guan <james_mango@yahoo.com>