### PR TITLE
Fix testHashTableCorrectness issue

### DIFF
--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -413,18 +413,16 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env)
 void
 MM_MarkingScheme::fixupForwardedSlot(omrobjectptr_t *slotPtr) {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
-		bool const compressed = _extensions->compressObjectReferences();
-		if (_extensions->getGlobalCollector()->isStwCollectionInProgress()) {
-			MM_ForwardedHeader forwardHeader(*slotPtr, compressed);
-			omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
+	bool const compressed = _extensions->compressObjectReferences();
+	if (_extensions->getGlobalCollector()->isStwCollectionInProgress()) {
+		MM_ForwardedHeader forwardHeader(*slotPtr, compressed);
+		omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
 
-			if (NULL != forwardPtr) {
-				if (forwardHeader.isSelfForwardedPointer()) {
-					forwardHeader.restoreSelfForwardedPointer();
-				} else {
-					*slotPtr = forwardPtr;
-				}
+		if (NULL != forwardPtr) {
+			if (forwardHeader.isSelfForwardedPointer()) {
+				forwardHeader.restoreSelfForwardedPointer();
+			} else {
+				*slotPtr = forwardPtr;
 			}
 		}
 	}

--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -289,9 +289,11 @@ public:
 	 */
 
 	MMINLINE void fixupForwardedSlot(GC_SlotObject *slotObject) {
-		omrobjectptr_t slot = slotObject->readReferenceFromSlot();
-		fixupForwardedSlot(&slot);
-		slotObject->writeReferenceToSlot(slot);
+		if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
+			omrobjectptr_t slot = slotObject->readReferenceFromSlot();
+			fixupForwardedSlot(&slot);
+			slotObject->writeReferenceToSlot(slot);
+		}
 	}
 
 	void fixupForwardedSlot(omrobjectptr_t *slotPtr);

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -2105,6 +2105,7 @@ MM_Scavenger::incrementalScavengeObjectSlots(MM_EnvironmentStandard *env, omrobj
 	/* Get an object scanner from the CLI if not resuming from a scan cache that was previously suspended */
 	GC_ObjectScanner *objectScanner = NULL;
 	if (!scanCache->_hasPartiallyScannedObject) {
+		scanCache->_shouldBeRemembered = false;
 		if (!scanCache->isSplitArray()) {
 			/* try to get a new scanner instance from the cli */
 			objectScanner = getObjectScanner(env, objectPtr, scanCache->getObjectScanner(), GC_ObjectScanner::scanHeap, SCAN_REASON_SCAVENGE, &scanCache->_shouldBeRemembered);
@@ -2127,7 +2128,6 @@ MM_Scavenger::incrementalScavengeObjectSlots(MM_EnvironmentStandard *env, omrobj
 				((GC_IndexableObjectScanner *)objectScanner)->scanToLimit();
 			}
 		}
-		scanCache->_shouldBeRemembered = false;
 	} else {
 		/* resume suspended object scanner */
 		objectScanner = scanCache->getObjectScanner();


### PR DESCRIPTION
	fixupForwardedSlot(mrobjectptr_t *slotPtr) has been created for
	sharing code between scanMixObject and scan Java stack of continuation
	Object in PR6575, we need to pull concurrent scavenger and backout
	conditions outside to avoid racing condition to update slot reference
	during concurrent marking.

	- also update initialize scanCache->_shouldBeRemembered earlier to avoid
	overwriting the flag, which could be updated via getObjectScanner()

fix: https://github.com/eclipse-openj9/openj9/issues/15791
Signed-off-by: Lin Hu <linhu@ca.ibm.com>