### PR TITLE
Fix Linux cgroup2 initialization

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -6112,6 +6112,7 @@ populateCgroupEntryListV2(struct OMRPortLibrary *portLibrary, int pid, OMRCgroup
 	 */
 	char subsystems[PATH_MAX];
 	char *cursor = NULL;
+	char *newline = NULL;
 	char *separator = NULL;
 
 	Assert_PRT_true(NULL != cgroupEntryList);
@@ -6184,6 +6185,15 @@ populateCgroupEntryListV2(struct OMRPortLibrary *portLibrary, int pid, OMRCgroup
 	}
 
 	cursor = subsystems;
+
+	/* Strip the \n at the end (see Linux kernel source, file
+	 * kernel/cgroup/cgroup.c, function cgroup_print_ss_mask()).
+	 */
+	newline = strchr(cursor, '\n');
+	if (NULL != newline) {
+		*newline = '\0';
+	}
+
 	do {
 		int32_t i = 0;
 


### PR DESCRIPTION
This commit fixes a subtle bug in cgroup2 initialization, namely in `populateCgroupEntryListV2()`.

Consider a system with only `memory` control group enabled. Then the `cgroup.controllers` for the process's cgroup2 would contain string `memory` followed by newline (`\n`). See Linux kernel source, file `kernel/cgroup/cgroup.c`, function `cgroup_print_ss_mask()` [1].

The code that iterates over cgroups listed only considers space as a separator:

    separator = strchr(cursor, ' ');
	if (NULL != separator) {
	    *separator = '\0';
	}

So the last (an in our example also the first) cgroup name (pointed to by `cursor`) contains the `\n` as the end, therefore the `strcmp` comparison fails:

    ...
       && (0 == strcmp(cursor, supportedSubsystems[i].name))
    ...

(since we're comparing `'memory\n'` with just `'memory'`). In other words, the last controller in controllers file is always "missed" by OMR.

This went unnoticed probably because most linux systems used have more (all?) controller enabled, so likely the last one was some that OMR is not interested in (such as `pids`, for example). However, if there's only one controller enabled, it is "missed" and OMR falsely reports CGroups2 are unavailable. This actually happened on RISC-V board running custom, stripped down kernel.

This commit fixes the problem by stripping the newline.

[1]: https://github.com/torvalds/linux/blob/197b6b60ae7bc51dd0814953c562833143b292aa/kernel/cgroup/cgroup.c#L3005