### PR TITLE
AArch64: Fix loadAddressConstantInSnippet()

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -5352,7 +5352,7 @@ TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *n
 
    if (isClassUnloadingConst)
       {
-      if (node->isMethodPointerConstant())
+      if (node->chkMethodPointerConstant())
          {
          cg->getMethodSnippetsToBePatchedOnClassUnload()->push_front(snippet);
          }


### PR DESCRIPTION
This commit replaces the call to isMethodPointerConstant() in loadAddressConstantInSnippet() by chkMethodPointerConstant(). The assertion in isMethodPointerConstant() could fail.