### PR TITLE
Kill correct registers for VLM

### DIFF
--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -713,7 +713,7 @@ static void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg
                  i != highRegNum ;
                  i  = ((i == (isVector ? numVRFs - 1 : 15)) ? 0 : i+1))
       {
-      TR::RealRegister *reg = cg->machine()->getRealRegister(i + TR::RealRegister::GPR0);
+      TR::RealRegister *reg = cg->machine()->getRealRegister(i + isVector ? TR::RealRegister::VRF0 : TR::RealRegister::GPR0);
 
       // Registers that are assigned need to be checked whether they have a matching STM--otherwise we spill.
       // Since we are called post RA for the LM, we check if assigned registers are last used on the LM so we can


### PR DESCRIPTION
Account for vector registers when calculating real register to check if spill is needed after a load multiple instruction. This fixes the behaviour of uneccessarily and incorrectly spilling GPRs when using VLM. An example of the error from my experience trying to accelerate crc32c on Z:
```
[     0x3ff8dcbd580]                          VLM     VRF_0095,VRF_0098,#415 0(&GPR_0033)VRF_0095(0/6)~FPR5 VRF_0098(0/6)~FPR8 
details:                      trying to free GPR_0099 for killed reg GPR6 by loadmultiple 

details:                      BEST FREE REG for GPR_0099 is GPR14 

 [     0x3ff8ddb3610]                          LGR     GPR6,GPR14       details:                      trying to free GPR_0050 for killed reg GPR7 by loadmultiple 

details:                      BEST FREE REG for GPR_0050 is GPR9

 [     0x3ff8ddb37f0]                          LGR     GPR7,GPR9      
 [     0x3ff8dcbd580]                          VLM     VRF5,VRF8,#415 0(GPR2)
```
Here GPR7 and GPR6 are unnecessarily spilled since GPR5-GPR8 are incorrectly used in the check at [1] rather than VRF5-VRF8. This patch solves this problem.

[1] https://github.com/eclipse/omr/blob/f99c9dd2248e6ee35e40536b3c243eee33924407/compiler/z/codegen/OMRInstruction.cpp#L722