### PR TITLE
Remove incorrect assertions and adjust stall time calculation

### DIFF
--- a/gc/base/standard/ParallelScavengeTask.cpp
+++ b/gc/base/standard/ParallelScavengeTask.cpp
@@ -95,7 +95,6 @@ MM_ParallelScavengeTask::synchronizeGCThreadsAndReleaseMain(MM_EnvironmentBase *
 	}
 
 	/* _syncCriticalSectionDuration must be set now, this thread's stall time is at least the duration of critical section */
-	Assert_MM_true((endTime - startTime) >= _syncCriticalSectionDuration);
 	env->_scavengerStats.addToSyncStallTime(startTime, endTime, _syncCriticalSectionDuration);
 
 	return result;
@@ -117,7 +116,6 @@ MM_ParallelScavengeTask::synchronizeGCThreadsAndReleaseSingleThread(MM_Environme
 	}
 
 	/* _syncCriticalSectionDuration must be set now, this thread's stall time is at least the duration of critical section */
-	Assert_MM_true((endTime - startTime) >= _syncCriticalSectionDuration);
 	env->_scavengerStats.addToSyncStallTime(startTime, endTime, _syncCriticalSectionDuration);
 
 	return result;

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -193,9 +193,21 @@ public:
 	MMINLINE void 
 	addToSyncStallTime(uint64_t startTime, uint64_t endTime, uint64_t criticalSectionDuration = 0)
 	{
+		uint64_t criticalTime = criticalSectionDuration;
+		uint64_t deltaTime = endTime - startTime;
+
+		/*
+		 * criticalSectionDuration and deltaTime can be measured on clocks running on different cores asynchronously.
+		 * It means for close intervals (despite clocks are monotonic) criticalTime can be measured
+		 * slightly larger than deltaTime. So, criticalSectionDuration should be adjusted in this case.
+		 */
+		if (criticalTime > deltaTime) {
+			criticalTime = deltaTime;
+		}
+
 		_syncStallCount += 1;
-		_syncStallTime += (endTime - startTime);
-		_adjustedSyncStallTime += ((endTime - startTime) - criticalSectionDuration);
+		_syncStallTime += deltaTime;
+		_adjustedSyncStallTime += (deltaTime - criticalTime);
 	}
 	
 	MMINLINE void


### PR DESCRIPTION
Comparing time intervals measured on different cores might be slightly different. Despite clocks are monotonic they might be out of sync slightly. As a result measuring of intervals with delta smaller than time unit might be off slightly. Such difference can cause false triggering of assertion.
Removing assertions and adjusting time calculation to prevent overrun of unsigned variable.