### PR TITLE
AArch64: Implement unordered fcmp/dcmp evaluators

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -711,7 +711,7 @@ OMR::ARM64::TreeEvaluator::ifdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *
    return NULL;
    }
 
-static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool isDouble, TR::CodeGenerator *cg)
+static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool isDouble, bool needsExplicitUnorderedCheck, TR::CodeGenerator *cg)
    {
    TR::Register *trgReg = cg->allocateRegister();
    TR::Node *firstChild = node->getFirstChild();
@@ -739,6 +739,15 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
       }
 
    generateCSetInstruction(cg, node, trgReg, cc);
+   if (needsExplicitUnorderedCheck)
+      {
+      TR::Register *tmpReg = cg->allocateRegister();
+      TR::ARM64ConditionCode ccNan = (cc == TR::CC_NE) ? TR::CC_VC : TR::CC_VS;
+      op = (cc == TR::CC_NE) ? TR::InstOpCode::andx : TR::InstOpCode::orrx;
+      generateCSetInstruction(cg, node, tmpReg, ccNan);
+      generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, tmpReg);
+      cg->stopUsingRegister(tmpReg);
+      }
 
    node->setRegister(trgReg);
    cg->decReferenceCount(firstChild);
@@ -749,73 +758,73 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_EQ, false, cg);
+   return fcmpHelper(node, TR::CC_EQ, false, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_NE, false, cg);
+   return fcmpHelper(node, TR::CC_NE, false, true, cg); // need to check NaN
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_MI, false, cg);
+   return fcmpHelper(node, TR::CC_MI, false, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_GE, false, cg);
+   return fcmpHelper(node, TR::CC_GE, false, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_GT, false, cg);
+   return fcmpHelper(node, TR::CC_GT, false, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_LS, false, cg);
+   return fcmpHelper(node, TR::CC_LS, false, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_EQ, true, cg);
+   return fcmpHelper(node, TR::CC_EQ, true, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_NE, true, cg);
+   return fcmpHelper(node, TR::CC_NE, true, true, cg); // need to check NaN
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_MI, true, cg);
+   return fcmpHelper(node, TR::CC_MI, true, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_GE, true, cg);
+   return fcmpHelper(node, TR::CC_GE, true, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_GT, true, cg);
+   return fcmpHelper(node, TR::CC_GT, true, false, cg);
    }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return fcmpHelper(node, TR::CC_LS, true, cg);
+   return fcmpHelper(node, TR::CC_LS, true, false, cg);
    }
 
 static TR::Register *
@@ -1078,40 +1087,77 @@ OMR::ARM64::TreeEvaluator::ifdcmpleuEvaluator(TR::Node *node, TR::CodeGenerator 
    return NULL;
    }
 
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpequEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_EQ, false, true, cg);
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpneuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_NE, false, false, cg); // no need to check NaN
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpltuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_MI, false, true, cg);
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpgeuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GE, false, true, cg);
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpgtuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GT, false, true, cg);
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::fcmpleuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_LS, false, true, cg);
+   }
+
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpequEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpequEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_EQ, true, true, cg);
+   }
+
+TR::Register*
+OMR::ARM64::TreeEvaluator::dcmpneuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_NE, true, false, cg); // no need to check NaN
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpltuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpltuEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_MI, true, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpgeuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpgeuEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_GE, true, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpgtuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpgtuEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_GT, true, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpleuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpleuEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_LS, true, true, cg);
+   }
 
 // also handles dselect
 TR::Register *

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -600,48 +600,6 @@ OMR::ARM64::TreeEvaluator::a2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpequEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpneuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpltuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpgeuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpgtuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::fcmpleuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::dcmpneuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
 OMR::ARM64::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::lcmpeqEvaluator(node, cg);

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corp. and others
+ * Copyright (c) 2018, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1434,7 +1434,6 @@ class FloatCompareOrUnordered : public TRTest::OpCodeTest<int32_t, float, float>
 
 TEST_P(FloatCompareOrUnordered, UsingConst) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1468,7 +1467,6 @@ TEST_P(FloatCompareOrUnordered, UsingConst) {
 
 TEST_P(FloatCompareOrUnordered, UsingRhsConst) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1502,7 +1500,6 @@ TEST_P(FloatCompareOrUnordered, UsingRhsConst) {
 
 TEST_P(FloatCompareOrUnordered, UsingLoadParam) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1581,7 +1578,6 @@ class DoubleCompareOrUnordered : public TRTest::OpCodeTest<int32_t, double, doub
 
 TEST_P(DoubleCompareOrUnordered, UsingConst) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1615,7 +1611,6 @@ TEST_P(DoubleCompareOrUnordered, UsingConst) {
 
 TEST_P(DoubleCompareOrUnordered, UsingRhsConst) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1649,7 +1644,6 @@ TEST_P(DoubleCompareOrUnordered, UsingRhsConst) {
 
 TEST_P(DoubleCompareOrUnordered, UsingLoadParam) {
     SKIP_ON_HAMMER(KnownBug) << "The x86_64 code generator crashes (see issue #5122)";
-    SKIP_ON_AARCH64(MissingImplementation);
 
     auto param = TRTest::to_struct(GetParam());
 


### PR DESCRIPTION
This commit implements unordered fcmp/dcmp evaluators for AArch64, such as fcmpequ and dcmpltu..

Closes: #5895

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>