### PR TITLE
x86: handle NaN inputs for vmmin/vmmax

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4287,7 +4287,9 @@ TR::Register* OMR::X86::TreeEvaluator::vectorBinaryArithmeticEvaluator(TR::Node*
       switch (node->getOpCode().getVectorOperation())
          {
          case TR::vmin:
+         case TR::vmmin:
          case TR::vmax:
+         case TR::vmmax:
             // These opcodes require special handling of NaN values
             // If either operand is NaN, the result must be NaN
             tmpNaNReg = cg->allocateRegister(TR_VRF);


### PR DESCRIPTION
It was discovered that NaN input values were not handled for masked versions of min/max opcodes. This change fixes that.

Signed-off-by: Bradley Wood <bradley.wood@ibm.com>