### PR TITLE
Verbose GC CRIU Support

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,6 +136,13 @@ public:
 	 * @param[in] env the current environment
 	 * @return void
 	 */
+	virtual void
+	adjustGCThreadCountForCheckpoint(MM_EnvironmentBase* env)
+	{
+		adjustGCThreadCountOnCheckpoint(env);
+	}
+
+	/* Temp: To be deleted and replaced by adjustGCThreadCountForCheckpoint.  */
 	virtual void adjustGCThreadCountOnCheckpoint(MM_EnvironmentBase* env);
 
 	/**
@@ -144,6 +151,13 @@ public:
 	 * @param[in] env the current environment
 	 * @return void
 	 */
+	virtual bool
+	reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env)
+	{
+		return reinitializeGCThreadCountOnRestore(env);
+	}
+
+	/* Temp: To be deleted and replaced by reinitializeGCThreadCountForRestore.  */
 	virtual bool reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/gc/verbose/VerboseManager.cpp
+++ b/gc/verbose/VerboseManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -138,6 +138,21 @@ MM_VerboseManager::closeStreams(MM_EnvironmentBase *env)
 		writer->closeStream(env);
 		writer = writer->getNextWriter();
 	}
+}
+
+bool
+MM_VerboseManager::openStreams(MM_EnvironmentBase *env)
+{
+	bool result = true;
+
+	MM_VerboseWriter *writer = _writerChain->getFirstWriter();
+	while (NULL != writer) {
+		/* Return false if any one of the streams fails to open. */
+		result = writer->openStream(env) && result;
+		writer = writer->getNextWriter();
+	}
+
+	return result;
 }
 
 void

--- a/gc/verbose/VerboseManager.hpp
+++ b/gc/verbose/VerboseManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -115,6 +115,35 @@ public:
 	 * @param env vm thread.
 	 */
 	virtual void closeStreams(MM_EnvironmentBase *env);
+
+	/**
+	 * Open all output mechanisms on the receiver.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if all output streams opened successfully.
+	 */
+	virtual bool openStreams(MM_EnvironmentBase *env);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Prepare the Verbose GC Components for checkpoint.
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	virtual void prepareForCheckpoint(MM_EnvironmentBase *env) { closeStreams(env); }
+
+	/**
+	 * Reinitalize the Verbose GC Components for restore.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if the verbose manager reinitialized successfully.
+	 */
+	virtual bool
+	reinitializeForRestore(MM_EnvironmentBase *env)
+	{
+		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+		setInitializedTime(omrtime_hires_clock());
+		return openStreams(env);
+	}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MMINLINE MM_VerboseWriterChain* getWriterChain() { return _writerChain; }
 	MM_VerboseHandlerOutput* getVerboseHandlerOutput() { return _verboseHandlerOutput; }

--- a/gc/verbose/VerboseManagerBase.hpp
+++ b/gc/verbose/VerboseManagerBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -234,9 +234,33 @@ public:
 
 	/**
 	 * Close all output mechanisms on the receiver.
-	 * @param env vm thread.
+	 * @param[in] env the current environment.
+	 * @return void
 	 */
 	virtual void closeStreams(MM_EnvironmentBase *env) = 0;
+
+	/**
+	 * Open all output mechanisms on the receiver.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if all output streams opened successfully.
+	 */
+	virtual bool openStreams(MM_EnvironmentBase *env) { return false; }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Prepare the Verbose GC Components for checkpoint.
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	virtual void prepareForCheckpoint(MM_EnvironmentBase *env) {}
+
+	/**
+	 * Reinitalize the Verbose GC Components for restore.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if the verbose manager reinitialized successfully.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env) { return false; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	uint64_t getLastOutputTime() { return _lastOutputTime; }
 	void setLastOutputTime(uint64_t time) {  _lastOutputTime = time; }

--- a/gc/verbose/VerboseWriter.hpp
+++ b/gc/verbose/VerboseWriter.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,13 @@ public:
 	virtual void endOfCycle(MM_EnvironmentBase *env) = 0;
 
 	virtual void closeStream(MM_EnvironmentBase *env) = 0;
+
+	/**
+	 * Open the output mechanism for the writer.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if the output stream opened successfully.
+	 */
+	virtual bool openStream(MM_EnvironmentBase *env) { return true; }
 
 	MMINLINE WriterType getType(void) { return _type; }
 

--- a/gc/verbose/VerboseWriterFileLogging.cpp
+++ b/gc/verbose/VerboseWriterFileLogging.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -292,6 +292,13 @@ void
 MM_VerboseWriterFileLogging::closeStream(MM_EnvironmentBase *env)
 {
 	closeFile(env);
+}
+
+bool
+MM_VerboseWriterFileLogging::openStream(MM_EnvironmentBase *env)
+{
+	/* Pass in true to print the verbose initialize header in the file being opened. */
+	return openFile(env, true);
 }
 
 /**

--- a/gc/verbose/VerboseWriterFileLogging.hpp
+++ b/gc/verbose/VerboseWriterFileLogging.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2020 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,13 @@ public:
 	virtual bool reconfigure(MM_EnvironmentBase *env, const char* filename, uintptr_t fileCount, uintptr_t iterations);
 
 	void closeStream(MM_EnvironmentBase *env);
+
+	/**
+	 * Open the output mechanism for the writer.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if the output stream opened successfully.
+	 */
+	bool openStream(MM_EnvironmentBase *env);
 
 	virtual void endOfCycle(MM_EnvironmentBase *env);
 


### PR DESCRIPTION
Files opened by Verbose GC must be excluded from the CRIU dump. Opened logs can be problematic as the restore file validation can fail if the logs change between checkpoint and restore (e.g. file contents/metadata changed or file not available at restore time, which is typical for CRIU use cases). Hence, Verbose GC file writers/streams must be closed prior to creating a check point image and reopened for restore.

- Introduced `openStream` for Verbose Writers
  - Used to openFile associated with file writers , only required for buffered and  synchronous file logging, base class `MM_VerboseWriterFileLogging`
- Introduced `openStreams` for Verbose Manager
  - To walk the set of verbose writers and open streams  (complementary to existing `closeStreams` routine)
- Introduced `prepareForCheckpoint` and `reinitializeForRestore` for Verbose Manager
  - Calls Manager's Close/OpenStreams 

Signed-off-by: Salman Rana <salman.rana@ibm.com>