### PR TITLE
Remove Java-specific interface signature logic from VP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7239,19 +7239,8 @@ bool OMR::ValuePropagation::transformDirectLoad(TR::Node *node)
 bool OMR::ValuePropagation::isUnreliableSignatureType(
    TR_OpaqueClassBlock *klass, TR_OpaqueClassBlock *&erased)
    {
-   // TODO: Move this Java-specific logic into OpenJ9
    erased = klass;
-   if (klass == NULL)
-      return false;
-
-   if (comp()->getOption(TR_TrustAllInterfaceTypeInfo))
-      return false;
-
-   if (!TR::Compiler->cls.isInterfaceClass(comp(), klass))
-      return false;
-
-   erased = NULL;
-   return true;
+   return false;
    }
 
 bool OMR::ValuePropagation::checkAllUnsafeReferences(TR::Node *node, vcount_t visitCount)


### PR DESCRIPTION
It has been moved into OpenJ9.