### PR TITLE
Add a flag OMRPORT_SLOPEN_NO_LOAD to test if a library was loaded

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -833,6 +833,9 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_SL_ZOS_31BIT_TARGET_MASK 0xFFFFFFFF /* Mask used to convert 31-bit tagged handles/addresses to proper values. */
 #endif /* defined(J9ZOS39064) */
 
+/* Supported on Linux/OSX/Unix/Windows platforms. */
+#define OMRPORT_SLOPEN_NO_LOAD 32
+
 #define OMRPORT_ARCH_X86       "x86"
 #define OMRPORT_ARCH_PPC       "ppc" 				/* in line with IBM JDK 1.22 and above for AIX and Linux/PPC */
 #define OMRPORT_ARCH_PPC64     "ppc64"

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1624,3 +1624,5 @@ TraceException=Trc_PRT_sysinfo_get_number_CPUs_by_type_read_failed Group=sysinfo
 
 TraceExit-Exception=Trc_PRT_mmap_map_file_unix_filestatfailed_exit Group=mmap Overhead=1 Level=1 NoEnv Template="omrmmap_map_file: Could not get stats about the file"
 TraceExit-Exception=Trc_PRT_mmap_map_file_cannotallocatehandle_exit Group=mmap Overhead=1 Level=1 NoEnv Template="omrmmap_map_file: Could not allocate memory for handle"
+
+TraceEvent=Trc_PRT_sl_open_shared_library_noload Group=sl Overhead=1 Level=3 NoEnv Template="omrsl_open_shared_library tests if a library is already loaded, returns handle=%p"

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -130,13 +130,14 @@ omrsl_close_shared_library(struct OMRPortLibrary *portLibrary, uintptr_t descrip
 uintptr_t
 omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintptr_t *descriptor, uintptr_t flags)
 {
-	void *handle;
+	void *handle = NULL;
 	char *openName = name;
 	char mangledName[MAX_STRING_LENGTH + 1];
 	char errBuf[MAX_ERR_BUF_LENGTH];
 	int lazyOrNow = OMR_ARE_ALL_BITS_SET(flags, OMRPORT_SLOPEN_LAZY) ? RTLD_LAZY : RTLD_NOW;
 	BOOLEAN decorate = OMR_ARE_ALL_BITS_SET(flags, OMRPORT_SLOPEN_DECORATE);
 	BOOLEAN openExec = OMR_ARE_ALL_BITS_SET(flags, OMRPORT_SLOPEN_OPEN_EXECUTABLE);
+	BOOLEAN openNoLoad = OMR_ARE_ALL_BITS_SET(flags, OMRPORT_SLOPEN_NO_LOAD);
 	uintptr_t pathLength = 0;
 
 	Trc_PRT_sl_open_shared_library_Entry(name, flags);
@@ -158,6 +159,13 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 	}
 
 	Trc_PRT_sl_open_shared_library_Event1(openName);
+
+	if (openNoLoad) {
+		/* One of RTLD_LAZY and RTLD_NOW must be included in the flag. */
+		handle = dlopen(openExec ? NULL : openName, RTLD_NOLOAD | lazyOrNow);
+		Trc_PRT_sl_open_shared_library_noload(handle);
+		goto exitOnSuccess;
+	}
 
 	/* dlopen(2) called with NULL filename opens a handle to current executable. */
 	handle = dlopen(openExec ? NULL : openName, lazyOrNow);
@@ -211,7 +219,8 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 		}
 	}
 
-	*descriptor = (uintptr_t) handle;
+exitOnSuccess:
+	*descriptor = (uintptr_t)handle;
 	Trc_PRT_sl_open_shared_library_Exit1(*descriptor);
 	return 0;
 }


### PR DESCRIPTION
Added a flag `OMRPORT_SLOPEN_NO_LOAD` for `omrsl_open_shared_library()` to test if a library was loaded, and returns its handle if loaded;
`unix/omrsl.c` uses `dlopen()` with `RTLD_NOLOAD` to test if a library is already resident;
win32/omrsl.c uses GetModuleHandleW() to retrieve a handle to a specified module;
There are no such OS APIs for `AIX/zOS` platforms, and `OMRPORT_SLOPEN_NO_LOAD` is not supported.

`AIX` platform could use [loadquery](https://www.ibm.com/docs/en/aix/7.2?topic=l-loadquery-subroutine) to get a list of library files loaded and compare with a target library to determine if it was already loaded. Such functionality seems to fit better in a separate API, or in the upstream caller of `omrsl_open_shared_library()`.

Required by https://github.com/eclipse-openj9/openj9/pull/17990

Signed-off-by: Jason Feng <fengj@ca.ibm.com>