### PR TITLE
Fix build breaks with gcc 11.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2021 IBM Corp. and others
+Copyright (c) 2016, 2022 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,7 +145,7 @@ source tree. For more detailed instructions please read [BuildingWithCMake.md](d
     cd build
 
     # Generate the build system using cmake
-    cmake ..
+    cmake -Wdev -C ../cmake/caches/Travis.cmake ..
 
     # Build (you can optionally compile in parallel by adding -j<N> to the make command)
     make

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2020 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,9 @@ omr_add_library(omrtrace STATIC
 # to implement variable length structs
 if (OMR_STRNCPY_FORTIFY_OPTIONS)
 	target_compile_options(omrtrace PRIVATE ${OMR_STRNCPY_FORTIFY_OPTIONS})
+	if (OMR_OS_LINUX)
+		target_compile_options(omrtrace PRIVATE -O3)
+	endif()
 endif()
 
 target_link_libraries(omrtrace


### PR DESCRIPTION
* Fix documentation to ensure `OMR_GC_MODRON_SCAVENGER` is enabled during the build
* Add `-O3` to `omrtrace` component to prevent warning about not compiling with `-O` when `_FORTIFY_SOURCE` is specified.