### PR TITLE
Do not resize Copy Scan Cache pool after overflow

### DIFF
--- a/gc/base/standard/CopyScanCacheList.cpp
+++ b/gc/base/standard/CopyScanCacheList.cpp
@@ -148,7 +148,6 @@ MM_CopyScanCacheList::resizeCacheEntries(MM_EnvironmentBase *env, uintptr_t allo
 	if (0 != ext->fvtest_scanCacheCount) {
 		if (0 == _totalAllocatedEntryCount) {
 			allocateCacheEntryCount = ext->fvtest_scanCacheCount;
-			_incrementEntryCount = 0;
 			return appendCacheEntries(env, allocateCacheEntryCount);
 		} else {
 			return true;
@@ -235,9 +234,6 @@ MM_CopyScanCacheList::removeAllHeapAllocatedChunks(MM_EnvironmentStandard *env)
 		_allocationInHeap = false;
 
 		Assert_MM_true(0 < reservedInHeap);
-
-		/* increase number of permanent scan caches by number of incrementEntryCount */
-		appendCacheEntries(env, _incrementEntryCount);
 	}
 }
 


### PR DESCRIPTION
Simplify the logic where we try to resize Copy Scan Cache pool at the end of Scavenge cycle, after we overflowed it and fullfilled it from Java Heap.

This overflow is extremly unlikely, and if does occur it means native memory is depleted and some other problems will soon occur anyway, so trying hard to preemtpively take that memory for our pool is probably just futile.

On the other side, currently we will try to resize at the end of Scavenge, but assert since the increment was previously set to 0, when we artifically set the limit of this pool (with an fvt option). We already have means of preventing further pool growth during GC (from initial growth) from native heap beyond the limit (by recognizing fvt option was set), and we don't even need to set increment to 0.