### PR TITLE
Factor VP interface type signature detection logic into its own method

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7236,6 +7236,24 @@ bool OMR::ValuePropagation::transformDirectLoad(TR::Node *node)
    return TR::TransformUtil::transformDirectLoad(comp(), node);
    }
 
+bool OMR::ValuePropagation::isUnreliableSignatureType(
+   TR_OpaqueClassBlock *klass, TR_OpaqueClassBlock *&erased)
+   {
+   // TODO: Move this Java-specific logic into OpenJ9
+   erased = klass;
+   if (klass == NULL)
+      return false;
+
+   if (comp()->getOption(TR_TrustAllInterfaceTypeInfo))
+      return false;
+
+   if (!TR::Compiler->cls.isInterfaceClass(comp(), klass))
+      return false;
+
+   erased = NULL;
+   return true;
+   }
+
 bool OMR::ValuePropagation::checkAllUnsafeReferences(TR::Node *node, vcount_t visitCount)
    {
    if (node->getVisitCount() == visitCount)

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -588,6 +588,16 @@ class ValuePropagation : public TR::Optimization
    virtual void constrainRecognizedMethod(TR::Node *node);
    virtual bool transformDirectLoad(TR::Node *node);
 
+   /**
+    * \brief Determine whether a signature naming \p klass is unreliable.
+    *
+    * \param      klass  The type named in the signature.
+    * \param[out] erased The type, if any, that is reliably known.
+    * \return true if the signature is unreliable, and false otherwise.
+    */
+   virtual bool isUnreliableSignatureType(
+      TR_OpaqueClassBlock *klass, TR_OpaqueClassBlock *&erased);
+
    struct ObjCloneInfo {
       TR_ALLOC(TR_Memory::ValuePropagation)
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1819,13 +1819,9 @@ TR::Node *constrainAload(OMR::ValuePropagation *vp, TR::Node *node)
          if (sig)
             {
             TR_OpaqueClassBlock *classBlock = vp->fe()->getClassFromSignature(sig, len, symRef->getOwningMethod(vp->comp()));
-
-            if (  classBlock
-               && TR::Compiler->cls.isInterfaceClass(vp->comp(), classBlock)
-               && !vp->comp()->getOption(TR_TrustAllInterfaceTypeInfo))
-               {
-               classBlock = NULL;
-               }
+            TR_OpaqueClassBlock *erased = NULL;
+            if (vp->isUnreliableSignatureType(classBlock, erased))
+               classBlock = erased;
 
             if (classBlock)
                {
@@ -2611,13 +2607,9 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
       {
       TR_ResolvedMethod *method = node->getSymbolReference()->getOwningMethod(vp->comp());
       TR_OpaqueClassBlock *classBlock = vp->fe()->getClassFromSignature(sig, len, method);
-
-      if (  classBlock
-         && TR::Compiler->cls.isInterfaceClass(vp->comp(), classBlock)
-         && !vp->comp()->getOption(TR_TrustAllInterfaceTypeInfo))
-         {
-         classBlock = NULL;
-         }
+      TR_OpaqueClassBlock *erased = NULL;
+      if (vp->isUnreliableSignatureType(classBlock, erased))
+         classBlock = erased;
 
       if (classBlock)
          {


### PR DESCRIPTION
This facilitates moving the logic to OpenJ9, where it belongs, and also fixing it (to deal with array-of-interface types) in a single place.

----

Also:
- Delete the long-inactive `constrainBaseObjectOfIndirectAccess()`