### PR TITLE
AArch64: Fix CodeGenerator to support the method starts with `proc` instruction

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -261,8 +261,11 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
       TR::Instruction *expandedOrSelf = data.cursorInstruction->expandInstruction();
       TR::Instruction *firstInstructionNotExpanded = expandedOrSelf->getNext();
 
-      /* The first instruction whose byte length has not been added to data.estimate */
-      data.cursorInstruction = prev->getNext();
+      if (prev != NULL)
+         {
+         /* The first instruction whose byte length has not been added to data.estimate */
+         data.cursorInstruction = prev->getNext();
+         }
       while (data.cursorInstruction && (data.cursorInstruction != firstInstructionNotExpanded))
          {
          data.estimate = data.cursorInstruction->estimateBinaryLength(data.estimate);


### PR DESCRIPTION
`doBinaryEncoding` function dereferences in the previous instruction pointer in the second while loop. However, if the method starts with `proc` pseudo instruction, the prev pointer is NULL. Fix it to avoid a NULL dereference.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>