### PR TITLE
Version guards with merged HCR/OSR guards only when possible

### DIFF
--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -391,6 +391,18 @@ class TR_LoopVersioner : public TR_LoopTransformer
        */
       flags32_t _flags;
 
+      /// Determine whether this expression is a guard merged with an HCR guard.
+      bool mergedWithHCRGuard() const
+         {
+         return _op.isIf() && _guard != NULL && _guard->mergedWithHCRGuard();
+         }
+
+      /// Determine whether this expression is a guard merged with an OSR guard.
+      bool mergedWithOSRGuard() const
+         {
+         return _op.isIf() && _guard != NULL && _guard->mergedWithOSRGuard();
+         }
+
       bool operator<(const Expr &rhs) const;
       };
 
@@ -697,6 +709,20 @@ class TR_LoopVersioner : public TR_LoopTransformer
 
       /// Check and branch nodes that will be removed if privatization is allowed.
       TR::NodeChecklist _optimisticallyRemovableNodes;
+
+      /// Guards that will be removed as long as HCR guard versioning is allowed.
+      TR::NodeChecklist _guardsRemovableWithHCR;
+
+      /// Guards that will be removed as long as both privatization and HCR
+      /// guard versioning are allowed.
+      TR::NodeChecklist _guardsRemovableWithPrivAndHCR;
+
+      /// Guards that will be removed as long as OSR guard versioning is allowed.
+      TR::NodeChecklist _guardsRemovableWithOSR;
+
+      /// Guards that will be removed as long as both privatization and OSR
+      /// guard versioning are allowed.
+      TR::NodeChecklist _guardsRemovableWithPrivAndOSR;
 
       /// Branch nodes that, if removed, will be taken.
       TR::NodeChecklist _takenBranches;


### PR DESCRIPTION
Loop versioner has been versioning virtual guards with merged HCR or OSR guards without taking the merged guards into account.

For example, consider a nonoverridden guard with a merged HCR guard. If the receiver is invariant, then it would be versioned, and the merged HCR guard would effectively be versioned along with it even if HCR guard versioning is not supposed to be possible in the loop, i.e. even if the hot loop will still have HCR invalidation points in it after versioning. So if the protected method were redefined during execution of the resulting hot loop, the loop would continue to run the old definition until it exited.

With this commit, virtual guards with merged HCR guards will now be versioned only when HCR guard versioning is possible, and those with merged OSR guards will now be versioned only when OSR guard versioning is possible.