### PR TITLE
Infra for new optimization `catchBlockProfiler`

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -382,7 +382,7 @@ OMR::Compilation::Compilation(
    // _methodSymbol must be initialized here because creating a jitted method symbol
    //   actually inspects TR::comp()->_methodSymbol (to compare against the new object)
    _methodSymbol = TR::ResolvedMethodSymbol::createJittedMethodSymbol(self()->trHeapMemory(), compilee, self());
-   
+
    // initPersistentCPUField and createOpCode must be done after method symbol creation
 
    if (self()->getOption(TR_EnableNodeGC))
@@ -2423,11 +2423,16 @@ OMR::Compilation::mayHaveLoops()
    return self()->getMethodSymbol()->mayHaveLoops();
    }
 
-
 bool
 OMR::Compilation::hasNews()
    {
    return self()->getMethodSymbol()->hasNews();
+   }
+
+bool
+OMR::Compilation::hasExceptionHandlers()
+   {
+   return self()->getMethodSymbol()->hasExceptionHandlers();
    }
 
 TR::HCRMode

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -533,6 +533,7 @@ public:
    bool mayHaveLoops();
    bool hasLargeNumberOfLoops();
    bool hasNews();
+   bool hasExceptionHandlers();
 
    ToNumberMap  &getToNumberMap()  { return _toNumberMap; }
    ToStringMap  &getToStringMap()  { return _toStringMap; }

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -88,7 +88,7 @@ enum TR_CompilationOptions
    TR_ReportMethodEnter          = 0x00000080,
    TR_ReportMethodExit           = 0x00000100,
    TR_EntryBreakPoints           = 0x00000200,
-   // Available                  = 0x00000400,
+   TR_EnableOldEDO               = 0x00000400,
    // Available                  = 0x00000800,
    TR_RegisterMaps               = 0x00001000,
    TR_CreatePCMaps               = 0x00002000,
@@ -1489,6 +1489,9 @@ public:
       _maxSzForVPInliningWarm = 0;
       _loopyAsyncCheckInsertionMaxEntryFreq = 0;
       _objectFileName = 0;
+      _edoRecompSizeThreshold = 0;
+      _edoRecompSizeThresholdInStartupMode = 0;
+      _catchBlockCounterThreshold = 0;
 
       memset(_options, 0, sizeof(_options));
       memset(_disabledOptimizations, false, sizeof(_disabledOptimizations));
@@ -1827,6 +1830,11 @@ public:
       {
       return _loopyAsyncCheckInsertionMaxEntryFreq;
       }
+
+   int32_t getEdoRecompSizeThreshold() { return _edoRecompSizeThreshold; }
+   int32_t getEdoRecompSizeThresholdInStartupMode() { return _edoRecompSizeThresholdInStartupMode; }
+   int32_t getCatchBlockCounterThreshold() { return _catchBlockCounterThreshold; }
+
 
 public:
 
@@ -2503,7 +2511,9 @@ protected:
    int32_t                     _loopyAsyncCheckInsertionMaxEntryFreq;
 
    char *                      _objectFileName; //Name of the relocatable ELF file *.o if one is to be generated
-
+   int32_t                     _edoRecompSizeThreshold; // Size threshold (in nodes) for candidates to recompilation through EDO
+   int32_t                     _edoRecompSizeThresholdInStartupMode; // Size threshold (in nodes) for candidates to recompilation through EDO during startup
+   int32_t                     _catchBlockCounterThreshold; // Counter threshold for catch blocks to trigger more aggresive inlining on the throw path
    }; // TR::Options
 
 }

--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -254,7 +254,7 @@ public:
    void setHasBranches(bool b)               { _methodFlags2.set(HasBranches, b); }
    bool hasVectorAPI()                       { return _methodFlags2.testAny(HasVectorAPI); }
    void setHasVectorAPI(bool b)              { _methodFlags2.set(HasVectorAPI, b); }
-   
+
    int32_t getNumberOfBackEdges();
 
    bool canDirectNativeCall()                { return _properties.testAny(CanDirectNativeCall); }
@@ -273,6 +273,8 @@ public:
 
    bool hasSnapshots()                       { return _properties.testAny(HasSnapshots); }
    void setHasSnapshots(bool v=true)         { _properties.set(HasSnapshots,v); }
+   bool hasExceptionHandlers()               { return _properties.testAny(HasExceptionHandlers); }
+   void setHasExceptionHandlers(bool v=true) { _properties.set(HasExceptionHandlers,v); }
 
    bool detectInternalCycles();
    bool catchBlocksHaveRealPredecessors();

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4679,6 +4679,9 @@ static void updateCallersFlags(TR::ResolvedMethodSymbol* callerSymbol, TR::Resol
    if (calleeSymbol->hasVectorAPI())
       callerSymbol->setHasVectorAPI(true);
 
+   if (calleeSymbol->hasExceptionHandlers())
+      callerSymbol->setHasExceptionHandlers(true);
+
    // Make sure we propagate to the top-level symbol too
    //
    static char *disablePropagatingCalleeFlagsToTopLevelMethod = feGetEnv("TR_disablePropagatingCalleeFlagsToTopLevelMethod");

--- a/compiler/optimizer/OMROptimizations.enum
+++ b/compiler/optimizer/OMROptimizations.enum
@@ -118,3 +118,4 @@
    OPTIMIZATION(regDepCopyRemoval)
    OPTIMIZATION(asyncCheckInsertion)
    OPTIMIZATION(methodHandleTransformer)
+   OPTIMIZATION(catchBlockProfiler)

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -861,7 +861,6 @@ OMR::Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *metho
       new (comp->allocator()) TR::OptimizationManager(self(), TR::RecognizedCallTransformer::create, OMR::recognizedCallTransformer);
    _opts[OMR::switchAnalyzer] =
       new (comp->allocator()) TR::OptimizationManager(self(), TR::SwitchAnalyzer::create, OMR::switchAnalyzer);
-
    // NOTE: Please add new OMR optimizations here!
 
    // initialize OMR optimization groups
@@ -1550,6 +1549,12 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
          {
          if (comp()->getMethodSymbol()->hasVectorAPI() &&
              !comp()->getOption(TR_DisableVectorAPIExpansion))
+            doThisOptimization = true;
+         }
+         break;
+      case IfExceptionHandlers:
+         {
+         if (comp()->hasExceptionHandlers())
             doThisOptimization = true;
          }
          break;

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -134,6 +134,7 @@ enum
    IfEAOpportunitiesAndNotOptServer,
    IfAggressiveLiveness,
    IfVectorAPI,  // JEP414: Extra analysis required to optimize Vector API
+   IfExceptionHandlers,
    MarkLastRun
    };
 
@@ -176,9 +177,9 @@ class Optimizer
     * functionality as the `optTest=` parameter, it does not require
     * reinitializing the JIT, nor manually changing the optFile.
     *
-    * If _mockStrategy is NULL, has no effect on the optimizer. 
+    * If _mockStrategy is NULL, has no effect on the optimizer.
     *
-    * @param strategy The #OptimizationStrategy to return when requested. 
+    * @param strategy The #OptimizationStrategy to return when requested.
     */
    static void setMockStrategy(const OptimizationStrategy *strategy) { _mockStrategy = strategy; };
 
@@ -361,9 +362,9 @@ class Optimizer
 
    const OptimizationStrategy *          _strategy;
 
-   /* 
+   /*
     * Since mock strategies are only used in testing right now, we make this
-    * static to ease implementation. 
+    * static to ease implementation.
     *
     * This is currently not a thread-safe implementation beause doing a
     * thread-safe implementation would require a more invasive compilation


### PR DESCRIPTION
This commit implements the OMR infrastructure needed for a new optimization pass called `catchBlockProfiler`, which will be used by the exception directed optimization (EDO) mechanism. This optimization will be implemented in OpenJ9 upstream project. Three controlling options are introduced:
-Xjit:edoRecompSizeThreshold=
-Xjit:edoRecompSizeThresholdInStartupMode=
-Xjit:catchBlockCounterThreshold=
There is another option, -Xjit:enableOldEDO that can be used to revert to the old way of doing EDO.
Yet, another option, -Xjit:traceCatchBlockProfiler, allows tracing of the new optimization.