### PR TITLE
Move Scavenger instantiation earlier

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -80,8 +80,20 @@ public:
 								   uintptr_t memoryMax,
 								   uintptr_t tenureFlags,
 								   MM_InitializationParameters* parameters);
-
-	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env) = 0;
+	/* temporary replace abstract to empty implementation, method will be deleted on next step */
+	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env)
+	{
+		return NULL;
+	};
+	/**
+	 * Create set of collectors for given configuration.
+	 * It might be a Global Collector accompanied with Local Collector if necessary.
+	 *
+	 * @param env[in] the current thread
+	 *
+	 * @return Pointer to created Global Collector or NULL
+	 */
+	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env) = 0;
 	MM_Heap* createHeap(MM_EnvironmentBase* env, uintptr_t heapBytesRequested);
 	virtual MM_Heap* createHeapWithManager(MM_EnvironmentBase* env, uintptr_t heapBytesRequested, MM_HeapRegionManager* regionManager) = 0;
 	virtual MM_HeapRegionManager* createHeapRegionManager(MM_EnvironmentBase* env) = 0;

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -992,13 +992,6 @@ public:
 	{
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		this->scavenger = scavenger;
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
-	}
-
-	virtual void unregisterScavenger()
-	{
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		scavenger = NULL;
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
 

--- a/gc/base/segregated/ConfigurationSegregated.cpp
+++ b/gc/base/segregated/ConfigurationSegregated.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -214,8 +214,22 @@ MM_ConfigurationSegregated::createHeapRegionManager(MM_EnvironmentBase *env)
 /**
  * Create the global collector for a Standard configuration
  */
+/* this temporary wrapper will be deleted on the next step */
 MM_GlobalCollector*
 MM_ConfigurationSegregated::createGlobalCollector(MM_EnvironmentBase* env)
+{
+	return createCollectors(env);
+}
+
+/**
+ * Create Global Collector for a Standard configuration
+ *
+ * @param[in] env the current environment.
+ *
+ * @return Pointer to Global Collector or NULL
+ */
+MM_GlobalCollector*
+MM_ConfigurationSegregated::createCollectors(MM_EnvironmentBase* env)
 {
 	return MM_SegregatedGC::newInstance(env);
 }

--- a/gc/base/segregated/ConfigurationSegregated.hpp
+++ b/gc/base/segregated/ConfigurationSegregated.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,7 @@ public:
 	static MM_Configuration *newInstance(MM_EnvironmentBase *env);
 
 	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
+	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);
 	virtual MM_MemorySpace *createDefaultMemorySpace(MM_EnvironmentBase *env, MM_Heap *heap, MM_InitializationParameters *parameters);

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,16 @@ public:
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, UDATA heapBytesRequested, MM_HeapRegionManager *regionManager);
 
 	virtual void defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void* defaultMemorySpace);
-	
+
+	/**
+	 * Create Local Collector and rely on parent MM_ConfigurationStandard to create Global Collector
+	 *
+	 * @param[in] env the current environment.
+	 *
+	 * @return Pointer to Global Collector or NULL
+	 */
+	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env);
+	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	/**

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,11 +98,18 @@ MM_ConfigurationStandard::initialize(MM_EnvironmentBase* env)
 	return result;
 }
 
+/* this temporary wrapper will be deleted on the next step */
+MM_GlobalCollector*
+MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
+{
+	return createCollectors(env);
+}
+
 /**
  * Create the global collector for a Standard configuration
  */
 MM_GlobalCollector*
-MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
+MM_ConfigurationStandard::createCollectors(MM_EnvironmentBase* env)
 {
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK) || defined(OMR_GC_MODRON_CONCCURENT_SWEEP)
 	MM_GCExtensionsBase *extensions = env->getExtensions();

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -61,6 +61,7 @@ private:
 	/* Methods */
 public:
 	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env);
+	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env);
 	virtual MM_Heap* createHeapWithManager(MM_EnvironmentBase* env, uintptr_t heapBytesRequested, MM_HeapRegionManager* regionManager);
 	virtual MM_HeapRegionManager* createHeapRegionManager(MM_EnvironmentBase* env);
 	virtual J9Pool* createEnvironmentPool(MM_EnvironmentBase* env);

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -184,13 +184,13 @@ MM_Scavenger::deleteSweepPoolState(MM_EnvironmentBase *env, void *sweepPoolState
  * @return a new instance of the receiver or NULL on failure.
  */
 MM_Scavenger *
-MM_Scavenger::newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *regionManager)
+MM_Scavenger::newInstance(MM_EnvironmentStandard *env)
 {
 	MM_Scavenger *scavenger;
 
 	scavenger = (MM_Scavenger *)env->getForge()->allocate(sizeof(MM_Scavenger), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (scavenger) {
-		new(scavenger) MM_Scavenger(env, regionManager);
+		new(scavenger) MM_Scavenger(env);
 		if (!scavenger->initialize(env)) {
 			scavenger->kill(env);
 			scavenger = NULL;

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -723,7 +723,7 @@ protected:
 	
 public:
 
-	static MM_Scavenger *newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *regionManager);
+	static MM_Scavenger *newInstance(MM_EnvironmentStandard *env);
 	virtual void kill(MM_EnvironmentBase *env);
 
 	MM_ScavengerDelegate* getDelegate() { return &_delegate; }
@@ -925,7 +925,7 @@ public:
 	virtual bool canCollectorExpand(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, uintptr_t expandSize);
 	virtual uintptr_t getCollectorExpandSize(MM_EnvironmentBase *env);
 
-	MM_Scavenger(MM_EnvironmentBase *env, MM_HeapRegionManager *regionManager) :
+	MM_Scavenger(MM_EnvironmentBase *env) :
 		MM_Collector()
 		, _cycleTimes()
 		, _delegate(env)
@@ -965,7 +965,7 @@ public:
 		, _backOutDoneIndex(0)
 		, _heapBase(NULL)
 		, _heapTop(NULL)
-		, _regionManager(regionManager)
+		, _regionManager(_extensions->heapRegionManager)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, _mainGCThread(env)
 		, _concurrentPhase(concurrent_phase_idle)

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -54,7 +54,7 @@ collectorCreationHelper(OMR_VM *omrVM, MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_OMRVM(omrVM);
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVM);
-	MM_GlobalCollector *globalCollector = extensions->configuration->createGlobalCollector(env);
+	MM_GlobalCollector *globalCollector = extensions->configuration->createCollectors(env);
 	omr_error_t rc = OMR_ERROR_NONE;
 
 	if (NULL == globalCollector) {


### PR DESCRIPTION
Current place of MM_Scavenger instantiation is
MM_ConfigurationGenerational::createDefaultMemorySpace(). It is relatively late in initialization path without any reason. Late creation required to have "Scavenger registration" in the classes created earlier. Moving Scavenger instantiation to
MM_ConfigurationGenerational::createGlobalCollector() makes more sense and resolves registration problem naturally. Method createGlobalCollector() is going to be renamed to createCollectors() to reflect the fact it might create not only Global, but Local collector too if necessary.

This step:
- creates ConfigurationGenerational createCollectors() and createGlobalCollector() as a wrapper
 - moves MM_Scavenger::newInstance() to createCollectors()
 - removes regionManager paramerer from Scavenger::newInstance() and Scavenger Constructor
 - removes unregisterScavenger()
 - maks createGlobalCollector() be wpappers for createCollectors()
 - removes abstract from createGlobalCollector() (to allow to remove implementation from downstream project) but add it to createCollectors()
 - call createCollectors() instead of createGlobalCollector() from collectorCreationHelper() in omrgcstartup.cpp

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>