### PR TITLE
Rename code generator variables

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -517,18 +517,18 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor)
 void
 TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::ParameterSymbol> &parmList)
    {
-   TR::CodeGenerator *codeGen = cg();
-   TR::Machine *machine = codeGen->machine();
+   TR::CodeGenerator *cg = this->cg();
+   TR::Machine *machine = cg->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    const TR::ARM64LinkageProperties& properties = getProperties();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
    TR::Node *firstNode = comp()->getStartTree()->getNode();
 
    // allocate stack space
-   uint32_t frameSize = (uint32_t)codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = (uint32_t)cg->getFrameSizeInBytes();
    if (constantIsUnsignedImm12(frameSize))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
       }
    else
       {
@@ -538,8 +538,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
    // save link register (x30)
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, 0);
-      cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::x30), cursor);
+      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, 0);
+      cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::x30), cursor);
       }
 
    // save callee-saved registers
@@ -549,8 +549,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
-         cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, rr, cursor);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, offset);
+         cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, rr, cursor);
          offset += 8;
          }
       }
@@ -559,8 +559,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
-         cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::vstrimmq, firstNode, stackSlot, rr, cursor);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, offset);
+         cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::vstrimmq, firstNode, stackSlot, rr, cursor);
          offset += 16;
          }
       }
@@ -571,9 +571,9 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
 void
 TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   TR::CodeGenerator *codeGen = cg();
+   TR::CodeGenerator *cg = this->cg();
    const TR::ARM64LinkageProperties& properties = getProperties();
-   TR::Machine *machine = codeGen->machine();
+   TR::Machine *machine = cg->machine();
    TR::Node *lastNode = cursor->getNode();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
@@ -585,8 +585,8 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
-         cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, rr, stackSlot, cursor);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, offset);
+         cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::ldrimmx, lastNode, rr, stackSlot, cursor);
          offset += 8;
          }
       }
@@ -595,8 +595,8 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
-         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, offset);
-         cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::vldrimmq, lastNode, rr, stackSlot, cursor);
+         TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, offset);
+         cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::vldrimmq, lastNode, rr, stackSlot, cursor);
          offset += 16;
          }
       }
@@ -605,15 +605,15 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
    if (machine->getLinkRegisterKilled())
       {
-      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(codeGen, sp, 0);
-      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
+      TR::MemoryReference *stackSlot = TR::MemoryReference::createWithDisplacement(cg, sp, 0);
+      cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
       }
 
    // remove space for preserved registers
-   uint32_t frameSize = codeGen->getFrameSizeInBytes();
+   uint32_t frameSize = cg->getFrameSizeInBytes();
    if (constantIsUnsignedImm12(frameSize))
       {
-      cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
+      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
       }
    else
       {
@@ -621,7 +621,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // return
-   cursor = generateRegBranchInstruction(codeGen, TR::InstOpCode::ret, lastNode, lr, cursor);
+   cursor = generateRegBranchInstruction(cg, TR::InstOpCode::ret, lastNode, lr, cursor);
    }
 
 

--- a/compiler/arm/codegen/ARMSystemLinkage.hpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.hpp
@@ -43,7 +43,7 @@ class ARMSystemLinkage : public TR::Linkage
 
    public:
 
-   ARMSystemLinkage(TR::CodeGenerator *codeGen);
+   ARMSystemLinkage(TR::CodeGenerator *cg);
 
    virtual uint32_t getRightToLeft();
    virtual void mapStack(TR::ResolvedMethodSymbol *method);

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -47,7 +47,7 @@ namespace TR { class Register; }
 extern TR::Instruction *armLoadConstant(TR::Node     *node,
                                     int32_t         value,
                                     TR::Register    *targetRegister,
-                                    TR::CodeGenerator *codeGen,
+                                    TR::CodeGenerator *cg,
                                     TR::Instruction *cursor=NULL);
 
 extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg,

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -81,7 +81,7 @@ void OMR::ARM::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbo
 
 TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -123,7 +123,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
                if (hasToBeOnStack)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                   }
                numIntArgs++;
                break;
@@ -133,11 +133,11 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
             	if (hasToBeOnStack)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
                      argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                     cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, codeGen), argRegister, cursor);
+                     cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, cg), argRegister, cursor);
                      }
                   }
                numIntArgs += 2;
@@ -150,7 +150,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
 
 TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -177,7 +177,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+               cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                }
             numIntArgs++;
             break;
@@ -185,7 +185,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
                 argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+                cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                 }
              numIntArgs++;
             break;
@@ -196,11 +196,11 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
+               cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                  cursor = generateTrg1MemInstruction(codeGen, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), cursor);
+                  cursor = generateTrg1MemInstruction(cg, TR::InstOpCode::ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, cg), cursor);
                   }
                }
             numIntArgs += 2;
@@ -213,7 +213,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
 
 TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
    {
-   TR::CodeGenerator     *codeGen    = self()->cg();
+   TR::CodeGenerator     *cg    = self()->cg();
    TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
@@ -240,7 +240,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+               cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                }
             numIntArgs++;
             break;
@@ -248,7 +248,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
                 argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-                cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+                cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                 }
              numIntArgs++;
             break;
@@ -259,11 +259,11 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
                 numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
+               cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg), argRegister, cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
                   argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
-                  cursor = generateMemSrc1Instruction(codeGen, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), argRegister, cursor);
+                  cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, cg), argRegister, cursor);
                   }
                }
             numIntArgs += 2;
@@ -381,16 +381,16 @@ TR::Register *OMR::ARM::Linkage::pushJNIReferenceArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushIntegerWordArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst() && (child->getDataType() != TR::Float)) /* XXX: We need to fix buildARMLinkageArgs(). */
       {
-      pushRegister = codeGen->allocateRegister();
-      armLoadConstant(child, child->getInt(), pushRegister, codeGen);
+      pushRegister = cg->allocateRegister();
+      armLoadConstant(child, child->getInt(), pushRegister, cg);
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -399,11 +399,11 @@ TR::Register *OMR::ARM::Linkage::pushIntegerWordArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
-      pushRegister = codeGen->allocateRegister();
+      pushRegister = cg->allocateRegister();
       if (child->isMethodPointerConstant())
          loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
       else
@@ -411,7 +411,7 @@ TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -420,22 +420,22 @@ TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushLongArg(TR::Node *child)
    {
-   TR::CodeGenerator *codeGen      = self()->cg();
+   TR::CodeGenerator *cg      = self()->cg();
    TR::Register         *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst() /* && (child->getDataType() != TR::Double) */)
       {
-      TR::Register *lowRegister  = codeGen->allocateRegister();
-      TR::Register *highRegister = codeGen->allocateRegister();
-      pushRegister = codeGen->allocateRegisterPair(lowRegister, highRegister);
+      TR::Register *lowRegister  = cg->allocateRegister();
+      TR::Register *highRegister = cg->allocateRegister();
+      pushRegister = cg->allocateRegisterPair(lowRegister, highRegister);
 #ifdef DEBUG_ARM_LINKAGE
 printf("pushing long arg: low = %d, high = %d\n", child->getLongIntLow(), child->getLongIntHigh()); fflush(stdout);
 #endif
-      armLoadConstant(child, child->getLongIntLow(), lowRegister, codeGen);
-      armLoadConstant(child, child->getLongIntHigh(), highRegister, codeGen);
+      armLoadConstant(child, child->getLongIntLow(), lowRegister, cg);
+      armLoadConstant(child, child->getLongIntHigh(), highRegister, cg);
       }
    else
       {
-      pushRegister = codeGen->evaluate(child);
+      pushRegister = cg->evaluate(child);
       child->setRegister(pushRegister);
       }
    child->decReferenceCount();
@@ -483,7 +483,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
    {
    const TR::ARMLinkageProperties &properties = self()->getProperties();
    TR::Compilation *comp = self()->comp();
-   TR::CodeGenerator  *codeGen      = self()->cg();
+   TR::CodeGenerator  *cg      = self()->cg();
    TR::ARMMemoryArgument *pushToMemory = NULL;
    void                 *stackMark;
 
@@ -527,7 +527,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
       TR::addDependency(dependencies, vftReg, TR::RealRegister::NoReg, TR_GPR, self()->cg());  // dep 0
 
 #ifndef LOCK_R14
-      TR::addDependency(dependencies, NULL, TR::RealRegister::gr14, TR_GPR, cg());  // dep 2
+      TR::addDependency(dependencies, NULL, TR::RealRegister::gr14, TR_GPR, self()->cg());  // dep 2
 #endif
       }
 
@@ -852,11 +852,11 @@ printf("pushing 64-bit arg %d %d %d %d\n", numIntegerArgs, memArg, totalSize, ar
                {
                if (child->getReferenceCount() > 0)
                   {
-                  tempReg = cg()->allocateRegister(TR_FPR);
-                  generateTrg1Src1Instruction(cg(), reg, tempReg, ARMOp_fmr);
+                  tempReg = self()->cg()->allocateRegister(TR_FPR);
+                  generateTrg1Src1Instruction(self()->cg(), reg, tempReg, ARMOp_fmr);
                   reg = tempReg;
                   }
-               TR::addDependency(dependencies, reg, properties.getFloatArgumentRegister(numFloatArgs), TR_FPR, cg());
+               TR::addDependency(dependencies, reg, properties.getFloatArgumentRegister(numFloatArgs), TR_FPR, self()->cg());
                }
             else
                {
@@ -874,11 +874,11 @@ printf("pushing 64-bit arg %d %d %d %d\n", numIntegerArgs, memArg, totalSize, ar
                {
                if (child->getReferenceCount() > 0)
                   {
-                  tempReg = cg()->allocateRegister(TR_FPR);
-                  generateTrg1Src1Instruction(cg(), reg, tempReg, ARMOp_fmr);
+                  tempReg = self()->cg()->allocateRegister(TR_FPR);
+                  generateTrg1Src1Instruction(self()->cg(), reg, tempReg, ARMOp_fmr);
                   reg = tempReg;
                   }
-               TR::addDependency(dependencies, reg, properties.getFloatArgumentRegister(numFloatArgs), TR_FPR, cg());
+               TR::addDependency(dependencies, reg, properties.getFloatArgumentRegister(numFloatArgs), TR_FPR, self()->cg());
                }
             else
                {
@@ -950,7 +950,7 @@ printf("pushing 64-bit arg %d %d %d %d\n", numIntegerArgs, memArg, totalSize, ar
       case TR_System:
 #ifndef LOCK_R14
          if (!isVirtual)
-            TR::addDependency(dependencies, NULL, TR::RealRegister::gr14, TR_GPR, cg());
+            TR::addDependency(dependencies, NULL, TR::RealRegister::gr14, TR_GPR, self()->cg());
 #endif
          break;
       }
@@ -997,7 +997,7 @@ printf("done\n"); fflush(stdout);
 
 TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNode, bool isSystem)
    {
-   TR::CodeGenerator *codeGen = self()->cg();
+   TR::CodeGenerator *cg = self()->cg();
 
    const TR::ARMLinkageProperties &pp = self()->getProperties();
    TR::RegisterDependencyConditions *dependencies =
@@ -1022,7 +1022,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    if ((callSymbol->isJITInternalNative() ||
         (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() && ((self()->comp()->compileRelocatableCode() && callSymbol->isHelper()) || !self()->comp()->compileRelocatableCode()))))
       {
-      gcPoint = generateImmSymInstruction(codeGen,
+      gcPoint = generateImmSymInstruction(cg,
                                           TR::InstOpCode::bl,
                                           callNode,
                                           isMyself ? 0 : (uintptr_t)callSymbol->getMethodAddress(),
@@ -1032,20 +1032,20 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    else
       {
 #ifdef J9_PROJECT_SPECIFIC
-      TR::LabelSymbol *label = generateLabelSymbol(codeGen);
+      TR::LabelSymbol *label = generateLabelSymbol(cg);
       TR::Snippet     *snippet;
 
       if (callSymRef->isUnresolved() || self()->comp()->compileRelocatableCode())
          {
-         snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(cg, callNode, label, argSize);
          }
       else
          {
-         snippet = new (self()->trHeapMemory()) TR::ARMCallSnippet(codeGen, callNode, label, argSize);
+         snippet = new (self()->trHeapMemory()) TR::ARMCallSnippet(cg, callNode, label, argSize);
          }
 
-      codeGen->addSnippet(snippet);
-      gcPoint = generateImmSymInstruction(codeGen,
+      cg->addSnippet(snippet);
+      gcPoint = generateImmSymInstruction(cg,
                                           TR::InstOpCode::bl,
                                           callNode,
                                           0,
@@ -1058,7 +1058,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
       }
    gcPoint->ARMNeedsGCMap(pp.getPreservedRegisterMapForGC());
    self()->machine()->setLinkRegisterKilled(true);
-   codeGen->setHasCall();
+   cg->setHasCall();
    TR::DataType resType = callNode->getType();
 
    switch(callNode->getOpCodeValue())
@@ -1071,8 +1071,8 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
          returnRegister = dependencies->searchPostConditionRegister(pp.getIntegerReturnRegister());
          if (resType.isFloatingPoint())
             {
-            TR::Register *tempReg = codeGen->allocateSinglePrecisionRegister();
-            TR::Instruction *cursor = generateTrg1Src1Instruction(codeGen, TR::InstOpCode::fmsr, callNode, tempReg, returnRegister);
+            TR::Register *tempReg = cg->allocateSinglePrecisionRegister();
+            TR::Instruction *cursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::fmsr, callNode, tempReg, returnRegister);
             returnRegister = tempReg;
             }
          break;
@@ -1085,11 +1085,11 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
          TR::Register *highReg;
          lowReg = dependencies->searchPostConditionRegister(pp.getLongLowReturnRegister());
          highReg = dependencies->searchPostConditionRegister(pp.getLongHighReturnRegister());
-         returnRegister = codeGen->allocateRegisterPair(lowReg, highReg);
+         returnRegister = cg->allocateRegisterPair(lowReg, highReg);
          if (resType.isDouble())
             {
-            TR::Register *tempReg = codeGen->allocateRegister(TR_FPR);
-            TR::Instruction *cursor = generateTrg1Src2Instruction(codeGen, TR::InstOpCode::fmdrr, callNode, tempReg, lowReg, highReg);
+            TR::Register *tempReg = cg->allocateRegister(TR_FPR);
+            TR::Instruction *cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::fmdrr, callNode, tempReg, lowReg, highReg);
             returnRegister = tempReg;
             }
          break;

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -453,27 +453,27 @@ OMR::CodeGenerator::addToAtlas(TR::Instruction * instr)
    }
 
 void
-TR_GCStackMap::addToAtlas(TR::Instruction * instruction, TR::CodeGenerator *codeGen)
+TR_GCStackMap::addToAtlas(TR::Instruction * instruction, TR::CodeGenerator *cg)
    {
    // Fill in the code range and add this map to the atlas.
    //
-   uint8_t * codeStart = codeGen->getCodeStart();
+   uint8_t * codeStart = cg->getCodeStart();
    setLowestCodeOffset(static_cast<uint32_t>(instruction->getBinaryEncoding() - codeStart));
-   codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
+   cg->getStackAtlas()->addStackMap(this);
+   bool osrEnabled = cg->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
-      codeGen->addToOSRTable(instruction);
+      cg->addToOSRTable(instruction);
    }
 
 void
-TR_GCStackMap::addToAtlas(uint8_t * callSiteAddress, TR::CodeGenerator *codeGen)
+TR_GCStackMap::addToAtlas(uint8_t * callSiteAddress, TR::CodeGenerator *cg)
    {
    // Fill in the code range and add this map to the atlas.
    //
-   uint32_t callSiteOffset = static_cast<uint32_t>(callSiteAddress - codeGen->getCodeStart());
+   uint32_t callSiteOffset = static_cast<uint32_t>(callSiteAddress - cg->getCodeStart());
    setLowestCodeOffset(callSiteOffset - 1);
-   codeGen->getStackAtlas()->addStackMap(this);
-   bool osrEnabled = codeGen->comp()->getOption(TR_EnableOSR);
+   cg->getStackAtlas()->addStackMap(this);
+   bool osrEnabled = cg->comp()->getOption(TR_EnableOSR);
    if (osrEnabled)
-      codeGen->addToOSRTable(callSiteOffset, getByteCodeInfo());
+      cg->addToOSRTable(callSiteOffset, getByteCodeInfo());
    }

--- a/compiler/codegen/GCStackMap.hpp
+++ b/compiler/codegen/GCStackMap.hpp
@@ -271,8 +271,8 @@ public:
       return newMap;
       }
 
-   void addToAtlas(TR::Instruction *instruction, TR::CodeGenerator *codeGen);
-   void addToAtlas(uint8_t *callSiteAddress, TR::CodeGenerator *codeGen);
+   void addToAtlas(TR::Instruction *instruction, TR::CodeGenerator *cg);
+   void addToAtlas(uint8_t *callSiteAddress, TR::CodeGenerator *cg);
 
 private:
    friend class TR_Debug;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -245,7 +245,7 @@ namespace TR
 namespace OMR
 {
 
-typedef TR::Register *(* TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *codeGen);
+typedef TR::Register *(* TreeEvaluatorFunctionPointer)(TR::Node *node, TR::CodeGenerator *cg);
 
 class TreeEvaluatorFunctionPointerTable
    {

--- a/compiler/codegen/OMRRegisterPair.cpp
+++ b/compiler/codegen/OMRRegisterPair.cpp
@@ -60,10 +60,10 @@ OMR::RegisterPair::getLowOrder()
    }
 
 TR::Register *
-OMR::RegisterPair::setLowOrder(TR::Register *lo, TR::CodeGenerator *codeGen)
+OMR::RegisterPair::setLowOrder(TR::Register *lo, TR::CodeGenerator *cg)
    {
-   if (!lo->isLive() && codeGen->getLiveRegisters(lo->getKind())!=NULL)
-      codeGen->getLiveRegisters(lo->getKind())->addRegister(lo);
+   if (!lo->isLive() && cg->getLiveRegisters(lo->getKind())!=NULL)
+      cg->getLiveRegisters(lo->getKind())->addRegister(lo);
 
    return (_lowOrder = lo);
    }
@@ -75,10 +75,10 @@ OMR::RegisterPair::getHighOrder()
    }
 
 TR::Register *
-OMR::RegisterPair::setHighOrder(TR::Register *ho, TR::CodeGenerator *codeGen)
+OMR::RegisterPair::setHighOrder(TR::Register *ho, TR::CodeGenerator *cg)
    {
-   if (!ho->isLive() && codeGen->getLiveRegisters(ho->getKind())!=NULL)
-      codeGen->getLiveRegisters(ho->getKind())->addRegister(ho);
+   if (!ho->isLive() && cg->getLiveRegisters(ho->getKind())!=NULL)
+      cg->getLiveRegisters(ho->getKind())->addRegister(ho);
 
    return (_highOrder = ho);
    }

--- a/compiler/codegen/OMRRegisterPair.hpp
+++ b/compiler/codegen/OMRRegisterPair.hpp
@@ -61,8 +61,8 @@ class OMR_EXTENSIBLE RegisterPair : public TR::Register
    virtual TR::Register     *getLowOrder();
    virtual TR::Register     *getHighOrder();
 
-   TR::Register     *setLowOrder(TR::Register *lo, TR::CodeGenerator *codeGen);
-   TR::Register     *setHighOrder(TR::Register *ho, TR::CodeGenerator *codeGen);
+   TR::Register     *setLowOrder(TR::Register *lo, TR::CodeGenerator *cg);
+   TR::Register     *setHighOrder(TR::Register *ho, TR::CodeGenerator *cg);
 
    virtual TR::Register     *getRegister();
    virtual TR::RegisterPair *getRegisterPair();

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -92,9 +92,9 @@ class Relocation
    /**dumps a trace of the internals - override as required */
    virtual void trace(TR::Compilation* comp);
 
-   virtual void addExternalRelocation(TR::CodeGenerator *codeGen) {}
+   virtual void addExternalRelocation(TR::CodeGenerator *cg) {}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelocation : public TR::Relocation
@@ -118,7 +118,7 @@ class LabelRelative8BitRelocation : public TR::LabelRelocation
    LabelRelative8BitRelocation() : TR::LabelRelocation() {}
    LabelRelative8BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative12BitRelocation : public TR::LabelRelocation
@@ -129,7 +129,7 @@ class LabelRelative12BitRelocation : public TR::LabelRelocation
    LabelRelative12BitRelocation(uint8_t *p, TR::LabelSymbol *l, bool isCheckDisp = true)
       : TR::LabelRelocation(p, l), _isCheckDisp(isCheckDisp) {}
    bool isCheckDisp() {return _isCheckDisp;}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 
@@ -155,7 +155,7 @@ class LabelRelative16BitRelocation : public TR::LabelRelocation
    int8_t getAddressDifferenceDivisor()  {return _addressDifferenceDivisor;}
    int8_t setAddressDifferenceDivisor(int8_t d) {return (_addressDifferenceDivisor = d);}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative24BitRelocation : public TR::LabelRelocation
@@ -164,7 +164,7 @@ class LabelRelative24BitRelocation : public TR::LabelRelocation
    LabelRelative24BitRelocation() : TR::LabelRelocation() {}
    LabelRelative24BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 class LabelRelative32BitRelocation : public TR::LabelRelocation
@@ -173,7 +173,7 @@ class LabelRelative32BitRelocation : public TR::LabelRelocation
    LabelRelative32BitRelocation() : TR::LabelRelocation() {}
    LabelRelative32BitRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 /** \brief
@@ -256,7 +256,7 @@ class LabelAbsoluteRelocation : public TR::LabelRelocation
    LabelAbsoluteRelocation() : TR::LabelRelocation() {}
    LabelAbsoluteRelocation(uint8_t *p, TR::LabelSymbol *l)
       : TR::LabelRelocation(p, l) {}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
    };
 
 
@@ -278,8 +278,8 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
                                   _full(false),
                                   _kind(TR_ConstantPool) {}
 
-   IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
-   IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *codeGen);
+   IteratedExternalRelocation(uint8_t *target, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg);
+   IteratedExternalRelocation(uint8_t *target, uint8_t *target2, TR_ExternalRelocationTargetKind k, flags8_t modifier, TR::CodeGenerator *cg);
 
    uint32_t getNumberOfRelocationSites() {return _numberOfRelocationSites;}
    uint32_t setNumberOfRelocationSites(uint32_t s)
@@ -296,7 +296,7 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
    uint8_t *getRelocationDataCursor()           {return _relocationDataCursor;}
    uint8_t *setRelocationDataCursor(uint8_t *p) {return (_relocationDataCursor = p);}
 
-   void initializeRelocation(TR::CodeGenerator * codeGen);
+   void initializeRelocation(TR::CodeGenerator * cg);
    void addRelocationEntry(uint32_t locationOffset);
 
    uint16_t getSizeOfRelocationData()             {return _sizeOfRelocationData;}
@@ -380,7 +380,7 @@ class ExternalRelocation : public TR::Relocation
    ExternalRelocation(uint8_t                        *p,
                       uint8_t                        *target,
                       TR_ExternalRelocationTargetKind kind,
-                      TR::CodeGenerator *codeGen)
+                      TR::CodeGenerator *cg)
       : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(NULL),
@@ -392,7 +392,7 @@ class ExternalRelocation : public TR::Relocation
                       uint8_t                        *target,
                       uint8_t                        *target2,
                       TR_ExternalRelocationTargetKind  kind,
-                      TR::CodeGenerator *codeGen)
+                      TR::CodeGenerator *cg)
       : TR::Relocation(p),
         _targetAddress(target),
         _targetAddress2(target2),
@@ -413,12 +413,12 @@ class ExternalRelocation : public TR::Relocation
 
    void trace(TR::Compilation* comp);
 
-   void addExternalRelocation(TR::CodeGenerator *codeGen);
+   void addExternalRelocation(TR::CodeGenerator *cg);
    virtual uint8_t collectModifier();
    virtual uint32_t getNarrowSize() {return 2;}
    virtual uint32_t getWideSize() {return 4;}
 
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
 
    virtual bool isExternalRelocation() { return true; }
 
@@ -457,7 +457,7 @@ class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
                                       uint8_t *location2,
                                       uint8_t *target,
                                       TR_ExternalRelocationTargetKind  k,
-                                      TR::CodeGenerator *codeGen);
+                                      TR::CodeGenerator *cg);
 
    uint8_t *getLocation2() {return _update2Location;}
    void setLocation2(uint8_t *l) {_update2Location = l;}
@@ -465,7 +465,7 @@ class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
    virtual uint8_t collectModifier();
    virtual uint32_t getNarrowSize() {return 4;}
    virtual uint32_t getWideSize() {return 8;}
-   virtual void apply(TR::CodeGenerator *codeGen);
+   virtual void apply(TR::CodeGenerator *cg);
 
    private:
    uint8_t                         *_update2Location;
@@ -484,8 +484,8 @@ class BeforeBinaryEncodingExternalRelocation : public TR::ExternalRelocation
    BeforeBinaryEncodingExternalRelocation(TR::Instruction *instr,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
-                                          TR::CodeGenerator *codeGen)
-      : TR::ExternalRelocation(NULL, target, kind, codeGen),
+                                          TR::CodeGenerator *cg)
+      : TR::ExternalRelocation(NULL, target, kind, cg),
         _instruction(instr)
          {}
 
@@ -493,8 +493,8 @@ class BeforeBinaryEncodingExternalRelocation : public TR::ExternalRelocation
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
-                                          TR::CodeGenerator *codeGen)
-      : TR::ExternalRelocation(NULL, target, target2, kind, codeGen),
+                                          TR::CodeGenerator *cg)
+      : TR::ExternalRelocation(NULL, target, target2, kind, cg),
         _instruction(instr)
          {}
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -4457,7 +4457,7 @@ OMR::Node::unsetRegister()
 
 
 int32_t
-OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
+OMR::Node::getEvaluationPriority(TR::CodeGenerator * cg)
    {
    if (_unionA._register == 0) // not evaluated into register & priority unknown
       {
@@ -4466,7 +4466,7 @@ OMR::Node::getEvaluationPriority(TR::CodeGenerator * codeGen)
       // This way we don't need to resort to visit counts
       self()->setEvaluationPriority(0); // FIXME: remove this once we have
       // dealt with the issue of cycles in nodes
-      return self()->setEvaluationPriority(codeGen->getEvaluationPriority(self()));
+      return self()->setEvaluationPriority(cg->getEvaluationPriority(self()));
       }
    if ((uintptr_t)(_unionA._register) & 1) // evaluation priority
       return static_cast<int32_t>(reinterpret_cast<uintptr_t>(_unionA._register) >> 1);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -844,7 +844,7 @@ public:
    TR::Register *  setRegister(TR::Register *reg);
    void *          unsetRegister();
 
-   int32_t         getEvaluationPriority(TR::CodeGenerator *codeGen);
+   int32_t         getEvaluationPriority(TR::CodeGenerator *cg);
    int32_t         setEvaluationPriority(int32_t p);
 
    /**

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -68,14 +68,14 @@ class PPCAlignmentNopInstruction : public TR::Instruction
       }
 
 public:
-   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen)
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg)
       {
       setAlignment(alignment);
       }
 
-   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen)
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg)
       {
       setAlignment(alignment);
       }
@@ -103,43 +103,43 @@ public:
    // 3. Has a specified preceding instruction, or it does not.
 
    //Without relocation types here.
-   PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+   PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t       imm,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
       {
       }
 
    //With relocation types here.
    PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
+                        TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
       setNeedsAOTRelocation(true);
       }
 
    //With relocation types and associated symbol references here.
    PPCImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
+                        TR::SymbolReference *sr, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
       }
 
    PPCImmInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, uint32_t bf = 0)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
+                        TR::SymbolReference *sr, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, uint32_t bf = 0)
+      : TR::Instruction(op, n, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
       setNeedsAOTRelocation(true);
       }
@@ -175,14 +175,14 @@ class PPCImm2Instruction : public PPCImmInstruction
 
    public:
 
-   PPCImm2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, uint32_t imm2, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, codeGen), _sourceImmediate2(imm2)
+   PPCImm2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm, uint32_t imm2, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, cg), _sourceImmediate2(imm2)
       {
       }
 
    PPCImm2Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, uint32_t       imm, uint32_t imm2,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, precedingInstruction, codeGen), _sourceImmediate2(imm2)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, precedingInstruction, cg), _sourceImmediate2(imm2)
       {
       }
 
@@ -201,15 +201,15 @@ class PPCSrc1Instruction : public PPCImmInstruction
    public:
 
    PPCSrc1Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Register   *sreg,
-                         uint32_t       imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, precedingInstruction, codeGen),
+                         uint32_t       imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, precedingInstruction, cg),
         _source1Register(sreg)
       {
       useRegister(sreg);
       }
 
-   PPCSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register *sreg, uint32_t imm, TR::CodeGenerator *codeGen)
-      : PPCImmInstruction(op, n, imm, codeGen), _source1Register(sreg)
+   PPCSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register *sreg, uint32_t imm, TR::CodeGenerator *cg)
+      : PPCImmInstruction(op, n, imm, cg), _source1Register(sreg)
       {
       useRegister(sreg);
       }
@@ -242,21 +242,21 @@ class PPCDepInstruction : public TR::Instruction
    public:
 
    PPCDepInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n,
-      TR::RegisterDependencyConditions *cond, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _conditions(cond)
+      TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _conditions(cond)
       {
       if( op != TR::InstOpCode::assocreg )
-         cond->bookKeepingRegisterUses(this, codeGen);
+         cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepInstruction(TR::InstOpCode::Mnemonic                       op,
                         TR::Node                            *n,
                         TR::RegisterDependencyConditions *cond,
-                        TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _conditions(cond)
+                        TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _conditions(cond)
       {
       if( op != TR::InstOpCode::assocreg )
-         cond->bookKeepingRegisterUses(this, codeGen);
+         cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDep; }
@@ -300,8 +300,8 @@ class PPCLabelInstruction : public TR::Instruction
 
    public:
 
-   PPCLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _symbol(sym)
+   PPCLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _symbol(sym)
       {
       if (sym!=NULL && op==TR::InstOpCode::label)
          sym->setInstruction(this);
@@ -310,8 +310,8 @@ class PPCLabelInstruction : public TR::Instruction
       }
 
    PPCLabelInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                          TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _symbol(sym)
+                          TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _symbol(sym)
       {
       if (sym!=NULL && op==TR::InstOpCode::label)
          sym->setInstruction(this);
@@ -348,21 +348,21 @@ class PPCDepLabelInstruction : public PPCLabelInstruction
    PPCDepLabelInstruction(TR::InstOpCode::Mnemonic                       op,
                              TR::Node                            *n,
                              TR::LabelSymbol                      *sym,
-                             TR::RegisterDependencyConditions *cond, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditions(cond)
+                             TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, cg), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepLabelInstruction(TR::InstOpCode::Mnemonic                        op,
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::RegisterDependencyConditions  *cond,
-                             TR::Instruction             *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                             TR::Instruction             *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDepLabel; }
@@ -411,8 +411,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
    public:
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                                      TR::Register    *cr, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditionRegister(cr),
+                                      TR::Register    *cr, TR::CodeGenerator *cg, bool likeliness)
+      : PPCLabelInstruction(op, n, sym, cg), _conditionRegister(cr),
         _estimatedBinaryLocation(0),  _farRelocation(false),_exceptBranch(false),
         _haveHint(true),  _likeliness(likeliness)
       {
@@ -420,8 +420,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
       }
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
-                                      TR::Register    *cr, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, codeGen), _conditionRegister(cr),
+                                      TR::Register    *cr, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, cg), _conditionRegister(cr),
         _estimatedBinaryLocation(0),  _farRelocation(false),_exceptBranch(false),
         _haveHint(false), _likeliness(false)
       {
@@ -430,8 +430,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
                                       TR::Register    *cr,
-                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, bool likeliness)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditionRegister(cr), _estimatedBinaryLocation(0),_exceptBranch(false),
         _farRelocation(false), _haveHint(true), _likeliness(likeliness)
       {
@@ -440,8 +440,8 @@ class PPCConditionalBranchInstruction : public PPCLabelInstruction
 
    PPCConditionalBranchInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::LabelSymbol *sym,
                                       TR::Register    *cr,
-                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen),
+                                      TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCLabelInstruction(op, n, sym, precedingInstruction, cg),
         _conditionRegister(cr), _estimatedBinaryLocation(0),_exceptBranch(false),
         _farRelocation(false), _haveHint(false), _likeliness(false)
       {
@@ -495,10 +495,10 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::Register                         *cr,
-                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, codeGen, likeliness), _conditions(cond)
+                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg, bool likeliness)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, cg, likeliness), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -506,10 +506,10 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::Node                             *n,
                              TR::LabelSymbol                       *sym,
                              TR::Register                         *cr,
-                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *codeGen)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, codeGen), _conditions(cond)
+                             TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, cg), _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -518,11 +518,11 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::LabelSymbol                      *sym,
                              TR::Register                        *cr,
                              TR::RegisterDependencyConditions *cond,
-                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen, bool likeliness)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, codeGen, likeliness),
+                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg, bool likeliness)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, cg, likeliness),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCDepConditionalBranchInstruction(
@@ -531,11 +531,11 @@ class PPCDepConditionalBranchInstruction : public PPCConditionalBranchInstructio
                              TR::LabelSymbol                      *sym,
                              TR::Register                        *cr,
                              TR::RegisterDependencyConditions *cond,
-                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, codeGen),
+                             TR::Instruction                     *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCConditionalBranchInstruction(op, n, sym, cr, precedingInstruction, cg),
         _conditions(cond)
       {
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsDepConditionalBranch; }
@@ -578,12 +578,12 @@ class PPCAdminInstruction : public TR::Instruction
 
    public:
 
-   PPCAdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Node * fenceNode, TR::CodeGenerator *codeGen) :
-      TR::Instruction(op, n, codeGen), _fenceNode(fenceNode) {}
+   PPCAdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Node * fenceNode, TR::CodeGenerator *cg) :
+      TR::Instruction(op, n, cg), _fenceNode(fenceNode) {}
 
    PPCAdminInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Node *fenceNode,
-                          TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen) :
-      TR::Instruction(op, n, precedingInstruction, codeGen), _fenceNode(fenceNode) {}
+                          TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
+      TR::Instruction(op, n, precedingInstruction, cg), _fenceNode(fenceNode) {}
 
    virtual Kind getKind() { return IsAdmin; }
 
@@ -609,8 +609,8 @@ class PPCDepImmSymInstruction : public PPCDepInstruction
                               uintptr_t                           imm,
                               TR::RegisterDependencyConditions *cond,
                               TR::SymbolReference                 *sr,
-                              TR::Snippet                         *s, TR::CodeGenerator *codeGen)
-      : PPCDepInstruction(op, n, cond, codeGen), _addrImmediate(imm), _symbolReference(sr),
+                              TR::Snippet                         *s, TR::CodeGenerator *cg)
+      : PPCDepInstruction(op, n, cond, cg), _addrImmediate(imm), _symbolReference(sr),
         _snippet(s) {}
 
    PPCDepImmSymInstruction(
@@ -620,8 +620,8 @@ class PPCDepImmSymInstruction : public PPCDepInstruction
                               TR::RegisterDependencyConditions *cond,
                               TR::SymbolReference                 *sr,
                               TR::Snippet                         *s,
-                              TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCDepInstruction(op, n, cond, precedingInstruction, codeGen),
+                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCDepInstruction(op, n, cond, precedingInstruction, cg),
         _addrImmediate(imm), _symbolReference(sr), _snippet(s) {}
 
    virtual Kind getKind() { return IsDepImmSym; }
@@ -649,15 +649,15 @@ class PPCTrg1Instruction : public TR::Instruction
 
    public:
 
-   PPCTrg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *reg, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen), _target1Register(reg)
+   PPCTrg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *reg, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg), _target1Register(reg)
       {
       useRegister(reg);
       }
 
    PPCTrg1Instruction(TR::InstOpCode::Mnemonic  op, TR::Node * n, TR::Register *reg,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen), _target1Register(reg)
+                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg), _target1Register(reg)
       {
       useRegister(reg);
       }
@@ -695,13 +695,13 @@ class PPCTrg1ImmInstruction : public PPCTrg1Instruction
    public:
 
    PPCTrg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
-                            uint32_t     imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Instruction(op, n, treg, codeGen), _sourceImmediate(imm) {};
+                            uint32_t     imm, TR::CodeGenerator *cg)
+           : PPCTrg1Instruction(op, n, treg, cg), _sourceImmediate(imm) {};
 
    PPCTrg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register  *treg,
                             uint32_t       imm,
-                            TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Instruction(op, n, treg, precedingInstruction, codeGen), _sourceImmediate(imm) {};
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Instruction(op, n, treg, precedingInstruction, cg), _sourceImmediate(imm) {};
 
    virtual Kind getKind() { return IsTrg1Imm; }
 
@@ -722,11 +722,11 @@ class PPCSrc2Instruction : public TR::Instruction
    public:
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register   *s1reg,
-                         TR::Register   *s2reg, TR::CodeGenerator *codeGen);
+                         TR::Register   *s2reg, TR::CodeGenerator *cg);
 
    PPCSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register   *s1reg,
                          TR::Register    *s2reg,
-                         TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsSrc2; }
 
@@ -804,11 +804,11 @@ class PPCTrg1Src1Instruction : public PPCTrg1Instruction
    public:
 
    PPCTrg1Src1Instruction(TR::InstOpCode::Mnemonic op,  TR::Node * n, TR::Register   *treg,
-                             TR::Register   *sreg, TR::CodeGenerator *codeGen);
+                             TR::Register   *sreg, TR::CodeGenerator *cg);
 
    PPCTrg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node * n,  TR::Register   *treg,
                              TR::Register    *sreg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsTrg1Src1; }
 
@@ -839,37 +839,37 @@ class PPCTrg1Src1ImmInstruction : public PPCTrg1Src1Instruction
    public:
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
-                                TR::Register    *sreg, uintptr_t imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, codeGen),
+                                TR::Register    *sreg, uintptr_t imm, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, cg),
              _source1Immediate(imm) {};
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
                                 TR::Register    *sreg, uintptr_t imm,
-                                TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, codeGen),
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, cg),
              _source1Immediate(imm) {};
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
-                                TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, codeGen),
+                                TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, cg),
              _source1Immediate(imm)
       {
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    PPCTrg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register    *treg,
                                 TR::Register *sreg, TR::Register *cr0reg, uintptr_t imm,
-                                TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, codeGen),
+                                TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1Instruction(op, n, treg, sreg, precedingInstruction, cg),
              _source1Immediate(imm)
       {
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsTrg1Src1Imm; }
@@ -898,8 +898,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *sreg,
                                  uint32_t       imm,
                                  uint64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, precedingInstruction, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -907,8 +907,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *treg,
                                  TR::Register    *sreg,
                                  uint32_t       imm,
-                                 uint64_t       m, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, codeGen),
+                                 uint64_t       m, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, imm, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -917,8 +917,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *sreg,
                                  TR::Register    *cr0reg,
                                  uint32_t       imm,
-                                 uint64_t       m, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, codeGen),
+                                 uint64_t       m, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, cg),
              _mask(m) {}
 
    PPCTrg1Src1Imm2Instruction(TR::InstOpCode::Mnemonic  op,
@@ -928,8 +928,8 @@ class PPCTrg1Src1Imm2Instruction : public PPCTrg1Src1ImmInstruction
                                  TR::Register    *cr0reg,
                                  uint32_t       imm,
                                  uint64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+           : PPCTrg1Src1ImmInstruction(op, n, treg, sreg, cr0reg, imm, precedingInstruction, cg),
              _mask(m) {}
 
    virtual Kind getKind() { return IsTrg1Src1Imm2; }
@@ -953,8 +953,8 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Node       *n,
                               TR::Register   *treg,
                               TR::Register   *s1reg,
-                              TR::Register   *s2reg, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, codeGen), _source2Register(s2reg)
+                              TR::Register   *s2reg, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, cg), _source2Register(s2reg)
       {
       useRegister(s2reg);
       }
@@ -964,8 +964,8 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Register   *treg,
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, codeGen),
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
       useRegister(s2reg);
@@ -977,15 +977,15 @@ class PPCTrg1Src2Instruction : public PPCTrg1Src1Instruction
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
                               TR::Register   *cr0reg,
-                             TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, codeGen),
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src1Instruction(op, n, treg, s1reg, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
       useRegister(s2reg);
-      TR::RegisterDependencyConditions *cond = new (codeGen->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, codeGen->trMemory() );
+      TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions( 0, 1, cg->trMemory() );
       cond->addPostCondition(cr0reg, TR::RealRegister::cr0, DefinesDependentRegister );
       setDependencyConditions( cond );
-      cond->bookKeepingRegisterUses(this, codeGen);
+      cond->bookKeepingRegisterUses(this, cg);
       }
 
    virtual Kind getKind() { return IsTrg1Src2; }
@@ -1021,8 +1021,8 @@ class PPCTrg1Src2ImmInstruction : public PPCTrg1Src2Instruction
                                  TR::Register   *treg,
                                  TR::Register   *s1reg,
                                  TR::Register   *s2reg,
-                                 int64_t       m, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, codeGen),
+                                 int64_t       m, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, cg),
       _mask(m) {}
 
    PPCTrg1Src2ImmInstruction( TR::InstOpCode::Mnemonic op,
@@ -1031,8 +1031,8 @@ class PPCTrg1Src2ImmInstruction : public PPCTrg1Src2Instruction
                                  TR::Register   *s1reg,
                                  TR::Register   *s2reg,
                                  int64_t       m,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, codeGen),
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, cg),
       _mask(m) {}
 
    virtual Kind getKind() { return IsTrg1Src2Imm; }
@@ -1056,8 +1056,8 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
                               TR::Register   *treg,
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
-                              TR::Register   *s3reg, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, codeGen), _source3Register(s3reg)
+                              TR::Register   *s3reg, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, cg), _source3Register(s3reg)
       {
       useRegister(s3reg);
       }
@@ -1068,8 +1068,8 @@ class PPCTrg1Src3Instruction : public PPCTrg1Src2Instruction
                               TR::Register   *s1reg,
                               TR::Register   *s2reg,
                               TR::Register   *s3reg,
-                              TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, codeGen),
+                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, precedingInstruction, cg),
                              _source3Register(s3reg)
       {
       useRegister(s3reg);
@@ -1150,13 +1150,13 @@ class PPCMemSrc1Instruction : public PPCMemInstruction
    PPCMemSrc1Instruction(TR::InstOpCode::Mnemonic op,
                             TR::Node *n,
                             TR::MemoryReference *mf,
-                            TR::Register *sreg, TR::CodeGenerator *codeGen);
+                            TR::Register *sreg, TR::CodeGenerator *cg);
 
    PPCMemSrc1Instruction(TR::InstOpCode::Mnemonic op,
                             TR::Node *n,
                             TR::MemoryReference *mf,
                             TR::Register *sreg,
-                            TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen);
+                            TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
    virtual Kind getKind() { return IsMemSrc1; }
 
@@ -1227,13 +1227,13 @@ class PPCTrg1MemInstruction : public PPCTrg1Instruction
    PPCTrg1MemInstruction(TR::InstOpCode::Mnemonic          op,
                             TR::Node                *n,
                             TR::Register            *treg,
-                            TR::MemoryReference *mf, TR::CodeGenerator *codeGen, int32_t hint = PPCOpProp_NoHint);
+                            TR::MemoryReference *mf, TR::CodeGenerator *cg, int32_t hint = PPCOpProp_NoHint);
 
    PPCTrg1MemInstruction(TR::InstOpCode::Mnemonic          op,
                             TR::Node                *n,
                             TR::Register            *treg,
                             TR::MemoryReference *mf,
-                            TR::Instruction         *precedingInstruction, TR::CodeGenerator *codeGen, int32_t hint = PPCOpProp_NoHint);
+                            TR::Instruction         *precedingInstruction, TR::CodeGenerator *cg, int32_t hint = PPCOpProp_NoHint);
 
    virtual Kind getKind() { return IsTrg1Mem; }
 
@@ -1351,28 +1351,28 @@ class PPCControlFlowInstruction : public TR::Instruction
    public:
 
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
-      TR::CodeGenerator *codeGen,
+      TR::CodeGenerator *cg,
       TR::RegisterDependencyConditions *deps=NULL,
       bool useRegPairForResult=false,
       bool useRegPairForCond=false)
-      : TR::Instruction(op, n, codeGen), _numSources(0), _numTargets(0), _label(NULL),
+      : TR::Instruction(op, n, cg), _numSources(0), _numTargets(0), _label(NULL),
         _opCode2(TR::InstOpCode::bad), _conditions(deps), _useRegPairForResult(useRegPairForResult),
         _useRegPairForCond(useRegPairForCond)
       {
-      if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
+      if (deps!=NULL) deps->bookKeepingRegisterUses(this, cg);
       }
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
       TR::Instruction *preceedingInstruction,
-      TR::CodeGenerator *codeGen,
+      TR::CodeGenerator *cg,
       TR::RegisterDependencyConditions *deps=NULL,
       bool useRegPairForResult=false,
       bool useRegPairForCond=false)
-      : TR::Instruction(op, n, preceedingInstruction, codeGen),
+      : TR::Instruction(op, n, preceedingInstruction, cg),
         _numSources(0), _numTargets(0), _label(NULL), _opCode2(TR::InstOpCode::bad),
         _conditions(deps), _useRegPairForResult(useRegPairForResult),
          _useRegPairForCond(useRegPairForCond)
       {
-      if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
+      if (deps!=NULL) deps->bookKeepingRegisterUses(this, cg);
       }
 
    bool useRegPairForResult() { return _useRegPairForResult; }
@@ -1461,16 +1461,16 @@ class PPCVirtualGuardNOPInstruction : public PPCDepLabelInstruction
                                     TR_VirtualGuardSite     *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                  *label,
-                                    TR::CodeGenerator               *codeGen)
-      : PPCDepLabelInstruction(TR::InstOpCode::vgnop, node, label, cond, codeGen), _site(site) {}
+                                    TR::CodeGenerator               *cg)
+      : PPCDepLabelInstruction(TR::InstOpCode::vgnop, node, label, cond, cg), _site(site) {}
 
    PPCVirtualGuardNOPInstruction(TR::Node                        *node,
                                     TR_VirtualGuardSite     *site,
                                     TR::RegisterDependencyConditions *cond,
                                     TR::LabelSymbol                  *label,
                                     TR::Instruction                 *precedingInstruction,
-                                    TR::CodeGenerator               *codeGen)
-      : PPCDepLabelInstruction(TR::InstOpCode::vgnop, node, label, cond, precedingInstruction, codeGen), _site(site) {}
+                                    TR::CodeGenerator               *cg)
+      : PPCDepLabelInstruction(TR::InstOpCode::vgnop, node, label, cond, precedingInstruction, cg), _site(site) {}
 
    virtual Kind getKind() { return IsVirtualGuardNOP; }
 

--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -50,8 +50,8 @@ class RtypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::Register      *s1reg,
          TR::Register      *s2reg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _source2Register(s2reg)
@@ -67,8 +67,8 @@ class RtypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          TR::Register      *s2reg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _source2Register(s2reg)
@@ -181,9 +181,9 @@ class ItypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::Register      *s1reg,
          uint32_t          imm,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : TR::Instruction(op, n, codeGen),
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -198,8 +198,8 @@ class ItypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          uint32_t          imm,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -214,8 +214,8 @@ class ItypeInstruction : public TR::Instruction
             TR::Register      *s1reg,
             uint32_t          imm,
             TR::RegisterDependencyConditions *cond,
-            TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, codeGen),
+            TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -231,8 +231,8 @@ class ItypeInstruction : public TR::Instruction
             uint32_t          imm,
             TR::RegisterDependencyConditions *cond,
             TR::Instruction   *precedingInstruction,
-            TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, precedingInstruction, codeGen),
+            TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, precedingInstruction, cg),
         _target1Register(treg),
         _source1Register(s1reg),
         _imm(imm)
@@ -332,13 +332,13 @@ class LoadInstruction : public TR::Instruction
          TR::Node          *n,
          TR::Register      *treg,
          TR::MemoryReference *mr,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _memoryReference(mr)
       {
       useRegister(treg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    LoadInstruction(TR::InstOpCode::Mnemonic op,
@@ -346,16 +346,16 @@ class LoadInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::MemoryReference *mr,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _memoryReference(mr)
       {
       useRegister(treg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       // TODO: why incRegisterTotalUseCounts() here but not above?
       // This is how it's done in Aarch64. but could be wrong. Investigate.
-      //mr->incRegisterTotalUseCounts(codeGen);
+      //mr->incRegisterTotalUseCounts(cg);
       }
 
    /**
@@ -455,8 +455,8 @@ class StypeInstruction : public TR::Instruction
          TR::Register      *s1reg,
          TR::Register      *s2reg,
          uint32_t          imm,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _source1Register(s1reg),
         _source2Register(s2reg),
         _imm(imm)
@@ -471,8 +471,8 @@ class StypeInstruction : public TR::Instruction
          TR::Register      *s2reg,
          uint32_t          imm,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _source1Register(s1reg),
         _source2Register(s2reg),
         _imm(imm)
@@ -571,13 +571,13 @@ class StoreInstruction : public TR::Instruction
          TR::Node          *n,
          TR::MemoryReference *mr,
          TR::Register      *sreg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _source1Register(sreg),
         _memoryReference(mr)
       {
       useRegister(sreg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    StoreInstruction(TR::InstOpCode::Mnemonic op,
@@ -585,13 +585,13 @@ class StoreInstruction : public TR::Instruction
          TR::MemoryReference *mr,
          TR::Register      *sreg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _source1Register(sreg),
         _memoryReference(mr)
       {
       useRegister(sreg);
-      mr->bookKeepingRegisterUses(this, codeGen);
+      mr->bookKeepingRegisterUses(this, cg);
       }
 
    /**
@@ -787,8 +787,8 @@ class UtypeInstruction : public TR::Instruction
          TR::Node          *n,
          uint32_t          imm,
          TR::Register      *treg,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -800,8 +800,8 @@ class UtypeInstruction : public TR::Instruction
          uint32_t          imm,
          TR::Register      *treg,
          TR::RegisterDependencyConditions *cond,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -813,8 +813,8 @@ class UtypeInstruction : public TR::Instruction
          uint32_t          imm,
          TR::Register      *treg,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, precedingInstruction, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -827,8 +827,8 @@ class UtypeInstruction : public TR::Instruction
          TR::Register      *treg,
          TR::RegisterDependencyConditions *cond,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : TR::Instruction(op, n, cond, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : TR::Instruction(op, n, cond, precedingInstruction, cg),
         _target1Register(treg),
         _imm(imm)
       {
@@ -917,8 +917,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::RegisterDependencyConditions *cond,
          TR::SymbolReference *sr,
          TR::Snippet       *s,
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, cond, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, cond, cg),
         _symbolReference(sr),
         _symbol(nullptr),
         _snippet(s)
@@ -933,8 +933,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::SymbolReference *sr,
          TR::Snippet       *s,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, cg),
         _symbolReference(sr),
         _symbol(nullptr),
         _snippet(s)
@@ -945,9 +945,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::Node          *n,
          TR::Register      *treg,
          TR::LabelSymbol   *label,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -958,9 +958,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::Register      *treg,
          TR::LabelSymbol   *label,
          TR::RegisterDependencyConditions *cond,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -972,9 +972,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::LabelSymbol   *label,
          TR::Snippet       *snippet,
          TR::RegisterDependencyConditions *cond,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, cg),
         _symbolReference(nullptr),
         _symbol(label),
         _snippet(snippet)
@@ -986,8 +986,8 @@ class JtypeInstruction : public UtypeInstruction
          TR::Register      *treg,
          TR::LabelSymbol   *label,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
-      : UtypeInstruction(op, n, 0, treg, precedingInstruction, codeGen),
+         TR::CodeGenerator *cg)
+      : UtypeInstruction(op, n, 0, treg, precedingInstruction, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -999,9 +999,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::LabelSymbol   *label,
          TR::RegisterDependencyConditions *cond,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, cg),
         _symbolReference(nullptr),
         _symbol(label)
       {
@@ -1014,9 +1014,9 @@ class JtypeInstruction : public UtypeInstruction
          TR::Snippet       *snippet,
          TR::RegisterDependencyConditions *cond,
          TR::Instruction   *precedingInstruction,
-         TR::CodeGenerator *codeGen)
+         TR::CodeGenerator *cg)
 
-      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, codeGen),
+      : UtypeInstruction(op, n, 0, treg, cond, precedingInstruction, cg),
         _symbolReference(nullptr),
         _symbol(label),
         _snippet(snippet)

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -224,7 +224,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *minmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   typedef TR::Register *(* EvaluatorComputesCarry)(TR::Node *node, TR::CodeGenerator *codeGen, bool computesCarry);
+   typedef TR::Register *(* EvaluatorComputesCarry)(TR::Node *node, TR::CodeGenerator *cg, bool computesCarry);
    // routines for integers (or addresses) that can fit in one register
    // (see also the integerPair*Evaluator functions)
    static TR::Register *integerStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/X86FPConversionSnippet.hpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.hpp
@@ -42,12 +42,12 @@ class X86FPConversionSnippet : public TR::X86RestartSnippet
 
    public:
 
-   X86FPConversionSnippet(TR::CodeGenerator   *codeGen,
+   X86FPConversionSnippet(TR::CodeGenerator   *cg,
                           TR::Node            *node,
                           TR::LabelSymbol      *restartlab,
                           TR::LabelSymbol      *snippetlab,
                           TR::SymbolReference *helperSymRef)
-      : TR::X86RestartSnippet(codeGen, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
+      : TR::X86RestartSnippet(cg, node, restartlab, snippetlab, helperSymRef->canCauseGC()),
            _helperSymRef(helperSymRef)
       {
       // The code generation for this snippet does not allow a proper GC map
@@ -76,8 +76,8 @@ class X86FPConvertToIntSnippet  : public TR::X86FPConversionSnippet
                             TR::LabelSymbol            *snippetlab,
                             TR::SymbolReference       *helperSymRef,
                             TR::X86RegInstruction     *convertInstr,
-                            TR::CodeGenerator *codeGen)
-      : TR::X86FPConversionSnippet(codeGen, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
+                            TR::CodeGenerator *cg)
+      : TR::X86FPConversionSnippet(cg, convertInstr->getNode(), restartlab, snippetlab, helperSymRef),
            _convertInstruction(convertInstr) {}
 
    TR::X86RegInstruction  * getConvertInstruction() {return _convertInstruction;}
@@ -118,8 +118,8 @@ class X86FPConvertToLongSnippet  : public TR::X86FPConversionSnippet
                              TR::Node                           *node,
                              TR::X86RegMemInstruction           *loadHighInstr,
                              TR::X86RegMemInstruction           *loadLowInstr,
-                             TR::CodeGenerator *codeGen)
-      : TR::X86FPConversionSnippet(codeGen, node, restartlab, snippetlab, helperSymRef),
+                             TR::CodeGenerator *cg)
+      : TR::X86FPConversionSnippet(cg, node, restartlab, snippetlab, helperSymRef),
            _loadHighInstruction(loadHighInstr),
            _loadLowInstruction(loadLowInstr),
            _lowRegister(0),

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -100,8 +100,8 @@ extern bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGener
 // TR::S390Linkage member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
-   : OMR::Linkage(codeGen),
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * cg)
+   : OMR::Linkage(cg),
       _linkageType(TR_None), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
@@ -135,8 +135,8 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * convention.
  * Even though this method is common, its implementation is machine-specific.
  */
-OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_LinkageConventions lc)
-   : OMR::Linkage(codeGen),
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * cg,TR_LinkageConventions lc)
+   : OMR::Linkage(cg),
       _linkageType(lc), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
@@ -2149,12 +2149,12 @@ OMR::Z::Linkage::storeLongDoubleArgumentOnStack(TR::Node * callNode, TR::DataTyp
 int64_t
 OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
    TR::Register ** virtualRegPtr, TR::RealRegister::RegNum regNum,
-   TR::CodeGenerator * codeGen, bool isAllocate, bool isDummy)
+   TR::CodeGenerator * cg, bool isAllocate, bool isDummy)
    {
    TR::Register * depVirReg = deps->searchPostConditionRegister(regNum);
    if (depVirReg)
       {
-      if (*virtualRegPtr) codeGen->stopUsingRegister(*virtualRegPtr);
+      if (*virtualRegPtr) cg->stopUsingRegister(*virtualRegPtr);
       *virtualRegPtr = depVirReg;
       return killMask;
       }
@@ -2174,7 +2174,7 @@ OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyC
 
       deps->addPostCondition(*virtualRegPtr, regNum, DefinesDependentRegister);
       if (isAllocate)
-         codeGen->stopUsingRegister(*virtualRegPtr);
+         cg->stopUsingRegister(*virtualRegPtr);
 
       if (isDummy)
          {
@@ -2191,24 +2191,24 @@ OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyC
 int64_t
 OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
    TR::Register ** virtualRegPtr, TR::RealRegister* realReg,
-   TR::CodeGenerator * codeGen, bool isAllocate, bool isDummy)
+   TR::CodeGenerator * cg, bool isAllocate, bool isDummy)
    {
-   return self()->killAndAssignRegister(killMask, deps, virtualRegPtr, realReg->getRegisterNumber(), codeGen, isAllocate, isDummy );
+   return self()->killAndAssignRegister(killMask, deps, virtualRegPtr, realReg->getRegisterNumber(), cg, isAllocate, isDummy );
    }
 
 
-void OMR::Z::Linkage::generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * codeGen, TR::RegisterDependencyConditions * &deps,
+void OMR::Z::Linkage::generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * cg, TR::RegisterDependencyConditions * &deps,
       TR::Register * javaReturnRegister, bool hasGlRegDeps, TR::Node *GlobalRegDeps)
    {
    TR::LabelSymbol * endOfDirectToJNILabel = generateLabelSymbol(self()->cg());
    TR::RegisterDependencyConditions * postDeps = new (self()->trHeapMemory())
                TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), self()->cg());
 
-   generateS390LabelInstruction(codeGen, TR::InstOpCode::label, callNode, endOfDirectToJNILabel, postDeps);
+   generateS390LabelInstruction(cg, TR::InstOpCode::label, callNode, endOfDirectToJNILabel, postDeps);
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (codeGen->getSupportsRuntimeInstrumentation())
-      TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(codeGen, TR::InstOpCode::RION, callNode);
+   if (cg->getSupportsRuntimeInstrumentation())
+      TR::TreeEvaluator::generateRuntimeInstrumentationOnOffSequence(cg, TR::InstOpCode::RION, callNode);
 #endif
 
    callNode->setRegister(javaReturnRegister);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -332,13 +332,13 @@ enum TR_DispatchType
 
    int64_t killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
       TR::Register ** virtualReg, TR::RealRegister::RegNum regNum,
-      TR::CodeGenerator * codeGen, bool isAllocate=false, bool isDummy=false);
+      TR::CodeGenerator * cg, bool isAllocate=false, bool isDummy=false);
 
    int64_t killAndAssignRegister(int64_t killMask, TR::RegisterDependencyConditions * deps,
       TR::Register ** virtualReg, TR::RealRegister* realReg,
-      TR::CodeGenerator * codeGen, bool isAllocate=false, bool isDummy=false);
+      TR::CodeGenerator * cg, bool isAllocate=false, bool isDummy=false);
 
-   virtual void generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * codeGen,
+   virtual void generateDispatchReturnLable(TR::Node * callNode, TR::CodeGenerator * cg,
 			TR::RegisterDependencyConditions * &deps, TR::Register * javaReturnRegister,bool hasGlRegDeps, TR::Node *GlobalRegDeps);
    virtual TR::Register * buildNativeDispatch(TR::Node * callNode, TR_DispatchType dispatchType);
    virtual TR::Register * buildNativeDispatch(TR::Node * callNode, TR_DispatchType dispatchType,

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -403,10 +403,10 @@ TR::S390zLinuxSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethod
 void
 TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR::RegisterDependencyConditions* deps, intptr_t targetAddress, TR::Register* methodAddressReg, TR::Register* javaLitOffsetReg, TR::LabelSymbol* returnFromJNICallLabel, TR::Snippet* callDataSnippet, bool isJNIGCPoint)
    {
-   TR::CodeGenerator * codeGen = cg();
+   TR::CodeGenerator * cg = this->cg();
 
    TR::RegisterDependencyConditions * postDeps = new (trHeapMemory())
-      TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), cg());
+      TR::RegisterDependencyConditions(NULL, deps->getPostConditions(), 0, deps->getAddCursorForPost(), this->cg());
 
    TR::Register * systemReturnAddressRegister =
       deps->searchPostConditionRegister(getReturnAddressRegister());
@@ -420,15 +420,15 @@ TR::S390zLinuxSystemLinkage::generateInstructionsForCall(TR::Node* callNode, TR:
          {
          TR_ASSERT(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->isComputed(), "system linkage only supports computed indirect call for now %p\n", callNode);
          // get the address of the function descriptor
-         TR::Register *targetReg = codeGen->evaluate(callNode->getFirstChild());
-         generateRRInstruction(codeGen, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, targetReg, deps);
+         TR::Register *targetReg = cg->evaluate(callNode->getFirstChild());
+         generateRRInstruction(cg, TR::InstOpCode::BASR, callNode, systemReturnAddressRegister, targetReg, deps);
          }
       else
          {
          TR::SymbolReference *callSymRef = callNode->getSymbolReference();
          TR::Symbol *callSymbol = callSymRef->getSymbol();
          TR::Register * fpReg = systemReturnAddressRegister;
-         TR::Instruction * callInstr = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, codeGen);
+         TR::Instruction * callInstr = new (trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, fpReg, callSymbol, callSymRef, cg);
          callInstr->setDependencyConditions(deps);
          }
       }

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -404,7 +404,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
    generateInstructionsForCall(callNode, deps, targetAddress, methodAddressReg,
          javaLitOffsetReg, returnFromJNICallLabel, callDataSnippet, isJNIGCPoint);
 
-   TR::CodeGenerator * codeGen = cg();
+   TR::CodeGenerator * cg = this->cg();
 
    TR::Register * retReg = NULL;
    TR::Register * returnRegister = NULL;
@@ -442,11 +442,11 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
             lowReg = deps->searchPostConditionRegister(getLongLowReturnRegister());
             highReg = deps->searchPostConditionRegister(getLongHighReturnRegister());
 
-            generateRSInstruction(codeGen, TR::InstOpCode::SLLG, callNode, highReg, highReg, 32);
+            generateRSInstruction(cg, TR::InstOpCode::SLLG, callNode, highReg, highReg, 32);
             cursor =
-               generateRRInstruction(codeGen, TR::InstOpCode::LR, callNode, highReg, lowReg);
+               generateRRInstruction(cg, TR::InstOpCode::LR, callNode, highReg, lowReg);
 
-            codeGen->stopUsingRegister(lowReg);
+            cg->stopUsingRegister(lowReg);
             retReg = highReg;
             returnRegister = retReg;
             }
@@ -473,7 +473,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
 
    if (returnRegister != retReg)
       {
-      generateRRInstruction(codeGen, TR::InstOpCode::getLoadRegOpCode(), callNode, returnRegister, retReg);
+      generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), callNode, returnRegister, retReg);
       }
 
    return returnRegister;


### PR DESCRIPTION
Make naming of variables holding the `TR::CodeGenerator` object consistent by renaming variables named `codeGen` to `cg`

Closes: #5594