### PR TITLE
AArch64: Handle unaligned immediate offset memory access case

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -558,6 +558,14 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
     */
    TR::Instruction *expandInstruction(TR::Instruction *currentInstruction, TR::CodeGenerator *cg);
 
+   /**
+    * @brief Validates the alignment of the immediate offset.
+    * @param[in] node: node
+    * @param[in] alignment: alignment in bytes
+    * @param[in] cg: CodeGenerator
+    */
+   void validateImmediateOffsetAlignment(TR::Node *node, uint32_t alignment, TR::CodeGenerator *cg);
+
    private:
 
    /**

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -4869,6 +4869,11 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, T
 
    node->setRegister(targetReg);
    TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node);
+   if (op == TR::InstOpCode::vldrimmq)
+      {
+      tempMR->validateImmediateOffsetAlignment(node, 16, cg);
+      }
+
    generateTrg1MemInstruction(cg, op, node, targetReg, tempMR);
 
    if (needSync)
@@ -4980,6 +4985,11 @@ OMR::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *c
 TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node);
+   if (op == TR::InstOpCode::vstrimmq)
+      {
+      tempMR->validateImmediateOffsetAlignment(node, 16, cg);
+      }
+
    bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    bool lazyVolatile = false;
    if (node->getSymbolReference()->getSymbol()->isShadow() &&


### PR DESCRIPTION
On aarch64, the immediate offset to the memory access must be the multiples of 16 when the size of access is 128-bit. This commit changes commonLoadEvaluator and commonStoreEvaluator to handle those cases manually.
In the longer term, MemoryReference class should take the size parameter and take it into acount when populating.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>