### PR TITLE
Upgrading inlined code to virtual methods for register scavenger

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -73,9 +73,7 @@ class MM_RememberedSetCardBucket;
 #if defined(OMR_GC_REALTIME)
 class MM_RememberedSetSATB;
 #endif /* defined(OMR_GC_REALTIME) */
-#if defined(OMR_GC_MODRON_SCAVENGER)
 class MM_Scavenger;
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 class MM_SizeClasses;
 class MM_SparseVirtualMemory;
 class MM_SweepHeapSectioning;
@@ -983,6 +981,20 @@ public:
 		return scavengerEnabled;
 #else /* defined(OMR_GC_MODRON_SCAVENGER) */
 		return false;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	virtual void registerScavenger(MM_Scavenger *scavenger)
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		this->scavenger = scavenger;
+#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
+	}
+
+	virtual void unregisterScavenger()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		scavenger = NULL;
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
 

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -68,10 +68,9 @@ MM_ConfigurationGenerational::tearDown(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
-	/* Set pointer to scavenger in extensions to NULL
-	 * before Scavenger is teared down as part of clean up of defaultMemorySpace
+	/* unregisterScavenger before Scavenger is teared down as part of clean up of defaultMemorySpace
 	 * in MM_Configuration::tearDown. */
-	extensions->scavenger = NULL;
+	extensions->unregisterScavenger();
 
 	MM_ConfigurationStandard::tearDown(env);
 }
@@ -202,8 +201,7 @@ MM_ConfigurationGenerational::createDefaultMemorySpace(MM_EnvironmentBase *envBa
 		return NULL;
 	}
 	
-	/* register the scavenger in GCExtensionsBase */
-	ext->scavenger = scavenger;
+	ext->registerScavenger(scavenger);
 
 	return MM_MemorySpace::newInstance(env, heap, physicalArena, memorySubSpaceGenerational, parameters, MEMORY_SPACE_NAME_GENERATIONAL, MEMORY_SPACE_DESCRIPTION_GENERATIONAL);
 }


### PR DESCRIPTION
Upgrading inlined code to virtual methods for register scavenger
so that subclasses could override behavior.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>