### PR TITLE
Call most derived getDefaultOptions method

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3196,7 +3196,7 @@ OMR::Options::processOptions(
    //
    if (strlen(options) == 0 && !envOptions)
       {
-      options = OMR::Options::getDefaultOptions();
+      options = TR::Options::getDefaultOptions();
       }
 
    return TR::Options::processOptions(options, envOptions, cmdLineOptions);


### PR DESCRIPTION
In processOptions(), a call to getDefaultOptions() should use TR::Options rather than OMR::Options so that a version of the method defined in any extension to the Options class will be used.