### PR TITLE
Have GLU consume budget only for successfully unrolled loops

### DIFF
--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -3566,21 +3566,42 @@ TR_GeneralLoopUnroller::perform()
       Q.remove(top);
 
       if (top->_cost > budget)
-         continue;
+         {
+         dumpOptDetails(
+            comp(),
+            "Loop %d unroll cost %d > %d remaining budget\n",
+            top->_loop->getNumber(),
+            top->_cost,
+            budget);
 
-      budget -= top->_cost;
+         continue;
+         }
 
       if (trace())
          traceMsg(comp(), "<unroll loop=\"%d\">\n", top->_loop->getNumber());
 
+      bool didUnroll = false;
       if (top->_loop->getPrimaryInductionVariable())
-         TR_LoopUnroller::unroll(comp(), top->_loop, top->_loop->getPrimaryInductionVariable(),
-                                 top->_unrollKind, top->_unrollCount, top->_peelCount, optimizer());
+         {
+         didUnroll = TR_LoopUnroller::unroll(
+            comp(),
+            top->_loop,
+            top->_loop->getPrimaryInductionVariable(),
+            top->_unrollKind,
+            top->_unrollCount,
+            top->_peelCount, optimizer());
+         }
       else
-         TR_LoopUnroller::unroll(comp(), top->_loop, top->_unrollCount, top->_peelCount, optimizer());
+         {
+         didUnroll = TR_LoopUnroller::unroll(
+            comp(), top->_loop, top->_unrollCount, top->_peelCount, optimizer());
+         }
 
       if (trace())
          traceMsg(comp(), "</unroll>\n");
+
+      if (didUnroll)
+         budget -= top->_cost;
       }
 
    return 1;


### PR DESCRIPTION
Otherwise, it's possible for loops that can't actually be unrolled to use up budget and prevent unrolling in other loops. The two overloads of `TR_LoopUnroller::unroll()` both already indicate whether unrolling was successful, but that result was ignored.

Also trace when GLU skips a loop for being too expensive to unroll.