### PR TITLE
AArch64: Add instruction classes for conditional compare instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -888,6 +888,34 @@ uint8_t *TR::ARM64ZeroSrc2Instruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64Src1ImmCondInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertConditionCodeField(toARM64Cursor(cursor));
+   insertConditionFlags(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Src2CondInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertConditionCodeField(toARM64Cursor(cursor));
+   insertConditionFlags(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 #ifdef J9_PROJECT_SPECIFIC
 uint8_t *TR::ARM64VirtualGuardNOPInstruction::generateBinaryEncoding()
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -934,6 +934,56 @@ TR::Instruction *generateCompareInstruction(
                   bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
+/**
+ * @brief Generates CCMP or CCMN (immediate) instruction
+ *
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sreg : source register
+ * @param[in] imm : unsigned 5-bit immediate
+ * @param[in] conditionFlags : condition flags to set if condition specified by cc is true
+ * @param[in] cc : Condition code
+ * @param[in] is64bit : true when it is 64-bit operation
+ * @param[in] isNegative : Generates CCMN instruction if true
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateConditionalCompareImmInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *sreg,
+                  uint32_t imm,
+                  uint32_t conditionFlags,
+                  TR::ARM64ConditionCode cc,
+                  bool is64bit = false,
+                  bool isNegative = false,
+                  TR::Instruction *preced = NULL);
+
+/**
+ * @brief Generates CCMP or CCMN (register) instruction
+ *
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sreg1 : source register1
+ * @param[in] sreg2 : source register2
+ * @param[in] conditionFlags : condition flags to set if condition specified by cc is true
+ * @param[in] cc : Condition code
+ * @param[in] is64bit : true when it is 64-bit operation
+ * @param[in] isNegative : Generates CCMN instruction if true
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateConditionalCompareInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *sreg1,
+                  TR::Register *sreg2,
+                  uint32_t conditionFlags,
+                  TR::ARM64ConditionCode cc,
+                  bool is64bit = false,
+                  bool isNegative = false,
+                  TR::Instruction *preced = NULL);
+
 /*
  * @brief Generates TST (immediate) instruction
  * @param[in] cg : CodeGenerator
@@ -1098,6 +1148,26 @@ TR::Instruction *generateCSetInstruction(
                   TR::Node *node,
                   TR::Register *treg,
                   TR::ARM64ConditionCode cc,
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates CINC instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] sreg : source register
+ * @param[in] cc : branch condition code
+ * @param[in] is64bit : true when it is 64-bit operation
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateCIncInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  TR::ARM64ConditionCode cc,
+                  bool is64bit,
                   TR::Instruction *preced = NULL);
 
 /*

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -63,5 +63,7 @@
       IsMemImm,
    IsSrc1,
       IsZeroSrc1Imm,
+      IsSrc1ImmCond,
       IsSrc2,
-         IsZeroSrc2
+         IsZeroSrc2,
+         IsSrc2Cond

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -372,6 +372,8 @@ namespace TR { class ARM64Src1Instruction; }
 namespace TR { class ARM64ZeroSrc1ImmInstruction; }
 namespace TR { class ARM64Src2Instruction; }
 namespace TR { class ARM64ZeroSrc2Instruction; }
+namespace TR { class ARM64Src1ImmCondInstruction; }
+namespace TR { class ARM64Src2CondInstruction; }
 namespace TR { class ARM64HelperCallSnippet; }
 
 namespace TR { class LabelInstruction; }
@@ -1164,6 +1166,8 @@ public:
    void print(TR::FILE *, TR::ARM64ZeroSrc1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Src2Instruction *);
    void print(TR::FILE *, TR::ARM64ZeroSrc2Instruction *);
+   void print(TR::FILE *, TR::ARM64Src1ImmCondInstruction *);
+   void print(TR::FILE *, TR::ARM64Src2CondInstruction *);
 #ifdef J9_PROJECT_SPECIFIC
    void print(TR::FILE *, TR::ARM64VirtualGuardNOPInstruction *);
 #endif

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2022 IBM Corp. and others
+ * Copyright (c) 2022, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -197,6 +197,48 @@ TEST_P(ARM64MovVectorElementEncodingTest, encode) {
     auto instr = generateMovVectorElementInstruction(cg(), op, fakeNode, trgReg, srcReg, trgIndex, srcIndex);
 
     ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
+}
+
+class ARM64Src1ImmCondEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, uint32_t, uint32_t, TR::ARM64ConditionCode, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64Src1ImmCondEncodingTest, encode) {
+    auto srcReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto imm = std::get<2>(GetParam());
+    auto conditionFlags = std::get<3>(GetParam());
+    auto cc = std::get<4>(GetParam());
+    auto isNegative = (op == TR::InstOpCode::ccmnimmx || op == TR::InstOpCode::ccmnimmw);
+    auto is64bit = (op == TR::InstOpCode::ccmpimmx || op == TR::InstOpCode::ccmnimmx);
+
+    auto instr = generateConditionalCompareImmInstruction(cg(), fakeNode, srcReg, imm, conditionFlags, cc, is64bit, isNegative);
+    ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
+}
+
+class ARM64Src2CondEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, uint32_t, TR::ARM64ConditionCode, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64Src2CondEncodingTest, encode) {
+    auto srcReg1 = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg2 = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto op = std::get<0>(GetParam());
+    auto conditionFlags = std::get<3>(GetParam());
+    auto cc = std::get<4>(GetParam());
+    auto isNegative = (op == TR::InstOpCode::ccmnx || op == TR::InstOpCode::ccmnw);
+    auto is64bit = (op == TR::InstOpCode::ccmpx || op == TR::InstOpCode::ccmnx);
+
+    auto instr = generateConditionalCompareInstruction(cg(), fakeNode, srcReg1, srcReg2, conditionFlags, cc, is64bit, isNegative);
+    ASSERT_EQ(encodeInstruction(instr), std::get<5>(GetParam()));
+}
+
+class ARM64CINCEncodingTest : public TRTest::BinaryEncoderTest<ARM64_INSTRUCTION_ALIGNMENT>, public ::testing::WithParamInterface<std::tuple<bool, TR::RealRegister::RegNum, TR::RealRegister::RegNum, TR::ARM64ConditionCode, ARM64BinaryInstruction>> {};
+
+TEST_P(ARM64CINCEncodingTest, encode) {
+    auto trgReg = cg()->machine()->getRealRegister(std::get<1>(GetParam()));
+    auto srcReg = cg()->machine()->getRealRegister(std::get<2>(GetParam()));
+    auto is64bit = std::get<0>(GetParam());
+    auto cc = std::get<3>(GetParam());
+
+    auto instr = generateCIncInstruction(cg(), fakeNode, trgReg, srcReg, cc, is64bit);
+    ASSERT_EQ(encodeInstruction(instr), std::get<4>(GetParam()));
 }
 
 INSTANTIATE_TEST_CASE_P(MOV, ARM64Trg1ImmEncodingTest, ::testing::Values(
@@ -2424,4 +2466,91 @@ INSTANTIATE_TEST_CASE_P(VectorXTN, ARM64Trg1Src1EncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::vxtn2_4s, TR::RealRegister::v31, TR::RealRegister::v0, "4ea1281f"),
     std::make_tuple(TR::InstOpCode::vxtn2_4s, TR::RealRegister::v0, TR::RealRegister::v15, "4ea129e0"),
     std::make_tuple(TR::InstOpCode::vxtn2_4s, TR::RealRegister::v0, TR::RealRegister::v31, "4ea12be0")
+));
+
+INSTANTIATE_TEST_CASE_P(CCMPIMM, ARM64Src1ImmCondEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x0, 31, 3, TR::CC_EQ, "fa5f0803"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x0, 31, 9, TR::CC_CC, "fa5f3809"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x0, 15, 3, TR::CC_NE, "fa4f1803"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x0, 15, 9, TR::CC_HI, "fa4f8809"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x15, 0, 12, TR::CC_CS, "fa4029ec"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x15, 0, 8, TR::CC_LT, "fa40b9e8"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x29, 0, 12, TR::CC_CC, "fa403bac"),
+    std::make_tuple(TR::InstOpCode::ccmpimmx, TR::RealRegister::x29, 0, 8, TR::CC_LE, "fa40dba8"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x0, 31, 3, TR::CC_EQ, "7a5f0803"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x0, 31, 9, TR::CC_CC, "7a5f3809"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x0, 15, 3, TR::CC_NE, "7a4f1803"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x0, 15, 9, TR::CC_HI, "7a4f8809"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x15, 0, 12, TR::CC_CS, "7a4029ec"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x15, 0, 8, TR::CC_LT, "7a40b9e8"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x29, 0, 12, TR::CC_CC, "7a403bac"),
+    std::make_tuple(TR::InstOpCode::ccmpimmw, TR::RealRegister::x29, 0, 8, TR::CC_LE, "7a40dba8")
+));
+
+INSTANTIATE_TEST_CASE_P(CCMNIMM, ARM64Src1ImmCondEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x0, 31, 3, TR::CC_EQ, "ba5f0803"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x0, 31, 9, TR::CC_CC, "ba5f3809"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x0, 15, 3, TR::CC_NE, "ba4f1803"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x0, 15, 9, TR::CC_HI, "ba4f8809"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x15, 0, 12, TR::CC_CS, "ba4029ec"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x15, 0, 8, TR::CC_LT, "ba40b9e8"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x29, 0, 12, TR::CC_CC, "ba403bac"),
+    std::make_tuple(TR::InstOpCode::ccmnimmx, TR::RealRegister::x29, 0, 8, TR::CC_LE, "ba40dba8"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x0, 31, 3, TR::CC_EQ, "3a5f0803"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x0, 31, 9, TR::CC_CC, "3a5f3809"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x0, 15, 3, TR::CC_NE, "3a4f1803"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x0, 15, 9, TR::CC_HI, "3a4f8809"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x15, 0, 12, TR::CC_CS, "3a4029ec"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x15, 0, 8, TR::CC_LT, "3a40b9e8"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x29, 0, 12, TR::CC_CC, "3a403bac"),
+    std::make_tuple(TR::InstOpCode::ccmnimmw, TR::RealRegister::x29, 0, 8, TR::CC_LE, "3a40dba8")
+));
+
+INSTANTIATE_TEST_CASE_P(CCMP, ARM64Src2CondEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x0, TR::RealRegister::x29, 3, TR::CC_EQ, "fa5d0003"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x0, TR::RealRegister::x29, 9, TR::CC_CC, "fa5d3009"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x0, TR::RealRegister::x15, 3, TR::CC_NE, "fa4f1003"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x0, TR::RealRegister::x15, 9, TR::CC_HI, "fa4f8009"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x15, TR::RealRegister::x0, 12, TR::CC_CS, "fa4021ec"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x15, TR::RealRegister::x0, 8, TR::CC_LT, "fa40b1e8"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x29, TR::RealRegister::x0, 12, TR::CC_CC, "fa4033ac"),
+    std::make_tuple(TR::InstOpCode::ccmpx, TR::RealRegister::x29, TR::RealRegister::x0, 8, TR::CC_LE, "fa40d3a8"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x0, TR::RealRegister::x29, 3, TR::CC_EQ, "7a5d0003"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x0, TR::RealRegister::x29, 9, TR::CC_CC, "7a5d3009"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x0, TR::RealRegister::x15, 3, TR::CC_NE, "7a4f1003"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x0, TR::RealRegister::x15, 9, TR::CC_HI, "7a4f8009"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x15, TR::RealRegister::x0, 12, TR::CC_CS, "7a4021ec"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x15, TR::RealRegister::x0, 8, TR::CC_LT, "7a40b1e8"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x29, TR::RealRegister::x0, 12, TR::CC_CC, "7a4033ac"),
+    std::make_tuple(TR::InstOpCode::ccmpw, TR::RealRegister::x29, TR::RealRegister::x0, 8, TR::CC_LE, "7a40d3a8")
+));
+
+INSTANTIATE_TEST_CASE_P(CCMN, ARM64Src2CondEncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x0, TR::RealRegister::x29, 3, TR::CC_EQ, "ba5d0003"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x0, TR::RealRegister::x29, 9, TR::CC_CC, "ba5d3009"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x0, TR::RealRegister::x15, 3, TR::CC_NE, "ba4f1003"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x0, TR::RealRegister::x15, 9, TR::CC_HI, "ba4f8009"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x15, TR::RealRegister::x0, 12, TR::CC_CS, "ba4021ec"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x15, TR::RealRegister::x0, 8, TR::CC_LT, "ba40b1e8"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x29, TR::RealRegister::x0, 12, TR::CC_CC, "ba4033ac"),
+    std::make_tuple(TR::InstOpCode::ccmnx, TR::RealRegister::x29, TR::RealRegister::x0, 8, TR::CC_LE, "ba40d3a8"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x0, TR::RealRegister::x29, 3, TR::CC_EQ, "3a5d0003"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x0, TR::RealRegister::x29, 9, TR::CC_CC, "3a5d3009"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x0, TR::RealRegister::x15, 3, TR::CC_NE, "3a4f1003"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x0, TR::RealRegister::x15, 9, TR::CC_HI, "3a4f8009"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x15, TR::RealRegister::x0, 12, TR::CC_CS, "3a4021ec"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x15, TR::RealRegister::x0, 8, TR::CC_LT, "3a40b1e8"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x29, TR::RealRegister::x0, 12, TR::CC_CC, "3a4033ac"),
+    std::make_tuple(TR::InstOpCode::ccmnw, TR::RealRegister::x29, TR::RealRegister::x0, 8, TR::CC_LE, "3a40d3a8")
+));
+
+INSTANTIATE_TEST_CASE_P(CINC, ARM64CINCEncodingTest, ::testing::Values(
+    std::make_tuple(true, TR::RealRegister::x0, TR::RealRegister::x29, TR::CC_EQ, "9a9d17a0"),
+    std::make_tuple(true, TR::RealRegister::x0, TR::RealRegister::x15, TR::CC_CC, "9a8f25e0"),
+    std::make_tuple(true, TR::RealRegister::x15, TR::RealRegister::x0, TR::CC_NE, "9a80040f"),
+    std::make_tuple(true, TR::RealRegister::x29, TR::RealRegister::x0, TR::CC_HI, "9a80941d"),
+    std::make_tuple(false, TR::RealRegister::x0, TR::RealRegister::x29, TR::CC_CS, "1a9d37a0"),
+    std::make_tuple(false, TR::RealRegister::x0, TR::RealRegister::x15, TR::CC_LT, "1a8fa5e0"),
+    std::make_tuple(false, TR::RealRegister::x15, TR::RealRegister::x0, TR::CC_CC, "1a80240f"),
+    std::make_tuple(false, TR::RealRegister::x29, TR::RealRegister::x0, TR::CC_LE, "1a80c41d")
 ));


### PR DESCRIPTION
- Add `ARM64Src1ImmCondInstruction` and `ARM64Src2CondInstruction` to enable `ccmp` and `ccmn` instructions.
- Add a utility method to generate `cinc` instruction.
- Add BinaryEncoding unit tests for those instructions.