### PR TITLE
Share method MM_Scavenger.shouldRememberSlot

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -2803,14 +2803,8 @@ MM_Scavenger::shouldRememberObject(MM_EnvironmentStandard *env, omrobjectptr_t o
 		GC_SlotObject *slotPtr;
 		while (NULL != (slotPtr = objectScanner->getNextSlot())) {
 			omrobjectptr_t slotObjectPtr = slotPtr->readReferenceFromSlot();
-			if (NULL != slotObjectPtr) {
-				if (isObjectInNewSpace(slotObjectPtr)) {
-					Assert_MM_true(!isObjectInEvacuateMemory(slotObjectPtr));
-					return true;
-				} else if (IS_CONCURRENT_ENABLED && isBackOutFlagRaised() && isObjectInEvacuateMemory(slotObjectPtr)) {
-					/* Could happen if we aborted before completing RS scan */
-					return true;
-				}
+			if (shouldRememberSlot(&slotObjectPtr)) {
+				return true;
 			}
 		}
 	}


### PR DESCRIPTION
Share method MM_Scavenger.shouldRememberSlot, remove duplicated logic
for checking if should remember the slot.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>