### PR TITLE
Fix eclipse-openj9/openj9#17694

### DIFF
--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -63,6 +63,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#PROFILING: ",
    "#JITServer: ",
    "#AOTCOMPRESSION: ",
+   "#BenefitInliner: ",
    "#FSD: ",
    "#VECTOR API: ",
    "#CHECKPOINT RESTORE: ",


### PR DESCRIPTION
This pull request is to fix eclipse-openj9/openj9#17694 by adding the corresponding string of `TR_Vlog_BI` to `TR_VerboseLog::_vlogTable`.