### PR TITLE
Expand bytecode offset variables to 32bit

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -2344,7 +2344,7 @@ OMR::Block::addExceptionRangeForSnippet(uint32_t startPC, uint32_t endPC)
    }
 
 void
-OMR::Block::setHandlerInfo(uint32_t c, uint8_t d, uint16_t i, TR_ResolvedMethod * m, TR::Compilation *comp)
+OMR::Block::setHandlerInfo(uint32_t c, uint8_t d, int32_t i, TR_ResolvedMethod * m, TR::Compilation *comp)
    {
    self()->ensureCatchBlockExtensionExists(comp);
    TR_CatchBlockExtension *cbe = _catchBlockExtension;
@@ -2364,7 +2364,7 @@ OMR::Block::setHandlerInfo(uint32_t c, uint8_t d, uint16_t i, TR_ResolvedMethod 
    }
 
 void
-OMR::Block::setHandlerInfoWithOutBCInfo(uint32_t c, uint8_t d, uint16_t i, TR_ResolvedMethod * m, TR::Compilation *comp)
+OMR::Block::setHandlerInfoWithOutBCInfo(uint32_t c, uint8_t d, int32_t i, TR_ResolvedMethod * m, TR::Compilation *comp)
    {
    self()->ensureCatchBlockExtensionExists(comp);
    TR_CatchBlockExtension *cbe = _catchBlockExtension;
@@ -2396,7 +2396,7 @@ OMR::Block::getInlineDepth()
    return _catchBlockExtension->_inlineDepth;
    }
 
-uint16_t
+int32_t
 OMR::Block::getHandlerIndex()
    {
    TR_ASSERT(_catchBlockExtension, "catch block extension does not exist");

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -331,7 +331,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       uint32_t                              _catchType;
       TR_ResolvedMethod *                   _owningMethod;
       TR_ByteCodeInfo                       _byteCodeInfo;
-      uint16_t                              _handlerIndex;
+      int32_t                               _handlerIndex;
       uint8_t                               _inlineDepth;
       bool                                  _isSyntheticHandler; // indicate whether the exception handler is inserted by the compiler rather than existing in the source code
       };
@@ -339,13 +339,13 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    TR_CatchBlockExtension* getCatchBlockExtension()               { return _catchBlockExtension; }
    void setCatchBlockExtension(TR_CatchBlockExtension *extension) { _catchBlockExtension = extension; }
 
-   void setHandlerInfo(uint32_t c, uint8_t d, uint16_t i, TR_ResolvedMethod * m, TR::Compilation *comp);
-   void setHandlerInfoWithOutBCInfo(uint32_t c, uint8_t d, uint16_t i, TR_ResolvedMethod * m, TR::Compilation *comp); //also used for estimatecodesize dummy blocks
+   void setHandlerInfo(uint32_t c, uint8_t d, int32_t i, TR_ResolvedMethod * m, TR::Compilation *comp);
+   void setHandlerInfoWithOutBCInfo(uint32_t c, uint8_t d, int32_t i, TR_ResolvedMethod * m, TR::Compilation *comp); //also used for estimatecodesize dummy blocks
 
    bool                   isCatchBlock();
    uint32_t               getCatchType();
    uint8_t                getInlineDepth();
-   uint16_t               getHandlerIndex();
+   int32_t                getHandlerIndex();
    TR_ByteCodeInfo        getByteCodeInfo();
    TR_OpaqueClassBlock *  getExceptionClass();
    char *                 getExceptionClassNameChars();

--- a/compiler/ilgen/ByteCodeIterator.hpp
+++ b/compiler/ilgen/ByteCodeIterator.hpp
@@ -46,7 +46,7 @@ public:
       {
       void *operator new(size_t s, void *p) { return p; }
 
-      TryCatchInfo(uint16_t s, uint16_t e, uint16_t h, uint32_t c) :
+      TryCatchInfo(int32_t s, int32_t e, int32_t h, uint32_t c) :
          _startIndex(s),
          _endIndex(e),
          _handlerIndex(h),
@@ -57,7 +57,7 @@ public:
          {
          }
 
-      void initialize(uint16_t s, uint16_t e, uint16_t h, uint32_t c)
+      void initialize(int32_t s, int32_t e, int32_t h, uint32_t c)
          {
          _startIndex = s;
          _endIndex = e;
@@ -70,9 +70,9 @@ public:
          return _handlerIndex == o._handlerIndex && _catchType == o._catchType;
          }
 
-      uint16_t      _startIndex;
-      uint16_t      _endIndex;
-      uint16_t      _handlerIndex;
+      int32_t       _startIndex;
+      int32_t       _endIndex;
+      int32_t       _handlerIndex;
       uint32_t      _catchType;
       TR::Block    * _firstBlock;
       TR::Block    * _lastBlock;

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -375,10 +375,14 @@ TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block
       for (auto e = tryBlock->getExceptionSuccessors().begin(); e != tryBlock->getExceptionSuccessors().end(); ++e)
          {
          TR::Block * b = toBlock((*e)->getTo());
-         if (b->getHandlerIndex() >= handlerDim)
-            handlerDim = b->getHandlerIndex() + 1;
-         if (b->getInlineDepth() >= inlineDim)
-            inlineDim = b->getInlineDepth() + 1;
+         if (!b->isOSRCatchBlock())
+            {
+            TR_ASSERT(b->getHandlerIndex()!=-1, "exception handler index is not defined" );
+            if (b->getHandlerIndex() >= handlerDim)
+               handlerDim = b->getHandlerIndex() + 1;
+            if (b->getInlineDepth() >= inlineDim)
+               inlineDim = b->getInlineDepth() + 1;
+            }
          }
 
       _dim = handlerDim * inlineDim;
@@ -388,8 +392,11 @@ TR_OrderedExceptionHandlerIterator::TR_OrderedExceptionHandlerIterator(TR::Block
       for (auto e = tryBlock->getExceptionSuccessors().begin(); e != tryBlock->getExceptionSuccessors().end(); ++e)
          {
          TR::Block * b = toBlock((*e)->getTo());
-         TR_ASSERT((_handlers[((inlineDim - b->getInlineDepth() - 1) * handlerDim) + b->getHandlerIndex()] == NULL), "handler entry is not NULL\n");
-         _handlers[((inlineDim - b->getInlineDepth() - 1) * handlerDim) + b->getHandlerIndex()] = b;
+         if (!b->isOSRCatchBlock())
+            {
+            TR_ASSERT((_handlers[((inlineDim - b->getInlineDepth() - 1) * handlerDim) + b->getHandlerIndex()] == NULL), "handler entry is not NULL\n");
+            _handlers[((inlineDim - b->getInlineDepth() - 1) * handlerDim) + b->getHandlerIndex()] = b;
+            }
          }
       }
    }


### PR DESCRIPTION
A user experienced a compile time crash in setHandlerInfoWithOutBCInfo() because a bytecode index to a catch handler is above the 2^16th limit that normally applies for Java methods. This limit can be exceeded in rare cases after the JVM expands the method size on load. A good example of this would be when the VM inlines a "jsr" bytecode. Because the handler index is larger then 2^16th the offset is truncated when it is placed into the 16bit integer that we were using to record the offset. This fix will expand the size of variables used to hold bytecode offsets to be 32bits.