### PR TITLE
Add missing getter/setters

### DIFF
--- a/compiler/x/codegen/DataSnippet.hpp
+++ b/compiler/x/codegen/DataSnippet.hpp
@@ -41,7 +41,8 @@ class X86DataSnippet : public TR::Snippet
    uint8_t*                       getRawData()                             { return _data.data(); }
    virtual size_t                 getDataSize() const                      { return _data.size(); }
    virtual uint32_t               getLength(int32_t estimatedSnippetStart) { return static_cast<uint32_t>(getDataSize()); }
-   virtual bool                   setClassAddress(bool isClassAddress)     { return _isClassAddress = isClassAddress;}
+   bool                           isClassAddress()                         { return _isClassAddress; }
+   bool                           setClassAddress(bool isClassAddress)     { return _isClassAddress = isClassAddress;}
    template <typename T> inline T getData()                                { return *((T*)getRawData()); }
 
    virtual uint8_t*               emitSnippetBody();

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -1877,6 +1877,8 @@ class X86MemImmInstruction : public TR::X86MemInstruction
    virtual uint8_t  getBinaryLengthLowerBound();
 
    virtual void addMetaDataForCodeAddress(uint8_t *cursor);
+   int32_t getReloKind() { return _reloKind; }
+   void setReloKind(int32_t reloKind) { _reloKind = reloKind; }
    };
 
 


### PR DESCRIPTION
* _reloKind in X86MemImmInstruction
* _isClassAddress in DataSnippet
* Remove unnecessary `virtual` from setClassAddress()