### PR TITLE
Define suppressEA option and implement regular expression matching based on a location in IL

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1097,6 +1097,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"suffixLogs",          "O\tadd the date/time/pid suffix to the file name of the logs", SET_OPTION_BIT(TR_EnablePIDExtension), "F", NOT_IN_SUBSET},
    {"suffixLogsFormat=",   "O\tadd the suffix in specified format to the file name of the logs", TR::Options::setString,  offsetof(OMR::Options, _suffixLogsFormat), 0, "P%s", NOT_IN_SUBSET},
    {"supportSwitchToInterpeter", "C\tGenerate code to allow each method to switch to the interpreter", SET_OPTION_BIT(TR_SupportSwitchToInterpreter), "P"},
+   {"suppressEA=",               "O{regex}\tSuppress stack allocations by Escape Analysis at locations that match the specified regex", TR::Options::setRegex, offsetof(OMR::Options, _suppressEA), 0, "P"},
    {"suspendCompThreadsEarly", "M\tSuspend compilation threads when QWeight drops under a threshold", SET_OPTION_BIT(TR_SuspendEarly), "F", NOT_IN_SUBSET },
    {"terseRegisterPressureTrace","L\tinclude only summary info about register pressure tracing when traceGRA is enabled", SET_OPTION_BIT(TR_TerseRegisterPressureTrace), "P" },
    {"test390LitPoolBufferSize=", "L\tInsert 8byte elements into Lit Pool to force testing of large lit pool sizes",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1716,6 +1716,7 @@ public:
    TR::SimpleRegex * getPackedTestRegex()              {return _packedTest;}
    TR::SimpleRegex * getClassesWithFoldableFinalFields(){return _classesWithFolableFinalFields;}
    TR::SimpleRegex * getDisabledIdiomPatterns()        {return _disabledIdiomPatterns;}
+   TR::SimpleRegex * getSuppressEARegex()              {return _suppressEA;}
 
    char* getInduceOSR()                               {return _induceOSR;}
    int32_t getBigCalleeThreshold() const              {return _bigCalleeThreshold;}
@@ -2355,6 +2356,7 @@ protected:
    TR::SimpleRegex *            _memUsage;
    TR::SimpleRegex *            _classesWithFolableFinalFields;
    TR::SimpleRegex *            _disabledIdiomPatterns;
+   TR::SimpleRegex *            _suppressEA;
    uintptr_t                   _gcCardSize;
    uintptr_t                   _heapBase;
    uintptr_t                   _heapTop;

--- a/compiler/infra/SimpleRegex.hpp
+++ b/compiler/infra/SimpleRegex.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,38 @@ class SimpleRegex
    static bool match(TR::SimpleRegex *regex, const char *, bool isCaseSensitive=true);
    static bool match(TR::SimpleRegex *regex, int, bool isCaseSensitive=true);
    static bool match(TR::SimpleRegex *regex, TR_ResolvedMethod *, bool isCaseSensitive=true);
+
+   /**
+    * \brief Check whether a location identified by the specified \ref TR_ByteCodeInfo
+    *        matches the specified regular expression
+    *
+    * The location described by the \c bcInfo argument is expanded into a string of the
+    * form
+    *
+    * [<tt>\#</tt> <em>outer-method-sig</em>] <tt>\@</tt> <em>bc-offset</em> { <tt>\#</tt> <em>callee-method-sig</em> <tt>\@</tt> <em>bc-offset</em> }*
+    *
+    * where each <i>callee-method-sig</i> is the signature of an inlined method invocation,
+    * and each <i>bc-offset</i> is a bytecode offset within the particular method.  The outermost method
+    * signature is optional.
+    *
+    * For example, if the outermost method <code>Outer.out()V</code> has an inlined reference to
+    * <code>Middle.mid()Z</code> at bytecode offset 13, and that in turn has an inlined
+    * reference to <code>Inner.in()I</code> at bytecode offset 17, then bytecode offset 19 of
+    * that innermost inlined reference would have the following two forms:
+    *
+    * <ul>
+    * <li><tt>#Outer.out()V@13#Middle.mid()Z@17#Inner.in()I@19</tt>
+    * <li><tt>@13#Middle.mid()Z@17#Inner.in()I@19</tt>
+    * </ul>
+    *
+    * If either form of the location matches the regular expression, the match is successful.
+    *
+    * \param[in] regex The regular expression against which to match
+    * \param[in] bcInfo A location in the IL
+    * \param[in] isCaseSensitive Optional.  Specifies whether the case of letters is significant in matching.  Default is \c true.
+    * \return \c true if the location matches the specified regular expression; \c false otherwise
+    */
+   static bool match(TR::SimpleRegex *regex, TR_ByteCodeInfo &bcInfo, bool isCaseSensitive=true);
    static bool matchIgnoringLocale(TR::SimpleRegex *regex, const char *, bool isCaseSensitive=true);
 
    void print(bool negate);


### PR DESCRIPTION
This change introduces the `suppressEA` option.  The intent is that a downstream project can use the option to suppress stack allocations at matching locations that might be performed in an Escape Analysis optimization.

The other part of the change defines a new `TR::SimpleRegex::match` method that will match a regular expression against a location in a sequence of inlined method invocations that are described by a `TR_ByteCodeInfo`. The `TR_ByteCodeInfo` is rendered as strings of the form
 
 ```   
    '#' <outermost-method-sig> '@' <bc-offset> { '#' <inlined-method-sig> '@' <bc-offset> } *
 ```
    
 and
 
```
   '@' <bc-offset> { '#' <inlined-method-sig> '@' <bc-offset> } *
```

where each &lt;bc-offset> is the bytecode offset from the start of a method, and each &lt;method-sig> is the signature of the outermost method or an inlined method invocation.  If either string matches the specified regular expression, the match is successful.  That makes the outermost method signature optional in the specified regular expression.

It is likely that projects taking advantage of the `suppressEA` option will use this new form of regular expression matching.