### PR TITLE
Fix MM_ConfigurationGenerational reinitializeForRestore

### DIFF
--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -303,7 +303,7 @@ MM_ConfigurationGenerational::reinitializeForRestore(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
-	bool result = MM_Configuration::reinitializeForRestore(env);
+	bool result = MM_ConfigurationStandard::reinitializeForRestore(env);
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	initializeConcurrentScavengerThreadCount(env);


### PR DESCRIPTION
MM_ConfigurationGenerational is using the wrong base class implementation of reinitializeForRestore. It should invoke MM_ConfigurationStandard rather than MM_Configuration.

Signed-off-by: Salman Rana <salman.rana@ibm.com>