### PR TITLE
Rework profiled to nop guard upgrades in VP

### DIFF
--- a/compiler/env/OMRVMEnv.hpp
+++ b/compiler/env/OMRVMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,6 +133,11 @@ public:
     */
    uintptr_t thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp) { return 0; }
 
+   /**
+    * @brief Returns true in startup phase and false otherwise. This value is
+    * to be used in a purely heuristic way.
+    */
+   bool isVMInStartupPhase(TR::Compilation *comp) { return false; }
    };
 
 }

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7719,27 +7719,6 @@ void OMR::ValuePropagation::doDelayedTransformations()
       }
    _devirtualizedCalls.setFirst(0);
 
-
-   for (VirtualGuardInfo *cvg = _convertedGuards.getFirst(); cvg; cvg = cvg->getNext())
-      {
-      if(cvg->_block->nodeIsRemoved())
-         continue;
-
-      //IL part
-      TR::Node* oldNode = cvg->_currentTree->getNode();
-
-      // !oldNode means that the branch was already removed
-      if (!oldNode || !performTransformation(comp(), "%sReplacing the old guard %p with the shiny new overridden guard %p at treetop %p\n", OPT_DETAILS, oldNode, cvg->_newGuardNode, cvg->_currentTree))
-         {
-         continue;
-         }
-
-      oldNode->recursivelyDecReferenceCount();
-      cvg->_currentTree->setNode(cvg->_newGuardNode);
-      oldNode->setVirtualGuardInfo(NULL, comp());
-      }
-   _convertedGuards.setFirst(0);
-
 #ifdef J9_PROJECT_SPECIFIC
    ListIterator<TR::Node> nodesIt(&_javaLangClassGetComponentTypeCalls);
    TR::Node *getComponentCallNode;

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -766,7 +766,6 @@ class ValuePropagation : public TR::Optimization
         TR::Block            *_block;
         };
 
-    TR_LinkHead<VirtualGuardInfo> _convertedGuards;
     TR_LinkHead<CallInfo> _devirtualizedCalls;
     TR_LinkHead<CallInfo> _unsafeCallsToInline;
 


### PR DESCRIPTION
For all profiled guards (VFT test or method test), when the guard is not folded, replace it with a noppable guard if possible.

Replacing a VFT test with a noppable guard is possible when there is a type bound *C* for the receiver, and *C* is the type expected by the VFT test, and *C* has not been extended. It's as though *C* is final (which would allow folding via a fixed-type constraint), but only until further notice.

Replacing a method test with a noppable guard is possible when there is a type bound *C* for the receiver, and *C* has the expected method, and the expected method is not overridden. It's as though the expected method is final (which would allow folding), but only until further notice.

By default such upgrades are performed only outside of the VM startup phase, since during startup the VM is still loading classes pretty frequently, so the non-extended or nonoverridden state is not as significant. To enable the transformation during startup, set the environment variable `TR_upgradeToNopGuardDuringStartup`.

A new query `VMEnv::isVMInStartupPhase(TR::Compilation*)` is defined to detect this startup phase. It is intended for downstream projects to override. The default implementation arbitrarily returns false.

There was pre-existing code that attempted to change profiled guards into nop guards, but it worked only for VFT tests, and only when the cold call was a virtual call (although part of the code appeared to be trying to handle interface calls). The new implementation also works for method tests and for interface calls, and in the case of method test, the logic that triggers the transformation is largely shared with other recent improvements to the handling of method test. As such, this commit deletes the prior implementation of this concept.