### PR TITLE
Ensure _hasLogFile is set when option set specifies a log file

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2333,6 +2333,15 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
    else // option set processing
       {
       _logFile = NULL;
+
+      if (_logFileName)
+         {
+         if (_logFileName[0])
+            _hasLogFile = true; // non-null log file name
+         else
+            _logFileName = NULL;// null log file name ... treat as no log file
+         }
+
       if (_logFileName)
          {
          if (!_debug)


### PR DESCRIPTION
`OMR::Options::_hasLogFile` is a static that is used by `OMR::Options::requiresDebugObject()` when determining whether a debug object is needed or not. It is set in `OMR::Options::jitPostProcess`; however, optionsets don't get processed till `OMR::Options::latePostProcess`. Therefore, this PR ensures that `_logFile` gets updated when a log file is specified in an option set.