### PR TITLE
Introduce CRIU reinitializeForRestore For Memory Pool

### DIFF
--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -422,6 +422,18 @@ public:
 	 * @return bytes of free memory in the pool released/decommited back to OS
 	 */
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Make adjustments to the Memory Pool to accommodate the restore configuration.
+	 * It is expected that subclasses will implement this method.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the memory pool was successfully updated.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env) { return true; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	/**
 	 * Create a MemoryPool object.
 	 */

--- a/gc/base/MemoryPoolSplitAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedList.cpp
@@ -1310,3 +1310,47 @@ MM_MemoryPoolSplitAddressOrderedList::releaseFreeMemoryPages(MM_EnvironmentBase*
 
 	return releasedMemory;
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+bool
+MM_MemoryPoolSplitAddressOrderedList::reinitializeForRestore(MM_EnvironmentBase *env)
+{
+	if (_extensions->splitFreeListSplitAmount > _heapFreeListCount) {
+		/* Free lists must not exceed the pre-allocated _maximumHeapFreeListCount number of entries. */
+		_extensions->splitFreeListSplitAmount = OMR_MIN(
+				_extensions->splitFreeListSplitAmount, _maximumHeapFreeListCount);
+
+		/* Initialize values from _heapFreeListCount to the newly set splitFreeListSplitAmount. */
+		for (uintptr_t i = _heapFreeListCount; i < _extensions->splitFreeListSplitAmount; ++i) {
+			_currentThreadFreeList[i] = 0;
+
+			_heapFreeLists[i] = J9ModronFreeList();
+
+			if (!_heapFreeLists[i].initialize(env)) {
+				return false;
+			}
+
+			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(env);
+
+			if (!_largeObjectAllocateStatsForFreeList[i].initialize(
+					env, (uint16_t)_extensions->largeObjectAllocationProfilingTopK,
+					_extensions->largeObjectAllocationProfilingThreshold,
+					_extensions->largeObjectAllocationProfilingVeryLargeObjectThreshold,
+					(float)_extensions->largeObjectAllocationProfilingSizeClassRatio / (float)100.0,
+					_extensions->heap->getMaximumMemorySize(), getTlhMaximumSize() + _minimumFreeEntrySize,
+					_extensions->tlhMinimumSize, 2)) {
+				return false;
+			}
+		}
+
+		_heapFreeListCount = _extensions->splitFreeListSplitAmount;
+	} else {
+		/* Free lists will not be reduced in size, splitFreeListSplitAmount
+		 * must be reset back to its pre-restore value.
+		 */
+		_extensions->splitFreeListSplitAmount = _heapFreeListCount;
+	}
+
+	return true;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/gc/base/MemoryPoolSplitAddressOrderedList.hpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedList.hpp
@@ -170,6 +170,16 @@ public:
 
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Modify the Memory Pool split lists according to the updated GC thread count.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the memory pool was successfully updated.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	/**
 	 * Create a MemoryPoolAddressOrderedList object.
 	 */

--- a/gc/base/MemoryPoolSplitAddressOrderedListBase.hpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedListBase.hpp
@@ -261,6 +261,7 @@ private:
 protected:
 	/* Basic free list support */
 	uintptr_t _heapFreeListCount;
+	uintptr_t _maximumHeapFreeListCount; /**< Maximum value for _heapFreeListCount that can be reinitialized to during VM restore. */
 	uintptr_t* _currentThreadFreeList;
 	J9ModronFreeList* _heapFreeLists;
 
@@ -369,11 +370,31 @@ public:
 	virtual uintptr_t getActualFreeEntryCount();
 
 	/**
+	 * Return the maximum TLH size taking into account scavengerScanCacheMaximumSize
+	 * when scavenger is being used.
+	 *
+	 * @return uintptr_t The maximum TLH size.
+	 */
+	MMINLINE uintptr_t getTlhMaximumSize()
+	{
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		/* this memoryPool can be used by scavenger, maximum tlh size
+		 * should be max(_extensions->tlhMaximumSize, _extensions->scavengerScanCacheMaximumSize)
+		 */
+		uintptr_t tlhMaximumSize = OMR_MAX(_extensions->tlhMaximumSize, _extensions->scavengerScanCacheMaximumSize);
+#else /* OMR_GC_MODRON_SCAVENGER */
+		uintptr_t tlhMaximumSize = _extensions->tlhMaximumSize;
+#endif /* OMR_GC_MODRON_SCAVENGER */
+		return tlhMaximumSize;
+	}
+
+	/**
 	 * Create a MemoryPoolAddressOrderedList object.
 	 */
 	MM_MemoryPoolSplitAddressOrderedListBase(MM_EnvironmentBase* env, uintptr_t minimumFreeEntrySize, uintptr_t splitAmount)
 		: MM_MemoryPoolAddressOrderedListBase(env, minimumFreeEntrySize)
 		, _heapFreeListCount(splitAmount)
+		, _maximumHeapFreeListCount(32) /* Optimize free lists up to 256 Threads. */
 		, _currentThreadFreeList(0)
 		, _heapFreeLists(NULL)
 		, _largeObjectAllocateStatsForFreeList(NULL)
@@ -384,6 +405,7 @@ public:
 	MM_MemoryPoolSplitAddressOrderedListBase(MM_EnvironmentBase* env, uintptr_t minimumFreeEntrySize, uintptr_t splitAmount, const char* name)
 		: MM_MemoryPoolAddressOrderedListBase(env, minimumFreeEntrySize, name)
 		, _heapFreeListCount(splitAmount)
+		, _maximumHeapFreeListCount(32) /* Optimize free lists up to 256 Threads. */
 		, _currentThreadFreeList(0)
 		, _heapFreeLists(NULL)
 		, _largeObjectAllocateStatsForFreeList(NULL)


### PR DESCRIPTION
For background, see https://github.com/eclipse/omr/issues/6888

MemoryPoolSplitAddressOrderedList must adjust its free lists to optimize for the GC thread count set at restore time. This is achieved  by pre-allocating all the heap free lists related arrays at VM startup. The number of entries allocated is _maximumFreeListSize, which is set to 8 by default, this allows the pool to be optimized for up to 64 threads (default max gc thread count). Only _heapFreeListCount number of entries are used, hence the lists may grow from _heapFreeListCount to _maximumFreeListSize at restore time. The heap lists will not shrink in case the GC thread count at restore is less than startup thread count.

Signed-off-by: Salman Rana <salman.rana@ibm.com>