### PR TITLE
AArch64: Disable GRA for vector types

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -738,6 +738,28 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
    return TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&self()->comp()->target().cpu, opcode);
    }
 
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::Node *node)
+   {
+   return !node->getOpCode().isVectorOpCode();
+   }
+
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::DataType dt)
+   {
+   return !(dt.isVector() || dt.isMask());
+   }
+
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
+   {
+   if (symRef && symRef->getSymbol())
+      {
+      return considerTypeForGRA(symRef->getSymbol()->getDataType());
+      }
+   else
+      {
+      return true;
+      }
+   }
+
 bool
 OMR::ARM64::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddress, intptr_t sourceAddress)
    {

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -587,6 +587,10 @@ public:
 
    bool internalPointerSupportImplemented() {return true;}
 
+   bool considerTypeForGRA(TR::Node *node);
+   bool considerTypeForGRA(TR::DataType dt);
+   bool considerTypeForGRA(TR::SymbolReference *symRef);
+
    private:
 
    enum // flags


### PR DESCRIPTION
Disable GRA for vector and mask types.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>