### PR TITLE
Stop sharing TR_VirtualGuard between multiple guards with the same BCI

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -40,6 +40,7 @@ namespace OMR { typedef OMR::Compilation CompilationConnector; }
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <set>
 #include "env/FrontEnd.hpp"
 #include "codegen/RecognizedMethods.hpp"
 #include "compile/CompilationTypes.hpp"
@@ -801,7 +802,11 @@ public:
    TR_DevirtualizedCallInfo * findOrCreateDevirtualizedCall(TR::Node *,
                          TR_OpaqueClassBlock *);
 
-   TR::list<TR_VirtualGuard*> &getVirtualGuards() { return _virtualGuards; }
+   typedef TR::typed_allocator<TR_VirtualGuard*, TR::Region&> GuardSetAlloc;
+   typedef std::less<TR_VirtualGuard*> GuardSetCmp;
+   typedef std::set<TR_VirtualGuard*, GuardSetCmp, GuardSetAlloc> GuardSet;
+
+   const GuardSet &getVirtualGuards() { return _virtualGuards; }
    TR_VirtualGuard *findVirtualGuardInfo(TR::Node *);
    void addVirtualGuard   (TR_VirtualGuard *guard);
    void removeVirtualGuard(TR_VirtualGuard *guard);
@@ -1214,7 +1219,7 @@ private:
    int32_t                            _inlinedCalls;
    int16_t                           _inlinedFramesAdded;
 
-   TR::list<TR_VirtualGuard*>              _virtualGuards;
+   GuardSet _virtualGuards;
 
    TR_LinkHead<TR_ClassLoadCheck>     _classesThatShouldNotBeLoaded;
    TR_LinkHead<TR_ClassExtendCheck>   _classesThatShouldNotBeNewlyExtended;

--- a/compiler/compile/VirtualGuard.hpp
+++ b/compiler/compile/VirtualGuard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,6 +98,9 @@ class TR_VirtualGuard
          TR::Node *guardNode=NULL,
          int32_t currentSiteIndex=-2);
 
+   TR_VirtualGuard(
+      TR_VirtualGuard *orig, TR::Node *newGuardNode, TR::Compilation *comp);
+
    static TR::Node *createVftGuard(
          TR_VirtualGuardKind,
          TR::Compilation *,
@@ -177,8 +180,6 @@ class TR_VirtualGuard
 
    static TR::Node *createBreakpointGuard(TR::Compilation * comp, int16_t calleeIndex, TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol);
    static TR::Node *createBreakpointGuardNode(TR::Compilation * comp, int16_t calleeIndex, TR::Node* callNode, TR::TreeTop * destination, TR::ResolvedMethodSymbol * calleeSymbol);
-
-   static void setGuardKind(TR::Node *guard, TR_VirtualGuardKind kind, TR::Compilation * comp);
 
    bool isNopable()
       {
@@ -268,7 +269,6 @@ class TR_VirtualGuard
    void                    setCurrentInlinedSiteIndex(int32_t index) { _currentInlinedSiteIndex = index; }
 
    TR::Node *getGuardNode() { return _guardNode; }
-   void setGuardNode(TR::Node *guardNode) { _guardNode = guardNode; }
 
    private:
 
@@ -281,12 +281,11 @@ class TR_VirtualGuard
    int32_t                   _byteCodeIndex;
    TR::SymbolReference       *_guardedMethod;
 
+   TR::Node                  *_guardNode;
+
    // Non-null for guarded-devirtualizations only
    TR::Node                  *_callNode;
-
-   // used for AOT
-   TR::Node                  *_guardNode;
-   int32_t                   _currentInlinedSiteIndex;
+   int32_t                   _currentInlinedSiteIndex; // used for AOT
 
    // used for Interface/Method, Abstract/Method, Hierarchy/Method
    TR_OpaqueClassBlock      *_thisClass;

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -370,13 +370,24 @@ OMR::Node::decFutureUseCount()
 uint16_t
 OMR::Node::getUseDefIndex()
    {
-   return _unionA._useDefIndex;
+   if (_opCode.isIf())
+      return 0;
+   else
+      return _unionA._useDefIndex;
    }
 
 uint16_t
 OMR::Node::setUseDefIndex(uint16_t udi)
    {
-   return (_unionA._useDefIndex = udi);
+   if (_opCode.isIf())
+      {
+      TR_ASSERT_FATAL_WITH_NODE(self(), udi == 0, "if node with use-def index");
+      return 0;
+      }
+   else
+      {
+      return (_unionA._useDefIndex = udi);
+      }
    }
 
 /**

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2027,6 +2027,9 @@ OMR::ResolvedMethodSymbol::removeTree(TR::TreeTop *tt)
    TR::Node *node = tt->getNode();
    if (node != NULL)
       {
+      if (node->isTheVirtualGuardForAGuardedInlinedCall())
+         node->setVirtualGuardInfo(NULL, self()->comp());
+
       node->recursivelyDecReferenceCount();
       if (self()->comp()->getOption(TR_TraceAddAndRemoveEdge))
          traceMsg(self()->comp(), "remove [%s]\n", node->getName(self()->comp()->getDebug()));

--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -350,6 +350,9 @@ class TR_LoopVersioner : public TR_LoopTransformer
 
          /// The symbol reference, when <tt>_op.hasSymbolReference()</tt>.
          TR::SymbolReference *_symRef;
+
+         /// The virtual guard, when <tt>_op.isIf()</tt>.
+         TR_VirtualGuard *_guard;
          };
 
       /**

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -292,6 +292,8 @@ OMR::Optimization::removeOrconvertIfToGoto(TR::Node* &node, TR::Block* block, in
    // doesn't matter taken or untaken, if it's a profiled guard we need to make sure the AOT relocation is created
    createGuardSiteForRemovedGuard(self()->comp(), node);
 #endif
+
+   node->setVirtualGuardInfo(NULL, self()->comp());
 
    if (takeBranch)
       {

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7188,6 +7188,7 @@ void OMR::ValuePropagation::transformUnknownTypeArrayCopy(TR_TreeTopWrtBarFlag *
 static void changeBranchToGoto(OMR::ValuePropagation *vp, TR::Node *guardNode, TR::Block *guard)
    {
    // change the if to goto
+   guardNode->setVirtualGuardInfo(NULL, vp->comp());
    TR::Node::recreate(guardNode, TR::Goto);
    guardNode->getFirstChild()->recursivelyDecReferenceCount();
    guardNode->getSecondChild()->recursivelyDecReferenceCount();
@@ -7735,10 +7736,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
 
       oldNode->recursivelyDecReferenceCount();
       cvg->_currentTree->setNode(cvg->_newGuardNode);
-      //Guards clean up
-      comp()->removeVirtualGuard(comp()->findVirtualGuardInfo(oldNode));
-      comp()->addVirtualGuard(cvg->_newVirtualGuard);
-      //
+      oldNode->setVirtualGuardInfo(NULL, comp());
       }
    _convertedGuards.setFirst(0);
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -8799,6 +8799,7 @@ static void changeConditionalToGoto(OMR::ValuePropagation *vp, TR::Node *node, T
 
    // Remove the children and change the node to a goto,
    //
+   node->setVirtualGuardInfo(NULL, vp->comp());
    vp->removeChildren(node, false);
    TR::Node::recreate(node, TR::Goto);
    vp->setEnableSimplifier();
@@ -8992,8 +8993,6 @@ static void addDelayedConvertedGuard (TR::Node* node,
       }
 
    TR_VirtualGuard* newGuard = vp->comp()->findVirtualGuardInfo(newGuardNode);
-   //do not add a new guard yet ... it will be added in doDelayedTransformation and we will fix the IL accordingly
-   vp->comp()->removeVirtualGuard(newGuard);
    //finish the rest of a transformation in doDelayedTransformation
    vp->_convertedGuards.add(new (vp->trStackMemory()) OMR::ValuePropagation::VirtualGuardInfo(vp, oldVirtualGuard, newGuard, newGuardNode, callNode));
 

--- a/compiler/optimizer/VirtualGuardCoalescer.cpp
+++ b/compiler/optimizer/VirtualGuardCoalescer.cpp
@@ -757,6 +757,7 @@ void TR_VirtualGuardTailSplitter::remergeGuard(TR_BlockCloner &cloner, VGInfo *i
    // convert the last treetop in G' into a goto
    //
    TR::TreeTop *ifTree = cloneG->getLastRealTreeTop();
+   ifTree->getNode()->setVirtualGuardInfo(NULL, comp());
    ifTree->getNode()->removeAllChildren();
    TR::Node::recreate(ifTree->getNode(), TR::Goto);
 
@@ -1038,7 +1039,6 @@ TR_InnerPreexistence::transform()
             TR_VirtualGuard *outerVirtualGuard = comp()->findVirtualGuardInfo(info->getGuardNode());
             TR_VirtualGuard *innerVirtualGuard = comp()->findVirtualGuardInfo(descendant->getGuardNode());
             outerVirtualGuard->addInnerAssumption(comp(), ordinal, innerVirtualGuard);
-            comp()->removeVirtualGuard(innerVirtualGuard);
             }
 
          devirtualize(descendant);
@@ -1063,6 +1063,9 @@ TR_InnerPreexistence::devirtualize(GuardInfo *info)
    TR_ASSERT(guardNode->getOpCodeValue() == TR::ificmpne ||
           guardNode->getOpCodeValue() == TR::ifacmpne,
           "Wrong kind of if discovered for virtual guard");
+
+   guardNode->setVirtualGuardInfo(NULL, comp());
+
    guardNode->getFirstChild()->recursivelyDecReferenceCount();
    guardNode->setAndIncChild(0, guardNode->getSecondChild());
 

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -652,7 +652,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
 
    // TODO: use compareAnalyser instead for BNDCHK
    //
-   if (nodeReg && !root->getOpCode().isBndCheck())
+   if (nodeReg && !root->getOpCode().isBndCheck() && !root->getOpCode().isBranch())
       {
       root->setRegister(nodeReg);
       }


### PR DESCRIPTION
Previously, the `TR_VirtualGuard` corresponding to a guard node was identified by a combination of its BCI and its guard kind. The guard kind was partially erased so that some of the guard kinds (e.g. HCR and OSR guards) were considered significant, while most regular virtual guard types were not distinguished from one another. So when given an HCR guard node, `findVirtualGuardInfo()` would look specifically for a `TR_VirtualGuard` with kind `TR_HCRGuard`, but when given, say, a profiled guard, it would turn up the first guard it found with matching BCI and without a 'significant' guard kind, which could be e.g. a nonoverridden guard instead.

This old way of correlating guard nodes each with their corresponding `TR_VirtualGuard` was troublesome because of two possible kinds of transformations, both of which must happen to cause an issue:

1. Duplication of the guard node. This can happen deliberately (as in versioner), or it can happen simply as part of duplication of the containing block.

2. (a) Removal of guards, or (b) replacement of guards by others, or (c) modification of `TR_VirtualGuard`, e.g. removing merged guards.

In 2(a), it makes sense to remove the `TR_VirtualGuard` along with the guard node so that we aren't left with orphan `TR_VirtualGuard` instances, and some code paths have been doing so. However, if there are other copies of the guard node, those share the `TR_VirtualGuard`, and removing it leaves them without one. Many callers of `findVirtualGuardInfo()` check defensively to make sure that the `TR_VirtualGuard` was found, but it's not necessarily always obvious what to do when the `TR_VirtualGuard` is missing. Ideally, a virtual guard node would always have one. This case could be solved by keeping the `TR_VirtualGuard` even when all of its corresponding nodes have been removed, or by reference counting it, but that won't work for 2(b) or 2(c).

In 2(b), we replace e.g. a profiled guard with a hierarchy guard. If there are other copies of the original profiled guard, then the old strategy of keying on BCI ensures that there will be a guard node for which `findVirtualGuardInfo()` finds a `TR_VirtualGuard` instance with a guard kind that differs from the kind expected by the node.

In 2(c), we update the `TR_VirtualGuard` based on its occurrence at one particular guard node. If there are other copies of the guard node, then the update will apply to those as well, even if it shouldn't. I don't believe it's currently possible for this (2(c)) issue to occur, but it would be easy to accidentally introduce via a seemingly innocuous change, e.g. running block splitter before OSR guard insertion.

This commit changes to a strategy where each guard node has its very own instance of `TR_VirtualGuard`, which can in a way now be considered to be part of the guard node itself, like the node extension. Whenever a guard node is removed or replaced, its `TR_VirtualGuard` can always be removed as well, since we know that it isn't shared with any other node. When a guard node is duplicated, its `TR_VirtualGuard` must now be duplicated along with it.

It's no longer necessary to search for the `TR_VirtualGuard` belonging to a given guard node, since the guard node now has a pointer to it.

The node flags no longer redundantly specify the guard kind, so there is no way for the node and the `TR_VirtualGuard` to disagree on it.

Finally, guard nodes in trace logs now show the test type and indicate the presence of any merged HCR or OSR guard or inner assumption (though the particular inner assumptions are still not shown).