### PR TITLE
Fix incorrectly-preserved flags in simplifier

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -471,6 +471,10 @@ OMR::Node::copyValidProperties(TR::Node *fromNode, TR::Node *toNode)
 
    // _flags
    toNode->setFlags(fromNode->getFlags());  // do not clear hasNodeExtension
+
+   // do not copy cannotOverflow
+   if (toNode->_flags.testAny(cannotOverFlow) && toNode->getOpCode().isArithmetic())
+      toNode->_flags.set(cannotOverFlow, false);
 #endif
 
    // DONE:

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -657,11 +657,10 @@ OMR::Node::create(TR::Node * originatingByteCodeNode, TR::ILOpCodes op, uint16_t
    TR_ASSERT(op != TR::bconst && op != TR::sconst, "Invalid constructor for 8/16-bit constants");
    TR::Node * node = TR::Node::create(originatingByteCodeNode, op, numChildren, dest);
    if (op == TR::lconst)
-      {
-      node->setConstValue(intValue);
-      }
+      node->setLongInt(intValue);
    else
-      node->setConstValue((int32_t)intValue);
+      node->setInt(intValue);
+
    return node;
    }
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1846,6 +1846,8 @@ protected:
 
 // Private functionality.
 private:
+   inline void setFlagsForConstIntegralValue(int64_t x);
+
    TR::Node * getExtendedChild(int32_t c);
    TR_YesNoMaybe computeIsCollectedReferenceImpl(TR::NodeChecklist &processedNodesCollected, TR::NodeChecklist &processedNodesNotCollected);
 

--- a/compiler/infra/Arith.hpp
+++ b/compiler/infra/Arith.hpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARITH_INCL
+#define ARITH_INCL
+
+#include <stdint.h>
+
+namespace TR {
+
+template<typename T> struct IsSignedIntegral { static const bool value = false; };
+template<> struct IsSignedIntegral<int8_t> { static const bool value = true; };
+template<> struct IsSignedIntegral<int16_t> { static const bool value = true; };
+template<> struct IsSignedIntegral<int32_t> { static const bool value = true; };
+template<> struct IsSignedIntegral<int64_t> { static const bool value = true; };
+
+// The following {add,sub}WithOverflow require that the build (C++) compiler
+// use two's complement (virtually guaranteed), and that type_t be a signed
+// integer type.
+
+template<typename T>
+T addWithOverflow(T a, T b, bool &overflow)
+   {
+   static_assert(IsSignedIntegral<T>::value, "expected a signed integral type");
+
+   // Cast to uintmax_t to avoid undefined behaviour on signed overflow.
+   //
+   // The uintmax_t-typed operands are sign-extended from a and b. They
+   // won't undergo integer promotions, because they're already as large as
+   // possible. And they're already at a common type, so they won't undergo
+   // the "usual arithmetic conversions" either. Therefore this will do
+   // unsigned (modular) arithmitic. Converting back to type_t produces the
+   // expected two's complement result.
+   T sum = uintmax_t(a) + uintmax_t(b);
+
+   //The overflow flag is set when the arithmetic used to compute the sum overflows. This happens exactly
+   //when both operand have the same sign and the resulting value has the opposite sign to this.
+   //A non-negative result from xoring two numbers indicates that their sign bits are either both
+   //set, or both unset, meaning they have the same sign, while a negative result from xoring two
+   //numbers means that exactly one of them has its sign bit set, meaning the signs of the two numbers
+   //differ.
+   overflow = ( a ^ b ) >= 0 && ( a ^ sum ) < 0;
+
+   return sum;
+   }
+
+template<typename T>
+T subWithOverflow(T a, T b, bool &overflow)
+   {
+   static_assert(IsSignedIntegral<T>::value, "expected a signed integral type");
+
+   // About uintmax_t, see addWithOverflow above.
+   T diff = uintmax_t(a) - uintmax_t(b);
+
+   //The overflow flag is set when the arithmetic used to compute the difference overflows. This happens exactly
+   //when both operand bounds have a differing sign and the resulting value has the same sign as the first operand.
+   //A non-negative result from xoring two numbers indicates that their sign bits are either both
+   //set, or both unset, meaning they have the same sign, while a negative result from xoring two
+   //numbers means that exactly one of them has its sign bit set, meaning the signs of the two numbers
+   //differ.
+   overflow = ( a ^ b ) < 0 && ( a ^ diff ) < 0;
+
+   return diff;
+   }
+
+template<typename T>
+void incWithOverflow(T &lhs, T rhs, bool &overflow)
+   {
+   lhs = addWithOverflow(lhs, rhs, overflow);
+   }
+
+template<typename T>
+void decWithOverflow(T &lhs, T rhs, bool &overflow)
+   {
+   lhs = subWithOverflow(lhs, rhs, overflow);
+   }
+
+// This makes it convenient to do multiple operations in a row and check only
+// at the end whether any have overflowed.
+struct StickyOverflowFlag
+   {
+   StickyOverflowFlag() : occurred(false) {}
+   bool occurred;
+   };
+
+template<typename T>
+T addWithOverflow(T a, T b, StickyOverflowFlag &overflow)
+   {
+   bool sumOverflow = false;
+   T result = addWithOverflow(a, b, sumOverflow);
+   overflow.occurred |= sumOverflow;
+   return result;
+   }
+
+template<typename T>
+T subWithOverflow(T a, T b, StickyOverflowFlag &overflow)
+   {
+   bool diffOverflow = false;
+   T result = subWithOverflow(a, b, diffOverflow);
+   overflow.occurred |= diffOverflow;
+   return result;
+   }
+
+template<typename T>
+void incWithOverflow(T &lhs, T rhs, StickyOverflowFlag &overflow)
+   {
+   lhs = addWithOverflow(lhs, rhs, overflow);
+   }
+
+template<typename T>
+void decWithOverflow(T &lhs, T rhs, StickyOverflowFlag &overflow)
+   {
+   lhs = subWithOverflow(lhs, rhs, overflow);
+   }
+
+}
+
+#endif

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -8127,20 +8127,15 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             productNode->setInt((int32_t)product);
             TR::Node::recreate(node, TR::iadd);
             }
-         if (firstChild->getReferenceCount() != 1)
-            {
-            TR::Node * newFirst = TR::Node::create(firstChild, TR::imul, 2);
-            newFirst->setReferenceCount(1);
-            newFirst->setAndIncChild(0, firstChild->getFirstChild());
-            newFirst->setAndIncChild(1, lrChild);
-            firstChild->recursivelyDecReferenceCount();
-            firstChild = newFirst;
-            node->setChild(0, firstChild);
-            }
-         else
-            {
-            TR::Node::recreate(firstChild, TR::imul);
-            }
+
+         TR::Node * newFirst = TR::Node::create(firstChild, TR::imul, 2);
+         newFirst->setReferenceCount(1);
+         newFirst->setAndIncChild(0, firstChild->getFirstChild());
+         newFirst->setAndIncChild(1, lrChild);
+         firstChild->recursivelyDecReferenceCount();
+         firstChild = newFirst;
+         node->setChild(0, firstChild);
+
          if (lrChild->getReferenceCount() != 1)
             {
             lrChild->decReferenceCount();

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -44,6 +44,7 @@
 #include "il/SymbolReference.hpp"
 #include "il/TreeTop.hpp"
 #include "il/TreeTop_inlines.hpp"
+#include "infra/Arith.hpp"
 #include "infra/Bit.hpp"
 #include "infra/BitVector.hpp"
 #include "infra/Cfg.hpp"
@@ -910,8 +911,10 @@ static TR::Node *addSimplifier(TR::Node * node, TR::Block * block, TR::Simplifie
       // Turn add with first child negated into a subtract
       else if (performTransformation(s->comp(), "%sReduced iadd with negated first child in node [%s] to isub\n", s->optDetailString(), node->getName(s->getDebug())))
          {
+         bool cannotOverflow = node->cannotOverflow() && firstChild->cannotOverflow();
          s->anchorChildren(node, s->_curTree);
          TR::Node::recreate(node, TR::ILOpCode::getSubOpCode<T>());
+         node->setCannotOverflow(cannotOverflow);
          node->setAndIncChild(1, newFirstChild);
          node->setChild(0, secondChild);
          firstChild->recursivelyDecReferenceCount();
@@ -6132,9 +6135,24 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized iadd of iconst > 0 in node [%s] to isub of -iconst\n", s->optDetailString(), node->getName(s->getDebug())))
          {
+         // Preserve flags that describe the resulting value, since it is
+         // unchanged. Also preserve cannotOverflow. The subtraction (x - (-c))
+         // overflows precisely when the original addition (x + c) does.
+         bool isNonZero = node->isNonZero();
+         bool isNonNegative = node->isNonNegative();
+         bool isNonPositive = node->isNonPositive();
+         bool cannotOverflow = node->cannotOverflow();
+
          TR::Node * newSecondChild = (secondChild->getReferenceCount() == 1) ? secondChild : TR::Node::create(secondChild, TR::iconst, 0);
          newSecondChild->setInt(-secondChild->getInt());
+
          TR::Node::recreateWithoutProperties(node, TR::isub, 2, firstChild, newSecondChild);
+
+         node->setIsNonZero(isNonZero);
+         node->setIsNonNegative(isNonNegative);
+         node->setIsNonPositive(isNonPositive);
+         node->setCannotOverflow(cannotOverflow);
+
          firstChild->recursivelyDecReferenceCount();
          secondChild->recursivelyDecReferenceCount();
          node->setVisitCount(0);
@@ -6163,8 +6181,10 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       // Turn add with first child negated into a subtract
       else if (performTransformation(s->comp(), "%sReduced iadd with negated first child in node [%s] to isub\n", s->optDetailString(), node->getName(s->getDebug())))
          {
+         bool cannotOverflow = node->cannotOverflow() && firstChild->cannotOverflow();
          s->anchorChildren(node, s->_curTree);
          TR::Node::recreate(node, TR::isub);
+         node->setCannotOverflow(cannotOverflow);
          node->setAndIncChild(1, newFirstChild);
          node->setChild(0, secondChild);
          firstChild->recursivelyDecReferenceCount();
@@ -6298,6 +6318,9 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             if (!s->reassociate() && // use new rules
                performTransformation(s->comp(), "%sFound iadd of iconst with iadd or isub of x and const in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
                {
+               bool cannotOverflow =
+                  node->cannotOverflow() && firstChild->cannotOverflow();
+
                if (firstChild->getReferenceCount()>1)
                   {
                   // it makes sense to uncommon it in this situation
@@ -6310,14 +6333,19 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   }
 
                int32_t value  = secondChild->getInt();
+               TR::StickyOverflowFlag valOverflow;
                if (firstChildOp == TR::iadd)
                   {
-                  value += lrChild->getInt();
+                  TR::incWithOverflow(value, lrChild->getInt(), valOverflow);
                   }
                else
                   {
-                  value -= lrChild->getInt();
+                  TR::decWithOverflow(value, lrChild->getInt(), valOverflow);
                   }
+
+               if (valOverflow.occurred)
+                  cannotOverflow = false;
+
                if (value > 0)
                   {
                   value = -value;
@@ -6335,6 +6363,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   secondChild->recursivelyDecReferenceCount();
                   }
 
+               node->setCannotOverflow(cannotOverflow);
                node->setAndIncChild(0, firstChild->getFirstChild());
                firstChild->recursivelyDecReferenceCount();
                node->setVisitCount(0);
@@ -6936,7 +6965,12 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sNormalized isub of iconst > 0 in node [%s] to iadd of -iconst \n", s->optDetailString(), node->getName(s->getDebug())))
          {
+         // If the original add couldn't overflow, then neither can the sub.
+         // Negating the constant doesn't overflow, so when the inputs are
+         // interpreted as signed, the true result is the same in both cases.
+         bool cannotOverflow = node->cannotOverflow();
          TR::Node::recreate(node, TR::iadd);
+         node->setCannotOverflow(cannotOverflow);
          if (secondChild->getReferenceCount() == 1)
             {
             secondChild->setInt(-secondChild->getInt());
@@ -7119,6 +7153,9 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             {
             if (performTransformation(s->comp(), "%sFound isub of iconst with iadd or isub of x and const in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
                {
+               bool cannotOverflow =
+                  node->cannotOverflow() && firstChild->cannotOverflow();
+
                if (firstChild->getReferenceCount()>1)
                   {
                   // it makes sense to uncommon it in this situation
@@ -7130,15 +7167,33 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   firstChild = newFirstChild;
                   }
 
-               int32_t value = - secondChild->getInt();
+               int32_t value = 0;
+               TR::StickyOverflowFlag valOverflow;
                if (firstChildOp == TR::iadd)
                   {
-                  value += lrChild->getInt();
+                  value = TR::subWithOverflow(
+                     lrChild->getInt(), secondChild->getInt(), valOverflow);
                   }
                else // firstChildOp == TR::isub
                   {
-                  value -= lrChild->getInt();
+                  TR::decWithOverflow(value, secondChild->getInt(), valOverflow);
+                  TR::decWithOverflow(value, lrChild->getInt(), valOverflow);
+                  if (valOverflow.occurred)
+                     {
+                     // Try the other order. If there is an order in which we
+                     // can negate one constant and subtract the other without
+                     // overflowing, then the calculation of the new constant
+                     // does not interfere with cannotOverflow.
+                     valOverflow.occurred = false;
+                     value = 0;
+                     TR::decWithOverflow(value, lrChild->getInt(), valOverflow);
+                     TR::decWithOverflow(value, secondChild->getInt(), valOverflow);
+                     }
                   }
+
+               if (valOverflow.occurred)
+                  cannotOverflow = false;
+
                if (value > 0)
                   {
                   value = -value;
@@ -7158,6 +7213,8 @@ TR::Node *isubSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                   foldedConstChild->setInt(value);
                   secondChild->recursivelyDecReferenceCount();
                   }
+
+               node->setCannotOverflow(cannotOverflow);
                node->setAndIncChild(0, firstChild->getFirstChild());
                firstChild->recursivelyDecReferenceCount();
                node->setVisitCount(0);
@@ -7943,22 +8000,54 @@ TR::Node *imulSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
        secondChild->getInt() != TR::getMinSigned<TR::Int32>() &&
        performTransformation(s->comp(), "%sFound a*(-c) = -(a*c) in imul [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
       {
+      int32_t absVal = -secondChild->getInt();
+      bool cannotOverflow = false;
+      if (node->cannotOverflow())
+         {
+         // Overflow can only happen if the original product can be INT32_MIN.
+         // In that case, the true result of the product a*c is INT32_MAX+1.
+         // If, OTOH, INT32_MIN (= -2**31) is not possible, then we know that
+         //
+         //    -2**31 < a*(-c) < 2**31
+         //    -2**31 <   a*c  < 2**31    ==> new imul a*c does not overflow
+         //    -2**31 < -(a*c) < 2**31    ==> ineg does not overflow
+         //
+         // Each of the following conditions rules out INT32_MIN and so
+         // guarantees that there will be no overflow.
+         //
+         cannotOverflow =
+            absVal == 1 // INT32_MIN only possible when original imul overflows
+            || !isPowerOf2(absVal) // a*(-c) = INT32_MIN ==> c is a power of 2
+            || node->isNonNegative(); // INT32_MIN < 0
+         }
+
       TR::Node::recreate(node, TR::ineg);
       node->setNumChildren(1);
+      node->setCannotOverflow(cannotOverflow);
+
       if (secondChild->getReferenceCount() == 1)
          {
-         secondChild->setInt(-secondChild->getInt());
+         secondChild->setInt(absVal);
          }
       else
          {
-         int32_t negVal = -secondChild->getInt();
          secondChild->decReferenceCount();
-         secondChild = TR::Node::iconst(negVal);
+         secondChild = TR::Node::iconst(absVal);
          secondChild->incReferenceCount();
          }
+
       TR::Node *newMul = TR::Node::create(TR::imul, 2);
       newMul->setChild(0, firstChild);
       newMul->setChild(1, secondChild);
+
+      newMul->setIsNonZero(node->isNonZero()); // even if overflow is possible
+      if (cannotOverflow)
+         {
+         newMul->setCannotOverflow(true);
+         newMul->setIsNonNegative(node->isNonPositive());
+         newMul->setIsNonPositive(node->isNonNegative());
+         }
+
       node->setAndIncChild(0, newMul);
       s->_alteredBlock = true;
       return s->simplify(node, block);
@@ -9687,7 +9776,9 @@ TR::Node *inegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       if (performTransformation(s->comp(), "%sReduced ineg with isub child in node [" POINTER_PRINTF_FORMAT "] to isub\n", s->optDetailString(), node))
          {
+         bool cannotOverflow = node->cannotOverflow() && firstChild->cannotOverflow();
          TR::Node::recreate(node, TR::isub);
+         node->setCannotOverflow(cannotOverflow);
          node->setNumChildren(2);
          node->setAndIncChild(0, firstChild->getSecondChild());
          node->setAndIncChild(1, firstChild->getFirstChild());

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,6 +45,7 @@
 #include "il/SymbolReference.hpp"
 #include "ilgen/IlGenRequest.hpp"
 #include "ilgen/IlGeneratorMethodDetails.hpp"
+#include "infra/Arith.hpp"
 #include "optimizer/Optimization_inlines.hpp"
 #include "optimizer/ValuePropagation.hpp"
 
@@ -4495,10 +4496,10 @@ TR::VPConstraint *TR::VPShortConstraint::add(TR::VPConstraint *other, TR::DataTy
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int16_t low  = addWithOverflow<int16_t>(getLow(), otherShort->getLow(), lowOverflow);
+   int16_t low  = TR::addWithOverflow<int16_t>(getLow(), otherShort->getLow(), lowOverflow);
 
    bool highOverflow;
-   int16_t high = addWithOverflow<int16_t>(getHigh(), otherShort->getHigh(), highOverflow);
+   int16_t high = TR::addWithOverflow<int16_t>(getHigh(), otherShort->getHigh(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
@@ -4523,10 +4524,10 @@ TR::VPConstraint *TR::VPIntConstraint::add(TR::VPConstraint *other, TR::DataType
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int32_t low  = addWithOverflow<int32_t>(getLow(), otherInt->getLow(), lowOverflow);
+   int32_t low  = TR::addWithOverflow<int32_t>(getLow(), otherInt->getLow(), lowOverflow);
 
    bool highOverflow;
-   int32_t high = addWithOverflow<int32_t>(getHigh(), otherInt->getHigh(), highOverflow);
+   int32_t high = TR::addWithOverflow<int32_t>(getHigh(), otherInt->getHigh(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
@@ -4603,10 +4604,10 @@ TR::VPConstraint *TR::VPShortConstraint::subtract(TR::VPConstraint *other, TR::D
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int16_t low  = subWithOverflow<int16_t>(getLow(), otherShort->getHigh(), lowOverflow);
+   int16_t low  = TR::subWithOverflow<int16_t>(getLow(), otherShort->getHigh(), lowOverflow);
 
    bool highOverflow;
-   int16_t high = subWithOverflow<int16_t>(getHigh(), otherShort->getLow(), highOverflow);
+   int16_t high = TR::subWithOverflow<int16_t>(getHigh(), otherShort->getLow(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
@@ -4628,10 +4629,10 @@ TR::VPConstraint *TR::VPIntConstraint::subtract(TR::VPConstraint *other, TR::Dat
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int32_t low  = subWithOverflow<int32_t>(getLow(), otherInt->getHigh(), lowOverflow);
+   int32_t low  = TR::subWithOverflow<int32_t>(getLow(), otherInt->getHigh(), lowOverflow);
 
    bool highOverflow;
-   int32_t high = subWithOverflow<int32_t>(getHigh(), otherInt->getLow(), highOverflow);
+   int32_t high = TR::subWithOverflow<int32_t>(getHigh(), otherInt->getLow(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
@@ -4727,10 +4728,10 @@ TR::VPConstraint *TR::VPLongConstraint::add(TR::VPConstraint *other, TR::DataTyp
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int64_t low  = addWithOverflow<int64_t>(getLow(), otherLong->getLow(), lowOverflow);
+   int64_t low  = TR::addWithOverflow<int64_t>(getLow(), otherLong->getLow(), lowOverflow);
 
    bool highOverflow;
-   int64_t high = addWithOverflow<int64_t>(getHigh(), otherLong->getHigh(), highOverflow);
+   int64_t high = TR::addWithOverflow<int64_t>(getHigh(), otherLong->getHigh(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }
@@ -4748,10 +4749,10 @@ TR::VPConstraint *TR::VPLongConstraint::subtract(TR::VPConstraint *other, TR::Da
    //Compute the lower and upper bound values, and determine whether or not the arithmetic
    //has overflowed in either case.
    bool lowOverflow;
-   int64_t low  = subWithOverflow<int64_t>(getLow(), otherLong->getHigh(), lowOverflow);
+   int64_t low  = TR::subWithOverflow<int64_t>(getLow(), otherLong->getHigh(), lowOverflow);
 
    bool highOverflow;
-   int64_t high = subWithOverflow<int64_t>(getHigh(), otherLong->getLow(), highOverflow);
+   int64_t high = TR::subWithOverflow<int64_t>(getHigh(), otherLong->getLow(), highOverflow);
 
    return getRange(low, high, lowOverflow, highOverflow, vp);
    }

--- a/compiler/optimizer/VPConstraint.hpp
+++ b/compiler/optimizer/VPConstraint.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -266,49 +266,6 @@ class VPConstraint
       TR::VPConstraint     *_other;
       const char          *_name;
    };
-
-   // The following {add,sub}WithOverflow require that the build (C++) compiler
-   // use two's complement (virtually guaranteed), and that type_t be a signed
-   // integer type.
-
-   template<typename type_t> type_t addWithOverflow(type_t a, type_t b, bool& overflow)
-      {
-      // Cast to uintmax_t to avoid undefined behaviour on signed overflow.
-      //
-      // The uintmax_t-typed operands are sign-extended from a and b. They
-      // won't undergo integer promotions, because they're already as large as
-      // possible. And they're already at a common type, so they won't undergo
-      // the "usual arithmetic conversions" either. Therefore this will do
-      // unsigned (modular) arithmitic. Converting back to type_t produces the
-      // expected two's complement result.
-      type_t sum = uintmax_t(a) + uintmax_t(b);
-
-      //The overflow flag is set when the arithmetic used to compute the sum overflows. This happens exactly
-      //when both operand have the same sign and the resulting value has the opposite sign to this.
-      //A non-negative result from xoring two numbers indicates that their sign bits are either both
-      //set, or both unset, meaning they have the same sign, while a negative result from xoring two
-      //numbers means that exactly one of them has its sign bit set, meaning the signs of the two numbers
-      //differ.
-      overflow = ( a ^ b ) >= 0 && ( a ^ sum ) < 0;
-
-      return sum;
-      }
-
-   template<typename type_t> type_t subWithOverflow(type_t a, type_t b, bool& overflow)
-      {
-      // About uintmax_t, see addWithOverflow above.
-      type_t diff = uintmax_t(a) - uintmax_t(b);
-
-      //The overflow flag is set when the arithmetic used to compute the difference overflows. This happens exactly
-      //when both operand bounds have a differing sign and the resulting value has the same sign as the first operand.
-      //A non-negative result from xoring two numbers indicates that their sign bits are either both
-      //set, or both unset, meaning they have the same sign, while a negative result from xoring two
-      //numbers means that exactly one of them has its sign bit set, meaning the signs of the two numbers
-      //differ.
-      overflow = ( a ^ b ) < 0 && ( a ^ diff ) < 0;
-
-      return diff;
-      }
 
    private:
    int32_t _mergePriority;


### PR DESCRIPTION
- Make `TR::Node::recreate()` unset the cannotOverflow flag
- Auto-set `X==0`, `X!=0`, `X>=0`, `X<=0` flags correctly for constant nodes
- Make `VPConstraint::{add,sub}WithOverflow()` freestanding functions
- Preserve flags in simplifier transformations
- Stop recreating `iadd`/`isub` as `imul` when distributing in simplifier

Please see the individual commit messages.