### PR TITLE
AArch64: Add byte and short shift and logical opcode evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -350,13 +350,13 @@ OMR::ARM64::TreeEvaluator::lshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 OMR::ARM64::TreeEvaluator::bshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ishlEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ishlEvaluator(node, cg);
    }
 
 TR::Register*
@@ -368,13 +368,13 @@ OMR::ARM64::TreeEvaluator::lshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 OMR::ARM64::TreeEvaluator::bshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ishrEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ishrEvaluator(node, cg);
    }
 
 TR::Register*
@@ -386,13 +386,13 @@ OMR::ARM64::TreeEvaluator::lushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 OMR::ARM64::TreeEvaluator::bushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iushrEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iushrEvaluator(node, cg);
    }
 
 TR::Register*
@@ -404,37 +404,37 @@ OMR::ARM64::TreeEvaluator::lrolEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register*
 OMR::ARM64::TreeEvaluator::bandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::borEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::bxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::sxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+   return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
 TR::Register*

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -299,8 +299,6 @@ class Int8ShiftAndRotate : public ShiftAndRotateArithmetic<int8_t> {};
 TEST_P(Int8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8"
@@ -328,8 +326,6 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -356,8 +352,6 @@ TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
 TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -383,8 +377,6 @@ TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshl/bshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -419,8 +411,6 @@ class Int16ShiftAndRotate : public ShiftAndRotateArithmetic<int16_t> {};
 TEST_P(Int16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16"
@@ -448,8 +438,6 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -476,8 +464,6 @@ TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
 TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int32]"
@@ -503,8 +489,6 @@ TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshl/sshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -753,8 +737,6 @@ class UInt8ShiftAndRotate : public ShiftAndRotateArithmetic<uint8_t> {};
 TEST_P(UInt8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8"
@@ -782,8 +764,6 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -810,8 +790,6 @@ TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
 TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int32]"
@@ -837,8 +815,6 @@ TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -872,8 +848,6 @@ class UInt16ShiftAndRotate : public ShiftAndRotateArithmetic<uint16_t> {};
 TEST_P(UInt16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16"
@@ -901,8 +875,6 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -929,8 +901,6 @@ TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
 TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int32]"
@@ -956,8 +926,6 @@ TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
 
 TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1304,8 +1272,6 @@ class UInt16MaskThenShift : public MaskThenShiftArithmetic<uint16_t> {};
 TEST_P(UInt16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int16 args=[Int16]"
@@ -1341,8 +1307,6 @@ class Int16MaskThenShift : public MaskThenShiftArithmetic<int16_t> {};
 
 TEST_P(Int16MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support sshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1380,8 +1344,6 @@ class UInt8MaskThenShift : public MaskThenShiftArithmetic<uint8_t> {};
 TEST_P(UInt8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
 
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bushr (see issue #5892)";
-
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
         "(method return=Int8 args=[Int8]"
@@ -1417,8 +1379,6 @@ class Int8MaskThenShift : public MaskThenShiftArithmetic<int8_t> {};
 
 TEST_P(Int8MaskThenShift, UsingLoadParam) {
     auto param = to_mask_then_shift_struct(GetParam());
-
-    SKIP_ON_AARCH64(MissingImplementation) << "The AArch64 codegen does not yet support bshr (see issue #5892)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),


### PR DESCRIPTION
- Add missing bshl/bshr/sshl/sshr/bushr/sushr/band/bor/bxor/sand/sor/sxor evaluators to aarch64 code generator.
- Enable ShiftAndRotate fvtest on aarch64.

Resolves #5892
Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>