### PR TITLE
Clear LOA remainder flag

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2022 IBM Corp. and others
+ * Copyright (c) 1991, 2023 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -410,6 +410,7 @@ MM_ParallelGlobalGC::cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescript
 		MM_EnvironmentStandard *threadEnvironment = MM_EnvironmentStandard::getEnvironment(walkThread);
 		threadEnvironment->_tenureTLHRemainderBase = NULL;
 		threadEnvironment->_tenureTLHRemainderTop = NULL;
+		threadEnvironment->_loaAllocation = false;
 	}
 
 	_extensions->_mainThreadTenureTLHRemainderTop = NULL;

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1113,6 +1113,7 @@ MM_Scavenger::activateTenureCopyScanCache(MM_EnvironmentStandard *env)
 			Assert_MM_true(env->_tenureTLHRemainderTop == cache->cacheTop);
 			env->_tenureTLHRemainderBase = NULL;
 			env->_tenureTLHRemainderTop = NULL;
+			env->_loaAllocation = false;
 			env->_tenureCopyScanCache = cache;
 			activateDeferredCopyScanCache(env);
 			/* Force slow path release VM access, to be able to push mutator copy caches to scanning and reliable tell if thread is inactive */


### PR DESCRIPTION
Fix a couple of spots where we clear Tenure TLH remainder pointers, but
we miss to clear a corresponding LOA flag.
