### PR TITLE
AArch64: Implement vector bitswap and byteswap evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -706,6 +706,10 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vmnotz:
       case TR::vnolz:
       case TR::vmnolz:
+      case TR::vbitswap:
+      case TR::vmbitswap:
+      case TR::vbyteswap:
+      case TR::vmbyteswap:
          // Float/ Double are not supported
          return (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64);
       case TR::vload:


### PR DESCRIPTION
This commit adds vector bitswap and byteswap evaluators to AArch64 codegen.