### PR TITLE
Improve vector opcodes and data types

### DIFF
--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -141,6 +141,15 @@ OMR::DataType::getVectorSize()
    return 0;
    }
 
+int32_t
+OMR::DataType::getVectorNumLanes()
+   {
+   TR_ASSERT_FATAL(isVector() || isMask(), "getVectorNumlanes() can only be called on vector or mask type\n");
+
+   return getVectorSize() / getSize(getVectorElementType());
+   }
+
+
 static int32_t OMRDataTypeSizes[] =
    {
    0,                 // TR::NoType

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -556,6 +556,15 @@ public:
    *     Vector size in bytes
    */
    int32_t                getVectorSize();
+
+   /** \brief
+   *     Returns number of lanes in a vector
+   *
+   *  \return
+   *     Number of lanes in a vector
+   */
+   int32_t                getVectorNumLanes();
+
    static int32_t         getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);
 

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -208,6 +208,31 @@ public:
       }
 
   /** \brief
+   *     Returns vector type
+   *
+   *  \return
+   *     Vector type
+   */
+   TR::DataType getVectorDataType() const
+      {
+      return getVectorDataType(_opCode);
+      }
+
+  /** \brief
+   *     Returns vector type
+   *
+   *  \param op
+   *     Opcode
+   *
+   *  \return
+   *     Vector type
+   */
+   static TR::DataType getVectorDataType(ILOpCode op)
+      {
+      return getVectorResultDataType(op);
+      }
+
+  /** \brief
    *     Returns vector result type
    *
    *  \return
@@ -342,14 +367,13 @@ public:
             TR::DataType dt = getVectorResultDataType(op);
             return TR::DataType::createMaskType(dt.getVectorElementType(), dt.getVectorLength());
             }
-         else if (opcode.isMaskReduction())
+         else if (opcode.isVectorElementResult())
             {
-            return _opCodeProperties[opcode.getTableIndex()].dataType;
+            return getVectorResultDataType(op).getVectorElementType();
             }
          else
             {
-            // scalar result type (e.g. reduction)
-            return getVectorResultDataType(op).getVectorElementType();
+            return _opCodeProperties[opcode.getTableIndex()].dataType;
             }
          }
 
@@ -384,6 +408,7 @@ public:
    bool isFloatingPoint()            const { return typeProperties().testAny(ILTypeProp::Floating_Point); }
    bool isVectorResult()             const { return typeProperties().testAny(ILTypeProp::VectorResult); }
    bool isMaskResult()               const { return typeProperties().testAny(ILTypeProp::MaskResult); }
+   bool isVectorElementResult()      const { return typeProperties().testAny(ILTypeProp::VectorElementResult); }
    bool isIntegerOrAddress()         const { return typeProperties().testAny(ILTypeProp::Integer | ILTypeProp::Address); }
    bool is1Byte()                    const { return typeProperties().testAny(ILTypeProp::Size_1); }
    bool is2Byte()                    const { return typeProperties().testAny(ILTypeProp::Size_2); }

--- a/compiler/il/OMRILProps.hpp
+++ b/compiler/il/OMRILProps.hpp
@@ -49,7 +49,8 @@ namespace ILTypeProp
       Unsigned                          = 0x00001000,
       VectorResult                      = 0x00002000,
       MaskResult                        = 0x00004000,
-      LastOMRILTypeProp                 = MaskResult
+      VectorElementResult               = 0x00008000,
+      LastOMRILTypeProp                 = VectorElementResult
       };
    }
 

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -668,7 +668,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -684,7 +684,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -700,7 +700,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -716,7 +716,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -732,7 +732,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -748,7 +748,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -764,7 +764,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -780,7 +780,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -796,7 +796,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -987,14 +987,14 @@ VECTOR_OPERATION_MACRO(\
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3             = */ 0, \
    /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::Int32, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    get first non-zero vector element */ \
+   /* .description             =    lanewise first non-zero*/ \
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vgetelem, \
@@ -1004,7 +1004,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ 0, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1479,7 +1479,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1495,7 +1495,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1511,7 +1511,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ 0, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1527,7 +1527,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1543,7 +1543,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1559,7 +1559,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1575,7 +1575,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1591,7 +1591,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1607,7 +1607,7 @@ VECTOR_OPERATION_MACRO(\
    /* .properties3             = */ ILProp3::VectorReduction, \
    /* .properties4             = */ 0, \
    /* .dataType                = */ TR::NoType, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorElementResult, \
    /* .childProperties         = */ TWO_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
@@ -1686,14 +1686,14 @@ VECTOR_OPERATION_MACRO(\
    /* .properties2             = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE, \
    /* .properties3             = */ 0, \
    /* .properties4             = */ 0, \
-   /* .dataType                = */ TR::Int32, \
-   /* .typeProperties          = */ TR::NoType, \
+   /* .dataType                = */ TR::NoType, \
+   /* .typeProperties          = */ ILTypeProp::VectorResult, \
    /* .childProperties         = */ THREE_SAME_CHILD(ILChildProp::UnspecifiedChildType), \
    /* .swapChildrenOperation   = */ TR::vBadOperation, \
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    get first non-zero vector element masked */ \
+   /* .description             =    masked lanewise first non-zero */ \
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ vmpopcnt, \


### PR DESCRIPTION
- in some cases, vector opcode type was not calculated correctly: add VectorElementResult flag to indicate that result is a vector element to solve that issue

- add ILOpCode::getVectorDataType() and OMR::DataType::getVectorNumLanes() methods for convenience