### PR TITLE
Infrastructure for enabling EDO with AOT  

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -99,6 +99,10 @@ static void loadRelocatableConstant(TR::Node *node,
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
          }
+      else if (symbol->isCatchBlockCounter())
+         {
+         loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_CatchBlockCounter);
+         }
       else if (symbol->isCompiledMethod())
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_RamMethodSequence);

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -1371,6 +1371,10 @@ static void loadRelocatableConstant(TR::Node               *node,
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
          }
+      else if (symbol->isCatchBlockCounter())
+         {
+         loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_CatchBlockCounter);
+         }
       else if (symbol->isCompiledMethod())
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_RamMethodSequence);

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -305,7 +305,7 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
 
    if (comp->target().cpu.isPower() &&
           (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethod || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
-           || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag))
+           || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();
@@ -337,7 +337,7 @@ void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
    TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
    if (comp->target().cpu.isPower() &&
       (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethodSequence || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
-       || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag))
+       || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();
@@ -467,6 +467,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ValidateJ2IThunkFromMethod (110)",
    "TR_StaticDefaultValueInstance (111)",
    "TR_ValidateIsClassVisible (112)",
+   "TR_CatchBlockCounter (113)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -468,6 +468,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_StaticDefaultValueInstance (111)",
    "TR_ValidateIsClassVisible (112)",
    "TR_CatchBlockCounter (113)",
+   "TR_StartPC (114)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -282,6 +282,9 @@ public:
    void setIsRecompQueuedFlag()             { _flags2.set(RecompQueuedFlag); }
    bool isRecompQueuedFlag()                { return _flags2.testAny(RecompQueuedFlag); }
 
+   void setIsCatchBlockCounter()            { _flags2.set(CatchBlockCounter); }
+   bool isCatchBlockCounter()               { return _flags2.testAny(CatchBlockCounter); }
+
    inline bool isNamed();
 
    // flag methods specific to Autos
@@ -588,6 +591,7 @@ public:
        * This flag is used to identify the value type default value instance slot address
        */
       StaticDefaultValueInstance = 0x00020000,
+      CatchBlockCounter          = 0x00040000,
       };
 
 protected:

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1593,6 +1593,12 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
          return;
          }
+      else if (symbol->isCatchBlockCounter() && cg->needRelocationsForBodyInfoData())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_CatchBlockCounter);
+         return;
+         }
       else if (symbol->isCompiledMethod() && cg->needRelocationsForCurrentMethodPC())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
@@ -1741,6 +1747,12 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
          loadAddressConstant(cg, cg->needRelocationsForBodyInfoData(), nodeForSymbol, 0, reg, NULL, false, TR_BodyInfoAddressLoad);
+         return;
+         }
+      else if ((refIsUnresolved || cg->needRelocationsForBodyInfoData()) && symbol->isCatchBlockCounter())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_CatchBlockCounter);
          return;
          }
       else if (symbol->isCompiledMethod() && (ref->isUnresolved() || cg->needRelocationsForCurrentMethodPC()))

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -339,7 +339,8 @@ typedef enum
    TR_StaticDefaultValueInstance          = 111,
    TR_ValidateIsClassVisible              = 112,
    TR_CatchBlockCounter                   = 113,
-   TR_NumExternalRelocationKinds          = 114,
+   TR_StartPC                             = 114,
+   TR_NumExternalRelocationKinds          = 115,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -338,7 +338,8 @@ typedef enum
    TR_ValidateJ2IThunkFromMethod          = 110,
    TR_StaticDefaultValueInstance          = 111,
    TR_ValidateIsClassVisible              = 112,
-   TR_NumExternalRelocationKinds          = 113,
+   TR_CatchBlockCounter                   = 113,
+   TR_NumExternalRelocationKinds          = 114,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -294,6 +294,8 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
       return true;
    else if (sr.getSymbol() && (sr.getSymbol()->isBlockFrequency() || sr.getSymbol()->isRecompQueuedFlag()) && cg->needRelocationsForPersistentProfileInfoData())
       return true;
+   else if (sr.getSymbol() && sr.getSymbol()->isCatchBlockCounter() && cg->needRelocationsForBodyInfoData())
+      return true;
    else if (cg->comp()->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject())
       return true; // If a class gets replaced, it may no longer fit in an immediate
    else if (IS_32BIT_SIGNED(displacement))
@@ -467,6 +469,12 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          {
          if (cg->needRelocationsForBodyInfoData())
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_BodyInfoAddress, cg),
+                                 __FILE__,__LINE__,containingInstruction->getNode());
+         }
+      else if (sr.getSymbol()->isCatchBlockCounter())
+         {
+         if (cg->needRelocationsForBodyInfoData())
+            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_CatchBlockCounter, cg),
                                  __FILE__,__LINE__,containingInstruction->getNode());
          }
       else if (sr.getSymbol()->isGCRPatchPoint())

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1271,6 +1271,13 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                                              __LINE__,
                                              node);
                         }
+                     else if (staticSym->isCatchBlockCounter())
+                        {
+                        cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_CatchBlockCounter, cg),
+                                             __FILE__,
+                                             __LINE__,
+                                             node);
+                        }
                      else if (staticSym->isGCRPatchPoint())
                         {
                         TR::ExternalRelocation* r= new (cg->trHeapMemory())

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -195,6 +195,13 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             }
          break;
 
+      case TR_CatchBlockCounter:
+         {
+         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_CatchBlockCounter, cg());
+         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         }
+         break;
+
       case TR_GlobalValue:
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile,
                                                                                 TR_GlobalValue, cg()),


### PR DESCRIPTION
These patches add the necessary support for two new relocations, `TR_CatchBlockCounter` and `TR_StartPC`, to allow EDO to be enabled while compiling AOT code.

- The `TR_CatchBlockCounter` relocation is responsible for relocating the address of the new `_catchBlockCounter` in the `TR_PersistentMethodInfo` (see https://github.com/eclipse-openj9/openj9/pull/16854, which has the new EDO implementation).

- The `TR_StartPC` relocation is responsible for relocating the address of the `startPC` of the method currently being compiled. Although from the documentation it might seem like the `TR_AbsoluteMethodAddress` could do this, it doesn't have the necessary support in openj9 for power; if you look at how the relocation is applied on that platform, you can see that the `loadAddress` method doesn't handle the case where the address is split across multiple instructions, something that can occur on power. It should be possible to modify that relocation to be able to handle such a scenario, and so eliminate the need for the `TR_StartPC` relocation, but I felt that was a little out of scope for the issue I'm dealing with. This situation is similar to the current `TR_BodyInfoAddress` and `TR_BodyInfoAddressLoad` relocations, as the latter exists to handle loads from addresses on arm and power that may be split across multiple instructions.

The `TR_CatchBlockCounter` relocation should be emitted automatically wherever a `TR_BodyInfoAddress` or `TR_BodyInfoAddressLoad` would be emitted. The `TR_StartPC` relocation is only emitted manually on power in openj9. I will be putting up the associated openj9 PR later.

I've tested this on 64-bit X, P, and Z so far.

Attn @mpirvu.