### PR TITLE
Z: Account for vector registers in bit masks for register assignment

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -491,6 +491,25 @@ OMR::Z::Machine::genBitMapOfAssignableGPRs()
    }
 
 /**
+ * @return a bit map identifying assignable vector regs as 1's.
+ */
+uint32_t
+OMR::Z::Machine::genBitMapOfAssignableVRFs()
+   {
+   uint32_t availRegMask = 0x0;
+
+   for (int32_t i = TR::RealRegister::FirstVRF; i <= TR::RealRegister::LastAssignableVRF; ++i)
+      {
+      if (_registerFile[i]->getState() != TR::RealRegister::Locked)
+         {
+         availRegMask |= _registerFile[i]->getRealRegisterMask();
+         }
+      }
+
+   return availRegMask;
+   }
+
+/**
  * @return a bit vector identifying live regs pairs as 1's.
  */
 uint8_t

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -200,6 +200,7 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
                                        uint64_t        availRegMask = 0x0000ffff);
 
    uint32_t genBitMapOfAssignableGPRs();
+   uint32_t genBitMapOfAssignableVRFs();
    uint8_t genBitVectOfLiveGPRPairs();
 
    TR::RealRegister* findBestSwapRegister(TR::Register* reg1, TR::Register* reg2);


### PR DESCRIPTION
- Add logic in `getRegMaskFromRange` and add `genBitMapOfAssignableVRFs` to account for vector registers when generating register bit masks
- Collect GPR/VRF specific logic to a single if-else statement in `handleLoadWithRegRanges`, cleaning up the `isVector ? ... : ...` idiom