### PR TITLE
Add non-helper for array element load and store

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -164,6 +164,31 @@
     */
    nonNullableArrayNullStoreCheckSymbol,
 
+   /**
+    * \brief This symbol represents a call that loads an array element. The array must have a reference
+    * type for its element type. It cannot be arrays of primitive types such as int[] or double[]
+    *
+    * \code
+    *   acall <loadFlattenableArrayElementNonHelperSymbol>
+    *     array-element-index
+    *     array-base-address
+    * \endcode
+    */
+   loadFlattenableArrayElementNonHelperSymbol,
+
+   /**
+    * \brief This symbol represents a call that stores a value into an array element. The array must have
+    * a reference type for its element type. It cannot be arrays of primitive types such as int[] or double[]
+    *
+    * \code
+    *   call <storeFlattenableArrayElementNonHelperSymbol>
+    *     value-reference-to-be-stored
+    *     array-element-index
+    *     array-reference-to-which-value-will-be-stored
+    * \endcode
+    */
+   storeFlattenableArrayElementNonHelperSymbol,
+
    /** \brief
     *
     *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -2147,6 +2147,8 @@ const char *OMR::SymbolReferenceTable::_commonNonHelperSymbolNames[] =
    "<objectEqualityComparison>",
    "<objectInequalityComparison>",
    "<nonNullableArrayNullStoreCheck>",
+   "<loadFlattenableArrayElementNonHelper>",
+   "<storeFlattenableArrayElementNonHelper>",
    "<synchronizedFieldLoad>",
    "<atomicAdd>",
    "<atomicFetchAndAdd>",

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -240,6 +240,31 @@ class SymbolReferenceTable
        */
       nonNullableArrayNullStoreCheckSymbol,
 
+      /**
+       * \brief This symbol represents a call that loads an array element. The array must have a reference
+       * type for its element type. It cannot be arrays of primitive types such as int[] or double[]
+       *
+       * \code
+       *   acall <loadFlattenableArrayElementNonHelperSymbol>
+       *     array-element-index
+       *     array-base-address
+       * \endcode
+       */
+      loadFlattenableArrayElementNonHelperSymbol,
+
+      /**
+       * \brief This symbol represents a call that stores a value into an array element. The array must have
+       * a reference type for its element type. It cannot be arrays of primitive types such as int[] or double[]
+       *
+       * \code
+       *   call <storeFlattenableArrayElementNonHelperSymbol>
+       *     value-reference-to-be-stored
+       *     array-element-index
+       *     array-reference-to-which-value-will-be-stored
+       * \endcode
+       */
+      storeFlattenableArrayElementNonHelperSymbol,
+
       /** \brief
        *
        *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -147,6 +147,11 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             {
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
             }
+         if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::loadFlattenableArrayElementNonHelperSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::storeFlattenableArrayElementNonHelperSymbol))
+            {
+            return &symRefTab->aliasBuilder.defaultMethodUseAliases();
+            }
 
          if (!methodSymbol->isHelper())
             {
@@ -339,7 +344,9 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectEqualityComparisonSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::objectInequalityComparisonSymbol) ||
-             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol))
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::loadFlattenableArrayElementNonHelperSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::storeFlattenableArrayElementNonHelperSymbol))
             {
             return &symRefTab->aliasBuilder.defaultMethodDefAliases();
             }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1647,6 +1647,10 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<objectInequalityComparison>";
          case TR::SymbolReferenceTable::nonNullableArrayNullStoreCheckSymbol:
              return "<nonNullableArrayNullStoreCheck>";
+         case TR::SymbolReferenceTable::loadFlattenableArrayElementNonHelperSymbol:
+             return "<loadFlattenableArrayElementNonHelper>";
+         case TR::SymbolReferenceTable::storeFlattenableArrayElementNonHelperSymbol:
+             return "<storeFlattenableArrayElementNonHelper>";
          case TR::SymbolReferenceTable::J9JNIMethodIDvTableIndexFieldSymbol:
              return "<J9JNIMethodIDvTableIndexFieldSymbol>";
          case TR::SymbolReferenceTable::defaultValueSymbol:
@@ -2112,6 +2116,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<objectEqualityComparison>",
    "<objectInequalityComparison>",
    "<nonNullableArrayNullStoreCheck>",
+   "<loadFlattenableArrayElementNonHelper>",
+   "<storeFlattenableArrayElementNonHelper>",
    "<synchronizedFieldLoad>",
    "<atomicAdd>",
    "<atomicFetchAndAdd>",


### PR DESCRIPTION
Add non-helper for array element load and store

The downstream usage of these non-helper calls are in https://github.com/eclipse-openj9/openj9/pull/17072