### PR TITLE
Enable TestOtherThreadCputime on AArch64 macOS again

### DIFF
--- a/fvtest/threadextendedtest/threadCpuTimeTest.cpp
+++ b/fvtest/threadextendedtest/threadCpuTimeTest.cpp
@@ -23,11 +23,6 @@
 #include "thread_api.h"
 #include "threadExtendedTestHelpers.hpp"
 
-#if defined(OSX) && defined(OMR_ARCH_AARCH64)
-/* See OMR Issue #6774 */
-#define TestOtherThreadCputime DISABLED_TestOtherThreadCputime
-#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
-
 #define NUM_ITERATIONS	50
 
 #define LONG_MILLI_TIMEOUT	900000


### PR DESCRIPTION
This commit enables TestOtherThreadCputime on AArch64 macOS again, which was temporarily disabled by #6903.