### PR TITLE
Minor Options Refactoring

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2496,6 +2496,50 @@ OMR::Options::processOptionsAOT(char *aotOptions, void *feBase, TR_FrontEnd *fe)
    return dummy_string;
    }
 
+void
+OMR::Options::setAggressivenessLevelOpts()
+   {
+   if (this == OMR::Options::getJITCmdLineOptions() || this == OMR::Options::getAOTCmdLineOptions())
+      {
+      if (_aggressivenessLevel >= 0 && _aggressivenessLevel < LAST_AGGRESSIVENESS_LEVEL)
+         {
+         // Set some default values for JIT and AOT main command line options
+         //
+         switch (_aggressivenessLevel)
+            {
+            case OMR::Options::DEFAULT: // default behavior
+               break;
+            case OMR::Options::CONSERVATIVE_DEFAULT: // conservative default
+               self()->setConservativeDefaultBehavior();
+               break;
+            case OMR::Options::AGGRESSIVE_AOT: // aggressive AOT (Rely on AOT as much as possible)
+               self()->setGlobalAggressiveAOT();
+               break;
+            case OMR::Options::AGGRESSIVE_QUICKSTART: // aggressive quickstart (Quickstart with interpreter profiler)
+               self()->setAggressiveQuickStart();
+               break;
+            case OMR::Options::QUICKSTART: // quickstart or -client
+               self()->setQuickStart();
+               break;
+            case OMR::Options::CONSERVATIVE_QUICKSTART: // conservative quickstart
+               self()->setConservativeQuickStart();
+               break;
+            case OMR::Options::AGGRESSIVE_THROUGHPUT: // Enabled with -Xtune:throughput
+               self()->setAggressiveThroughput();
+               break;
+            } // end switch
+         }
+      else  // Some message that the aggressivenessLevel is invalid
+         {
+         if (_aggressivenessLevel != -1) // -1 means not set
+            {
+            if (OMR::Options::isAnyVerboseOptionSet())
+               TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "_aggressivenessLevel=%d; must be between 0 and 5; Option ignored", _aggressivenessLevel);
+            _aggressivenessLevel = -1;
+            }
+         }
+      }
+   }
 
 void
 OMR::Options::jitPreProcess()
@@ -2712,46 +2756,7 @@ OMR::Options::jitPreProcess()
       // The aggressivenessLevel is set as a VM option. JIT options have not been processed at this point
       // When JIT processing is taking place, some of these decisions can be overidden
       //
-      if (this == OMR::Options::getJITCmdLineOptions() || this == OMR::Options::getAOTCmdLineOptions())
-         {
-         if (_aggressivenessLevel >= 0 && _aggressivenessLevel < LAST_AGGRESSIVENESS_LEVEL)
-            {
-            // Set some default values for JIT and AOT main command line options
-            //
-            switch (_aggressivenessLevel)
-               {
-               case OMR::Options::DEFAULT: // default behavior
-                  break;
-               case OMR::Options::CONSERVATIVE_DEFAULT: // conservative default
-                  self()->setConservativeDefaultBehavior();
-                  break;
-               case OMR::Options::AGGRESSIVE_AOT: // aggressive AOT (Rely on AOT as much as possible)
-                  self()->setGlobalAggressiveAOT();
-                  break;
-               case OMR::Options::AGGRESSIVE_QUICKSTART: // aggressive quickstart (Quickstart with interpreter profiler)
-                  self()->setAggressiveQuickStart();
-                  break;
-               case OMR::Options::QUICKSTART: // quickstart or -client
-                  self()->setQuickStart();
-                  break;
-               case OMR::Options::CONSERVATIVE_QUICKSTART: // conservative quickstart
-                  self()->setConservativeQuickStart();
-                  break;
-               case OMR::Options::AGGRESSIVE_THROUGHPUT: // Enabled with -Xtune:throughput
-                  self()->setAggressiveThroughput();
-                  break;
-               } // end switch
-            }
-         else  // Some message that the aggressivenessLevel is invalid
-            {
-            if (_aggressivenessLevel != -1) // -1 means not set
-               {
-               if (OMR::Options::isAnyVerboseOptionSet())
-                     TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "_aggressivenessLevel=%d; must be between 0 and 5; Option ignored", _aggressivenessLevel);
-               _aggressivenessLevel = -1;
-               }
-            }
-         }
+      self()->setAggressivenessLevelOpts();
 
       _enableSCHintFlags = TR_HintFailedValidation;
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1531,8 +1531,7 @@ public:
    static TR::Options *getAOTCmdLineOptions();
    static void        setAOTCmdLineOptions(TR::Options *options);
    static TR::Options *getJITCmdLineOptions();
-          void        addOptionSet(TR::OptionSet *o) {o->setNext(_optionSets);_optionSets = o;}
-          void        addPostRestoreOptionSet(TR::OptionSet *o) {o->setNext(_postRestoreOptionSets);_postRestoreOptionSets = o;}
+          void        saveOptionSet(TR::OptionSet *o);
           void        mergePostRestoreOptionSets();
           bool        hasOptionSets() {return _optionSets != NULL;}
    char*              setCounts();
@@ -1848,6 +1847,8 @@ public:
    static bool    _fullyInitialized;
    static bool    _canJITCompile;
 
+   static bool    _postRestoreProcessing;
+
    static int32_t _samplingFrequency;
 
    static int32_t _sampleInterval;
@@ -2029,6 +2030,8 @@ protected:
    bool  fePostProcessJIT(void *base);
    bool  jitLatePostProcess(TR::OptionSet *optionSet, void *jitConfig);
    bool  feLatePostProcess(void *base, TR::OptionSet *optionSet);
+   void  addOptionSet(TR::OptionSet *o) {o->setNext(_optionSets);_optionSets = o;}
+   void  addPostRestoreOptionSet(TR::OptionSet *o) {o->setNext(_postRestoreOptionSets);_postRestoreOptionSets = o;}
 
 private:
    friend class OMR::Compilation;
@@ -2075,7 +2078,7 @@ private:
 
    static char *processOptionSet(char *options, char *envOptions, TR::Options *jitBase, bool isAOT);
    static char *processOptionSet(char *options, char *envOptions, TR::OptionSet *optionSet);
-   static char *processOptionSet(char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT, bool postRestore = false);
+   static char *processOptionSet(char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT);
    static char *processOption(char *option, TR::OptionTable *table, void *base, int32_t numEntries, TR::OptionSet *optionSet);
           void  printOptions(char *options, char *envOptions);
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -2032,6 +2032,7 @@ protected:
    bool  feLatePostProcess(void *base, TR::OptionSet *optionSet);
    void  addOptionSet(TR::OptionSet *o) {o->setNext(_optionSets);_optionSets = o;}
    void  addPostRestoreOptionSet(TR::OptionSet *o) {o->setNext(_postRestoreOptionSets);_postRestoreOptionSets = o;}
+   void  setAggressivenessLevelOpts();
 
 private:
    friend class OMR::Compilation;

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -676,7 +676,7 @@ TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Opti
       newSet->init(startOptString);
       newSet->setMethodRegex(methodRegex);
       newSet->setOptLevelRegex(optLevelRegex);
-      cmdLineOptions->addOptionSet(newSet);
+      cmdLineOptions->saveOptionSet(newSet);
       }
 
    return p;


### PR DESCRIPTION
There are multiple places that call `addOptionSet`. However, post restore, `addPostRestoreOptionSet` should be called (these sets will eventually get merged into the main linked list). In order to ensure that callers of `addOptionSet` do not need to have to consider whether they need to worry about a checkpoint/restore scenario, this commit introduces a new public API called `saveOptionSet`. `addOptionSet`/`addPostRestoreOptionSet` are made protected. `saveOptionSet` will call the right method based on the value of a new static boolean field `_postRestoreProcessing`.

Additionally, the code that sets options based on `_aggressivenessLevel ` is refactored into its own method.