### PR TITLE
AArch64: Implement evaluators for masked vector binary operations

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -654,6 +654,8 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vreductionMul:
       case TR::vreductionMax:
       case TR::vreductionMin:
+      case TR::vmadd:
+      case TR::vmsub:
       case TR::vcmpeq:
       case TR::vcmpge:
       case TR::vcmpgt:
@@ -669,6 +671,9 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vreductionOr:
       case TR::vreductionXor:
       case TR::vbitselect:
+      case TR::vmand:
+      case TR::vmor:
+      case TR::vmxor:
          // Float/ Double are not supported
          return (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64);
       case TR::vload:


### PR DESCRIPTION
This commit implements vmadd/vmsub/vmand/vmor/vmxor evaluators. They simply do unmasked operations and use bitselect to insert the value of the first operand for unmasked lanes.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>