### PR TITLE
Fix discrepancy in GC Extensions Base functions

### DIFF
--- a/example/glue/ObjectModelDelegate.hpp
+++ b/example/glue/ObjectModelDelegate.hpp
@@ -208,6 +208,19 @@ public:
 	{
 		return U_8_MAX;
 	}
+
+	/**
+	 * Returns the field offset of the third hottest field of the object referred to by the forwarded header.
+	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
+	 *
+	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
+	 * @return the offset of the third hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
+	 */
+	MMINLINE uint8_t
+	getHotFieldOffset3(MM_ForwardedHeader *forwardedHeader)
+	{
+		return U_8_MAX;
+	}
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 
 	/**
@@ -227,19 +240,6 @@ public:
 	isIndexable(MM_ForwardedHeader *forwardedHeader)
 	{
 		return false;
-	}
-
-	/**
-	 * Returns the field offset of the third hottest field of the object referred to by the forwarded header.
-	 * Valid if scavenger dynamicBreadthFirstScanOrdering is enabled
-	 *
-	 * @param forwardedHeader pointer to the MM_ForwardedHeader instance encapsulating the object
-	 * @return the offset of the third hottest field of the given object referred to by the forwarded header, return U_8_MAX if the hot field does not exist
-	 */
-	MMINLINE uint8_t
-	getHotFieldOffset3(MM_ForwardedHeader *forwardedHeader)
-	{
-		return U_8_MAX;
 	}
 
 	/**

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -75,7 +75,7 @@ class MM_RememberedSetSATB;
 #endif /* defined(OMR_GC_REALTIME) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 class MM_Scavenger;
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 class MM_SizeClasses;
 class MM_SparseVirtualMemory;
 class MM_SweepHeapSectioning;
@@ -222,8 +222,8 @@ private:
 	bool debugConcurrentScavengerPageAlignment; /**< if true allows debug output prints for Concurrent Scavenger Page Alignment logic */
 	uintptr_t concurrentScavengerPageSectionSize; /**< selected section size for Concurrent Scavenger Page */
 	void *concurrentScavengerPageStartAddress; /**< start address for Concurrent Scavenger Page, UDATA_MAX if it is not initialized */
-#endif	/* OMR_GC_CONCURRENT_SCAVENGER */
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 protected:
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
@@ -253,26 +253,26 @@ public:
 	MM_Scavenger *scavenger;
 	void *_mainThreadTenureTLHRemainderBase;  /**< base and top pointers of the last unused tenure TLH copy cache, that will be loaded to thread env during main setup */
 	void *_mainThreadTenureTLHRemainderTop;
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 	J9Pool* environments;
 	MM_ExcessiveGCStats excessiveGCStats;
 #if defined(OMR_GC_MODRON_STANDARD) || defined(OMR_GC_REALTIME)
 	MM_GlobalGCStats globalGCStats;
-#endif /* OMR_GC_MODRON_STANDARD || OMR_GC_REALTIME */
+#endif /* defined(OMR_GC_MODRON_STANDARD) || defined(OMR_GC_REALTIME) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	MM_ScavengerStats incrementScavengerStats; /**< scavengerStats for the current phase/increment; typically just used for reporting purposes */
 	MM_ScavengerStats scavengerStats; /**< cumulative scavengerStats for all phases/increments (STW and concurrent) within a single cycle; typically used for various heursitics at the end of GC */
 	MM_ScavengerCopyScanRatio copyScanRatio; /* Most recent estimate of ratio of aggregate slots copied to slots scanned in completeScan() */
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_VLHGC)
 	MM_GlobalVLHGCStats globalVLHGCStats; /**< Global summary of all GC activity for VLHGC */
-#endif /* OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_VLHGC) */
 
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 	/* Temporary move from the leaf implementation */
 	bool concurrentSweep;
-#endif /* OMR_GC_CONCURRENT_SWEEP */
+#endif /* defined(OMR_GC_CONCURRENT_SWEEP) */
 
 	bool largePageWarnOnError;
 	bool largePageFailOnError;
@@ -294,7 +294,7 @@ public:
 	uintptr_t freeOldHeapSizeOnLastGlobalGC;
 	float concurrentKickoffTenuringHeadroom; /**< percentage of free memory remaining in tenure heap. Used in conjunction with free memory to determine concurrent mark kickoff */
 	float tenureBytesDeviationBoost; /**< boost factor for tenuring deviation used for concurrent mark kickoff math */
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_REALTIME)
 	MM_RememberedSetSATB* sATBBarrierRememberedSet; /**< The snapshot at the beginning barrier remembered set used for the write barrier */
 #endif /* defined(OMR_GC_REALTIME) */
@@ -342,7 +342,7 @@ public:
 	bool _isVLHGC; /**< Is balanced GC policy */
 	bool _isMetronomeGC; /**< Is metronome GC policy */
 	bool _isStandardGC; /**< Is it one of standard GC policy */
-#endif /* OMR_GC_COMBINATION_SPEC */
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 
 	uintptr_t tlhMinimumSize;
 	uintptr_t tlhMaximumSize;
@@ -378,7 +378,7 @@ public:
 	uintptr_t lastGlobalGCFreeBytesLOA; /**< records the LOA free memory size from after Global GC cycle */
 	ConcurrentMetering concurrentMetering;
 	uintptr_t minimumContractionRatio;
-#endif /* OMR_GC_LARGE_OBJECT_AREA */
+#endif /* defined(OMR_GC_LARGE_OBJECT_AREA) */
 
 	bool disableExplicitGC;
 	uintptr_t heapAlignment;
@@ -426,8 +426,8 @@ public:
 	bool fvtest_forcePoisonEvacuate; /**< if true poison Evacuate space with pattern at the end of scavenge */
 	bool fvtest_forceNurseryResize;
 	uintptr_t fvtest_nurseryResizeCounter;
-#endif /* OMR_GC_MODRON_SCAVENGER */
-#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 	bool fvtest_alwaysApplyOverflowRounding; /**< always round down the allocated heap as if overflow rounding were required */
 	uintptr_t fvtest_forceExcessiveAllocFailureAfter; /**< force excessive GC to occur after this many global GCs */
 	void* fvtest_verifyHeapAbove; /**< if non-NULL, will force start-up failure if any part of the heap is below this value */
@@ -460,7 +460,7 @@ public:
 
 #if defined(OMR_GC_BATCH_CLEAR_TLH)
 	uintptr_t batchClearTLH;
-#endif /* OMR_GC_BATCH_CLEAR_TLH */
+#endif /* defined(OMR_GC_BATCH_CLEAR_TLH) */
 	omrthread_monitor_t gcStatsMutex;
 	uintptr_t gcThreadCount; /**< Initial number of GC threads - chosen default or specified in java options*/
 	bool gcThreadCountForced; /**< true if number of GC threads is specified in java options. Currently we have a few ways to do this:
@@ -514,7 +514,7 @@ public:
 	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
 	float concurrentScavengerAllocDeviationBoost; /**< boost factor for allocate rate and its deviation, used for tilt calcuation in Concurrent Scavenger */
 	bool concurrentScavengeExhaustiveTermination; /**< control flag to enable/disable concurrent phase termination optimization using involing async mutator callbacks */
-#endif	/* OMR_GC_CONCURRENT_SCAVENGER */
+#endif	/* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
 	uintptr_t scvArraySplitMaximumAmount; /**< maximum number of elements to split array scanning work in the scavenger */
@@ -560,8 +560,8 @@ public:
 	};
 
 	HeapInitializationSplitHeapSection splitHeapSection; /**< Split Heap section to be requested */
-#endif /* OMR_GC_MODRON_SCAVENGER */
-#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 	double globalMaximumContraction; /**< maximum percentage of committed global heap which can contract in one GC cycle (set through -Xgc:globalMaximumContraction=) */
 	double globalMinimumContraction; /**< minimum percentage of committed global heap which can contract in one GC cycle (set through -Xgc:globalMinimumContraction=) */
 
@@ -587,7 +587,7 @@ public:
 	uintptr_t compactOnSystemGC;
 	uintptr_t nocompactOnSystemGC;
 	bool compactToSatisfyAllocate;
-#endif /* OMR_GC_MODRON_COMPACTION */
+#endif /* defined(OMR_GC_MODRON_COMPACTION) */
 
 	bool payAllocationTax;
 
@@ -609,7 +609,7 @@ public:
 	UDATA fvtest_forceConcurrentTLHMarkMapCommitFailureCounter; /**< Force failure at Concurrent TLH Mark Map commit operation counter */
 	UDATA fvtest_forceConcurrentTLHMarkMapDecommitFailure; /**< Force failure at Concurrent TLH Mark Map decommit operation */
 	UDATA fvtest_forceConcurrentTLHMarkMapDecommitFailureCounter; /**< Force failure at Concurrent TLH Mark Map decommit operation  counter */
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 
 	UDATA fvtest_forceCardTableCommitFailure; /**< Force failure at Card Table commit operation */
 	UDATA fvtest_forceCardTableCommitFailureCounter; /**< Force failure at Card Table commit operation  counter */
@@ -661,7 +661,7 @@ public:
 	bool fixHeapForWalk; /**< configuration flag set by command line option or GC Check onload */
 	uintptr_t minArraySizeToSetAsScanned;
 	uintptr_t overflowCacheCount; /**< How many entries should there be in the environments local overflow cache */
-#endif /* OMR_GC_REALTIME */
+#endif /* defined(OMR_GC_REALTIME) */
 
 #if defined(OMR_GC_REALTIME)
 	bool concurrentSweepingEnabled; /**< if this is set, the sweep phase of GC will be run concurrently */
@@ -676,7 +676,7 @@ public:
 
 #if defined(OMR_GC_REALTIME) || defined(OMR_GC_SEGREGATED_HEAP)
 	uintptr_t managedAllocationContextCount; /**< The number of allocation contexts which will be instantiated and managed by the GlobalAllocationManagerRealtime (currently 2*cpu_count) */
-#endif /* OMR_GC_REALTIME || OMR_GC_SEGREGATED_HEAP */
+#endif /* defined(OMR_GC_REALTIME) || defined(OMR_GC_SEGREGATED_HEAP) */
 
 #if defined(OMR_GC_SEGREGATED_HEAP)
 	MM_SizeClasses* defaultSizeClasses;
@@ -819,7 +819,7 @@ public:
 	uintptr_t tarokTargetMaxPauseTime; /**< An optional, user specified soft max pause time for PGC's in balanced GC*/
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 	bool _isConcurrentCopyForward;
-#endif
+#endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 	enum TarokRegionTailCondidateListSortOrder {
 		SORT_ORDER_NOORDER = 0,
 		SORT_ORDER_ASCENDING,
@@ -862,7 +862,7 @@ public:
 	bool gcOnIdle; /**< Enables releasing free heap pages if true while systemGarbageCollect invoked with IDLE GC code, default is false */
 	bool compactOnIdle; /**< Forces compaction if global GC executed while VM Runtime State set to IDLE, default is false */
 	float gcOnIdleCompactThreshold; /** TODO cleanup after openj9 fixes */
-#endif
+#endif /* defined(OMR_GC_IDLE_HEAP_MANAGER) */
 
 #if defined(OMR_VALGRIND_MEMCHECK)
 	uintptr_t valgrindMempoolAddr; /**< Memory pool's address for valgrind **/
@@ -927,9 +927,9 @@ public:
 		if (isStandardGC()) {
 #if defined(OMR_GC_MODRON_SCAVENGER)
 			return static_cast<MM_SublistPool>(rememberedSet).countElements();
-#else
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
 			return 0;
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 		} else {
 			return 0;
 		}
@@ -951,7 +951,7 @@ public:
 	{
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		return concurrentScavenger;
-#else
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
@@ -961,7 +961,7 @@ public:
 	{
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		return concurrentScavengerHWSupport;
-#else
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
@@ -971,7 +971,7 @@ public:
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
       return softwareRangeCheckReadBarrier;
-#else
+#else /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
       return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
    }
@@ -983,7 +983,7 @@ public:
 	{
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		return scavengerEnabled;
-#else
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
 		return false;
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
@@ -993,7 +993,7 @@ public:
 	{
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 		return concurrentMark;
-#else
+#else /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 		return false;
 #endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 	}
@@ -1003,7 +1003,7 @@ public:
 	{
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 		return concurrentSweep;
-#else
+#else /* defined(OMR_GC_CONCURRENT_SWEEP) */
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SWEEP) */
 	}
@@ -1013,11 +1013,11 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		return _isSegregatedHeap;
-#elif defined(OMR_GC_SEGREGATED_HEAP)
+#elif defined(OMR_GC_SEGREGATED_HEAP) /* defined(OMR_GC_COMBINATION_SPEC) */
 		return true;
-#else
+#else /* defined(OMR_GC_SEGREGATED_HEAP) */
 		return false;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE void
@@ -1025,7 +1025,7 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		_isSegregatedHeap = value;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE bool
@@ -1033,11 +1033,11 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		return _isVLHGC;
-#elif defined(OMR_GC_VLHGC)
+#elif defined(OMR_GC_VLHGC) /* defined(OMR_GC_COMBINATION_SPEC) */
 		return true;
-#else
+#else /* defined(OMR_GC_VLHGC) */
 		return false;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE void
@@ -1045,7 +1045,7 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		_isVLHGC = value;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE bool
@@ -1053,7 +1053,7 @@ public:
 	{
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 		return _isConcurrentCopyForward;
-#else
+#else /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 		return false;
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 	}
@@ -1063,11 +1063,11 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		return _isMetronomeGC;
-#elif defined(OMR_GC_REALTIME)
+#elif defined(OMR_GC_REALTIME) /* defined(OMR_GC_COMBINATION_SPEC) */
 		return true;
-#else
+#else /* defined(OMR_GC_REALTIME) */
 		return false;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE void
@@ -1075,7 +1075,7 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		_isMetronomeGC = value;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE bool
@@ -1083,11 +1083,11 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		return _isStandardGC;
-#elif defined(OMR_GC_MODRON_STANDARD)
+#elif defined(OMR_GC_MODRON_STANDARD) /* defined(OMR_GC_COMBINATION_SPEC) */
 		return true;
-#else
+#else /* defined(OMR_GC_MODRON_STANDARD) */
 		return false;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE void
@@ -1095,7 +1095,7 @@ public:
 	{
 #if defined(OMR_GC_COMBINATION_SPEC)
 		_isStandardGC = value;
-#endif
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 	}
 
 	MMINLINE J9HookInterface** getPrivateHookInterface() { return J9_HOOK_INTERFACE(privateHookInterface); }
@@ -1105,49 +1105,135 @@ public:
 
 	MMINLINE MM_Heap* getHeap() { return heap; }
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
 	MMINLINE void
 	setGuaranteedNurseryRange(void* start, void* end)
 	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
 		_guaranteedNurseryStart = start;
 		_guaranteedNurseryEnd = end;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
 
 	MMINLINE void
 	getGuaranteedNurseryRange(void** start, void** end)
 	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
 		*start = _guaranteedNurseryStart;
 		*end = _guaranteedNurseryEnd;
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
+		*start = NULL;
+		*end = NULL;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
 
-	MMINLINE bool isRememberedSetInOverflowState() { return _isRememberedSetInOverflow; }
-	MMINLINE void setRememberedSetOverflowState() { _isRememberedSetInOverflow = true; }
-	MMINLINE void clearRememberedSetOverflowState() { _isRememberedSetInOverflow = false; }
+	MMINLINE bool
+	isRememberedSetInOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		return _isRememberedSetInOverflow;
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
+		return false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
 
-	MMINLINE void setScavengerBackOutState(BackOutState backOutState) { _backOutState = backOutState; }
-	MMINLINE BackOutState getScavengerBackOutState() { return _backOutState; }
-	MMINLINE bool isScavengerBackOutFlagRaised() { return backOutFlagCleared < _backOutState; }
+	MMINLINE void
+	setRememberedSetOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		_isRememberedSetInOverflow = true;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
 
-	MMINLINE bool shouldScavengeNotifyGlobalGCOfOldToOldReference() { return _concurrentGlobalGCInProgress; }
-	MMINLINE void setConcurrentGlobalGCInProgress(bool inProgress) { _concurrentGlobalGCInProgress = inProgress; }
+	MMINLINE void
+	clearRememberedSetOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		_isRememberedSetInOverflow = false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	MMINLINE bool
+	isScavengerRememberedSetInOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		return _isRememberedSetInOverflow;
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
+		return false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	MMINLINE void
+	setScavengerRememberedSetOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		_isRememberedSetInOverflow = true;
+#endif /* OMR_GC_MODRON_SCAVENGER */
+	}
+
+	MMINLINE void
+	clearScavengerRememberedSetOverflowState()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		_isRememberedSetInOverflow = false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	MMINLINE bool
+	isScavengerBackOutFlagRaised()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		return backOutFlagCleared < _backOutState;
+#else /* defined(OMR_GC_MODRON_SCAVENGER) */
+		return false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	MMINLINE void
+	setConcurrentGlobalGCInProgress(bool inProgress)
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		_concurrentGlobalGCInProgress = inProgress;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	MMINLINE void
+	setScavengerBackOutState(BackOutState backOutState)
+	{
+		_backOutState = backOutState;
+	}
+
+	MMINLINE BackOutState
+	getScavengerBackOutState()
+	{
+		return _backOutState;
+	}
+
+	MMINLINE bool
+	shouldScavengeNotifyGlobalGCOfOldToOldReference()
+	{
+		return _concurrentGlobalGCInProgress;
+	}
 
 	/**
 	 * Determine whether Adaptive Threading is enabled. AdaptiveGCThreading flag
 	 * is not sufficient; Adaptive threading must be ignored if GC thread count is forced.
 	 * @return TRUE if adaptive threading routines can proceed, FALSE otherwise
 	 */
-	MMINLINE bool adaptiveThreadingEnabled()
+	MMINLINE bool
+	adaptiveThreadingEnabled()
 	{
 		return (adaptiveGCThreading && !gcThreadCountForced);
 	}
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 
 	/**
 	 * Returns TRUE if an object is old, FALSE otherwise.
 	 * @param objectPtr Pointer to an object
 	 * @return TRUE if an object is in the old area, FALSE otherwise
 	 */
-	MMINLINE bool isOld(omrobjectptr_t objectPtr)
+	MMINLINE bool
+	isOld(omrobjectptr_t objectPtr)
 	{
 		return ((uintptr_t)objectPtr - (uintptr_t)_tenureBase) < _tenureSize;
 	}
@@ -1158,7 +1244,8 @@ public:
 	 * @param topSlotPtr Pointer to first slot >= baseSlotPtr and NOT in range
 	 * @return TRUE if entire range is in the old area, FALSE otherwise
 	 */
-	MMINLINE bool isOld(void *baseSlotPtr, void *topSlotPtr)
+	MMINLINE bool
+	isOld(void *baseSlotPtr, void *topSlotPtr)
 	{
 		return ((uintptr_t)baseSlotPtr >= (uintptr_t)_tenureBase) && ((uintptr_t)topSlotPtr - (uintptr_t)_tenureBase) < _tenureSize;
 	}
@@ -1213,7 +1300,7 @@ public:
 	{
 		return isFvtestForce(&fvtest_forceConcurrentTLHMarkMapDecommitFailure, &fvtest_forceConcurrentTLHMarkMapDecommitFailureCounter);
 	}
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 
 	MMINLINE bool
 	isFvtestForceCardTableCommitFailure()
@@ -1395,7 +1482,7 @@ public:
 		, concurrentScavengerPageSectionSize(0)
 		, concurrentScavengerPageStartAddress((void *)UDATA_MAX)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 		, _compressObjectReferences(false)
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
@@ -1414,7 +1501,7 @@ public:
 		, scavenger(NULL)
 		, _mainThreadTenureTLHRemainderBase(NULL)
 		, _mainThreadTenureTLHRemainderTop(NULL)
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 		, environments(NULL)
 		, excessiveGCStats()
 #if defined(OMR_GC_MODRON_STANDARD) || defined(OMR_GC_REALTIME)
@@ -1424,20 +1511,20 @@ public:
 		, incrementScavengerStats()
 		, scavengerStats()
 		, copyScanRatio()
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_VLHGC)
 		, globalVLHGCStats()
-#endif /* OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_VLHGC) */
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 		, concurrentSweep(false)
-#endif /* OMR_GC_CONCURRENT_SWEEP */
+#endif /* defined(OMR_GC_CONCURRENT_SWEEP) */
 		, largePageWarnOnError(false)
 		, largePageFailOnError(false)
 		, largePageFailedToSatisfy(false)
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 		, isArrayletDoubleMapRequested(false)
 		, isArrayletDoubleMapAvailable(false)
-#endif /* OMR_GC_DOUBLE_MAP_ARRAYLETS */
+#endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 		, isVirtualLargeObjectHeapRequested(false)
 		, isVirtualLargeObjectHeapEnabled(false)
 		, requestedPageSize(0)
@@ -1450,7 +1537,7 @@ public:
 		, freeOldHeapSizeOnLastGlobalGC(UDATA_MAX)
 		, concurrentKickoffTenuringHeadroom((float)0.02)
 		, tenureBytesDeviationBoost((float)2)
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 #if defined(OMR_GC_REALTIME)
 		, sATBBarrierRememberedSet(NULL)
 #endif /* defined(OMR_GC_REALTIME) */
@@ -1484,7 +1571,7 @@ public:
 		, _isVLHGC(false)
 		, _isMetronomeGC(false)
 		, _isStandardGC(false)
-#endif /* OMR_GC_COMBINATION_SPEC */
+#endif /* defined(OMR_GC_COMBINATION_SPEC) */
 		, tlhMinimumSize(MINIMUM_TLH_SIZE)
 		, tlhMaximumSize(131072)
 		, tlhInitialSize(2048)
@@ -1510,7 +1597,7 @@ public:
 		, lastGlobalGCFreeBytesLOA(0)
 		, concurrentMetering(METER_BY_SOA)
 		, minimumContractionRatio(DEFAULT_MINIMUM_CONTRACTION_RATIO)
-#endif /* OMR_GC_LARGE_OBJECT_AREA */
+#endif /* defined(OMR_GC_LARGE_OBJECT_AREA) */
 		, disableExplicitGC(false)
 		, heapAlignment(HEAP_ALIGNMENT)
 		, absoluteMinimumOldSubSpaceSize(MINIMUM_OLD_SPACE_SIZE)
@@ -1547,8 +1634,8 @@ public:
 		, fvtest_forcePoisonEvacuate(0)
 		, fvtest_forceNurseryResize(0)
 		, fvtest_nurseryResizeCounter(0)
-#endif /* OMR_GC_MODRON_SCAVENGER */
-#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 		, fvtest_alwaysApplyOverflowRounding(0)
 		, fvtest_forceExcessiveAllocFailureAfter(0)
 		, fvtest_verifyHeapAbove(0)
@@ -1576,7 +1663,7 @@ public:
 		, softMx(0) /* softMx only set if specified */
 #if defined(OMR_GC_BATCH_CLEAR_TLH)
 		, batchClearTLH(0)
-#endif /* OMR_GC_BATCH_CLEAR_TLH */
+#endif /* defined(OMR_GC_BATCH_CLEAR_TLH) */
 		, gcThreadCount(0)
 		, gcThreadCountForced(false)
 		, dispatcherHybridNotifyThreadBound(16)
@@ -1597,7 +1684,7 @@ public:
 		, maxHotFieldListLength(10)
 		, minCpuUtil (1)
 		/* End of options relating to dynamicBreadthFirstScanOrdering */
-#endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		, scvTenureRatioHigh(OMR_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(OMR_SCV_TENURE_RATIO_LOW)
@@ -1656,7 +1743,7 @@ public:
 		, adaptiveThreadingWeightActiveThreads(0.50f)
 		, adaptiveThreadBooster(0.85f)
 		, splitHeapSection(HEAP_INITIALIZATION_SPLIT_HEAP_UNKNOWN)
-#endif /* OMR_GC_MODRON_SCAVENGER */
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 		, globalMaximumContraction(0.05) /* by default, contract must be at most 5% of the committed heap */
 		, globalMinimumContraction(0.01) /* by default, contract must be at least 1% of the committed heap */
 		, excessiveGCEnabled()
@@ -1678,7 +1765,7 @@ public:
 		, compactOnSystemGC(0)
 		, nocompactOnSystemGC(0)
 		, compactToSatisfyAllocate(false)
-#endif /* OMR_GC_MODRON_COMPACTION */
+#endif /* defined(OMR_GC_MODRON_COMPACTION) */
 		, payAllocationTax(false)
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 		, concurrentMark(false)
@@ -1696,7 +1783,7 @@ public:
 		, fvtest_forceConcurrentTLHMarkMapCommitFailureCounter(0)
 		, fvtest_forceConcurrentTLHMarkMapDecommitFailure(0)
 		, fvtest_forceConcurrentTLHMarkMapDecommitFailureCounter(0)
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+#endif /* defined(OMR_GC_MODRON_CONCURRENT_MARK) */
 		, fvtest_forceCardTableCommitFailure(0)
 		, fvtest_forceCardTableCommitFailureCounter(0)
 		, fvtest_forceCardTableDecommitFailure(0)

--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -998,7 +998,7 @@ MM_ConcurrentCardTable::cleanSingleCard(MM_EnvironmentBase *env, Card *card, uin
 	 * mean we re-trace objects not in the RS but RS overflow is assumed to be
 	 * an exceptional circumstance.
 	 */
-	if (rememberedObjectsFound && (env->getExtensions()->isRememberedSetInOverflowState())) {
+	if (rememberedObjectsFound && (env->getExtensions()->isScavengerRememberedSetInOverflowState())) {
 		*card = (Card)CARD_DIRTY;
 	}
 

--- a/gc/base/standard/ConcurrentOverflow.cpp
+++ b/gc/base/standard/ConcurrentOverflow.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,12 +70,14 @@ MM_ConcurrentOverflow::initialize(MM_EnvironmentBase *env)
 {
 	bool result = MM_WorkPacketOverflow::initialize(env);
 
+#if defined(OMR_GC_MODRON_SCAVENGER)
 	if (result) {
 		/* Initialize monitor for safe initial Cards cleaning in Work Packets Overflow handler */
 		if(omrthread_monitor_init_with_name(&_cardsClearingMonitor, 0, "MM_ConcurrentOverflow::cardsClearingMonitor")) {
 			result = false;
 		}
 	}
+#endif /*  OMR_GC_MODRON_SCAVENGER */
 
 	return result;
 }
@@ -86,10 +88,12 @@ MM_ConcurrentOverflow::initialize(MM_EnvironmentBase *env)
 void
 MM_ConcurrentOverflow::tearDown(MM_EnvironmentBase *env)
 {
-	if(NULL != _cardsClearingMonitor) {
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	if (NULL != _cardsClearingMonitor) {
 		omrthread_monitor_destroy(_cardsClearingMonitor);
 		_cardsClearingMonitor = NULL;
 	}
+#endif /*  OMR_GC_MODRON_SCAVENGER */
 
 	MM_WorkPacketOverflow::tearDown(env);
 }

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,7 +217,6 @@ MM_ConfigurationGenerational::createHeapWithManager(MM_EnvironmentBase *env, UDA
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 	MM_Heap *heap = NULL;
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
 	/* gencon supports split heaps so check that flag here when deciding what kind of MM_Heap to create */
 	if (extensions->enableSplitHeap) {
 		UDATA lowSize = extensions->oldSpaceSize;
@@ -228,9 +227,7 @@ MM_ConfigurationGenerational::createHeapWithManager(MM_EnvironmentBase *env, UDA
 		 * set and "inverted" flag in the extensions and check that in the PSA attach code when determining attachment policy.
 		 * May allow more versatile use cases of the split heaps, though.
 		 */
-	} else
-#endif /* OMR_GC_MODRON_SCAVENGER */
-	{
+	} else {
 		heap = MM_ConfigurationStandard::createHeapWithManager(env, heapBytesRequested, regionManager);
 	}
 	return heap;

--- a/gc/base/standard/HeapWalker.cpp
+++ b/gc/base/standard/HeapWalker.cpp
@@ -182,14 +182,12 @@ MM_HeapWalker::allObjectSlotsDo(MM_EnvironmentBase *env, MM_HeapWalkerSlotFunc f
 	SlotObjectDoUserData slotObjectDoUserData = { function, userData, walkFlags, this };
 	uintptr_t modifiedWalkFlags = walkFlags;
 
-#if defined(OMR_GC_MODRON_SCAVENGER)
 	/* If J9_MU_WALK_NEW_AND_REMEMBERED_ONLY is specified, and rsOverflow has
 	 * occurred, any object in old space might be remembered, so we must walk them all
 	 */
-	if (env->getExtensions()->isRememberedSetInOverflowState()) {
+	if (env->getExtensions()->isScavengerRememberedSetInOverflowState()) {
 		modifiedWalkFlags &= ~J9_MU_WALK_NEW_AND_REMEMBERED_ONLY;
 	}
-#endif /* OMR_GC_MODRON_SCAVENGER */
 
 	allObjectsDo(env, heapWalkerObjectSlotsDo, (void *)&slotObjectDoUserData, modifiedWalkFlags, parallel, prepareHeapForWalk);
 

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -192,7 +192,7 @@ hookGlobalGcSweepEndRsoSafetyFixHeap(J9HookInterface** hook, uintptr_t eventNum,
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 
-	extensions->scavengerRsoScanUnsafe = !extensions->isRememberedSetInOverflowState();
+	extensions->scavengerRsoScanUnsafe = !extensions->isScavengerRememberedSetInOverflowState();
 	if (!extensions->scavengerRsoScanUnsafe) {
 		MM_ParallelGlobalGC *pggc = (MM_ParallelGlobalGC *)userData;
 		pggc->fixHeapForWalk(env, MEMORY_TYPE_OLD_RAM, FIXUP_DEBUG_TOOLING, fixObject);

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -535,9 +535,9 @@ public:
 
 	void clearRememberedSetLists(MM_EnvironmentStandard *env);
 
-	MMINLINE bool isRememberedSetInOverflowState() { return _extensions->isRememberedSetInOverflowState(); }
-	MMINLINE void setRememberedSetOverflowState() { _extensions->setRememberedSetOverflowState(); }
-	MMINLINE void clearRememberedSetOverflowState() { _extensions->clearRememberedSetOverflowState(); }
+	MMINLINE bool isRememberedSetInOverflowState() { return _extensions->isScavengerRememberedSetInOverflowState(); }
+	MMINLINE void setRememberedSetOverflowState() { _extensions->setScavengerRememberedSetOverflowState(); }
+	MMINLINE void clearRememberedSetOverflowState() { _extensions->clearScavengerRememberedSetOverflowState(); }
 
 	/* Auto-remember stack objects so JIT can omit generational barriers */
 	void rescanThreadSlots(MM_EnvironmentStandard *env);

--- a/gc/structs/SublistFragment.cpp
+++ b/gc/structs/SublistFragment.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,9 +53,7 @@ allocateMemoryForSublistFragment(void *vmThreadRawPtr, J9VMGC_SublistFragment *f
 	if (result) {
 		return 0;
 	} else {
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		env->getExtensions()->setRememberedSetOverflowState();
-#endif /* OMR_GC_MODRON_SCAVENGER */
+		env->getExtensions()->setScavengerRememberedSetOverflowState();
 		return 1;
 	}
 }


### PR DESCRIPTION
There is a number of functions in the GC Extensions Base defined under
the OMR_GC_MODRON_SCAVENGER flag. However, there are many places where
these functions are called unconditionally without checking this flag.
This flag is always enabled in our compilation environment, which
allows the code to compile. If it is disabled, the code fails to
compile. The solution is to always define these functions and wrap
Scavenger related content inside them.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>