### PR TITLE
Use LDE to load single precision floating point values

### DIFF
--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -618,8 +618,7 @@ floadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * srcMR
       tempMR = TR::MemoryReference::create(cg, node);
       //traceMsg(cg->comp(), "Generated memory reference %p for node %p with offset %d",tempMR,node,tempMR->getOffset());
       }
-
-   generateRXInstruction(cg, TR::InstOpCode::LE, node, tempReg, tempMR);
+   generateRXEInstruction(cg, TR::InstOpCode::LDE, node, tempReg, tempMR);
    tempMR->stopUsingMemRefRegister(cg);
    return tempReg;
    }
@@ -645,7 +644,7 @@ OMR::Z::TreeEvaluator::fconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * targetReg = cg->allocateRegister(TR_FPR);
    float value = node->getFloat();
 
-   generateS390ImmOp(cg, TR::InstOpCode::LE, node, targetReg, value);
+   generateS390ImmOp(cg, TR::InstOpCode::LDE, node, targetReg, value);
    node->setRegister(targetReg);
    return targetReg;
    }
@@ -1074,7 +1073,7 @@ OMR::Z::TreeEvaluator::ibits2fEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       TR::MemoryReference * tempMR = generateS390MemoryReference(node, i2fSR, cg);
       TR::MemoryReference * tempMR1 = generateS390MemoryReference(node, i2fSR, cg);
       generateRXInstruction(cg, TR::InstOpCode::ST, node, sourceReg, tempMR);
-      generateRXInstruction(cg, TR::InstOpCode::LE, node, targetReg, tempMR1);
+      generateRXEInstruction(cg, TR::InstOpCode::LDE, node, targetReg, tempMR1);
       }
    node->setRegister(targetReg);
    cg->decReferenceCount(firstChild);

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -1007,8 +1007,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
             case TR::Float:
                if (freeScratchable.isSet(ai))
                   {
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getRealRegister(REGNUM(ai)),
-                              generateS390MemoryReference(stackPtr, offset, self()->cg()), (TR::Instruction *) cursor);
+                  cursor = generateRXEInstruction(self()->cg(), TR::InstOpCode::LDE, firstNode, self()->getRealRegister(REGNUM(ai)),
+                              generateS390MemoryReference(stackPtr, offset, self()->cg()), 0, static_cast<TR::Instruction *>(cursor));
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
 
                   freeScratchable.reset(ai);
@@ -1101,8 +1101,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   break;
                   }
                case 3: // Floats
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getRealRegister(REGNUM(target)),
-                              generateS390MemoryReference(stackPtr, source, self()->cg()), (TR::Instruction *) cursor);
+                  cursor = generateRXEInstruction(self()->cg(), TR::InstOpCode::LDE, firstNode, self()->getRealRegister(REGNUM(target)),
+                              generateS390MemoryReference(stackPtr, source, self()->cg()), 0, static_cast<TR::Instruction *>(cursor));
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   break;
                case 4:  // Doubles

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -2451,6 +2451,7 @@ OMR::Z::MemoryReference::needsAdjustDisp(TR::Instruction * instr, OMR::Z::Memory
       opCode == TR::InstOpCode::CE ||
       opCode == TR::InstOpCode::DE ||
       opCode == TR::InstOpCode::LE ||
+      opCode == TR::InstOpCode::LDE ||
       opCode == TR::InstOpCode::MEEB ||
       opCode == TR::InstOpCode::MAEB ||
       opCode == TR::InstOpCode::SEB ||

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -2453,7 +2453,7 @@ generateLoad32BitConstant(TR::CodeGenerator * cg, TR::Node * constExpr)
          }
       case TR::Float:
          tempReg = cg->allocateRegister(TR_FPR);
-         generateRegLitRefInstruction(cg, TR::InstOpCode::LE, constExpr, tempReg, constExpr->getFloat());
+         generateRegLitRefInstruction(cg, TR::InstOpCode::LDE, constExpr, tempReg, constExpr->getFloat());
          break;
       case TR::Double:
          tempReg = cg->allocateRegister(TR_FPR);

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2635,7 +2635,13 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    {
 
    TR::MemoryReference * dataref = generateS390MemoryReference(imm, TR::Float, cg, node);
-   return generateRXInstruction(cg, op, node, treg, dataref);
+   auto instructionFormat = TR::InstOpCode(op).getInstructionFormat();
+   TR::Instruction *instr = NULL;
+   if (instructionFormat == RXE_FORMAT)
+      instr = generateRXEInstruction(cg, op, node, treg, dataref);
+   else
+      instr = generateRXInstruction(cg, op, node, treg, dataref);
+   return instr;
    }
 
 /**

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -365,7 +365,7 @@ TR::Instruction * generateRXEInstruction(
                    TR::Node                *n,
                    TR::Register            *treg,
                    TR::MemoryReference *mf,
-                   uint8_t                mask3,
+                   uint8_t                mask3 = 0,
                    TR::Instruction     *preced = 0);
 
 TR::Instruction * generateRXFInstruction(

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -3192,9 +3192,16 @@ TR::S390RXEInstruction::generateBinaryEncoding()
 
    cursor += (getOpCode().getInstructionLength());
 
+   // Finish patching up if long disp was needed
+   int32_t longDispTouchUpPadding = 0;
+   if (getMemoryReference() != NULL)
+      {
+      longDispTouchUpPadding = getMemoryReference()->generateBinaryEncodingTouchUpForLongDisp(cursor, cg(), this);
+      }
+
    setBinaryLength(cursor - instructionStart);
    setBinaryEncoding(instructionStart);
-   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength() - padding);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength() - padding - longDispTouchUpPadding);
 
    return cursor;
    }


### PR DESCRIPTION
LE instruction on IBM Z loads single precision floating values into the FPR register. In certain scenarios this operation may perform poorly espcecially in case of Write after Read or Write after Write scenario where hardware may not be able to break the dependency chain. In such scenarios, using LDE instruction to load from memory would help. This commit replaces the use of LE instruction with LDE.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>