### PR TITLE
Rename TLS macros to satisfy the uppercase convention

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -146,7 +146,7 @@ namespace TR { class RegisterMappedSymbol; }
 
 namespace OMR
 {
-tlsDefine(TR::Compilation *, compilation);
+TR_TLS_DEFINE(TR::Compilation *, compilation);
 }
 
 TR::SymbolReference *

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1343,7 +1343,7 @@ private:
 
 // extern DWORD compilation
 //
-tlsDeclare(TR::Compilation *, compilation);
+TR_TLS_DECLARE(TR::Compilation *, compilation);
 
 }
 namespace TR {
@@ -1352,7 +1352,7 @@ namespace TR {
    /// \note Inlined for performance
    inline TR::Compilation *comp()
       {
-      return tlsGet(OMR::compilation, TR::Compilation *);
+      return TR_TLS_GET(OMR::compilation, TR::Compilation *);
       }
 }
 

--- a/compiler/compile/TLSCompilationManager.cpp
+++ b/compiler/compile/TLSCompilationManager.cpp
@@ -25,10 +25,10 @@
 
 TR::TLSCompilationManager::TLSCompilationManager(TR::Compilation &comp)
    {
-   tlsSet(OMR::compilation, &comp);
+   TR_TLS_SET(OMR::compilation, &comp);
    }
 
 TR::TLSCompilationManager::~TLSCompilationManager()
    {
-   tlsSet(OMR::compilation, NULL);
+   TR_TLS_SET(OMR::compilation, NULL);
    }

--- a/compiler/control/CompilationController.cpp
+++ b/compiler/control/CompilationController.cpp
@@ -58,7 +58,7 @@ bool TR::CompilationController::init(TR::CompilationInfo *compInfo)
    if (TR::Options::getCmdLineOptions() && TR::Options::getCmdLineOptions()->getOption(TR_EnableCompYieldStats))
       TR::Compilation::allocateCompYieldStatsMatrix();
 #endif
-   tlsAlloc(OMR::compilation);
+   TR_TLS_ALLOC(OMR::compilation);
    _tlsCompObjCreated = true;
    return _useController;
    }
@@ -67,7 +67,7 @@ void TR::CompilationController::shutdown()
    {
    if (_tlsCompObjCreated)
       {
-      tlsFree(OMR::compilation);
+      TR_TLS_FREE(OMR::compilation);
       }
       
    if (!_useController)

--- a/compiler/infra/ThreadLocal.hpp
+++ b/compiler/infra/ThreadLocal.hpp
@@ -39,96 +39,96 @@
 #if defined(OMR_OS_WINDOWS)
    #include "windows.h"
 
-   #define tlsDeclare(type, variable) \
+   #define TR_TLS_DECLARE(type, variable) \
       extern DWORD variable
 
-   #define tlsDefine(type, variable) \
+   #define TR_TLS_DEFINE(type, variable) \
       DWORD variable = TLS_OUT_OF_INDEXES
 
-   #define tlsAlloc(variable)                                                                                      \
+   #define TR_TLS_ALLOC(variable)                                                                                      \
       {                                                                                                            \
       (variable) = TlsAlloc();                                                                                     \
       TR_ASSERT_FATAL((variable) != TLS_OUT_OF_INDEXES, "TlsAlloc failed with GetLastError = %d", GetLastError()); \
       }
 
-   #define tlsFree(variable)                                                             \
+   #define TR_TLS_FREE(variable)                                                             \
       {                                                                                  \
       DWORD rc = TlsFree(variable);                                                      \
       TR_ASSERT_FATAL(rc != 0, "TlsFree failed with GetLastError = %d", GetLastError()); \
       }
 
-   #define tlsSet(variable, value)                                                           \
+   #define TR_TLS_SET(variable, value)                                                           \
       {                                                                                      \
       BOOL rc = TlsSetValue((variable), value);                                              \
       TR_ASSERT_FATAL(rc != 0, "TlsSetValue failed with GetLastError = %d", GetLastError()); \
       }
 
-   #define tlsGet(variable, type) \
+   #define TR_TLS_GET(variable, type) \
       ((type)TlsGetValue(variable))
 #elif (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)
-   #define tlsDeclare(type, variable) \
+   #define TR_TLS_DECLARE(type, variable) \
       extern __thread type variable
 
-   #define tlsDefine(type, variable) \
+   #define TR_TLS_DEFINE(type, variable) \
       __thread type variable = NULL
 
-   #define tlsAlloc(variable)
-   #define tlsFree(variable)
+   #define TR_TLS_ALLOC(variable)
+   #define TR_TLS_FREE(variable)
 
-   #define tlsSet(variable, value) \
+   #define TR_TLS_SET(variable, value) \
       variable = value
 
-   #define tlsGet(variable, type) \
+   #define TR_TLS_GET(variable, type) \
       (variable)
 #elif defined(OMRZTPF) || defined(J9ZOS390)
    #include <pthread.h>
    
-   #define tlsDeclare(type, variable) \
+   #define TR_TLS_DECLARE(type, variable) \
       extern pthread_key_t variable
 
-   #define tlsDefine(type, variable) \
+   #define TR_TLS_DEFINE(type, variable) \
       pthread_key_t variable
 
-   #define tlsAlloc(variable)                                                                                                     \
+   #define TR_TLS_ALLOC(variable)                                                                                                     \
       {                                                                                                                           \
       int rc = pthread_key_create(&variable, NULL);                                                                               \
       TR_ASSERT_FATAL(rc == 0, "pthread_key_create failed with rc = %d, errorno = %d, message = %s", rc, errno, strerror(errno)); \
       }
 
-   #define tlsFree(variable)                                                                                                      \
+   #define TR_TLS_FREE(variable)                                                                                                      \
       {                                                                                                                           \
       int rc = pthread_key_delete(variable);                                                                                      \
       TR_ASSERT_FATAL(rc == 0, "pthread_key_delete failed with rc = %d, errorno = %d, message = %s", rc, errno, strerror(errno)); \
       }
 
-   #define tlsSet(variable, value)                                                                                                 \
+   #define TR_TLS_SET(variable, value)                                                                                                 \
       {                                                                                                                            \
       int rc = pthread_setspecific(variable, value);                                                                               \
       TR_ASSERT_FATAL(rc == 0, "pthread_setspecific failed with rc = %d, errorno = %d, message = %s", rc, errno, strerror(errno)); \
       }
 
    #if defined(J9ZOS390)
-      #define tlsGet(variable, type) \
+      #define TR_TLS_GET(variable, type) \
          ((type) pthread_getspecific_d8_np(variable))
    #else
-      #define tlsGet(variable, type) \
+      #define TR_TLS_GET(variable, type) \
          ((type) pthread_getspecific(variable))
    #endif
 #endif
 #else /* !defined(SUPPORTS_THREAD_LOCAL) */
-   #define tlsDeclare(type, variable) \
+   #define TR_TLS_DECLARE(type, variable) \
       extern type variable
 
-   #define tlsDefine(type, variable) \
+   #define TR_TLS_DEFINE(type, variable) \
       type variable = NULL
 
-   #define tlsAlloc(variable)
-   #define tlsFree(variable)
+   #define TR_TLS_ALLOC(variable)
+   #define TR_TLS_FREE(variable)
 
-   #define tlsSet(variable, value) \
+   #define TR_TLS_SET(variable, value) \
       variable = value
 
-   #define tlsGet(variable, type) \
+   #define TR_TLS_GET(variable, type) \
       (variable)
 #endif
 #endif /* THREADLOCAL_INCL */


### PR DESCRIPTION
Capitalize `tlsFree` and sibling macros in the form `TR_TLS_...`

Closes: #6050