### PR TITLE
Enable vxor, vor, and vand IL opcodes on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1853,7 +1853,7 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vxor:
       case TR::vor:
       case TR::vand:
-         if (et == TR::Int32 || et == TR::Int64)
+         if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
             return true;
          else
             return false;


### PR DESCRIPTION
Enable vxor, vor, and vand for all integer vector types (byte, short, int, long), which will allow the vectorization of various integer-only vector operations (such as logical opersations) to occur.