### PR TITLE
Stop special-casing unevaluated aconst in Power and ARM linkage

### DIFF
--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -399,21 +399,7 @@ TR::Register *OMR::ARM::Linkage::pushIntegerWordArg(TR::Node *child)
 
 TR::Register *OMR::ARM::Linkage::pushAddressArg(TR::Node *child)
    {
-   TR::CodeGenerator *cg      = self()->cg();
-   TR::Register         *pushRegister = NULL;
-   if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
-      {
-      pushRegister = cg->allocateRegister();
-      if (child->isMethodPointerConstant())
-         loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
-      else
-         loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister);
-      }
-   else
-      {
-      pushRegister = cg->evaluate(child);
-      child->setRegister(pushRegister);
-      }
+   TR::Register *pushRegister = self()->cg()->evaluate(child);
    child->decReferenceCount();
    return pushRegister;
    }

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -723,22 +723,8 @@ TR::Register *OMR::Power::Linkage::pushIntegerWordArg(TR::Node *child)
 
 TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
    {
-   TR::Register *pushRegister = NULL;
    TR_ASSERT(child->getDataType() == TR::Address, "assumption violated");
-   if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
-      {
-      pushRegister = self()->cg()->allocateRegister();
-      if (child->isMethodPointerConstant())
-         loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
-      else
-         loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister);
-
-      child->setRegister(pushRegister);
-      }
-   else
-      {
-      pushRegister = self()->cg()->evaluate(child);
-      }
+   TR::Register *pushRegister = self()->cg()->evaluate(child);
    self()->cg()->decReferenceCount(child);
    return pushRegister;
    }


### PR DESCRIPTION
Instead, simply evaluate it like we do for other arguments.

These were the only two places where a `TR_RamMethodSequence` relocation could be generated for a method other than the outermost method, which is not expected. All remaining uses of `TR_RamMethodSequence` are for `compiledMethodSymbol`, which always represents the outermost method.

Fixes eclipse-openj9/openj9#17889