### PR TITLE
Simplify SupportsConst(I|L)Div to Supports(I|L)MulHigh

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -103,6 +103,8 @@ OMR::ARM64::CodeGenerator::initialize()
 
    cg->setSupportsAlignedAccessOnly();
 
+   cg->setSupportsLMulHigh();
+
    if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
       {
       _numberBytesReadInaccessible = 4096;

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -153,7 +153,7 @@ OMR::ARM::CodeGenerator::initialize()
    cg->setSupportsAlignedAccessOnly();
    cg->setSupportsPrimitiveArrayCopy();
    cg->setSupportsReferenceArrayCopy();
-   cg->setSupportsLoweringConstIDiv();
+   cg->setSupportsIMulHigh();
    cg->setSupportsNewInstanceImplOpt();
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1739,11 +1739,11 @@ public:
    bool getSupportsLDivAndLRemWithThreeChildren() {return _flags2.testAny(SupportsLDivAndLRemWithThreeChildren);}
    void setSupportsLDivAndLRemWithThreeChildren() {_flags2.set(SupportsLDivAndLRemWithThreeChildren);}
 
-   bool getSupportsLoweringConstIDiv() {return _flags2.testAny(SupportsLoweringConstIDiv);}
-   void setSupportsLoweringConstIDiv() {_flags2.set(SupportsLoweringConstIDiv);}
+   bool getSupportsIMulHigh() {return _flags2.testAny(SupportsIMulHigh);}
+   void setSupportsIMulHigh() {_flags2.set(SupportsIMulHigh);}
 
-   bool getSupportsLoweringConstLDiv() {return _flags2.testAny(SupportsLoweringConstLDiv);}
-   void setSupportsLoweringConstLDiv() {_flags2.set(SupportsLoweringConstLDiv);}
+   bool getSupportsLMulHigh() {return _flags2.testAny(SupportsLMulHigh);}
+   void setSupportsLMulHigh() {_flags2.set(SupportsLMulHigh);}
 
    bool getSupportsLoweringConstLDivPower2() {return _flags2.testAny(SupportsLoweringConstLDivPower2);}
    void setSupportsLoweringConstLDivPower2() {_flags2.set(SupportsLoweringConstLDivPower2);}
@@ -1842,8 +1842,8 @@ public:
       SupportsVirtualGuardNOPing                          = 0x00000008,
       SupportsEfficientNarrowIntComputation               = 0x00000010,
       SupportsNewInstanceImplOpt                          = 0x00000020,
-      SupportsLoweringConstIDiv                           = 0x00000040,
-      SupportsLoweringConstLDiv                           = 0x00000080,
+      SupportsIMulHigh                                    = 0x00000040,
+      SupportsLMulHigh                                    = 0x00000080,
       SupportsArrayTranslate                              = 0x00000100,
       HasDoubleWordAlignedStack                           = 0x00000200,
       SupportsReadOnlyLocks                               = 0x00000400,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -8690,7 +8690,7 @@ TR::Node *idivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                }
             node->getFirstChild()->incReferenceCount();
             }
-         else if (s->cg()->getSupportsLoweringConstIDiv() && !isPowerOf2(divisor) &&
+         else if (s->cg()->getSupportsIMulHigh() && !isPowerOf2(divisor) &&
                   performTransformation(s->comp(), "%sMagic number idiv opt in node %p\n", s->optDetailString(), node))
             {
              // leave idiv as is if the divisor is 2^n. CodeGen generates a fast instruction squence for it.
@@ -8981,7 +8981,7 @@ TR::Node *ldivSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                node->getFirstChild()->incReferenceCount();
                }
             }       // end power of 2
-         else if (s->cg()->getSupportsLoweringConstLDiv() && !isPowerOf2(divisor))
+         else if (s->cg()->getSupportsLMulHigh() && !isPowerOf2(divisor))
             {
              // otherwise, expose the magic number squence to allow optimization
              // lowered tree will look like this:
@@ -9322,7 +9322,7 @@ TR::Node *iremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
                }
             }
          else if (node->getOpCodeValue() == TR::irem &&
-                  s->cg()->getSupportsLoweringConstIDiv() && !isPowerOf2(divisor) &&
+                  s->cg()->getSupportsIMulHigh() && !isPowerOf2(divisor) &&
                   !skipRemLowering(divisor, s) &&
                   performTransformation(s->comp(), "%sMagic number irem opt in node %p\n", s->optDetailString(), node))
             {
@@ -9447,7 +9447,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             }
          // Disabled pending approval of design 1055.
 #ifdef TR_DESIGN_1055
-         else if (s->cg()->getSupportsLoweringConstLDiv() && !isPowerOf2(divisor) && !skipRemLowering(divisor, s))
+         else if (s->cg()->getSupportsLMulHigh() && !isPowerOf2(divisor) && !skipRemLowering(divisor, s))
             {
             // otherwise, expose the magic number squence to allow optimization
             // lowered tree will look like this:

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -256,9 +256,7 @@ OMR::Power::CodeGenerator::initialize()
    cg->setSupportsJavaFloatSemantics();
 
    cg->setSupportsDivCheck();
-   cg->setSupportsLoweringConstIDiv();
-   if (comp->target().is64Bit())
-      cg->setSupportsLoweringConstLDiv();
+   cg->setSupportsIMulHigh();
    cg->setSupportsLoweringConstLDivPower2();
 
    static bool disableDCAS = (feGetEnv("TR_DisablePPCDCAS") != NULL);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -423,15 +423,16 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
    // TODO (#5642): Re-enable byteswap support on x86 and Power
    // self()->setSupportsByteswap();
 
-   // allows [i/l]div to decompose to [i/l]mulh in TreeSimplifier
-   //
+   // Enables following optimizations:
+   // + Fast division by constant in TreeSimplifier
+   // +
    static char * enableMulHigh = feGetEnv("TR_X86MulHigh");
    if (enableMulHigh)
       {
-      self()->setSupportsLoweringConstIDiv();
+      self()->setSupportsIMulHigh();
 
       if (comp->target().is64Bit())
-         self()->setSupportsLoweringConstLDiv();
+         self()->setSupportsLMulHigh();
       }
 
    self()->setSpillsFPRegistersAcrossCalls(); // TODO:AMD64: Are the preserved XMMRs relevant here?

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -479,7 +479,7 @@ OMR::Z::CodeGenerator::initialize()
 
    cg->setUsesRegisterPairsForLongs();
    cg->setSupportsDivCheck();
-   cg->setSupportsLoweringConstIDiv();
+   cg->setSupportsIMulHigh();
    cg->setSupportsTestUnderMask();
 
    // Initialize to be 8 bytes for bodyInfo / methodInfo


### PR DESCRIPTION
This commit is motivated by eclipse-openj9/openj9#17861.
A check whether the underlying target supports 64 bit multiplication returning the high word is needed
in order to intrinsify java.lang.Math.multiplyHigh

As a side effect, this has simplified the
SupportsConst(I|L)Div checks as they are transitive to the newly added checks