### PR TITLE
GC CRIU: Reinit Scavenger Caches (Split CopyScanCacheList)

### DIFF
--- a/gc/base/standard/CopyScanCacheList.cpp
+++ b/gc/base/standard/CopyScanCacheList.cpp
@@ -44,13 +44,15 @@ MM_CopyScanCacheList::initialize(MM_EnvironmentBase *env, volatile uintptr_t *ca
 	_sublistCount = extensions->cacheListSplit;
 	Assert_MM_true(0 < _sublistCount);
 
-	_sublists = (struct CopyScanCacheSublist *)extensions->getForge()->allocate(sizeof(struct CopyScanCacheSublist) * _sublistCount, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_sublists = (CopyScanCacheSublist *)extensions->getForge()->allocate(
+			sizeof(CopyScanCacheSublist) * _sublistCount,
+			OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == _sublists) {
 		result = false;
 	} else {
 		for (uintptr_t i = 0; i < _sublistCount; i++) {
 			new (&_sublists[i]) CopyScanCacheSublist();
-			if (_sublists[i].initialize(env)) {
+			if (!_sublists[i].initialize(env)) {
 				result = false;
 				break;
 			}
@@ -61,6 +63,48 @@ MM_CopyScanCacheList::initialize(MM_EnvironmentBase *env, volatile uintptr_t *ca
 
 	return result;
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+bool
+MM_CopyScanCacheList::reinitializeForRestore(MM_EnvironmentBase *env)
+{
+	MM_GCExtensionsBase *extensions = env->getExtensions();
+	bool result = true;
+
+	uintptr_t newSublistCount = extensions->cacheListSplit;
+	Assert_MM_true(0 < newSublistCount);
+
+	if (newSublistCount > _sublistCount) {
+		CopyScanCacheSublist *newSublists = (CopyScanCacheSublist *)extensions->getForge()->allocate(
+						sizeof(CopyScanCacheSublist) * newSublistCount,
+						OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
+
+		if (NULL == newSublists) {
+			result = false;
+		} else {
+			for (uintptr_t i = 0; i < _sublistCount; i++) {
+				newSublists[i] = _sublists[i];
+			}
+
+			for (uintptr_t i = _sublistCount; i < newSublistCount; i++) {
+				new (&newSublists[i]) CopyScanCacheSublist();
+				if (!newSublists[i].initialize(env)) {
+					result = false;
+					break;
+				}
+			}
+
+			if (result) {
+				extensions->getForge()->free(_sublists);
+				_sublists = newSublists;
+				_sublistCount = newSublistCount;
+			}
+		}
+	}
+
+	return result;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void
 MM_CopyScanCacheList::tearDown(MM_EnvironmentBase *env)

--- a/gc/base/standard/CopyScanCacheList.hpp
+++ b/gc/base/standard/CopyScanCacheList.hpp
@@ -66,14 +66,14 @@ private:
 
 		bool initialize(MM_EnvironmentBase *env) {
 			MM_GCExtensionsBase *extensions = env->getExtensions();
-			if (_cacheLock.initialize(env, &extensions->lnrlOptions, "MM_CopyScanCacheList:_sublists[]._cacheLock")) {
+			if (!_cacheLock.initialize(env, &extensions->lnrlOptions, "MM_CopyScanCacheList:_sublists[]._cacheLock")) {
 				return false;
 			}
 			return true;
 		}
 	};
 	
-	struct CopyScanCacheSublist *_sublists;	/**< An array of CopyScanCacheSublist structures which is _sublistCount elements long */
+	CopyScanCacheSublist *_sublists;	/**< An array of CopyScanCacheSublist structures which is _sublistCount elements long */
 	uintptr_t _sublistCount; /**< the number of lists (split for parallelism). Must be at least 1 */
 	
 	MM_CopyScanCacheChunk *_chunkHead; 
@@ -128,6 +128,17 @@ protected:
 public:
 	bool initialize(MM_EnvironmentBase *env, volatile uintptr_t *cachedEntryCount);
 	virtual void tearDown(MM_EnvironmentBase *env);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Split the cache list into multiple sublists based on the cacheListSplit
+	 * computed for the restore configuration.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the CopyScanCacheList split failed.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	/**
 	 * Retrieve Allocated cache entry count

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -323,6 +323,22 @@ MM_Scavenger::tearDown(MM_EnvironmentBase *env)
 	(*mmOmrHooks)->J9HookUnregister(mmOmrHooks, J9HOOK_MM_OMR_GLOBAL_GC_END, hookGlobalCollectionComplete, (void *)this);
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+bool
+MM_Scavenger::reinitializeForRestore(MM_EnvironmentBase *env)
+{
+	bool rc = true;
+
+	if (!_scavengeCacheFreeList.reinitializeForRestore(env)
+		|| !_scavengeCacheScanList.reinitializeForRestore(env)
+	) {
+		rc = false;
+	}
+
+	return rc;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 /**
  * Perform any collector initialization particular to the concurrent collector.
  */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -925,6 +925,17 @@ public:
 	virtual bool canCollectorExpand(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, uintptr_t expandSize);
 	virtual uintptr_t getCollectorExpandSize(MM_EnvironmentBase *env);
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Reinitialize the CopyScanCacheLists (used by Scavenger) by splitting them
+	 * to optimize for the number of restore GC threads.
+	 *
+	 * @param[in] env the current environment.
+	 * @return boolean indicating whether the CopyScanCacheLists were successfully updated.
+	 */
+	virtual bool reinitializeForRestore(MM_EnvironmentBase *env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_Scavenger(MM_EnvironmentBase *env) :
 		MM_Collector()
 		, _cycleTimes()


### PR DESCRIPTION
Scavenger cache lists must be reinitialized during restore (CRIU) according to the new GC thread count. Specifically, when the thread count is increased, it is necessary to divide the CopyScanCacheLists into smaller sublists. This is required to reduce contention on the cache lists (_scavengeCacheFreeList and
_scavengeCacheScanList) and ultimately improve GC performance for the restore environment. 

The following changes have been made:
- Reinit each inited CopyScanCacheList (2 in total, owned by Scavenger)
  - Introduced reinitializeForRestore for Scavenger
  - Introduced reinitializeForRestore for CopyScanCacheList
- CopyScanCacheList must allocate a new array of sublists, copy over old sublists and init new sublists

For background, see https://github.com/eclipse/omr/issues/6888 (Compensate for Thread Count Change)

Signed-off-by: Salman Rana <salman.rana@ibm.com>