### PR TITLE
Fix VABS evaluator

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14642,6 +14642,7 @@ OMR::Z::TreeEvaluator::inlineVectorUnaryOp(TR::Node * node,
          generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, 3);
          break;
       case TR::InstOpCode::VLC:
+      case TR::InstOpCode::VLP:
          generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, getVectorElementSizeMask(node));
          break;
       case TR::InstOpCode::VFPSO:
@@ -14669,7 +14670,7 @@ OMR::Z::TreeEvaluator::inlineVectorUnaryOp(TR::Node * node,
          generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, getVectorElementSizeMask(node));
          break;
       default:
-         TR_ASSERT(false, "Unary Vector IL evaluation unimplemented for node : %s\n", cg->getDebug()->getName(node));
+         TR_ASSERT_FATAL_WITH_NODE(node, false, "Unary Vector IL evaluation unimplemented for node\n");
          break;
       }
 


### PR DESCRIPTION
InlineVectorUnaryOp evaluator was called to generate instruction for VABS for integral type but did not emit VLP instruction to load positive value of the operand for ABS. This commit fixes that and also changes an assert to fatal assert to make sure it is called for the op which is supported.

Fixes: https://github.com/eclipse-openj9/openj9/issues/15918

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>