### PR TITLE
AArch64: Implement arraycmp evaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -174,6 +174,14 @@ OMR::ARM64::CodeGenerator::initialize()
    // Enable compaction of local stack slots.  i.e. variables with non-overlapping live ranges
    // can share the same slot.
    cg->setSupportsCompactedLocals();
+   if (!TR::Compiler->om.canGenerateArraylets())
+      {
+      static const bool disableArrayCmp = feGetEnv("TR_aarch64DisableArrayCmp") != NULL;
+      if (!disableArrayCmp)
+         {
+         cg->setSupportsArrayCmp();
+         }
+      }
    }
 
 void


### PR DESCRIPTION
This commit implements arraycmp evaluator.
It implements two variants. One of them returns the length of the identical data from the beginning of the arrays.
The other returns 2/0/1 when the first array is greater than/equal to/less than the second array.
The main loop reads a 16-byte chunk from the both array in a single interation. It uses ldp instruction to read 16-byte data into two 64-bit registers. Then, it compares each 64-bit registers to find mismatch. If any mismatch is found in 16-byte chunks, the bit position of the first mismatch is searched by clz instruction for the variant returning the length. If no mismatch is found in 16-byte chunks and there is still remaining data to be compared (which is smaller than 16 bytes),
the secondary loop, which reads a single byte in each iteration, is executed.