### PR TITLE
Add infrastructure to process compiler options post restore

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1653,6 +1653,7 @@ int64_t       OMR::Options::INLINE_calleeHasTooManyNodesSum      = 0;
 int32_t       OMR::Options::_inlinerVeryLargeCompiledMethodAdjustFactor = 20;
 
 int32_t       OMR::Options::_numUsableCompilationThreads = -1; // -1 means not initialized
+int32_t       OMR::Options::_numAllocatedCompilationThreads = -1; // -1 means not initialized
 
 int32_t       OMR::Options::_trampolineSpacePercentage = 0; // 0 means no change from default
 
@@ -5460,7 +5461,10 @@ void OMR::Options::setDefaultsForDeterministicMode()
       self()->setOption(TR_DisablePersistIProfile, true); // AOT specific
       OMR::Options::_bigAppThreshold = 1;
       if (TR::Options::getNumUsableCompilationThreads() == -1) // not yet set
+         {
          OMR::Options::_numUsableCompilationThreads = 7;
+         OMR::Options::_numAllocatedCompilationThreads = OMR::Options::_numUsableCompilationThreads;
+         }
 #ifdef J9_PROJECT_SPECIFIC
       TR::Options::_veryHotSampleThreshold = 240; // 12.5 %
       TR::Options::_scorchingSampleThreshold = 120; // 25% CPU

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1345,7 +1345,8 @@ public:
 
    void init()
    {
-      _optionSets = 0;
+      _optionSets = NULL;
+      _postRestoreOptionSets = NULL;
       _startOptions = NULL;
       _envOptions = NULL;
       _logFileName = NULL;
@@ -1531,6 +1532,8 @@ public:
    static void        setAOTCmdLineOptions(TR::Options *options);
    static TR::Options *getJITCmdLineOptions();
           void        addOptionSet(TR::OptionSet *o) {o->setNext(_optionSets);_optionSets = o;}
+          void        addPostRestoreOptionSet(TR::OptionSet *o) {o->setNext(_postRestoreOptionSets);_postRestoreOptionSets = o;}
+          void        mergePostRestoreOptionSets();
           bool        hasOptionSets() {return _optionSets != NULL;}
    char*              setCounts();
 
@@ -2004,6 +2007,18 @@ public:
 
    const char *getObjectFileName() { return _objectFileName; }
 
+   /**
+    * \brief API to process options post restore (from a checkpoint).
+    *
+    * \param jitConfig Pointer to a JitConfig instance.
+    * \param options Pointer to the options string to be parsed and processed.
+    * \param optBase Pointer to the TR::Options object that will represent the parsed options.
+    * \param isAOT bool to represent whether optBase represents relocatable compilation options.
+    *
+    * \return pointer to the end of the options string if success, or to the invalid option
+    */
+   static char *processOptionSetPostRestore(void *jitConfig, char *options, TR::Options *optBase, bool isAOT);
+
 protected:
    void  jitPreProcess();
    bool  fePreProcess(void *base);
@@ -2058,7 +2073,7 @@ private:
 
    static char *processOptionSet(char *options, char *envOptions, TR::Options *jitBase, bool isAOT);
    static char *processOptionSet(char *options, char *envOptions, TR::OptionSet *optionSet);
-   static char *processOptionSet(char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT);
+   static char *processOptionSet(char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT, bool postRestore = false);
    static char *processOption(char *option, TR::OptionTable *table, void *base, int32_t numEntries, TR::OptionSet *optionSet);
           void  printOptions(char *options, char *envOptions);
 
@@ -2276,6 +2291,7 @@ protected:
    static TR::Options    *_jitCmdLineOptions;
    static TR::Options    *_aotCmdLineOptions;
           TR::OptionSet  *_optionSets;
+          TR::OptionSet  *_postRestoreOptionSets;
    static void          *_feBase;
    static TR_FrontEnd   *_fe;
    static bool           _hasLogFile;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1833,6 +1833,7 @@ public:
    static void shutdown(TR_FrontEnd * fe);
 
    static int32_t getNumUsableCompilationThreads() { return _numUsableCompilationThreads; }
+   static int32_t getNumAllocatedCompilationThreads() { return _numAllocatedCompilationThreads; }
 
    static int32_t getTrampolineSpacePercentage() { return _trampolineSpacePercentage; }
    static size_t getScratchSpaceLimit() { return _scratchSpaceLimit; }
@@ -1898,6 +1899,7 @@ public:
    static int32_t _inlinerVeryLargeCompiledMethodAdjustFactor;
 
    static int32_t _numUsableCompilationThreads;
+   static int32_t _numAllocatedCompilationThreads;
 
    static int32_t _trampolineSpacePercentage;
 


### PR DESCRIPTION
* Add infrastructure to process options post restore (from a checkpoint)
    * Add `_postRestoreOptionSets` field to collect options sets when `processOptionSet` is called on the global options.
    * Add the method `processOptionSetPostRestore` which can be called to process options post restore. This first processes the global options (caching away the options sets into `_postRestoreOptionSets`) and then processes the options sets.
    * Add the method `mergePostRestoreOptionSets` to merge the options sets in `_postRestoreOptionSets` into `_optionSets` once the former has been processed.
* Add `_numAllocatedCompilationThreads` to distinguish between usable comp threads and allocated comp threads
    * When implementing Checkpoint/Restore functionality this new field allows a runtime to change the number of compilation threads post restore.