### PR TITLE
Fix Crashes in 32-bit PPC due to incorrect relocation initialization

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -294,6 +294,20 @@ TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation(
    setTargetKind(k);
    }
 
+TR::ExternalOrderedPair32BitRelocation::ExternalOrderedPair32BitRelocation(
+                 uint8_t                         *location1,
+                 uint8_t                         *location2,
+                 uint8_t                         *target,
+                 uint8_t                         *target2,
+                 TR_ExternalRelocationTargetKind  k,
+                 TR::CodeGenerator                *cg) :
+   TR::ExternalRelocation(), _update2Location(location2)
+   {
+   setUpdateLocation(location1);
+   setTargetAddress(target);
+   setTargetAddress2(target2);
+   setTargetKind(k);
+   }
 
 uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    {

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -400,13 +400,14 @@ class ExternalRelocation : public TR::Relocation
         _relocationRecord(NULL)
         {}
 
-   uint8_t *getTargetAddress()           {return _targetAddress;}
-   uint8_t *setTargetAddress(uint8_t *p) {return (_targetAddress = p);}
+   uint8_t *getTargetAddress()            { return _targetAddress;        }
+   uint8_t *setTargetAddress(uint8_t *p)  { return (_targetAddress = p);  }
 
-   uint8_t *getTargetAddress2()          {return _targetAddress2;}
+   uint8_t *getTargetAddress2()           { return _targetAddress2;       }
+   uint8_t *setTargetAddress2(uint8_t *p) { return (_targetAddress2 = p); }
 
-   TR_ExternalRelocationTargetKind getTargetKind()                                  {return _kind;}
-   TR_ExternalRelocationTargetKind setTargetKind(TR_ExternalRelocationTargetKind k) {return (_kind = k);}
+   TR_ExternalRelocationTargetKind getTargetKind()                                  { return _kind;       }
+   TR_ExternalRelocationTargetKind setTargetKind(TR_ExternalRelocationTargetKind k) { return (_kind = k); }
 
    TR::IteratedExternalRelocation *getRelocationRecord()
       {return _relocationRecord;}
@@ -456,6 +457,13 @@ class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation
    ExternalOrderedPair32BitRelocation(uint8_t *location1,
                                       uint8_t *location2,
                                       uint8_t *target,
+                                      TR_ExternalRelocationTargetKind  k,
+                                      TR::CodeGenerator *cg);
+
+   ExternalOrderedPair32BitRelocation(uint8_t *location1,
+                                      uint8_t *location2,
+                                      uint8_t *target,
+                                      uint8_t *target2,
                                       TR_ExternalRelocationTargetKind  k,
                                       TR::CodeGenerator *cg);
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2166,6 +2166,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
    else if (typeAddress == TR_MethodEnterExitHookAddress)
       {
       self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
+                                                                                          (uint8_t *)secondInstruction,
                                                                                           (uint8_t *)node->getSymbolReference(),
                                                                                           (uint8_t *)orderedPairSequence2,
                                                                                           (TR_ExternalRelocationTargetKind)TR_MethodEnterExitHookAddress, self()),


### PR DESCRIPTION
The initialization of the `TR::ExternalOrderedPair32BitRelocation` object used for `TR_MethodEnterExitHookAddress` had a couple of issues:

1. It was missing the secondInstruction
2. It assumed that the constructor of `TR::ExternalOrderedPair32BitRelocation` took in two target addrs

this PR fixes both issues by adding the second instruction, as well as adding a new constructor to take in two target addresses.

Fixes https://github.com/eclipse-openj9/openj9/issues/17882