### PR TITLE
Do not skip l2a if the memory reference has unresolved snippet

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -586,7 +586,10 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
    {
    if (cg->comp()->useCompressedPointers())
       {
-      if (subTree->getOpCodeValue() == TR::l2a && subTree->getReferenceCount() == 1 && subTree->getRegister() == NULL)
+      if ((subTree->getOpCodeValue() == TR::l2a) &&
+          (subTree->getReferenceCount() == 1) &&
+          (subTree->getRegister() == NULL) &&
+          !self()->getUnresolvedSnippet())  // If there is unresolved data snippet, l2a cannot be skipped
          {
          cg->decReferenceCount(subTree);
          subTree = subTree->getFirstChild();

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -520,8 +520,10 @@ OMR::X86::MemoryReference::populateMemoryReference(
 
    if (comp->useCompressedPointers())
        {
-       if ((subTree->getOpCodeValue() == TR::l2a) && (subTree->getReferenceCount() == 1) &&
-             (subTree->getRegister() == NULL))
+       if ((subTree->getOpCodeValue() == TR::l2a) &&
+           (subTree->getReferenceCount() == 1) &&
+           (subTree->getRegister() == NULL) &&
+           !self()->hasUnresolvedDataSnippet()) // If there is unresolved data snippet, l2a cannot be skipped
           {
           cg->decReferenceCount(subTree);
           subTree = subTree->getFirstChild();

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1798,8 +1798,11 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
 
    noteAllNodesWithRefCountNotOne(nodesBefore, subTree, comp);
 
-   if (((comp->useCompressedPointers() && subTree->getOpCodeValue() == TR::l2a))
-           && (subTree->getReferenceCount() == 1) && (subTree->getRegister() == NULL))
+   if (comp->useCompressedPointers() &&
+       (subTree->getOpCodeValue() == TR::l2a) &&
+       (subTree->getReferenceCount() == 1) &&
+       (subTree->getRegister() == NULL) &&
+       !self()->getUnresolvedSnippet()) // If there is unresolved data snippet, l2a cannot be skipped
       {
       noopNode = subTree;
       subTree = subTree->getFirstChild();


### PR DESCRIPTION
Do not skip l2a if the memory reference has unresolved snippet. 

Fixes: [#17240](https://github.com/eclipse-openj9/openj9/issues/17240)