### PR TITLE
Restore VP unsafe shadow refinement

### DIFF
--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -128,7 +128,6 @@ OMR::AliasBuilder::createAliasInfo()
    nonIntPrimitiveStaticSymRefs().pack();
    methodSymRefs().pack();
    unsafeSymRefNumbers().pack();
-   unsafeArrayElementSymRefs().pack();
    gcSafePointSymRefNumbers().pack();
 
    setCatchLocalUseSymRefs();

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -35,6 +35,7 @@ namespace OMR { typedef OMR::ClassEnv ClassEnvConnector; }
 #include "infra/Annotations.hpp"
 #include "env/jittypes.h"
 #include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
 
 struct OMR_VMThread;
 namespace TR { class ClassEnv; }
@@ -102,6 +103,7 @@ public:
     */
    bool isZeroInitializable(TR_OpaqueClassBlock *clazz) { return true; }
    bool isPrimitiveArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
+   TR::DataTypes primitiveArrayComponentType(TR::Compilation *comp, TR_OpaqueClassBlock *) { return TR::NoType; }
    bool isReferenceArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
    bool isClassArray(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }
    bool isClassFinal(TR::Compilation *comp, TR_OpaqueClassBlock *) { return false; }

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -606,15 +606,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          if ((self()->isUnresolved() && !_symbol->isConstObjectRef()) || _symbol->isVolatile() || self()->isLiteralPoolAddress() || self()->isFromLiteralPool() ||
              (_symbol->isUnsafeShadowSymbol() && !self()->reallySharesSymbol()))
             {
-            if (symRefTab->aliasBuilder.unsafeArrayElementSymRefs().get(self()->getReferenceNumber()))
-               {
-               TR_BitVector *aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
-               *aliases |= comp->getSymRefTab()->aliasBuilder.defaultMethodDefAliasesWithoutImmutable();
-               *aliases -= symRefTab->aliasBuilder.cpSymRefs();
-               return aliases;
-               }
-            else
-               return &comp->getSymRefTab()->aliasBuilder.defaultMethodDefAliasesWithoutImmutable();
+            return &comp->getSymRefTab()->aliasBuilder.defaultMethodDefAliasesWithoutImmutable();
             }
 
          TR_BitVector *aliases = NULL;
@@ -752,11 +744,6 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
 
          if (aliases)
             aliases->set(self()->getReferenceNumber());
-
-         if (symRefTab->aliasBuilder.unsafeArrayElementSymRefs().get(self()->getReferenceNumber()))
-            *aliases -= symRefTab->aliasBuilder.cpSymRefs();
-         else if (symRefTab->aliasBuilder.cpSymRefs().get(self()->getReferenceNumber()))
-            *aliases -= symRefTab->aliasBuilder.unsafeArrayElementSymRefs();
 
          return aliases;
          }

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7243,40 +7243,6 @@ bool OMR::ValuePropagation::isUnreliableSignatureType(
    return false;
    }
 
-bool OMR::ValuePropagation::checkAllUnsafeReferences(TR::Node *node, vcount_t visitCount)
-   {
-   if (node->getVisitCount() == visitCount)
-      return true;
-
-   node->setVisitCount(visitCount);
-
-   if (node->getOpCode().hasSymbolReference() &&
-       node->getSymbol()->isUnsafeShadowSymbol())
-      {
-      if (_unsafeArrayAccessNodes->get(node->getGlobalIndex()))
-         {
-         comp()->getSymRefTab()->aliasBuilder.unsafeArrayElementSymRefs().set(node->getSymbolReference()->getReferenceNumber());
-         }
-      else
-         {
-         if (trace())
-            traceMsg(comp(), "Node is unsafe but not an array access %p \n", node);
-         return false;
-         }
-      }
-
-   int32_t childNum;
-   for (childNum=0; childNum < node->getNumChildren(); childNum++)
-      {
-      if (!checkAllUnsafeReferences(node->getChild(childNum), visitCount))
-         return false;
-      }
-
-   return true;
-   }
-
-
-
 void OMR::ValuePropagation::doDelayedTransformations()
    {
    ListIterator<TR_TreeTopNodePair> treesIt1(&_scalarizedArrayCopies);
@@ -8044,31 +8010,6 @@ void OMR::ValuePropagation::doDelayedTransformations()
       }
 
    _classesToCheckInit.setFirst(0);
-
-   comp()->getSymRefTab()->aliasBuilder.unsafeArrayElementSymRefs().empty();
-
-   if (!_unsafeArrayAccessNodes->isEmpty())
-      {
-      vcount_t visitCount = comp()->incVisitCount();
-      TR::TreeTop *curTree = comp()->getStartTree();
-      while (curTree)
-         {
-         if (curTree->getNode() &&
-            !checkAllUnsafeReferences(curTree->getNode(), visitCount))
-            {
-            comp()->getSymRefTab()->aliasBuilder.unsafeArrayElementSymRefs().empty();
-            break;
-            }
-         curTree = curTree->getNextTreeTop();
-         }
-      }
-
-   if (trace())
-      {
-      traceMsg(comp(), "Unsafe references that are only used to access array elements: ");
-      comp()->getSymRefTab()->aliasBuilder.unsafeArrayElementSymRefs().print(comp());
-      traceMsg(comp(), "\n");
-      }
    }
 
 TR_OpaqueClassBlock *OMR::ValuePropagation::findLikelySubtype(TR_OpaqueClassBlock *klass)

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -217,8 +217,6 @@ class ValuePropagation : public TR::Optimization
 
    TR_LinkHead<StoreRelationship> _storeRelationshipCache;
 
-   void addUnsafeArrayAccessNode(ncount_t index) { _unsafeArrayAccessNodes->set(index); }
-
    // Value constraint. This represents constraints applied to a particular
    // value number, and is represented by a linked list of relationships.
    //
@@ -878,8 +876,6 @@ class ValuePropagation : public TR::Optimization
    bool _enableVersionBlocks;
    bool _disableVersionBlockForThisBlock;
    TR::Block *_startEBB;
-
-   TR_BitVector *_unsafeArrayAccessNodes;
 
    // Blocks that are unreachable and can be removed.
    //

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -832,7 +832,7 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
 
       if (!performTransformation(
             comp,
-            "%sRefine unsafe shadow acess n%un [%p] to %s array shadow #%d\n",
+            "%sRefine unsafe shadow access n%un [%p] to %s array shadow #%d\n",
             OPT_DETAILS,
             node->getGlobalIndex(),
             node,
@@ -898,7 +898,7 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (!performTransformation(
          comp,
-         "%sRefine unsafe shadow acess n%un [%p] to field shadow #%d %.*s.%s %s\n",
+         "%sRefine unsafe shadow access n%un [%p] to field shadow #%d %.*s.%s %s\n",
          OPT_DETAILS,
          node->getGlobalIndex(),
          node,

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -41,10 +41,9 @@
 #include "env/ObjectModel.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/TRMemory.hpp"
+#include "env/TypeLayout.hpp"
 #include "env/jittypes.h"
-#ifdef J9_PROJECT_SPECIFIC
 #include "env/VMAccessCriticalSection.hpp"
-#endif
 #include "il/AliasSetInterface.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/Block.hpp"
@@ -667,33 +666,222 @@ static bool findConstant(OMR::ValuePropagation *vp, TR::Node *node)
    return false;
    }
 
-static bool containsUnsafeSymbolReference(OMR::ValuePropagation *vp, TR::Node *node)
+static bool refuseToConstrainUnsafe(
+   OMR::ValuePropagation *vp, TR::Node *node, const char *why)
    {
-   if (node->getSymbolReference()->isLitPoolReference())
-      return true;
-
-   if (node->getSymbolReference()->getSymbol()->isShadow())
+   if (vp->trace())
       {
-      if (node->getSymbol()->isUnsafeShadowSymbol())
-         {
-         if (vp->trace())
-            traceMsg(vp->comp(), "Node [%p] has an unsafe symbol reference %d, no constraint\n", node,
-                     node->getSymbolReference()->getReferenceNumber());
-         return true;
-         }
-
-
-      if (node->getSymbolReference() == vp->getSymRefTab()->findInstanceShapeSymbolRef() ||
-          node->getSymbolReference() == vp->getSymRefTab()->findInstanceDescriptionSymbolRef() ||
-          node->getSymbolReference() == vp->getSymRefTab()->findDescriptionWordFromPtrSymbolRef() ||
-#ifdef J9_PROJECT_SPECIFIC
-          node->getSymbolReference() == vp->getSymRefTab()->findClassFromJavaLangClassAsPrimitiveSymbolRef() ||
-#endif
-          (node->getSymbolReference()->getSymbol() == vp->comp()->getSymRefTab()->findGenericIntShadowSymbol()))
-         return true;
+      traceMsg(
+         vp->comp(),
+         "Refusing to constrain unsafe access n%un [%p]: %s\n",
+         node->getGlobalIndex(),
+         node,
+         why);
       }
 
-   return false;
+   return true;
+   }
+
+// Returns true to tell the handler to leave node unconstrained, or false to
+// allow it to keep constraining. When the result is false, node may have been
+// mutated.
+static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
+   {
+   const bool okToConstrainNormally = false;
+   TR::Compilation *comp = vp->comp();
+
+   TR::SymbolReference *symRef = node->getSymbolReference();
+   if (symRef->isLitPoolReference())
+      return refuseToConstrainUnsafe(vp, node, "literal pool reference");
+
+   TR::Symbol *sym = symRef->getSymbol();
+   if (!sym->isShadow())
+      return okToConstrainNormally;
+
+   if (symRef == vp->getSymRefTab()->findInstanceShapeSymbolRef()
+       || symRef == vp->getSymRefTab()->findInstanceDescriptionSymbolRef()
+       || symRef == vp->getSymRefTab()->findDescriptionWordFromPtrSymbolRef()
+#ifdef J9_PROJECT_SPECIFIC
+       || symRef == vp->getSymRefTab()->findClassFromJavaLangClassAsPrimitiveSymbolRef()
+#endif
+       || sym == comp->getSymRefTab()->findGenericIntShadowSymbol())
+      {
+      return refuseToConstrainUnsafe(vp, node, "special symref other than unsafe shadow");
+      }
+
+   if (!sym->isUnsafeShadowSymbol())
+      return okToConstrainNormally;
+
+   if (vp->trace())
+      {
+      traceMsg(
+         comp,
+         "Found unsafe shadow access n%un [%p]\n",
+         node->getGlobalIndex(),
+         node);
+      }
+
+   if (comp->compileRelocatableCode()
+       && !comp->getOption(TR_UseSymbolValidationManager))
+      {
+      return refuseToConstrainUnsafe(vp, node, "AOT without SVM");
+      }
+
+   if (symRef->getOffset() != 0)
+      return refuseToConstrainUnsafe(vp, node, "shadow symref has nonzero offset");
+
+   TR::Node *addr = node->getChild(0);
+   TR::ILOpCodes addrOp = addr->getOpCodeValue();
+   if (addrOp != TR::aladd && addrOp != TR::aiadd)
+      return refuseToConstrainUnsafe(vp, node, "address not from an offset op");
+
+   TR::Node *obj = addr->getChild(0);
+   bool objIsGlobal = false;
+   TR::VPConstraint *objConstraint = vp->getConstraint(obj, objIsGlobal);
+   if (objConstraint == NULL)
+      return refuseToConstrainUnsafe(vp, node, "unconstrained base object");
+
+   TR_OpaqueClassBlock *objClass = NULL;
+   if (objConstraint->isClassObject() != TR_yes)
+      {
+      objClass = objConstraint->getClass();
+      }
+   else
+      {
+      // objConstraint->getClass() is a bound on the *represented* class. If
+      // the base happens to be a known object, try to get its type that way.
+      TR::VPKnownObject *knownObj = objConstraint->getKnownObject();
+      if (knownObj != NULL)
+         {
+         TR::VMAccessCriticalSection getClassCriticalSection(
+            comp,
+            TR::VMAccessCriticalSection::tryToAcquireVMAccess);
+
+         if (getClassCriticalSection.hasVMAccess())
+            {
+            TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+            TR::KnownObjectTable::Index koi = knownObj->getIndex();
+            objClass = TR::Compiler->cls.objectClass(comp, knot->getPointer(koi));
+            }
+         else if (vp->trace())
+            {
+            traceMsg(comp, "Failed to get VM access\n");
+            }
+         }
+      }
+
+   if (objClass == NULL)
+      return refuseToConstrainUnsafe(vp, node, "unknown-type base object");
+
+   int32_t objClassSigLen = 0;
+   const char *objClassSig =
+      TR::VPResolvedClass::create(vp, objClass)->getClassSignature(objClassSigLen);
+
+   if (vp->trace())
+      {
+      traceMsg(
+         comp,
+         "Base object type is %p %.*s\n",
+         objClass,
+         objClassSigLen,
+         objClassSig);
+      }
+
+   TR::DataTypes nodeType = node->getOpCode().getDataType().getDataType();
+   TR::SymbolReferenceTable *srTab = comp->getSymRefTab();
+
+   if (TR::Compiler->cls.isClassArray(comp, objClass))
+      {
+      if (vp->trace())
+         traceMsg(comp, "Base object is an array\n");
+
+      TR::DataTypes elemType = TR::NoType;
+      if (TR::Compiler->cls.isPrimitiveArray(comp, objClass))
+         elemType = TR::Compiler->cls.primitiveArrayComponentType(comp, objClass);
+      else if (TR::Compiler->cls.isReferenceArray(comp, objClass))
+         elemType = TR::Address;
+
+      if (elemType == TR::NoType)
+         return refuseToConstrainUnsafe(vp, node, "unknown array component type");
+
+      if (elemType != nodeType)
+         {
+         static const bool dontRefineTypePun =
+            feGetEnv("TR_dontRefineUnsafeToTypePunnedArrayShadow") != NULL;
+
+         if (dontRefineTypePun)
+            return refuseToConstrainUnsafe(vp, node, "type-punned array access");
+         }
+
+      TR::SymbolReference *arrayShadow =
+         srTab->findOrCreateArrayShadowSymbolRef(elemType, obj);
+
+      if (!performTransformation(
+            comp,
+            "%sRefine unsafe shadow acess n%un [%p] to %s array shadow #%d\n",
+            OPT_DETAILS,
+            node->getGlobalIndex(),
+            node,
+            TR::DataType::getName(elemType),
+            arrayShadow->getReferenceNumber()))
+         return refuseToConstrainUnsafe(vp, node, "performTransformation denied");
+
+      node->setSymbolReference(arrayShadow);
+      return okToConstrainNormally;
+      }
+
+   const TR::TypeLayout *layout = comp->typeLayout(objClass);
+   if (layout == NULL)
+      return refuseToConstrainUnsafe(vp, node, "missing type layout");
+
+   TR::Node *offset = addr->getChild(1);
+   if (!offset->getOpCode().isLoadConst())
+      return refuseToConstrainUnsafe(vp, node, "non-constant offset");
+
+   int64_t offsetValueSigned = offset->getConstValue();
+   if (offsetValueSigned < 0)
+      return refuseToConstrainUnsafe(vp, node, "negative offset");
+
+   uint64_t offsetValue = (uint64_t)offsetValueSigned;
+   const TR::TypeLayoutEntry *field = NULL;
+   size_t i = 0;
+   for (; i < layout->count(); i++)
+      {
+      field = &layout->entry(i);
+      if (field->_offset == offsetValue && field->_datatype.getDataType() == nodeType)
+         break;
+      }
+
+   if (i >= layout->count())
+      return refuseToConstrainUnsafe(vp, node, "no matching field");
+
+   TR::SymbolReference *refinedSymRef = srTab->findOrFabricateShadowSymbol(
+      objClass,
+      field->_datatype,
+      field->_offset,
+      field->_isVolatile,
+      field->_isPrivate,
+      field->_isFinal,
+      field->_fieldname,
+      field->_typeSignature);
+
+   if (!performTransformation(
+         comp,
+         "%sRefine unsafe shadow acess n%un [%p] to field shadow #%d %.*s.%s %s\n",
+         OPT_DETAILS,
+         node->getGlobalIndex(),
+         node,
+         refinedSymRef->getReferenceNumber(),
+         objClassSigLen,
+         objClassSig,
+         field->_fieldname,
+         field->_typeSignature))
+      return refuseToConstrainUnsafe(vp, node, "performTransformation denied");
+
+   node->setSymbolReference(refinedSymRef);
+   node->setAndIncChild(0, obj);
+   addr->recursivelyDecReferenceCount();
+   return okToConstrainNormally;
    }
 
 static bool owningMethodDoesNotContainNullChecks(OMR::ValuePropagation *vp, TR::Node *node)
@@ -1336,38 +1524,6 @@ bool simplifyJ9ClassFlags(OMR::ValuePropagation *vp, TR::Node *node, bool isLong
    return false;
    }
 
-static void checkUnsafeArrayAccess(OMR::ValuePropagation *vp, TR::Node *node)
-   {
-      if (node->getSymbol()->isUnsafeShadowSymbol())
-         {
-         if (vp->trace())
-            traceMsg(vp->comp(), "Node [%p] has an unsafe symbol reference %d\n", node,
-                     node->getSymbolReference()->getReferenceNumber());
-
-         if (node->getFirstChild()->getOpCode().isArrayRef() &&
-             node->getFirstChild()->getFirstChild()->getOpCode().isRef())
-            {
-            TR::Node *baseAddress = node->getFirstChild()->getFirstChild();
-            bool isGlobal;
-            TR::VPConstraint *baseConstraint = vp->getConstraint(baseAddress, isGlobal);
-
-            if (baseConstraint &&
-                baseConstraint->getClassType() &&
-                baseConstraint->getClassType()->isArray())
-               {
-               if (vp->trace())
-                  traceMsg(vp->comp(), "is an array access\n");
-               vp->addUnsafeArrayAccessNode(node->getGlobalIndex());
-               }
-            else
-               {
-               if (vp->trace())
-                 traceMsg(vp->comp(), "is not an array access\n");
-               }
-            }
-         }
-   }
-
 // Also handles lloadi
 //
 TR::Node *constrainLload(OMR::ValuePropagation *vp, TR::Node *node)
@@ -1378,11 +1534,7 @@ TR::Node *constrainLload(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (node->getOpCode().isIndirect())
       {
-      checkUnsafeArrayAccess(vp, node);
-
-      // if the node contains an unsafe symbol reference
-      // then don't inject a constraint
-      if (containsUnsafeSymbolReference(vp, node))
+      if (refineUnsafeAccess(vp, node))
          return node;
 
       if (constrainCompileTimeLoad(vp, node))
@@ -1424,9 +1576,7 @@ TR::Node *constrainFload(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (node->getOpCode().isIndirect())
       {
-      // if the node contains an unsafe symbol reference
-      // then don't inject a constraint
-      if (containsUnsafeSymbolReference(vp, node))
+      if (refineUnsafeAccess(vp, node))
          return node;
       }
 
@@ -1446,11 +1596,7 @@ TR::Node *constrainDload(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (node->getOpCode().isIndirect())
       {
-      checkUnsafeArrayAccess(vp, node);
-
-      // if the node contains an unsafe symbol reference
-      // then don't inject a constraint
-      if (containsUnsafeSymbolReference(vp, node))
+      if (refineUnsafeAccess(vp, node))
          return node;
       }
 
@@ -1951,9 +2097,7 @@ TR::Node *constrainIiload(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   // if the node contains an unsafe symbol reference
-   // then don't inject a constraint
-   if (containsUnsafeSymbolReference(vp, node))
+   if (refineUnsafeAccess(vp, node))
       return node;
 
    if (constrainCompileTimeLoad(vp, node))
@@ -2023,9 +2167,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   // if the node contains an unsafe symbol reference
-   // then don't inject a constraint
-   if (containsUnsafeSymbolReference(vp, node))
+   if (refineUnsafeAccess(vp, node))
       return node;
 
    bool isGlobal;
@@ -2683,10 +2825,7 @@ TR::Node *constrainStore(OMR::ValuePropagation *vp, TR::Node *node)
          }
       }
 
-
-   // if the node contains an unsafe symbol reference
-   // then don't inject a constraint
-   if (containsUnsafeSymbolReference(vp, node) ||
+   if (refineUnsafeAccess(vp, node) ||
        (node->getSymbol()->isAutoOrParm() &&
         node->storedValueIsIrrelevant()))
       return node;
@@ -2873,9 +3012,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (node->getOpCode().isIndirect())
       {
-      // if the node contains an unsafe symbol reference
-      // then don't inject a constraint
-      if (containsUnsafeSymbolReference(vp, node))
+      if (refineUnsafeAccess(vp, node))
          return node;
       }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -712,6 +712,12 @@ static bool refineUnsafeAccess(OMR::ValuePropagation *vp, TR::Node *node)
    if (!sym->isUnsafeShadowSymbol())
       return okToConstrainNormally;
 
+   static const bool disable =
+      feGetEnv("TR_disableUnsafeShadowRefinement") != NULL;
+
+   if (disable)
+      return refuseToConstrainUnsafe(vp, node, "unsafe shadow refinement is disabled");
+
    if (vp->trace())
       {
       traceMsg(

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -364,8 +364,6 @@ void OMR::ValuePropagation::initialize()
          _startEBB = NULL;
          }
       }
-
-     _unsafeArrayAccessNodes = new (trStackMemory()) TR_BitVector(comp()->getNodeCount(), trMemory(), stackAlloc, growable);
    }
 
 OMR::ValuePropagation::Relationship *OMR::ValuePropagation::copyRelationships(Relationship *first)


### PR DESCRIPTION
Restore e69fc2b6d06bb13926bd6ccf1290a76357563142, which was reverted in c2ccbcae4ea8552bf7c64789ef252996774252da because it was causing failures in OpenJ9's OMR acceptance build (eclipse-openj9/openj9#17337).

It seems that the problem was that e69fc2b6d06bb13926bd6ccf1290a76357563142 could inadvertently change a volatile access into a non-volatile one. I've included a fix in this PR. I see similar sanity.openjdk failures in personal builds without the fix, and the failures disappear with the fix.

- Revert c2ccbcae4ea8552bf7c64789ef252996774252da
- Respect volatile when refining unsafe shadow *(aforementioned fix)*
- Allow disabling unsafe shadow refinement by environment variable
- Fix typo in performTransformation() messages in refineUnsafeAccess()