### PR TITLE
AArch64: Add ARM64Trg2MemInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -743,6 +743,25 @@ int32_t TR::ARM64Trg1MemInstruction::estimateBinaryLength(int32_t currentEstimat
    return currentEstimate + getEstimatedBinaryLength();
    }
 
+uint8_t *TR::ARM64Trg2MemInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertTarget2Register(toARM64Cursor(cursor));
+   cursor = getMemoryReference()->generateBinaryEncoding(this, cursor, cg());
+   setBinaryLength(cursor - instructionStart);
+   setBinaryEncoding(instructionStart);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+   return cursor;
+   }
+
+int32_t TR::ARM64Trg2MemInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
+   return currentEstimate + getEstimatedBinaryLength();
+   }
+
 TR::Instruction *TR::ARM64MemInstruction::expandInstruction()
    {
    return getMemoryReference()->expandInstruction(self(), cg());

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1166,6 +1166,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1Mem:
          print(pOutFile, (TR::ARM64Trg1MemInstruction *)instr);
          break;
+      case OMR::Instruction::IsTrg2Mem:
+         print(pOutFile, (TR::ARM64Trg2MemInstruction *)instr);
+         break;
       case OMR::Instruction::IsMem:
          print(pOutFile, (TR::ARM64MemInstruction *)instr);
          break;
@@ -2291,6 +2294,22 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1MemInstruction *instr)
       {
       trfprintf(pOutFile, "\t\t; Backpatched branch to Unresolved Data %s", getName(instr->getSnippetForGC()->getSnippetLabel()));
       }
+
+   printMemoryReferenceComment(pOutFile, instr->getMemoryReference());
+   printInstructionComment(pOutFile, 1, instr);
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg2MemInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getTarget2Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+
+   print(pOutFile, instr->getMemoryReference());
 
    printMemoryReferenceComment(pOutFile, instr->getMemoryReference());
    printInstructionComment(pOutFile, 1, instr);

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3377,6 +3377,119 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
     *          performed.
     */
    virtual TR::Instruction *expandInstruction();
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
+   };
+
+class ARM64Trg2MemInstruction : public ARM64Trg1MemInstruction
+   {
+   TR::Register *_target2Register;
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg1 : target register 1
+    * @param[in] treg2 : target register 2
+    * @param[in] mr : memory reference
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg2MemInstruction(TR::InstOpCode::Mnemonic op,
+                            TR::Node *node,
+                            TR::Register *treg1,
+                            TR::Register *treg2,
+                            TR::MemoryReference *mr, TR::CodeGenerator *cg)
+      : ARM64Trg1MemInstruction(op, node, treg1, mr, cg), _target2Register(treg2)
+      {
+      useRegister(treg2);
+      }
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register 1
+    * @param[in] treg2 : target register 2
+    * @param[in] mr : memory reference
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg2MemInstruction(TR::InstOpCode::Mnemonic op,
+                            TR::Node *node,
+                            TR::Register *treg1,
+                            TR::Register *treg2,
+                            TR::MemoryReference *mr,
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1MemInstruction(op, node, treg1, mr, precedingInstruction, cg), _target2Register(treg2)
+      {
+      useRegister(treg2);
+      }
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg2Mem; }
+   /**
+    * @brief Gets target register 2
+    * @return target register 2
+    */
+   TR::Register *getTarget2Register() {return _target2Register;}
+   /**
+    * @brief Sets target register 2
+    * @param[in] tr : target register 2
+    * @return target register 2
+    */
+   TR::Register *setTarget2Register(TR::Register *tr) {return (_target2Register = tr);}
+   /**
+    * @brief Sets target 2 register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertTarget2Register(uint32_t *instruction)
+      {
+      TR::RealRegister *target2 = toRealRegister(_target2Register);
+      target2->setRegisterFieldRT2(instruction);
+      }
+   /**
+    * @brief Answers whether this instruction references the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction references the virtual register
+    */
+   virtual bool refsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction uses the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction uses the virtual register
+    */
+   virtual bool usesRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction defines the virtual register
+    */
+   virtual bool defsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given real register
+    * @param[in] reg : real register
+    * @return true when the instruction defines the real register
+    */
+   virtual bool defsRealRegister(TR::Register *reg);
+   /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
    /**
     * @brief Generates binary encoding of the instruction

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -338,6 +338,14 @@ TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, TR::InstOpCod
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64Trg1MemInstruction(op, node, treg, mr, preced, cg);
    return new (cg->trHeapMemory()) TR::ARM64Trg1MemInstruction(op, node, treg, mr, cg);
+   }
+
+TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg1, TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg2MemInstruction(op, node, treg1, treg2, mr, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg2MemInstruction(op, node, treg1, treg2, mr, cg);
    }
 
 TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -683,6 +683,26 @@ TR::Instruction *generateTrg1MemInstruction(
                    TR::InstOpCode::Mnemonic op,
                    TR::Node *node,
                    TR::Register *treg,
+                   TR::MemoryReference *mr,
+                   TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates mem-to-trg2 instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg1 : target 1 register
+ * @param[in] treg2 : target 2 register
+ * @param[in] mr : memory reference
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTrg2MemInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg1,
+                   TR::Register *treg2,
                    TR::MemoryReference *mr,
                    TR::Instruction *preced = NULL);
 

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corp. and others
+ * Copyright (c) 2018, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,6 +56,7 @@
             IsTrg1Src3,
       IsTrg1Mem,
          IsTrg1MemSrc1,
+         IsTrg2Mem,
    IsMem,
       IsMemSrc1,
          IsMemSrc2,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -362,6 +362,7 @@ namespace TR { class ARM64Trg1Src2IndexedElementInstruction; }
 namespace TR { class ARM64Trg1Src2ZeroInstruction; }
 namespace TR { class ARM64Trg1Src3Instruction; }
 namespace TR { class ARM64Trg1MemInstruction; }
+namespace TR { class ARM64Trg2MemInstruction; }
 namespace TR { class ARM64MemInstruction; }
 namespace TR { class ARM64MemImmInstruction; }
 namespace TR { class ARM64MemSrc1Instruction; }
@@ -1153,6 +1154,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1Src2ZeroInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src3Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1MemInstruction *);
+   void print(TR::FILE *, TR::ARM64Trg2MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemImmInstruction *);
    void print(TR::FILE *, TR::ARM64MemSrc1Instruction *);


### PR DESCRIPTION
Add `ARM64Trg2MemInstruction` which takes 2 target registers for loading from memory.