### PR TITLE
Use omrtime_hires_clock() for monotonic time when necessary in gc

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3288,7 +3288,7 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 	if (NULL == cache) {
 		env->_scavengerStats._scanCacheOverflow = 1;
 		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-		uint64_t duration = omrtime_current_time_millis();
+		uint64_t duration = omrtime_hires_clock();
 
 		bool resizePerformed = false;
 		omrthread_monitor_enter(_freeCacheMonitor);
@@ -3305,8 +3305,8 @@ MM_Scavenger::getFreeCache(MM_EnvironmentStandard *env)
 			/* Still need a new cache and nothing left reserved - create it in Heap */
 			cache = createCacheInHeap(env);
 		}
-		duration = omrtime_current_time_millis() - duration;
-		env->_scavengerStats._scanCacheAllocationDurationDuringSavenger += duration;
+		duration = omrtime_hires_clock() - duration;
+		env->_scavengerStats._scanCacheAllocationDurationDuringSavenger += omrtime_hires_delta(0, duration, OMRPORT_TIME_DELTA_IN_MILLISECONDS);
 
 	}
 


### PR DESCRIPTION
The omrtime_current_time_millis() uses UNIX gettimeofday() function,
and is therefore non-monotonic and error-prone.
We turn to use omrtime_hires_clock() function call
whenever we need the time to be monotonic.

Issue: https://github.com/eclipse/omr/issues/7051