### PR TITLE
Avoid size overflow when allocating memory

### DIFF
--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -300,9 +300,19 @@ omrmem_reallocate_memory(struct OMRPortLibrary *portLibrary, void *memoryPointer
 		}
 		if (NULL != pointer) {
 			pointer = wrapBlockAndSetTags(portLibrary, pointer, byteAmount, callSite, category);
-		}
-		if (NULL == pointer) {
+		} else {
 			Trc_PRT_mem_omrmem_reallocate_memory_failed_2(callSite, memoryPointer, allocationByteAmount);
+
+			/* Original pointer is still valid, restore mem tags. */
+			if (NULL != memoryPointer) {
+				J9MemTag *savedMemTag = (J9MemTag *)memoryPointer;
+				wrapBlockAndSetTags(
+						portLibrary,
+						memoryPointer,
+						savedMemTag->allocSize,
+						savedMemTag->callSite,
+						savedMemTag->category->categoryCode);
+			}
 		}
 	}
 


### PR DESCRIPTION
**Commit 1** - Guard against very large allocation sizes which overflow
when memory tagging overhead is added.

**Commit 2** - omrmemtest: check that large allocations don't overflow.

**Commit 3** - Handle reallocation failures: Restore allocation headers in
the case realloc fails.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>