### PR TITLE
Add disableInliningUnrecognizedIntrinsics option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -389,6 +389,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableInlining",                    "O\tdisable IL inlining",                            TR::Options::disableOptimization, inlining, 0, "P"},
    {"disableInliningDuringVPAtWarm",       "O\tdisable inlining during VP for warm bodies",    SET_OPTION_BIT(TR_DisableInliningDuringVPAtWarm), "F"},
    {DisableInliningOfNativesString,       "O\tdisable inlining of natives",                    SET_OPTION_BIT(TR_DisableInliningOfNatives), "F"},
+   {"disableInliningUnrecognizedIntrinsics", "M\tdisable inlining of IntrinsicCandidate that is not a recognized method",               SET_OPTION_BIT(TR_DisableInliningUnrecognizedIntrinsics), "F"},
    {"disableInnerPreexistence",           "O\tdisable inner preexistence",                     TR::Options::disableOptimization, innerPreexistence, 0, "P"},
    {"disableIntegerCompareSimplification",      "O\tdisable byte/short/int/long compare simplification  ",      SET_OPTION_BIT(TR_DisableIntegerCompareSimplification), "F"},
    {"disableInterfaceCallCaching",                          "O\tdisable interfaceCall caching   ",      SET_OPTION_BIT(TR_disableInterfaceCallCaching), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -379,7 +379,7 @@ enum TR_CompilationOptions
    TR_CountWriteBarriersRT                = 0x02000000 + 9,
    TR_DisableNoServerDuringStartup        = 0x04000000 + 9,  // set TR_NoOptServer during startup and insert GCR trees
    TR_BreakOnNew                          = 0x08000000 + 9,
-   // Available                           = 0x10000000 + 9,
+   TR_DisableInliningUnrecognizedIntrinsics = 0x10000000 + 9,
    // Available                           = 0x20000000 + 9,
    // Available                           = 0x40000000 + 9,
    // Available                           = 0x80000000 + 9,


### PR DESCRIPTION
- the option is needed in case a down stream project wants to control whether to inline IntrinsicCandidate methods that are not otherwise recognized methods