### PR TITLE
Fixes for porttest on AArch64 macOS

### DIFF
--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -203,6 +203,8 @@ elseif(OMR_OS_LINUX AND OMR_ARCH_RISCV AND CMAKE_CROSSCOMPILING)
 	set(EXCLUDE_LIST "${EXCLUDE_LIST}:PortSysinfoTest.sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE")
 elseif(OMR_OS_LINUX AND OMR_ENV_DATA32)
 	set(EXCLUDE_LIST "${EXCLUDE_LIST}-PortVmemTest.vmem_test_reserveExecutableMemory")
+elseif(OMR_OS_OSX AND OMR_ARCH_AARCH64)
+	set(EXCLUDE_LIST "${EXCLUDE_LIST}-PortMemTest.mem_test7_allocate32")
 endif()
 
 if($ENV{OMR_RUNNING_IN_DOCKER})

--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1058,6 +1058,7 @@ TEST(PortMemTest, mem_test8_categories)
 		}
 	}
 
+#if !defined(OSX) || !defined(OMR_ARCH_AARCH64)
 	/* Try allocating with allocate32 */
 	{
 		uintptr_t initialBlocks = 0;
@@ -1219,6 +1220,7 @@ TEST(PortMemTest, mem_test8_categories)
 		}
 	}
 #endif /* defined(OMR_ENV_DATA64) */
+#endif /* !defined(OSX) || !defined(OMR_ARCH_AARCH64) */
 
 	/* Try allocating and reallocating */
 	{

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -43,6 +43,10 @@
 #include <sys/vminfo.h>
 #endif /* defined(AIXPPC) */
 
+#if defined(OSX) && defined(OMR_ARCH_AARCH64)
+#include <pthread.h> /* for pthread_jit_write_protect_np */
+#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
+
 #define TWO_GIG_BAR 0x7FFFFFFF
 #define ONE_MB (1*1024*1024)
 #define FOUR_KB (4*1024)
@@ -2620,6 +2624,11 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			} else {
 #endif /* J9ZOS39064 */
 
+#if defined(OSX) && defined(OMR_ARCH_AARCH64)
+				/* Start writing to executable memory */
+				pthread_jit_write_protect_np(0);
+#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
+
 				memset(memPtr, 0, params.pageSize);
 
 				if ((uintptr_t)&myFunction2 > (uintptr_t)&myFunction1) {
@@ -2635,6 +2644,11 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 				portTestEnv->log("function length = %d\n", length);
 
 				memcpy(memPtr, (void *)&myFunction1, length);
+
+#if defined(OSX) && defined(OMR_ARCH_AARCH64)
+				/* Stop writing to executable memory */
+				pthread_jit_write_protect_np(1);
+#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
 
 				portTestEnv->log("*memPtr: 0x%zx\n", *((unsigned int *)memPtr));
 


### PR DESCRIPTION
This commit fixes the following failures with porttest on AArch64 macOS.

- memTest: You cannot allocate memory with omrmem_allocate_memory32().
  Exclude related tests.
- vmemTest: You need to call pthread_jit_write_protect_np().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>