### PR TITLE
Add retry 10 around clone with 1 minute delays

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -346,15 +346,23 @@ def getSources() {
     stage('Get Sources') {
         def gitConfig = scm.getUserRemoteConfigs().get(0)
         def refspec = (gitConfig.getRefspec()) ? gitConfig.getRefspec() : ''
-        scmVars = checkout poll: false,
-            scm: [$class: 'GitSCM',
-            branches: [[name: "${scm.branches[0].name}"]],
-            extensions: [[$class: 'CloneOption', honorRefspec: true, timeout: 30, reference: SPECS[buildSpec].reference]],
-            userRemoteConfigs: [[name: 'origin',
-                refspec: "${refspec}",
-                url: "${gitConfig.getUrl()}"]
+        def ret = false
+        retry(10) {
+            if (ret) {
+                sleep time: 60, unit: 'SECONDS'
+            } else {
+                ret = true
+            }
+            scmVars = checkout poll: false,
+                scm: [$class: 'GitSCM',
+                branches: [[name: "${scm.branches[0].name}"]],
+                extensions: [[$class: 'CloneOption', honorRefspec: true, timeout: 30, reference: SPECS[buildSpec].reference]],
+                userRemoteConfigs: [[name: 'origin',
+                    refspec: "${refspec}",
+                    url: "${gitConfig.getUrl()}"]
+                ]
             ]
-        ]
+        }
         if (!pullId) {
             setBuildStatus("In Progress","PENDING","${scmVars.GIT_COMMIT}")
         }


### PR DESCRIPTION
There is a problem on zos where the known_hosts
for github.com cannot be verified. It is intermittent
and can come and go on either machine seemingly randomly.
This changes adds a retry wrapper to the clone which will
retry the clone if it fails up to 10 times. It also adds
a delay of 1 minute in between each try.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>