### PR TITLE
AArch64 macOS: Change the limit value for ADDRESS_SPACE

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -669,7 +669,11 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 	uint64_t originalCurLimit;
 	uint64_t originalMaxLimit;
 	uint64_t currentLimit;
+#if defined(OSX) && defined(OMR_ARCH_AARCH64)
+	const uint64_t as1 = 420000000000;
+#else /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
 	const uint64_t as1 = 300000;
+#endif /* defined(OSX) && defined(OMR_ARCH_AARCH64) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 


### PR DESCRIPTION
This commit changes the limit value for setting
OMRPORT_RESOURCE_ADDRESS_SPACE in
sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE for AArch64 macOS.