### PR TITLE
Remove callMustBeInlinedRegardlessOfSize

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4256,13 +4256,6 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
    return;
    }
 
-//return true if the call is dominated hot call
-bool TR_InlinerBase::callMustBeInlinedRegardlessOfSize(TR_CallSite *callsite)
-   {
-
-   return false;
-   }
-
 static bool traceIfMatchesPattern(TR::Compilation* comp)
    {
    static char* cRegex = feGetEnv ("TR_printIfRegex");
@@ -5505,10 +5498,7 @@ OMR_InlinerPolicy::callMustBeInlined(TR_CallTarget *calltarget)
 bool
 TR_InlinerBase::forceInline(TR_CallTarget *calltarget)
    {
-   if (getPolicy()->callMustBeInlined(calltarget) || callMustBeInlinedRegardlessOfSize(calltarget->_myCallSite))
-      return true;
-
-   return false;
+   return getPolicy()->callMustBeInlined(calltarget);
    }
 
 void TR_CallSite::tagcalltarget(int32_t index, TR_InlinerTracer *tracer, TR_InlinerFailureReason reason)

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -332,7 +332,6 @@ class TR_InlinerBase: public TR_HasRandomGenerator
       void getSymbolAndFindInlineTargets(TR_CallStack *, TR_CallSite *, bool findNewTargets=true);
 
       void applyPolicyToTargets(TR_CallStack *, TR_CallSite *);
-      bool callMustBeInlinedRegardlessOfSize(TR_CallSite *callsite);
 
       bool forceInline(TR_CallTarget *calltarget);
       bool forceVarInitInlining(TR_CallTarget *calltarget);


### PR DESCRIPTION
This commit removes callMustBeInlinedRegardlessOfSize and all its uses since it has no overriding implementations.

Closes: #6148