### PR TITLE
Add option to skip ilgen optimizations

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -366,6 +366,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
                                           TR::Options::setRegex, offsetof(OMR::Options, _disabledIdiomPatterns), 0, "P"},
    {"disableIdiomRecognition",            "O\tdisable idiom recognition",                       TR::Options::disableOptimization, idiomRecognition, 0, "P"},
 #endif
+   {"disableIlgenOpts", "O\tDo not run the optimizer during ilgen", SET_OPTION_BIT(TR_DisableIlgenOpts), "F"},
    {"disableImmutableFieldAliasing",      "O\tdisable special handling for immutable fields.", SET_OPTION_BIT(TR_DisableImmutableFieldAliasing), "P"},
    {"disableIncrementalCCR",              "O\tdisable incremental ccr",      SET_OPTION_BIT(TR_DisableIncrementalCCR), "F" ,NOT_IN_SUBSET},
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -229,7 +229,7 @@ enum TR_CompilationOptions
    TR_EnableYieldVMAccess                 = 0x02000000 + 4,
    TR_DisableNoVMAccess                   = 0x04000000 + 4,
    TR_DisableStoreSinking                 = 0x08000000 + 4,
-   // Available                           = 0x10000000 + 4,
+   TR_DisableIlgenOpts                    = 0x10000000 + 4,
    TR_HWProfileDeleteEmptyBlocks          = 0x20000000 + 4,
    TR_DisableLiveMonitorMetadata          = 0x40000000 + 4,
    TR_DisableMonitorOpts                  = 0x80000000 + 4,

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1233,9 +1233,12 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
                && comp->supportsInduceOSR()
                && !self()->cannotAttemptOSRDuring(siteIndex, comp);
 
-            optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
-            previousOptimizer = comp->getOptimizer();
-            comp->setOptimizer(optimizer);
+            if (!(comp->getOption(TR_DisableIlgenOpts)))
+               {
+               optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
+               previousOptimizer = comp->getOptimizer();
+               comp->setOptimizer(optimizer);
+               }
 
             self()->detectInternalCycles();
 


### PR DESCRIPTION
Introduces a TR_DisableIlgenOpts option flag that can be set in order to skip optimizations run during ilgen.