### PR TITLE
GC Reinitialize Sweep For Restore (CRIU)

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1732,7 +1732,7 @@ public:
 		, heapRegionManager(NULL)
 		, memoryManager(NULL)
 		, aggressive(0)
-		, sweepHeapSectioning(0)
+		, sweepHeapSectioning(NULL)
 #if defined(OMR_GC_MODRON_COMPACTION)
 		, compactOnGlobalGC(0) /* By default we will only compact on triggers, no forced compactions */
 		, noCompactOnGlobalGC(0)

--- a/gc/base/SweepHeapSectioning.hpp
+++ b/gc/base/SweepHeapSectioning.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2021 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,11 +41,10 @@ class MM_HeapRegionDescriptor;
 class MM_SweepHeapSectioning : public MM_BaseVirtual {
 private:
 protected:
-	MM_ParallelSweepChunkArray* _head; /**< head pointer to a list of Chunk arrays */
-	uintptr_t _totalUsed; /**< total elements used across all arrays */
 	uintptr_t _totalSize; /**< total elements available across all arrays */
 
-	MM_ParallelSweepChunkArray* _baseArray; /**< pointer to the base array allocated at initialization */
+	MM_ParallelSweepChunkArray* _head; /**< Head pointer to the list of chunk arrays (pointer to the base array). */
+	MM_ParallelSweepChunkArray* _tail; /**< Tail pointer to the list of chunk arrays. */
 	MM_GCExtensionsBase* _extensions;
 
 	virtual bool initialize(MM_EnvironmentBase* env);
@@ -56,6 +55,14 @@ protected:
 	virtual bool isReadyToSweep(MM_EnvironmentBase* env, MM_HeapRegionDescriptor* region) { return false; }
 
 	bool initArrays(uintptr_t);
+
+	/**
+	 * If the chunk size is not set, then set it heuristically
+	 * based on the max heap size and thread count.
+	 * @param[in] env the current environment.
+	 * @return void
+	 */
+	void initializeChunkSize(MM_EnvironmentBase* env);
 
 	friend class MM_SweepHeapSectioningIterator;
 
@@ -68,11 +75,22 @@ public:
 	void* getBackingStoreAddress();
 	uintptr_t getBackingStoreSize();
 
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Update the sectioning data (sweep chuck size and pool)
+	 * to reflect the adjusted thread count at restore.
+	 * @param[in] env the current environment.
+	 * @return boolean indicating if the chunk size and pool were
+	 * successfully updated to accommodate the new thread count.
+	 */
+	bool reinitializeForRestore(MM_EnvironmentBase *env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_SweepHeapSectioning(MM_EnvironmentBase* env)
-		: _head(NULL)
-		, _totalUsed(0)
-		, _totalSize(0)
-		, _baseArray(NULL)
+		: _totalSize(0)
+		, _head(NULL)
+		, _tail(NULL)
 		, _extensions(env->getExtensions())
 	{
 		_typeId = __FUNCTION__;


### PR DESCRIPTION
Reinitialize and update the sweep sectioning data, sweep chuck size and pool, to reflect the adjusted thread count for restore (for background, see https://github.com/eclipse/omr/issues/6888). This requires the chunk pool growth and utilization order to be changed, from LIFO to FIFO style. The pool now grows at the tail and is consumed starting at the head. This is necessary because the baseArray (first inited pool array) is shared with compaction. Compaction looks to the used size of the this baseArray to determine size it can use (getBackingStoreSize()). In a traditional VM run, backing store size will never be 0 (as asserted by compact). However,  if the pool continued to use LIFO style with CRIU, it could result in unused baseArray and backing store size of 0. Specifically, when a decrease in thread count results in increased chunk size/less utilized chunks. FIFO will guarantee that the baseArray is utilized first.

Signed-off-by: Salman Rana <salman.rana@ibm.com>