### PR TITLE
Check receiver class initialized or not before checking overridden bits

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5276,7 +5276,9 @@ static bool canFoldNonOverriddenGuard(OMR::ValuePropagation *vp, TR::Node *callN
        methodSymbol->isVirtual())
       {
       TR::ResolvedMethodSymbol * resolvedMethodSymbol = methodSymbol->getResolvedMethodSymbol();
-      if (resolvedMethodSymbol)
+      // The receiver class has to be initialized at this point. Otherwise updateCHTable might
+      // not have been called to update overridden bits
+      if (resolvedMethodSymbol && TR::Compiler->cls.isClassInitialized(vp->comp(), thisType))
          {
          TR_ResolvedMethod *originalResolvedMethod = resolvedMethodSymbol->getResolvedMethod();
          TR_OpaqueClassBlock *originalMethodClass = originalResolvedMethod->classOfMethod();


### PR DESCRIPTION
`updateOverriddenFlag` is called by `updateCHTable` to update overridden bits. `updateCHTable` is triggered either by `jitHookClassLoad` or `jitHookClassPreinitialize`. For fixed classes, we need to make sure the class is initialized so that the overridden bits are up to date before calling `virtualMethodIsOverridden`. Otherwise, `canFoldNonOverriddenGuard` could fold away non-overridden guards when a method is already overridden but the JIT thinks otherwise because the overridden bits has not been updated.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>