### PR TITLE
Check disableArrayCopyOpts in canTransformUnsafeCopyToArrayCopy P/A64

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -848,3 +848,8 @@ OMR::ARM64::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
 
    return result;
    }
+
+bool OMR::ARM64::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
+   {
+   return !self()->comp()->getOption(TR_DisableArrayCopyOpts);
+   }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -538,7 +538,7 @@ public:
     * @brief Answers whether Unsafe.copyMemory transformation is supported or not
     * @return true if supported, false otherwise
     */
-   bool canTransformUnsafeCopyToArrayCopy() { return true; }
+   bool canTransformUnsafeCopyToArrayCopy();
 
    /**
     * @brief Generates instructions for incrementing debug counter

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -828,6 +828,11 @@ TR::Register *OMR::Power::CodeGenerator::gprClobberEvaluate(TR::Node *node)
       }
    }
 
+bool OMR::Power::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
+   {
+   return !self()->comp()->getOption(TR_DisableArrayCopyOpts);
+   }
+
 bool OMR::Power::CodeGenerator::canTransformUnsafeSetMemory()
    {
    return (self()->comp()->target().is64Bit());

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -271,7 +271,7 @@ public:
 
    int32_t getPreferredLoopUnrollFactor();
 
-   bool canTransformUnsafeCopyToArrayCopy() { return true; }
+   bool canTransformUnsafeCopyToArrayCopy();
    bool canTransformUnsafeSetMemory();
    bool supportsMergingGuards() {return false;}
 


### PR DESCRIPTION
Correct the implementation of `canTransformUnsafeCopyToArrayCopy()` to check for the `disableArrayCopyOpts` option in P and AArch64.

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>