### PR TITLE
AArch64: Enable mask load/store evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -680,6 +680,10 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vloadi:
       case TR::vstore:
       case TR::vstorei:
+      case TR::mload:
+      case TR::mloadi:
+      case TR::mstore:
+      case TR::mstorei:
       case TR::vsplats:
          return true;
       case TR::vfma:


### PR DESCRIPTION
Enable mload/mloadi/mstore/mstorei evaluators.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>