### PR TITLE
Make vector compare opcodes two-type vector opcodes

### DIFF
--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -469,102 +469,6 @@ VECTOR_OPERATION_MACRO(\
    /* .description             =    indirect call returning a vector */ \
 )
 VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmpeq, \
-   /* .name                    = */ "vcmpeq", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfEqual, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmpeq, \
-   /* .reverseBranchOperation  = */ TR::vcmpne, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare equal  (return vector mask) */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmpne, \
-   /* .name                    = */ "vcmpne", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmpne, \
-   /* .reverseBranchOperation  = */ TR::vcmpeq, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare not equal  (return vector mask) */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmpgt, \
-   /* .name                    = */ "vcmpgt", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfGreater, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmplt, \
-   /* .reverseBranchOperation  = */ TR::vcmple, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare greater than */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmpge, \
-   /* .name                    = */ "vcmpge", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfGreater | ILProp3::CompareTrueIfEqual, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmple, \
-   /* .reverseBranchOperation  = */ TR::vcmplt, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare greater equal */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmplt, \
-   /* .name                    = */ "vcmplt", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfLess, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmpgt, \
-   /* .reverseBranchOperation  = */ TR::vcmpge, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare less than */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vcmple, \
-   /* .name                    = */ "vcmple", \
-   /* .properties1             = */ ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfEqual, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vcmpge, \
-   /* .reverseBranchOperation  = */ TR::vcmpgt, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector compare less equal */ \
-)
-VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vdiv, \
    /* .name                    = */ "vdiv", \
    /* .properties1             = */ ILProp1::Div, \
@@ -1160,102 +1064,6 @@ VECTOR_OPERATION_MACRO(\
    /* .description             =    vector masked logical AND */ \
 )
 VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmpeq, \
-   /* .name                    = */ "vmcmpeq", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmpeq, \
-   /* .reverseBranchOperation  = */ TR::vmcmpne, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare equal  (return vector mask) */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmpne, \
-   /* .name                    = */ "vmcmpne", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmpne, \
-   /* .reverseBranchOperation  = */ TR::vmcmpeq, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare not equal  (return vector mask) */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmpgt, \
-   /* .name                    = */ "vmcmpgt", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmplt, \
-   /* .reverseBranchOperation  = */ TR::vmcmple, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare greater than */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmpge, \
-   /* .name                    = */ "vmcmpge", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmple, \
-   /* .reverseBranchOperation  = */ TR::vmcmplt, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare greater equal */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmplt, \
-   /* .name                    = */ "vmcmplt", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmpgt, \
-   /* .reverseBranchOperation  = */ TR::vmcmpge, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare less than */ \
-)
-VECTOR_OPERATION_MACRO(\
-   /* .operation               = */ vmcmple, \
-   /* .name                    = */ "vmcmple", \
-   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
-   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
-   /* .properties3             = */ 0, \
-   /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ ILTypeProp::MaskResult, \
-   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
-   /* .swapChildrenOperation   = */ TR::vmcmpge, \
-   /* .reverseBranchOperation  = */ TR::vmcmpgt, \
-   /* .booleanCompareOpCode    = */ TR::BadILOp, \
-   /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    vector masked compare less equal */ \
-)
-VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vmdiv, \
    /* .name                    = */ "vmdiv", \
    /* .properties1             = */ ILProp1::VectorMasked, \
@@ -1721,4 +1529,196 @@ VECTOR_OPERATION_MACRO(\
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
    /* .description             =    convert platform specific vector mask into boolean vector with the same number of elements */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmpeq, \
+   /* .name                    = */ "vcmpeq", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfEqual, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmpeq, \
+   /* .reverseBranchOperation  = */ TR::vcmpne, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare equal  (return vector mask) */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmpne, \
+   /* .name                    = */ "vcmpne", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfGreater, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmpne, \
+   /* .reverseBranchOperation  = */ TR::vcmpeq, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare not equal  (return vector mask) */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmpgt, \
+   /* .name                    = */ "vcmpgt", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfGreater, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmplt, \
+   /* .reverseBranchOperation  = */ TR::vcmple, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare greater than */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmpge, \
+   /* .name                    = */ "vcmpge", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfGreater | ILProp3::CompareTrueIfEqual, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmple, \
+   /* .reverseBranchOperation  = */ TR::vcmplt, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare greater equal */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmplt, \
+   /* .name                    = */ "vcmplt", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfLess, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmpgt, \
+   /* .reverseBranchOperation  = */ TR::vcmpge, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare less than */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vcmple, \
+   /* .name                    = */ "vcmple", \
+   /* .properties1             = */ ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ ILProp3::CompareTrueIfLess | ILProp3::CompareTrueIfEqual, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vcmpge, \
+   /* .reverseBranchOperation  = */ TR::vcmpgt, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector compare less equal */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmpeq, \
+   /* .name                    = */ "vmcmpeq", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmpeq, \
+   /* .reverseBranchOperation  = */ TR::vmcmpne, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare equal  (return vector mask) */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmpne, \
+   /* .name                    = */ "vmcmpne", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmpne, \
+   /* .reverseBranchOperation  = */ TR::vmcmpeq, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare not equal  (return vector mask) */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmpgt, \
+   /* .name                    = */ "vmcmpgt", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmplt, \
+   /* .reverseBranchOperation  = */ TR::vmcmple, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare greater than */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmpge, \
+   /* .name                    = */ "vmcmpge", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmple, \
+   /* .reverseBranchOperation  = */ TR::vmcmplt, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare greater equal */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmplt, \
+   /* .name                    = */ "vmcmplt", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmpgt, \
+   /* .reverseBranchOperation  = */ TR::vmcmpge, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare less than */ \
+)
+VECTOR_OPERATION_MACRO(\
+   /* .operation               = */ vmcmple, \
+   /* .name                    = */ "vmcmple", \
+   /* .properties1             = */ ILProp1::VectorMasked | ILProp1::BooleanCompare, \
+   /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
+   /* .properties3             = */ 0, \
+   /* .properties4             = */ 0, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::MaskResult, \
+   /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
+   /* .swapChildrenOperation   = */ TR::vmcmpge, \
+   /* .reverseBranchOperation  = */ TR::vmcmpgt, \
+   /* .booleanCompareOpCode    = */ TR::BadILOp, \
+   /* .ifCompareOpCode         = */ TR::BadILOp, \
+   /* .description             =    vector masked compare less equal */ \
 )


### PR DESCRIPTION
- since vector compare opcodes take vectors and return a mask (with possibly different element type) they should be two-type opcodes
- mask element type is Int32 for Float vectors and Int64 for Double vectors