### PR TITLE
Use non-asserting query to print nodeCreatedByPRE

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -6683,7 +6683,8 @@ OMR::Node::canChkNodeCreatedByPRE()
 bool
 OMR::Node::isNodeCreatedByPRE()
    {
-   return self()->canChkNodeCreatedByPRE() && _flags.testAny(nodeCreatedByPRE);
+   TR_ASSERT(self()->canChkNodeCreatedByPRE(), "Unexpected opcode %s in isNodeCreatedByPRE()",self()->getOpCode().getName());
+   return _flags.testAny(nodeCreatedByPRE);
    }
 
 void
@@ -6707,8 +6708,7 @@ OMR::Node::resetIsNodeCreatedByPRE()
 bool
 OMR::Node::chkNodeCreatedByPRE()
    {
-   TR_ASSERT(self()->canChkNodeCreatedByPRE(), "Unexpected opcode %s in chkNodeCreatedByPRE()",self()->getOpCode().getName());
-   return _flags.testAny(nodeCreatedByPRE) && self()->getOpCode().isLoadVarDirect();
+   return self()->getOpCode().isLoadVarDirect() && _flags.testAny(nodeCreatedByPRE);
    }
 
 bool


### PR DESCRIPTION
In nodePrintAllFlags(), chkNodeCreatedByPRE() is used to check for the presence of the flag, but it will assert (on a debug build) whenever the flags are printed on a node for which isLoadVarDirect() is false. nodePrintAllFlags() should use the form of the query that simply returns false if the query is invalid for that node, which is isNodeCreatedByPRE().