### PR TITLE
Update ParallelHeapWalker.newInstance for initializing the delegate

### DIFF
--- a/gc/base/ParallelHeapWalker.cpp
+++ b/gc/base/ParallelHeapWalker.cpp
@@ -91,6 +91,10 @@ MM_ParallelHeapWalker::newInstance(MM_ParallelGlobalGC *globalCollector, MM_Mark
 	heapWalker = (MM_ParallelHeapWalker *)env->getForge()->allocate(sizeof(MM_ParallelHeapWalker), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (heapWalker) {
 		new(heapWalker) MM_ParallelHeapWalker(globalCollector, markMap);
+		if (!heapWalker->initialize(env)) {
+			heapWalker->kill(env);
+			heapWalker = NULL;
+		}
 	}
 
 	return heapWalker;


### PR DESCRIPTION
Missing initializing could cause crashing during heap walking.

fix: https://github.com/eclipse-openj9/openj9/issues/15852
Signed-off-by: Lin Hu <linhu@ca.ibm.com>