### PR TITLE
Add RSYInstruction generate function for immed

### DIFF
--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1006,11 +1006,27 @@ TR::Instruction *
 generateRSInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg, uint32_t imm,
                       TR::Instruction * preced)
    {
-   if (preced)
+   auto instructionFormat = TR::InstOpCode(op).getInstructionFormat();
+   TR::Instruction *result = NULL;
+   switch(instructionFormat)
       {
-      return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, preced, cg);
+      case RSa_FORMAT:
+      case RSb_FORMAT:
+         result = preced != NULL ?
+            new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, preced, cg) :
+            new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, cg);
+         break;
+      case RSYa_FORMAT:
+      case RSYb_FORMAT:
+         result = preced != NULL ?
+            new (INSN_HEAP) TR::S390RSYInstruction(op, n, treg, sreg, imm, preced, cg) :
+            new (INSN_HEAP) TR::S390RSYInstruction(op, n, treg, sreg, imm, cg);
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Mnemonic (%s) is incorrectly used as RS instruction", TR::InstOpCode::metadata[op].name);
+         break;
       }
-   return new (INSN_HEAP) TR::S390RSInstruction(op, n, treg, sreg, imm, cg);
+   return result;
    }
 
 

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2362,7 +2362,19 @@ TR::S390RSInstruction::generateBinaryEncoding()
       }
    else
       {
-      (*(int16_t *) (cursor + 2)) |= bos(getSourceImmediate());
+      /**
+       * We should only reach here where RS-a or RSY type instruction is used
+       * with source immediate (Shit or Rotate instructions where shift amount
+       * is in the displacement field only. In this bits 16-19 which are used fo
+       * Base Register should be set to 0 and Disp field are stored in bits
+       * 20-31. In case of RSY type instruction that would need long
+       * displacement, bits 32-39 contains higher 8 bits of displacement.
+       */
+      (*(int16_t *) (cursor + 2)) |= (0xFFF & bos(getSourceImmediate()));
+      if (getKind() == TR::Instruction::IsRSY)
+         {
+         (*(int8_t *) (cursor + 3)) |= (bos(getSourceImmediate() >> 12));
+         }
       }
 
    if (getMaskImmediate())

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2854,6 +2854,27 @@ class S390RSYInstruction : public TR::S390RSInstruction
                         TR::Instruction   *preced,
                         TR::CodeGenerator *cg)
       : S390RSInstruction(op, n, treg, sreg, mf, preced, cg)
+      {
+      }
+
+   S390RSYInstruction(TR::InstOpCode::Mnemonic op,
+                        TR::Node *n,
+                        TR::Register *treg,
+                        TR::Register *sreg,
+                        uint32_t          imm,
+                        TR::Instruction   *preced,
+                        TR::CodeGenerator *cg)
+      : S390RSInstruction(op, n, treg, sreg, imm, preced, cg)
+      {
+      }
+
+   S390RSYInstruction(TR::InstOpCode::Mnemonic op,
+                        TR::Node *n,
+                        TR::Register *treg,
+                        TR::Register *sreg,
+                        uint32_t          imm,
+                        TR::CodeGenerator *cg)
+      : S390RSInstruction(op, n, treg, sreg, imm, cg)
       {
       }
 


### PR DESCRIPTION
Some RSY type instructions can be used with immediate source field as well where long displacement may be required without memory reference for example for shift or rotate instruction where the second operand is used to provide shift amount. Currently for those instrucions it was constructing RSInstruction object where we lost the information if it contains long displacement field or not. In one case where we tried to generate RLL instruction with negative displacement, generated instruction was incorrectly encoded base register field with displacement value which was resulting in incorrect behaviour. This commit adds those necessary functions S390Instruction and handles case where RSY type instruction is generated without memory reference correctly.

Fixes: eclipse-openj9/openj9#16479