### PR TITLE
AArch64: Implement vector number of leading/trailing zeroes evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -702,6 +702,10 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vmrol:
       case TR::vpopcnt:
       case TR::vmpopcnt:
+      case TR::vnotz:
+      case TR::vmnotz:
+      case TR::vnolz:
+      case TR::vmnolz:
          // Float/ Double are not supported
          return (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64);
       case TR::vload:


### PR DESCRIPTION
This commit adds vnolz, vmnolz, vnotz and vmnotz evaluators to AArch64 codegen.