### PR TITLE
Add options to disable inlining Thread.currentThread

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -502,6 +502,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableProfilingDataReclamation",    "O\tdisable reclamation for profiling data",         SET_OPTION_BIT(TR_DisableProfilingDataReclamation), "F", NOT_IN_SUBSET},
    {"disableRampupImprovements",          "M\tDisable various changes that improve rampup",    SET_OPTION_BIT(TR_DisableRampupImprovements), "F", NOT_IN_SUBSET},
    {"disableReadMonitors",                 "O\tdisable read monitors",                         SET_OPTION_BIT(TR_DisableReadMonitors), "F"},
+   {"disableRecognizeCurrentThread",       "O\tdisable recognize Thread.currentThread",        SET_OPTION_BIT(TR_DisableRecognizeCurrentThread), "F"},
    {"disableRecognizedCallTransformer",    "O\tdisable recognized call transformer",           TR::Options::disableOptimization, recognizedCallTransformer, 0, "P"},
    {"disableRecognizedMethods",            "O\tdisable recognized methods",                    SET_OPTION_BIT(TR_DisableRecognizedMethods), "F"},
    {"disableRecompDueToInlinedMethodRedefinition", "O\tdisable recompilation for method body with patched HCR guard",  SET_OPTION_BIT(TR_DisableRecompDueToInlinedMethodRedefinition), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -813,7 +813,7 @@ enum TR_CompilationOptions
    TR_DumpFinalMethodNamesAndCounts                   = 0x00000020 + 25,
    TR_DisableRecognizedMethods                        = 0x00000040 + 25,
    TR_DisableBitOpcode                                = 0x00000080 + 25,
-   // Available                                       = 0x00000100 + 25,
+   TR_DisableRecognizeCurrentThread                   = 0x00000100 + 25,
    // Available                                       = 0x00000200 + 25,
    // Available                                       = 0x00000400 + 25,
    // Available                                       = 0x00000800 + 25,


### PR DESCRIPTION
Add option `disableRecognizeCurrentThread` to disable inlining `Thread.currentThread()`