### PR TITLE
Use CRIU technology term instead of vendor-specific product naming

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -872,16 +872,16 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_CTLDATA_VMEM_ADVISE_HUGEPAGE  "VMEM_ADVISE_HUGEPAGE"
 #define OMRPORT_CTLDATA_VMEM_PERFORM_FULL_MEMORY_SEARCH  "VMEM_PERFORM_FULL_SEARCH"
 #define OMRPORT_CTLDATA_VMEM_HUGE_PAGES_MMAP_ENABLED "VMEM_HUGE_PAGES_MMAP_ENABLED"
-#define OMRPORT_CTLDATA_INSTANTON_FLAGS "INSTANTON_FLAGS"
+#define OMRPORT_CTLDATA_CRIU_SUPPORT_FLAGS "CRIU_SUPPORT_FLAGS"
 
-/* InstantOn is enabled, a checkpoint could be taken
+/* CRIU support is enabled, a checkpoint could be taken
  * if current VM is not from a final restoration.
  */
-#define OMRPORT_INSTANTON_ENABLED  0x1
+#define OMRPORT_CRIU_SUPPORT_ENABLED  0x1
 /* Current VM is from a final restoration,
  * i.e., no more checkpoint is allowed.
  */
-#define OMRPORT_INSTANTON_FINAL_RESTORE  0x2
+#define OMRPORT_CRIU_SUPPORT_FINAL_RESTORE  0x2
 
 #define OMRPORT_FILE_READ_LOCK  1
 #define OMRPORT_FILE_WRITE_LOCK  2

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -319,12 +319,12 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		return 0;
 	}
 
-#if defined(PPG_instantOnFlags)
-	if (0 == strcmp(OMRPORT_CTLDATA_INSTANTON_FLAGS, key)) {
-		PPG_instantOnFlags = value;
+#if defined(PPG_criuSupportFlags)
+	if (0 == strcmp(OMRPORT_CTLDATA_CRIU_SUPPORT_FLAGS, key)) {
+		PPG_criuSupportFlags = value;
 		return 0;
 	}
-#endif /* defined(PPG_instantOnFlags) */
+#endif /* defined(PPG_criuSupportFlags) */
 
 	return 1;
 }

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -1430,11 +1430,11 @@ populateWithDefaultTokens(struct OMRPortLibrary *portLibrary, struct J9StringTok
 	 * socket connection, and cause a checkpoint failure.
 	 * - More details are at https://github.com/eclipse-openj9/openj9/issues/15800.
 	 */
-#if defined(PPG_instantOnFlags)
-	if (OMR_ARE_NO_BITS_SET(PPG_instantOnFlags, OMRPORT_INSTANTON_ENABLED)
-		|| OMR_ARE_ANY_BITS_SET(PPG_instantOnFlags, OMRPORT_INSTANTON_FINAL_RESTORE)
+#if defined(PPG_criuSupportFlags)
+	if (OMR_ARE_NO_BITS_SET(PPG_criuSupportFlags, OMRPORT_CRIU_SUPPORT_ENABLED)
+		|| OMR_ARE_ANY_BITS_SET(PPG_criuSupportFlags, OMRPORT_CRIU_SUPPORT_FINAL_RESTORE)
 	)
-#endif /* defined(PPG_instantOnFlags) */
+#endif /* defined(PPG_criuSupportFlags) */
 	{
 		statusCode = portLibrary->sysinfo_get_username(portLibrary, username, USERNAME_BUF_LEN);
 	}

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -3939,7 +3939,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	BOOLEAN runningInContainer = FALSE;
 #endif /* defined(LINUX) && !defined(OMRZTPF) */
 
-	PPG_instantOnFlags = 0;
+	PPG_criuSupportFlags = 0;
 	PPG_sysinfoControlFlags = 0;
 	/* Obtain and cache executable name; if this fails, executable name remains NULL, but
 	 * shouldn't cause failure to startup port library.  Failure will be noticed only

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -113,7 +113,7 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(AIXPPC)
 	int pageProtectionPossible;
 #endif
-	uintptr_t instantOnFlags;
+	uintptr_t criuSupportFlags;
 } OMRPortPlatformGlobals;
 
 
@@ -174,7 +174,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PAGE_PROTECTION_NOTCHECKED 2
 #endif
 
-#define PPG_instantOnFlags (portLibrary->portGlobals->platformGlobals.instantOnFlags)
+#define PPG_criuSupportFlags (portLibrary->portGlobals->platformGlobals.criuSupportFlags)
 
 #endif /* omrportpg_h */
 

--- a/port/zos390/omrportpg.h
+++ b/port/zos390/omrportpg.h
@@ -84,7 +84,7 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(OMR_ENV_DATA64)
 	char iptTtoken[TTOKEN_BUF_SZ];
 #endif /* defined(OMR_ENV_DATA64) */
-	uintptr_t instantOnFlags;
+	uintptr_t criuSupportFlags;
 } OMRPortPlatformGlobals;
 
 #define PPG_si_osType (portLibrary->portGlobals->platformGlobals.si_osType)
@@ -109,6 +109,6 @@ typedef struct OMRPortPlatformGlobals {
 
 #define PPG_stfleCache (portLibrary->portGlobals->platformGlobals.stfleCache)
 
-#define PPG_instantOnFlags (portLibrary->portGlobals->platformGlobals.instantOnFlags)
+#define PPG_criuSupportFlags (portLibrary->portGlobals->platformGlobals.criuSupportFlags)
 
 #endif /* omrportpg_h */


### PR DESCRIPTION
Use CRIU technology term instead of vendor-specific product naming

Replace `instantOn` with `criuSupport`.

Related https://github.com/eclipse/omr/pull/6796#issuecomment-1313996929

Signed-off-by: Jason Feng <fengj@ca.ibm.com>