### PR TITLE
Refactor Configuration CRIU APIs

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -147,6 +147,13 @@ public:
 	/* Number of GC threads supported based on hardware and dispatcher's max. */
 	virtual uintptr_t supportedGCThreadCount(MM_EnvironmentBase* env);
 
+	/**
+	 * Sets the number of gc threads
+	 *
+	 * @param env[in] - the current environment
+	 */
+	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	/**
 	 * Shutdown GC threads on checkpoint.
@@ -164,6 +171,14 @@ public:
 	 * successfully set and accommodated (thread pool resized).
 	 */
 	virtual bool reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env);
+
+	/**
+	 * Update the configuration to reflect the restore environment and parameters.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the configuration was successfully updated.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase* env) { return true; }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_Configuration(MM_EnvironmentBase* env, MM_GCPolicy gcPolicy, MM_AlignmentType alignmentType, uintptr_t defaultRegionSize, uintptr_t defaultArrayletLeafSize, MM_GCWriteBarrierType writeBarrierType, MM_GCAllocationType allocationType)
@@ -204,14 +219,6 @@ protected:
 	 * @return whether NUMAMAnager was initialized or not.  False implies startup failure.
 	 */
 	virtual bool initializeNUMAManager(MM_EnvironmentBase* env);
-	
-	/**
-	 * Sets the number of gc threads
-	 *
-	 * @param env[in] - the current environment
-	 */
-	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
-	
 private:
 
 	/**

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -652,6 +652,12 @@ MM_ParallelDispatcher::reinitAfterFork(MM_EnvironmentBase *env, uintptr_t newThr
 void
 MM_ParallelDispatcher::contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount)
 {
+	return prepareForCheckpoint(env, newThreadCount);
+}
+
+void
+MM_ParallelDispatcher::prepareForCheckpoint(MM_EnvironmentBase *env, uintptr_t newThreadCount)
+{
 	Assert_MM_false(_workerThreadsReservedForGC);
 	Assert_MM_false(_inShutdown);
 
@@ -716,6 +722,12 @@ MM_ParallelDispatcher::contractThreadPool(MM_EnvironmentBase *env, uintptr_t new
 
 bool
 MM_ParallelDispatcher::expandThreadPool(MM_EnvironmentBase *env)
+{
+	return reinitializeForRestore(env);
+}
+
+bool
+MM_ParallelDispatcher::reinitializeForRestore(MM_EnvironmentBase *env)
 {
 	Trc_MM_ParallelDispatcher_expandThreadPool_Entry();
 

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -148,6 +148,9 @@ public:
 	 * @param[in] env the current environment.
 	 * @return boolean indicating if threads started up successfully.
 	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env);
+
+	/* TODO: Remove in follow up changes. */
 	virtual bool expandThreadPool(MM_EnvironmentBase *env);
 
 	/**
@@ -164,6 +167,9 @@ public:
 	 * @param[in] newThreadCount the number of threads to keep in the thread pool.
 	 * @return void
 	 */
+	virtual void prepareForCheckpoint(MM_EnvironmentBase *env, uintptr_t newThreadCount);
+
+	/* TODO: Remove in follow up changes. */
 	virtual void contractThreadPool(MM_EnvironmentBase *env, uintptr_t newThreadCount);
 
 	/**

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -301,8 +301,15 @@ MM_ConfigurationGenerational::initializeConcurrentScavengerThreadCount(MM_Enviro
 bool
 MM_ConfigurationGenerational::reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env)
 {
+	return reinitializeForRestore(env);
+}
+
+bool
+MM_ConfigurationGenerational::reinitializeForRestore(MM_EnvironmentBase* env)
+{
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
+	/* TODO: MM_Configuration::reinitializeForRestore should be called in the follow up changes. */
 	bool result = MM_Configuration::reinitializeGCThreadCountForRestore(env);
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -81,6 +81,16 @@ public:
 	 * successfully set and accommodated (thread pool resized).
 	 */
 	virtual bool reinitializeGCThreadCountForRestore(MM_EnvironmentBase* env);
+
+	/**
+	 * Reinitialize Scavenger specific related thread counts:
+	 *  - concurrent thread count
+	 *  - recommended thread count (Adaptive Threading)
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the configuration was successfully updated.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase* env);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	MM_ConfigurationGenerational(MM_EnvironmentBase *env)


### PR DESCRIPTION
The goal is to remove the following APIs from configuration:
 - reinitializeGCThreadCountForRestore
    - Currently, this method has 2 distinct responsibilities, to set the GC thread count and expand the thread pool. Its more appropriate to set the thread count earlier in the GC restore phase (in j9gc_reinitializeDefaults) and then expand the thread pool directly through the dispatcher. 
 - adjustGCThreadCountForCheckpoint
   - This is just an indirection to dispatcher contractThreadPool, the dispatcher should be invoked directly from top level CRIU GC helper.
   
A single reinitializeForRestore CRIU API is more consistent with other component implementations, this will be used in the future to do specific configuration reinit (e.g  memory pools). 

Follow up changes will remove these 2 APIs after downstream OpenJ9 in updated. 

Signed-off-by: Salman Rana <salman.rana@ibm.com>

