### PR TITLE
Attempt user name retrieval with sysinfo_get_env()

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -872,6 +872,16 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_CTLDATA_VMEM_ADVISE_HUGEPAGE  "VMEM_ADVISE_HUGEPAGE"
 #define OMRPORT_CTLDATA_VMEM_PERFORM_FULL_MEMORY_SEARCH  "VMEM_PERFORM_FULL_SEARCH"
 #define OMRPORT_CTLDATA_VMEM_HUGE_PAGES_MMAP_ENABLED "VMEM_HUGE_PAGES_MMAP_ENABLED"
+#define OMRPORT_CTLDATA_INSTANTON_FLAGS "INSTANTON_FLAGS"
+
+/* InstantOn is enabled, a checkpoint could be taken
+ * if current VM is not from a final restoration.
+ */
+#define OMRPORT_INSTANTON_ENABLED  0x1
+/* Current VM is from a final restoration,
+ * i.e., no more checkpoint is allowed.
+ */
+#define OMRPORT_INSTANTON_FINAL_RESTORE  0x2
 
 #define OMRPORT_FILE_READ_LOCK  1
 #define OMRPORT_FILE_WRITE_LOCK  2

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -319,7 +319,12 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		return 0;
 	}
 
+#if defined(PPG_instantOnFlags)
+	if (0 == strcmp(OMRPORT_CTLDATA_INSTANTON_FLAGS, key)) {
+		PPG_instantOnFlags = value;
+		return 0;
+	}
+#endif /* defined(PPG_instantOnFlags) */
+
 	return 1;
 }
-
-

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -3939,6 +3939,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	BOOLEAN runningInContainer = FALSE;
 #endif /* defined(LINUX) && !defined(OMRZTPF) */
 
+	PPG_instantOnFlags = 0;
 	PPG_sysinfoControlFlags = 0;
 	/* Obtain and cache executable name; if this fails, executable name remains NULL, but
 	 * shouldn't cause failure to startup port library.  Failure will be noticed only

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -113,6 +113,7 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(AIXPPC)
 	int pageProtectionPossible;
 #endif
+	uintptr_t instantOnFlags;
 } OMRPortPlatformGlobals;
 
 
@@ -172,6 +173,8 @@ typedef struct OMRPortPlatformGlobals {
 #define PAGE_PROTECTION_NOTAVAILABLE 1
 #define PAGE_PROTECTION_NOTCHECKED 2
 #endif
+
+#define PPG_instantOnFlags (portLibrary->portGlobals->platformGlobals.instantOnFlags)
 
 #endif /* omrportpg_h */
 

--- a/port/zos390/omrportpg.h
+++ b/port/zos390/omrportpg.h
@@ -84,6 +84,7 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(OMR_ENV_DATA64)
 	char iptTtoken[TTOKEN_BUF_SZ];
 #endif /* defined(OMR_ENV_DATA64) */
+	uintptr_t instantOnFlags;
 } OMRPortPlatformGlobals;
 
 #define PPG_si_osType (portLibrary->portGlobals->platformGlobals.si_osType)
@@ -107,5 +108,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_ipt_ttoken (portLibrary->portGlobals->platformGlobals.iptTtoken)
 
 #define PPG_stfleCache (portLibrary->portGlobals->platformGlobals.stfleCache)
+
+#define PPG_instantOnFlags (portLibrary->portGlobals->platformGlobals.instantOnFlags)
 
 #endif /* omrportpg_h */


### PR DESCRIPTION
Attempt user name retrieval with `sysinfo_get_env()`

To generate platform independent tokens, try `sysinfo_get_username()` if `CRIU` is not enabled or it is a final restoration; if it fails, try `sysinfo_get_username()` instead.
This doesn't take the user name longer than `USERNAME_BUF_LEN`, if the call fails, we just don't add it;
`CRIU` requires `sysinfo_get_env()` if a checkpoint is to be taken and avoid `sysinfo_get_username()` at VM early startup which might call `getpwuid()`, trigger `SSSD` socket connection, and cause a checkpoint failure;
More details are at https://github.com/eclipse-openj9/openj9/issues/15800;
Add `PPG_instantOnFlags` for the state `OMRPORT_INSTANTON_ENABLED` and `OMRPORT_INSTANTON_FINAL_RESTORE`;
Fix a few method signature mismatching.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>