### PR TITLE
Misc fixes

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2022,6 +2022,7 @@ OMR::IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, ...)
    TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   methodSymRef->getSymbol()->getMethodSymbol()->setLinkage(TR_System);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
    }
 
@@ -2041,6 +2042,7 @@ OMR::IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, TR::IlVa
    TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   methodSymRef->getSymbol()->getMethodSymbol()->setLinkage(TR_System);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
    }
 
@@ -2143,6 +2145,7 @@ OMR::IlBuilder::Call(const char *functionName, int32_t numArgs, ...)
    TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   methodSymRef->getSymbol()->getMethodSymbol()->setLinkage(TR_System);
    return genCall(methodSymRef, numArgs, argValues);
    }
 
@@ -2156,6 +2159,7 @@ OMR::IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** a
    TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   methodSymRef->getSymbol()->getMethodSymbol()->setLinkage(TR_System);
    return genCall(methodSymRef, numArgs, argValues);
    }
 

--- a/fvtest/tril/CMakeLists.txt
+++ b/fvtest/tril/CMakeLists.txt
@@ -22,6 +22,9 @@
 project(tril_project)
 
 set(OMR_WARNINGS_AS_ERRORS OFF)
+if(NOT OMR_TEST_COMPILER)
+    message(FATAL_ERROR "tril requries -DOMR_TEST_COMPILER=1")
+endif(NOT OMR_TEST_COMPILER)
 
 add_subdirectory(tril)
 add_subdirectory(test)


### PR DESCRIPTION
Two changes, both of which have potential to break builds:
1) the tril project doesn't currently check its dependence on testcompiler so now it will assert if not also enabled (not sure our build scripts currently do this)
2) set the linkage on all JitBuilder method symbols to use TR_System convention (currently uses default which, at least on some platforms, is TR_Private).