### PR TITLE
Fix various misspellings of "address"

### DIFF
--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -82,16 +82,16 @@ TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
                {
                //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
                //so we need to pass it to relocation in targetaddress2 for now
-               uint8_t * targetAdress2 = NULL;
+               uint8_t * targetAddress2 = NULL;
                if (getNode()->getOpCodeValue() != TR::aconst)
                   {
-                  targetAdress2 = reinterpret_cast<uint8_t *>(*(reinterpret_cast<uint64_t*>(cursor)));
+                  targetAddress2 = reinterpret_cast<uint8_t *>(*(reinterpret_cast<uint64_t*>(cursor)));
                   }
                cg()->addExternalRelocation(
                   TR::ExternalRelocation::create(
                      cursor,
                      reinterpret_cast<uint8_t *>(node),
-                     targetAdress2,
+                     targetAddress2,
                      reloType,
                      cg()),
                   __FILE__,

--- a/compiler/il/OMRStaticSymbol.hpp
+++ b/compiler/il/OMRStaticSymbol.hpp
@@ -45,7 +45,7 @@ namespace OMR
 {
 
 /**
- * A symbol with an adress
+ * A symbol with an address
  */
 class OMR_EXTENSIBLE StaticSymbol : public TR::Symbol
    {

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -297,19 +297,19 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
             //so we need to pass it to relocation in targetaddress2 for now
             //two instances where use this relotype in such way are: profile checkcast and arraystore check object check optimiztaions
-            uint8_t * targetAdress2 = NULL;
+            uint8_t * targetAddress2 = NULL;
             if (getNode()->getOpCodeValue() != TR::aconst)
                {
                if (cg()->comp()->target().is64Bit())
-                  targetAdress2 = (uint8_t *) *((uint64_t*) cursor);
+                  targetAddress2 = (uint8_t *) *((uint64_t*) cursor);
                else
-                  targetAdress2 = (uint8_t *) *((uintptr_t*) cursor);
+                  targetAddress2 = (uint8_t *) *((uintptr_t*) cursor);
                }
             cg()->addExternalRelocation(
                TR::ExternalRelocation::create(
                   cursor,
                   (uint8_t *) getNode(),
-                  targetAdress2,
+                  targetAddress2,
                   (TR_ExternalRelocationTargetKind) reloType,
                   cg()),
                __FILE__,

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -1645,7 +1645,7 @@ TEST(PortVmemTest, vmem_testReserveMemoryExTopDown)
 /**
  * See @ref omrvmem_testReserveMemoryEx_impl
  */
-TEST(PortVmemTest, vmem_testReserveMemoryExStrictAdress)
+TEST(PortVmemTest, vmem_testReserveMemoryExStrictAddress)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	if (memoryIsAvailable(OMRPORTLIB, TRUE)) {

--- a/jitbuilder/lljb/include/lljb/Compiler.hpp
+++ b/jitbuilder/lljb/include/lljb/Compiler.hpp
@@ -63,7 +63,7 @@ public:
 
    /**
     * @brief create a mapping between the llvm::Function in a module to
-    * the adress in the codecache with the compiled method
+    * the address in the codecache with the compiled method
     *
     * @param llvmFunc the llvm::Function *
     * @param entry the void *

--- a/port/ztpf/omrosdump_helpers.c
+++ b/port/ztpf/omrosdump_helpers.c
@@ -598,7 +598,7 @@ buildELFHeader(Elf64_Ehdr *buffer)
  * 0004 0004    p_flags        Phdr flags (permissions +OS_specific bits)<b>
  * 0008 0008    p_offset    Offset in file (0-relative) of memory image<b>
  * 0010 0008    p_vaddr        Virtual address of memory image @ run time<b>
- * 0018 0008    p_addr        Physical adress of memory image @ run time<b>
+ * 0018 0008    p_addr        Physical address of memory image @ run time<b>
  * 0020 0008    p_filesz    Size of memory image in file<b>
  * 0028 0008    p_memsz        Size of memory image in memory<b>
  * 0030    0008    p_align        Boundary to align to when loaded<b>


### PR DESCRIPTION
Fix a few occurrences of "address" being misspelled as "adress"

Closes: #6979