### PR TITLE
Arch64: Add vector extract instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -619,6 +619,20 @@ uint8_t *TR::ARM64CondTrg1Src2Instruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64Trg1Src2ImmInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64Trg1Src2ShiftedInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -901,6 +901,7 @@ static const char *opCodeToNameMap[] =
    "vuzp2_8h",
    "vuzp2_4s",
    "vuzp2_2d",
+   "vext16b",
    "vneg16b",
    "vneg8h",
    "vneg4s",
@@ -1120,6 +1121,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
          break;
       case OMR::Instruction::IsCondTrg1Src2:
          print(pOutFile, (TR::ARM64CondTrg1Src2Instruction *)instr);
+         break;
+      case OMR::Instruction::IsTrg1Src2Imm:
+         print(pOutFile, (TR::ARM64Trg1Src2ImmInstruction *)instr);
          break;
       case OMR::Instruction::IsTrg1Src2Shifted:
          print(pOutFile, (TR::ARM64Trg1Src2ShiftedInstruction *)instr);
@@ -2102,6 +2106,20 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CondTrg1Src2Instruction *instr)
 
    if (instr->getDependencyConditions())
       print(pOutFile, instr->getDependencyConditions());
+
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ImmInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg);
+   trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
 
    trfflush(_comp->getOutFile());
    }

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2666,6 +2666,89 @@ class ARM64CondTrg1Src2Instruction : public ARM64Trg1Src2Instruction
    virtual uint8_t *generateBinaryEncoding();
 };
 
+class ARM64Trg1Src2ImmInstruction : public ARM64Trg1Src2Instruction
+   {
+   uint32_t _sourceImmediate; /* imm4 */
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] imm : immediate value
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ImmInstruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             uint32_t imm, TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg), _sourceImmediate(imm)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] imm : immediate value
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ImmInstruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             uint32_t imm,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg),
+        _sourceImmediate(imm)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg1Src2Imm; }
+
+   /**
+    * @brief Gets source immediate
+    * @return source immediate
+    */
+   uint32_t getSourceImmediate() {return _sourceImmediate;}
+   /**
+    * @brief Sets source immediate
+    * @param[in] si : immediate value
+    * @return source immediate
+    */
+   uint32_t setSourceImmediate(uint32_t si) {return (_sourceImmediate = si);}
+
+   /**
+    * @brief Sets immediate field in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertImmediateField(uint32_t *instruction)
+      {
+      *instruction |= ((_sourceImmediate & 0xf) << 11);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
 class ARM64Trg1Src2ShiftedInstruction : public ARM64Trg1Src2Instruction
    {
    ARM64ShiftCode _shiftType;

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -264,6 +264,15 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::Inst
    return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cond, cg);
    }
 
+TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg,
+   uint32_t imm, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ImmInstruction(op, node, treg, s1reg, s2reg, imm, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ImmInstruction(op, node, treg, s1reg, s2reg, imm, cg);
+   }
+
 TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg,
    TR::ARM64ShiftCode shiftType, uint32_t shiftAmount, TR::Instruction *preced)

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -531,6 +531,28 @@ TR::Instruction *generateCondTrg1Src2Instruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates src2-to-trg imm instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] s1reg : source register 1
+ * @param[in] s2reg : source register 2
+ * @param[in] imm : immediate value
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTrg1Src2ImmInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg,
+                   TR::Register *s1reg,
+                   TR::Register *s2reg,
+                   uint32_t imm,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates src2-to-trg instruction (shifted register)
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -869,6 +869,7 @@
 		vbif16b,                                                  	/* 0x6EE01C00	BIF       	 */
 		vbit16b,                                                  	/* 0x6EA01C00	BIT       	 */
 		vbsl16b,                                                  	/* 0x6E601C00	BSL       	 */
+	/* Vector permute */
 		vzip1_16b,                                                	/* 0x4E003800	ZIP1      	 */
 		vzip1_8h,                                                 	/* 0x4E403800	ZIP1      	 */
 		vzip1_4s,                                                 	/* 0x4E803800	ZIP1      	 */
@@ -885,6 +886,8 @@
 		vuzp2_8h,                                                 	/* 0x4E405800	UZP2      	 */
 		vuzp2_4s,                                                 	/* 0x4E805800	UZP2      	 */
 		vuzp2_2d,                                                 	/* 0x4EC05800	UZP2      	 */
+	/* Vector extract */
+		vext16b,                                                  	/* 0x6E000000	EXT      	 */
 	/* Vector Data-processing (1 source) */
 		vneg16b,                                                  	/* 0x6E20B800	NEG      	 */
 		vneg8h,                                                  	/* 0x6E60B800	NEG      	 */

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -48,6 +48,7 @@
          IsTrg1Src1Imm,
          IsTrg1Src2,
             IsCondTrg1Src2,
+            IsTrg1Src2Imm,
             IsTrg1Src2Shifted,
             IsTrg1Src2Extended,
             IsTrg1Src2IndexedElement,

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -870,6 +870,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6EE01C00,	/* BIF       	vbif16b	 */
 		0x6EA01C00,	/* BIT       	vbit16b	 */
 		0x6E601C00,	/* BSL       	vbsl16b	 */
+	/* Vector permute */
 		0x4E003800,	/* ZIP1      	vzip1_16b */
 		0x4E403800,	/* ZIP1      	vzip1_8h */
 		0x4E803800,	/* ZIP1      	vzip1_4s */
@@ -886,6 +887,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E405800,	/* UZP2      	vuzp2_8h */
 		0x4E805800,	/* UZP2      	vuzp2_4s */
 		0x4EC05800,	/* UZP2      	vuzp2_2d */
+	/* Vector extract */
+		0x6E000000,	/* EXT       	vext16b	 */
 	/* Vector Data-processing (1 source) */
 		0x6E20B800,	/* NEG      	vneg16b	 */
 		0x6E60B800,	/* NEG      	vneg8h	 */

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -350,6 +350,7 @@ namespace TR { class ARM64Trg1ZeroImmInstruction; }
 namespace TR { class ARM64Trg1Src1ImmInstruction; }
 namespace TR { class ARM64Trg1Src2Instruction; }
 namespace TR { class ARM64CondTrg1Src2Instruction; }
+namespace TR { class ARM64Trg1Src2ImmInstruction; }
 namespace TR { class ARM64Trg1Src2ShiftedInstruction; }
 namespace TR { class ARM64Trg1Src2ExtendedInstruction; }
 namespace TR { class ARM64Trg1Src2IndexedElementInstruction; }
@@ -1134,6 +1135,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1Src1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2Instruction *);
    void print(TR::FILE *, TR::ARM64CondTrg1Src2Instruction *);
+   void print(TR::FILE *, TR::ARM64Trg1Src2ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ShiftedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ExtendedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2IndexedElementInstruction *);

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -103,6 +103,19 @@ TEST_P(ARM64Trg1Src2IndexedElementEncodingTest, encode) {
     ASSERT_EQ(std::get<5>(GetParam()), encodeInstruction(instr));
 }
 
+class ARM64Trg1Src2ImmEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64Trg1Src2ImmEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto src1Reg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto src2Reg = cg()->machine()->getRealRegister(std::get<3>(GetParam()));
+
+    auto instr = generateTrg1Src2ImmInstruction(cg(), std::get<0>(GetParam()), fakeNode, trgReg, src1Reg, src2Reg, std::get<4>(GetParam()));
+
+    ASSERT_EQ(std::get<5>(GetParam()), encodeInstruction(instr));
+}
+
+
 class ARM64VectorShiftImmediateEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, ARM64BinaryInstruction>> {};
 
 TEST_P(ARM64VectorShiftImmediateEncodingTest, encode) {
@@ -2161,6 +2174,15 @@ INSTANTIATE_TEST_CASE_P(VectorFmulElem, ARM64Trg1Src2IndexedElementEncodingTest,
     std::make_tuple(TR::InstOpCode::vfmulelem_2d, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, 1, "4fc09be0"),
     std::make_tuple(TR::InstOpCode::vfmulelem_2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, 0, "4fcf9000"),
     std::make_tuple(TR::InstOpCode::vfmulelem_2d, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, 1, "4fdf9800")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorExt, ARM64Trg1Src2ImmEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, 1, "6e00080f"),
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, 9, "6e00481f"),
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, 5, "6e0029e0"),
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, 13, "6e006be0"),
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, 7, "6e0f3800"),
+    std::make_tuple(TR::InstOpCode::vext16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, 15, "6e1f7800")
 ));
 
 INSTANTIATE_TEST_CASE_P(VectorFloatMinMaxPairwise, ARM64Trg1Src2EncodingTest, ::testing::Values(


### PR DESCRIPTION
This commit adds vector extract instruction and
binary encoding unit tests.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>