### PR TITLE
Add type hint class to VP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -8082,6 +8082,21 @@ void OMR::ValuePropagation::doDelayedTransformations()
       }
    }
 
+TR_OpaqueClassBlock *OMR::ValuePropagation::findLikelySubtype(TR_OpaqueClassBlock *klass)
+   {
+   return NULL;
+   }
+
+TR_OpaqueClassBlock *OMR::ValuePropagation::findLikelySubtype(const char *sig, int32_t len, TR_ResolvedMethod *owningMethod)
+   {
+   return NULL;
+   }
+
+TR::VPConstraint *OMR::ValuePropagation::createTypeHintConstraint(TR_ResolvedMethod *owningMethod, const char *sig, int32_t len)
+   {
+   return NULL;
+   }
+
 void constrainRangeByPrecision(const int64_t low, const int64_t high, const int32_t precision, int64_t &lowResult, int64_t &highResult, bool isNonNegative)
    {
    lowResult = low;

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -480,6 +480,35 @@ class ValuePropagation : public TR::Optimization
    bool checkAllUnsafeReferences(TR::Node *node, vcount_t visitCount);
    virtual void doDelayedTransformations();
 
+   /**
+    * @brief Look for a likely sub type for a given class
+    *
+    * @param[in] klass : The class to be used to look for its sub type
+    *
+    * @return Resulting sub type class
+    */
+   virtual TR_OpaqueClassBlock *findLikelySubtype(TR_OpaqueClassBlock *klass);
+   /**
+    * @brief Look for a likely sub type for a given class signature
+    *
+    * @param[in] sig : The class signature to be used to look for its sub type
+    * @param[in] len : The class signature length
+    * @param[in] owningMethod : The owning method
+    *
+    * @return Resulting sub type class
+    */
+   virtual TR_OpaqueClassBlock *findLikelySubtype(const char *sig, int32_t len, TR_ResolvedMethod *owningMethod);
+   /**
+    * @brief Create a constraint if a likely sub type for a given class signature is found
+    *
+    * @param[in] owningMethod : The owning method
+    * @param[in] sig : The class signature to be used to look for its sub type
+    * @param[in] len : The class signature length
+    *
+    * @return Resulting constraint
+    */
+   virtual TR::VPConstraint *createTypeHintConstraint(TR_ResolvedMethod *owningMethod, const char *sig, int32_t len);
+
    struct TR_TreeTopNodePair
       {
       TR_ALLOC(TR_Memory::ValuePropagation)


### PR DESCRIPTION
Type hint class is added to `VPClass` and `VPClassType`. It suggests
the value is LIKELY an exact type. It could be used along with
runtime checks on this speculation for other optimizations.

This change also adds the following APIs:
- Add `findLikelySubtype` to look for a likely sub type
  given a `TR_OpaqueClassBlock` pointer or a class signature.
- Add `createTypeHintConstraint` to create a constraint if
  a likely sub type for a given class signature is found

Co-Authored-By: Devin Papineau <devin@ajdmp.ca>
Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>