### PR TITLE
Clearing LOA remainder flag

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -410,6 +410,7 @@ MM_ParallelGlobalGC::cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescript
 		MM_EnvironmentStandard *threadEnvironment = MM_EnvironmentStandard::getEnvironment(walkThread);
 		threadEnvironment->_tenureTLHRemainderBase = NULL;
 		threadEnvironment->_tenureTLHRemainderTop = NULL;
+		threadEnvironment->_loaAllocation = false;
 	}
 
 	_extensions->_mainThreadTenureTLHRemainderTop = NULL;

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1113,6 +1113,7 @@ MM_Scavenger::activateTenureCopyScanCache(MM_EnvironmentStandard *env)
 			Assert_MM_true(env->_tenureTLHRemainderTop == cache->cacheTop);
 			env->_tenureTLHRemainderBase = NULL;
 			env->_tenureTLHRemainderTop = NULL;
+			env->_loaAllocation = false;
 			env->_tenureCopyScanCache = cache;
 			activateDeferredCopyScanCache(env);
 			/* Force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */


### PR DESCRIPTION
Fix a couple of spots where we clear Tenure TLH remainder pointers, but we miss to clear a correspodning LOA flag.

Signed-off-by: Aleksandar Micic <Aleksandar_Micic@ca.ibm.com>