### PR TITLE
AArch64: Implement mmAnyTrue and mmAllTrue evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -710,6 +710,8 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
       case TR::vmbitswap:
       case TR::vbyteswap:
       case TR::vmbyteswap:
+      case TR::mmAllTrue:
+      case TR::mmAnyTrue:
          // Float/ Double are not supported
          return (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64);
       case TR::vload:


### PR DESCRIPTION
This commit implements `mmAnyTrue` and `mmAllTrue` evaluators on AArch64 codegen.