### PR TITLE
Add relocation infrastructure to make enter/exit tracing consistent with default compilation

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -114,6 +114,10 @@ static void loadRelocatableConstant(TR::Node *node,
       {
       loadAddressConstant(cg, true, GCRnode, (intptr_t)ref, reg, NULL, TR_ClassAddress);
       }
+   else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+      {
+      loadAddressConstant(cg, true, GCRnode, 1, reg, NULL, TR_MethodEnterExitHookAddress);
+      }
    else
       {
       loadConstant64(cg, node, addr, reg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -5926,6 +5926,16 @@ addMetaDataForLoadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node *node, TR
             }
          break;
          }
+
+      case TR_MethodEnterExitHookAddress:
+         {
+         relo = new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+            firstInstruction,
+            (uint8_t *)node->getSymbolReference(),
+            NULL,
+            TR_MethodEnterExitHookAddress, cg);
+         break;
+         }
       }
 
    if (!relo)

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -1383,6 +1383,10 @@ static void loadRelocatableConstant(TR::Node               *node,
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_DataAddress);
          }
+      else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+         {
+         loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_MethodEnterExitHookAddress);
+         }
       else
          {
          cg->addSnippet(mr->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, node->getOpCode().isStore(), false)));

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -3106,6 +3106,20 @@ TR::Instruction *loadAddressConstantFixed(TR::CodeGenerator *cg, TR::Node * node
                                  node);
                }
             }
+         else if (typeAddress == TR_MethodEnterExitHookAddress)
+            {
+            if (doAOTRelocation)
+               {
+               cg->addExternalRelocation(new (cg->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                                 cursor,
+                                 (uint8_t *)node->getSymbolReference(),
+                                 (uint8_t *)seqKind,
+                                 (TR_ExternalRelocationTargetKind)typeAddress, cg),
+                                 __FILE__,
+                                 __LINE__,
+                                 node);
+               }
+            }
          else
             {
             if (doAOTRelocation)

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -322,9 +322,9 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    int32_t iLoc2 = static_cast<int32_t>(updateLocation2 - relocatableMethodCodeStart);
 
    if ( (iLoc < MIN_SHORT_OFFSET  || iLoc > MAX_SHORT_OFFSET ) || (iLoc2 < MIN_SHORT_OFFSET || iLoc2 > MAX_SHORT_OFFSET ) )
-      return RELOCATION_TYPE_WIDE_OFFSET | RELOCATION_TYPE_ORDERED_PAIR;
+      return RELOCATION_TYPE_WIDE_OFFSET | ITERATED_RELOCATION_TYPE_ORDERED_PAIR;
 
-   return RELOCATION_TYPE_ORDERED_PAIR;
+   return ITERATED_RELOCATION_TYPE_ORDERED_PAIR;
    }
 
 

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -305,7 +305,7 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
 
    if (comp->target().cpu.isPower() &&
           (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethod || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
-           || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter))
+           || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter || kind == TR_MethodEnterExitHookAddress))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();
@@ -337,7 +337,7 @@ void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *cg)
    TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
    if (comp->target().cpu.isPower() &&
       (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethodSequence || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress
-       || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter))
+       || kind == TR_DebugCounter || kind == TR_BlockFrequency || kind == TR_RecompQueuedFlag || kind == TR_CatchBlockCounter || kind == TR_MethodEnterExitHookAddress))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
       TR::Instruction *instr2 = (TR::Instruction *)getLocation2();
@@ -469,6 +469,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ValidateIsClassVisible (112)",
    "TR_CatchBlockCounter (113)",
    "TR_StartPC (114)",
+   "TR_MethodEnterExitHookAddress (115)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -307,8 +307,8 @@ class IteratedExternalRelocation : public TR_Link<TR::IteratedExternalRelocation
       {return _recordModifier.testAny(RELOCATION_TYPE_WIDE_OFFSET);}
    void setNeedsWideOffsets() {_recordModifier.set(RELOCATION_TYPE_WIDE_OFFSET);}
 
-   bool isOrderedPair() {return _recordModifier.testAny(RELOCATION_TYPE_ORDERED_PAIR);}
-   void setOrderedPair() {_recordModifier.set(RELOCATION_TYPE_ORDERED_PAIR);}
+   bool isOrderedPair() {return _recordModifier.testAny(ITERATED_RELOCATION_TYPE_ORDERED_PAIR);}
+   void setOrderedPair() {_recordModifier.set(ITERATED_RELOCATION_TYPE_ORDERED_PAIR);}
 
    uint8_t getModifierValue() {return _recordModifier.getValue();}
    void    setModifierValue(uint8_t v) {_recordModifier.setValue(0x00, v);}

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -293,6 +293,12 @@ public:
    void setIsCatchBlockCounter()            { _flags2.set(CatchBlockCounter); }
    bool isCatchBlockCounter()               { return _flags2.testAny(CatchBlockCounter); }
 
+   void setIsEnterEventHookAddress()        { _flags2.set(EnterEventHookAddress); }
+   bool isEnterEventHookAddress()           { return _flags2.testAny(EnterEventHookAddress); }
+
+   void setIsExitEventHookAddress()         { _flags2.set(ExitEventHookAddress); }
+   bool isExitEventHookAddress()            { return _flags2.testAny(ExitEventHookAddress); }
+
    inline bool isNamed();
 
    // flag methods specific to Autos
@@ -600,6 +606,8 @@ public:
        */
       StaticDefaultValueInstance = 0x00020000,
       CatchBlockCounter          = 0x00040000,
+      EnterEventHookAddress      = 0x00080000,
+      ExitEventHookAddress       = 0x00100000,
       };
 
 protected:

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1987,6 +1987,16 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          value = (uintptr_t)node->getSymbolReference();
          break;
          }
+
+      case TR_MethodEnterExitHookAddress:
+         {
+         relo = new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+            firstInstruction,
+            (uint8_t *)node->getSymbolReference(),
+            (uint8_t *)seqKind,
+            TR_MethodEnterExitHookAddress, self());
+         break;
+         }
       }
 
    if (comp->getOption(TR_UseSymbolValidationManager) && !relo)
@@ -2152,6 +2162,14 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
                                                                                           (uint8_t *)recordInfo,
                                                                                           (TR_ExternalRelocationTargetKind)typeAddress, self()),
                                                                                           __FILE__, __LINE__, node);
+      }
+   else if (typeAddress == TR_MethodEnterExitHookAddress)
+      {
+      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
+                                                                                          (uint8_t *)node->getSymbolReference(),
+                                                                                          (uint8_t *)orderedPairSequence2,
+                                                                                          (TR_ExternalRelocationTargetKind)TR_MethodEnterExitHookAddress, self()),
+                           __FILE__, __LINE__, node);
       }
    else if (typeAddress != -1)
       {

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1490,7 +1490,7 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
             cg,
             TR::InstOpCode::Op_st,
             node,
-            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen), 
+            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen),
             rX,
             prevInstruction
          );
@@ -1504,7 +1504,7 @@ TR::Instruction *OMR::Power::MemoryReference::expandInstruction(TR::Instruction 
             TR::InstOpCode::Op_load,
             node,
             rX,
-            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen), 
+            TR::MemoryReference::createWithDisplacement(cg, stackPtr, -saveLen, saveLen),
             currentInstruction
          );
          }
@@ -1630,6 +1630,12 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RecompQueuedFlag);
+         return;
+         }
+      else if ((symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress()) && cg->comp()->compileRelocatableCode())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_MethodEnterExitHookAddress);
          return;
          }
       else
@@ -1782,7 +1788,12 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RecompQueuedFlag);
          return;
          }
-
+      else if ((symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress()) && cg->comp()->compileRelocatableCode())
+         {
+         TR::Register *reg = _baseRegister = cg->allocateRegister();
+         loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_MethodEnterExitHookAddress);
+         return;
+         }
       else if (refIsUnresolved || useUnresSnippetToAvoidRelo)
          {
          self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, isStore, false));

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -348,9 +348,11 @@ typedef enum
    TR_ValidateIsClassVisible              = 112,
    TR_CatchBlockCounter                   = 113,
    TR_StartPC                             = 114,
-   TR_NumExternalRelocationKinds          = 115,
+   TR_MethodEnterExitHookAddress          = 115,
+   TR_NumExternalRelocationKinds          = 116,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
+
 
 namespace TR {
 

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -184,16 +184,21 @@ inline TR_LinkageConventions runtimeHelperLinkage(TR_RuntimeHelper h) { return r
 
 // -----------------------------------------------------------------------------
 
+// Relocation flags and masks
+typedef enum
+   {
+   ITERATED_RELOCATION_TYPE_ORDERED_PAIR = 0x20,
 
-#define RELOCATION_TYPE_DESCRIPTION_MASK  15
-#define RELOCATION_TYPE_ORDERED_PAIR  32
-#define RELOCATION_TYPE_EIP_OFFSET  0x40
-#define RELOCATION_TYPE_WIDE_OFFSET  0x80
-#define RELOCATION_CROSS_PLATFORM_FLAGS_MASK (RELOCATION_TYPE_EIP_OFFSET | RELOCATION_TYPE_WIDE_OFFSET)
-#define RELOCATION_RELOC_FLAGS_MASK (~RELOCATION_CROSS_PLATFORM_FLAGS_MASK)
+   RELOCATION_TYPE_EIP_OFFSET            = 0x40,
+   RELOCATION_TYPE_WIDE_OFFSET           = 0x80,
 
-#define RELOCATION_TYPE_ARRAY_COPY_SUBTYPE 32
-#define RELOCATION_TYPE_ARRAY_COPY_TOC     64
+   // ITERATED_RELOCATION_TYPE_ORDERED_PAIR is not stored in the binary template
+   // as the isOrderedPairRelocation API is used to determine whether a given
+   // relocation is an Orderd Pair Relocation or not.
+   RELOCATION_CROSS_PLATFORM_FLAGS_MASK  = (RELOCATION_TYPE_EIP_OFFSET | RELOCATION_TYPE_WIDE_OFFSET),
+   RELOCATION_RELOC_FLAGS_MASK           = (~RELOCATION_CROSS_PLATFORM_FLAGS_MASK),
+   } TR_RelocationCrossPlatformMask;
+
 // These macros are intended for use when HI_VALUE and LO_VALUE will be recombined after LO_VALUE is sign-extended
 // (e.g. when LO_VALUE is used with an instruction that takes a signed 16-bit operand).
 // In this case we have to adjust HI_VALUE now so that the original value will be obtained once the two are recombined.

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -187,17 +187,20 @@ inline TR_LinkageConventions runtimeHelperLinkage(TR_RuntimeHelper h) { return r
 // Relocation flags and masks
 typedef enum
    {
-   ITERATED_RELOCATION_TYPE_ORDERED_PAIR = 0x20,
+   RELOCATION_TYPE_EIP_OFFSET            = 0x1,
+   RELOCATION_TYPE_WIDE_OFFSET           = 0x2,
 
-   RELOCATION_TYPE_EIP_OFFSET            = 0x40,
-   RELOCATION_TYPE_WIDE_OFFSET           = 0x80,
+   ITERATED_RELOCATION_TYPE_ORDERED_PAIR = 0x4,
 
    // ITERATED_RELOCATION_TYPE_ORDERED_PAIR is not stored in the binary template
    // as the isOrderedPairRelocation API is used to determine whether a given
    // relocation is an Orderd Pair Relocation or not.
    RELOCATION_CROSS_PLATFORM_FLAGS_MASK  = (RELOCATION_TYPE_EIP_OFFSET | RELOCATION_TYPE_WIDE_OFFSET),
+
    RELOCATION_RELOC_FLAGS_MASK           = (~RELOCATION_CROSS_PLATFORM_FLAGS_MASK),
-   } TR_RelocationCrossPlatformMask;
+   RELOCATION_RELOC_FLAGS_SHIFT          = 4,
+
+   } TR_RelocationFlagUtilities;
 
 // These macros are intended for use when HI_VALUE and LO_VALUE will be recombined after LO_VALUE is sign-extended
 // (e.g. when LO_VALUE is used with an instruction that takes a signed 16-bit operand).

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -570,6 +570,22 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
                                                  counter);
             }
          }
+      else if (sr.getSymbol()->isEnterEventHookAddress() || sr.getSymbol()->isExitEventHookAddress())
+         {
+         if (cg->needRelocationsForStatics())
+            {
+            cg->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  displacementLocation,
+                  (uint8_t *)srCopy,
+                  NULL,
+                  TR_MethodEnterExitHookAddress,
+                  cg),
+               __FILE__,
+               __LINE__,
+               containingInstruction->getNode());
+            }
+         }
       }
    else
       {

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1344,6 +1344,19 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                                                              node,
                                                              counter);
                         }
+                     else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+                        {
+                        cg->addExternalRelocation(
+                           TR::ExternalRelocation::create(
+                              cursor,
+                              (uint8_t *)&self()->getSymbolReference(),
+                              NULL,
+                              TR_MethodEnterExitHookAddress,
+                              cg),
+                           __FILE__,
+                           __LINE__,
+                           node);
+                        }
                      else
                         {
                         cg->addExternalRelocation(

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1170,6 +1170,10 @@ TR::X86RegImmSymInstruction::autoSetReloKind()
       {
       setReloKind(TR_RecompQueuedFlag);
       }
+   else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+      {
+      setReloKind(TR_MethodEnterExitHookAddress);
+      }
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4460,6 +4464,8 @@ TR::AMD64RegImm64SymInstruction::autoSetReloKind()
       setReloKind(TR_BlockFrequency);
    else if (symbol->isRecompQueuedFlag())
       setReloKind(TR_RecompQueuedFlag);
+   else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+      setReloKind(TR_MethodEnterExitHookAddress);
    else
       setReloKind(-1);
    }

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1289,6 +1289,19 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   __LINE__,
                   getNode());
                }
+            else if (sym->isEnterEventHookAddress() || sym->isExitEventHookAddress())
+               {
+               cg()->addExternalRelocation(
+                  TR::ExternalRelocation::create(
+                     cursor,
+                     (uint8_t *)getSymbolReference(),
+                     NULL,
+                     TR_MethodEnterExitHookAddress,
+                     cg()),
+                  __FILE__,
+                  __LINE__,
+                  getNode());
+               }
             else
                {
                cg()->addExternalRelocation(
@@ -2117,6 +2130,21 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          }
          break;
 
+      case TR_MethodEnterExitHookAddress:
+         {
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)getSymbolReference(),
+               NULL,
+               TR_MethodEnterExitHookAddress,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
+         }
+         break;
+
       default:
          TR_ASSERT(0, "invalid relocation kind for TR::X86RegImmSymInstruction");
       }
@@ -2581,6 +2609,19 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             cursor,
             NULL,
             TR_RecompQueuedFlag,
+            cg()),
+         __FILE__,
+         __LINE__,
+         getNode());
+      }
+   else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
+      {
+      cg()->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)getSymbolReference(),
+            NULL,
+            TR_MethodEnterExitHookAddress,
             cg()),
          __FILE__,
          __LINE__,
@@ -3458,6 +3499,21 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   cursor,
                   NULL,
                   TR_RecompQueuedFlag,
+                  cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
+            }
+            break;
+
+         case TR_MethodEnterExitHookAddress:
+            {
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)getSymbolReference(),
+                  NULL,
+                  TR_MethodEnterExitHookAddress,
                   cg()),
                __FILE__,
                __LINE__,

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -364,6 +364,21 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
          }
          break;
 
+      case TR_MethodEnterExitHookAddress:
+         {
+         cg()->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *) getNode()->getSymbolReference(),
+               NULL,
+               TR_MethodEnterExitHookAddress,
+               cg()),
+            __FILE__,
+            __LINE__,
+            getNode());
+         }
+         break;
+
       default:
          TR_ASSERT( 0,"relocation type not handled yet");
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -2358,6 +2358,8 @@ getRelocationTargetKindFromSymbol(TR::CodeGenerator* cg, TR::Symbol *sym)
       reloKind = TR_RecompQueuedFlag;
    else if (cg->needRelocationsForBodyInfoData() && sym->isCatchBlockCounter())
       reloKind = TR_CatchBlockCounter;
+   else if (cg->comp()->compileRelocatableCode() && (sym->isEnterEventHookAddress() || sym->isExitEventHookAddress()))
+      reloKind = TR_MethodEnterExitHookAddress;
 
    return reloKind;
    }
@@ -8289,6 +8291,10 @@ OMR::Z::TreeEvaluator::checkAndSetMemRefDataSnippetRelocationType(TR::Node * nod
       {
       reloType = TR_RecompQueuedFlag;
       }
+   else if (cg->comp()->compileRelocatableCode() && (node->getSymbol()->isEnterEventHookAddress() || node->getSymbol()->isExitEventHookAddress()))
+      {
+      reloType = TR_MethodEnterExitHookAddress;
+      }
 
    if (reloType != 0)
       {
@@ -11466,6 +11472,12 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
                cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister,
                                                         (uintptr_t) node->getSymbol()->getStaticSymbol()->getStaticAddress(),
                                                         TR_RecompQueuedFlag, NULL, NULL, NULL);
+               }
+            else if (comp->compileRelocatableCode() && sym && (sym->isEnterEventHookAddress() || sym->isExitEventHookAddress()))
+               {
+               cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::getLoadOpCode(), node, targetRegister,
+                                                        (uintptr_t) node->getSymbol()->getStaticSymbol()->getStaticAddress(),
+                                                        TR_MethodEnterExitHookAddress, NULL, NULL, NULL);
                }
             else
                {


### PR DESCRIPTION
Enter/exit hooks can be guarded by a runtime test to determine whether or not the hook should be invoked. This PR adds relocation support to allow Relocatable Compilations to generate code that can make use of this runtime test.

This PR also includes some refactoring to facilitate the use of a larger set of relocation flags. This is needed to ensure that inlined methods can be validated in case a previously compiled relocatable compiled method cannot support enter/exit hooks.

Should be merged in tandem with https://github.com/eclipse-openj9/openj9/pull/17621