### PR TITLE
Expose a new limitOption for OpenJ9

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -463,6 +463,7 @@ public:
    virtual char *          limitfileOption(char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr = 0);
    virtual char *          inlinefileOption(char *, void *, TR::OptionTable *, TR::Options *);
    virtual char *          limitOption(char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit);
+   char *                  limitOption(char *, void *, TR::OptionTable *, TR::Options *, TR::CompilationFilters * &);
    virtual int32_t *       loadCustomStrategy(char *optFileName);
    virtual bool            methodCanBeCompiled(TR_Memory *mem, TR_ResolvedMethod *, TR_FilterBST * &);
    virtual bool            methodCanBeRelocated(TR_Memory *mem, TR_ResolvedMethod *, TR_FilterBST * &);

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -612,12 +612,12 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
    }
 
 char *
-TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit)
+TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, TR::CompilationFilters *&filters)
    {
    char *p = option;
 
-   // this use the old interface
-   TR_FilterBST *filter = addFilter(p, static_cast<int32_t>(entry->parm1), 0, 0, loadLimit);
+   filters = findOrCreateFilters(filters);
+   TR_FilterBST *filter = addFilter(p, static_cast<int32_t>(entry->parm1), 0, 0, filters);
 
    if (!filter)
       return option;
@@ -680,6 +680,19 @@ TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Opti
       }
 
    return p;
+   }
+
+char *
+TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit)
+   {
+   if (loadLimit)
+      {
+      return limitOption(option, base, entry, cmdLineOptions, _relocationFilters);
+      }
+   else
+      {
+      return limitOption(option, base, entry, cmdLineOptions, _compilationFilters);
+      }
    }
 
 


### PR DESCRIPTION
The option processing framework now includes a limitOption function overload that allows the user to specify a particular compilation filter set.

Fixes: eclipse-openj9/openj9#15399
Signed-off-by: Christian Despres <despresc@ibm.com>