### PR TITLE
Consider possibility of TR::newvalue operation in some optimizations

### DIFF
--- a/compiler/il/OMRAutomaticSymbol.cpp
+++ b/compiler/il/OMRAutomaticSymbol.cpp
@@ -245,6 +245,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, T
    {
    TR_ASSERT(kind == TR::newarray     ||
              kind == TR::New          ||
+             kind == TR::newvalue     ||
              kind == TR::anewarray,
              "Invalid kind passed to local object factory");
    TR::AutomaticSymbol * sym  = new (m) TR::AutomaticSymbol(d, s);

--- a/compiler/optimizer/LocalReordering.cpp
+++ b/compiler/optimizer/LocalReordering.cpp
@@ -357,6 +357,7 @@ void TR_LocalReordering::moveStoresEarlierIfRhsAnchored(TR::Block *block, TR::Tr
        !node->getOpCode().isTreeTop() &&
        !node->getOpCode().isCall() &&
        (node->getOpCodeValue() != TR::New) &&
+       (node->getOpCodeValue() != TR::newvalue) &&
        (node->getOpCodeValue() != TR::newarray) &&
        (node->getOpCodeValue() != TR::anewarray) &&
        (node->getOpCodeValue() != TR::multianewarray) &&


### PR DESCRIPTION
This pull request includes changes to consider the possibility that an object allocation is being performed by way of a `TR::newvalue` operation.  One is in the context of `LocalReordering`, which already prevented reordering of other kinds of object allocations.  The second is in the context of `OMR::AutomaticSymbol::createLocalObject` which is used in the process of stack allocating short-lived objects that do not need to be allocated on the heap, allowing downstream projects to stack allocate objects that were created by a `TR::newvalue` operation.