### PR TITLE
WIP:Handle code cache allocation for low physical memory

### DIFF
--- a/compiler/control/CompilationController.cpp
+++ b/compiler/control/CompilationController.cpp
@@ -40,7 +40,6 @@ TR::CompilationInfo *    TR::CompilationController::_compInfo = 0;
 bool                     TR::CompilationController::_useController = false;
 bool                     TR::CompilationController::_tlsCompObjCreated = false;
 
-
 bool TR::CompilationController::init(TR::CompilationInfo *compInfo)
    {
    _compInfo = compInfo;
@@ -77,4 +76,58 @@ void TR::CompilationController::shutdown()
    int32_t remainingPlans = TR_OptimizationPlan::freeEntirePool();
 
    _compilationStrategy->shutdown();
+   }
+
+uint64_t
+TR::CompilationController::computeFreePhysicalMemory(bool &incompleteInfo)
+   {
+   bool incomplete = false;
+   OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
+
+   static bool _cgroupMemorySubsystemEnabled = (OMR_CGROUP_SUBSYSTEM_MEMORY == omrsysinfo_cgroup_are_subsystems_enabled(OMR_CGROUP_SUBSYSTEM_MEMORY));
+   uint64_t freePhysicalMemory = OMRPORT_MEMINFO_NOT_AVAILABLE;
+   J9MemoryInfo memInfo;
+   if (0 == omrsysinfo_get_memory_info(&memInfo)
+      && memInfo.availPhysical != OMRPORT_MEMINFO_NOT_AVAILABLE
+      && memInfo.hostAvailPhysical != OMRPORT_MEMINFO_NOT_AVAILABLE)
+      {
+      freePhysicalMemory = memInfo.availPhysical;
+      uint64_t freeHostPhysicalMemorySizeB = memInfo.hostAvailPhysical;
+
+      if (memInfo.cached != OMRPORT_MEMINFO_NOT_AVAILABLE)
+         freePhysicalMemory += memInfo.cached;
+      else
+         incomplete = !_cgroupMemorySubsystemEnabled;
+
+      if (memInfo.hostCached != OMRPORT_MEMINFO_NOT_AVAILABLE)
+         freeHostPhysicalMemorySizeB += memInfo.hostCached;
+      else
+         incomplete = true;
+#if defined(LINUX)
+      if (memInfo.buffered != OMRPORT_MEMINFO_NOT_AVAILABLE)
+         freePhysicalMemory += memInfo.buffered;
+      else
+         incomplete = incomplete || !_cgroupMemorySubsystemEnabled;
+
+      if (memInfo.hostBuffered != OMRPORT_MEMINFO_NOT_AVAILABLE)
+         freeHostPhysicalMemorySizeB += memInfo.hostBuffered;
+      else
+         incomplete = true;
+#endif
+      // If we run in a container, freePhysicalMemory is the difference between
+      // the container memory limit and how much physical memory the container used
+      // It's possible that on the entire machine there is less physical memory
+      // available because other processes have consumed it. Thus, we need to take
+      // into account the available physical memory on the host
+      if (freeHostPhysicalMemorySizeB < freePhysicalMemory)
+         freePhysicalMemory = freeHostPhysicalMemorySizeB;
+      }
+   else
+      {
+      incomplete= true;
+      freePhysicalMemory = OMRPORT_MEMINFO_NOT_AVAILABLE;
+      }
+
+   incompleteInfo = incomplete;
+   return freePhysicalMemory;
    }

--- a/compiler/control/CompilationController.hpp
+++ b/compiler/control/CompilationController.hpp
@@ -44,6 +44,14 @@ class CompilationController
    static void    setVerbose(int32_t v) { _verbose = v; }
    static TR::CompilationStrategy * getCompilationStrategy() { return _compilationStrategy; }
    static TR::CompilationInfo     * getCompilationInfo() { return _compInfo; }
+   /**
+   * @brief Compute free physical memory taking into account container limits
+   *
+   * @param incompleteInfo   [OUTPUT] Boolean indicating that cached/buffered memory couldn't be read
+   * @return                 A value representing the free physicalMemory
+                             or OMRPORT_MEMINFO_NOT_AVAILABLE in case of error
+   */
+   static uint64_t computeFreePhysicalMemory(bool &incompleteInfo);
    private:
    static TR::CompilationStrategy *_compilationStrategy;
    static TR::CompilationInfo     *_compInfo;        // stored here for convenience

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1597,6 +1597,7 @@ bool OMR::Options::_hasLogFile = false;
 bool OMR::Options::_suppressLogFileBecauseDebugObjectNotCreated = false;
 TR_Debug *OMR::Options::_debug = 0;
 
+int32_t OMR::Options::_safeReservePhysicalMemoryValue = 32 << 20;  // 32 MB
 bool OMR::Options::_canJITCompile = false;
 bool OMR::Options::_fullyInitialized = false;
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1540,6 +1540,10 @@ public:
           bool        hasOptionSets() {return _optionSets != NULL;}
    char*              setCounts();
 
+   static int32_t _safeReservePhysicalMemoryValue;
+   inline static int32_t getSafeReservePhysicalMemoryValue() { return _safeReservePhysicalMemoryValue; }
+   inline static void setSafeReservePhysicalMemoryValue(int32_t size) { _safeReservePhysicalMemoryValue = size; }
+
    static bool     useCompressedPointers();
 
    TR::FILE *          getLogFile()          {return _logFile;}


### PR DESCRIPTION
In `OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize..` calculate available physical memory and perform new code cache allocation if we have the safe amount returned for the memory.