### PR TITLE
Guard isNodeCreatedByPRE() with canChkNodeCreatedByPRE()

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3444,7 +3444,7 @@ void TR_LoopVersioner::updateDefinitionsAndCollectProfiledExprs(TR::Node *parent
                 if ((valueInfo->getTopProbability() > MIN_PROFILED_FREQUENCY) &&
                     (valueInfo->getTotalFrequency() > 0) &&
                     !_containsCall &&
-                    !node->getByteCodeInfo().doNotProfile() && !node->isNodeCreatedByPRE() &&
+                    !node->getByteCodeInfo().doNotProfile() && node->canChkNodeCreatedByPRE() && !node->isNodeCreatedByPRE() &&
                     // Only collect nodes from unspecialized blocks to avoid specializing the same nodes twice
                     !block->isSpecialized())
                    {


### PR DESCRIPTION
Fix assertion failure in isNodeCreatedByPRE() while PROD_WITH_ASSUMES is enabled by checking its condition first and only calling isNodeCreatedByPRE() if the condition passes.

Issue: [openj9 #17446](https://github.com/eclipse-openj9/openj9/issues/17446)