### PR TITLE
Ensure _suppressEA option field is initialized to NULL

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1402,6 +1402,7 @@ public:
       _memUsage = NULL;
       _classesWithFolableFinalFields = NULL;
       _disabledIdiomPatterns = NULL;
+      _suppressEA = NULL;
       _gcCardSize = 0;
       _heapBase = 0;
       _heapTop = 0;


### PR DESCRIPTION
The `_suppressEA` field in `OMR::Options` was not initialized to `NULL` in the `OMR::Options::init` method, which means it could contain garbage that will cause intermittent crashes if the field is dereferenced.

Fixes eclipse-openj9/openj9#16834