### PR TITLE
Check const values to ensure correct pattern in selectSimplifier

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15578,9 +15578,13 @@ TR::Node *selectSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
       //       condition
       //       const 0/1
       //       boolean expression
-      else if ((node->getChild(2)->getOpCode().isLoadConst()
+      else if (((node->getChild(2)->getOpCode().isLoadConst()
+                    && (node->getChild(2)->get64bitIntegralValue() == 0
+                        || node->getChild(2)->get64bitIntegralValue() == 1))
                 && isBooleanExpression(node->getChild(1)))
-               || (node->getChild(1)->getOpCode().isLoadConst()
+               || ((node->getChild(1)->getOpCode().isLoadConst()
+                    && (node->getChild(1)->get64bitIntegralValue() == 0
+                        || node->getChild(1)->get64bitIntegralValue() == 1))
                    && isBooleanExpression(node->getChild(2))))
          {
          TR::Node *replacement = NULL;


### PR DESCRIPTION
When simplifying a select of a const 0/1 and a boolean expression, the selectSimplifier currently only checks for whether there is a const initially, and then for whether that const's value is either 0 or something else. This allows consts that are not either 0 or 1 to be used incorrectly in this simplification.