### PR TITLE
Fix issue with Binary16NaN conversion on Power

### DIFF
--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corp. and others
+ * Copyright (c) 2000, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,7 +82,6 @@ TR::Instruction *generateMvFprGprInstructions(TR::CodeGenerator *cg, TR::Node *n
    else if (checkp8DirectMove && mode == fpr2gprSp)
       {
       cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::xscvdpspn, node, reg1, reg1, cursor);
-      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, reg1, reg1, 0, cursor);
       cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mfvsrwz, node, reg0, reg1, cursor);
       }
    else if (checkp8DirectMove && mode == gpr2fprHost64)
@@ -97,7 +96,7 @@ TR::Instruction *generateMvFprGprInstructions(TR::CodeGenerator *cg, TR::Node *n
       {
       cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::mtvsrwz, node, reg0, reg1, cursor);
       cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, reg0, reg0, 1, cursor);
-      cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::xscvspdp, node, reg0, reg0, cursor);
+      cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::xscvspdpn, node, reg0, reg0, cursor);
       }
    else if (checkp8DirectMove && mode == gpr2fprHost32)
       {


### PR DESCRIPTION
This fixes the incorrect results which was generated with int2float/float2int conversion with NaNs on Power on JDK20 new testcases. Issue was with `xscvspdp` instruction that converts SNaN(src) to QNaN which sets the 9th bit set in the converted results. Using `xscvspdpn` generates right results.
 
Closes #https://github.com/eclipse-openj9/openj9/issues/16660

Signed-off-by: Bhavani SN bhavani.sn@ibm.com