### PR TITLE
Restore GC Thread Count Limit

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -539,6 +539,14 @@ MM_Configuration::reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env)
 
 	initializeGCThreadCount(env);
 
+	/* Limit the restore thread count/ensure it is reasonable considering that the collector was initialized to
+	 * optimize for the initial startup thread count (e.g., allocated split lists).
+	 */
+	if (!extensions->gcThreadCountForced) {
+		uintptr_t threadCountLimit = MM_Math::roundToCeiling(8, extensions->dispatcher->getPoolMaxCapacity()) * 2;
+		extensions->gcThreadCount = OMR_MIN(threadCountLimit, extensions->gcThreadCount);
+	}
+
 	/* Currently, threads don't shutdown during restore, so ensure
 	 * thread count doesn't fall below the checkpoint thread count.
 	 * This adjustment can be removed in the future when dispatcher


### PR DESCRIPTION
Limit the default restore thread count to:  2 X (initial thread count ceiling to a factor of 8). For example, if the initial thread count was in a range of 1-8, we would allow up max 16 thread for restore. This ensures that the restore thread count is reasonable considering the GC was initialized to optimize for the initial startup GC thread count (e.g., allocated split lists).

Signed-off-by: Salman Rana <salman.rana@ibm.com>