### PR TITLE
Create and use factory method for ExternalRelocations

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -72,13 +72,37 @@ uint8_t *TR::ARM64RelocatableImmInstruction::generateBinaryEncoding()
       switch(getReloKind())
          {
          case TR_AbsoluteHelperAddress:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  TR_AbsoluteHelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_RamMethod:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  NULL,
+                  TR_RamMethod,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_BodyInfoAddress:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  NULL,
+                  TR_BodyInfoAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          default:
             TR_ASSERT(false, "Unsupported AOT relocation type specified.");
@@ -92,7 +116,15 @@ uint8_t *TR::ARM64RelocatableImmInstruction::generateBinaryEncoding()
       //
       void **locationToPatch = (void**)cursor;
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)locationToPatch,
+            (uint8_t *)*locationToPatch,
+            TR_HCR,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    cursor += sizeof(uintptr_t);
@@ -161,11 +193,14 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
             insertImmediateField(toARM64Cursor(cursor), distance);
             setAddrImmediate(destination);
 
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                                           cursor,
-                                           (uint8_t *)symRef,
-                                           TR_HelperAddress, cg()),
-                                        __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)symRef,
+                  TR_HelperAddress, cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -42,10 +42,15 @@ TR::ARM64HelperCallSnippet::emitSnippetBody()
 
    *(int32_t *)cursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x3ffffff); // imm26
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               (uint8_t *)getDestination(),
-                               TR_HelperAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)getDestination(),
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += ARM64_INSTRUCTION_LENGTH;
 
    gcMap().registerStackMap(cursor, cg());

--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -67,17 +67,19 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
                TR_ASSERT_FATAL(getData<uint8_t *>(), "Static Sym can not be NULL");
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                    getData<uint8_t *>(),
-                                                                                    reinterpret_cast<uint8_t *>(symbolKind),
-                                                                                    TR_SymbolFromManager,
-                                                                                    cg()),
-                                                                                    __FILE__, __LINE__,
-                                                                                    node);
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     getData<uint8_t *>(),
+                     reinterpret_cast<uint8_t *>(symbolKind),
+                     TR_SymbolFromManager,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  node);
                }
             else
                {
-               TR::Relocation *relo;
                //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
                //so we need to pass it to relocation in targetaddress2 for now
                uint8_t * targetAdress2 = NULL;
@@ -85,9 +87,16 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
                   {
                   targetAdress2 = reinterpret_cast<uint8_t *>(*(reinterpret_cast<uint64_t*>(cursor)));
                   }
-               relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, reinterpret_cast<uint8_t *>(node),
-                                                                        targetAdress2, reloType, cg());
-               cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     reinterpret_cast<uint8_t *>(node),
+                     targetAdress2,
+                     reloType,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  node);
                }
             break;
 
@@ -95,9 +104,16 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             uint8_t *targetAddress = reinterpret_cast<uint8_t *>(*(reinterpret_cast<uint64_t*>(cursor)));
             uint8_t *targetAddress2 = getNode() ? reinterpret_cast<uint8_t *>(getNode()->getInlinedSiteIndex()) : reinterpret_cast<uint8_t *>(-1);
-            TR::Relocation *relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, targetAddress,
-                                                                        targetAddress2, reloType, cg());
-            cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  targetAddress,
+                  targetAddress2,
+                  reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               node);
             }
             break;
 

--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -82,10 +82,14 @@ uint32_t encodeHelperBranch(bool isBranchAndLink, TR::SymbolReference *symRef, u
       }
 
    cg->addExternalRelocation(
-      new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                     (uint8_t *)symRef,
-                                     TR_HelperAddress, cg),
-      __FILE__, __LINE__, node);
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)symRef,
+         TR_HelperAddress,
+         cg),
+      __FILE__,
+      __LINE__,
+      node);
 
    return (isBranchAndLink ? 0x0B000000 : 0x0A000000) | encodeBranchDistance((uintptr_t) cursor, (uint32_t)target) | (((uint32_t) cc) << 28);
    }
@@ -218,13 +222,37 @@ uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
       switch(getReloKind())
          {
          case TR_AbsoluteHelperAddress:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  TR_AbsoluteHelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_RamMethod:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  NULL,
+                  TR_RamMethod,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_BodyInfoAddress:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  0,
+                  TR_BodyInfoAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          default:
             TR_ASSERT(false, "Unsupported AOT relocation type specified.");
@@ -236,7 +264,15 @@ uint8_t *TR::ARMImmInstruction::generateBinaryEncoding()
       //
       void **locationToPatch = (void**)cursor;
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)locationToPatch,
+            (uint8_t *)*locationToPatch,
+            TR_HCR,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    cursor += ARM_INSTRUCTION_LENGTH;
@@ -327,12 +363,15 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
 #endif
                // no need to add 4 to cursor, it is done below in the
                // common path
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                  cursor,
-                  NULL,
-                  TR_AbsoluteMethodAddress,
-                  cg()),
-                  __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     NULL,
+                     TR_AbsoluteMethodAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             }
          }

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -305,9 +305,15 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
 
                if (kind != TR_NoRelocation)
                   {
-                  TR::Relocation *relo;
-                  relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
-                  cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        codeCursor,
+                        (uint8_t *)node,
+                        kind,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     node);
                   }
                }
             }

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -543,3 +543,22 @@ void TR::IteratedExternalRelocation::addRelocationEntry(uint32_t locationOffset)
       _relocationDataCursor += 4;
       }
    }
+
+TR::ExternalRelocation *TR::ExternalRelocation::create(
+      uint8_t *codeAddress,
+      uint8_t *targetAddress,
+      TR_ExternalRelocationTargetKind kind,
+      TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::ExternalRelocation(codeAddress, targetAddress, kind, cg);
+   }
+
+TR::ExternalRelocation *TR::ExternalRelocation::create(
+      uint8_t *codeAddress,
+      uint8_t *targetAddress,
+      uint8_t *targetAddress2,
+      TR_ExternalRelocationTargetKind kind,
+      TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::ExternalRelocation(codeAddress, targetAddress, targetAddress2, kind, cg);
+   }

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -334,6 +334,41 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
 class ExternalRelocation : public TR::Relocation
    {
    public:
+
+   /**
+    * @brief Factory method for ExternalRelocation
+    *
+    * @param[in] codeAddress : the code cache address this relocation applies to
+    * @param[in] targetAddress : the external address for this relocation
+    * @param[in] kind : external relocation kind
+    * @param[in] cg : \c TR::CodeGenerator object
+    *
+    * @return Allocated \c ExternalRelocation object
+    */
+   static ExternalRelocation *create(
+      uint8_t *codeAddress,
+      uint8_t *targetAddress,
+      TR_ExternalRelocationTargetKind kind,
+      TR::CodeGenerator *cg);
+
+   /**
+    * @brief Factory method for ExternalRelocation
+    *
+    * @param[in] codeAddress : the code cache address this relocation applies to
+    * @param[in] targetAddress : the external address for this relocation
+    * @param[in] targetAddress2 : the second external address for this relocation
+    * @param[in] kind : external relocation kind
+    * @param[in] cg : \c TR::CodeGenerator object
+    *
+    * @return Allocated \c ExternalRelocation object
+    */
+   static ExternalRelocation *create(
+      uint8_t *codeAddress,
+      uint8_t *targetAddress,
+      uint8_t *targetAddress2,
+      TR_ExternalRelocationTargetKind kind,
+      TR::CodeGenerator *cg);
+
    ExternalRelocation()
       : TR::Relocation(),
         _targetAddress(NULL),

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -258,8 +258,16 @@ OMR::ConstantDataSnippet::emitAddressConstant(PPCConstant<intptr_t> *acursor, ui
             else
                TR_ASSERT_FATAL(false, "Unable to relocate node %p", node);
 
-            TR::Relocation *relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(codeCursor, (uint8_t *)node->getAddress(), (uint8_t*)type, TR_SymbolFromManager, cg());
-            cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  codeCursor,
+                  (uint8_t *)node->getAddress(),
+                  (uint8_t*)type,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               node);
             }
          else
             {
@@ -271,8 +279,15 @@ OMR::ConstantDataSnippet::emitAddressConstant(PPCConstant<intptr_t> *acursor, ui
 
             if (kind != TR_NoRelocation)
                {
-               TR::Relocation *relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(codeCursor, (uint8_t *)node, kind, cg());
-               cg()->addExternalRelocation(relo, __FILE__, __LINE__, node);
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     codeCursor,
+                     (uint8_t *)node,
+                     kind,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  node);
                }
             }
          }

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1362,13 +1362,21 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          switch(getReloKind())
             {
             case TR_AbsoluteHelperAddress:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)getSymbolReference(),
+                     TR_AbsoluteHelperAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                break;
             case TR_RamMethod:
                if (comp()->getOption(TR_UseSymbolValidationManager))
                   {
                   cg()->addExternalRelocation(
-                     new (comp()->trHeapMemory()) TR::ExternalRelocation(
+                     TR::ExternalRelocation::create(
                         cursor,
                         (uint8_t *)comp()->getJittedMethodSymbol()->getResolvedMethod()->resolvedMethodAddress(),
                         (uint8_t *)TR::SymbolType::typeMethod,
@@ -1380,11 +1388,27 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   }
                else
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        NULL,
+                        TR_RamMethod,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                break;
             case TR_BodyInfoAddress:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     0,
+                     TR_BodyInfoAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                break;
             default:
                TR_ASSERT(false, "Unsupported AOT relocation type specified.");
@@ -1408,7 +1432,15 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       //
       void **locationToPatch = (void**)(cursor - (comp->target().is64Bit()?4:0));
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)locationToPatch,
+            (uint8_t *)*locationToPatch,
+            TR_HCR,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    }

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -141,12 +141,15 @@ TR::DebugCounter::generateRelocation(TR::Compilation *comp, uint8_t *location, T
    {
    counter->finalizeReloData(comp, node);
 
-   TR::ExternalRelocation *r = new (comp->trHeapMemory()) TR::ExternalRelocation(location,
-                                                                                 (uint8_t *)counter,
-                                                                                 TR_DebugCounter,
-                                                                                 comp->cg());
-
-   comp->cg()->addExternalRelocation(r, __FILE__, __LINE__, node);
+   comp->cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         location,
+         (uint8_t *)counter,
+         TR_DebugCounter,
+         comp->cg()),
+      __FILE__,
+      __LINE__,
+      node);
    }
 
 void

--- a/compiler/riscv/codegen/RVHelperCallSnippet.cpp
+++ b/compiler/riscv/codegen/RVHelperCallSnippet.cpp
@@ -42,10 +42,15 @@ TR::RVHelperCallSnippet::emitSnippetBody()
 
    *(int32_t *)cursor = TR_RISCV_UJTYPE(TR::InstOpCode::_jal, cg()->machine()->getRealRegister(OMR::RealRegister::ra) , distance);
 
-   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                               cursor,
-                               (uint8_t *)getDestination(),
-                               TR_HelperAddress, cg()), __FILE__, __LINE__, getNode());
+   cg()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         cursor,
+         (uint8_t *)getDestination(),
+         TR_HelperAddress,
+         cg()),
+      __FILE__,
+      __LINE__,
+      getNode());
    cursor += RISCV_INSTRUCTION_LENGTH;
 
    gcMap().registerStackMap(cursor, cg());

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -438,20 +438,29 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
                {
                if (cg->comp()->getOption(TR_UseSymbolValidationManager))
                   {
-                  cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation,
-                                                                                            (uint8_t *)sr.getSymbol()->castToStaticSymbol()->getStaticAddress(),
-                                                                                            (uint8_t *)TR::SymbolType::typeClass,
-                                                                                            TR_SymbolFromManager,
-                                                                                            cg),
-                                                                                   __FILE__, __LINE__,
-                                                                                   containingInstruction->getNode());
+                  cg->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        displacementLocation,
+                        (uint8_t *)sr.getSymbol()->castToStaticSymbol()->getStaticAddress(),
+                        (uint8_t *)TR::SymbolType::typeClass,
+                        TR_SymbolFromManager,
+                        cg),
+                     __FILE__,
+                     __LINE__,
+                     containingInstruction->getNode());
                   }
                else
                   {
-                  cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, (uint8_t *)srCopy,
-                                                                                            (uint8_t *)(uintptr_t)containingInstruction->getNode()->getInlinedSiteIndex(),
-                                                                                            TR_ClassAddress, cg),__FILE__, __LINE__,
-                                                                                            containingInstruction->getNode());
+                  cg->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        displacementLocation,
+                        (uint8_t *)srCopy,
+                        (uint8_t *)(uintptr_t)containingInstruction->getNode()->getInlinedSiteIndex(),
+                        TR_ClassAddress,
+                        cg),
+                     __FILE__,
+                     __LINE__,
+                     containingInstruction->getNode());
                   }
                }
             }
@@ -459,46 +468,92 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       else if (sr.getSymbol()->isCountForRecompile())
          {
          if (cg->needRelocationsForPersistentInfoData())
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(
-                                   displacementLocation, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
-                                 __FILE__,
-                                 __LINE__,
-                                 containingInstruction->getNode());
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  (uint8_t *) TR_CountForRecompile,
+                  TR_GlobalValue,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
          }
       else if (sr.getSymbol()->isRecompilationCounter())
          {
          if (cg->needRelocationsForBodyInfoData())
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_BodyInfoAddress, cg),
-                                 __FILE__,__LINE__,containingInstruction->getNode());
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  0,
+                  TR_BodyInfoAddress,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
          }
       else if (sr.getSymbol()->isCatchBlockCounter())
          {
          if (cg->needRelocationsForBodyInfoData())
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_CatchBlockCounter, cg),
-                                 __FILE__,__LINE__,containingInstruction->getNode());
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  0,
+                  TR_CatchBlockCounter,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
          }
       else if (sr.getSymbol()->isGCRPatchPoint())
          {
          if (cg->needRelocationsForStatics())
             {
-            TR::ExternalRelocation* r= new (cg->trHeapMemory())
-                           TR::ExternalRelocation(displacementLocation,
-                                                      0,
-                                                      TR_AbsoluteMethodAddress, cg);
-            cg->addExternalRelocation(r, __FILE__, __LINE__, containingInstruction->getNode());
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  0,
+                  TR_AbsoluteMethodAddress,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
             }
          }
       else if (sr.getSymbol()->isCompiledMethod())
          {
          if (cg->needRelocationsForStatics())
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_RamMethod, cg),
-                                 __FILE__,__LINE__,containingInstruction->getNode());
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  0,
+                  TR_RamMethod,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
          }
       else if (sr.getSymbol()->isStartPC())
          {
          if (cg->needRelocationsForStatics())
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_AbsoluteMethodAddress, cg),
-                                 __FILE__,__LINE__,containingInstruction->getNode());
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  0,
+                  TR_AbsoluteMethodAddress,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
          }
       else if (sr.getSymbol()->isDebugCounter())
          {
@@ -520,12 +575,15 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       {
       if (self()->needsCodeAbsoluteExternalRelocation())
          {
-         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation,
-                                                                                 (uint8_t *)0,
-                                                                                 TR_AbsoluteMethodAddress, cg),
-                              __FILE__,
-                              __LINE__,
-                              containingInstruction->getNode());
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               displacementLocation,
+               (uint8_t *)0,
+               TR_AbsoluteMethodAddress,
+               cg),
+            __FILE__,
+            __LINE__,
+            containingInstruction->getNode());
          }
       }
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2365,8 +2365,15 @@ OMR::X86::CodeGenerator::addMetaDataForBranchTableAddress(
       TR::X86MemTableInstruction *jmpTableInstruction)
    {
 
-   self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalRelocation(target, 0, TR_AbsoluteMethodAddress, self()),
-                           __FILE__, __LINE__, caseNode->getBranchDestination()->getNode());
+   self()->addExternalRelocation(
+      TR::ExternalRelocation::create(
+         target,
+         0,
+         TR_AbsoluteMethodAddress,
+         self()),
+      __FILE__,
+      __LINE__,
+      caseNode->getBranchDestination()->getNode());
 
    TR::LabelSymbol *label = caseNode->getBranchDestination()->getNode()->getLabel();
    TR::LabelRelocation *relocation = new (self()->trHeapMemory()) TR::LabelAbsoluteRelocation(target, label);

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -56,9 +56,15 @@ TR::X86DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       bool needRelocation = TR::Compiler->cls.classUnloadAssumptionNeedsRelocation(cg()->comp());
       if (needRelocation && !cg()->comp()->compileRelocatableCode())
          {
-         cg()->addExternalRelocation(new (TR::comp()->trHeapMemory())
-                                  TR::ExternalRelocation(cursor, NULL, TR_ClassUnloadAssumption, cg()),
-                                  __FILE__, __LINE__, self()->getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_ClassUnloadAssumption,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
 
       if (cg()->comp()->target().is64Bit())
@@ -75,11 +81,16 @@ TR::X86DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       TR_OpaqueClassBlock *clazz = getData<TR_OpaqueClassBlock *>();
       if (clazz && cg()->comp()->compileRelocatableCode() && cg()->comp()->getOption(TR_UseSymbolValidationManager))
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                               (uint8_t *)clazz,
-                                                               (uint8_t *)TR::SymbolType::typeClass,
-                                                               TR_SymbolFromManager,
-                                                               cg()),  __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)clazz,
+               (uint8_t *)TR::SymbolType::typeClass,
+               TR_SymbolFromManager,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       }
    }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1197,17 +1197,27 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
          {
          if (self()->needsCodeAbsoluteExternalRelocation())
             {
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  0,
-                                                                  TR_AbsoluteMethodAddress, cg),
-                                 __FILE__,__LINE__, node);
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  0,
+                  TR_AbsoluteMethodAddress,
+                  cg),
+               __FILE__,
+               __LINE__,
+               node);
             }
          else if (self()->getReloKind() == TR_ACTIVE_CARD_TABLE_BASE)
             {
-            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t*)TR_ActiveCardTableBase,
-                                                                  TR_GlobalValue, cg),
-                                 __FILE__,__LINE__, node);
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_ActiveCardTableBase,
+                  TR_GlobalValue,
+                  cg),
+               __FILE__,
+               __LINE__,
+               node);
             }
 
          break;
@@ -1226,12 +1236,16 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                   {
                   if (symbol->isConst())
                      {
-                     TR::Compilation *comp = cg->comp();
-                     cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                            (uint8_t *)self()->getSymbolReference().getOwningMethod(comp)->constantPool(),
-                                                                            node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                           TR_ConstantPool, cg),
-                                          __FILE__, __LINE__, node);
+                     cg->addExternalRelocation(
+                        TR::ExternalRelocation::create(
+                           cursor,
+                           (uint8_t *)self()->getSymbolReference().getOwningMethod(cg->comp())->constantPool(),
+                           node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
+                           TR_ConstantPool,
+                           cg),
+                        __FILE__,
+                        __LINE__,
+                        node);
                      }
                   else if (symbol->isClassObject())
                      {
@@ -1240,18 +1254,29 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                         *(int32_t *)cursor = (int32_t)(TR::Compiler->cls.persistentClassPointerFromClassPointer(cg->comp(), (TR_OpaqueClassBlock*)(self()->getSymbolReference().getOffset() + (intptr_t)staticSym->getStaticAddress())));
                         if (cg->comp()->getOption(TR_UseSymbolValidationManager))
                            {
-                           cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                                     (uint8_t *)(self()->getSymbolReference().getOffset() + (intptr_t)staticSym->getStaticAddress()),
-                                                                                                     (uint8_t *)TR::SymbolType::typeClass,
-                                                                                                     TR_SymbolFromManager,
-                                                                                                     cg),
-                                                                                           __FILE__, __LINE__, node);
+                           cg->addExternalRelocation(
+                              TR::ExternalRelocation::create(
+                                 cursor,
+                                 (uint8_t *)(self()->getSymbolReference().getOffset() + (intptr_t)staticSym->getStaticAddress()),
+                                 (uint8_t *)TR::SymbolType::typeClass,
+                                 TR_SymbolFromManager,
+                                 cg),
+                              __FILE__,
+                              __LINE__,
+                              node);
                            }
                         else
                            {
-                           cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)&self()->getSymbolReference(),
-                                                                                                    node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                                    TR_ClassAddress, cg), __FILE__, __LINE__, node);
+                           cg->addExternalRelocation(
+                              TR::ExternalRelocation::create(
+                                 cursor,
+                                 (uint8_t *)&self()->getSymbolReference(),
+                                 node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
+                                 TR_ClassAddress,
+                                 cg),
+                              __FILE__,
+                              __LINE__,
+                              node);
                            }
                         }
                      }
@@ -1259,32 +1284,51 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                      {
                      if (staticSym->isCountForRecompile())
                         {
-                        cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
-                                             __FILE__,
-                                             __LINE__,
-                                             node);
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              (uint8_t *) TR_CountForRecompile,
+                              TR_GlobalValue,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
                         }
                      else if (staticSym->isRecompilationCounter())
                         {
-                        cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg),
-                                             __FILE__,
-                                             __LINE__,
-                                             node);
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              0,
+                              TR_BodyInfoAddress,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
                         }
                      else if (staticSym->isCatchBlockCounter())
                         {
-                        cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_CatchBlockCounter, cg),
-                                             __FILE__,
-                                             __LINE__,
-                                             node);
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              0,
+                              TR_CatchBlockCounter,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
                         }
                      else if (staticSym->isGCRPatchPoint())
                         {
-                        TR::ExternalRelocation* r= new (cg->trHeapMemory())
-                           TR::ExternalRelocation(cursor,
-                                                      0,
-                                                      TR_AbsoluteMethodAddress, cg);
-                        cg->addExternalRelocation(r, __FILE__, __LINE__, node);
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              0,
+                              TR_AbsoluteMethodAddress,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
                         }
                      else if (symbol->isDebugCounter())
                         {
@@ -1300,13 +1344,16 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                         }
                      else
                         {
-                        cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                           (uint8_t *)&self()->getSymbolReference(),
-                                                                           node ? (uint8_t *)(uintptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                           TR_DataAddress, cg),
-                                             __FILE__,
-                                             __LINE__,
-                                             node);
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              (uint8_t *)&self()->getSymbolReference(),
+                              node ? (uint8_t *)(uintptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
+                              TR_DataAddress,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
                         }
                      }
                   }
@@ -1333,10 +1380,15 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                else
                   {
                   cg->addRelocation(new (cg->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
-                  cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                        0,
-                                                                        TR_AbsoluteMethodAddress, cg),
-                                       __FILE__, __LINE__, node);
+                  cg->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        0,
+                        TR_AbsoluteMethodAddress,
+                        cg),
+                     __FILE__,
+                     __LINE__,
+                     node);
                   }
                }
             }

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -864,10 +864,11 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       if (needsAOTRelocation())
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()),
-                                __FILE__,
-                                __LINE__,
-                                getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(cursor, 0, TR_BodyInfoAddress, cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
 
       if (getReloKind() != -1) // TODO: need to change Body info one to use this
@@ -878,9 +879,16 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_StaticRamMethodConst:
             case TR_VirtualRamMethodConst:
             case TR_SpecialRamMethodConst:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getNode()->getSymbolReference(),
-                  (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() , (TR_ExternalRelocationTargetKind) getReloKind(), cg()),
-                  __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)getNode()->getSymbolReference(),
+                     (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex(),
+                     (TR_ExternalRelocationTargetKind) getReloKind(),
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                break;
             case TR_MethodPointer:
                if (getNode() && getNode()->getInlinedSiteIndex() == -1 &&
@@ -893,27 +901,37 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_ClassPointer:
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                            (uint8_t *)symbolKind,
-                                                                                            TR_SymbolFromManager,
-                                                                                            cg()),
-                                                                                   __FILE__, __LINE__,
-                                                                                   getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)(uintptr_t)getSourceImmediate(),
+                        (uint8_t *)symbolKind,
+                        TR_SymbolFromManager,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                else
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                              (uint8_t*)getNode(),
-                                                                              (TR_ExternalRelocationTargetKind) _reloKind,
-                                                                              cg()),
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t*)getNode(),
+                        (TR_ExternalRelocationTargetKind) _reloKind,
+                        cg()),
                      __FILE__,
                      __LINE__,
                      getNode());
                   }
                   break;
             default:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, (TR_ExternalRelocationTargetKind)getReloKind(), cg()),
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     0,
+                     (TR_ExternalRelocationTargetKind)getReloKind(),
+                     cg()),
                   __FILE__,
                   __LINE__,
                   getNode());
@@ -1109,12 +1127,14 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
 
                   cg()->addExternalRelocation(
-                     new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                                                   startOfInstruction,
-                                                   reinterpret_cast<uint8_t *>(info),
-                                                   static_cast<TR_ExternalRelocationTargetKind>(reloTypes[rType]),
-                                                   cg()),
-                     __FILE__, __LINE__, getNode());
+                     TR::ExternalRelocation::create(
+                        startOfInstruction,
+                        reinterpret_cast<uint8_t *>(info),
+                        static_cast<TR_ExternalRelocationTargetKind>(reloTypes[rType]),
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                else if (resolvedMethod)
                   {
@@ -1131,24 +1151,32 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          }
       else if (getOpCodeValue() == TR::InstOpCode::DDImm4)
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                               TR_ConstantPool,
-                                                               cg()),
-                             __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)(uintptr_t)getSourceImmediate(),
+               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+               TR_ConstantPool,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       else if (getOpCodeValue() == TR::InstOpCode::PUSHImm4)
          {
          TR::Symbol *symbol = getSymbolReference()->getSymbol();
          if (symbol->isConst())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
-                                                                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                  TR_ConstantPool,
-                                                                  cg()),
-                                   __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  TR_ConstantPool,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else if (symbol->isClassObject())
             {
@@ -1156,42 +1184,72 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                {
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                            (uint8_t *)TR::SymbolType::typeClass,
-                                                                                            TR_SymbolFromManager,
-                                                                                            cg()),
-                                                                                  __FILE__, __LINE__, getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)(uintptr_t)getSourceImmediate(),
+                        (uint8_t *)TR::SymbolType::typeClass,
+                        TR_SymbolFromManager,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                else
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                   (uint8_t *)getSymbolReference(),
-                                                                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                   TR_ClassAddress,
-                                                                   cg()), __FILE__,__LINE__, getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)getSymbolReference(),
+                        getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                        TR_ClassAddress,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                }
             }
          else if (symbol->isMethod())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t *)getSymbolReference(),
-                                                                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                  TR_MethodObject,
-                                                                  cg()),
-                                   __FILE__,__LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  TR_MethodObject,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
             TR::StaticSymbol *staticSym = sym->getStaticSymbol();
             if (staticSym && staticSym->isCompiledMethod())
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_RamMethod, cg()),
-                                      __FILE__, __LINE__, getNode());
+               {
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     0,
+                     TR_RamMethod,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
+               }
             else if (staticSym && staticSym->isStartPC())
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                   (uint8_t *) (staticSym->getStaticAddress()), TR_AbsoluteMethodAddress, cg()),
-                                      __FILE__, __LINE__, getNode());
+               {
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *) (staticSym->getStaticAddress()),
+                     TR_AbsoluteMethodAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
+               }
             else if (sym->isDebugCounter())
                {
                TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(getSymbolReference());
@@ -1209,19 +1267,40 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
                recordInfo->data1 = (uintptr_t)getSymbolReference();
                recordInfo->data2 = 0; // seqKind
-               TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
-               cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)recordInfo,
+                     TR_BlockFrequency,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             else if (sym->isRecompQueuedFlag())
                {
-               TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
-               cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     NULL,
+                     TR_RecompQueuedFlag,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             else
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                   (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
-                                       __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)getSymbolReference(),
+                     getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                     TR_DataAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             }
 
@@ -1692,7 +1771,16 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
       if (staticHCRPIC)
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *)(uintptr_t)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               (uint8_t *)cursor,
+               (uint8_t *)(uintptr_t)getSourceImmediate(),
+               TR_HCR,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
+
          cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *)(uintptr_t) getSourceImmediateAsAddress()), (void *) cursor);
          }
 
@@ -1706,40 +1794,63 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (_reloKind)
          {
          case TR_HEAP_BASE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                    (uint8_t*)TR_HeapBase,
-                                                      TR_GlobalValue,
-                                                      cg()),
-                          __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapBase,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
 
          case TR_HEAP_TOP:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                      (uint8_t*)TR_HeapTop,
-                                                      TR_GlobalValue,
-                                                      cg()),
-                          __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapTop,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
+
          case TR_HEAP_BASE_FOR_BARRIER_RANGE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                      (uint8_t*)TR_HeapBaseForBarrierRange0,
-                                                      TR_GlobalValue,
-                                                      cg()),
-                          __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapBaseForBarrierRange0,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
+
          case TR_HEAP_SIZE_FOR_BARRIER_RANGE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                      (uint8_t*)TR_HeapSizeForBarrierRange0,
-                                                      TR_GlobalValue,
-                                                      cg()),
-                          __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapSizeForBarrierRange0,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
+
          case TR_ACTIVE_CARD_TABLE_BASE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                      (uint8_t*)TR_ActiveCardTableBase,
-                                                      TR_GlobalValue,
-                                                      cg()),
-                          __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_ActiveCardTableBase,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
 
          case TR_MethodPointer:
@@ -1753,21 +1864,28 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          case TR_ClassPointer:
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                         (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                         (uint8_t *)symbolKind,
-                                                                                         TR_SymbolFromManager,
-                                                                                         cg()),
-                                                                                __FILE__, __LINE__,
-                                                                                getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)(uintptr_t)getSourceImmediate(),
+                     (uint8_t *)symbolKind,
+                     TR_SymbolFromManager,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             else
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                 (uint8_t*)getNode(),
-                                                                 (TR_ExternalRelocationTargetKind) _reloKind,
-                                                                 cg()),
-                                      __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t*)getNode(),
+                     (TR_ExternalRelocationTargetKind) _reloKind,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             break;
 
@@ -1857,14 +1975,16 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       case TR_ConstantPool:
          TR_ASSERT(symbol->isConst() || symbol->isConstantPoolAddress(), "unknown symbol type for TR_ConstantPool relocation %p\n", this);
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                   (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
-                                                                                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                   (TR_ExternalRelocationTargetKind)getReloKind(),
-                                                                                   cg()),
-                                __FILE__,
-                                __LINE__,
-                                getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
+               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+               (TR_ExternalRelocationTargetKind)getReloKind(),
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          break;
       case TR_ClassAddress:
       case TR_ClassObject:
@@ -1877,23 +1997,29 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(), (TR_OpaqueClassBlock*)(uintptr_t)getSourceImmediate());
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                         (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                         (uint8_t *)TR::SymbolType::typeClass,
-                                                                                         TR_SymbolFromManager,
-                                                                                         cg()),
-                                                                               __FILE__, __LINE__, getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)(uintptr_t)getSourceImmediate(),
+                     (uint8_t *)TR::SymbolType::typeClass,
+                     TR_SymbolFromManager,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             else
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                     (uint8_t *)getSymbolReference(),
-                                                                                     getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                     (TR_ExternalRelocationTargetKind)getReloKind(),
-                                                                                     cg()),
-                                  __FILE__,
-                                  __LINE__,
-                                  getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)getSymbolReference(),
+                     getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                     (TR_ExternalRelocationTargetKind)getReloKind(),
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             }
          }
@@ -1902,14 +2028,16 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_DataAddress:
          TR_ASSERT(!(getSymbolReference()->isUnresolved() && !symbol->isClassObject()), "expecting a resolved symbol for this instruction class!\n");
 
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                   (uint8_t *)getSymbolReference(),
-                                                                                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                   (TR_ExternalRelocationTargetKind)getReloKind(),
-                                                                                   cg()),
-                                __FILE__,
-                                __LINE__,
-                                getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)getSymbolReference(),
+               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+               (TR_ExternalRelocationTargetKind)getReloKind(),
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          break;
       case TR_MethodPointer:
          if (getNode() && getNode()->getInlinedSiteIndex() == -1 &&
@@ -1920,21 +2048,28 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_ClassPointer:
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                      (uint8_t *)symbolKind,
-                                                                                      TR_SymbolFromManager,
-                                                                                      cg()),
-                                                                             __FILE__, __LINE__,
-                                                                             getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)(uintptr_t)getSourceImmediate(),
+                  (uint8_t *)symbolKind,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                              (uint8_t*)getNode(),
-                                                              (TR_ExternalRelocationTargetKind)getReloKind(),
-                                                              cg()),
-                                   __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)getNode(),
+                  (TR_ExternalRelocationTargetKind)getReloKind(),
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          break;
       case TR_DebugCounter:
@@ -1956,15 +2091,29 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data1 = (uintptr_t)getSymbolReference();
          recordInfo->data2 = 0; // seqKind
-         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
-         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)recordInfo,
+               TR_BlockFrequency,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
       case TR_RecompQueuedFlag:
          {
-         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
-         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_RecompQueuedFlag,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
@@ -2189,22 +2338,29 @@ TR::X86MemImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          TR_ASSERT(getNode(), "node expected to be non-NULL here");
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                      (uint8_t *)TR::SymbolType::typeClass,
-                                                                                      TR_SymbolFromManager,
-                                                                                      cg()),
-                                                                             __FILE__, __LINE__,
-                                                                             getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)(uintptr_t)getSourceImmediate(),
+                  (uint8_t *)TR::SymbolType::typeClass,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                          (uint8_t *)getNode()->getSymbolReference(),
-                                                          (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex(),
-                                                          TR_ClassAddress,
-                                                          cg()),
-                           __FILE__,__LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getNode()->getSymbolReference(),
+                  (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex(),
+                  TR_ClassAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
 
@@ -2334,14 +2490,15 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
    if (symbol->isConst())
       {
       cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                  (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
-                                                                   getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                   TR_ConstantPool,
-                                                                   cg()),
-                 __FILE__, __LINE__, getNode()
-            );
-
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
+            getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_ConstantPool,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
    else if (symbol->isClassObject())
       {
@@ -2351,25 +2508,44 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(), (TR_OpaqueClassBlock*)(uintptr_t)getSourceImmediate());
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
-                                                                                      (uint8_t *)TR::SymbolType::typeClass,
-                                                                                      TR_SymbolFromManager,
-                                                                                      cg()),
-                                                                             __FILE__, __LINE__,
-                                                                             getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)(uintptr_t)getSourceImmediate(),
+                  (uint8_t *)TR::SymbolType::typeClass,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_ClassAddress, cg()),
-                                                                                         __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  TR_ClassAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
       }
    else if (symbol->isMethod())
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_MethodObject, cg()),
-                              __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)getSymbolReference(),
+            getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_MethodObject,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
    else if (symbol->isDebugCounter())
       {
@@ -2388,18 +2564,40 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)getSymbolReference();
       recordInfo->data2 = 0; // seqKind
-      TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
-      cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)recordInfo,
+            TR_BlockFrequency,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
    else if (symbol->isRecompQueuedFlag())
       {
-      TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
-      cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            NULL,
+            TR_RecompQueuedFlag,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
    else
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1, TR_DataAddress, cg()),
-                              __FILE__, __LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)getSymbolReference(),
+            getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+            TR_DataAddress,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
    }
 
@@ -2899,11 +3097,15 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
           (methodSymRef->getReferenceNumber() == TR_referenceArrayCopy ||
           methodSymRef->getReferenceNumber() == TR_prepareForOSR))
          {// the reference number is set in j9x86evaluator.cpp/VMarrayStoreCheckArrayCopyEvaluator
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                         (uint8_t *)methodSymRef,
-                                                         TR_AbsoluteHelperAddress,
-                                                         cg()),
-                             __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)methodSymRef,
+               TR_AbsoluteHelperAddress,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       }
 
@@ -2912,25 +3114,37 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (_reloKind)
          {
          case TR_HEAP_BASE_FOR_BARRIER_RANGE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                            (uint8_t*)TR_HeapBaseForBarrierRange0,
-                                                            TR_GlobalValue,
-                                                            cg()),
-                                __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapBaseForBarrierRange0,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_HEAP_SIZE_FOR_BARRIER_RANGE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                            (uint8_t*)TR_HeapSizeForBarrierRange0,
-                                                            TR_GlobalValue,
-                                                            cg()),
-                                __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_HeapSizeForBarrierRange0,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          case TR_ACTIVE_CARD_TABLE_BASE:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                            (uint8_t*)TR_ActiveCardTableBase,
-                                                            TR_GlobalValue,
-                                                            cg()),
-                                __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t*)TR_ActiveCardTableBase,
+                  TR_GlobalValue,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          }
       }
@@ -2939,11 +3153,15 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       if (((getNode()->getOpCodeValue() == TR::aconst) && getNode()->isMethodPointerConstant() && needsAOTRelocation()) || staticHCRPIC)
          {
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                         NULL,
-                                                         TR_RamMethod,
-                                                         cg()),
-                             __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_RamMethod,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
       else
          {
@@ -2955,22 +3173,29 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                TR_ASSERT(getNode(), "node assumed to be non-NULL here");
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)getSourceImmediate(),
-                                                                                            (uint8_t *)TR::SymbolType::typeClass,
-                                                                                            TR_SymbolFromManager,
-                                                                                            cg()),
-                                                                                   __FILE__, __LINE__,
-                                                                                   getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)getSourceImmediate(),
+                        (uint8_t *)TR::SymbolType::typeClass,
+                        TR_SymbolFromManager,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                else
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                   (uint8_t *)methodSymRef,
-                                                                   (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex(),
-                                                                   TR_ClassAddress,
-                                                                   cg()),
-                                    __FILE__,__LINE__, getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)methodSymRef,
+                        (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex(),
+                        TR_ClassAddress,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                }
                break;
@@ -2986,36 +3211,43 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
             case TR_ClassPointer:
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)getSourceImmediate(),
-                                                                                            (uint8_t *)symbolKind,
-                                                                                            TR_SymbolFromManager,
-                                                                                            cg()),
-                                                                                   __FILE__, __LINE__,
-                                                                                   getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t *)getSourceImmediate(),
+                        (uint8_t *)symbolKind,
+                        TR_SymbolFromManager,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                else
                   {
-                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                    (uint8_t*)getNode(),
-                                                                    (TR_ExternalRelocationTargetKind) _reloKind,
-                                                                    cg()),
-                                         __FILE__, __LINE__, getNode());
+                  cg()->addExternalRelocation(
+                     TR::ExternalRelocation::create(
+                        cursor,
+                        (uint8_t*)getNode(),
+                        (TR_ExternalRelocationTargetKind) _reloKind,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
                   }
                break;
             case TR_StaticRamMethodConst:
             case TR_VirtualRamMethodConst:
             case TR_SpecialRamMethodConst:
                cg()->addExternalRelocation(
-                  new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                                                cursor,
-                                                (uint8_t *) getNode()->getSymbolReference(),
-                                                getNode()
-                                                   ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex()
-                                                   : (uint8_t *)-1,
-                                                (TR_ExternalRelocationTargetKind) _reloKind,
-                                                cg()),
-                     __FILE__,__LINE__, getNode());
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *) getNode()->getSymbolReference(),
+                     getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                     (TR_ExternalRelocationTargetKind) _reloKind,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                break;
             case TR_JNIStaticTargetAddress:
             case TR_JNISpecialTargetAddress:
@@ -3036,12 +3268,14 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
 
                cg()->addExternalRelocation(
-                  new (cg()->trHeapMemory()) TR::ExternalRelocation(
-                                                startOfInstruction,
-                                                reinterpret_cast<uint8_t *>(info),
-                                                static_cast<TR_ExternalRelocationTargetKind>(_reloKind),
-                                                cg()),
-                     __FILE__,__LINE__, getNode());
+                  TR::ExternalRelocation::create(
+                     startOfInstruction,
+                     reinterpret_cast<uint8_t *>(info),
+                     static_cast<TR_ExternalRelocationTargetKind>(_reloKind),
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
                break;
             }
@@ -3056,7 +3290,15 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
    if (staticHCRPIC)
       {
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)cursor, (uint8_t *)getSourceImmediate(), TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)cursor,
+            (uint8_t *)getSourceImmediate(),
+            TR_HCR,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       cg()->jitAddPicToPatchOnClassRedefinition(((void *) getSourceImmediate()), (void *) cursor);
       }
 
@@ -3117,7 +3359,15 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (getReloKind())
          {
          case TR_AbsoluteMethodAddress:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_AbsoluteMethodAddress, cg()), __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  NULL,
+                  TR_AbsoluteMethodAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
          default:
             break;
@@ -3129,14 +3379,16 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
       switch (getReloKind())
          {
          case TR_ConstantPool:
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
-                                                                                       getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                       (TR_ExternalRelocationTargetKind) getReloKind(),
-                                                                                       cg()),
-                                   __FILE__,
-                                   __LINE__,
-                                   getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference()->getOwningMethod(comp)->constantPool(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  (TR_ExternalRelocationTargetKind) getReloKind(),
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             break;
 
          case TR_DataAddress:
@@ -3144,14 +3396,16 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             if (cg()->needRelocationsForStatics())
                {
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                         (uint8_t *) getSymbolReference(),
-                                                                                         (uint8_t *)getNode() ? (uint8_t *)(intptr_t) getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                         (TR_ExternalRelocationTargetKind) getReloKind(),
-                                                                                         cg()),
-                                                                                         __FILE__,
-                                                                                         __LINE__,
-                                                                                         getNode());
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *) getSymbolReference(),
+                     (uint8_t *)getNode() ? (uint8_t *)(intptr_t) getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                     (TR_ExternalRelocationTargetKind) getReloKind(),
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
                }
             break;
             }
@@ -3186,14 +3440,28 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
             recordInfo->data1 = (uintptr_t)getSymbolReference();
             recordInfo->data2 = 0; // seqKind
-            TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
-            cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)recordInfo,
+                  TR_BlockFrequency,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
             break;
          case TR_RecompQueuedFlag:
             {
-            TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
-            cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  NULL,
+                  TR_RecompQueuedFlag,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
             break;
 

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -98,33 +98,45 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             {
             TR_ASSERT_FATAL(getDataAs8Bytes(), "Static Sym can not be NULL");
 
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                       (uint8_t *) getDataAs8Bytes(),
-                                                                                       (uint8_t *) TR::SymbolType::typeClass,
-                                                                                       TR_SymbolFromManager,
-                                                                                       cg()),
-                                                                                       __FILE__, __LINE__, getNode());
-
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) getDataAs8Bytes(),
+                  (uint8_t *) TR::SymbolType::typeClass,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) reloSymRef,
-                                                                                 getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
-                                                                                 __FILE__, __LINE__, getNode());
-
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) reloSymRef,
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  (TR_ExternalRelocationTargetKind) reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
-
-
          }
          break;
       case TR_MethodObject:
          {
          TR::SymbolReference *reloSymRef= (reloType==TR_ClassAddress)?getNode()->getSymbolReference():getSymbolReference();
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) reloSymRef,
-                                                                                getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                (TR_ExternalRelocationTargetKind) reloType, cg()),
-                                   __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) reloSymRef,
+               getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+               (TR_ExternalRelocationTargetKind) reloType,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
@@ -139,12 +151,14 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          info->data3 = static_cast<uintptr_t>(inlinedSiteIndex);
 
          cg()->addExternalRelocation(
-            new (cg()->trHeapMemory()) TR::ExternalRelocation(
+            TR::ExternalRelocation::create(
                cursor,
                reinterpret_cast<uint8_t *>(info),
                static_cast<TR_ExternalRelocationTargetKind>(reloType),
                cg()),
-            __FILE__, __LINE__, getNode());
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
@@ -152,30 +166,56 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          {
          if (cg()->needRelocationsForStatics())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode()->getSymbolReference(),
-                                     getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                   (TR_ExternalRelocationTargetKind) reloType, cg()),
-                                     __FILE__,__LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) getNode()->getSymbolReference(),
+                  getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                  (TR_ExternalRelocationTargetKind) reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          }
          break;
 
       case TR_ArrayCopyHelper:
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getSymbolReference(),
-                                                                                (TR_ExternalRelocationTargetKind) reloType, cg()),
-                                __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) getSymbolReference(),
+               (TR_ExternalRelocationTargetKind) reloType,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          break;
 
       case TR_HelperAddress:
          if (cg()->comp()->target().is64Bit())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_AbsoluteHelperAddress, cg()),
-                                __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) *((uint64_t*) cursor),
+                  TR_AbsoluteHelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor), TR_AbsoluteHelperAddress, cg()),
-                                __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)(intptr_t) *((uint32_t*) cursor),
+                  TR_AbsoluteHelperAddress,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          break;
 
@@ -183,29 +223,54 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_BodyInfoAddress:
          if (cg()->comp()->target().is64Bit())
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor),
-                  (TR_ExternalRelocationTargetKind) reloType, cg()),
-                  __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) *((uint64_t*) cursor),
+                  (TR_ExternalRelocationTargetKind) reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)(intptr_t) *((uint32_t*) cursor),
-                  (TR_ExternalRelocationTargetKind) reloType, cg()),
-                  __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)(intptr_t) *((uint32_t*) cursor),
+                  (TR_ExternalRelocationTargetKind) reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          break;
 
       case TR_CatchBlockCounter:
          {
-         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_CatchBlockCounter, cg());
-         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_CatchBlockCounter,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
       case TR_GlobalValue:
-         cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) TR_CountForRecompile,
-                                                                                TR_GlobalValue, cg()),
-                                  __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) TR_CountForRecompile,
+               TR_GlobalValue,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          break;
 
       case TR_RamMethod:
@@ -216,17 +281,19 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             TR_ASSERT_FATAL(getDataAs8Bytes(), "Static Sym can not be NULL");
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                 (uint8_t *) getDataAs8Bytes(),
-                                                                                 (uint8_t *)symbolKind,
-                                                                                 TR_SymbolFromManager,
-                                                                                 cg()),
-                                                                              __FILE__, __LINE__,
-                                                                              getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) getDataAs8Bytes(),
+                  (uint8_t *)symbolKind,
+                  TR_SymbolFromManager,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          else
             {
-            TR::Relocation *relo;
             //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
             //so we need to pass it to relocation in targetaddress2 for now
             //two instances where use this relotype in such way are: profile checkcast and arraystore check object check optimiztaions
@@ -238,8 +305,16 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
                else
                   targetAdress2 = (uint8_t *) *((uintptr_t*) cursor);
                }
-            relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode(), targetAdress2, (TR_ExternalRelocationTargetKind) reloType, cg());
-            cg()->addExternalRelocation(relo, __FILE__, __LINE__, getNode());
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *) getNode(),
+                  targetAdress2,
+                  (TR_ExternalRelocationTargetKind) reloType,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
             }
          break;
 
@@ -263,15 +338,29 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
          recordInfo->data1 = (uintptr_t)getNode()->getSymbolReference();
          recordInfo->data2 = 0; // seqKind
-         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)recordInfo, TR_BlockFrequency, cg());
-         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)recordInfo,
+               TR_BlockFrequency,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 
       case TR_RecompQueuedFlag:
          {
-         TR::Relocation *relocation = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RecompQueuedFlag, cg());
-         cg()->addExternalRelocation(relocation, __FILE__, __LINE__, getNode());
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               NULL,
+               TR_RecompQueuedFlag,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
          }
          break;
 

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1165,7 +1165,15 @@ TR::S390ImmInstruction::generateBinaryEncoding()
       //
       void **locationToPatch = (void**)(cursor - (comp->target().is64Bit()?4:0));
       cg()->jitAddPicToPatchOnClassRedefinition(*locationToPatch, locationToPatch);
-      cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation((uint8_t *)locationToPatch, (uint8_t *)*locationToPatch, TR_HCR, cg()), __FILE__,__LINE__, getNode());
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            (uint8_t *)locationToPatch,
+            (uint8_t *)*locationToPatch,
+            TR_HCR,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
       }
 
    cursor += getOpCode().getInstructionLength();


### PR DESCRIPTION
Provide a factory method for external relocations to simplify the code and reduce code footprint slightly.  Replace all TR::ExternalRelocation allocations throughout with the factory method.

Take this opportunity to clean up the wildly inconsistent source formatting for all these allocation sites as well.