### PR TITLE
Add 'const' qualifier to some string fields and parameters

### DIFF
--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -93,7 +93,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     * @brief Instruction description string
     * @return description string
     */
-   virtual char *description() { return "ARM64"; }
+   virtual const char *description() { return "ARM64"; }
    /**
     * @brief Gets instruction kind
     * @return instruction kind

--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -82,7 +82,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
                TR::RegisterDependencyConditions    *cond,
                TR::CodeGenerator                   *cg);
 
-   virtual char *description() { return "ARM"; }
+   virtual const char *description() { return "ARM"; }
 
    virtual Kind getKind() { return IsNotExtended; }
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1893,7 +1893,7 @@ void OMR::Compilation::setUsesPreexistence(bool v)
 
 // Dump the trees for the method and return the number of nodes in the trees.
 //
-void OMR::Compilation::dumpMethodTrees(char *title, TR::ResolvedMethodSymbol * methodSymbol)
+void OMR::Compilation::dumpMethodTrees(const char *title, TR::ResolvedMethodSymbol * methodSymbol)
    {
    if (self()->getOutFile() == NULL)
       return;
@@ -1911,7 +1911,7 @@ void OMR::Compilation::dumpMethodTrees(char *title, TR::ResolvedMethodSymbol * m
    trfflush(self()->getOutFile());
    }
 
-void OMR::Compilation::dumpMethodTrees(char *title1, const char *title2, TR::ResolvedMethodSymbol *methodSymbol)
+void OMR::Compilation::dumpMethodTrees(const char *title1, const char *title2, TR::ResolvedMethodSymbol *methodSymbol)
    {
    TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
    char *title = (char*)self()->trMemory()->allocateStackMemory(20 + strlen(title1) + strlen(title2));

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -727,8 +727,8 @@ public:
    //
    int32_t getPrevSymRefTabSize() { return _prevSymRefTabSize; }
    void setPrevSymRefTabSize( int32_t prevSize ) { _prevSymRefTabSize = prevSize; }
-   void dumpMethodTrees(char *title, TR::ResolvedMethodSymbol * = 0);
-   void dumpMethodTrees(char *title1, const char *title2, TR::ResolvedMethodSymbol * = 0);
+   void dumpMethodTrees(const char *title, TR::ResolvedMethodSymbol * = 0);
+   void dumpMethodTrees(const char *title1, const char *title2, TR::ResolvedMethodSymbol * = 0);
    void dumpFlowGraph( TR::CFG * = 0);
 
    bool getAddressEnumerationOption(TR_CompilationOptions o) {return _options->getAddressEnumerationOption(o);}

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -42,7 +42,7 @@ OMR::Monitor::operator delete(void *p)
    }
 
 TR::Monitor *
-OMR::Monitor::create(char *name)
+OMR::Monitor::create(const char *name)
    {
    TR::Monitor * monitor = new TR::Monitor();
    monitor->init(name);
@@ -61,7 +61,7 @@ OMR::Monitor::self()
    }
 
 bool
-OMR::Monitor::init(char *name)
+OMR::Monitor::init(const char *name)
    {
    _name = name;
 #if defined(OMR_OS_WINDOWS)

--- a/compiler/infra/OMRMonitor.hpp
+++ b/compiler/infra/OMRMonitor.hpp
@@ -44,7 +44,7 @@ class Monitor
    ~Monitor();
 
    TR::Monitor *self();
-   static TR::Monitor *create(char *name);
+   static TR::Monitor *create(const char *name);
    static void destroy(TR::Monitor *monitor);
    void enter();
    int32_t try_enter() { TR_UNIMPLEMENTED(); return 0; }
@@ -56,7 +56,7 @@ class Monitor
    void notifyAll() { TR_UNIMPLEMENTED(); }
    int32_t num_waiting() { TR_UNIMPLEMENTED(); return 0; }
    char const *getName();
-   bool init(char *name);
+   bool init(const char *name);
 
 #if defined(J9ZOS390) || defined(AIXPPC)
    // xlc cannot handle private delete operator
@@ -68,7 +68,7 @@ class Monitor
    void *operator new(size_t size);
    void operator delete(void *p);
 
-   char const *_name;
+   const char *_name;
    MUTEX _monitor;
    };
 

--- a/compiler/infra/OMRMonitorTable.hpp
+++ b/compiler/infra/OMRMonitorTable.hpp
@@ -64,7 +64,7 @@ class OMR_EXTENSIBLE MonitorTable
    friend class TR::Monitor;
    friend class TR::MonitorTable;
 
-   TR::Monitor *create(char *name) { TR_UNIMPLEMENTED(); return 0; }
+   TR::Monitor *create(const char *name) { TR_UNIMPLEMENTED(); return 0; }
    };
 
 }

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -65,7 +65,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node = 0);
    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::Node *node = 0);
 
-   virtual char *description() { return "PPC"; }
+   virtual const char *description() { return "PPC"; }
    virtual Kind getKind() { return IsNotExtended; }
 
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);

--- a/compiler/ras/Delimiter.hpp
+++ b/compiler/ras/Delimiter.hpp
@@ -37,10 +37,10 @@ class Delimiter
    Delimiter(
          TR::Compilation * comp,
          bool trace,
-         char * tag,
-         char * comment0 = NULL,
-         char * comment1 = NULL,
-         char * comment2 = NULL) :
+         const char * tag,
+         const char * comment0 = NULL,
+         const char * comment1 = NULL,
+         const char * comment2 = NULL) :
       _tag(tag),
       _comp(comp),
       _trace(trace)
@@ -81,7 +81,7 @@ class Delimiter
 
    // pin an address is good enough
    // char _buffer[tagsize];
-   char * _tag;
+   const char * _tag;
 
    TR::Compilation *_comp;
 

--- a/compiler/riscv/codegen/OMRInstruction.hpp
+++ b/compiler/riscv/codegen/OMRInstruction.hpp
@@ -94,7 +94,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     * @brief Instruction description string
     * @return description string
     */
-   virtual char *description() { return "RV"; }
+   virtual const char *description() { return "RV"; }
 
    /**
     * @brief Gets instruction kind

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -91,7 +91,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    public:
 
-   virtual char *description() { return "X86"; }
+   virtual const char *description() { return "X86"; }
    virtual Kind getKind() { return IsNotExtended; }
 
    OMR::X86::Encoding getEncodingMethod() { return _encodingMethod; }

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -123,7 +123,7 @@ class X86PaddingInstruction : public TR::Instruction
    virtual uint8_t *generateBinaryEncoding();
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
 
-   virtual char *description() { return "X86RegMem"; }
+   virtual const char *description() { return "X86RegMem"; }
 
    virtual Kind getKind() { return IsPadding; }
 
@@ -156,7 +156,7 @@ class X86PaddingSnippetInstruction : public TR::X86PaddingInstruction
       _unresolvedSnippet(NULL)
       {}
 
-   virtual char *description() { return "PaddingSnippetInstruction"; }
+   virtual const char *description() { return "PaddingSnippetInstruction"; }
 
    virtual TR::Snippet *getSnippetForGC();
 
@@ -230,7 +230,7 @@ class X86BoundaryAvoidanceInstruction : public TR::Instruction
    virtual uint8_t *generateBinaryEncoding();
    virtual OMR::X86::EnlargementResult  enlarge(int32_t requestedEnlargementSize, int32_t maxEnlargementSize, bool allowPartialEnlargement);
 
-   virtual char *description() { return "X86BoundaryAvoidance"; }
+   virtual const char *description() { return "X86BoundaryAvoidance"; }
 
    virtual Kind getKind() { return IsBoundaryAvoidance; }
 
@@ -288,7 +288,7 @@ class X86PatchableCodeAlignmentInstruction : public TR::X86BoundaryAvoidanceInst
 
    TR::Instruction *getPatchableCode(){ return getTargetCode(); }
 
-   virtual char *description() { return "PatchableCodeAlignment"; }
+   virtual const char *description() { return "PatchableCodeAlignment"; }
 
    virtual Kind getKind() { return IsPatchableCodeAlignment; }
    virtual int32_t betterPadLength(int32_t oldPadLength, const TR_AtomicRegion *unaccommodatedRegion, int32_t unaccommodatedRegionStart);
@@ -317,7 +317,7 @@ class X86LabelInstruction : public TR::Instruction
 
    void prohibitShortening() { _permitShortening = false; }
 
-   virtual char *description() { return "X86LabelInstruction"; }
+   virtual const char *description() { return "X86LabelInstruction"; }
    virtual bool isPatchBarrier(TR::CodeGenerator *cg) { return getOpCodeValue() == TR::InstOpCode::label && _symbol && _symbol->isTargeted(cg) != TR_no; }
 
    uint8_t    getReloType() {return _reloType; };
@@ -354,7 +354,7 @@ class X86AlignmentInstruction : public TR::Instruction
 
    public:
 
-   virtual char *description() { return "X86Alignment"; }
+   virtual const char *description() { return "X86Alignment"; }
 
    virtual Kind getKind() { return IsAlignment; }
 
@@ -444,7 +444,7 @@ class X86FenceInstruction : public TR::Instruction
                           TR::Node *n,
                           TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86Fence"; }
+   virtual const char *description() { return "X86Fence"; }
 
    virtual Kind getKind() { return IsFence; }
 
@@ -485,7 +485,7 @@ class X86VirtualGuardNOPInstruction : public TR::X86LabelInstruction
                                     TR::LabelSymbol *label = 0)
       : TR::X86LabelInstruction(precedingInstruction, op, label, cond, cg), _site(site), _nopSize(0), _register(TR::RealRegister::NoReg) { setNode(node); }
 
-   virtual char *description() { return "X86VirtualGuardNOP"; }
+   virtual const char *description() { return "X86VirtualGuardNOP"; }
 
    virtual Kind getKind() { return IsVirtualGuardNOP; }
 
@@ -590,7 +590,7 @@ class X86ImmInstruction : public TR::Instruction
                         TR::CodeGenerator *cg,
                         int32_t reloKind=TR_NoRelocation);
 
-   virtual char *description() { return "X86Imm"; }
+   virtual const char *description() { return "X86Imm"; }
 
    virtual Kind getKind() { return IsImm; }
 
@@ -639,7 +639,7 @@ class X86ImmSnippetInstruction : public TR::X86ImmInstruction
                                TR::UnresolvedDataSnippet *us,
                                TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86ImmSnippet"; }
+   virtual const char *description() { return "X86ImmSnippet"; }
 
    virtual Kind getKind() { return IsImmSnippet; }
 
@@ -688,7 +688,7 @@ class X86ImmSymInstruction : public TR::X86ImmInstruction
                            TR::RegisterDependencyConditions *cond,
                            TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86ImmSym"; }
+   virtual const char *description() { return "X86ImmSym"; }
 
    virtual Kind getKind() { return IsImmSym; }
 
@@ -821,7 +821,7 @@ class X86RegInstruction : public TR::Instruction
                         TR::CodeGenerator *cg,
                         OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86Reg"; }
+   virtual const char *description() { return "X86Reg"; }
 
    virtual Kind getKind() { return IsReg; }
 
@@ -980,7 +980,7 @@ class X86RegRegInstruction : public TR::X86RegInstruction
                             TR::CodeGenerator                    *cg,
                             OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86RegReg"; }
+   virtual const char *description() { return "X86RegReg"; }
 
    virtual Kind getKind() { return IsRegReg; }
 
@@ -1110,7 +1110,7 @@ class X86RegImmInstruction : public TR::X86RegInstruction
                            TR::CodeGenerator                    *cg,
                            int32_t                              reloKind=TR_NoRelocation);
 
-   virtual char *description() { return "X86RegImm"; }
+   virtual const char *description() { return "X86RegImm"; }
 
    virtual Kind getKind() { return IsRegImm; }
 
@@ -1153,7 +1153,7 @@ class X86RegImmSymInstruction : public TR::X86RegImmInstruction
                               TR::SymbolReference     *sr,
                               TR::CodeGenerator       *cg);
 
-   virtual char *description() { return "X86RegImmSym"; }
+   virtual const char *description() { return "X86RegImmSym"; }
 
    virtual Kind getKind() { return IsRegImmSym; }
 
@@ -1192,7 +1192,7 @@ class X86RegRegImmInstruction : public TR::X86RegRegInstruction
                               TR::CodeGenerator        *cg,
                               OMR::X86::Encoding       encoding);
 
-   virtual char *description() { return "X86RegRegImm"; }
+   virtual const char *description() { return "X86RegRegImm"; }
 
    virtual Kind getKind() { return IsRegRegImm; }
 
@@ -1302,7 +1302,7 @@ class X86RegRegRegInstruction : public TR::X86RegRegInstruction
                                TR::CodeGenerator                    *cg,
                                OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86RegRegReg"; }
+   virtual const char *description() { return "X86RegRegReg"; }
 
    virtual Kind getKind() { return IsRegRegReg; }
 
@@ -1403,7 +1403,7 @@ class X86RegMaskRegInstruction : public TR::X86RegRegInstruction
       useRegister(mreg);
       }
 
-   virtual char *description() { return "X86RegMaskReg"; }
+   virtual const char *description() { return "X86RegMaskReg"; }
 
    virtual Kind getKind() { return IsRegMaskReg; }
 
@@ -1469,7 +1469,7 @@ class X86RegMaskRegRegInstruction : public TR::X86RegRegRegInstruction
       useRegister(mreg);
       }
 
-   virtual char *description() { return "X86RegMaskRegReg"; }
+   virtual const char *description() { return "X86RegMaskRegReg"; }
 
    virtual Kind getKind() { return IsRegMaskRegReg; }
 
@@ -1534,7 +1534,7 @@ class X86RegMaskRegRegImmInstruction : public TR::X86RegMaskRegRegInstruction
       {
       }
 
-   virtual char *description() { return "X86RegMaskRegRegImm"; }
+   virtual const char *description() { return "X86RegMaskRegRegImm"; }
    virtual Kind getKind() { return IsRegMaskRegRegImm; }
 
    int32_t getSourceImmediate()           {return _sourceImmediate;}
@@ -1698,7 +1698,7 @@ class X86MemInstruction : public TR::Instruction
                          TR::Register                         *sreg=NULL,
                          OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86Mem"; }
+   virtual const char *description() { return "X86Mem"; }
 
    virtual Kind getKind() { return IsMem; }
 
@@ -1765,7 +1765,7 @@ class X86MemTableInstruction : public TR::X86MemInstruction
       _relocations = (TR::LabelRelocation**)cg->trMemory()->allocateHeapMemory(numEntries * sizeof(_relocations[0]));
       }
 
-   virtual char *description() { return "X86MemTable"; }
+   virtual const char *description() { return "X86MemTable"; }
 
    virtual Kind getKind() { return IsMemTable; }
 
@@ -1814,7 +1814,7 @@ class X86CallMemInstruction : public TR::X86MemInstruction
                              TR::MemoryReference               *mr,
                              TR::CodeGenerator                    *cg);
 
-   virtual char *description() { return "X86CallMem"; }
+   virtual const char *description() { return "X86CallMem"; }
 
    virtual Kind getKind() { return IsCallMem; }
 
@@ -1864,7 +1864,7 @@ class X86MemImmInstruction : public TR::X86MemInstruction
                            TR::CodeGenerator       *cg,
                            int32_t                reloKind = TR_NoRelocation);
 
-   virtual char *description() { return "X86MemImm"; }
+   virtual const char *description() { return "X86MemImm"; }
 
    virtual Kind getKind() { return IsMemImm; }
 
@@ -1902,7 +1902,7 @@ class X86MemImmSymInstruction : public TR::X86MemImmInstruction
                               TR::SymbolReference     *sr,
                               TR::CodeGenerator       *cg);
 
-   virtual char *description() { return "X86MemImmSym"; }
+   virtual const char *description() { return "X86MemImmSym"; }
 
    virtual Kind getKind() { return IsMemImmSym; }
 
@@ -1999,7 +1999,7 @@ class X86MemRegInstruction : public TR::X86MemInstruction
                             TR::CodeGenerator                    *cg,
                             OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86MemReg"; }
+   virtual const char *description() { return "X86MemReg"; }
 
    virtual Kind getKind() { return IsMemReg; }
 
@@ -2062,7 +2062,7 @@ class X86MemMaskRegInstruction : public TR::X86MemRegInstruction
       useRegister(mreg);
       }
 
-   virtual char *description() { return "X86MemMaskReg"; }
+   virtual const char *description() { return "X86MemMaskReg"; }
 
    virtual Kind getKind() { return IsMemMaskReg; }
 
@@ -2102,7 +2102,7 @@ class X86MemRegImmInstruction : public TR::X86MemRegInstruction
                               int32_t                imm,
                               TR::CodeGenerator      *cg);
 
-   virtual char *description() { return "X86MemRegImm"; }
+   virtual const char *description() { return "X86MemRegImm"; }
 
    virtual Kind getKind() { return IsMemRegImm; }
 
@@ -2198,7 +2198,7 @@ class X86RegMemInstruction : public TR::X86RegInstruction
                             TR::CodeGenerator                    *cg,
                             OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86RegMem"; }
+   virtual const char *description() { return "X86RegMem"; }
 
    virtual Kind getKind() { return IsRegMem; }
 
@@ -2273,7 +2273,7 @@ class X86RegMemImmInstruction : public TR::X86RegMemInstruction
                               TR::CodeGenerator        *cg,
                               OMR::X86::Encoding encoding);
 
-   virtual char *description() { return "X86RegMemImm"; }
+   virtual const char *description() { return "X86RegMemImm"; }
 
    virtual Kind getKind() { return IsRegMemImm; }
 
@@ -2311,7 +2311,7 @@ class X86RegRegMemInstruction : public TR::X86RegMemInstruction
                            TR::CodeGenerator                *cg,
                            OMR::X86::Encoding encoding = OMR::X86::Default);
 
-   virtual char *description() { return "X86RegRegMem"; }
+   virtual const char *description() { return "X86RegRegMem"; }
 
    virtual Kind getKind() { return IsRegRegMem; }
 
@@ -2411,7 +2411,7 @@ class X86RegMaskMemInstruction : public TR::X86RegMemInstruction
       useRegister(mreg);
       }
 
-   virtual char *description() { return "X86RegMaskMem"; }
+   virtual const char *description() { return "X86RegMaskMem"; }
 
    virtual Kind getKind() { return IsRegMaskMem; }
 
@@ -2544,7 +2544,7 @@ class AMD64RegImm64Instruction : public TR::X86RegInstruction
                                int32_t                              reloKind=TR_NoRelocation)
       : TR::X86RegInstruction(cond, treg, op, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(reloKind) {}
 
-   virtual char *description() { return "AMD64RegImm64"; }
+   virtual const char *description() { return "AMD64RegImm64"; }
 
    virtual Kind getKind() { return IsRegImm64; }
 
@@ -2585,7 +2585,7 @@ class AMD64RegImm64SymInstruction : public TR::AMD64RegImm64Instruction
                                   TR::SymbolReference     *sr,
                                   TR::CodeGenerator       *cg);
 
-   virtual char *description() { return "AMD64RegImm64Sym"; }
+   virtual const char *description() { return "AMD64RegImm64Sym"; }
 
    virtual Kind getKind() { return IsRegImm64Sym; }
 
@@ -2665,7 +2665,7 @@ class AMD64Imm64Instruction : public TR::Instruction
          cond->createRegisterAssociationDirective(this, cg);
       }
 
-   virtual char *description() { return "AMD64Imm64"; }
+   virtual const char *description() { return "AMD64Imm64"; }
 
    virtual Kind getKind() { return IsImm64; }
 
@@ -2715,7 +2715,7 @@ class AMD64Imm64SymInstruction : public TR::AMD64Imm64Instruction
                               TR::CodeGenerator                    *cg)
       : TR::AMD64Imm64Instruction(cond, imm, op, precedingInstruction, cg), _symbolReference(sr) {}
 
-   virtual char *description() { return "AMD64Imm64Sym"; }
+   virtual const char *description() { return "AMD64Imm64Sym"; }
 
    virtual Kind getKind() { return IsImm64Sym; }
 
@@ -2766,7 +2766,7 @@ class X86FPRegRegInstruction : public TR::X86RegRegInstruction
                              TR::RegisterDependencyConditions  *cond,
                              TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86FPRegReg"; }
+   virtual const char *description() { return "X86FPRegReg"; }
 
    virtual Kind getKind() { return IsRegRegReg; }
 
@@ -2852,7 +2852,7 @@ class X86FPST0ST1RegRegInstruction : public TR::X86FPRegRegInstruction
                                     TR::Register      *sreg,
                                     TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86FPST0ST1RegReg"; }
+   virtual const char *description() { return "X86FPST0ST1RegReg"; }
 
    virtual Kind getKind() { return IsFPST0ST1RegReg; }
 
@@ -2877,7 +2877,7 @@ class X86FPST0STiRegRegInstruction : public TR::X86FPRegRegInstruction
                                     TR::Register      *sreg,
                                     TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86FPST0STiRegReg"; }
+   virtual const char *description() { return "X86FPST0STiRegReg"; }
 
    virtual Kind getKind() { return IsFPST0STiRegReg; }
 
@@ -2903,7 +2903,7 @@ class X86FPSTiST0RegRegInstruction : public TR::X86FPRegRegInstruction
                                     TR::Register      *sreg,
                                     TR::CodeGenerator *cg, bool forcePop = false);
 
-   virtual char *description() { return "X86FPSTiST0RegReg"; }
+   virtual const char *description() { return "X86FPSTiST0RegReg"; }
 
    virtual Kind getKind() { return IsFPSTiST0RegReg; }
 
@@ -2930,7 +2930,7 @@ class X86FPArithmeticRegRegInstruction : public TR::X86FPRegRegInstruction
                                         TR::Register      *sreg,
                                         TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86FPArithmeticRegReg"; }
+   virtual const char *description() { return "X86FPArithmeticRegReg"; }
 
    virtual Kind getKind() { return IsFPArithmeticRegReg; }
 
@@ -2988,7 +2988,7 @@ class X86FPRemainderRegRegInstruction : public TR::X86FPST0ST1RegRegInstruction
                                       TR::Register      *sreg,
                                       TR::CodeGenerator *cg);
 
-   virtual char *description() { return "X86FPRemainderRegReg"; }
+   virtual const char *description() { return "X86FPRemainderRegReg"; }
 
    virtual Kind getKind() { return IsFPRemainderRegReg; }
    virtual void assignRegisters(TR_RegisterKinds kindsToBeAssigned);
@@ -3012,7 +3012,7 @@ class X86FPMemRegInstruction : public TR::X86MemRegInstruction
                               TR::Register            *sreg,
                               TR::CodeGenerator       *cg);
 
-   virtual char *description() { return "X86FPMemReg"; }
+   virtual const char *description() { return "X86FPMemReg"; }
 
    virtual Kind getKind() { return IsFPMemReg; }
 
@@ -3042,7 +3042,7 @@ class X86FPRegMemInstruction : public TR::X86RegMemInstruction
                               TR::MemoryReference  *mr,
                               TR::CodeGenerator       *cg);
 
-   virtual char *description() { return "X86FPRegMem"; }
+   virtual const char *description() { return "X86FPRegMem"; }
 
    virtual Kind getKind() { return IsFPRegMem; }
 
@@ -3069,7 +3069,7 @@ class X86VFPSaveInstruction : public TR::Instruction
    X86VFPSaveInstruction(TR::Node *node, TR::CodeGenerator *cg) :
       TR::Instruction(node, TR::InstOpCode::AdjustFramePtr, cg) {}
 
-   virtual char *description() { return "X86VFPSave"; }
+   virtual const char *description() { return "X86VFPSave"; }
 
    virtual Kind getKind() { return IsVFPSave; }
 
@@ -3099,7 +3099,7 @@ class X86VFPRestoreInstruction : public TR::Instruction
       _saveInstruction(saveInstruction),
       TR::Instruction(node, TR::InstOpCode::AdjustFramePtr, cg) {}
 
-   virtual char *description() { return "X86VFPRestore"; }
+   virtual const char *description() { return "X86VFPRestore"; }
 
    virtual Kind getKind() { return IsVFPRestore; }
 
@@ -3146,7 +3146,7 @@ class X86VFPDedicateInstruction : public TR::X86RegMemInstruction
    X86VFPDedicateInstruction(TR::RealRegister *framePointerReg, TR::Node *node, TR::RegisterDependencyConditions  *cond, TR::CodeGenerator *cg):
       TR::X86RegMemInstruction(TR::InstOpCode::LEARegMem(), node, framePointerReg, memref(cg), cond, cg){}
 
-   virtual char *description() { return "X86VFPDedicate"; }
+   virtual const char *description() { return "X86VFPDedicate"; }
 
    virtual Kind getKind() { return IsVFPDedicate; }
 
@@ -3181,7 +3181,7 @@ class X86VFPReleaseInstruction : public TR::Instruction
       _dedicateInstruction(dedicateInstruction),
       TR::Instruction(node, TR::InstOpCode::AdjustFramePtr, cg){}
 
-   virtual char *description() { return "X86VFPRelease"; }
+   virtual const char *description() { return "X86VFPRelease"; }
 
    virtual Kind getKind() { return IsVFPRelease; }
 
@@ -3234,7 +3234,7 @@ class X86VFPCallCleanupInstruction : public TR::Instruction
       _stackPointerAdjustment(adjustment),
       TR::Instruction(node, TR::InstOpCode::AdjustFramePtr, cg) {}
 
-   virtual char *description() { return "X86VFPCallCleanup"; }
+   virtual const char *description() { return "X86VFPCallCleanup"; }
 
    virtual Kind getKind() { return IsVFPCallCleanup; }
 

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -241,7 +241,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    const char *getName(TR_Debug * debug);
    bool isWillBePatched() { return (_index & WillBePatched) != 0; }
    void setWillBePatched() { _index |= WillBePatched; }
-   virtual char *description() { return "S390"; }
+   virtual const char *description() { return "S390"; }
 
 
    private:

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -190,7 +190,7 @@ class S390LabeledInstruction : public TR::Instruction
 
    TR::Snippet     *getCallSnippet()                    {return _snippet;}
 
-   virtual char *description() { return "S390Instruction"; }
+   virtual const char *description() { return "S390Instruction"; }
    virtual Kind getKind()=0;
    virtual uint8_t *generateBinaryEncoding()=0;
    virtual int32_t estimateBinaryLength(int32_t currentEstimate)=0;
@@ -287,7 +287,7 @@ class S390BranchInstruction : public TR::S390LabeledInstruction
         _branchCondition(branchCondition)
       {}
 
-   virtual char *description() { return "S390Branch"; }
+   virtual const char *description() { return "S390Branch"; }
    virtual Kind getKind() { return IsBranch; }
 
    virtual TR::Snippet *getSnippetForGC()
@@ -332,7 +332,7 @@ class S390VirtualGuardNOPInstruction : public TR::S390BranchInstruction
                                     TR::CodeGenerator                    *cg)
       : S390BranchInstruction(TR::InstOpCode::BRC, TR::InstOpCode::COND_VGNOP, node, label, cond, precedingInstruction, cg), _site(site) {}
 
-   virtual char *description() { return "S390VirtualGuardNOP"; }
+   virtual const char *description() { return "S390VirtualGuardNOP"; }
    virtual Kind getKind() { return IsVirtualGuardNOP; }
 
    void setSite(TR_VirtualGuardSite *site) { _site = site; }
@@ -387,7 +387,7 @@ class S390BranchOnCountInstruction : public TR::S390LabeledInstruction
       : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
       {useTargetRegister(targetReg);}
 
-   virtual char *description() { return "S390BranchOnCount"; }
+   virtual const char *description() { return "S390BranchOnCount"; }
    virtual Kind getKind() { return IsBranchOnCount; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -443,7 +443,7 @@ class S390BranchOnIndexInstruction : public TR::S390LabeledInstruction
       : S390LabeledInstruction(op, n, sym, precedingInstruction, cg)
       {useTargetRegister(targetReg); useSourceRegister(sourceReg);}
 
-   virtual char *description() { return "S390BranchOnIndex"; }
+   virtual const char *description() { return "S390BranchOnIndex"; }
    virtual Kind getKind() { return IsBranchOnIndex; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -535,7 +535,7 @@ class S390LabelInstruction : public TR::S390LabeledInstruction
       : S390LabeledInstruction(op, n, s, cond, precedingInstruction, cg), _alignment(0)
       {}
 
-   virtual char *description() { return "S390LabelInstruction"; }
+   virtual const char *description() { return "S390LabelInstruction"; }
    virtual Kind getKind() { return IsLabel; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -612,7 +612,7 @@ class S390PseudoInstruction : public TR::Instruction
         _callDescLabel(NULL),
         _shouldBeginNewLine(false){}
 
-   virtual char *description() { return "S390PseudoInstruction"; }
+   virtual const char *description() { return "S390PseudoInstruction"; }
    virtual Kind getKind() { return IsPseudo; }
 
    TR::Node * getFenceNode() { return _fenceNode; }
@@ -775,7 +775,7 @@ public:
       setRegionNumber(regionNum);
       }
 
-   virtual char *description() { return "S390AnnotInstruction"; }
+   virtual const char *description() { return "S390AnnotInstruction"; }
    virtual Kind getKind()      { return IsAnnot; }
    char *getAnnotation()       { return _annotation; }
    int32_t getFlags()          { return _flags; }
@@ -829,7 +829,7 @@ class S390ImmInstruction : public TR::Instruction
       : TR::Instruction(op, n, cond, precedingInstruction, cg), _sourceImmediate(imm)
       {}
 
-   virtual char *description() { return "S390ImmInstruction"; }
+   virtual const char *description() { return "S390ImmInstruction"; }
    virtual Kind getKind() { return IsImm; }
 
    uint32_t getSourceImmediate()            {return _sourceImmediate;}
@@ -886,7 +886,7 @@ class S390Imm2Instruction : public TR::Instruction
       : TR::Instruction(op, n, cond, precedingInstruction, cg), _sourceImmediate(imm)
       { setEstimatedBinaryLength(2); }
 
-   virtual char *description() { return "S390Imm2Instruction"; }
+   virtual const char *description() { return "S390Imm2Instruction"; }
    virtual Kind getKind() { return IsImm2Byte; }
 
    uint16_t getSourceImmediate()            {return _sourceImmediate;}
@@ -925,7 +925,7 @@ class S390ImmSnippetInstruction : public TR::S390ImmInstruction
       : S390ImmInstruction(op, n, imm, precedingInstruction, cg),
         _unresolvedSnippet(us), _snippet(s) {}
 
-   virtual char *description() { return "S390ImmSnippetInstruction"; }
+   virtual const char *description() { return "S390ImmSnippetInstruction"; }
    virtual Kind getKind() { return IsImmSnippet; }
 
    TR::UnresolvedDataSnippet *getUnresolvedSnippet() {return _unresolvedSnippet;}
@@ -983,7 +983,7 @@ class S390ImmSymInstruction : public TR::S390ImmInstruction
                             TR::CodeGenerator                    *cg)
      : S390ImmInstruction(op, node, imm, cond, precedingInstruction, cg), _symbolReference(sr)
      {}
-   virtual char *description() { return "S390ImmSymInstruction"; }
+   virtual const char *description() { return "S390ImmSymInstruction"; }
    virtual Kind getKind() { return IsImmSym; }
 
    TR::SymbolReference *getSymbolReference() {return _symbolReference;}
@@ -1256,7 +1256,7 @@ class S390RegInstruction : public TR::Instruction
                 (_targetPairFlag)?"cannot":"should");
       }
 
-   virtual char *description() { return "S390RegInstruction"; }
+   virtual const char *description() { return "S390RegInstruction"; }
    virtual Kind getKind() { return IsReg; }
    virtual bool isRegInstruction() { return true; }
 
@@ -1508,7 +1508,7 @@ class S390RRInstruction : public TR::S390RegInstruction
       {
       }
 
-   virtual char *description() { return "S390RRInstruction"; }
+   virtual const char *description() { return "S390RRInstruction"; }
    virtual Kind getKind() { return IsRR; }
 
    //   TR::Register  *getSourceRegister()                {return (_sourceRegSize!=0) ? (sourceRegBase())[0] : NULL;  }
@@ -1603,7 +1603,7 @@ class S390TranslateInstruction : public TR::Instruction
       useSourceRegister(termCharReg);
       }
 
-   virtual char *description() { return "S390TranslateInstruction"; }
+   virtual const char *description() { return "S390TranslateInstruction"; }
    virtual Kind getKind() { return IsRRE; }
 
    TR::Register *getTableRegister()                             {return getRegisterOperand(tr_tblidx); }
@@ -1811,7 +1811,7 @@ class S390RRFInstruction : public TR::S390RRInstruction
       {
       }
 
-   virtual char *description() { return "S390RRFInstruction"; }
+   virtual const char *description() { return "S390RRFInstruction"; }
    virtual Kind getKind()
       {
       if (_encodeAsRRD)
@@ -1908,7 +1908,7 @@ class S390RRRInstruction : public TR::S390RRInstruction
          useTargetRegister(sreg2);
       }
 
-   virtual char *description() { return "S390RRRInstruction"; }
+   virtual const char *description() { return "S390RRRInstruction"; }
    virtual Kind getKind()
       {
       return IsRRR;
@@ -1979,7 +1979,7 @@ class S390RIInstruction : public TR::S390RegInstruction
                             TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg), _sourceImmediate(imm), _isImm(true) {};
 
-   virtual char *description() { return "S390RIInstruction"; }
+   virtual const char *description() { return "S390RIInstruction"; }
    virtual Kind getKind() { return IsRI; }
 
    int32_t getSourceImmediate()            {return _sourceImmediate;}
@@ -2349,7 +2349,7 @@ class S390RILInstruction : public TR::Instruction
          useTargetRegister(treg);
       }
 
-   virtual char *description() { return "S390RILInstruction"; }
+   virtual const char *description() { return "S390RILInstruction"; }
    virtual Kind getKind() { return IsRIL; }
 
    bool isLiteralPoolAddress() {return _flagsRIL.testAny(isLiteralPoolAddressFlag); }
@@ -2725,7 +2725,7 @@ class S390RSInstruction : public TR::S390RegInstruction
            useSourceRegister(sreg);
         };
 
-   virtual char *description() { return "S390RSInstruction"; }
+   virtual const char *description() { return "S390RSInstruction"; }
    virtual Kind getKind()                   {return IsRS;}
    uint32_t getSourceImmediate()            {return _sourceImmediate;}
    uint32_t setSourceImmediate(uint32_t si) {return _sourceImmediate = si;}
@@ -2884,7 +2884,7 @@ class S390RSYInstruction : public TR::S390RSInstruction
       {
       }
 
-   virtual char *description() { return "S390RSYInstruction"; }
+   virtual const char *description() { return "S390RSYInstruction"; }
    virtual Kind getKind() { return IsRSY; }
 
    //virtual uint8_t *generateBinaryEncoding();
@@ -2934,7 +2934,7 @@ class S390RRSInstruction : public TR::S390RRInstruction
    setupThrowsImplicitNullPointerException(n,branchDestination);
    }
 
-   virtual char *description() { return "S390RRSInstruction"; }
+   virtual const char *description() { return "S390RRSInstruction"; }
    virtual Kind getKind() { return IsRRS; }
 
    /** Get branch condition information */
@@ -3013,7 +3013,7 @@ class S390RREInstruction : public TR::S390RRInstruction
       {
       }
 
-   virtual char *description() { return "S390RREInstruction"; }
+   virtual const char *description() { return "S390RREInstruction"; }
    virtual Kind getKind() { return IsRRE; }
 
    //virtual uint8_t *generateBinaryEncoding();
@@ -3054,7 +3054,7 @@ class S390IEInstruction : public TR::Instruction
    uint8_t getImmediateField1() { return _immediate1; }
    uint8_t getImmediateField2() { return _immediate2; }
 
-   virtual char *description() { return "S390IEInstruction"; }
+   virtual const char *description() { return "S390IEInstruction"; }
    virtual Kind getKind() { return IsIE; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -3331,7 +3331,7 @@ class S390RIEInstruction : public TR::S390RegInstruction
 
 
    /** Determine the form of this instruction */
-   virtual char *description() { return "S390RIEInstruction"; }
+   virtual const char *description() { return "S390RIEInstruction"; }
    virtual Kind getKind() { return IsRIE; }
    virtual RIEForm getRieForm() { return _instructionFormat; }
 
@@ -3446,7 +3446,7 @@ class S390SMIInstruction : public TR::Instruction
    uint8_t getMask()             {return _mask;}
    uint8_t setMask(uint8_t mask) {return _mask = mask;}
 
-   virtual char *description() { return "S390SMIInstruction"; }
+   virtual const char *description() { return "S390SMIInstruction"; }
    virtual Kind getKind() { return IsSMI; }
    virtual TR::LabelSymbol *getLabelSymbol()
       {
@@ -3510,7 +3510,7 @@ class S390MIIInstruction : public TR::Instruction
    uint8_t getMask()             {return _mask;}
    uint8_t setMask(uint8_t mask) {return _mask = mask;}
 
-   virtual char *description() { return "S390MIIInstruction"; }
+   virtual const char *description() { return "S390MIIInstruction"; }
    virtual Kind getKind() { return IsMII; }
    virtual TR::LabelSymbol *getLabelSymbol()
       {
@@ -3562,7 +3562,7 @@ class S390RISInstruction : public TR::S390RIInstruction
       setupThrowsImplicitNullPointerException(n,branchDestination);
       }
 
-   virtual char *description() { return "S390RISInstruction"; }
+   virtual const char *description() { return "S390RISInstruction"; }
    virtual Kind getKind() { return IsRIS; }
 
    /** Get branch condition information */
@@ -3712,7 +3712,7 @@ class S390MemInstruction : public TR::Instruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   virtual char *description() { return "S390MemInstruction"; }
+   virtual const char *description() { return "S390MemInstruction"; }
    virtual Kind getKind() { return IsMem; }
 
    virtual TR::MemoryReference *getMemoryReference() { return _memref; }
@@ -3751,7 +3751,7 @@ class S390SIInstruction : public TR::S390MemInstruction
       useSourceMemoryReference(mf);
       };
 
-   virtual char *description() { return "S390SIInstruction"; }
+   virtual const char *description() { return "S390SIInstruction"; }
    virtual Kind getKind()                   { return IsSI; }
 
    uint8_t getSourceImmediate() { return _sourceImmediate; }
@@ -3779,7 +3779,7 @@ class S390SIYInstruction : public TR::S390SIInstruction
                          TR::CodeGenerator *cg)
            : S390SIInstruction(op, n, mf, imm, precedingInstruction, cg) {};
 
-   virtual char *description() { return "S390SIYInstruction"; }
+   virtual const char *description() { return "S390SIYInstruction"; }
    virtual Kind getKind() { return IsSIY; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -3817,7 +3817,7 @@ class S390SILInstruction : public TR::S390MemInstruction
          useSourceMemoryReference(mf);
       }
 
-   virtual char *description() { return "S390SILInstruction"; }
+   virtual const char *description() { return "S390SILInstruction"; }
    virtual Kind getKind() { return IsSIL; }
 
    uint16_t getSourceImmediate() { return _sourceImmediate; }
@@ -3845,7 +3845,7 @@ class S390SInstruction : public TR::S390MemInstruction
                        TR::CodeGenerator *cg)
            : S390MemInstruction(op, n, mf, precedingInstruction, cg) {};
 
-   virtual char *description() { return "S390SInstruction"; }
+   virtual const char *description() { return "S390SInstruction"; }
    virtual Kind getKind() { return IsS; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -3886,7 +3886,7 @@ class S390RSLInstruction : public TR::S390MemInstruction
       {
       }
 
-   virtual char *description() { return "S390RSLInstruction"; }
+   virtual const char *description() { return "S390RSLInstruction"; }
    virtual Kind getKind() { return IsRSL; }
 
    uint16_t getLen()             {return _len;}
@@ -3943,7 +3943,7 @@ class S390RSLbInstruction : public TR::S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   virtual char *description() { return "S390RSLbInstruction"; }
+   virtual const char *description() { return "S390RSLbInstruction"; }
    virtual Kind getKind() { return IsRSLb; }
 
    uint16_t getLen()             {return _length;}
@@ -4025,7 +4025,7 @@ class S390MemMemInstruction : public TR::S390MemInstruction
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   virtual char *description() { return "S390MemMemInstruction"; }
+   virtual const char *description() { return "S390MemMemInstruction"; }
    virtual Kind getKind() { return IsMemMem; }
 
    virtual TR::MemoryReference *getMemoryReference2() { return (_targetMemSize!=0) ? (targetMemBase())[0] : NULL;}
@@ -4089,7 +4089,7 @@ class S390SS1Instruction : public TR::S390MemMemInstruction
       {
       }
 
-   virtual char *description() { return "S390SS1Instruction"; }
+   virtual const char *description() { return "S390SS1Instruction"; }
    virtual Kind getKind() { return IsSS1; }
 
    uint32_t getLen()             {return _len;}
@@ -4220,7 +4220,7 @@ class S390SS2Instruction : public TR::S390SS1Instruction
       {
       }
 
-   virtual char *description() { return "S390SS2Instruction"; }
+   virtual const char *description() { return "S390SS2Instruction"; }
    virtual Kind getKind() { return IsSS2; }
 
 
@@ -4296,7 +4296,7 @@ class S390SS4Instruction : public TR::S390SS1Instruction
          _operands[i+nr]=vp[i];
       }
 
-   virtual char *description() { return "S390SS4Instruction"; }
+   virtual const char *description() { return "S390SS4Instruction"; }
    virtual Kind getKind() { return IsSS4; }
 
    TR::Register * getLengthReg()    { return (_ss4_lenidx!=-1) ?  (sourceRegBase())[_ss4_lenidx] : NULL; }
@@ -4413,7 +4413,7 @@ class S390SSEInstruction : public TR::S390MemMemInstruction
       {
       }
 
-   virtual char *description() { return "S390SSEInstruction"; }
+   virtual const char *description() { return "S390SSEInstruction"; }
    virtual Kind getKind() { return IsSSE; }
    };
 
@@ -4474,7 +4474,7 @@ class S390RXInstruction : public TR::S390RegInstruction
          (mf->getUnresolvedSnippet())->setDataReferenceInstruction(this);
       }
 
-   virtual char *description() { return "S390RXInstruction"; }
+   virtual const char *description() { return "S390RXInstruction"; }
    virtual Kind getKind() { return IsRX; }
 
    virtual TR::MemoryReference *getMemoryReference() { return (_sourceMemSize!=0) ? (sourceMemBase())[0] : NULL;}
@@ -4521,7 +4521,7 @@ class S390RXEInstruction : public TR::S390RXInstruction
       mask3 = m3;
       }
    uint8_t getM3() {return mask3;}
-   virtual char *description() { return "S390RXEInstruction"; }
+   virtual const char *description() { return "S390RXEInstruction"; }
    virtual Kind getKind() { return IsRXE; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -4570,7 +4570,7 @@ class S390RXYInstruction : public TR::S390RXInstruction
       {
       }
 
-   virtual char *description() { return "S390RXYInstruction"; }
+   virtual const char *description() { return "S390RXYInstruction"; }
    virtual Kind getKind() { return IsRXY; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -4603,7 +4603,7 @@ class S390RXYbInstruction : public TR::S390MemInstruction
       }
 
 
-   virtual char *description() { return "S390RXYbInstruction"; }
+   virtual const char *description() { return "S390RXYbInstruction"; }
 
    virtual Kind getKind() { return IsRXYb; }
    virtual void setKind(Kind kind) { return; }
@@ -4678,7 +4678,7 @@ class S390SSFInstruction : public TR::S390RXInstruction
       setupThrowsImplicitNullPointerException(n,mf2);
       }
 
-   virtual char *description() { return "S390SSFInstruction"; }
+   virtual const char *description() { return "S390SSFInstruction"; }
    virtual Kind getKind() { return IsSSF; }
 
    virtual TR::MemoryReference *getMemoryReference2() { return (_sourceMemSize==2) ? (sourceMemBase())[1] : NULL; }
@@ -4744,7 +4744,7 @@ class S390RXFInstruction : public TR::S390RRInstruction
       setupThrowsImplicitNullPointerException(n,mf);
       }
 
-   virtual char *description() { return "S390RXFInstruction"; }
+   virtual const char *description() { return "S390RXFInstruction"; }
    virtual Kind getKind() { return IsRXF; }
 
    virtual TR::MemoryReference *getMemoryReference() {return (_sourceMemSize!=0) ? (sourceMemBase())[0] : NULL;}
@@ -4815,7 +4815,7 @@ class S390VInstruction : public S390RegInstruction
       TR::Instruction::setMaskField(instruction, mask, nibbleIndex);
       }
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
-   virtual char *description() { return "S390VInstruction"; }
+   virtual const char *description() { return "S390VInstruction"; }
    virtual Kind getKind() = 0;
    virtual uint8_t * generateBinaryEncoding() = 0;
    virtual char *setOpCodeBuffer(char *c);
@@ -4886,7 +4886,7 @@ class S390VRIInstruction : public S390VInstruction
    uint16_t getImmediateField16(){ return _constantImm16; }
    uint8_t  getImmediateField8(){ return _constantImm8; }
 
-   virtual char *description() { return "S390VRIInstruction"; }
+   virtual const char *description() { return "S390VRIInstruction"; }
    virtual Kind getKind() = 0;
 
    const char *getExtendedMnemonicName();
@@ -4929,7 +4929,7 @@ class S390VRIaInstruction : public S390VRIInstruction
 
    uint16_t getImmediateField2() { return getImmediateField16(); }
 
-   virtual char *description() { return "S390VRIaInstruction"; }
+   virtual const char *description() { return "S390VRIaInstruction"; }
    virtual Kind getKind() { return IsVRIa; }
    uint8_t * generateBinaryEncoding();
    };
@@ -4961,7 +4961,7 @@ class S390VRIbInstruction : public S390VRIInstruction
    uint8_t getImmediateField2() { return getImmediateField16() >> 8; }
    uint8_t getImmediateField3() { return getImmediateField16() & 0xff; }
 
-   virtual char *description() { return "S390VRIbInstruction"; }
+   virtual const char *description() { return "S390VRIbInstruction"; }
    virtual Kind getKind() { return IsVRIb; }
    uint8_t * generateBinaryEncoding();
    };
@@ -4993,7 +4993,7 @@ class S390VRIcInstruction : public S390VRIInstruction
 
    uint16_t getImmediateField2() { return getImmediateField16(); }
 
-   virtual char *description() { return "S390VRIcInstruction"; }
+   virtual const char *description() { return "S390VRIcInstruction"; }
    virtual Kind getKind() { return IsVRIc; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5031,7 +5031,7 @@ class S390VRIdInstruction : public S390VRIInstruction
       }
 
    uint8_t getImmediateField4() { return getImmediateField16() & 0xff; }
-   virtual char *description() { return "S390VRIdInstruction"; }
+   virtual const char *description() { return "S390VRIdInstruction"; }
    virtual Kind getKind() { return IsVRId; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5069,7 +5069,7 @@ class S390VRIeInstruction : public S390VRIInstruction
 
    uint16_t getImmediateField3() { return getImmediateField16() >> 4; }
 
-   virtual char *description() { return "S390VRIeInstruction"; }
+   virtual const char *description() { return "S390VRIeInstruction"; }
    virtual Kind getKind() { return IsVRIe; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5108,7 +5108,7 @@ class S390VRIfInstruction : public S390VRIInstruction
 
    uint8_t getImmediateField4() { return getImmediateField16() & 0xff; }
 
-   char *description() { return "S390VRIfInstruction"; }
+   const char *description() { return "S390VRIfInstruction"; }
    Kind getKind() { return IsVRIf; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5143,7 +5143,7 @@ class S390VRIgInstruction : public S390VRIInstruction
    uint16_t getImmediateField3() { return getImmediateField16() & 0xff; }
    uint8_t getImmediateField4() { return getImmediateField8(); }
 
-   char *description() { return "S390VRIgInstruction"; }
+   const char *description() { return "S390VRIgInstruction"; }
    Kind getKind() { return IsVRIg; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5174,7 +5174,7 @@ class S390VRIhInstruction : public S390VRIInstruction
    uint16_t getImmediateField2() { return getImmediateField16(); }
    uint8_t getImmediateField3() { return getImmediateField8(); }
 
-   char *description() { return "S390VRIhInstruction"; }
+   const char *description() { return "S390VRIhInstruction"; }
    Kind getKind() { return IsVRIh; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5209,7 +5209,7 @@ class S390VRIiInstruction : public S390VRIInstruction
 
    uint8_t getImmediateField3() { return getImmediateField8(); }
 
-   char *description() { return "S390VRIiInstruction"; }
+   const char *description() { return "S390VRIiInstruction"; }
    Kind getKind() { return IsVRIi; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5235,7 +5235,7 @@ class S390VRRInstruction : public S390VInstruction
    bool          _printM5;
    bool          _printM6;
    public:
-   virtual char *description() { return "S390VRRInstruction"; }
+   virtual const char *description() { return "S390VRRInstruction"; }
    virtual Kind getKind() = 0;
    uint8_t getM3() {return mask3;}
    uint8_t getM4() {return mask4;}
@@ -5353,7 +5353,7 @@ class S390VRRaInstruction: public S390VRRInstruction
       {
       }
 
-   char *description() { return "S390VRRaInstruction"; }
+   const char *description() { return "S390VRRaInstruction"; }
    Kind getKind() { return IsVRRa; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5385,7 +5385,7 @@ class S390VRRbInstruction: public S390VRRInstruction
          useSourceRegister(sourceReg3);
       }
 
-   char *description() { return "S390VRRbInstruction"; }
+   const char *description() { return "S390VRRbInstruction"; }
    Kind getKind() { return IsVRRb; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5418,7 +5418,7 @@ class S390VRRcInstruction: public S390VRRInstruction
          useSourceRegister(sourceReg3);
       }
 
-   char *description() { return "S390VRRcInstruction"; }
+   const char *description() { return "S390VRRcInstruction"; }
    Kind getKind() { return IsVRRc; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5456,7 +5456,7 @@ class S390VRRdInstruction: public S390VRRInstruction
          useSourceRegister(sourceReg4);
       }
 
-   char *description() { return "S390VRRdInstruction"; }
+   const char *description() { return "S390VRRdInstruction"; }
    Kind getKind() { return IsVRRd; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5494,7 +5494,7 @@ class S390VRReInstruction: public S390VRRInstruction
          useSourceRegister(sourceReg4);
       }
 
-   char *description() { return "S390VRReInstruction"; }
+   const char *description() { return "S390VRReInstruction"; }
    Kind getKind() { return IsVRRe; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5524,7 +5524,7 @@ class S390VRRfInstruction: public S390VRRInstruction
          useSourceRegister(sourceReg3);
       }
 
-   char *description() { return "S390VRRfInstruction"; }
+   const char *description() { return "S390VRRfInstruction"; }
    Kind getKind() { return IsVRRf; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5549,7 +5549,7 @@ class S390VRRgInstruction: public S390VRRInstruction
       {
       }
 
-   char *description() { return "S390VRRgInstruction"; }
+   const char *description() { return "S390VRRgInstruction"; }
    Kind getKind() { return IsVRRg; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5575,7 +5575,7 @@ class S390VRRhInstruction: public S390VRRInstruction
       {
       }
 
-   char *description() { return "S390VRRhInstruction"; }
+   const char *description() { return "S390VRRhInstruction"; }
    Kind getKind() { return IsVRRh; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5605,7 +5605,7 @@ class S390VRRiInstruction: public S390VRRInstruction
       {
       }
 
-   char *description() { return "S390VRRiInstruction"; }
+   const char *description() { return "S390VRRiInstruction"; }
    Kind getKind() { return IsVRRi; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5632,7 +5632,7 @@ class S390VRRkInstruction: public S390VRRInstruction
       {
       }
 
-   char *description() { return "S390VRRkInstruction"; }
+   const char *description() { return "S390VRRkInstruction"; }
    Kind getKind() { return IsVRRk; }
    uint8_t * generateBinaryEncoding();
    };
@@ -5715,7 +5715,7 @@ class S390VStorageInstruction: public S390VInstruction
 
    public:
    virtual TR::MemoryReference* getMemoryReference()  { return (_sourceMemSize!=0) ? (sourceMemBase())[0] : NULL; }
-   virtual char *description() { return "S390VStorageInstruction"; }
+   virtual const char *description() { return "S390VStorageInstruction"; }
    virtual Kind getKind() = 0;
    uint8_t getMaskField() { return _maskField; }
 
@@ -5793,7 +5793,7 @@ class S390VRSaInstruction : public S390VStorageInstruction
       }
 
    Kind getKind() { return IsVRSa; }
-   virtual char *description() { return "S390VRSaInstruction"; }
+   virtual const char *description() { return "S390VRSaInstruction"; }
    };
 
 /**
@@ -5834,7 +5834,7 @@ class S390VRSbInstruction : public S390VStorageInstruction
       }
 
    Kind getKind() { return IsVRSb; }
-   virtual char *description() { return "S390VRSbInstruction"; }
+   virtual const char *description() { return "S390VRSbInstruction"; }
    };
 
 /**
@@ -5875,7 +5875,7 @@ class S390VRScInstruction : public S390VStorageInstruction
       }
 
    Kind getKind() { return IsVRSc; }
-   virtual char *description() { return "S390VRScInstruction"; }
+   virtual const char *description() { return "S390VRScInstruction"; }
    };
 
 /**
@@ -5922,7 +5922,7 @@ class S390VRSdInstruction : public S390VStorageInstruction
 
    Kind getKind() { return IsVRSd; }
    uint8_t * generateBinaryEncoding();
-   char *description() { return "S390VRSdInstruction"; }
+   const char *description() { return "S390VRSdInstruction"; }
 
 private:
    void initVRSd(TR::Register* r3Reg, TR::Register* v1Reg, TR::MemoryReference* mr)
@@ -6066,7 +6066,7 @@ class S390VSIInstruction : public S390VStorageInstruction
 
    Kind getKind() { return IsVSI; }
    uint8_t getImmediateField3() { return _constantImm3; }
-   char *description() { return "S390VSIInstruction"; }
+   const char *description() { return "S390VSIInstruction"; }
    uint8_t * generateBinaryEncoding();
 private:
    uint8_t _constantImm3;
@@ -6123,7 +6123,7 @@ class S390NOPInstruction : public TR::Instruction
       setEstimatedBinaryLength(numbytes);
       }
 
-   virtual char *description() { return "S390NOPInstruction"; }
+   virtual const char *description() { return "S390NOPInstruction"; }
    virtual Kind getKind() { return IsNOP; }
 
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
@@ -6154,7 +6154,7 @@ public:
       setAlignment(alignment);
       }
 
-   virtual char *description() { return "S390AlignmentNopInstruction"; }
+   virtual const char *description() { return "S390AlignmentNopInstruction"; }
    virtual Kind getKind() { return IsAlignmentNop; }
 
    uint32_t getAlignment() { return _alignment; }
@@ -6189,7 +6189,7 @@ class S390IInstruction : public TR::Instruction
       {
       }
 
-   virtual char *description() { return "S390IInstruction"; }
+   virtual const char *description() { return "S390IInstruction"; }
    virtual Kind getKind() { return IsI; }
 
    uint32_t getImmediateField() { return _immediate; }
@@ -6263,7 +6263,7 @@ class S390EInstruction : public TR::Instruction
       setEstimatedBinaryLength(2);
       }
 
-   virtual char *description() { return "S390EInstruction"; }
+   virtual const char *description() { return "S390EInstruction"; }
    virtual Kind getKind() { return IsE; }
 
    virtual uint8_t *generateBinaryEncoding();
@@ -6292,7 +6292,7 @@ class S390OpCodeOnlyInstruction : public TR::Instruction
       {
       }
 
-   virtual char *description() { return "S390OpCodeOnlyInstruction"; }
+   virtual const char *description() { return "S390OpCodeOnlyInstruction"; }
    virtual Kind getKind() { return IsOpCodeOnly; }
 
    };


### PR DESCRIPTION
Work towards fixing AIX warnings about converting string literals to non-const char pointers by adding a 'const' qualifier to string fields and parameters in a variety of locations throughout OMR.

Contributes to (but doesn't close) [openj9 #14859](https://github.com/eclipse-openj9/openj9/issues/14859)