### PR TITLE
Add verbose option and tags for checkpoint restore

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4844,7 +4844,9 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "aotcompression",
    "JITServerConns",
    "vectorAPI",
-   "iprofilerPersistence"
+   "iprofilerPersistence",
+   "CheckpointRestore",
+   "CheckpointRestoreDetails"
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1070,6 +1070,8 @@ enum TR_VerboseFlags
    TR_VerboseJITServerConns,
    TR_VerboseVectorAPI,
    TR_VerboseIProfilerPersistence,
+   TR_VerboseCheckpointRestore,
+   TR_VerboseCheckpointRestoreDetails,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -65,6 +65,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#AOTCOMPRESSION: ",
    "#FSD: ",
    "#VECTOR API: ",
+   "#CHECKPOINT RESTORE: ",
    };
 
 void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -73,6 +73,7 @@ enum TR_VlogTag
    TR_Vlog_AOTCOMPRESSION,
    TR_Vlog_FSD,
    TR_Vlog_VECTOR_API,
+   TR_Vlog_CHECKPOINT_RESTORE,
    TR_Vlog_numTags
    };
 


### PR DESCRIPTION
This PR adds the ability for downstream projects to print checkpoint/restore specific information to the verbose log.