### PR TITLE
Remove definition of _OE_SOCKETS

### DIFF
--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -28,11 +28,6 @@
 #include <sys/socketvar.h>
 #endif
 
-/* According to ZOS documentation, this definition is needed. */
-#if defined(OMR_OS_ZOS) && !defined(_OE_SOCKETS)
-#define _OE_SOCKETS
-#endif
-
 /* This exposes some definitions needed by the socket api */
 #if defined(OMR_OS_ZOS) && !defined(_OPEN_SYS_SOCK_IPV6)
 #define _OPEN_SYS_SOCK_IPV6


### PR DESCRIPTION
_OE_SOCKETS is not compatible with LP64. OMR_OS_ZOS was not defined
previously. So, _OE_SOCKETS was never defined in the builds.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>