### PR TITLE
Enable vload/vstore/mload/mstore for Byte and ShortVectors on P9+/big endian power systems

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1831,7 +1831,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::mloadi:
       case TR::mstore:
       case TR::mstorei:
-         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double)
+         // since lxvb16x, stxvb16x, lxvh8x, and stxvh8x are not available on P8 and lower, vector/loads and stores should only be enabled under these conditions:
+         if (et == TR::Int32 || et == TR::Int64 || et == TR::Float || et == TR::Double || cpu->isAtLeast(OMR_PROCESSOR_PPC_P9) || cpu->isBigEndian())
             return true;
          else
             return false;


### PR DESCRIPTION
There are currently two situations in which vector loads and stores for sub-int types can be used PPC while preseving the order of the elements:

- On P9 and up, using one of the VSX load/store instructions specifically for vectors with byte/halfword-length elements (lxvb16x, stxvb16x, lxvh8x, stxvh8x)
- On big endian systems, where that coupled with the semantics of the VSX load/store instructions for word-length elements (lxvw4x, stxvw4x) mean that element order is preserved regardless of which VSX load/store instruction is used

Thus, vload and vstore have been re-enabled on PPC for those two situations