### PR TITLE
Add ability to reinitialize TR_X86ProcessorInfo

### DIFF
--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,12 +85,12 @@ class OMR_EXTENSIBLE CPU
    {
 protected:
 
-   /** 
+   /**
     * @brief Default constructor that defaults down to OMR minimum supported CPU and features
     */
    CPU();
 
-   /** 
+   /**
     * @brief Constructor that initializes the cpu from processor description provided by user
     * @param[in] OMRProcessorDesc : the input processor description
     */
@@ -100,14 +100,14 @@ public:
 
    TR::CPU *self();
 
-   /** 
-    * @brief Detects the underlying processor type and features using the port library and constructs a TR::CPU object 
+   /**
+    * @brief Detects the underlying processor type and features using the port library and constructs a TR::CPU object
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
     */
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
-  /** 
+  /**
     * @brief Returns the processor type and features that will be used by portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
@@ -116,8 +116,9 @@ public:
 
    /**
     * @brief API to initialize platform specific target processor info if it exists
+    * @param[in] force : force initialization even if the target processor info has already been initialized
     */
-   static void initializeTargetProcessorInfo() {}
+   static void initializeTargetProcessorInfo(bool force = false) {}
 
    TR_Processor setProcessor(TR_Processor p) { return(_processor = p); }
 
@@ -172,13 +173,13 @@ public:
    bool isI386() { return _minorArch == TR::m_arch_i386; }
    bool isAMD64() { return _minorArch == TR::m_arch_amd64; }
 
-   /** 
+   /**
     * @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
     * @return false; this is the default answer unless overridden by an extending class.
     */
    bool supportsTransactionalMemoryInstructions() { return false; }
 
-   /** 
+   /**
     * @brief Determines whether current processor is the same as the input processor type
     * @param[in] p : the input processor type
     * @return true when current processor is the same as the input processor type
@@ -192,20 +193,20 @@ public:
     */
    bool isAtLeast(OMRProcessorArchitecture p) { return _processorDescription.processor >= p; }
 
-   /** 
+   /**
     * @brief Determines whether current processor is equal or older than the input processor type
     * @param[in] p : the input processor type
     * @return true when current processor is equal or newer than the input processor type
     */
    bool isAtMost(OMRProcessorArchitecture p) { return _processorDescription.processor <= p; }
 
-   /** 
+   /**
     * @brief Retrieves current processor's processor description
     * @return processor description which includes processor type and processor features
     */
    OMRProcessorDesc getProcessorDescription() { return _processorDescription; }
 
-   /** 
+   /**
     * @brief Determines whether current processor supports the input processor feature
     * @param[in] feature : the input processor feature
     * @return true when current processor supports the input processor feature

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -207,9 +207,9 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
    {
    bool supportsSSE2 = false;
 
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isGenuineIntel() == _targetProcessorInfo.isGenuineIntel(), "isGenuineIntel() failed\n");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == _targetProcessorInfo.isAuthenticAMD(), "isAuthenticAMD() failed\n");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.prefersMultiByteNOP() == _targetProcessorInfo.prefersMultiByteNOP(), "prefersMultiByteNOP() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isGenuineIntel() == getX86ProcessorInfo().isGenuineIntel(), "isGenuineIntel() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == getX86ProcessorInfo().isAuthenticAMD(), "isAuthenticAMD() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.prefersMultiByteNOP() == getX86ProcessorInfo().prefersMultiByteNOP(), "prefersMultiByteNOP() failed\n");
 
    // Pick a padding table
    //
@@ -229,7 +229,7 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 
 #if defined(TR_TARGET_X86)
 #if !defined(J9HAMMER)
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) == _targetProcessorInfo.supportsSSE2(), "supportsSSE2() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) == getX86ProcessorInfo().supportsSSE2(), "supportsSSE2() failed\n");
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE2) && comp->target().cpu.testOSForSSESupport())
       supportsSSE2 = true;
@@ -239,7 +239,7 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 #endif // !defined(J9HAMMER)
 #endif // defined(TR_TARGET_X86)
 
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_RTM) == _targetProcessorInfo.supportsTM(), "supportsTM() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.supportsFeature(OMR_FEATURE_X86_RTM) == getX86ProcessorInfo().supportsTM(), "supportsTM() failed\n");
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_RTM) && !comp->getOption(TR_DisableTM))
       {
@@ -249,7 +249,7 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
         *
         * TODO: Need to figure out from which mode of Broadwell start supporting TM
         */
-      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELHASWELL) == _targetProcessorInfo.isIntelHaswell(), "isIntelHaswell() failed\n");
+      TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.is(OMR_PROCESSOR_X86_INTELHASWELL) == getX86ProcessorInfo().isIntelHaswell(), "isIntelHaswell() failed\n");
       if (!comp->target().cpu.is(OMR_PROCESSOR_X86_INTELHASWELL))
          {
          if (comp->target().is64Bit())
@@ -266,7 +266,7 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 
    // Choose the best XMM double precision load instruction for the target architecture.
    //
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == _targetProcessorInfo.isAuthenticAMD(), "isAuthenticAMD() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == getX86ProcessorInfo().isAuthenticAMD(), "isAuthenticAMD() failed\n");
    static char *forceMOVLPD = feGetEnv("TR_forceMOVLPDforDoubleLoads");
    if (comp->target().cpu.isAuthenticAMD() || forceMOVLPD)
       {
@@ -427,9 +427,9 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
    // Make a conservative estimate of the boundary over which an executable instruction cannot
    // be patched.
    //
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isGenuineIntel() == _targetProcessorInfo.isGenuineIntel(), "isGenuineIntel() failed\n");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == _targetProcessorInfo.isAuthenticAMD(), "isAuthenticAMD() failed\n");
-   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H) == _targetProcessorInfo.isAMD15h(), "isAMD15h() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isGenuineIntel() == getX86ProcessorInfo().isGenuineIntel(), "isGenuineIntel() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.isAuthenticAMD() == getX86ProcessorInfo().isAuthenticAMD(), "isAuthenticAMD() failed\n");
+   TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode() || comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H) == getX86ProcessorInfo().isAMD15h(), "isAMD15h() failed\n");
    int32_t boundary;
    if (comp->target().cpu.isGenuineIntel() || (comp->target().cpu.isAuthenticAMD() && comp->target().cpu.is(OMR_PROCESSOR_X86_AMDFAMILY15H)))
       boundary = 32;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -105,9 +105,6 @@ namespace TR { class RegisterDependencyConditions; }
 // Hack markers
 #define CANT_REMATERIALIZE_ADDRESSES(cg) (cg->comp()->target().is64Bit()) // AMD64 produces a memref with an unassigned addressRegister
 
-
-TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
-
 TR_X86ProcessorInfo::TR_X86ProcessorInfo()
    : _vendorFlags(0),
      _featureFlags(0),
@@ -641,6 +638,13 @@ OMR::X86::CodeGenerator::endInstructionSelection()
              "endInstructionSelection() ==> Could not find the dummy finally block!\n");
       generateMemInstruction(self()->getLastCatchAppendInstruction(), TR::InstOpCode::LDCWMem, generateX86MemoryReference(self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST), self()), self());
       }
+   }
+
+TR_X86ProcessorInfo &
+OMR::X86::CodeGenerator::getX86ProcessorInfo()
+   {
+   static TR_X86ProcessorInfo processorInfo = TR_X86ProcessorInfo();
+   return processorInfo;
    }
 
 int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableGPRs()

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -114,10 +114,17 @@ void TR_X86ProcessorInfo::reset()
    _processorDescription = 0;
    }
 
-void TR_X86ProcessorInfo::initialize()
+void TR_X86ProcessorInfo::initialize(bool force)
    {
-   if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))
+   if (force)
+      {
+      reset();
+      }
+   else if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))
+      {
       return;
+      }
+
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
    //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -108,6 +108,14 @@ namespace TR { class RegisterDependencyConditions; }
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
+TR_X86ProcessorInfo::TR_X86ProcessorInfo()
+   : _vendorFlags(0),
+     _featureFlags(0),
+     _featureFlags2(0),
+     _featureFlags8(0),
+     _processorDescription(0)
+   {}
+
 void TR_X86ProcessorInfo::initialize()
    {
    if (_featureFlags.testAny(TR_X86ProcessorInfoInitialized))

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -105,13 +105,14 @@ namespace TR { class RegisterDependencyConditions; }
 // Hack markers
 #define CANT_REMATERIALIZE_ADDRESSES(cg) (cg->comp()->target().is64Bit()) // AMD64 produces a memref with an unassigned addressRegister
 
-TR_X86ProcessorInfo::TR_X86ProcessorInfo()
-   : _vendorFlags(0),
-     _featureFlags(0),
-     _featureFlags2(0),
-     _featureFlags8(0),
-     _processorDescription(0)
-   {}
+void TR_X86ProcessorInfo::reset()
+   {
+   _vendorFlags = 0;
+   _featureFlags = 0;
+   _featureFlags2 = 0;
+   _featureFlags8 = 0;
+   _processorDescription = 0;
+   }
 
 void TR_X86ProcessorInfo::initialize()
    {

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -121,7 +121,7 @@ struct TR_X86ProcessorInfo
 
    TR_ALLOC(TR_Memory::IA32ProcessorInfo)
 
-   TR_X86ProcessorInfo();
+   TR_X86ProcessorInfo() { reset(); }
 
    enum TR_X86ProcessorVendors
       {
@@ -228,6 +228,16 @@ private:
 
    friend class OMR::X86::CodeGenerator;
 
+   /**
+    * @brief Zero initalize all member variables
+    *
+    */
+   void reset();
+
+   /**
+    * @brief Initialize all member variables
+    *
+    */
    void initialize();
 
    /**

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -347,7 +347,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void endInstructionSelection();
 
 
-   static TR_X86ProcessorInfo &getX86ProcessorInfo() {return _targetProcessorInfo;}
+   static TR_X86ProcessorInfo &getX86ProcessorInfo();
    static void initializeX86TargetProcessorInfo() { getX86ProcessorInfo().initialize(); }
 
    typedef enum
@@ -650,9 +650,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     * \return : a constant data snippet containing one type T element
     */
    template<typename T> inline TR::X86ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node* node, T data) { return findOrCreateConstantDataSnippet(node, &data, sizeof(data)); }
-
-
-   static TR_X86ProcessorInfo _targetProcessorInfo;
 
    // The core "clobberEvaluate" logic for single registers (not register
    // pairs), parameterized by the opcode used to move the desired value into a

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -346,7 +346,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
 
    static TR_X86ProcessorInfo &getX86ProcessorInfo() {return _targetProcessorInfo;}
-   static void initializeX86TargetProcessorInfo() { _targetProcessorInfo.initialize(); }
+   static void initializeX86TargetProcessorInfo() { getX86ProcessorInfo().initialize(); }
 
    typedef enum
       {

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -121,6 +121,8 @@ struct TR_X86ProcessorInfo
 
    TR_ALLOC(TR_Memory::IA32ProcessorInfo)
 
+   TR_X86ProcessorInfo();
+
    enum TR_X86ProcessorVendors
       {
       TR_AuthenticAMD                  = 0x01,

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -237,8 +237,9 @@ private:
    /**
     * @brief Initialize all member variables
     *
+    * @param force Force initialization even if it has already been performed
     */
-   void initialize();
+   void initialize(bool force = false);
 
    /**
     * @brief testFlag Ensures that the feature being tested for exists in the mask
@@ -356,9 +357,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void beginInstructionSelection();
    void endInstructionSelection();
 
-
    static TR_X86ProcessorInfo &getX86ProcessorInfo();
-   static void initializeX86TargetProcessorInfo() { getX86ProcessorInfo().initialize(); }
+   static void initializeX86TargetProcessorInfo(bool force = false) { getX86ProcessorInfo().initialize(force); }
 
    typedef enum
       {

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -74,9 +74,9 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
    }
 
 void
-OMR::X86::CPU::initializeTargetProcessorInfo()
+OMR::X86::CPU::initializeTargetProcessorInfo(bool force)
    {
-   OMR::X86::CodeGenerator::initializeX86TargetProcessorInfo();
+   OMR::X86::CodeGenerator::initializeX86TargetProcessorInfo(force);
    }
 
 TR_X86CPUIDBuffer *

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -59,7 +59,7 @@ public:
 
    static TR::CPU detect(OMRPortLibrary * const omrPortLib);
 
-   static void initializeTargetProcessorInfo();
+   static void initializeTargetProcessorInfo(bool force = false);
 
    TR_X86CPUIDBuffer *queryX86TargetCPUID();
    const char *getX86ProcessorVendorId();


### PR DESCRIPTION
The initialization of the static instance of `TR_X86ProcessorInfo` is changed. 
Instead of the instance being a member of `OMR::X86::CodeGenerator`, it is 
changed to be an instance of a method of `OMR::X86::CodeGenerator`. This 
is necessary because prior to this PR, the static instance was never zero initialized.

This PR also adds the ability to reinitialize the static TR_X86ProcessorInfo instance.