### PR TITLE
Avoid analyzing OSR guards as virtual guards in versioner

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -475,8 +475,17 @@ TR_VirtualGuard::createOSRGuard(TR::Compilation *comp, TR::TreeTop *destination)
                flag,
                destination);
 
-   TR_VirtualGuard *vguard = new (comp->trHeapMemory()) TR_VirtualGuard(TR_DummyTest, TR_OSRGuard, comp,
-         NULL, guard, destination ? destination->getNode()->getByteCodeInfo().getCallerIndex() : -1, comp->getCurrentInlinedSiteIndex(), NULL);
+   int16_t calleeIndex = -1;
+   TR_VirtualGuard *vguard = new (comp->trHeapMemory()) TR_VirtualGuard(
+      TR_DummyTest,
+      TR_OSRGuard,
+      comp,
+      NULL,
+      guard,
+      calleeIndex,
+      comp->getCurrentInlinedSiteIndex(),
+      NULL);
+
    vguard->dontGenerateChildrenCode();
    return guard;
    }

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -1407,6 +1407,7 @@ bool TR_LoopVersioner::detectInvariantTrees(TR_RegionStructure *whileLoop, List<
          if (onlyDetectHighlyBiasedBranches
              && (thisChild || nextRealNode)
              && node->isTheVirtualGuardForAGuardedInlinedCall()
+             && !node->isOSRGuard()
              && !node->isHCRGuard()
              && !node->isDirectMethodGuard()
              && !node->isBreakpointGuard())
@@ -1479,7 +1480,10 @@ bool TR_LoopVersioner::detectInvariantTrees(TR_RegionStructure *whileLoop, List<
                   }
                }
             }
-         else if (!node->isHCRGuard() && !node->isDirectMethodGuard() && !node->isBreakpointGuard())
+         else if (!node->isOSRGuard()
+                  && !node->isHCRGuard()
+                  && !node->isDirectMethodGuard()
+                  && !node->isBreakpointGuard())
             {
             for (int32_t childNum=0;childNum < node->getNumChildren(); childNum++)
                {
@@ -5675,8 +5679,12 @@ void TR_LoopVersioner::buildConditionalTree(
 
       TR::Node *dupThisChild = NULL;
 
-      if (conditionalNode->isTheVirtualGuardForAGuardedInlinedCall() &&
-          !conditionalNode->isNonoverriddenGuard()  && !conditionalNode->isHCRGuard() && !conditionalNode->isBreakpointGuard())
+      if (conditionalNode->isTheVirtualGuardForAGuardedInlinedCall()
+          && !conditionalNode->isNonoverriddenGuard()
+          && !conditionalNode->isOSRGuard()
+          && !conditionalNode->isHCRGuard()
+          && !conditionalNode->isDirectMethodGuard()
+          && !conditionalNode->isBreakpointGuard())
          {
          bool searchReqd = true;
          TR::Node *nextRealNode = NULL;


### PR DESCRIPTION
It used to be that a standalone OSR guard could not target a cold call. However, virtual guards target cold calls even when they are merged with OSR guards. Recently, VP learned to remove the virtual part of a virtual guard despite any merged guards (3d1fec9523d4f9e779dc1b85119a6b0b5c642ced, #6762). The merged HCR or OSR guard is promoted to a standalone HCR or OSR guard, and any standalone OSR guard produced in this way does target a cold call.

It was possible for such an OSR guard to be confused for a virtual guard, and therefore for loop versioner to try to version it as though it were a virtual guard, resulting in an assertion failure:

    guardOkForExpr: should not intern OSR guard ...

This happened only very rarely because the OSR guard does not use VFT test or method test, so in order to confuse it for a virtual guard, the OSR guard's BCI must correspond to that of the cold call in the same way as it would for a virtual guard. An OSR guard's inlined call site index is copied from the BBStart on the taken side, which usually identifies the caller rather than the callee, but the latter is required in order to provoke the bug.

Additionally, `buildConditionalTree()` had a path that excluded HCR guard but not direct method guard. It shouldn't matter, since neither should be considered an invariant conditional there, but that path now also excludes direct method guard for consistency.

-----

There is an additional commit to prevent this confusion in another way:
- Set inlined call site index to -1 for all OSR guards

----

Fixes eclipse/openj9#16115