### PR TITLE
Consider array size that might be outside range of valid values

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4187,8 +4187,12 @@ TR::Node *constrainNewArray(OMR::ValuePropagation *vp, TR::Node *node)
       dumpOptDetails(vp->comp(), "size node has no known constraint for newarray %p\n", sizeNode);
       //node->setAllocationCanBeRemoved(false)
       }
-   else
+   else if (sizeConstraint->getLowInt() >= 0 && sizeConstraint->getHighInt() <= maxSize)
+      {
+      // If array size is known to be non-negative and the number of elements will
+      // not exceed the maximum array size, allocation will not throw an exception
       node->setAllocationCanBeRemoved(true);
+      }
 
    // The array size (the first child) can be constrained because of memory
    // limitations on the allocation.
@@ -4299,8 +4303,11 @@ TR::Node *constrainANewArray(OMR::ValuePropagation *vp, TR::Node *node)
       dumpOptDetails(vp->comp(), "size node has no known constraint for anewarray %p\n", sizeNode);
       //node->setAllocationCanBeRemoved(false)
       }
-   else
+   else if (sizeConstraint->getLowInt() >= 0 && sizeConstraint->getHighInt() <= maxSize)
       {
+      // If array size is known to be non-negative, the number of elements
+      // will not exceed the maximum array size, and the type of the
+      // array is known and resolved, allocation will not throw an exception
       if (typeConstraint && typeConstraint->getClassType() &&
           typeConstraint->getClassType()->getClass())
          {


### PR DESCRIPTION
The Value Propagation handlers for `newarray` and `anewarray` assume that if a size constraint exists for the array length, and it's not definitely negative and definitely does not exceed the maximum possible array size, the operation must not throw an Exception or Error.  In such cases, they set the `AllocationCanBeRemoved` flag for the node, which allows Dead Trees Elimination to delete the node later if the array is not used.

However, even if the length is not definitely negative or not definitely too great, does not mean that it's definitely non-negative nor definitely not too great - it might have a range that includes "reasonable" non-negative values, but also includes values that are negative or too great.

Fixed this by only setting the `AllocationCanBeRemoved` flag if the lower bound of array length is non-negative and the upper bound does not exceed the maximum possible array size.

Fixes:  Issue eclipse-openj9/openj9#17139