### PR TITLE
Remove findOrFabricateFlattenedArrayElementFieldShadowSymbol

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1670,13 +1670,6 @@ OMR::SymbolReferenceTable::findOrCreateShadowSymbol(TR::ResolvedMethodSymbol * o
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrFabricateShadowSymbol(TR_OpaqueClassBlock *containingClass, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, const char * name, const char * signature)
-   {
-   TR_UNIMPLEMENTED();
-   return NULL;
-   }
-
-TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrFabricateFlattenedArrayElementFieldShadowSymbol(TR_OpaqueClassBlock *arrayComponentClass, TR::DataType type, uint32_t offset, bool isPrivate, const char * name, const char * signature)
    {
    TR_UNIMPLEMENTED();
    return NULL;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -678,26 +678,6 @@ class SymbolReferenceTable
     */
    TR::SymbolReference * findOrFabricateShadowSymbol(TR_OpaqueClassBlock *containingClass, TR::DataType type, uint32_t offset, bool isVolatile, bool isPrivate, bool isFinal, const char * name, const char * signature);
 
-   /** \brief
-    *     Returns an array shadow symbol reference fabricated for the field of a flattened array element.
-    *
-    *  \param arrayComponentClass
-    *     The array component class that contains the field.
-    *  \param type
-    *     The data type of the field.
-    *  \param fieldOffset
-    *     The offset of the field.
-    *  \param isPrivate
-    *     Specifies whether the field is private.
-    *  \param fieldName
-    *     The name of the field.
-    *  \param fieldSignature
-    *     The signature of the field.
-    *  \return
-    *     Returns an array shadow symbol reference fabricated for the field of a flattened array element.
-    */
-   TR::SymbolReference * findOrFabricateFlattenedArrayElementFieldShadowSymbol(TR_OpaqueClassBlock *arrayComponentClass, TR::DataType type, uint32_t fieldOffset, bool isPrivate, const char *fieldName, const char *fieldSignature);
-
    // --------------------------------------------------------------------------
    // OMR
    // --------------------------------------------------------------------------


### PR DESCRIPTION
`findOrFabricateFlattenedArrayElementFieldShadowSymbol` is not used in OMR

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>