### PR TITLE
Unbounded GC Thread Pool Expansion for CRIU Restore

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -136,29 +136,16 @@ public:
 	 * @param[in] env the current environment
 	 * @return void
 	 */
-	virtual void
-	adjustGCThreadCountForCheckpoint(MM_EnvironmentBase* env)
-	{
-		adjustGCThreadCountOnCheckpoint(env);
-	}
-
-	/* Temp: To be deleted and replaced by adjustGCThreadCountForCheckpoint.  */
-	virtual void adjustGCThreadCountOnCheckpoint(MM_EnvironmentBase* env);
+	virtual void adjustGCThreadCountForCheckpoint(MM_EnvironmentBase* env);
 
 	/**
 	 * Startup GC threads on restore.
 	 *
 	 * @param[in] env the current environment
-	 * @return void
+	 * @return bool indicating if the restore thread count was
+	 * successfully set and accommodated (thread pool resized).
 	 */
-	virtual bool
-	reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env)
-	{
-		return reinitializeGCThreadCountOnRestore(env);
-	}
-
-	/* Temp: To be deleted and replaced by reinitializeGCThreadCountForRestore.  */
-	virtual bool reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env);
+	virtual bool reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_Configuration(MM_EnvironmentBase* env, MM_GCPolicy gcPolicy, MM_AlignmentType alignmentType, uintptr_t defaultRegionSize, uintptr_t defaultArrayletLeafSize, MM_GCWriteBarrierType writeBarrierType, MM_GCAllocationType allocationType)

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -289,11 +289,11 @@ MM_ConfigurationGenerational::initializeConcurrentScavengerThreadCount(MM_Enviro
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 bool
-MM_ConfigurationGenerational::reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env)
+MM_ConfigurationGenerational::reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
-	bool result = MM_Configuration::reinitializeGCThreadCountOnRestore(env);
+	bool result = MM_Configuration::reinitializeGCThreadCountForRestore(env);
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	initializeConcurrentScavengerThreadCount(env);

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,9 +60,10 @@ public:
 	 * Startup GC threads on restore.
 	 *
 	 * @param[in] env the current environment.
-	 * @return void
+	 * @return bool indicating if the restore thread count was
+	 * successfully set and accommodated (thread pool resized).
 	 */
-	virtual bool reinitializeGCThreadCountOnRestore(MM_EnvironmentBase* env);
+	virtual bool reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_ConfigurationGenerational(MM_EnvironmentBase *env)


### PR DESCRIPTION
Initial set of changes to expand the GC thread pool beyond the dispatcher initialization done at VM startup. This involves reallocating memory for the dispatcher tables, these tables store thread pointers/meta data and are sized based on the initial thread count at startup. Given the restore machine configuration, the thread pool may need to be expanded beyond the initial capacity, hence these tables must be reinited to accommodate a larger thread count.

Some things to note for unbounded expansion considering this capability is still under development:
- By default, the restore thread count is still capped based on startup conditions (i.e this capability is disabled). To enable this, a restore thread count must be explicitly set.
- Only expected to work with the standard collectors.
- Performance regressions are expected, no other known issues/crashes with standard collectors (GC components function as expected).
- Disabled for non-standard collectors. Balanced GC requires further work, Balanced GC components require reinit (ones tightly coupled to the # of GC threads). 

Signed-off-by: Salman Rana <salman.rana@ibm.com>