### PR TITLE
Migrate riscv cross-compiles to docker container

### DIFF
--- a/buildenv/docker/riscv64/debian11/Dockerfile
+++ b/buildenv/docker/riscv64/debian11/Dockerfile
@@ -1,0 +1,97 @@
+# Copyright IBM Corp. and others 2023
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+
+# Create the OMR build environment with Debian 11.7.
+
+FROM debian:11.7-slim AS base
+
+# Workaround for a hang during docker build.
+ENV TZ=America/Toronto
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y \
+	binfmt-support \
+        bison \
+	build-essential \
+        ccache \
+        cmake \
+        flex \
+	gcc-riscv64-linux-gnu \
+        gdb \
+        git \
+	g++-riscv64-linux-gnu \
+        libelf-dev \
+        libdwarf-dev \
+	libglib2.0-dev \
+	lsb-release \
+	mmdebstrap \
+        ninja-build \
+	pkg-config \
+        python3 \
+	qemu-user-static \
+	time \
+	tzdata \
+        vim \
+	wget \
+        && rm -rf /var/lib/apt/lists/*
+
+# Create jenkins user and group to match that of OMR host systems
+RUN groupadd -g 1001 jenkins \
+&& useradd -rm -u 1001 -g jenkins jenkins
+
+RUN wget -O /usr/local/include/riscv.h 'https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=include/opcode/riscv.h;hb=2f973f134d7752cbc662ec65da8ad8bbe4c6fb8f' \
+&& wget -O /usr/local/include/riscv-opc.h 'https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=include/opcode/riscv-opc.h;hb=2f973f134d7752cbc662ec65da8ad8bbe4c6fb8f'
+
+# Install Debian ports GPG keys
+RUN gpg --homedir /tmp \
+	--no-default-keyring --primary-keyring "/tmp/debian-ports-keyring.gpg" \
+        --keyserver keyserver.ubuntu.com --recv-key B523E5F3FC4E5F2C
+RUN gpg --homedir /tmp \
+	--no-default-keyring --primary-keyring "/tmp/debian-ports-keyring.gpg" \
+        --keyserver keyserver.ubuntu.com --recv-key 8D69674688B6CB36
+RUN gpg --homedir /tmp \
+	--no-default-keyring --primary-keyring "/tmp/debian-ports-keyring.gpg" \
+        --export 8D69674688B6CB36 > /etc/apt/trusted.gpg.d/debian-ports-archive-2023.gpg
+RUN gpg --homedir /tmp \
+	--no-default-keyring --primary-keyring "/tmp/debian-ports-keyring.gpg" \
+        --export 8D69674688B6CB36 > /etc/apt/trusted.gpg.d/debian-ports-archive-2023.gpg
+
+# Install RISC-V 64 build root in /opt/sysroot
+RUN apt-get install -y fakeroot
+RUN wget -O /tmp/libfakeroot_1.31-1.2_riscv64.deb \
+	 http://ftp.ports.debian.org/debian-ports/pool-riscv64/main/f/fakeroot/libfakeroot_1.31-1.2_riscv64.deb
+RUN wget -O /tmp/libfakechroot_2.20.1+ds-15_riscv64.deb \
+	http://ftp.ports.debian.org/debian-ports/pool-riscv64/main/f/fakechroot/libfakechroot_2.20.1+ds-15_riscv64.deb
+RUN dpkg -X /tmp/libfakeroot_1.31-1.2_riscv64.deb /
+RUN dpkg -X /tmp/libfakechroot_2.20.1+ds-15_riscv64.deb /
+
+RUN update-alternatives --set  fakeroot /usr/bin/fakeroot-tcp
+
+RUN mmdebstrap \
+	--mode=fakeroot \
+	--variant=minbase \
+	--architectures=riscv64 \
+	--include="debian-ports-archive-keyring,build-essential,libdwarf-dev,libelf-dev,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libasound2-dev,libcups2-dev,libfontconfig1-dev" \
+	bullseye "/opt/sysroot" \
+	"deb http://deb.debian.org/debian-ports/ sid main" \
+	"deb http://deb.debian.org/debian-ports/ unreleased main"
+
+ENV CROSS_SYSROOT_RISCV64=/opt/sysroot
+USER jenkins

--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright IBM Corp. and others 2020
+ * Copyright IBM Corp. and others 2023
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -17,7 +17,7 @@
  * [1] https://www.gnu.org/software/classpath/license.html
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
 defaultCompile = 'make -j4'
@@ -44,7 +44,7 @@ pullId = params.ghprbPullId
 
 cgroupV1Specs = ["linux_x86"]
 cgroupV2Specs = ["linux_x86-64", "linux_ppc-64_le_gcc"]
-dockerSpecs = ["linux_x86", "linux_x86-64"]
+dockerSpecs = ["linux_x86", "linux_x86-64", "linux_riscv64_cross"]
 
 nodeLabels = []
 runInDocker = false
@@ -172,7 +172,7 @@ SPECS = [
         'builds' : [
             [
                 'buildDir' : cmakeBuildDir,
-                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake "-DOMR_EXE_LAUNCHER=/home/jenkins/qemu/build/qemu-riscv64;-L;${CROSS_SYSROOT_RISCV64}" "-DCMAKE_SYSROOT=${CROSS_SYSROOT_RISCV64}"',
+                'configureArgs' : '-Wdev -C../cmake/caches/Travis.cmake -DOMR_DDR=OFF  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/riscv64-linux-cross.cmake "-DOMR_EXE_LAUNCHER=qemu-riscv64-static;-L;${CROSS_SYSROOT_RISCV64}" "-DCMAKE_SYSROOT=${CROSS_SYSROOT_RISCV64}"',
                 'compile' : defaultCompile
             ]
         ],


### PR DESCRIPTION
A recent loss of the debian 10 system that was used for riscv compiles pushed me into moving this to a container.  Due so memory consumption issues @janvrany has an open PR to address (https://github.com/eclipse/omr/pull/6912), the hosts currently require ~10gb ram.  Once #6912 has been reviewed/changed/merged...the hosts for riscv cross-compiles can be reduced in ram requirement.

Also needs a dependent jiro change. https://github.com/eclipse-cbi/jiro/pull/277
* remove deb10-x64-1 as its dead
* add label "compile:riscv64:cross" to ub20-x64-omr7 and ub20-x64-omr9
** docker container also has a requirement on cgroup.v2 configuration on the host

fyi @babsingh @janvrany @AdamBrousseau 