### PR TITLE
Adjust binary length estimation to account for REX prefix

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -396,6 +396,12 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerato
       // the size after adding the big load instruction.)
       //
       estimate += IMM64_LOAD_SIZE;
+
+      // Add one byte to the estimate to account for the REX prefix
+      // in the event that the index register has been changed during
+      // code generation due to the insertion of an address load instruction
+      if (_indexRegister == NULL)
+         estimate += 1;
       }
 
    return estimate;


### PR DESCRIPTION
Adjust binary length estimation to account for the REX prefix in the event that the index register has been changed during code generation due to the insertion of an address load instruction

Closes: [omr #17442](https://github.com/eclipse-openj9/openj9/issues/17442)