### PR TITLE
Implement TR_Debug::getRealRegisterName() for AArch64

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2913,6 +2913,9 @@ TR_Debug::getRealRegisterName(uint32_t regNum)
 #if defined(TR_TARGET_ARM)
    return getName(regNum+1);
 #endif
+#if defined(TR_TARGET_ARM64)
+   return getARM64RegisterName(regNum+1);
+#endif
 #if defined(TR_TARGET_S390)
    return getS390RegisterName(regNum+1);
 #endif


### PR DESCRIPTION
This commit implements TR_Debug::getRealRegisterName() for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>