### PR TITLE
Handling potential overwriting in Concurrent scavenger back out case

### DIFF
--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -410,7 +410,7 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env)
 	return workPackets;
 }
 
-void
+bool
 MM_MarkingScheme::fixupForwardedSlot(omrobjectptr_t *slotPtr) {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool const compressed = _extensions->compressObjectReferences();
@@ -423,10 +423,12 @@ MM_MarkingScheme::fixupForwardedSlot(omrobjectptr_t *slotPtr) {
 				forwardHeader.restoreSelfForwardedPointer();
 			} else {
 				*slotPtr = forwardPtr;
+				return true;
 			}
 		}
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	return false;
 }
 
 uintptr_t

--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -291,12 +291,13 @@ public:
 	MMINLINE void fixupForwardedSlot(GC_SlotObject *slotObject) {
 		if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
 			omrobjectptr_t slot = slotObject->readReferenceFromSlot();
-			fixupForwardedSlot(&slot);
-			slotObject->writeReferenceToSlot(slot);
+			if (fixupForwardedSlot(&slot)) {
+				slotObject->writeReferenceToSlot(slot);
+			}
 		}
 	}
 
-	void fixupForwardedSlot(omrobjectptr_t *slotPtr);
+	bool fixupForwardedSlot(omrobjectptr_t *slotPtr);
 	virtual uintptr_t setupIndexableScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo, uintptr_t *sizeInElementsToDo, fomrobject_t **basePtr, uintptr_t *flags);
 
 	/**


### PR DESCRIPTION
Update Method fixupForwardedSlot return true or false for the condition
to update heap object reference slot(we won't need to update the
reference slot if the reference is not fixed up) in order to avoid
potential reference slot overwriting(concurrent marking) during
Concurrent scavenger back out case.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>