### PR TITLE
x86: Fix min/max reduction on AVX-512

### DIFF
--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -1095,5 +1095,7 @@ INSTANTIATE_TEST_CASE_P(Long128ReductionTest, BinaryDataDriven128Int64Test, ::te
     std::make_tuple(TR::vreductionXor, BinaryLongTest { { 3 }, { 2, 1}, {}, }),
     std::make_tuple(TR::vreductionXor, BinaryLongTest { { 0 }, { 1, 1}, {}, }),
     std::make_tuple(TR::vreductionMin, BinaryLongTest { { -1 }, { -1, 12}, {}, }),
-    std::make_tuple(TR::vreductionMax, BinaryLongTest { { 100 }, { 100, -100}, {}, })
+    std::make_tuple(TR::vreductionMin, BinaryLongTest { { 9223372036854775801 }, { 9223372036854775801, 9223372036854775804}, {}, }),
+    std::make_tuple(TR::vreductionMax, BinaryLongTest { { 100 }, { 100, -100}, {}, }),
+    std::make_tuple(TR::vreductionMax, BinaryLongTest { { 9223372036854775804 }, { 9223372036854775801, 9223372036854775804}, {}, })
 )));


### PR DESCRIPTION
This commit fixes a binary encoding issue
present on AVX-512 hardware whereby EVEX
instructions would become VEX encoded.
This causes functional issues for instructions
that are not supported pre-AVX512. This
problem is fixed by querying for the best
encodding method.

Signed-off-by: BradleyWood <bradley.wood@ibm.com>