### PR TITLE
AArch64: Implement arrayset evaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -182,6 +182,10 @@ OMR::ARM64::CodeGenerator::initialize()
          cg->setSupportsArrayCmp();
          }
       }
+      if (!comp->getOption(TR_DisableArraySetOpts))
+         {
+         cg->setSupportsArraySet();
+         }
    }
 
 void

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -17391,6 +17391,10 @@ TR::Node * arraysetSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier
       {
       uint64_t fillVal = fill->getConst<uint64_t>();
       if ((fillVal & 0x0FFFFFFFFL) == ((fillVal >> 32) & 0x0FFFFFFFFL) &&
+#ifdef TR_TARGET_ARM64
+          /* 0 and -1 can be efficiently loaded and stored as 64-bit data on AArch64. */
+          (fillVal != 0) && (fillVal != -1) &&
+#endif /* TR_TARGET_ARM64 */
           performTransformation(s->comp(), "%sTransform large fill arrayset to 4byte fill arrayset [" POINTER_PRINTF_FORMAT "]\n",
                 s->optDetailString(), node))
          {


### PR DESCRIPTION
This commit adds arrayset evaluator to aarch64 codegen.
- For variable length arrays, the main loop writes a 64-byte chunk to the array in a single interation. It uses stp instructions which store 32-byte data using two 128-bit vector registers. If the length of the array is less than 96 bytes, then the secondary loop, which writes 16-byte data in each iteration, is executed. If the length of the array is less than 16 bytes, then the loop which writes a single byte per iteration is executed.
- For constant length arrays, if the length is greater than or equal to 32 bytes, stp instructions with vector registers are used. If the length is larger than certain threshold, then the loop which stores 256 bytes in a single iteration is executed.