### PR TITLE
Use https links in notice file

### DIFF
--- a/.copyrightignore
+++ b/.copyrightignore
@@ -1,3 +1,4 @@
 //List of files that don't require copyrights
 //One file per line, and full paths must be used
 .copyrightignore
+Notice.html

--- a/Notice.html
+++ b/Notice.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
 <title>Eclipse Foundation Software User Agreement</title>
@@ -58,12 +58,12 @@ that directory.</p>
 OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
 
 <ul>
-       <li>Eclipse Distribution License Version 1.0 (available at <a href="http://www.eclipse.org/licenses/edl-v10.html">http://www.eclipse.org/licenses/edl-v1.0.html</a>)</li>
+       <li>Eclipse Distribution License Version 1.0 (available at <a href="https://www.eclipse.org/licenses/edl-v10.html">https://www.eclipse.org/licenses/edl-v1.0.html</a>)</li>
        <li>Eclipse Distribution License Version 2.0 (available at <a href="https://www.eclipse.org/legal/epl-2.0">https://www.eclipse.org/legal/epl-2.0</a>)</li>
-       <li>Common Public License Version 1.0 (available at <a href="http://www.eclipse.org/legal/cpl-v10.html">http://www.eclipse.org/legal/cpl-v10.html</a>)</li>
-       <li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
-       <li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
-       <li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+       <li>Common Public License Version 1.0 (available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>)</li>
+       <li>Apache Software License 1.1 (available at <a href="https://www.apache.org/licenses/LICENSE">https://www.apache.org/licenses/LICENSE</a>)</li>
+       <li>Apache Software License 2.0 (available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+       <li>Mozilla Public License Version 1.1 (available at <a href="https://www.mozilla.org/MPL/MPL-1.1.html">https://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
 </ul>
 
 <p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT.  If no About, Feature License, or Feature Update License is provided, please
@@ -76,7 +76,7 @@ contact the Eclipse Foundation to determine what terms and conditions govern tha
    Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or
    other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to
    install, extend and update Eclipse-based products. Information about packaging Installable Software is available at <a
-       href="http://eclipse.org/equinox/p2/repository_packaging.html">http://eclipse.org/equinox/p2/repository_packaging.html</a>
+       href="https://eclipse.org/equinox/p2/repository_packaging.html">https://eclipse.org/equinox/p2/repository_packaging.html</a>
    (&quot;Specification&quot;).</p>
 
 <p>You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the


### PR DESCRIPTION
http links are insecure. This was flagged by an IBM security scan.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>