### PR TITLE
AArch64: Implement popcnt evaluators

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -943,6 +943,8 @@ static const char *opCodeToNameMap[] =
    "vxtn2_16b",
    "vxtn2_8h",
    "vxtn2_4s",
+   "vcnt8b",
+   "vcnt16b",
    "vdup16b",
    "vdup8h",
    "vdup4s",
@@ -990,6 +992,7 @@ static const char *opCodeToNameMap[] =
    "vumull2_8h",
    "vumull2_4s",
    "vumull2_2d",
+   "vaddv8b",
    "vaddv16b",
    "vaddv8h",
    "vaddv4s",

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -930,6 +930,8 @@
 		vxtn2_16b,                                               	/* 0x4E212800	XTN2    	 */
 		vxtn2_8h,                                                	/* 0x4E612800	XTN2    	 */
 		vxtn2_4s,                                                	/* 0x4EA12800	XTN2    	 */
+		vcnt8b,                                                  	/* 0x0E205800	CNT     	 */
+		vcnt16b,                                                  	/* 0x4E205800	CNT     	 */
 	/* Vector Copy */
 		/* DUP (general) */
 		vdup16b,                                               		/* 0x4E010C00	DUP      	 */
@@ -987,6 +989,7 @@
 		vumull2_4s,                                              	/* 0x6E60C000	UMULL2   	 */
 		vumull2_2d,                                              	/* 0x6EA0C000	UMULL2   	 */
 	/* Vector reduce instructions */
+		vaddv8b,                                                	/* 0x0E31B800	ADDV    	 */
 		vaddv16b,                                               	/* 0x4E31B800	ADDV    	 */
 		vaddv8h,                                                	/* 0x4E71B800	ADDV    	 */
 		vaddv4s,                                                	/* 0x4EB1B800	ADDV    	 */

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4789,18 +4789,6 @@ OMR::ARM64::TreeEvaluator::iuminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register*
 OMR::ARM64::TreeEvaluator::luminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::ipopcntEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::ARM64::TreeEvaluator::lpopcntEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -931,6 +931,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x4E212800,	/* XTN2    	vxtn2_16b */
 		0x4E612800,	/* XTN2    	vxtn2_8h  */
 		0x4EA12800,	/* XTN2    	vxtn2_4s  */
+		0x0E205800,	/* CNT  	vcnt8b */
+		0x4E205800,	/* CNT  	vcnt16b */
 	/* Vector Copy */
 		/* DUP (general) */
 		0x4E010C00,	/* DUP   	vdup16b */
@@ -988,6 +990,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6E60C000,	/* UMULL2  	vumull2_4s */
 		0x6EA0C000,	/* UMULL2  	vumull2_2d */
 	/* Vector reduce instructions */
+		0x0E31B800,	/* ADDV   	vaddv8b */
 		0x4E31B800,	/* ADDV   	vaddv16b */
 		0x4E71B800,	/* ADDV   	vaddv8h */
 		0x4Eb1B800,	/* ADDV   	vaddv4s */

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corp. and others
+ * Copyright (c) 2019, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,6 +63,12 @@ public:
     * @return true if supported, false otherwise
     */
    bool getSupportsHardwareSQRT() { return true; }
+
+   /**
+    * @brief Answers whether the CPU has instruction for population count or not
+    * @return true if supported, false otherwise
+    */
+   bool hasPopulationCountInstruction() { return true; }
 
    /**
     * @brief Provides the maximum forward branch displacement in bytes reachable


### PR DESCRIPTION
This commit implements ipopcnt/lpopcnt evaluators for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>