### PR TITLE
Generalize management of write access to dynamically generated code

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,10 +33,6 @@
 #include "il/Node_inlines.hpp"
 #include "il/StaticSymbol.hpp"
 #include "runtime/CodeCacheManager.hpp"
-
-#if defined(OSX)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 uint8_t *OMR::ARM64::Instruction::generateBinaryEncoding()
    {
@@ -181,12 +177,10 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
                TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(destination, (intptr_t)cursor),
                                "Call target address is out of range");
 
-#if defined(OSX)
                // Re-acquire permission for writing to the code buffer.
                // methodTrampolineLookup() may call createTrampoline() which will acquire/release
                // write protection leaving the write permission disabled in this path.
-               pthread_jit_write_protect_np(0);
-#endif
+               omrthread_jit_write_protect_disable();
                }
 
             intptr_t distance = destination - (intptr_t)cursor;

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,10 +45,6 @@
 #include "il/Node_inlines.hpp"
 #include "il/StaticSymbol.hpp"
 #include "ras/DebugCounter.hpp"
-
-#if defined(OSX)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 OMR::ARM64::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
       OMR::CodeGenerator(comp),
@@ -288,9 +284,7 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
    uint8_t *coldCode = NULL;
    uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);
@@ -331,9 +325,7 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
 
    self()->getLinkage()->performPostBinaryEncoding();
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+   omrthread_jit_write_protect_enable();
    }
 
 TR::Linkage *OMR::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
@@ -572,15 +564,13 @@ void OMR::ARM64::CodeGenerator::apply16BitLabelRelativeRelocation(int32_t *curso
    // for "tbz/tbnz" instruction
    TR_ASSERT(label->getCodeLocation(), "Attempt to relocate to a NULL label address!");
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
+
    intptr_t distance = reinterpret_cast<intptr_t>(label->getCodeLocation() - reinterpret_cast<uint8_t *>(cursor));
    TR_ASSERT_FATAL(constantIsSignedImm16(distance), "offset (%d) is too large for imm14", distance);
    *cursor |= ((distance >> 2) & 0x3fff) << 5; // imm14
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+
+   omrthread_jit_write_protect_enable();
    }
 
 void OMR::ARM64::CodeGenerator::apply24BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label)
@@ -588,14 +578,12 @@ void OMR::ARM64::CodeGenerator::apply24BitLabelRelativeRelocation(int32_t *curso
    // for "b.cond" instruction
    TR_ASSERT(label->getCodeLocation(), "Attempt to relocate to a NULL label address!");
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
+
    intptr_t distance = (uintptr_t)label->getCodeLocation() - (uintptr_t)cursor;
    *cursor |= ((distance >> 2) & 0x7ffff) << 5; // imm19
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+
+   omrthread_jit_write_protect_enable();
    }
 
 void OMR::ARM64::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label)
@@ -603,14 +591,12 @@ void OMR::ARM64::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *curso
    // for unconditional "b" instruction
    TR_ASSERT(label->getCodeLocation(), "Attempt to relocate to a NULL label address!");
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
+
    intptr_t distance = (uintptr_t)label->getCodeLocation() - (uintptr_t)cursor;
    *cursor |= ((distance >> 2) & 0x3ffffff); // imm26
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+
+   omrthread_jit_write_protect_enable();
    }
 
 int64_t OMR::ARM64::CodeGenerator::getLargestNegConstThatMustBeMaterialized()

--- a/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,22 +26,16 @@
 #include "env/jittypes.h"
 #include <infra/Assert.hpp>
 
-#if defined(OSX)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
-
 extern void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
 
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
    int64_t distance = (int64_t)destinationAddr - (int64_t)locationAddr;
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
+
    *(uint32_t *)locationAddr = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b) | ((distance >> 2) & 0x3ffffff); /* imm26 */
    arm64CodeSync((unsigned char *)locationAddr, ARM64_INSTRUCTION_LENGTH);
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+
+   omrthread_jit_write_protect_enable();
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,10 +111,6 @@
 #include "runtime/Runtime.hpp"
 #include "stdarg.h"
 #include "OMR/Bytes.hpp"
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 namespace TR { class Optimizer; }
 namespace TR { class RegisterDependencyConditions; }
@@ -2373,9 +2369,7 @@ OMR::CodeGenerator::emitSnippets()
    uint8_t *codeOffset;
    uint8_t *retVal;
 
-#if defined(OSX) && defined(AARCH64)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
 
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
@@ -2400,9 +2394,7 @@ OMR::CodeGenerator::emitSnippets()
       self()->emitDataSnippets();
       }
 
-#if defined(OSX) && defined(AARCH64)
-   pthread_jit_write_protect_np(1);
-#endif
+   omrthread_jit_write_protect_enable();
 
    return retVal;
    }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,10 +53,6 @@
 TR::CodeCacheSymbolContainer * OMR::CodeCacheManager::_symbolContainer = NULL;
 
 #endif //HOST_OS == OMR_LINUX
-
-#if defined(OSX) && defined(AARCH64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 OMR::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator) :
    _rawAllocator(rawAllocator),
@@ -843,16 +839,12 @@ OMR::CodeCacheManager::allocateCodeCacheRepository(size_t repositorySize)
       // a TR::CodeCache structure and the first two entries in the cache
       // to be warmCodeAlloc and coldCodeAlloc.
 
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(0);
-#endif
+      omrthread_jit_write_protect_disable();
 
       uint8_t * start = _codeCacheRepositorySegment->segmentAlloc();
       *((TR::CodeCache**)start) = self()->getRepositoryCodeCacheAddress();
 
-#if defined(OSX) && defined(AARCH64)
-      pthread_jit_write_protect_np(1);
-#endif
+      omrthread_jit_write_protect_enable();
 
       _codeCacheRepositorySegment->adjustAlloc(sizeof(TR::CodeCache*)); // jump over the pointer we setup
 

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,10 +32,6 @@
 #include "runtime/CodeCacheConfig.hpp"
 #include "runtime/Runtime.hpp"
 #include "env/CompilerEnv.hpp"
-
-#if defined(OSX) && defined(TR_TARGET_ARM64)
-#include <pthread.h> // for pthread_jit_write_protect_np
-#endif
 
 #if defined(JITTEST)
 #include "env/ConcreteFE.hpp"
@@ -351,9 +347,8 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
    {
    uint32_t *buffer = (uint32_t *)((uint8_t *)trampPtr + TRAMPOLINE_SIZE);  // Skip the first trampoline for index 0
 
-#if defined(OSX)
-   pthread_jit_write_protect_np(0);
-#endif
+   omrthread_jit_write_protect_disable();
+
    for (int32_t i=1; i<numHelpers; i++)
       {
       *((int32_t *)buffer) = 0x58000050; //LDR R16 PC+8
@@ -363,9 +358,8 @@ void arm64CreateHelperTrampolines(void *trampPtr, int32_t numHelpers)
       *((intptr_t *)buffer) = (intptr_t)runtimeHelperValue((TR_RuntimeHelper)i);
       buffer += 2;
       }
-#if defined(OSX)
-   pthread_jit_write_protect_np(1);
-#endif
+
+   omrthread_jit_write_protect_enable();
    }
 
 void arm64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t *numHelpers, int32_t* CCPreLoadedCodeSize)

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,10 +42,6 @@
 #if defined(AIXPPC)
 #include <sys/vminfo.h>
 #endif /* defined(AIXPPC) */
-
-#if defined(OSX) && defined(OMR_ARCH_AARCH64)
-#include <pthread.h> /* for pthread_jit_write_protect_np */
-#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
 
 #define TWO_GIG_BAR 0x7FFFFFFF
 #define ONE_MB (1*1024*1024)
@@ -2624,10 +2620,8 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			} else {
 #endif /* J9ZOS39064 */
 
-#if defined(OSX) && defined(OMR_ARCH_AARCH64)
 				/* Start writing to executable memory */
-				pthread_jit_write_protect_np(0);
-#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
+				omrthread_jit_write_protect_disable();
 
 				memset(memPtr, 0, params.pageSize);
 
@@ -2645,10 +2639,8 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 
 				memcpy(memPtr, (void *)&myFunction1, length);
 
-#if defined(OSX) && defined(OMR_ARCH_AARCH64)
 				/* Stop writing to executable memory */
-				pthread_jit_write_protect_np(1);
-#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
+				omrthread_jit_write_protect_enable();
 
 				portTestEnv->log("*memPtr: 0x%zx\n", *((unsigned int *)memPtr));
 


### PR DESCRIPTION
Centralize access to `pthread_jit_write_protect_np()`.

Define `omrthread_jit_write_protect_disable()` and `omrthread_jit_write_protect_enable()` to reduce repetition and simplify porting to platforms where writes are normally disallowed to executable memory. It will also reduce the cost of reacting to changes to already supported platforms (e.g. it should not surprise anyone if the protection that must be managed on Aarch64 becomes a necessity on x86 processors as well).