### PR TITLE
Remove disableWrtBarSrcObjCheck option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -590,7 +590,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableVMCSProfiling",               "O\tdisable VM data for virtual call sites", SET_OPTION_BIT(TR_DisableVMCSProfiling), "F", NOT_IN_SUBSET},
    {"disableVSSStackCompaction",          "O\tdisable VariableSizeSymbol stack compaction", SET_OPTION_BIT(TR_DisableVSSStackCompaction), "F"},
    {"disableWriteBarriersRangeCheck",     "O\tdisable adding range check to write barriers",   SET_OPTION_BIT(TR_DisableWriteBarriersRangeCheck), "F"},
-   {"disableWrtBarSrcObjCheck",           "O\tdisable to not check srcObj location for wrtBar in gc", SET_OPTION_BIT(TR_DisableWrtBarSrcObjCheck), "F"},
    {"disableZ10",                         "O\tdisable z10 support",                            SET_OPTION_BIT(TR_DisableZ10), "F"},
    {"disableZ13",                         "O\tdisable z13 support",                        SET_OPTION_BIT(TR_DisableZ13), "F"},
    {"disableZ14",                         "O\tdisable z14 support",                            SET_OPTION_BIT(TR_DisableZ14), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -701,7 +701,7 @@ enum TR_CompilationOptions
    // Option word 21
    // Available                                       = 0x00000020 + 21,
    // Available                                       = 0x00000040 + 21,
-   TR_DisableWrtBarSrcObjCheck                        = 0x00000080 + 21, // enable srcobj range check for wrtBar
+   // Available                                       = 0x00000080 + 21,
    TR_DisableCodeCacheReclamation                     = 0x00000100 + 21, // Disable the freeing of compiled methods
    TR_DisableClearCodeCacheFullFlag                   = 0x00000200 + 21, // Disable the re-enabling of the code cache when a method body is freed after the cache has become full
    // Available                                       = 0x00000400 + 21,


### PR DESCRIPTION
The `disableWrtBarSrcObjCheck` option is not used anymore and can be removed.