### PR TITLE
Remove getNanoTimeTemp() from OMR

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -506,7 +506,6 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 
 OMR::X86::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
    OMR::CodeGenerator(comp),
-   _nanoTimeTemp(NULL),
    _assignmentDirection(Backward),
    _lastCatchAppendInstruction(NULL),
    _betterSpillPlacements(NULL),
@@ -1285,23 +1284,6 @@ TR::RealRegister *
 OMR::X86::CodeGenerator::getMethodMetaDataRegister()
    {
    return toRealRegister(self()->getVMThreadRegister());
-   }
-
-TR::SymbolReference *
-OMR::X86::CodeGenerator::getNanoTimeTemp()
-   {
-   if (_nanoTimeTemp == NULL)
-      {
-      TR::AutomaticSymbol *sym;
-#if defined(LINUX) || defined(OSX)
-      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
-#else
-      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,8);
-#endif
-      self()->comp()->getMethodSymbol()->addAutomatic(sym);
-      _nanoTimeTemp = new (self()->trHeapMemory()) TR::SymbolReference(self()->comp()->getSymRefTab(), sym);
-      }
-   return _nanoTimeTemp;
    }
 
 bool

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -424,8 +424,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool isReturnInstruction(TR::Instruction *instr);
    bool isBranchInstruction(TR::Instruction *instr);
 
-   TR::SymbolReference *getNanoTimeTemp();
-
    /**
     * @brief Computes the 32-bit displacement between the given direct branch instruction
     *        and either the target helper or a trampoline to reach the target helper
@@ -742,8 +740,6 @@ protected:
    bool nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state);
 
    TR::RealRegister             *_frameRegister;
-
-   TR::SymbolReference             *_nanoTimeTemp;
 
    TR::Instruction                 *_lastCatchAppendInstruction;
    TR_BetterSpillPlacement        *_betterSpillPlacements;


### PR DESCRIPTION
Remove getNanoTimeTemp() from OMR as the final step of migrating it from OMR to OpenJ9

Closes: #5133