### PR TITLE
Fix Heap Fixup Tracing Schema Failure

### DIFF
--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -92,6 +92,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="memory-traced" type="vgc:memory-traced" />
 	<element name="regions" type="vgc:regions"/>
 	<element name="heap-resize" type="vgc:heap-resize" />
+	<element name="heap-fixup" type="vgc:heap-fixup" />
 	<element name="concurrent-start" type="vgc:concurrent-start" />
 	<element name="concurrent-end" type="vgc:concurrent-end" />
 	<element name="concurrent-mark-start" type="vgc:concurrent-mark-start" />
@@ -156,6 +157,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 				<element ref="vgc:trigger-start" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:trigger-end" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:heap-resize" maxOccurs="1" minOccurs="1" />
+				<element ref="vgc:heap-fixup" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:allocation-satisfied" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:allocation-unsatisfied" maxOccurs="1" minOccurs="1" />
 				<element ref="vgc:warning" maxOccurs="1" minOccurs="1" />
@@ -619,6 +621,12 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="space" type="string" use="required" />
 		<attribute name="amount" type="integer" use="required" />
 		<attribute name="count" type="integer" use="required" />
+		<attribute name="timems" type="float" use="required" />
+		<attribute name="reason" type="string" use="required" />
+		<attribute name="timestamp" type="dateTime" use="optional" />
+	</complexType>
+
+	<complexType name="heap-fixup">
 		<attribute name="timems" type="float" use="required" />
 		<attribute name="reason" type="string" use="required" />
 		<attribute name="timestamp" type="dateTime" use="optional" />


### PR DESCRIPTION
Fix heap fixup tracing schema failures due to previously added heap fixup verbose GC logging and J9mm tracepoints found in https://github.com/eclipse/omr/pull/6593.

Signed-off-by: Jonathan Oommen jon.oommen@gmail.com