### PR TITLE
AArch64: Add callUsesHelperImplementation query to code generator

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -177,7 +177,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
          {
          TR::MethodSymbol *method = symRef->getSymbol()->getMethodSymbol();
 
-         if (method && method->isHelper())
+         if (method && method->isHelper() || cg()->callUsesHelperImplementation(symRef->getSymbol()))
             {
             intptr_t destination = (intptr_t)symRef->getMethodAddress();
 

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -556,6 +556,16 @@ public:
    bool canTransformUnsafeCopyToArrayCopy();
 
    /**
+    * @brief Answers whether a method call is implemented using an internal runtime
+    *           helper routine (ex. a j2iTransition)
+    *
+    * @param[in] sym : The symbol holding the call information
+    *
+    * @return : true if the call is represented by a helper; false otherwise.
+    */
+   bool callUsesHelperImplementation(TR::Symbol *sym) { return false; }
+
+   /**
     * @brief Generates instructions for incrementing debug counter
     * @param[in] cursor:   instruction cursor
     * @param[in] counter:  debug counter


### PR DESCRIPTION
This commit adds `callUsesHelperImplementation` query to code generator. It updates `TR::ARM64ImmSymInstruction::generateBinaryEncoding()` function to add a `TR_Helper` relocation to the branch instruction if that query returns true for the symbol.