### PR TITLE
Replace sprintf() in pugixml with snprintf()

### DIFF
--- a/third_party/pugixml-1.5/pugixml.cpp
+++ b/third_party/pugixml-1.5/pugixml.cpp
@@ -11,6 +11,12 @@
  * Copyright (C) 2003, by Kristen Wegner (kristen@tima.net)
  */
 
+/*
+ * ===========================================================================
+ * Copyright (c) 2018, 2023 IBM Corp. and others
+ * ===========================================================================
+ */
+
 #ifndef SOURCE_PUGIXML_CPP
 #define SOURCE_PUGIXML_CPP
 
@@ -144,6 +150,11 @@ PUGI__NS_BEGIN
 	typedef unsigned __int32 uint32_t;
 PUGI__NS_END
 #endif
+
+// snprintf
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf(s, n, format, ...) _snprintf_s(s, n, _TRUNCATE, format, __VA_ARGS__)
+#endif /* defined(_MSC_VER) && (_MSC_VER < 1900) */
 
 // Memory allocation
 PUGI__NS_BEGIN
@@ -3986,7 +3997,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, int value)
 	{
 		char buf[128];
-		sprintf(buf, "%d", value);
+		snprintf(buf, sizeof(buf), "%d", value);
 	
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -3994,7 +4005,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, unsigned int value)
 	{
 		char buf[128];
-		sprintf(buf, "%u", value);
+		snprintf(buf, sizeof(buf), "%u", value);
 
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -4002,7 +4013,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, double value)
 	{
 		char buf[128];
-		sprintf(buf, "%g", value);
+		snprintf(buf, sizeof(buf), "%g", value);
 
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -4016,7 +4027,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, long long value)
 	{
 		char buf[128];
-		sprintf(buf, "%lld", value);
+		snprintf(buf, sizeof(buf), "%lld", value);
 	
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -4024,7 +4035,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, unsigned long long value)
 	{
 		char buf[128];
-		sprintf(buf, "%llu", value);
+		snprintf(buf, sizeof(buf), "%llu", value);
 	
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -7197,9 +7208,7 @@ PUGI__NS_BEGIN
 	PUGI__FN void convert_number_to_mantissa_exponent(double value, char* buffer, size_t buffer_size, char** out_mantissa, int* out_exponent)
 	{
 		// get a scientific notation value with IEEE DBL_DIG decimals
-		sprintf(buffer, "%.*e", DBL_DIG, value);
-		assert(strlen(buffer) < buffer_size);
-		(void)!buffer_size;
+		snprintf(buffer, buffer_size, "%.*e", DBL_DIG, value);
 
 		// get the exponent (possibly negative)
 		char* exponent_string = strchr(buffer, 'e');


### PR DESCRIPTION
This commit replaces sprintf() used in pugixml with snprintf().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>