### PR TITLE
Prevent ldiv/i2l -> i2l/idiv simplification when idiv could overflow

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -9046,6 +9046,8 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       firstChild = node->getFirstChild();
       secondChild = node->getSecondChild();
       if ((firstChild->getOpCodeValue() == TR::i2l) && (secondChild->getOpCodeValue() == TR::i2l) &&
+          // Make sure the generated idiv won't be able to overflow
+          (firstChild->isNonNegative() || secondChild->isNonNegative()) &&
           performTransformation(s->comp(), "%sReduced ldiv [%p] of two i2l children to i2l of idiv \n", s->optDetailString(), node))
          {
          TR::TreeTop *curTree = s->_curTree;


### PR DESCRIPTION
Simplifier detects the following pattern and rewrites it:

    ldiv                                i2l
      i2l                                 idiv
        <dividend>          ==>             <dividend>
      i2l                                   <divisor>
        <divisor>

But this is correct only if the resulting `idiv` will never overflow. The original tree always produces the true mathematical result.

To rule out overflow of `idiv`, simplifier now requires that at least one of the operands be nonnegative, since signed division overflows only when dividing the minimum signed value by -1.