### PR TITLE
When skipping global DSE for a single block, still run local DSE

### DIFF
--- a/compiler/ilgen/OMRThunkBuilder.cpp
+++ b/compiler/ilgen/OMRThunkBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,8 +47,8 @@ OMR::ThunkBuilder::ThunkBuilder(TR::TypeDictionary *types, const char *name, TR:
    _numCalleeParams(numCalleeParams),
    _calleeParamTypes(calleeParamTypes)
    {
-   DefineLine(__FILE__);
-   DefineFile(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+   DefineLine(LINETOSTR(__LINE__));
    DefineName(name);
    DefineReturnType(returnType);
    DefineParameter("target", Address); // target

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -378,6 +378,7 @@ const OptimizationStrategy isolatedStoreOpts[] =
 const OptimizationStrategy globalDeadStoreOpts[] =
    {
    { globalDeadStoreElimination, IfMoreThanOneBlock },
+   { localDeadStoreElimination,  IfOneBlock },
    { deadTreesElimination                 },
    { endGroup                             }
    };

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -171,6 +171,8 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
       new (comp->allocator()) TR::OptimizationManager(self(), TR_HoistBlocks::create, OMR::basicBlockHoisting);
    _opts[OMR::globalValuePropagation] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR::GlobalValuePropagation::create, OMR::globalValuePropagation);
+   _opts[OMR::localDeadStoreElimination] =
+      new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalDeadStoreElimination::create, OMR::localDeadStoreElimination);
    _opts[OMR::localValuePropagation] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR::LocalValuePropagation::create, OMR::localValuePropagation);
    _opts[OMR::trivialDeadTreeRemoval] =


### PR DESCRIPTION
Without running some DSE pass, obvious dead stores can make it all the way to code generation.