### PR TITLE
Cleanup after Scavenger instantiation refactoring

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -80,11 +80,7 @@ public:
 								   uintptr_t memoryMax,
 								   uintptr_t tenureFlags,
 								   MM_InitializationParameters* parameters);
-	/* temporary replace abstract to empty implementation, method will be deleted on next step */
-	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env)
-	{
-		return NULL;
-	};
+
 	/**
 	 * Create set of collectors for given configuration.
 	 * It might be a Global Collector accompanied with Local Collector if necessary.

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -988,13 +988,6 @@ public:
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */
 	}
 
-	virtual void registerScavenger(MM_Scavenger *scavenger)
-	{
-#if defined(OMR_GC_MODRON_SCAVENGER)
-		this->scavenger = scavenger;
-#endif /* defined(OMR_GC_MODRON_SCAVENGER) */
-	}
-
 	MMINLINE bool
 	isConcurrentMarkEnabled()
 	{

--- a/gc/base/segregated/ConfigurationSegregated.cpp
+++ b/gc/base/segregated/ConfigurationSegregated.cpp
@@ -212,16 +212,6 @@ MM_ConfigurationSegregated::createHeapRegionManager(MM_EnvironmentBase *env)
 }
 
 /**
- * Create the global collector for a Standard configuration
- */
-/* this temporary wrapper will be deleted on the next step */
-MM_GlobalCollector*
-MM_ConfigurationSegregated::createGlobalCollector(MM_EnvironmentBase* env)
-{
-	return createCollectors(env);
-}
-
-/**
  * Create Global Collector for a Standard configuration
  *
  * @param[in] env the current environment.

--- a/gc/base/segregated/ConfigurationSegregated.hpp
+++ b/gc/base/segregated/ConfigurationSegregated.hpp
@@ -57,7 +57,6 @@ private:
 public:
 	static MM_Configuration *newInstance(MM_EnvironmentBase *env);
 
-	virtual MM_GlobalCollector *createGlobalCollector(MM_EnvironmentBase *env);
 	virtual MM_GlobalCollector *createCollectors(MM_EnvironmentBase *env);
 	virtual MM_Heap *createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager);
 	virtual MM_HeapRegionManager *createHeapRegionManager(MM_EnvironmentBase *env);

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -198,13 +198,6 @@ MM_ConfigurationGenerational::createDefaultMemorySpace(MM_EnvironmentBase *envBa
 	return MM_MemorySpace::newInstance(env, heap, physicalArena, memorySubSpaceGenerational, parameters, MEMORY_SPACE_NAME_GENERATIONAL, MEMORY_SPACE_DESCRIPTION_GENERATIONAL);
 }
 
-/* this temporary wrapper will be deleted on the next step */
-MM_GlobalCollector*
-MM_ConfigurationGenerational::createGlobalCollector(MM_EnvironmentBase* envBase)
-{
-	return createCollectors(envBase);
-}
-
 /**
  * Create Local Collector and rely on parent MM_ConfigurationStandard to create Global Collector
  */

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -61,7 +61,6 @@ public:
 	 *
 	 * @return Pointer to Global Collector or NULL
 	 */
-	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env);
 	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -98,13 +98,6 @@ MM_ConfigurationStandard::initialize(MM_EnvironmentBase* env)
 	return result;
 }
 
-/* this temporary wrapper will be deleted on the next step */
-MM_GlobalCollector*
-MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
-{
-	return createCollectors(env);
-}
-
 /**
  * Create the global collector for a Standard configuration
  */

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -60,7 +60,6 @@ private:
 
 	/* Methods */
 public:
-	virtual MM_GlobalCollector* createGlobalCollector(MM_EnvironmentBase* env);
 	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env);
 	virtual MM_Heap* createHeapWithManager(MM_EnvironmentBase* env, uintptr_t heapBytesRequested, MM_HeapRegionManager* regionManager);
 	virtual MM_HeapRegionManager* createHeapRegionManager(MM_EnvironmentBase* env);


### PR DESCRIPTION
 - remove GCExtensionsBase::registerScavenger() method
 - remove createGlobalCollector() methods (wrappers)

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>