### PR TITLE
AArch64: Enable vbitselect opcode for all element types

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -678,6 +678,7 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vmcmple:
       case TR::vmcmplt:
       case TR::vmcmpne:
+      case TR::vbitselect:
          return true;
       case TR::vand:
       case TR::vor:
@@ -689,7 +690,6 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vmreductionOr:
       case TR::vreductionXor:
       case TR::vmreductionXor:
-      case TR::vbitselect:
       case TR::vmand:
       case TR::vmor:
       case TR::vmxor:

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -3061,11 +3061,9 @@ OMR::ARM64::TreeEvaluator::vbitselectEvaluator(TR::Node *node, TR::CodeGenerator
       case TR::Int16:
       case TR::Int32:
       case TR::Int64:
-         break;
       case TR::Float:
       case TR::Double:
-         TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s", node->getFirstChild()->getDataType().toString());
-         return NULL;
+         break;
       default:
          TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getFirstChild()->getDataType().toString());
          return NULL;
@@ -3091,7 +3089,7 @@ OMR::ARM64::TreeEvaluator::vbitselectEvaluator(TR::Node *node, TR::CodeGenerator
       }
 
    /*
-    * vbitselect extracts bits from the first operand if the corresponding bit of the third operand is 1,
+    * vbitselect extracts bits from the first operand if the corresponding bit of the third operand is 0,
     * otherwise from the second operand.
     */
    generateTrg1Src2Instruction(cg, TR::InstOpCode::vbsl16b, node, targetReg, secondReg, firstReg);


### PR DESCRIPTION
Enable `vbitselect` for all vector types.
`vbitselect` is a kind of masked operations which takes the third argument as a mask.
We can apply it to vectors with float or double elements in addition to vectors with integer elements.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>