### PR TITLE
AArch64: Fix helper trampoline lookup fo ARM64Trg1SymImmInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -177,7 +177,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
          {
          TR::MethodSymbol *method = symRef->getSymbol()->getMethodSymbol();
 
-         if (method && method->isHelper() || cg()->callUsesHelperImplementation(symRef->getSymbol()))
+         if (method && method->isHelper())
             {
             intptr_t destination = (intptr_t)symRef->getMethodAddress();
 
@@ -192,15 +192,6 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
             intptr_t distance = destination - (intptr_t)cursor;
             insertImmediateField(toARM64Cursor(cursor), distance);
             setAddrImmediate(destination);
-
-            cg()->addExternalRelocation(
-               TR::ExternalRelocation::create(
-                  cursor,
-                  (uint8_t *)symRef,
-                  TR_HelperAddress, cg()),
-               __FILE__,
-               __LINE__,
-               getNode());
             }
          else
             {
@@ -220,6 +211,20 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
 
             intptr_t distance = destination - (intptr_t)cursor;
             insertImmediateField(toARM64Cursor(cursor), distance);
+            }
+         if (method && method->isHelper() || cg()->callUsesHelperImplementation(symRef->getSymbol()))
+            {
+            cg()->addExternalRelocation(
+               TR::ExternalRelocation::create(
+                  cursor,
+                  (uint8_t *)symRef,
+                  TR_HelperAddress, cg()),
+               __FILE__,
+               __LINE__,
+               getNode());
+            }
+         else
+            {
             cg()->addProjectSpecializedRelocation(cursor, reinterpret_cast<uint8_t *>(getSymbolReference()->getMethodAddress()), NULL, TR_MethodCallAddress,
                                                    __FILE__, __LINE__, getNode());
             }


### PR DESCRIPTION
OMR #7077 introduced the `callUsesHelperImplementation()` query to add a `TR_Helper` relocation for methods that are actually helper calls. That PR also changes the way the binary encoder finds necessary trampolines. Before OMR #7077, `methodTrampolineLookup()` was used for call targets whose method object returns false for the `isHelper()` query. The behavior was changed to call `findHelperTrampoline()` instead of `methodTrampolineLookup()` if the `callUsesHelperImplementation()` query returns true.

The problem is that the symbol reference for a certain method (which is actually a helper call) does not have a valid helper index as the reference number, thus causing `findHelperTrampoline` to return an incorrect address.

This commit fixes the binary encoder to use `methodTrampolineLookup` for the call target whose method object returns false for the `isHelper()` query.