### PR TITLE
Make Debug verifyTrees work and allow nodePrintAllFlags override

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -673,7 +673,7 @@ public:
 
    TR_OpaqueClassBlock * containingClass(TR::SymbolReference *);
    const char * signature(TR::ResolvedMethodSymbol *s);
-   void nodePrintAllFlags(TR::Node *, TR_PrettyPrinterString &);
+   virtual void nodePrintAllFlags(TR::Node *, TR_PrettyPrinterString &);
 
    // used by DebugExt and may be overridden
    virtual void printDestination(TR::FILE *, TR::TreeTop *);

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2328,7 +2328,7 @@ TR_Debug::verifyTreesPass1(TR::Node *node)
             expectedType = TR::Address;
             }
 
-         if (debug("checkTypes") && expectedType != TR::NoType)
+         if (debug("checkTypes") && expectedType != TR::NoType && expectedType < TR::NumAllTypes)
             {
             // See if the child's type is compatible with this node's type
             // Temporarily allow known cases to succeed


### PR DESCRIPTION
When the necessary env variable is set, verifyTreesPass1() checks the child type of a given Node's IL op, but it fails to check for whether the expectedType is a valid DataType (if the expected child type is "unspecified", for example, then it should not try to match the expectedType to the actual childType). Add this check for a valid child type.
Make nodePrintAllFlags virtual to allow downstream projects to provide project-specific modifications.