### PR TITLE
CRIU Verbose Logging Reinit/Reconfig for Restore

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1443,6 +1443,15 @@ public:
 	bool isSATBBarrierActive();
 	bool usingSATBBarrier();
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Helper function to determine whether a GC reinitialization is taking place
+	 * as a result of a VM snapshot restore.
+	 * @return boolean indicating whether GC reinitialization is taking place.
+	 */
+	MMINLINE virtual bool reinitializationInProgress() { return false; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_GCExtensionsBase()
 		: MM_BaseVirtual()
 #if defined(OMR_GC_MODRON_SCAVENGER)

--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -277,4 +277,12 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="omrobjectptr_t" name="newObject" description="the new pointer to the object." />
 	</event>
 
+	<event>
+		<name>J9HOOK_MM_OMR_REINITIALIZED</name>
+		<description>Triggered as soon as the GC is fully reinitialized.</description>
+		<struct>MM_ReinitializedEvent</struct>
+		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
+		<data type="uint64_t" name="timestamp" description="time of event" />
+	</event>
+
 </interface>

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -399,6 +399,17 @@ public:
 	 */
 	virtual void handleInitialized(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Handle any output or data tracking for the reinitialization (restore) phase of verbose GC.
+	 * Called during reinitialization of GC, stanza printed to all writers via writer chain.
+	 * @param hook Hook interface used by the JVM.
+	 * @param eventNum The hook event number.
+	 * @param eventData hook specific event data.
+	 */
+	virtual void handleReinitialized(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	/**
 	 * Write verbose stanza for Initialization of GC in to a verbose buffer
 	 * @param env GC thread used for output.

--- a/gc/verbose/VerboseManager.hpp
+++ b/gc/verbose/VerboseManager.hpp
@@ -129,7 +129,12 @@ public:
 	 * @param[in] env the current environment.
 	 * @return void
 	 */
-	virtual void prepareForCheckpoint(MM_EnvironmentBase *env) { closeStreams(env); }
+	virtual void
+	prepareForCheckpoint(MM_EnvironmentBase *env)
+	{
+		closeStreams(env);
+		disableVerboseGC();
+	}
 
 	/**
 	 * Reinitalize the Verbose GC Components for restore.

--- a/gc/verbose/VerboseManagerBase.hpp
+++ b/gc/verbose/VerboseManagerBase.hpp
@@ -271,6 +271,13 @@ public:
 	J9HookInterface** getPrivateHookInterface(){ return _mmPrivateHooks; }
 	J9HookInterface** getOMRHookInterface(){ return _omrHooks; }
 
+	/**
+	 * Query used by verbose writers to determine the file open flags required by the verbose manager.
+	 * @param[in] env the current environment.
+	 * @return int32_t flags that must be used for opening a verbose log.
+	 */
+	virtual int32_t fileOpenMode(MM_EnvironmentBase *env) { return EsOpenTruncate; }
+
 	MM_VerboseManagerBase(OMR_VM *omrVM)
 		: MM_BaseVirtual()
 		, _omrVM(omrVM)

--- a/gc/verbose/VerboseWriter.cpp
+++ b/gc/verbose/VerboseWriter.cpp
@@ -72,10 +72,16 @@ void
 MM_VerboseWriter::tearDown(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* ext = env->getExtensions();
-	ext->getForge()->free(_header);
-	_header = NULL;
-	ext->getForge()->free(_footer);
-	_footer = NULL;
+
+	if (NULL != _header) {
+		ext->getForge()->free(_header);
+		_header = NULL;
+	}
+
+	if (NULL != _footer) {
+		ext->getForge()->free(_footer);
+		_footer = NULL;
+	}
 }
 
 void

--- a/gc/verbose/VerboseWriterFileLogging.cpp
+++ b/gc/verbose/VerboseWriterFileLogging.cpp
@@ -95,10 +95,15 @@ MM_VerboseWriterFileLogging::tearDown(MM_EnvironmentBase *env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
-	omrstr_free_tokens(_tokens);
-	_tokens = NULL;
-	extensions->getForge()->free(_filename);
-	_filename = NULL;
+	if (NULL != _tokens) {
+		omrstr_free_tokens(_tokens);
+		_tokens = NULL;
+	}
+
+	if (NULL != _filename) {
+		extensions->getForge()->free(_filename);
+		_filename = NULL;
+	}
 
 	MM_VerboseWriter::tearDown(env);
 }
@@ -329,6 +334,7 @@ bool
 MM_VerboseWriterFileLogging::reconfigure(MM_EnvironmentBase *env, const char *filename, uintptr_t numFiles, uintptr_t numCycles)
 {
 	closeFile(env);
+	tearDown(env);
 	return initialize(env, filename, numFiles, numCycles);
 }
 

--- a/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
@@ -94,7 +94,9 @@ MM_VerboseWriterFileLoggingBuffered::openFile(MM_EnvironmentBase *env, bool prin
 		return false;
 	}
 	
-	_logFileStream = omrfilestream_open(filenameToOpen, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666);
+	int32_t openFlags =  EsOpenWrite | EsOpenCreate | _manager->fileOpenMode(env);
+
+	_logFileStream = omrfilestream_open(filenameToOpen, openFlags, 0666);
 	if(NULL == _logFileStream) {
 		char *cursor = filenameToOpen;
 		/**
@@ -108,7 +110,7 @@ MM_VerboseWriterFileLoggingBuffered::openFile(MM_EnvironmentBase *env, bool prin
 		}
 
 		/* Try again */
-		_logFileStream = omrfilestream_open(filenameToOpen, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666);
+		_logFileStream = omrfilestream_open(filenameToOpen, openFlags, 0666);
 		if (NULL == _logFileStream) {
 			_manager->handleFileOpenError(env, filenameToOpen);
 			extensions->getForge()->free(filenameToOpen);

--- a/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
@@ -95,7 +95,9 @@ MM_VerboseWriterFileLoggingSynchronous::openFile(MM_EnvironmentBase *env, bool p
 		return false;
 	}
 	
-	_logFileDescriptor = omrfile_open(filenameToOpen, EsOpenRead | EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666);
+	int32_t openFlags =  EsOpenRead | EsOpenWrite | EsOpenCreate | _manager->fileOpenMode(env);
+
+	_logFileDescriptor = omrfile_open(filenameToOpen, openFlags, 0666);
 	if(-1 == _logFileDescriptor) {
 		char *cursor = filenameToOpen;
 		/**
@@ -109,7 +111,7 @@ MM_VerboseWriterFileLoggingSynchronous::openFile(MM_EnvironmentBase *env, bool p
 		}
 
 		/* Try again */
-		_logFileDescriptor = omrfile_open(filenameToOpen, EsOpenRead | EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666);
+		_logFileDescriptor = omrfile_open(filenameToOpen, openFlags, 0666);
 		if (-1 == _logFileDescriptor) {
 			_manager->handleFileOpenError(env, filenameToOpen);
 			extensions->getForge()->free(filenameToOpen);


### PR DESCRIPTION
Verbose GC API changes to support CRIU Verbose GC logging: https://github.com/eclipse-openj9/openj9/pull/16845

- Introduced J9HOOK_MM_OMR_REINITIALIZED event. This is required by the verbose handler to print init details upon snapshot restore.
- Added missing tearDown call to MM_VerboseWriterFileLogging::reconfigure to free memory before a reinit.
- GC Extensions Base class reinitializationInProgress introduced, this is to be implemented by downstream J9 derived class. 
- VerboseManagerBase fileOpenMode query introduced, this is to be implemented by downstream J9 derived class.
- Verbose file writers now query the verbose manager (fileOpenMode) to determine if an opened file should be appended to.

Related: https://github.com/eclipse/omr/issues/6888#issuecomment-1458810193

Signed-off-by: Salman Rana <salman.rana@ibm.com>