### PR TITLE
Check that _vlogTable size matches TR_VlogTag with static_assert()

### DIFF
--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -125,3 +125,13 @@ void TR_VerboseLog::initialize(void *config)
    {
    _config = config;
    }
+
+// This is never called. It's just a place to put static_assert() where
+// definitions in this file are available (for e.g. array initializers) and
+// where private members of TR_VerboseLog are also visible.
+void TR_VerboseLog::privateStaticAsserts()
+   {
+   static_assert(
+      sizeof(_vlogTable) / sizeof(_vlogTable[0]) == TR_Vlog_numTags,
+      "TR_VlogTag and _vlogTable are out of sync");
+   }

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -120,7 +120,11 @@ class TR_VerboseLog
 
    //only called once early on, after we can print to the vlog
    static void initialize(void *config);
+
    private:
+
+   static void privateStaticAsserts();
+
    static void vwrite(const char *format, va_list args); //defined in each front end
    static void writeTimeStamp();
    static const char *_vlogTable[];


### PR DESCRIPTION
If either of `TR_VlogTag` or `_vlogTable` is modified to add or remove an element without making the corresponding change in the other, this will cause a build error.