### PR TITLE
Fix the data type of vector mask reduction node

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -342,6 +342,10 @@ public:
             TR::DataType dt = getVectorResultDataType(op);
             return TR::DataType::createMaskType(dt.getVectorElementType(), dt.getVectorLength());
             }
+         else if (opcode.isMaskReduction())
+            {
+            return _opCodeProperties[opcode.getTableIndex()].dataType;
+            }
          else
             {
             // scalar result type (e.g. reduction)

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -154,7 +154,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::MaskReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::Int64, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::Size_8 | ILTypeProp::Integer, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -170,7 +170,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::MaskReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::Int64, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::Size_8 | ILTypeProp::Integer, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -186,7 +186,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::MaskReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::Int64, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::Size_8 | ILTypeProp::Integer, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -202,7 +202,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::MaskReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::Int64, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::Size_8 | ILTypeProp::Integer, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \


### PR DESCRIPTION
Return the correct value for the `getDataType` query when the node has mask reduction opcode.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>