### PR TITLE
GC Thread Pool Tuning for CRIU

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,6 +125,27 @@ public:
 	virtual void defaultMemorySpaceAllocated(MM_GCExtensionsBase* extensions, void* defaultMemorySpace);
 
 	virtual void kill(MM_EnvironmentBase* env);
+
+	/* Number of GC threads supported based on hardware and dispatcher's max. */
+	virtual uintptr_t supportedGCThreadCount(MM_EnvironmentBase* env);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Shutdown GC threads on checkpoint.
+	 *
+	 * @param[in] env the current environment
+	 * @return void
+	 */
+	virtual void adjustGCThreadCountOnCheckpoint(MM_EnvironmentBase* env);
+
+	/**
+	 * Startup GC threads on restore.
+	 *
+	 * @param[in] env the current environment
+	 * @return void
+	 */
+	virtual bool reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_Configuration(MM_EnvironmentBase* env, MM_GCPolicy gcPolicy, MM_AlignmentType alignmentType, uintptr_t defaultRegionSize, uintptr_t defaultArrayletLeafSize, MM_GCWriteBarrierType writeBarrierType, MM_GCAllocationType allocationType)
 		: MM_BaseVirtual()

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -616,6 +616,10 @@ public:
 
 	MM_ParallelDispatcher* dispatcher;
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	uintptr_t checkpointGCthreadCount;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_CardTable* cardTable;
 
 	/* Begin command line options temporary home */
@@ -1773,6 +1777,9 @@ public:
 		, fvtest_forceCardTableDecommitFailure(0)
 		, fvtest_forceCardTableDecommitFailureCounter(0)
 		, dispatcher(NULL)
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		, checkpointGCthreadCount(4)
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 		, cardTable(NULL)
 		, memoryMax(0)
 		, initialMemorySize(0)

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,7 @@
 
 #include "Collector.hpp"
 #include "CollectorLanguageInterfaceImpl.hpp"
+#include "Configuration.hpp"
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "Heap.hpp"
@@ -259,6 +260,11 @@ MM_ParallelDispatcher::initialize(MM_EnvironmentBase *env)
 	OMR::GC::Forge *forge = env->getForge();
 
 	_threadCountMaximum = env->getExtensions()->gcThreadCount;
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	_threadCountMaximumAtCheckpointStartup = _threadCountMaximum;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	Assert_MM_true(0 < _threadCountMaximum);
 
 	if(omrthread_monitor_init_with_name(&_workerThreadMutex, 0, "MM_ParallelDispatcher::workerThread")
@@ -295,24 +301,39 @@ error_no_memory:
 bool
 MM_ParallelDispatcher::startUpThreads()
 {
+	_threadShutdownCount = 0;
+
+	/* The main thread may concurrently start at the same time. */
+	uintptr_t workerThreadCount = useSeparateMainThread() ? 0 : 1;
+
+	bool result = internalStartupThreads(workerThreadCount, _threadCountMaximum);
+
+	if (result) {
+		_threadCount = _threadCountMaximum;
+		_activeThreadCount = adjustThreadCount(_threadCount);
+	}
+
+	return result;
+}
+
+bool
+MM_ParallelDispatcher::internalStartupThreads(uintptr_t workerThreadCount, uintptr_t maxWorkerThreadIndex)
+{
 	intptr_t threadForkResult;
-	uintptr_t workerThreadCount;
 	workerThreadInfo workerInfo;
 
 	/* Fork the worker threads */
 	workerInfo.omrVM = _extensions->getOmrVM();
 	workerInfo.dispatcher = this;
 
-	_threadShutdownCount = 0;
-
 	omrthread_monitor_enter(_dispatcherMonitor);
 
-	/* We may be starting the main thread at this point too */
-	workerThreadCount = useSeparateMainThread() ? 0 : 1;
-	
-	while (workerThreadCount < _threadCountMaximum) {
+	while (workerThreadCount < maxWorkerThreadIndex) {
 		workerInfo.workerFlags = 0;
 		workerInfo.workerID = workerThreadCount;
+
+		Assert_MM_true(NULL == _threadTable[workerThreadCount]);
+		Assert_MM_true(worker_status_inactive == _statusTable[workerThreadCount]);
 
 		threadForkResult =
 			createThreadWithCategory(
@@ -343,18 +364,14 @@ MM_ParallelDispatcher::startUpThreads()
 	}
 	omrthread_monitor_exit(_dispatcherMonitor);
 
-	_threadCount = _threadCountMaximum;
-	
-	_activeThreadCount = adjustThreadCount(_threadCount);
-
 	return true;
 
 error:
 	/* exit from monitor */
 	omrthread_monitor_exit(_dispatcherMonitor);
 
-	/* Clean up the thread table and monitors */
-	shutDownThreads();
+	Trc_MM_ParallelDispatcher_internalStartupThreads_Failed(workerThreadCount, maxWorkerThreadIndex, _threadShutdownCount);
+
 	return false;
 }
 
@@ -375,7 +392,7 @@ MM_ParallelDispatcher::shutDownThreads()
 	}
 
 	/* Set the worker thread mode to dying */
-	for(uintptr_t index=0; index < _threadCountMaximum; index++) {
+	for (uintptr_t index=0; index < _threadCountMaximum; index++) {
 		_statusTable[index] = worker_status_dying;
 	}
 
@@ -464,7 +481,7 @@ MM_ParallelDispatcher::recomputeActiveThreadCountForTask(MM_EnvironmentBase *env
 	 *  2) Adaptive threading flag is not set (-XX:-AdaptiveGCThreading)
 	 *  3) or simply the task wasn't recommended a thread count (currently only recommended for STW Scavenge Tasks)
 	 */
-	if (task->getRecommendedWorkingThreads() != UDATA_MAX) {
+	if (UDATA_MAX != task->getRecommendedWorkingThreads()) {
 		/* Bound the recommended thread count. Determine the  upper bound for the thread count,
 		 * This will either be the user specified gcMaxThreadCount (-XgcmaxthreadsN) or else default max
 		 */
@@ -630,3 +647,114 @@ MM_ParallelDispatcher::reinitAfterFork(MM_EnvironmentBase *env, uintptr_t newThr
 
 	startUpThreads();
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void
+MM_ParallelDispatcher::contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount)
+{
+	Assert_MM_false(_workerThreadsReservedForGC);
+	Assert_MM_false(_inShutdown);
+
+	Assert_MM_true(_threadShutdownCount == (_threadCountMaximumAtCheckpointStartup - 1));
+	Assert_MM_true(_threadCountMaximum == _extensions->gcThreadCount);
+	Assert_MM_true(_threadCountMaximum == _threadCountMaximumAtCheckpointStartup);
+
+	uintptr_t preShutdownThreadCount = _extensions->gcThreadCount;
+
+	Trc_MM_ParallelDispatcher_contractThreadPool_Entry(preShutdownThreadCount, newThreadCount);
+
+	/* The main thread can't shutdown since the dispatcher didn't start it. */
+	if (0 == newThreadCount) {
+		newThreadCount = 1;
+	}
+
+	if (newThreadCount < _threadCountMaximum) {
+		Trc_MM_ParallelDispatcher_contractThreadPool_Attempt();
+
+		omrthread_monitor_enter(_workerThreadMutex);
+
+		_inShutdown = true;
+
+		/* Clip the thread pool past newThreadCount. */
+		for (uintptr_t index = newThreadCount; index < _threadCountMaximum; index++) {
+			_statusTable[index] = worker_status_dying;
+		}
+
+		omrthread_monitor_notify_all(_workerThreadMutex);
+
+		omrthread_monitor_exit(_workerThreadMutex);
+
+		uintptr_t expectedThreadShutdownThread = newThreadCount - 1;
+
+		omrthread_monitor_enter(_dispatcherMonitor);
+		while (expectedThreadShutdownThread != _threadShutdownCount) {
+			omrthread_monitor_wait(_dispatcherMonitor);
+		}
+		omrthread_monitor_exit(_dispatcherMonitor);
+
+		/* Cleanup the dispatcher tables. */
+		for (uintptr_t index = newThreadCount; index < _threadCountMaximum; index++) {
+			Assert_MM_true(worker_status_dying == _statusTable[index]);
+			_statusTable[index] = worker_status_inactive;
+			_threadTable[index] = NULL;
+		}
+
+		Assert_MM_true(_threadShutdownCount == expectedThreadShutdownThread);
+
+		_extensions->gcThreadCount = newThreadCount;
+		_activeThreadCount = newThreadCount;
+		_threadCount = newThreadCount;
+		_threadCountMaximum = newThreadCount;
+
+		_inShutdown = false;
+
+		Trc_MM_ParallelDispatcher_contractThreadPool_Success(preShutdownThreadCount, newThreadCount);
+	}
+
+	Trc_MM_ParallelDispatcher_contractThreadPool_Exit(_extensions->gcThreadCount);
+}
+
+bool
+MM_ParallelDispatcher::expandThreadPool(MM_EnvironmentBase *env)
+{
+	Trc_MM_ParallelDispatcher_expandThreadPool_Entry();
+
+	Assert_MM_false(_workerThreadsReservedForGC);
+	Assert_MM_false(_inShutdown);
+
+	Assert_MM_true(_threadShutdownCount == (_threadCountMaximum - 1));
+	Assert_MM_true(_threadCountMaximum == _extensions->gcThreadCount);
+
+	bool result = true;
+
+	uintptr_t supportedGCThreadCount = _extensions->configuration->supportedGCThreadCount(env);
+	uintptr_t preExpandThreadCount = _extensions->gcThreadCount;
+	uintptr_t newThreadCount = OMR_MIN(_threadCountMaximumAtCheckpointStartup, supportedGCThreadCount);
+
+	Trc_MM_ParallelDispatcher_expandThreadPool_params(
+			newThreadCount, _threadCountMaximumAtCheckpointStartup,
+			supportedGCThreadCount, preExpandThreadCount);
+
+	if (newThreadCount > preExpandThreadCount) {
+
+		result = internalStartupThreads(preExpandThreadCount, newThreadCount);
+
+		if (result) {
+			Assert_MM_true(_threadShutdownCount == (newThreadCount - 1));
+		} else {
+			/* Infer from _threadShutdownCount to determine the number of threads that started up prior to failing.  */
+			newThreadCount = _threadShutdownCount + 1;
+		}
+
+		_extensions->gcThreadCount = newThreadCount;
+		_threadCount = newThreadCount;
+		_threadCountMaximum = newThreadCount;
+	}
+
+	_activeThreadCount = adjustThreadCount(_threadCount);
+
+	Trc_MM_ParallelDispatcher_expandThreadPool_Exit(preExpandThreadCount, _extensions->gcThreadCount, _threadShutdownCount);
+
+	return result;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,8 +83,11 @@ protected:
 	void* _handler_arg;
 	uintptr_t _defaultOSStackSize; /**< default OS stack size */
 
-public:
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	uintptr_t _threadCountMaximumAtCheckpointStartup;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
+public:
 	/*
 	 * Function members
 	 */
@@ -116,9 +119,53 @@ protected:
 	
 	uintptr_t adjustThreadCount(uintptr_t maxThreadCount);
 	
+	/**
+	 * Main routine to fork and startup GC threads.
+	 *
+	 * @param[in] workerThreadCount the thread pool index to start at.
+	 * @param[in] maxWorkerThreadIndex the max thread pool index.
+	 * @return boolean indicating if threads started up successfully.
+	 */
+	virtual bool internalStartupThreads(uintptr_t workerThreadCount, uintptr_t maxWorkerThreadIndex);
+
 public:
 	virtual bool startUpThreads();
 	virtual void shutDownThreads();
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Expand/fill the thread pool by starting up threads based on what H/W supports.
+	 * This API is capped by the initial thread pool size, i.e expanding
+	 * past _threadCountMaximumAtCheckpointStartup is not possible
+	 * (expanding the dispatcher tables is currently not supported).
+	 *
+	 * This API assumes CRIU is the only consumer (not tested for general use).
+	 * The following conditions are required while expanding the thread pool:
+	 *     1) Caller is NOT holding exclusive VM access.
+	 *     2) Dispatcher is idle (no task can be dispatched).
+	 *     3) Dispatcher can't be in/enter shutdown.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if threads started up successfully.
+	 */
+	virtual bool expandThreadPool(MM_EnvironmentBase *env);
+
+	/**
+	 * Contract the thread pool by shutting down threads in the pool to obtain newThreadCount.
+	 *
+	 * This API assumes  CRIU is the only consumer (not tested for general use).
+	 * The following conditions are assumed while contracting the thread pool:
+	 *     1) API can only be called once during VM lifetime.
+	 *     2) Caller is NOT holding exclusive VM access.
+	 *     3) Dispatcher is idle (no task can be dispatched).
+	 *     4) Another party can't enter Dispatcher shutdown.
+	 *
+	 * @param[in] env the current environment.
+	 * @param[in] newThreadCount the number of threads to keep in the thread pool.
+	 * @return void
+	 */
+	virtual void contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	virtual bool condYieldFromGCWrapper(MM_EnvironmentBase *env, uint64_t timeSlack = 0) { return false; }
 	
@@ -158,6 +205,9 @@ public:
 		,_handler(handler)
 		,_handler_arg(handler_arg)
 		,_defaultOSStackSize(defaultOSStackSize)
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+		,_threadCountMaximumAtCheckpointStartup(0)
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1005,3 +1005,14 @@ TraceExit=Trc_MM_getSparseAddressAndDecommitLeaves_Exit Overhead=1 Level=3 Group
 
 TraceEntry=Trc_MM_DoFixHeapForCompact_Entry Overhead=1 Level=1 Template="Trc_MM_DoFixHeapForCompact Entry with walkflags: %zx and walkReason: %zx"
 TraceExit=Trc_MM_DoFixHeapForCompact_Exit Overhead=1 Level=1 Template="Trc_MM_DoFixHeapForCompact Exit after fixing up %zu objects"
+
+TraceEntry=Trc_MM_ParallelDispatcher_expandThreadPool_Entry noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool Entry"
+TraceEvent=Trc_MM_ParallelDispatcher_expandThreadPool_params noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool_params: newThreadCount: %zu, _threadCountMaximumAtCheckpointStartup: %zu, supportedGCThreadCount: %zu, preExpandThreadCount: %zu"
+TraceExit=Trc_MM_ParallelDispatcher_expandThreadPool_Exit noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool Exit: preExpandThreadCount: %zu, gcThreadCount: %zu, _threadShutdownCount: %zu"
+
+TraceEntry=Trc_MM_ParallelDispatcher_contractThreadPool_Entry noEnv Overhead=1 Level=1 Group=dispatcher Template="contractThreadPool Entry: gcThreadCount: %zu, requested newThreadCount: %zu"
+TraceEvent=Trc_MM_ParallelDispatcher_contractThreadPool_Attempt noEnv Overhead=1 Level=1 Group=dispatcher Template="Attempt to shutdown GC threads"
+TraceEvent=Trc_MM_ParallelDispatcher_contractThreadPool_Success noEnv Overhead=1 Level=1 Group=dispatcher Template="Successfully shutdown GC threads: %zu -> %zu"
+TraceExit=Trc_MM_ParallelDispatcher_contractThreadPool_Exit noEnv Overhead=1 Level=1 Group=dispatcher Template="contractThreadPool Exit: gcThreadCount: %zu"
+
+TraceException=Trc_MM_ParallelDispatcher_internalStartupThreads_Failed noEnv Overhead=1 Level=1 Group=dispatcher Template="Failed to startup threads: workerThreadCount: %zu, maxWorkerThreadIndex: %zu, _threadShutdownCount: %zu"

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,6 +54,17 @@ public:
 
 	virtual void defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void* defaultMemorySpace);
 	
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Startup GC threads on restore.
+	 *
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	virtual bool reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_ConfigurationGenerational(MM_EnvironmentBase *env)
 		: MM_ConfigurationStandard(env, gc_policy_gencon, calculateDefaultRegionSize(env))
 	{
@@ -64,8 +75,25 @@ protected:
 	bool initialize(MM_EnvironmentBase* env);
 	MM_MemorySubSpaceSemiSpace *createSemiSpace(MM_EnvironmentBase *envBase, MM_Heap *heap, MM_Scavenger *scavenger, MM_InitializationParameters *parameters, UDATA numaNode = UDATA_MAX);
 	virtual void tearDown(MM_EnvironmentBase* env);
+	/**
+	 * Sets the number of GC threads.
+	 *
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
 private:
 	uintptr_t calculateDefaultRegionSize(MM_EnvironmentBase *env);
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/**
+	 * Sets the number of GC threads for Concurrent Scavenger.
+	 *
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	void initializeConcurrentScavengerThreadCount(MM_EnvironmentBase* env);
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 };
 
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,26 +97,6 @@ MM_ConfigurationStandard::initialize(MM_EnvironmentBase* env)
 
 	return result;
 }
-
-
-void
-MM_ConfigurationStandard::initializeGCThreadCount(MM_EnvironmentBase* env)
-{
-
-	MM_Configuration::initializeGCThreadCount(env);
-
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	MM_GCExtensionsBase* extensions = env->getExtensions();
-
-	/* If not explicitly set, concurrent phase of CS runs with approx 1/4 the thread count (relative to STW phases thread count */
-	if (!extensions->concurrentScavengerBackgroundThreadsForced) {
-		extensions->concurrentScavengerBackgroundThreads = OMR_MAX(1, (extensions->gcThreadCount + 1) / 4);
-	} else if (extensions->concurrentScavengerBackgroundThreads > extensions->gcThreadCount) {
-		extensions->concurrentScavengerBackgroundThreads = extensions->gcThreadCount;
-	}
-#endif
-}
-
 
 /**
  * Create the global collector for a Standard configuration

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,13 +74,6 @@ public:
 protected:
 	virtual bool initialize(MM_EnvironmentBase* env);
 	virtual MM_EnvironmentBase* allocateNewEnvironment(MM_GCExtensionsBase* extensions, OMR_VMThread* omrVMThread);
-	
-	/**
-	 * Sets the number of gc threads
-	 *
-	 * @param env[in] - the current environment
-	 */
-	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
 
 private:
 	static MM_GCWriteBarrierType getWriteBarrierType(MM_EnvironmentBase* env)

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -600,6 +600,13 @@ public:
 	 */
 	void calculateRecommendedWorkingThreads(MM_EnvironmentStandard *env);
 
+	/**
+	 * Sets the collector recommended thread count to UDATA_MAX (default value).
+	 *
+	 * @return void
+	 */
+	void resetRecommendedThreads() { _recommendedThreads = UDATA_MAX; };
+
 	void scavenge(MM_EnvironmentBase *env);
 	bool scavengeCompletedSuccessfully(MM_EnvironmentStandard *env);
 	virtual	void mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool initMarkMap = false, bool rebuildMarkBits = false);


### PR DESCRIPTION
These changes aim to optimize/tune GC threading footprint observed when using CRIU (Checkpoint/Restore) capabilities. Tests have shown excessive number of GC threads to have a significant impact on checkpoint image footprint and restore times. Contracting the GC thread pool during the checkpoint phase and expanding it during restore phase has shown to be a better strategy.

These changes introduce APIs to adjust the size of the GC (dispatcher) thread pool and make adjustments to dependent parties consuming the thread count:
- Introduced `contractThreadPool` (to shutdownThreads for checkpoint) and expandThreadPool (to startupThreads for restore)
- Introduced `checkpointGCthreadCount` in extensions (user adjustable via cmd line opts), consumed to contract thread pool.
- Refactored and introduced `supportedGCThreadCount` API to return number of GC threads supported based on hardware and dispatcher's max
- `_threadCountMaximumAtCheckpointStartup` introduced in dispatcher to take snapshot of initial thread pool size, this is used as hard cap on # of threads during restore.
- Exisiting `startupThreads()` main routine refactored into `internalStartupThreads` for reusability with expandThreadPool.
- New MM Trace Point introduced to log `contractThreadPool` and `expandThreadPool`, all trc points configured as `noEnv Overhead=1 Level=1 Group=dispatcher`
- Introduced  `adjustGCThreadCountOnCheckpoint` & `reinitializeGCThreadCountOnRestore` in `MM_Configuration` as general high level entry point to coordinate  checkpoint/restore between GC subcomponents
  - Overide `reinitializeGCThreadCountOnRestore` for `MM_ConfigurationGenerational` to make Scavenger specific adjustments on thread count change.

Signed-off-by: Salman Rana <salman.rana@ibm.com>