### PR TITLE
Fix problems in handling of summation reduction and invariant expressions in Expressions Simplification

### DIFF
--- a/compiler/optimizer/ExpressionsSimplification.hpp
+++ b/compiler/optimizer/ExpressionsSimplification.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,9 +163,90 @@ class TR_ExpressionsSimplification : public TR::Optimization
    void removeUnsupportedCandidates();
    bool isSupportedNodeForExpressionSimplification(TR::Node *node);
 
+   /**
+    * Holds information from analysis of a candidate for expression simplification.
+    * Used to determine the kind of transformation that should be attempted.
+    */
+   class SimplificationCandidateTuple
+      {
+      public:
+
+      /**
+       * Public constructor for a candidate for expression simplification
+       * \param tt    The \ref TR::TreeTop whose tree is a candidate for expression
+       *              simplification
+       * \param flags Flags describing the kind of expression simplification that
+       *              should be attempted on this candidate
+       */
+      SimplificationCandidateTuple(TR::TreeTop *tt, flags32_t flags) : _treeTop(tt), _flags(flags) {}
+
+      enum
+         {
+         /**
+          * Flag that indicates this is a candidate for a loop invariant transformation
+          */
+         InvariantExpressionCandidate = 0x01,
+
+         /**
+          * Flag that indicates this is a candidate for a summation reduction transformation
+          */
+         SummationReductionCandidate = 0x02,
+         };
+
+      /**
+       * Query to check whether this was identified to be a candidate for a loop
+       * invariant transformation
+       * \return \c true if and only if this is a candidate for a loop invariant
+       *         transformation
+       */
+      bool isInvariantExpressionCandidate()
+         {
+         return _flags.testAny(InvariantExpressionCandidate);
+         }
+
+      /**
+       * Query to check whether this was identified to be a candidate for a summation
+       * reduction transformation
+       * \return \c true if and only if this is a candidate for a summation
+       *         reduction transformation
+       */
+      bool isSummationReductionCandidate()
+         {
+         return _flags.testAny(SummationReductionCandidate);
+         }
+
+      /**
+       * Query to retrieve the \ref TR::TreeTop whose tree is the candidate for an
+       * expression simplification transformation
+       * \return This candidate's \c TR::TreeTop
+       */
+      TR::TreeTop *getTreeTop()
+         {
+         return _treeTop;
+         }
+
+      /**
+       * Prints trace output describing this candidate for expression simplification
+       */
+      void print(TR::Compilation *comp);
+
+      private:
+
+      /**
+       * The \ref TR::TreeTop whose tree is the candidate for an expression
+       * simplification transformation
+       */
+      TR::TreeTop *_treeTop;
+
+      /**
+       * Flags describing the kind of expression simplification that should be
+       * attempted on this candidate
+       */
+      flags32_t _flags;
+      };
 
    TR_RegionStructure* _currentRegion;
-   List<TR::TreeTop> *_candidateTTs;
+   List<SimplificationCandidateTuple> *_candidates;
 
    TR_BitVector *_supportedExpressions;
    };


### PR DESCRIPTION
This pull request fixes two problem in Expressions Simplification.

1. In considering whether expressions are invariant and can be pulled out of a loop, `TR_ExpressionsSimplification::removeUncertainBlocks` checks whether blocks will be executed exactly once within each iteration of the loop, and if not, it removes them from consideration.  It does this by checking whether the block post-dominates the entry block for the loop.  However, if a block is in another loop nested within the loop, it might post-dominate the entry but still be executed more than once in each iteration of the outer loop.  Such blocks must also be removed from consideration.
2. Expressions Simplification tracks candidates for summation reduction transformation and invariant expression transformation in a list of `TR::TreeTop` pointers.  It later iterates over the candidates, and in checking whether it's working with a summation reduction candidate, it simply checks whether the first child operation of the store is one of `iadd`, `isub`, `ixor` or `ineg`.  However, a candidate for an invariant expression transformation might also have one of those operations as the first child of its store operation.  This can result in an invariant expression candidate being transformed as if it had been summation reduction candidate.<br><br>Fixed this by changing the list of candidate `TR::TreeTop` pointers into a list of `SimplificationCandidateTuple` objects that contain the candidate `TR::TreeTop` along with flags indicating the kind of candidate it is.
</ol>

Fixes eclipse-openj9/openj9#15306