### PR TITLE
Move scavenger->kill() to ConfigurationGenerational for symmetry

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,11 +102,7 @@ MM_Configuration::tearDown(MM_EnvironmentBase* env)
 		extensions->referenceChainWalkerMarkMap = NULL;
 	}
 
-	MM_Collector *collector = extensions->getGlobalCollector();
-	if (NULL != collector) {
-		collector->kill(env);
-		extensions->setGlobalCollector(NULL);
-	}
+	destroyCollectors(env);
 
 	if (!extensions->isMetronomeGC()) {
 		/* In Metronome, dispatcher is created and destroyed by the collector */
@@ -148,6 +144,21 @@ MM_Configuration::tearDown(MM_EnvironmentBase* env)
 	extensions->_numaManager.shutdownNUMASupport(env);
 
 	_delegate.tearDown(env);
+}
+
+/**
+ * Destroy Garbage Collectors
+ */
+void
+MM_Configuration::destroyCollectors(MM_EnvironmentBase* env)
+{
+	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_Collector *collector = extensions->getGlobalCollector();
+
+	if (NULL != collector) {
+		collector->kill(env);
+		extensions->setGlobalCollector(NULL);
+	}
 }
 
 /**

--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -90,6 +90,16 @@ public:
 	 * @return Pointer to created Global Collector or NULL
 	 */
 	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env) = 0;
+
+	/**
+	 * Destroy Garbage Collectors
+	 *
+	 * @param[in] env the current environment.
+	 *
+	 * @return void
+	 */
+	virtual void destroyCollectors(MM_EnvironmentBase* env);
+
 	MM_Heap* createHeap(MM_EnvironmentBase* env, uintptr_t heapBytesRequested);
 	virtual MM_Heap* createHeapWithManager(MM_EnvironmentBase* env, uintptr_t heapBytesRequested, MM_HeapRegionManager* regionManager) = 0;
 	virtual MM_HeapRegionManager* createHeapRegionManager(MM_EnvironmentBase* env) = 0;

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -465,12 +465,6 @@ MM_MemorySubSpace::tearDown(MM_EnvironmentBase* env)
 	if (NULL != _physicalSubArena) {
 		_physicalSubArena->kill(env);
 		_physicalSubArena = NULL;
-	}
-
-	/* Kill the collector (if applicable) */
-	if ((NULL != _collector) && !_usesGlobalCollector) {
-		_collector->kill(env);
-		_collector = NULL;
 	}
 
 	/* Kill all children */

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -63,6 +63,15 @@ public:
 	 */
 	virtual MM_GlobalCollector* createCollectors(MM_EnvironmentBase* env);
 
+	/**
+	 * Destroy Local Collector and rely on parent MM_ConfigurationStandard to destroy Global Collector
+	 *
+	 * @param[in] env the current environment.
+	 *
+	 * @return void
+	 */
+	virtual void destroyCollectors(MM_EnvironmentBase* env);
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	/**
 	 * Startup GC threads on restore.
@@ -82,7 +91,6 @@ public:
 protected:
 	bool initialize(MM_EnvironmentBase* env);
 	MM_MemorySubSpaceSemiSpace *createSemiSpace(MM_EnvironmentBase *envBase, MM_Heap *heap, MM_Scavenger *scavenger, MM_InitializationParameters *parameters, UDATA numaNode = UDATA_MAX);
-	virtual void tearDown(MM_EnvironmentBase* env);
 	/**
 	 * Sets the number of GC threads.
 	 *

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -205,9 +205,7 @@ MM_Scavenger::newInstance(MM_EnvironmentStandard *env)
 void
 MM_Scavenger::kill(MM_EnvironmentBase *env)
 {
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
-
-	tearDown(envStandard);
+	tearDown(env);
 	env->getForge()->free(this);
 }
 


### PR DESCRIPTION
- introduce virtual destroyCollectors() for Configuration symmetrical to createCollectors()
- move scavenger->kill() from MM_MemorySubSpace::tearDown() to MM_ConfigurationGenerational::destroyCollectors()

Also do some minor code clean up
- remove MM_ConfigurationGenerational::tearDown() not required any more
- remove unnecessary conversion of MM_EnvironmentBase to MM_EnvironmentStandard in _Scavenger::kill()