### PR TITLE
AArch64: Add vector pairwise max/min instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1043,6 +1043,18 @@ static const char *opCodeToNameMap[] =
    "vfminp2d",
    "fminp2s",
    "fminp2d",
+   "vsmaxp16b",
+   "vsmaxp8h",
+   "vsmaxp4s",
+   "vsminp16b",
+   "vsminp8h",
+   "vsminp4s",
+   "vumaxp16b",
+   "vumaxp8h",
+   "vumaxp4s",
+   "vuminp16b",
+   "vuminp8h",
+   "vuminp4s",
    "nop",
    };
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -1041,6 +1041,18 @@
 		vfminp2d,                                               	/* 0x6EE0F400	FMINP        	 */
 		fminp2s,                                                	/* 0x7EB0F800	FMINP(scalar)  	 */
 		fminp2d,                                                	/* 0x7EF0F800	FMINP(scalar)  	 */
+		vsmaxp16b,                                              	/* 0x4E20A400	SMAXP        	 */
+		vsmaxp8h,                                               	/* 0x4E60A400	SMAXP        	 */
+		vsmaxp4s,                                               	/* 0x4EA0A400	SMAXP        	 */
+		vsminp16b,                                              	/* 0x4E20AC00	SMINP        	 */
+		vsminp8h,                                               	/* 0x4E60AC00	SMINP        	 */
+		vsminp4s,                                               	/* 0x4EA0AC00	SMINP        	 */
+		vumaxp16b,                                              	/* 0x6E20A400	UMAXP        	 */
+		vumaxp8h,                                               	/* 0x6E60A400	UMAXP        	 */
+		vumaxp4s,                                               	/* 0x6EA0A400	UMAXP        	 */
+		vuminp16b,                                              	/* 0x6E20AC00	UMINP        	 */
+		vuminp8h,                                               	/* 0x6E60AC00	UMINP        	 */
+		vuminp4s,                                               	/* 0x6EA0AC00	UMINP        	 */
 /* Hint instructions */
 		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -1042,6 +1042,18 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x6EE0F400,	/* FMINP 	vfminp2d */
 		0x7EB0F800,	/* FMINP(scalar) 	fminp2s */
 		0x7EF0F800,	/* FMINP(scalar) 	fminp2d */
+		0x4E20A400,	/* SMAXP 	vsmaxp16b */
+		0x4E60A400,	/* SMAXP 	vsmaxp8h */
+		0x4EA0A400,	/* SMAXP 	vsmaxp4s */
+		0x4E20AC00,	/* SMINP 	vsminp16b */
+		0x4E60AC00,	/* SMINP 	vsminp8h */
+		0x4EA0AC00,	/* SMINP 	vsminp4s */
+		0x6E20A400,	/* UMAXP 	vumaxp16b */
+		0x6E60A400,	/* UMAXP 	vumaxp8h */
+		0x6EA0A400,	/* UMAXP 	vumaxp4s */
+		0x6E20AC00,	/* UMINP 	vuminp16b */
+		0x6E60AC00,	/* UMINP 	vuminp8h */
+		0x6EA0AC00,	/* UMINP 	vuminp4s */
 	/* Hint instructions */
 		0xD503201F,	/* NOP          nop      */
 };

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -2554,3 +2554,79 @@ INSTANTIATE_TEST_CASE_P(CINC, ARM64CINCEncodingTest, ::testing::Values(
     std::make_tuple(false, TR::RealRegister::x15, TR::RealRegister::x0, TR::CC_CC, "1a80240f"),
     std::make_tuple(false, TR::RealRegister::x29, TR::RealRegister::x0, TR::CC_LE, "1a80c41d")
 ));
+
+INSTANTIATE_TEST_CASE_P(VectorSMAXP, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e20a40f"),
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e20a41f"),
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e20a5e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e20a7e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e2fa400"),
+    std::make_tuple(TR::InstOpCode::vsmaxp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e3fa400"),
+    std::make_tuple(TR::InstOpCode::vsmaxp8h, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e60a41f"),
+    std::make_tuple(TR::InstOpCode::vsmaxp8h, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e60a5e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp8h, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e60a7e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e6fa400"),
+    std::make_tuple(TR::InstOpCode::vsmaxp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e7fa400"),
+    std::make_tuple(TR::InstOpCode::vsmaxp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4ea0a41f"),
+    std::make_tuple(TR::InstOpCode::vsmaxp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4ea0a5e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4ea0a7e0"),
+    std::make_tuple(TR::InstOpCode::vsmaxp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eafa400"),
+    std::make_tuple(TR::InstOpCode::vsmaxp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4ebfa400")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorSMINP, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "4e20ac0f"),
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e20ac1f"),
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e20ade0"),
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e20afe0"),
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e2fac00"),
+    std::make_tuple(TR::InstOpCode::vsminp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e3fac00"),
+    std::make_tuple(TR::InstOpCode::vsminp8h, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4e60ac1f"),
+    std::make_tuple(TR::InstOpCode::vsminp8h, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4e60ade0"),
+    std::make_tuple(TR::InstOpCode::vsminp8h, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4e60afe0"),
+    std::make_tuple(TR::InstOpCode::vsminp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4e6fac00"),
+    std::make_tuple(TR::InstOpCode::vsminp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4e7fac00"),
+    std::make_tuple(TR::InstOpCode::vsminp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "4ea0ac1f"),
+    std::make_tuple(TR::InstOpCode::vsminp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "4ea0ade0"),
+    std::make_tuple(TR::InstOpCode::vsminp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "4ea0afe0"),
+    std::make_tuple(TR::InstOpCode::vsminp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "4eafac00"),
+    std::make_tuple(TR::InstOpCode::vsminp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "4ebfac00")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorUMAXP, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "6e20a40f"),
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e20a41f"),
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e20a5e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e20a7e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e2fa400"),
+    std::make_tuple(TR::InstOpCode::vumaxp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e3fa400"),
+    std::make_tuple(TR::InstOpCode::vumaxp8h, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e60a41f"),
+    std::make_tuple(TR::InstOpCode::vumaxp8h, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e60a5e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp8h, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e60a7e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e6fa400"),
+    std::make_tuple(TR::InstOpCode::vumaxp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e7fa400"),
+    std::make_tuple(TR::InstOpCode::vumaxp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6ea0a41f"),
+    std::make_tuple(TR::InstOpCode::vumaxp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6ea0a5e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6ea0a7e0"),
+    std::make_tuple(TR::InstOpCode::vumaxp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6eafa400"),
+    std::make_tuple(TR::InstOpCode::vumaxp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6ebfa400")
+));
+
+INSTANTIATE_TEST_CASE_P(VectorUMINP, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v15, TR::RealRegister::v0, TR::RealRegister::v0, "6e20ac0f"),
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e20ac1f"),
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e20ade0"),
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e20afe0"),
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e2fac00"),
+    std::make_tuple(TR::InstOpCode::vuminp16b, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e3fac00"),
+    std::make_tuple(TR::InstOpCode::vuminp8h, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6e60ac1f"),
+    std::make_tuple(TR::InstOpCode::vuminp8h, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6e60ade0"),
+    std::make_tuple(TR::InstOpCode::vuminp8h, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6e60afe0"),
+    std::make_tuple(TR::InstOpCode::vuminp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6e6fac00"),
+    std::make_tuple(TR::InstOpCode::vuminp8h, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6e7fac00"),
+    std::make_tuple(TR::InstOpCode::vuminp4s, TR::RealRegister::v31, TR::RealRegister::v0, TR::RealRegister::v0, "6ea0ac1f"),
+    std::make_tuple(TR::InstOpCode::vuminp4s, TR::RealRegister::v0, TR::RealRegister::v15, TR::RealRegister::v0, "6ea0ade0"),
+    std::make_tuple(TR::InstOpCode::vuminp4s, TR::RealRegister::v0, TR::RealRegister::v31, TR::RealRegister::v0, "6ea0afe0"),
+    std::make_tuple(TR::InstOpCode::vuminp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v15, "6eafac00"),
+    std::make_tuple(TR::InstOpCode::vuminp4s, TR::RealRegister::v0, TR::RealRegister::v0, TR::RealRegister::v31, "6ebfac00")
+));


### PR DESCRIPTION
This commit adds vector pairwise max/min instructions and binary encoding unit tests.