### PR TITLE
Fix encoding of smulh/umulh instructions on AArch64

### DIFF
--- a/compiler/aarch64/codegen/OMRInstOpCode.enum
+++ b/compiler/aarch64/codegen/OMRInstOpCode.enum
@@ -616,8 +616,8 @@
 		msubx,                                                  	/* 0x9B008000	MSUB      	 */
 		smsubl,                                                 	/* 0x9B208000	SMSUBL    	 */
 		umsubl,                                                 	/* 0x9BA08000	UMSUBL    	 */
-		smulh,                                                  	/* 0x9B400000	SMULH     	 */
-		umulh,                                                  	/* 0x9BC00000	UMULH     	 */
+		smulh,                                                  	/* 0x9B407C00	SMULH     	 */
+		umulh,                                                  	/* 0x9BC07C00	UMULH     	 */
 		fmaddd,                                                 	/* 0X1F000000   FMADD        */
 		fmadds,                                                 	/* 0X1F400000   FMADD        */
 	/* Data-processing (2 source) */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -622,8 +622,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x9B008000,	/* MSUB      	msubx	 */
 		0x9B208000,	/* SMSUBL    	smsubl	 */
 		0x9BA08000,	/* UMSUBL    	umsubl	 */
-		0x9B400000,	/* SMULH     	smulh	 */
-		0x9BC00000,	/* UMULH     	umulh	 */
+		0x9B407C00,	/* SMULH     	smulh	 */
+		0x9BC07C00,	/* UMULH     	umulh	 */
 		0X1F400000,	/* FMADD        fmaddd   */
 		0X1F000000,	/* FMADD        fmadds   */
 	/* Data-processing (2 source) */

--- a/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/aarch64/BinaryEncoder.cpp
@@ -2697,3 +2697,21 @@ INSTANTIATE_TEST_CASE_P(VectorRBIT, ARM64Trg1Src1EncodingTest, ::testing::Values
     std::make_tuple(TR::InstOpCode::vrbit16b, TR::RealRegister::v31, TR::RealRegister::v0, "6e60581f"),
     std::make_tuple(TR::InstOpCode::vrbit16b, TR::RealRegister::v31, TR::RealRegister::v0, "6e60581f")
 ));
+
+INSTANTIATE_TEST_CASE_P(SMULH, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x0, TR::RealRegister::x15, TR::RealRegister::x29, "9b5d7de0"),
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x0, TR::RealRegister::x29, TR::RealRegister::x15, "9b4f7fa0"),
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x15, TR::RealRegister::x0, TR::RealRegister::x29, "9b5d7c0f"),
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x15, TR::RealRegister::x29, TR::RealRegister::x0, "9b407faf"),
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x29, TR::RealRegister::x0, TR::RealRegister::x15, "9b4f7c1d"),
+    std::make_tuple(TR::InstOpCode::smulh, TR::RealRegister::x29, TR::RealRegister::x15, TR::RealRegister::x0, "9b407dfd")
+));
+
+INSTANTIATE_TEST_CASE_P(UMULH, ARM64Trg1Src2EncodingTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x0, TR::RealRegister::x15, TR::RealRegister::x29, "9bdd7de0"),
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x0, TR::RealRegister::x29, TR::RealRegister::x15, "9bcf7fa0"),
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x15, TR::RealRegister::x0, TR::RealRegister::x29, "9bdd7c0f"),
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x15, TR::RealRegister::x29, TR::RealRegister::x0, "9bc07faf"),
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x29, TR::RealRegister::x0, TR::RealRegister::x15, "9bcf7c1d"),
+    std::make_tuple(TR::InstOpCode::umulh, TR::RealRegister::x29, TR::RealRegister::x15, TR::RealRegister::x0, "9bc07dfd")
+));


### PR DESCRIPTION
AArch64 code generator incorrectly encodes `smulh` and `umulh` instructions, and those malformed instructions produce unexpected results. This commit fixes encoding of those instructions and adds binary encoding unit tests.

Issue https://github.com/eclipse-openj9/openj9/issues/18057