### PR TITLE
Add declared class to Symbol, like a signature but as a class pointer

### DIFF
--- a/compiler/il/OMRSymbol.cpp
+++ b/compiler/il/OMRSymbol.cpp
@@ -60,6 +60,7 @@ TR::Symbol * OMR::Symbol::create(AllocatorType m, TR::DataType d, uint32_t s)
 OMR::Symbol::Symbol(TR::DataType d) :
    _size(0),
    _name(0),
+   _declaredClass(0),
    _flags(0),
    _flags2(0),
    _localIndex(0)
@@ -69,6 +70,7 @@ OMR::Symbol::Symbol(TR::DataType d) :
 
 OMR::Symbol::Symbol(TR::DataType d, uint32_t size) :
    _name(0),
+   _declaredClass(0),
    _flags(0),
    _flags2(0),
    _localIndex(0)

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -49,6 +49,7 @@ namespace OMR { typedef OMR::Symbol SymbolConnector; }
 #include <stdint.h>
 #include "infra/Annotations.hpp"
 #include "env/TRMemory.hpp"
+#include "env/jittypes.h"
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 #include "infra/Flags.hpp"
@@ -102,6 +103,7 @@ protected:
    Symbol() :
       _size(0),
       _name(0),
+      _declaredClass(0),
       _flags(0),
       _flags2(0),
       _localIndex(0)
@@ -196,6 +198,12 @@ public:
 
    const char * getName()                   { return _name; }
    void         setName(const char * name)  { _name = name; }
+
+   // When DataType is TR::Address, the declared class of the field, so that it
+   // can be found even without a signature. When present, this type info is
+   // exactly as reliable as the type signature.
+   TR_OpaqueClassBlock *getDeclaredClass() { return _declaredClass; }
+   void setDeclaredClass(TR_OpaqueClassBlock* klass) { _declaredClass = klass; }
 
    uint32_t getFlags()                      { return _flags.getValue(); }
    uint32_t getFlags2()                     { return _flags2.getValue(); }
@@ -598,6 +606,7 @@ protected:
 
    size_t        _size;
    const char *  _name;
+   TR_OpaqueClassBlock *_declaredClass;
    flags32_t     _flags;
    flags32_t     _flags2;
    uint16_t      _localIndex;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1237,7 +1237,7 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
          case TR::Symbol::IsShadow:
             if (sym->isNamedShadowSymbol() && sym->getNamedShadowSymbol()->getName() != NULL)
                {
-               symRefKind.appendf(" %s", sym->getNamedShadowSymbol()->getName());
+               symRefKind.appendf(" Named Shadow");
                symRefName.appendf(" %s", getName(symRef));
                }
             else
@@ -1279,7 +1279,20 @@ TR_Debug::print(TR::SymbolReference * symRef, TR_PrettyPrinterString& output, bo
 
        if(sym)
           {
-          output.appendf(" (%s)",TR::DataType::getName(sym->getDataType()));
+          output.appendf(" (%s",TR::DataType::getName(sym->getDataType()));
+
+          TR_OpaqueClassBlock *klass = sym->getDeclaredClass();
+          if (klass != NULL)
+             {
+             int32_t len = 0;
+             const char *className =
+                TR::Compiler->cls.classNameChars(_comp, klass, len);
+
+             output.appendf(": %p %.*s", klass, len, className);
+             }
+
+          output.appendf(")");
+
           if (sym->isVolatile())
              {
              output.appends(" [volatile]");


### PR DESCRIPTION
...and consult it when constraining `aloadi` in VP.

With this declared class (once it is populated appropriately) VP can determine the type of the result of `aloadi` of fabricated field shadows.

We don't store signatures, but rather get them based on the owning method and the constant pool index, so in particular after fabricating a field shadow we lose track of the signature. Furthermore, even if we had a signature in that case, we wouldn't necessarily have any owning method that would be appropriate to use for looking up the class by name.

While creating a fabricated field shadow, however, the compiler will have access to the definition of the containing type, so it will be able to look up the correct class and remember it.

The `aloadi` VP handler now ignores the signature in favour of the declared class whenever the latter is present. It's fine to set the declared class for regular (i.e. non-fabricated) field shadows as well, in which case we can simply avoid repeated lookups. Some logic using the signature in this VP handler has been changed to use the class pointer `classBlock` instead, since it only ran when `classBlock` was available anyway. The other use of the signature is deleted because it consulted field info from class lookahead, which is broken and not enabled.

The declared class is printed along with the `DataType` in the verbose incremental symref table output. Additionally, named shadows now print "Named Shadow" instead of repeating the name a second time.