### PR TITLE
AArch64: Implement mRegLoad and mRegStore evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -684,6 +684,8 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::mloadi:
       case TR::mstore:
       case TR::mstorei:
+      case TR::mRegLoad:
+      case TR::mRegStore:
       case TR::vsplats:
          return true;
       case TR::vfma:

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1316,13 +1316,20 @@ OMR::ARM64::TreeEvaluator::mstoreiEvaluator(TR::Node *node, TR::CodeGenerator *c
 TR::Register*
 OMR::ARM64::TreeEvaluator::mRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   TR::Register *globalReg = node->getRegister();
+
+   if (globalReg == NULL)
+      {
+      globalReg = cg->allocateRegister(TR_VRF);
+      node->setRegister(globalReg);
+      }
+   return globalReg;
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::mRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
    }
 
 // vector evaluators


### PR DESCRIPTION
This commit implements mRegLoad and mRegStore evaluators.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>