### PR TITLE
Remove sigvec reference in CMakeLists.txt

### DIFF
--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -56,11 +56,6 @@ if(OMR_OS_ZOS)
 		__sigactionset
 	)
 endif()
-if((NOT OMR_OS_WINDOWS) AND (NOT OMR_OS_ZOS))
-	omr_add_exports(omrsig
-		sigvec
-	)
-endif()
 
 target_link_libraries(omrsig
 	PRIVATE


### PR DESCRIPTION
This was overlooked in #972 which removed all instances of sigvec.

Fixes the below LLVM toolchain error:

error: version script assignment of 'global' to symbol 'sigvec'
failed: symbol not defined error when using LLVM toolchain