### PR TITLE
AArch64 Mac: Update TestCodeCacheManager to enable compiler unit tests

### DIFF
--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,10 @@
 #include "runtime/CodeCacheConfig.hpp"
 #include "runtime/Runtime.hpp"
 #include "env/CompilerEnv.hpp"
+
+#if defined(OSX) && defined(TR_TARGET_ARM64)
+#include <pthread.h> // for pthread_jit_write_protect_np
+#endif
 
 #if defined(JITTEST)
 #include "env/ConcreteFE.hpp"
@@ -347,6 +351,9 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
    {
    uint32_t *buffer = (uint32_t *)((uint8_t *)trampPtr + TRAMPOLINE_SIZE);  // Skip the first trampoline for index 0
 
+#if defined(OSX)
+   pthread_jit_write_protect_np(0);
+#endif
    for (int32_t i=1; i<numHelpers; i++)
       {
       *((int32_t *)buffer) = 0x58000050; //LDR R16 PC+8
@@ -356,6 +363,9 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
       *((intptr_t *)buffer) = (intptr_t)runtimeHelperValue((TR_RuntimeHelper)i);
       buffer += 2;
       }
+#if defined(OSX)
+   pthread_jit_write_protect_np(1);
+#endif
    }
 
 void arm64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *numHelpers, int32_t* CCPreLoadedCodeSize)

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,12 +78,21 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
          mmap(NULL,
               codeCacheSizeToAllocate,
               PROT_READ | PROT_WRITE | PROT_EXEC,
+#if defined(OMR_ARCH_AARCH64) && defined(OSX)
+              MAP_ANONYMOUS | MAP_PRIVATE | MAP_JIT,
+#else
               MAP_ANONYMOUS | MAP_PRIVATE,
+#endif /* OMR_ARCH_AARCH64 && OSX */
               -1,
               0));
 #endif /* OMR_OS_WINDOWS */
+#if defined(OMR_ARCH_AARCH64) && defined(OSX)
+   TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) malloc(sizeof(TR::CodeCacheMemorySegment));
+   new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memorySlab) + codeCacheSizeToAllocate);
+#else  /* OMR_ARCH_AARCH64 && OSX */
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));
    new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memSegment));
+#endif
    return memSegment;
    }
 
@@ -94,6 +103,9 @@ TestCompiler::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment 
    VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
 #elif defined(J9ZOS390)
    free(memSegment->_base);
+#elif defined(OMR_ARCH_AARCH64) && defined(OSX)
+   munmap(memSegment->_base, memSegment->_top - memSegment->_base);
+   free(memSegment);
 #else
    munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));
 #endif


### PR DESCRIPTION
This commit updates `TestCodeCacheManager` to allocate the `CodeCacheMemorySegment` object by malloc instead of using a part of the mmaped memory segment on AArch64 Mac. If the `CodeCacheMemorySegment` object is allocated on the mmaped segment, `pthread_jit_write_protect_np` calls are required before/after updating the fields of the object.
Also, `pthread_jit_write_protect_np` calls are added into `arm64CreateHelperTrampolines`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>