### PR TITLE
AArch64: Fix handling of mask and shift operation

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1422,6 +1422,11 @@ generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGenerator *cg)
           * to bit position shiftValue of the destination register.
           */
          uint32_t width = populationCount(maskValue);
+         uint32_t maxWidth = (is64bit ? 64 : 32) - static_cast<uint32_t>(shiftValue);
+         if (width > maxWidth)
+            {
+            width = maxWidth;
+            }
 
          TR::Register *reg;
          TR::Register *sreg = cg->evaluate(sourceNode);


### PR DESCRIPTION
`generateUBFMForMaskAndShift()` generates incorrect `ubfm` instruction when the sum of  left shift amount and mask width exceeds the size of integer. Some tests in [ShiftAndRotateTest](https://github.com/eclipse/omr/blob/master/fvtest/compilertriltest/ShiftAndRotateTest.cpp) fail due to this problem.

This commit fixes `generateUBFMForMaskAndShift` to validate width value before generating `ubfm` instruction.



Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>