### PR TITLE
Stop devirtualizing interface calls in preexistence

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -7288,7 +7288,62 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
 
    // Quit if class is not compatible with the method
    if (resolvedMethod && receiverInfo->getClass() && !classIsCompatibleWithMethod(receiverInfo->getClass(), resolvedMethod))
+      {
+      if (trace())
+         traceMsg(comp(), "PREX:        - Receiver type incompatible with method \n");
+
       return;
+      }
+
+   TR::MethodSymbol *methSymbol = node->getSymbol()->getMethodSymbol();
+   if (methSymbol->isInterface())
+      {
+      // Interface type signatures can't be trusted most places in bytecode, so
+      // only transform interface calls when we have a class bound for the
+      // receiver.
+      TR_OpaqueClassBlock *klass = receiverInfo->getClass();
+      if (klass == NULL || TR::Compiler->cls.isInterfaceClass(comp(), klass))
+         {
+         if (trace())
+            {
+            traceMsg(
+               comp(),
+               "PREX:        - No class type bound for interface call receiver\n");
+            }
+
+         return;
+         }
+
+      TR_ResolvedMethod *caller = node->getSymbolReference()->getOwningMethod(comp());
+      TR::Method *callee = methSymbol->getMethod();
+      bool aotOk = true;
+      TR_OpaqueClassBlock *iface = fe()->getClassFromSignature(
+         callee->classNameChars(), callee->classNameLength(), caller, aotOk);
+
+      if (iface == NULL)
+         {
+         if (trace())
+            {
+            traceMsg(
+               comp(),
+               "PREX:        - Failed to identify interface for interface call\n");
+            }
+
+         return;
+         }
+
+      if (fe()->isInstanceOf(klass, iface, true, true, true) != TR_yes)
+         {
+         if (trace())
+            {
+            traceMsg(
+               comp(),
+               "PREX:        - Insufficient class type bound for interface call receiver\n");
+            }
+
+         return;
+         }
+      }
 
    //
    // Step 2: Transform
@@ -7392,7 +7447,6 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
          TR::ClassTableCriticalSection processIndirectCall(comp()->fe());
          TR::SymbolReference *symRef = node->getSymbolReference();
          TR_PersistentCHTable * chTable = comp()->getPersistentInfo()->getPersistentCHTable();
-         TR::MethodSymbol *methSymbol = node->getSymbol()->getMethodSymbol();
          if (methSymbol->isInterface() || methodSymbol)
             {
             TR_ResolvedMethod * method = NULL;
@@ -7411,8 +7465,16 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
                {
                if (comp()->getPersistentInfo()->getRuntimeAssumptionTable()->getAssumptionCount(RuntimeAssumptionOnClassExtend) < 100000)
                   method = chTable->findSingleInterfaceImplementer(receiverInfo->getClass(), node->getSymbolReference()->getCPIndex(), node->getSymbolReference()->getOwningMethod(comp()), comp());
-               //if (method)
-               //   fprintf(stderr, "%s assumptios=%d\n", comp()->signature(), comp()->getPersistentInfo()->getRuntimeAssumptionTable()->getAssumptionCount(RuntimeAssumptionOnClassExtend));
+               if (method == NULL)
+                  {
+                  if (trace())
+                     {
+                     traceMsg(
+                        comp(),
+                        "PREX:        - Failed to find interface callee\n");
+                     }
+                  return;
+                  }
                }
             else
                {


### PR DESCRIPTION
Previously, it was possible for the JIT to devirtualize an interface call, and for execution to reach the call (whether inlined or not) with a receiver that is not an instance of the class expected by the implementing method. The callee could then access fields of the receiver as though it were of the expected type.

The conditionals added in this commit still allow (on their own) for an interface call to be devirtualized when preexistence has already proven that the receiver is an instance of some particular class that implements the expected interface. However, preexistence currently fails to devirtualize in that situation. It passes the class to `TR_PersistentCHTable::findSingleInterfaceImplementer()`, which needs the interface. This can be improved in the future by having preexistence treat the call in the same way as a non-interface call, but with the added requirement that the devirtualized callee must be public.