### PR TITLE
Fix Large VFP-relative memory-references

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -190,6 +190,12 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
       {
       mightNeedAddressRegister = true;
       }
+   else if (sr.getSymbol() != NULL && (sr.isUnresolved() || (sr.stackAllocatedArrayAccess() && !IS_32BIT_SIGNED(self()->getDisplacement()))))
+      {
+      // Once resolved, the address could be anything, so be conservative.
+      //
+      mightNeedAddressRegister = true;
+      }
    else if (self()->getBaseRegister() == cg->getFrameRegister())
       {
       // We should never see stack frames 2GB in size, so don't waste a register.
@@ -197,12 +203,6 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
       // pointer adjustment.)
       //
       mightNeedAddressRegister = false;
-      }
-   else if (sr.getSymbol() != NULL && sr.isUnresolved())
-      {
-      // Once resolved, the address could be anything, so be conservative.
-      //
-      mightNeedAddressRegister = true;
       }
    else if (comp->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject())
       {

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -377,18 +377,14 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerato
       _addressRegister = NULL;
       }
 
-   if (_addressRegister == NULL)
-      {
-      // Just use inherited logic
-      //
-      estimate = OMR::X86::MemoryReference::estimateBinaryLength(cg);
+   estimate = OMR::X86::MemoryReference::estimateBinaryLength(cg);
 
-      // For [disp32], AMD64 needs a SIB byte
-      //
-      if (_baseRegister == NULL && _indexRegister == NULL)
-         estimate += 1;
-      }
-   else
+   // For [disp32], AMD64 needs a SIB byte
+   //
+   if (_baseRegister == NULL && _indexRegister == NULL)
+      estimate += 1;
+
+   if (_addressRegister != NULL)
       {
 
       // TODO:AMD64: Should be able to do a tighter estimate than this
@@ -397,12 +393,10 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerato
       // great big load instruction.  Thus, the size we use for the estimate is
       // the size after adding the big load instruction.)
       //
-      estimate = IMM64_LOAD_SIZE + MAX_MEMREF_SIZE;
-
+      estimate += IMM64_LOAD_SIZE;
       }
 
    return estimate;
-
    }
 
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -894,7 +894,7 @@ OMR::X86::MemoryReference::assignRegisters(
             {
             // Note: a MemRef can be used only once -- if you want to reuse make a copy using
             // generateX86MemoryReference(OMR::X86::MemoryReference  &, intptr_t, TR::CodeGenerator *cg).
-            TR_ASSERT(!_baseRegister->getRealRegister(),"_baseRegister is a Real Register already, are you reusing a Memory Reference?");
+            TR_ASSERT_FATAL(!_baseRegister->getRealRegister(),"_baseRegister is a Real Register already, are you reusing a Memory Reference?");
             assignedBaseRegister = assignGPRegister(currentInstruction, _baseRegister, TR_WordReg, cg);
             }
 
@@ -1581,7 +1581,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
             {
-            TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
+            TR_ASSERT_FATAL(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
                    "virtual frame pointer must be assigned before binary encoding!\n");
 
             base = toRealRegister(cg->machine()->
@@ -1598,7 +1598,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             }
 
          displacement = self()->getDisplacement();
-         TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
+         TR_ASSERT_FATAL(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
 
          if (!isForceWideDisplacement() && isEvex && (displacement % displacementDivisor) == 0 && IS_8BIT_SIGNED(displacement / displacementDivisor))
             {

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -402,9 +402,14 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          //
          TR::Register *baseRegister;
          if (toRealRegister(_baseRegister)->getRegisterNumber() == TR::RealRegister::vfp)
+            {
             baseRegister = toRealRegister(_baseRegister)->getAssignedRealRegister();
+            TR_ASSERT_FATAL(baseRegister, "virtual frame pointer must be assigned before binary encoding!\n");
+            }
          else
+            {
             baseRegister = _baseRegister;
+            }
          rxbBits |= toRealRegister(baseRegister)->rexBits(TR::RealRegister::REX_B, false);
          }
       if (_indexRegister)


### PR DESCRIPTION
See my comments on the issue [here](https://github.com/eclipse-openj9/openj9/issues/15363#issuecomment-1481820466).

Fixes eclipse-openj9/openj9#15363
