### PR TITLE
Remove wantToPatchClassPointer() and the hcrPatchClassPointers option

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -70,15 +70,6 @@ static void loadRelocatableConstant(TR::Node *node,
    bool isStatic = symbol->isStatic();
    bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
    bool isClass = isStatic && symbol->isClassObject();
-   bool isPicSite = isClass;
-
-   if (isPicSite && !cg->comp()->compileRelocatableCode()
-       && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)symbol->getStaticSymbol()->getStaticAddress(), node))
-      {
-      intptr_t address = (intptr_t)symbol->getStaticSymbol()->getStaticAddress();
-      loadAddressConstantInSnippet(cg, node ? node : cg->getCurrentEvaluationTreeTop()->getNode(), address, reg, TR_ClassAddress);
-      return;
-      }
 
    uintptr_t addr = symbol->isStatic() ? (uintptr_t)symbol->getStaticSymbol()->getStaticAddress() : (uintptr_t)symbol->getMethodSymbol()->getMethodAddress();
 

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -403,19 +403,11 @@ TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
-      bool isClass = child->isClassPointerConstant();
       pushRegister = codeGen->allocateRegister();
-      if (isClass && self()->cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)child->getAddress(), child))
-         {
-         loadAddressConstantInSnippet(self()->cg(), child, child->getAddress(), pushRegister);
-         }
+      if (child->isMethodPointerConstant())
+         loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
       else
-         {
-          if (child->isMethodPointerConstant())
-             loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
-          else
-             loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister);
-         }
+         loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister);
       }
    else
       {

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1340,22 +1340,12 @@ static void loadRelocatableConstant(TR::Node               *node,
    TR::Compilation * comp = cg->comp();
    symbol = ref->getSymbol();
    /* This method is called only if symbol->isStatic() && !ref->isUnresolved(). */
-   TR_ASSERT(symbol->isStatic() || symbol->isMethod(), "loadRelocatableConstant, problem with new symbol hierarchy");
-
    bool isStatic = symbol->isStatic();
-   bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
-   bool isClass = isStatic && symbol->isClassObject();
-   bool isPicSite = isClass;
-   if (isPicSite
-       && !cg->comp()->compileRelocatableCode()
-       && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)symbol->getStaticSymbol()->getStaticAddress(), node))
-      {
-      intptr_t address = (intptr_t)symbol->getStaticSymbol()->getStaticAddress();
-      loadAddressConstantInSnippet(cg, node ? node : cg->getCurrentEvaluationTreeTop()->getNode(), address, reg); // isStore ? TR::InstOpCode::Op_st : TR::InstOpCode::Op_load
-      return;
-      }
+   TR_ASSERT(isStatic || symbol->isMethod(), "loadRelocatableConstant, problem with new symbol hierarchy");
 
-   addr = symbol->isStatic() ? (uintptr_t)symbol->getStaticSymbol()->getStaticAddress() : (uintptr_t)symbol->getMethodSymbol()->getMethodAddress();
+   bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
+
+   addr = isStatic ? (uintptr_t)symbol->getStaticSymbol()->getStaticAddress() : (uintptr_t)symbol->getMethodSymbol()->getMethodAddress();
 
    if (symbol->isStartPC())
       {

--- a/compiler/arm/codegen/UnaryEvaluator.cpp
+++ b/compiler/arm/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,7 +65,6 @@ TR::Register *OMR::ARM::TreeEvaluator::commonConstEvaluator(TR::Node *node, int3
 TR::Register *OMR::ARM::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   bool isClass = node->isClassPointerConstant();
    TR_ResolvedMethod * method = comp->getCurrentMethod();
 
    bool isPicSite = node->isClassPointerConstant() && cg->fe()->isUnloadAssumptionRequired((TR_OpaqueClassBlock *) node->getAddress(), method);
@@ -74,10 +73,8 @@ TR::Register *OMR::ARM::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeG
 
    bool isProfiledPointerConstant = node->isClassPointerConstant() || node->isMethodPointerConstant();
 
-   // use data snippet only on class pointers when HCR is enabled
    int32_t address = node->getInt();
-   if (isClass && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)address, node) ||
-       isProfiledPointerConstant && cg->profiledPointersRequireRelocation())
+   if (isProfiledPointerConstant && cg->profiledPointersRequireRelocation())
       {
       TR::Register *trgReg = cg->allocateRegister();
       loadAddressConstantInSnippet(cg, node, address, trgReg, isPicSite, NULL);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1324,8 +1324,6 @@ public:
    void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt) { return false; } //J9
 
    // --------------------------------------------------------------------------
    // Unclassified

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -814,7 +814,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"GCRresetCount=",       "R<nnn>\tthe value to which the counter is reset to after being tripped by guarded counting recompilations (postive value)",
     TR::Options::setCount, offsetof(OMR::Options,_GCRResetCount), 0, "F%d"},
    {"generateCompleteInlineRanges", "O\tgenerate meta data ranges for each change in inliner depth", SET_OPTION_BIT(TR_GenerateCompleteInlineRanges), "F"},
-   {"hcrPatchClassPointers", "I\tcreate runtime assumptions for patching pointers to classes, even though they are now updated in-place", SET_OPTION_BIT(TR_HCRPatchClassPointers), "F"},
    {"help",               " \tdisplay this help information", TR::Options::helpOption, 0, 0, "F", NOT_IN_SUBSET},
    {"help=",              " {regex}\tdisplay help for options whose names match {regex}", TR::Options::helpOption, 1, 0, "F", NOT_IN_SUBSET},
    {"highCodeCacheOccupancyBCount=", "R<nnn>\tthe initial invocation count used during high code cache occupancy for methods with loops",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -922,7 +922,7 @@ enum TR_CompilationOptions
 
    // Option word 29
    TR_InlineVeryLargeCompiledMethods                  = 0x00000040 + 29,
-   TR_HCRPatchClassPointers                           = 0x00000080 + 29,
+   // Available                                       = 0x00000080 + 29,
    TR_UseOldHCRGuardAOTRelocations                    = 0x00000100 + 29,
    // Available                                       = 0x00000200 + 29,
    TR_DisableSupportForCpuSpentInCompilation          = 0x00000400 + 29,

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -727,17 +727,12 @@ TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
    TR_ASSERT(child->getDataType() == TR::Address, "assumption violated");
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
-      bool isClass = child->isClassPointerConstant();
       pushRegister = self()->cg()->allocateRegister();
-      if (isClass && self()->cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)child->getAddress(), child))
-         loadAddressConstantInSnippet(self()->cg(), child, child->getAddress(), pushRegister, NULL,TR::InstOpCode::Op_load, NULL, NULL);
+      if (child->isMethodPointerConstant())
+         loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
       else
-         {
-         if (child->isMethodPointerConstant())
-            loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
-         else
-            loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister);
-         }
+         loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister);
+
       child->setRegister(pushRegister);
       }
    else

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1544,16 +1544,6 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
    bool isStatic = symbol->isStatic() && !ref->isUnresolved();
    bool isStaticField = isStatic && (ref->getCPIndex() > 0) && !symbol->isClassObject();
    bool isClass = isStatic && symbol->isClassObject();
-   bool isPicSite = isClass;
-   if (isPicSite
-       && !cg->comp()->compileRelocatableCode()
-       && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)symbol->getStaticSymbol()->getStaticAddress(), node))
-      {
-      TR::Register *reg = _baseRegister = cg->allocateRegister();
-      intptr_t address = (intptr_t)symbol->getStaticSymbol()->getStaticAddress();
-      loadAddressConstantInSnippet(cg, node ? node : cg->getCurrentEvaluationTreeTop()->getNode(), address, reg, NULL, isStore?TR::InstOpCode::Op_st :TR::InstOpCode::Op_load, false, NULL);
-      return;
-      }
 
    TR::Node *topNode = cg->getCurrentEvaluationTreeTop()->getNode();
    TR::Node *nodeForSymbol = node ? node : topNode;

--- a/compiler/p/codegen/PPCTableOfConstants.cpp
+++ b/compiler/p/codegen/PPCTableOfConstants.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -180,7 +180,7 @@ TR_PPCTableOfConstants::lookUp(int32_t val, struct TR_tocHashEntry *tmplate, int
    {
    TR::Compilation *comp = cg->comp();
 
-   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC) || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)) || comp->getOption(TR_MimicInterpreterFrameShape))
+   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC) || comp->getOption(TR_MimicInterpreterFrameShape))
       return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
@@ -391,7 +391,7 @@ int32_t TR_PPCTableOfConstants::lookUp(int8_t *name, int32_t len, bool isAddr, i
    struct TR_tocHashEntry localEntry;
    int32_t                val, offsetInSlot;
 
-   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC) || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)))
+   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC))
       return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
@@ -568,7 +568,7 @@ int32_t TR_PPCTableOfConstants::allocateChunk(uint32_t numEntries, TR::CodeGener
    {
    TR_PPCTableOfConstants *tocManagement = toPPCTableOfConstants(TR_PersistentMemory::getNonThreadSafePersistentInfo()->getPersistentTOC());
 
-   if (tocManagement == NULL || cg->comp()->getOption(TR_DisableTOC) || cg->comp()->compileRelocatableCode() || (cg->comp()->getOption(TR_EnableHCR) && cg->comp()->getOption(TR_HCRPatchClassPointers)))
+   if (tocManagement == NULL || cg->comp()->getOption(TR_DisableTOC) || cg->comp()->compileRelocatableCode())
       return PTOC_FULL_INDEX;
 
    if (grabMonitor)

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -72,8 +72,7 @@ TR::Register *OMR::Power::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::Cod
 
    // use data snippet only on class pointers when HCR is enabled
    intptr_t address = cg->comp()->target().is64Bit()? node->getLongInt(): node->getInt();
-   if (isClass && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)address, node) ||
-       isProfiledPointerConstant && cg->profiledPointersRequireRelocation())
+   if (isProfiledPointerConstant && cg->profiledPointersRequireRelocation())
       {
       TR::Register *trgReg = cg->allocateRegister();
       loadAddressConstantInSnippet(cg, node, address, trgReg, NULL,TR::InstOpCode::Op_load, isPicSite, NULL);

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -423,8 +423,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          TR::Compilation *comp = cg->comp();
          if (comp->getOption(TR_EnableHCR)
              && (!sr.getSymbol()->isStatic()
-                 || !sr.getSymbol()->isClassObject()
-                 || cg->wantToPatchClassPointer(NULL, containingInstruction->getBinaryEncoding()))) // unresolved
+                 || !sr.getSymbol()->isClassObject()))
             {
             cg->jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(containingInstruction->getBinaryEncoding());
             }
@@ -452,11 +451,6 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
                                                                                             TR_ClassAddress, cg),__FILE__, __LINE__,
                                                                                             containingInstruction->getNode());
                   }
-               }
-
-            if (cg->wantToPatchClassPointer(NULL, displacementLocation)) // may not point to beginning of class
-               {
-               cg->jitAddPicToPatchOnClassRedefinition(((void *)displacement), displacementLocation);
                }
             }
          }
@@ -524,25 +518,6 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
                               __FILE__,
                               __LINE__,
                               containingInstruction->getNode());
-         }
-      }
-
-   }
-
-
-void
-OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressDisplacementOnly(
-      intptr_t displacement,
-      uint8_t *cursor,
-      TR::CodeGenerator *cg)
-   {
-
-   if (IS_32BIT_SIGNED(displacement) && !_forceRIPRelative)
-      {
-      if (_symbolReference.getSymbol() && _symbolReference.getSymbol()->isClassObject()
-         && cg->wantToPatchClassPointer(NULL, cursor)) // may not point to beginning of class
-         {
-         cg->jitAdd32BitPicToPatchOnClassRedefinition(((void *)displacement), cursor);
          }
       }
 
@@ -728,8 +703,6 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
          self()->ModRM(modRM)->setIndexOnlyDisp32();
          *(uint32_t*)cursor = (uint32_t)(displacement - (intptr_t)nextInstructionAddress);
          }
-
-      self()->addMetaDataForCodeAddressDisplacementOnly(displacement, cursor, cg);
 
       // Unresolved shadows whose base object is explicitly NULL need to report the
       // offset of the disp32 field.

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -168,7 +168,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::X86::MemoryReference
       }
 
    void addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation, TR::Instruction *containingInstruction, TR::CodeGenerator *cg, TR::SymbolReference *srCopy);
-   void addMetaDataForCodeAddressDisplacementOnly(intptr_t displacement, uint8_t *cursor, TR::CodeGenerator *cg);
 
    protected:
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -931,13 +931,6 @@ void OMR::X86::TreeEvaluator::compareIntegersForEquality(TR::Node *node, TR::Cod
             {
             cmpInstruction = generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(is64Bit), node, firstChildReg, static_cast<int32_t>(constValue), cg);
             }
-         TR::Symbol *symbol = NULL;
-         if (node && secondChild->getOpCode().hasSymbolReference())
-            symbol = secondChild->getSymbol();
-         bool isPICCandidate = symbol ? symbol->isStatic() && symbol->isClassObject() : false;
-
-         if (isPICCandidate && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)constValue, secondChild))
-            comp->getStaticHCRPICSites()->push_front(cmpInstruction);
 
          if (secondChild->getOpCodeValue() == TR::aconst)
             {

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,19 +65,11 @@ TR::X86DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          {
          if (!needRelocation)
             cg()->jitAddPicToPatchOnClassUnload((void*)-1, (void *) cursor);
-         if (cg()->wantToPatchClassPointer(NULL, cursor)) // unresolved
-            {
-            cg()->jitAddPicToPatchOnClassRedefinition(((void *) -1), (void *) cursor, true);
-            }
          }
       else
          {
          if (!needRelocation)
             cg()->jitAdd32BitPicToPatchOnClassUnload((void*)-1, (void *) cursor);
-         if (cg()->wantToPatchClassPointer(NULL, cursor)) // unresolved
-            {
-            cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *) -1), (void *) cursor, true);
-            }
          }
 
       TR_OpaqueClassBlock *clazz = getData<TR_OpaqueClassBlock *>();

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,8 +128,7 @@ TR::X86HelperCallSnippet::addMetaDataForLoadAddrArg(
    TR::StaticSymbol *sym = child->getSymbol()->getStaticSymbol();
 
    if (cg()->comp()->getOption(TR_EnableHCR)
-       && (!child->getSymbol()->isClassObject()
-           || cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)sym->getStaticAddress(), buffer)))
+       && !child->getSymbol()->isClassObject())
       {
       if (cg()->comp()->target().is64Bit())
          cg()->jitAddPicToPatchOnClassRedefinition(((void *) (uintptr_t)sym->getStaticAddress()), (void *) buffer);

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1210,13 +1210,6 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                                  __FILE__,__LINE__, node);
             }
 
-         if (self()->getSymbolReference().getSymbol()
-            && self()->getSymbolReference().getSymbol()->isClassObject()
-            && cg->wantToPatchClassPointer(NULL, cursor)) // might not point to beginning of class
-            {
-            cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, self()->getUnresolvedDataSnippet() != NULL);
-            }
-
          break;
          }
 
@@ -1260,11 +1253,6 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                                                                                                     node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                                     TR_ClassAddress, cg), __FILE__, __LINE__, node);
                            }
-                        }
-
-                     if (cg->wantToPatchClassPointer(NULL, cursor)) // might not point to beginning of class
-                        {
-                        cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, false);
                         }
                      }
                   else
@@ -1315,13 +1303,6 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                         }
                      }
                   }
-               else
-                  {
-                  if (symbol->isClassObject() && cg->wantToPatchClassPointer(NULL, cursor)) // unresolved
-                     {
-                     cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)-1, (void *) cursor, true);
-                     }
-                  }
                }
             }
          else
@@ -1355,50 +1336,6 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
 
          break;
          }
-
-      case 5:
-         {
-         intptr_t displacement = self()->getDisplacement();
-         TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
-
-         if (!(displacement == 0 &&
-               !base->needsDisp() &&
-               !base->needsDisp() &&
-               !self()->isForceWideDisplacement()) &&
-             !(displacement >= -128 &&
-               displacement <= 127  &&
-               !self()->isForceWideDisplacement()))
-            {
-            if (self()->getSymbolReference().getSymbol()
-               && self()->getSymbolReference().getSymbol()->isClassObject()
-               && cg->wantToPatchClassPointer(NULL, cursor)) // possibly unresolved, may not point to beginning of class
-               {
-               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, self()->getUnresolvedDataSnippet() != NULL);
-               }
-            }
-
-         break;
-         }
-
-      case 7:
-         {
-         intptr_t displacement = self()->getDisplacement();
-
-         if (!(displacement >= -128 &&
-               displacement <= 127  &&
-               !self()->isForceWideDisplacement()))
-            {
-            if (self()->getSymbolReference().getSymbol()
-               && self()->getSymbolReference().getSymbol()->isClassObject()
-               && cg->wantToPatchClassPointer(NULL, cursor)) // possibly unresolved, may not point to beginning of class
-               {
-               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *)cursor, self()->getUnresolvedDataSnippet() != NULL);
-               }
-            }
-
-         break;
-         }
-
       }
 
    }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -274,14 +274,6 @@ TR::Instruction *OMR::X86::TreeEvaluator::insertLoadConstant(TR::Node           
          movInstruction = generateRegImmInstruction(currentInstruction, ops[opsRow][MOV], target, static_cast<int32_t>(value), cg, reloKind);
          }
 
-      // HCR register PIC site in TR::TreeEvaluator::insertLoadConstant
-      TR::Symbol *symbol = NULL;
-      if (node && node->getOpCode().hasSymbolReference())
-         symbol = node->getSymbol();
-      bool isPICCandidate = symbol ? target && symbol->isStatic() && symbol->isClassObject() : false;
-      if (isPICCandidate && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)value, node))
-         comp->getStaticHCRPICSites()->push_front(movInstruction);
-
       if (target && node &&
           node->getOpCodeValue() == TR::aconst &&
           node->isClassPointerConstant() &&
@@ -466,12 +458,6 @@ OMR::X86::TreeEvaluator::insertLoadMemory(
       i = generateRegMemInstruction(opCode, node, target, tempMR, cg);
       }
 
-   // HCR in insertLoadMemory to do: handle unresolved data
-   if (node && node->getSymbol()->isStatic() && node->getSymbol()->isClassObject() && cg->wantToPatchClassPointer(NULL, node))
-      {
-      // I think this has no effect; i has no immediate source operand.
-      comp->getStaticHCRPICSites()->push_front(i);
-      }
    return i;
    }
 
@@ -3174,12 +3160,6 @@ TR::Register *OMR::X86::TreeEvaluator::generateLEAForLoadAddr(TR::Node *node,
 
    TR::Instruction *instr = generateRegMemInstruction(op, node, targetRegister, memRef, cg);
    memRef->decNodeReferenceCounts(cg);
-   // HCR register PIC site in generateLEAForLoadAddr
-   if (node && node->getSymbol()->isClassObject() && cg->wantToPatchClassPointer(NULL, node))
-      {
-      // I think this has no effect; instr has no immediate source operand.
-      comp->getStaticHCRPICSites()->push_front(instr);
-      }
    if (cg->enableRematerialisation())
        {
        TR_RematerializableTypes type;

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -311,10 +311,6 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       TR_ASSERT(udsPatchLocation != NULL,"Literal Pool Reference has NULL Unresolved Data Snippet patch site!");
       *(intptr_t *)udsPatchLocation = (intptr_t)cursor;
       getUnresolvedDataSnippet()->setLiteralPoolSlot(cursor);
-      if (getUnresolvedDataSnippet()->getDataSymbol()->isClassObject() && cg()->wantToPatchClassPointer(NULL, cursor)) // unresolved
-         {
-         cg()->jitAddPicToPatchOnClassRedefinition((void*) *(uintptr_t *)cursor , (void *) cursor, true);
-         }
       }
 #endif
 


### PR DESCRIPTION
These were introduced a long time ago to allow a certain change to be toggled. The change was to stop generating runtime assumptions for patching class pointers on class redefinition, and to stop generating slower but more easily patchable instruction sequences to allow for those runtime assumptions. The patching was no longer needed because class redefinition had been made in-place.

As a result, `wantToPatchClassPointer()` and `hcrPatchClassPointers` are no longer necessary. They are removed, and all use sites now behave as though `hcrPatchClassPointers` is not set and `wantToPatchClassPointer()` returns false.