### PR TITLE
Handle code cache allocation for low physical memory

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -269,6 +269,18 @@ public:
 
    bool canAddNewCodeCache();
 
+   /**
+    * @brief Answers whether there is enough physical memory available to perform
+    * code cache allocation for the requested size.
+    *
+    * Downstream projects can provide an implementation for this method to check
+    * for safe memory limits before code cache allocation.
+    *
+    * @param requestedCodeCacheSize: requested code cache size
+    *
+    * @return true if there is enough physical memory; false otherwise
+    */
+   bool isSufficientPhysicalMemoryAvailableForAllocation(size_t requestedCodeCacheSize);
    // Code Cache Consolidation
    TR::CodeCache *allocateRepositoryCodeCache();
    TR::CodeCacheMemorySegment *allocateCodeCacheRepository(size_t repositorySize);


### PR DESCRIPTION
In `OMR::CodeCacheManager::carveCodeCacheSpaceFromRepository(size_t segmentSize..` calculate available physical memory and perform new code cache allocation if we have the safe amount returned for the memory. 

Depends on OpenJ9 change: Handle code cache allocation when available memory becomes low [[17620](https://github.com/eclipse-openj9/openj9/pull/17620)]