### PR TITLE
Move SimplifierTable opcode macros to table instead of enum file

### DIFF
--- a/compiler/optimizer/OMRSimplifier.cpp
+++ b/compiler/optimizer/OMRSimplifier.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 #include "optimizer/Simplifier.hpp"
 
 #include "optimizer/OMRSimplifierHelpers.hpp"
-#include "optimizer/OMRSimplifierHandlers.hpp"
+#include "optimizer/SimplifierHandlers.hpp"
 #include "optimizer/SimplifierTable.hpp"
 
 #include <limits.h>

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,7 @@
 #define OMR_SIMPLIFIERHANDLERS_INCL
 
 #include "optimizer/OMRSimplifierHelpers.hpp"
-#include "optimizer/OMRSimplifierHandlers.hpp"
+#include "optimizer/SimplifierHandlers.hpp"
 
 #include <limits.h>
 #include <math.h>

--- a/compiler/optimizer/OMRSimplifierTable.enum
+++ b/compiler/optimizer/OMRSimplifierTable.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -656,48 +656,5 @@
 #define ibitpermuteSimplifierHandler dftSimplifier
 #define lbitpermuteSimplifierHandler dftSimplifier
 #define PrefetchSimplifierHandler dftSimplifier
-
-#define OPCODE_MACRO(\
-   opcode, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) opcode ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-#include "il/Opcodes.enum"
-
-#define VECTOR_OPERATION_MACRO(\
-   operation, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) operation ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-#include "il/VectorOperations.enum"
-
-#undef OPCODE_MACRO
-#undef VECTOR_OPERATION_MACRO
 
 #endif

--- a/compiler/optimizer/SimplifierHandlers.hpp
+++ b/compiler/optimizer/SimplifierHandlers.hpp
@@ -19,62 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef SIMPLIFIERTABLE_INCL
-#define SIMPLIFIERTABLE_INCL
+#ifndef SIMPLIFIERHANDLERS_INCL
+#define SIMPLIFIERHANDLERS_INCL
 
-namespace TR { class Block; }
-namespace TR { class Node; }
-namespace TR { class Simplifier; }
-
-#include "optimizer/SimplifierHandlers.hpp"
-
-const SimplifierPointerTable simplifierOpts;
-
-const SimplifierPtr SimplifierPointerTable::table[] =
-   {
-   #include "optimizer/SimplifierTable.enum"
-#define OPCODE_MACRO(\
-   opcode, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) opcode ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-   #include "il/Opcodes.enum"
-
-#define VECTOR_OPERATION_MACRO(\
-   operation, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) operation ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-   #include "il/VectorOperations.enum"
-
-#undef OPCODE_MACRO
-#undef VECTOR_OPERATION_MACRO
-   };
+#include "optimizer/OMRSimplifierHandlers.hpp"
 
 #endif

--- a/compiler/optimizer/SimplifierTable.enum
+++ b/compiler/optimizer/SimplifierTable.enum
@@ -19,62 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef SIMPLIFIERTABLE_INCL
-#define SIMPLIFIERTABLE_INCL
+#ifndef SIMPLIFIERTABLE_ENUM_INCL
+#define SIMPLIFIERTABLE_ENUM_INCL
 
-namespace TR { class Block; }
-namespace TR { class Node; }
-namespace TR { class Simplifier; }
-
-#include "optimizer/SimplifierHandlers.hpp"
-
-const SimplifierPointerTable simplifierOpts;
-
-const SimplifierPtr SimplifierPointerTable::table[] =
-   {
-   #include "optimizer/SimplifierTable.enum"
-#define OPCODE_MACRO(\
-   opcode, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) opcode ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-   #include "il/Opcodes.enum"
-
-#define VECTOR_OPERATION_MACRO(\
-   operation, \
-   name, \
-   prop1, \
-   prop2, \
-   prop3, \
-   prop4, \
-   dataType, \
-   typeProps, \
-   childProps, \
-   swapChildrenOpcode, \
-   reverseBranchOpcode, \
-   boolCompareOpcode, \
-   ifCompareOpcode, \
-   ...) operation ## SimplifierHandler,
-
-   BadILOpSimplifierHandler,
-
-   #include "il/VectorOperations.enum"
-
-#undef OPCODE_MACRO
-#undef VECTOR_OPERATION_MACRO
-   };
+#include "optimizer/OMRSimplifierTable.enum"
 
 #endif


### PR DESCRIPTION
Allows projects to map a different/project-specific simplifier handler function for common IL opcodes (i.e., for opcodes that are defined in OMR, not just at the project level). 