### PR TITLE
Implement vectorized negation for Integer vector types on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1800,11 +1800,12 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
          else
             return false;
       case TR::vdiv:
-      case TR::vneg:
          if (et == TR::Int32 || et == TR::Float || et == TR::Double)
             return true;
          else
             return false;
+      case TR::vneg:
+         return true;
       case TR::vabs:
          if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Float || et == TR::Double)
             return true;

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -616,8 +616,8 @@
    vmuleuw,          // Vector Multiply Even Unsigned Word
 // vmulosw,          // Vector Multiply Odd Signed Word
    vmulouw,          // Vector Multiply Odd Unsigned Word
-// vnegw,            // vector negate word
-// vnegd,            // vector negate DWord
+   vnegw,            // vector negate word
+   vnegd,            // vector negate DWord
 // vprtybw,          // vector parity byte word
 // vprtybd,          // vector parity byte DWord
 // vprtybq,          // vector parity byte qword

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -7208,29 +7208,29 @@
                         PPCOpProp_SyncSideEffectFree,
    },
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vnegw, */
-   /* .name        =    "vnegw", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vnegw,
+   /* .name        = */ "vnegw",
    /* .description =    "vector negate word", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10060602, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10060602,
+   /* .format      = */ FORMAT_VRT_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P9,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
-   /* { */
-   /* .mnemonic    =    OMR::InstOpCode::vnegd, */
-   /* .name        =    "vnegd", */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vnegd,
+   /* .name        = */ "vnegd",
    /* .description =    "vector negate DWord", */
-   /* .prefix      =    0x00000000, */
-   /* .opcode      =    0x10070602, */
-   /* .format      =    FORMAT_UNKNOWN, */
-   /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-   /* .properties  =    PPCOpProp_IsVMX | */
-   /*                   PPCOpProp_SyncSideEffectFree, */
-   /* }, */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x10070602,
+   /* .format      = */ FORMAT_VRT_VRB,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P9,
+   /* .properties  = */ PPCOpProp_IsVMX |
+                        PPCOpProp_SyncSideEffectFree,
+   },
 
    /* { */
    /* .mnemonic    =    OMR::InstOpCode::vprtybw, */

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -292,7 +292,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vdivInt32Helper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdivFloatHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vdivDoubleHelper(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *vnegInt32Helper(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vnegIntHelper(TR::Node *node, TR::CodeGenerator *cg, TR::DataType type);
    static TR::Register *vnegFloatHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnegDoubleHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vabsIntHelper(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic shift, TR::InstOpCode::Mnemonic add);

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -2163,7 +2163,11 @@ INSTANTIATE_TEST_CASE_P(VMX, PPCTrg1Src1EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vctzlsbb, TR::RealRegister::gr0,  TR::RealRegister::vr0,  TRTest::BinaryInstruction("10010602")),
     std::make_tuple(TR::InstOpCode::vctzlsbb, TR::RealRegister::gr31, TR::RealRegister::vr0,  TRTest::BinaryInstruction("13e10602")),
     std::make_tuple(TR::InstOpCode::vctzlsbb, TR::RealRegister::gr0,  TR::RealRegister::vr31, TRTest::BinaryInstruction("1001fe02")),
-    std::make_tuple(TR::InstOpCode::vctzlsbb, TR::RealRegister::gr31, TR::RealRegister::vr31, TRTest::BinaryInstruction("13e1fe02"))
+    std::make_tuple(TR::InstOpCode::vctzlsbb, TR::RealRegister::gr31, TR::RealRegister::vr31, TRTest::BinaryInstruction("13e1fe02")),
+    std::make_tuple(TR::InstOpCode::vnegw,    TR::RealRegister::vr31, TR::RealRegister::vr0,  TRTest::BinaryInstruction("13e60602")),
+    std::make_tuple(TR::InstOpCode::vnegw,    TR::RealRegister::vr0,  TR::RealRegister::vr31, TRTest::BinaryInstruction("1006fe02")),
+    std::make_tuple(TR::InstOpCode::vnegd,    TR::RealRegister::vr31, TR::RealRegister::vr0,  TRTest::BinaryInstruction("13e70602")),
+    std::make_tuple(TR::InstOpCode::vnegd,    TR::RealRegister::vr0,  TR::RealRegister::vr31, TRTest::BinaryInstruction("1007fe02"))
 ));
 
 INSTANTIATE_TEST_CASE_P(VMX, PPCTrg1Src2EncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, TR::RealRegister::RegNum, TRTest::BinaryInstruction>>(
@@ -2538,7 +2542,9 @@ INSTANTIATE_TEST_CASE_P(VMX, PPCRecordFormSanityTest, ::testing::ValuesIn(*TRTes
     std::make_tuple(TR::InstOpCode::vupkhsh,  TR::InstOpCode::bad,        TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vupklsb,  TR::InstOpCode::bad,        TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::vupklsh,  TR::InstOpCode::bad,        TRTest::BinaryInstruction()),
-    std::make_tuple(TR::InstOpCode::vxor,     TR::InstOpCode::bad,        TRTest::BinaryInstruction())
+    std::make_tuple(TR::InstOpCode::vxor,     TR::InstOpCode::bad,        TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::vnegw,    TR::InstOpCode::bad,        TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::vnegd,    TR::InstOpCode::bad,        TRTest::BinaryInstruction())
 )));
 
 INSTANTIATE_TEST_CASE_P(VSXScalarFixed, PPCTrg1Src1EncodingTest, ::testing::Values(


### PR DESCRIPTION
This contribution includes the following changes:

- vneg IL opcodes have been enabled for all vector types on PPC
- Codegen sequences for vectorized negation for all integer-type vectors have been implemented/improved on PPC
- Binary encoder unit tests have been added for newly enabled PPC instructions
