### PR TITLE
WIP: Replace placeholder DataTypes enum values

### DIFF
--- a/compiler/il/DataTypesEnum.hpp
+++ b/compiler/il/DataTypesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,3 +20,11 @@
  *******************************************************************************/
 
 // This file is used by projects to define their own data types
+
+#ifndef DATATYPES_ENUM_INCL
+#define DATATYPES_ENUM_INCL
+
+FirstTRScalarType = FirstOMRScalarType,
+LastTRScalarType = LastOMRScalarType,
+
+#endif

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -236,6 +236,7 @@ enum VectorLength
  */
 enum DataTypes
    {
+   FirstOMRScalarType,
    NoType=0,
    Int8,
    Int16,
@@ -245,25 +246,29 @@ enum DataTypes
    Double,
    Address,
    Aggregate,
-   NumOMRTypes,
+   LastOMRScalarType = Aggregate,
 #include "il/DataTypesEnum.hpp"
-   NumScalarTypes,
-   NumVectorElementTypes = Double,
+   FirstVectorElementType = Int8,
+   LastVectorElementType = Double,
+   NumVectorElementTypes = Double, //currently equivalent to more general LastVectorElementType - FirstVectorElementType + 1
    //
    // this space is reserved for vector and mask types generated at runtime
    // the generated types can be used to index tables of size NumAllTypes as any other type
    //
-   NumVectorTypes = NumVectorElementTypes * NumVectorLengths,
-   NumMaskTypes = NumVectorTypes,
 
-   FirstVectorType = NumScalarTypes,
-   LastVectorType = FirstVectorType + NumVectorTypes - 1,
+   FirstVectorType = LastTRScalarType + 1,
+   LastVectorType = FirstVectorType + (NumVectorElementTypes * NumVectorLengths) - 1,
 
    FirstMaskType = LastVectorType + 1,
-   LastMaskType = FirstMaskType + NumMaskTypes - 1,
+   LastMaskType = FirstMaskType + (NumVectorElementTypes * NumVectorLengths) - 1,
 
-   NumAllTypes =  NumScalarTypes + NumVectorTypes + NumMaskTypes
+   LastTRDataType = LastMaskType
    };
+
+   const uint32_t NumOMRTypes = LastOMRScalarType + 1;
+   const uint32_t NumVectorTypes = NumVectorElementTypes * NumVectorLengths;
+   const uint32_t NumMaskTypes = NumVectorTypes;
+   const uint32_t NumAllTypes = LastTRDataType + 1;
 }
 
 

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -577,12 +577,8 @@ bool decodeConversionOpcode(TR::ILOpCode op, TR::DataType nodeDataType, TR::Data
       {
       targetDataType = nodeDataType;
       TR::ILOpCodes opValue = op.getOpCodeValue();
-      for (int i = 0; i < TR::NumAllTypes; i++)
+      for (int i = 0; i <= TR::LastTRScalarType; i++)
           {
-          if (TR::NumOMRTypes == i)
-             {
-             continue;
-             }
           sourceDataType = (TR::DataTypes)i;
           if (opValue == TR::ILOpCode::getProperConversion(sourceDataType, targetDataType, false /*!wantZeroExtension*/))
              {


### PR DESCRIPTION
The DataTypes enum contains some placeholders representing values such as the number of different categories of DataTypes. To prevent those placeholders from being treated as though they are a value representing a valid DataType, mark the first and last of each category of DataTypes instead and remove the placeholders from the enum. For those placeholder values used extensively elsewhere, replace them with a constant in the TR namespace of the same value.

Introduce FirstTRScalarType and LastTRScalarType in DataTypesEnum.hpp to indicate to downstream projects that they should set these values appropriately based on their extensions to the DataTypes enum.