### PR TITLE
Apply various fixes for the Mask and Vector types

### DIFF
--- a/compiler/il/ILOpCodes.hpp
+++ b/compiler/il/ILOpCodes.hpp
@@ -61,11 +61,11 @@ namespace TR
       NumScalarIlOps,
 
       NumOneVectorTypeOperations = TR::firstTwoTypeVectorOperation,
-      NumTwoTypeVectorOperations = TR::NumVectorOperations - TR::firstTwoTypeVectorOperation,
+      NumTwoVectorTypeOperations = TR::NumVectorOperations - TR::firstTwoTypeVectorOperation,
 
       NumOneVectorTypeOps = NumOneVectorTypeOperations * TR::NumVectorTypes,
-      NumTwoTypeVectorOps = NumTwoTypeVectorOperations * TR::NumVectorTypes * TR::NumVectorTypes,
-      NumAllIlOps = TR::NumScalarIlOps + NumOneVectorTypeOps + NumTwoTypeVectorOps
+      NumTwoVectorTypeOps = NumTwoVectorTypeOperations * TR::NumVectorTypes * TR::NumVectorTypes,
+      NumAllIlOps = TR::NumScalarIlOps + NumOneVectorTypeOps + NumTwoVectorTypeOps
       };
    }
 

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -512,6 +512,19 @@ public:
    */
    inline static TR::DataTypes createMaskType(TR::DataType elementType, TR::VectorLength length);
 
+
+  /** \brief
+   *     Creates Vector type corresponding to a Mask type (the same length and element type)
+   *
+   *  \param maskType
+   *     Mask type
+   *
+   *  \return
+   *     Vector type
+   */
+   inline static TR::DataTypes vectorFromMaskType(TR::DataType maskType);
+
+
    /** \brief
    *     Initializes static table with all vector type names
    *

--- a/compiler/il/OMRDataTypes_inlines.hpp
+++ b/compiler/il/OMRDataTypes_inlines.hpp
@@ -281,4 +281,14 @@ OMR::DataType::createMaskType(TR::DataType elementType, TR::VectorLength length)
    return type;
    }
 
+
+TR::DataTypes
+OMR::DataType::vectorFromMaskType(TR::DataType maskType)
+   {
+   TR_ASSERT_FATAL(maskType.isMask(), "vectorFromMaskType should take mask type\n");
+
+   return static_cast<TR::DataTypes>(maskType - TR::NumVectorTypes);
+   }
+
+
 #endif // OMR_DATATYPES_INLINES_INCL

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -555,7 +555,7 @@ OMR::IL::opCodeForSelect(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForSelect) / sizeof(OMR::IL::opCodesForSelect[0])),
               "OMR::IL::opCodesForSelect is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
 
@@ -568,7 +568,7 @@ OMR::IL::opCodeForConst(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForConst) / sizeof(OMR::IL::opCodesForConst[0])),
               "OMR::IL::opCodesForConst is not the correct size");
 
-   TR_ASSERT_FATAL(!dt.isVector(), "Vector constants are not supported\n");
+   TR_ASSERT_FATAL(!dt.isVector()  && !dt.isMask(), "Vector and Mask constants are not supported\n");
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -595,7 +595,7 @@ OMR::IL::opCodeForDirectReadBarrier(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectReadBarrier) / sizeof(OMR::IL::opCodesForDirectReadBarrier[0])),
               "OMR::IL::opCodesForDirectReadBarrier is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -622,7 +622,7 @@ OMR::IL::opCodeForDirectWriteBarrier(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForDirectWriteBarrier) / sizeof(OMR::IL::opCodesForDirectWriteBarrier[0])),
               "OMR::IL::opCodesForDirectWriteBarrier is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -650,7 +650,7 @@ OMR::IL::opCodeForIndirectReadBarrier(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectReadBarrier) / sizeof(OMR::IL::opCodesForIndirectReadBarrier[0])),
               "OMR::IL::opCodesForIndirectReadBarrier is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -677,7 +677,7 @@ OMR::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIndirectWriteBarrier) / sizeof(OMR::IL::opCodesForIndirectWriteBarrier[0])),
               "OMR::IL::opCodesForIndirectWriteBarrier is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -719,6 +719,7 @@ OMR::IL::opCodeForRegisterLoad(TR::DataType dt)
               "OMR::IL::opCodesForRegisterLoad is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vRegLoad, dt);
+   if (dt.isMask()) return TR::ILOpCode::createVectorOpCode(TR::mRegLoad, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -732,6 +733,7 @@ OMR::IL::opCodeForRegisterStore(TR::DataType dt)
               "OMR::IL::opCodesForRegisterStore is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vRegStore, dt);
+   if (dt.isMask()) return TR::ILOpCode::createVectorOpCode(TR::mRegStore, dt);
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -745,6 +747,7 @@ OMR::IL::opCodeForCompareEquals(TR::DataType dt)
               "OMR::IL::opCodesForCompareEquals is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmpeq, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -757,7 +760,7 @@ OMR::IL::opCodeForIfCompareEquals(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareEquals) / sizeof(OMR::IL::opCodesForIfCompareEquals[0])),
               "OMR::IL::opCodesForIfCompareEquals is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -771,6 +774,7 @@ OMR::IL::opCodeForCompareNotEquals(TR::DataType dt)
               "OMR::IL::opCodesForCompareNotEquals is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmpne, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -783,7 +787,7 @@ OMR::IL::opCodeForIfCompareNotEquals(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareNotEquals) / sizeof(OMR::IL::opCodesForIfCompareNotEquals[0])),
               "OMR::IL::opCodesForIfCompareNotEquals is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -797,6 +801,7 @@ OMR::IL::opCodeForCompareLessThan(TR::DataType dt)
               "OMR::IL::opCodesForCompareLessThan is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmplt, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -810,6 +815,7 @@ OMR::IL::opCodeForCompareLessOrEquals(TR::DataType dt)
               "OMR::IL::opCodesForCompareLessOrEquals is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmple, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -822,7 +828,7 @@ OMR::IL::opCodeForIfCompareLessThan(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessThan) / sizeof(OMR::IL::opCodesForIfCompareLessThan[0])),
               "OMR::IL::opCodesForIfCompareLessThan is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -835,7 +841,7 @@ OMR::IL::opCodeForIfCompareLessOrEquals(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareLessOrEquals) / sizeof(OMR::IL::opCodesForIfCompareLessOrEquals[0])),
               "OMR::IL::opCodesForIfCompareLessOrEquals is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -849,6 +855,7 @@ OMR::IL::opCodeForCompareGreaterThan(TR::DataType dt)
               "OMR::IL::opCodesForCompareGreaterThan is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmpgt, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -862,6 +869,7 @@ OMR::IL::opCodeForCompareGreaterOrEquals(TR::DataType dt)
               "OMR::IL::opCodesForCompareGreaterOrEquals is not the correct size");
 
    if (dt.isVector()) return TR::ILOpCode::createVectorOpCode(TR::vcmpge, dt);
+   if (dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -874,7 +882,7 @@ OMR::IL::opCodeForIfCompareGreaterThan(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterThan) / sizeof(OMR::IL::opCodesForIfCompareGreaterThan[0])),
               "OMR::IL::opCodesForIfCompareGreaterThan is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -886,7 +894,7 @@ OMR::IL::opCodeForIfCompareGreaterOrEquals(TR::DataType dt)
    static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals) / sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals[0])),
               "OMR::IL::opCodesForIfCompareGreaterOrEquals is not the correct size");
 
-   if (dt.isVector()) return TR::BadILOp;
+   if (dt.isVector() || dt.isMask()) return TR::BadILOp;
 
    TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 

--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -337,6 +337,8 @@ OMR::ILOpCode::getDataTypeConversion(TR::DataType t1, TR::DataType t2)
    if (t1.isVector() || t2.isVector())
       return TR::BadILOp;
 
+   if (t1.isMask() || t2.isMask())
+      return TR::BadILOp;
 
    TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());
    TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %s requested", t2.toString());
@@ -347,6 +349,9 @@ TR::ILOpCodes
 OMR::ILOpCode::getDataTypeBitConversion(TR::DataType t1, TR::DataType t2)
    {
    if (t1.isVector() || t2.isVector())
+      return TR::BadILOp;
+
+   if (t1.isMask() || t2.isMask())
       return TR::BadILOp;
 
    TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -82,47 +82,59 @@ public:
       }
 
   /** \brief
-   *     Creates vector opcode given vector operation and resulting vector type
+   *     Creates vector opcode given vector operation and the source/result vector or mask type
    *
    *  \param operation
    *     Vector operation
    *
    *  \param vectorType
-   *     Type of the vector which is either source or result (or both)
+   *     Type of the vector or mask which is either source or result (or both)
    *
    *  \return
    *     Vector opcode
    */
-   static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, DataType vectorType)
+   static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, TR::DataType vectorType)
       {
-      TR_ASSERT_FATAL(vectorType.isVector(), "createVectorOpCode should take vector type\n");
+      TR_ASSERT_FATAL(vectorType.isVector() || vectorType.isMask(), "createVectorOpCode should take vector or mask type\n");
 
       TR_ASSERT_FATAL(operation < TR::firstTwoTypeVectorOperation, "Vector operation should be one vector type operation\n");
+
+      if (vectorType.isMask())
+         vectorType = TR::DataType::vectorFromMaskType(vectorType);
 
       return (TR::ILOpCodes)(TR::NumScalarIlOps + operation*TR::NumVectorTypes + (vectorType - TR::FirstVectorType));
       }
 
   /** \brief
-   *     Creates vector opcode given vector operation and resulting vector type
+   *     Creates vector opcode given vector operation and both source and result vector or mask type
    *
    *  \param operation
    *     Vector operation
    *
-   *  \param vectorType
-   *     Type of the vector which is either source or result (or both)
+   *  \param srcVectorType
+   *     Type of the vector or mask which is the source
+   *
+   *  \param resVectorType
+   *     Type of the vector or mask which is the result
    *
    *  \return
    *     Vector opcode
    */
-   static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, DataType srcVectorType, DataType resVectorType)
+   static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, TR::DataType srcVectorType, TR::DataType resVectorType)
       {
-      TR_ASSERT_FATAL(srcVectorType.isVector(), "createVectorOpCode should take vector source type\n");
-      TR_ASSERT_FATAL(resVectorType.isVector(), "createVectorOpCode should take vector result type\n");
+      TR_ASSERT_FATAL(srcVectorType.isVector() || srcVectorType.isMask(), "createVectorOpCode should take vector or mask source type\n");
+      TR_ASSERT_FATAL(resVectorType.isVector() || resVectorType.isMask(), "createVectorOpCode should take vector or mask result type\n");
 
       TR_ASSERT_FATAL(operation >= TR::firstTwoTypeVectorOperation, "Vector operation should be two vector type operation\n");
 
+      if (srcVectorType.isMask())
+         srcVectorType = TR::DataType::vectorFromMaskType(srcVectorType);
+
+      if (resVectorType.isMask())
+         resVectorType = TR::DataType::vectorFromMaskType(resVectorType);
+
       return (TR::ILOpCodes)(TR::NumScalarIlOps + TR::NumOneVectorTypeOps +
-                             operation * TR::NumVectorTypes * TR::NumVectorTypes +
+                             (operation - TR::firstTwoTypeVectorOperation) * TR::NumVectorTypes * TR::NumVectorTypes +
                              (srcVectorType - TR::FirstVectorType) * TR::NumVectorTypes +
                              (resVectorType - TR::FirstVectorType));
       }
@@ -191,8 +203,8 @@ public:
       TR::ILOpCodes opcode = op._opCode;
 
       return (TR::VectorOperation) ((opcode < (TR::NumScalarIlOps + TR::NumOneVectorTypeOps)) ?
-                                   (opcode - TR::NumScalarIlOps) / TR::NumVectorTypes :
-                                    (opcode - TR::NumScalarIlOps - TR::NumOneVectorTypeOps) / (TR::NumVectorTypes * TR::NumVectorTypes));
+                                    (opcode - TR::NumScalarIlOps) / TR::NumVectorTypes :
+                                    (opcode - TR::NumScalarIlOps - TR::NumOneVectorTypeOps) / (TR::NumVectorTypes * TR::NumVectorTypes) + TR::firstTwoTypeVectorOperation - 1);
       }
 
   /** \brief

--- a/compiler/ilgen/OMRIlType.cpp
+++ b/compiler/ilgen/OMRIlType.cpp
@@ -61,6 +61,17 @@ OMR::IlType::signatureNameForVectorType[TR::NumVectorElementTypes] =
    "VD", // VectorDouble
    };
 
+const char *
+OMR::IlType::signatureNameForMaskType[TR::NumVectorElementTypes] =
+   {
+   "M1", // MaskInt8
+   "M2", // MaskInt16
+   "M4", // MaskInt32
+   "M8", // MaskInt64
+   "MF", // MaskFloat
+   "MD", // MaskDouble
+   };
+
 const uint8_t
 OMR::IlType::primitiveTypeAlignment[TR::NumOMRTypes] =
    {
@@ -103,6 +114,9 @@ OMR::IlType::getSignatureName()
 
    if (dt.isVector())
       return (char *) signatureNameForVectorType[dt.getVectorElementType() - 1];
+
+   if (dt.isMask())
+      return (char *) signatureNameForMaskType[dt.getVectorElementType() - 1];
 
    return (char *) signatureNameForType[dt];
    }

--- a/compiler/ilgen/OMRIlType.hpp
+++ b/compiler/ilgen/OMRIlType.hpp
@@ -122,6 +122,7 @@ protected:
 
    static const char    * signatureNameForType[TR::NumOMRTypes];
    static const char    * signatureNameForVectorType[TR::NumVectorElementTypes];
+   static const char    * signatureNameForMaskType[TR::NumVectorElementTypes];
    static const uint8_t   primitiveTypeAlignment[TR::NumOMRTypes];
    static const uint8_t   primitiveVectorTypeAlignment[TR::NumVectorElementTypes];
    };

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2484,6 +2484,8 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
                break;
             default:
                {
+               TR_ASSERT_FATAL(!node1->getDataType().isMask(), "OMR does not support mask constants\n");
+
                if (node1->getDataType().isVector())
                   {
                   if (node1->getLiteralPoolOffset() != node2->getLiteralPoolOffset())


### PR DESCRIPTION
- fix creation of two-type vector opcodes
- allow Mask opcodes to be created using Mask type
- handle Mask type in the opcode mapping methods
- handle Mask opcodes in TRIL
- handle two-type Mask and Vector opcodes in TRIL