### PR TITLE
new getLowAddressAllocate API for MemorySubSpace

### DIFF
--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  * Copyright (c) 1991, 2022 IBM Corp. and others
  *
@@ -2013,4 +2014,10 @@ MM_MemorySubSpace::releaseFreeMemoryPages(MM_EnvironmentBase* env)
 {
 	Assert_MM_unreachable();
         return 0;
+}
+
+void *
+MM_MemorySubSpace::getLowAddressAllocate()
+{
+	return getFirstRegion()->getLowAddress();
 }

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -448,6 +448,8 @@ public:
 
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env);
 
+	virtual void *getLowAddressAllocate();
+
 	/**
 	 * Create a MemorySubSpace object.
 	 */

--- a/gc/base/MemorySubSpaceFlat.hpp
+++ b/gc/base/MemorySubSpaceFlat.hpp
@@ -86,6 +86,8 @@ public:
 	virtual uintptr_t getAvailableContractionSize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);	
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env);
 
+	virtual void *getLowAddressAllocate() { return _memorySubSpace->getLowAddressAllocate(); }
+
 	/**
 	 * Create a new MM_MemorySubSpaceFlat object
 	 */

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,8 @@ public:
 	 * Not thread safe - caller has to make sure no other threads are modifying the stats for any of children.
 	 */
 	virtual void mergeLargeObjectAllocateStats(MM_EnvironmentBase *env);
+
+	virtual void *getLowAddressAllocate() { return _memorySubSpaceAllocate->getLowAddressAllocate(); }
 
 	/**
 	 * Create a MemorySubSpaceSemiSpace object.


### PR DESCRIPTION
	- new api getLowAddressAllocate() return base address for eden
	or nursery allocate.


Signed-off-by: Lin Hu <linhu@ca.ibm.com>