### PR TITLE
AArch64: Validate immediate offset of memory references

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -292,28 +292,28 @@ OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg
 TR::Register *
 OMR::ARM64::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vldrimms, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::vldrimms, 4, cg);
    }
 
 // also handles dloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vldrimmd, cg);
+   return commonLoadEvaluator(node, TR::InstOpCode::vldrimmd, 8, cg);
    }
 
 // also handles fstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, 4, cg);
    }
 
 // also handles dstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, 8, cg);
    }
 
 TR::Register *

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -348,6 +348,11 @@ void OMR::ARM64::MemoryReference::validateImmediateOffsetAlignment(TR::Node *nod
    intptr_t displacement = self()->getOffset();
    if ((displacement % alignment) != 0)
       {
+      TR::Compilation *comp = cg->comp();
+      if (comp->getOption(TR_TraceCG))
+         {
+         traceMsg(comp, "Validating immediate offset (%d) at node %p for alignment (%d)\n", displacement, node, alignment);
+         }
       TR::Register *newBase;
 
       self()->setOffset(0);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -53,26 +53,29 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
  * @brief Helper function for xloadEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for load
+ * @param[in] size : size
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
 
 /**
  * @brief Helper function for xloadEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for load
+ * @param[in] size : size
  * @param[in] targetReg : target register
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Register *targetReg, TR::CodeGenerator *cg);
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::Register *targetReg, TR::CodeGenerator *cg);
 
 /**
  * @brief Helper function for xstoreEvaluators
  * @param[in] node : node
  * @param[in] op : instruction for store
+ * @param[in] size : size
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
+TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
 
 namespace OMR
 {

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -545,7 +545,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeG
        && child->getRegister() == NULL)
       {
       // Use unsigned load
-      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrbimm, cg);
+      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrbimm, 1, cg);
       node->setRegister(trgReg);
       cg->decReferenceCount(child);
       return trgReg;
@@ -565,7 +565,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
        && child->getRegister() == NULL)
       {
       // Use unsigned load
-      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrhimm, cg);
+      TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrhimm, 2, cg);
       node->setRegister(trgReg);
       cg->decReferenceCount(child);
       return trgReg;


### PR DESCRIPTION
Validate immediate offset of memory references so that the alignment requirement of instructions is satisfied.