### PR TITLE
We do not need disableOSRGuardsMerging to enforceVectorAPIExpansion

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1881,7 +1881,6 @@ OMR::Options::Options(
    // Vector API, clean up is needed once we have resolved all workarounds.
    if (self()->getOption(TR_EnforceVectorAPIExpansion))
       {
-      self()->setOption(TR_DisableOSRGuardMerging);
       self()->setOption(TR_ProcessHugeMethods);
       optimizationPlan->setOptLevel(scorching);
       }


### PR DESCRIPTION
Since we have made improvements to allow marking guards for the Vector JEP method does not kill fear, we no longer need to disable merging of OSR guards to enforce Vector API Expansion. Remove setting that option.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>