### PR TITLE
Correct constraint range for iushr and lushr with negative operand

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7510,11 +7510,9 @@ TR::Node *constrainIushr(OMR::ValuePropagation *vp, TR::Node *node)
 
       TR::VPConstraint *constraint = NULL;
       if (low == high)
-         constraint = TR::VPIntConst::create(vp, ((uint32_t)low) >> shiftAmount/*, isUnsigned*/);
-      else if (low >= 0)
-         constraint = TR::VPIntRange::create(vp, ((uint32_t)low) >> shiftAmount, ((uint32_t)high) >> shiftAmount/*, isUnsigned*/);
-      else if (high < 0 /*&& !isUnsigned*/)
-         constraint = TR::VPIntRange::create(vp, ((uint32_t)high) >> shiftAmount, ((uint32_t)low) >> shiftAmount);
+         constraint = TR::VPIntConst::create(vp, ((uint32_t)low) >> shiftAmount);
+      else if (low >= 0 || high < 0)
+         constraint = TR::VPIntRange::create(vp, ((uint32_t)low) >> shiftAmount, ((uint32_t)high) >> shiftAmount);
       // this path is probably never taken for unsigned
       else
          {
@@ -7582,10 +7580,8 @@ TR::Node *constrainLushr(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPConstraint *constraint = NULL;
       if (low == high)
          constraint = TR::VPLongConst::create(vp, ((uint64_t)low) >> shiftAmount);
-      else if (low >= 0)
+      else if (low >= 0 || high < 0)
          constraint = TR::VPLongRange::create(vp, ((uint64_t)low) >> shiftAmount, ((uint64_t)high) >> shiftAmount);
-      else if (high < 0)
-         constraint = TR::VPLongRange::create(vp, ((uint64_t)high) >> shiftAmount, ((uint64_t)low) >> shiftAmount);
       else
          {
          if (shiftAmount > 0)


### PR DESCRIPTION
The value propagation handlers for `iushr` and `lushr` have special handling for the cases where the lower bound (L) of the left operand is non-negative or its upper bound (U) is negative, if the right hand operand's value (S) has a constant constraint.  If L is non-negative, the handler sets the range of the result of the operation to be in the range [L>>S,U>>S]; if U is negative, it sets the range of the result to be [U>>S,L>>S].  However, the latter range has the bounds reversed, as can be seen by considering an example.

For instance, if L is 0x80FFFFFF (-2130706433) and U is 0xFFFFFFFF (-1) and S is 24, [U>>S,L>>S] yields the range [0xFF, 0x80] or [255,128].

Corrected this by computing the result range the same way for both non-negative ranges and negative ranges.

Fixes eclipse-openj9/openj9#15874