### PR TITLE
AArch64: Implement mask conversion opcode evaluators

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -649,6 +649,28 @@ TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, 
    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm, preced);
    }
 
+TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+                  bool isUXTL2, TR::Instruction *preced)
+   {
+   TR::InstOpCode::Mnemonic op;
+   switch (elementType)
+      {
+      case TR::Int8:
+         op = isUXTL2 ? TR::InstOpCode::vushll2_8h : TR::InstOpCode::vushll_8h;
+         break;
+      case TR::Int16:
+         op = isUXTL2 ? TR::InstOpCode::vushll2_4s : TR::InstOpCode::vushll_4s;
+         break;
+      case TR::Int32:
+         op = isUXTL2 ? TR::InstOpCode::vushll2_2d : TR::InstOpCode::vushll_2d;
+         break;
+      default:
+         TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
+         break;
+      }
+   return generateVectorShiftImmediateInstruction(cg, op, node, treg, sreg, 0, preced);
+   }
+
 static
 bool isVectorRegister(TR::Register *reg)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1188,6 +1188,26 @@ TR::Instruction *generateVectorShiftImmediateInstruction(
                   TR::Instruction *preced = NULL);
 
 /**
+ * @brief Generates vector unsigned extend long instruction
+ *
+ * @param[in] cg          : CodeGenerator
+ * @param[in] elementType : element type
+ * @param[in] node        : node
+ * @param[in] treg        : target register
+ * @param[in] sreg        : source register
+ * @param[in] isUXTL2     : if true, UXTL2 instruction is generated
+ * @param[in] preced      : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateVectorUXTLInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::DataType elementType,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  bool isUXTL2,
+                  TR::Instruction *preced = NULL);
+/**
  * @brief Generates duplicate vector element instruction
  *
  * @param[in] cg          : CodeGenerator

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -700,6 +700,25 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vsqrt:
       case TR::vmsqrt:
          return (et == TR::Float || et == TR::Double);
+      case TR::s2m:
+      case TR::m2s:
+         /*
+          * For s2m/m2s, the mask has 2 lanes because each byte in the short value represents the mask value for a lane.
+          * Since we are dealing with 128-bit vector, the type of elements of the mask with 2 lanes are either 64-bit integer or double.
+          */
+         return (et == TR::Int64 || et == TR::Double);
+      case TR::i2m:
+      case TR::m2i:
+         /* For the same reason, the number of lanes is 4, which means that the type of elements is 32-bit integer or float. */
+         return (et == TR::Int32 || et == TR::Float);
+      case TR::l2m:
+      case TR::m2l:
+         /* For the same reason, the number of lanes is 8, which means that the type of elements is 16-bit integer. */
+         return et == TR::Int16;
+      case TR::v2m:
+      case TR::m2v:
+         /* For the same reason, the number of lanes is 16, which means that the type of elements is 8-bit integer. */
+         return et == TR::Int8;
       default:
          return false;
       }

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -58,6 +58,15 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
 TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
 /**
+ * @brief Helper function for xloadEvaluators
+ * @param[in] node : node
+ * @param[in] op : instruction for load
+ * @param[in] targetReg : target register
+ * @param[in] cg : CodeGenerator
+ */
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Register *targetReg, TR::CodeGenerator *cg);
+
+/**
  * @brief Helper function for xstoreEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for store


### PR DESCRIPTION
This commit implements s2m, i2m, l2m, v2m, m2s, m2i, m2l and m2v evaluators.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>