### PR TITLE
Remove vectorToScalar OMRDataType query

### DIFF
--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -688,7 +688,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             {
             if (!aliases)
                aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
-            aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().vectorToScalar()));
+            aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().getVectorElementType()));
             }
          // the other way around
          if (_symbol->isArrayShadowSymbol() && _symbol->getDataType().isVectorElement())

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -88,12 +88,6 @@ OMR::DataType::getVectorIntegralType()
    }
 
 TR::DataType
-OMR::DataType::vectorToScalar()
-   {
-   return self()->getVectorElementType();
-   }
-
-TR::DataType
 OMR::DataType::scalarToVector(TR::VectorLength length)
    {
    TR::DataTypes type = self()->getDataType();

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -480,14 +480,6 @@ public:
    static bool initVectorNames();
 
   /** \brief
-   *     Returns vector element type
-   *
-   *  \return
-   *     Vector element type
-   */
-   TR::DataType vectorToScalar();
-
-  /** \brief
    *     Creates vector type based on element type and provided vector length
    *
    *  \param length


### PR DESCRIPTION
Remove using vectorToScalar query from codebase and use
getVectorElementType() query instead to get the element type of the
vector opcode.

Closes: https://github.com/eclipse/omr/issues/6658

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>