### PR TITLE
Enable arraycmp and arraycmplen uniformly

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -179,12 +179,12 @@ OMR::ARM64::CodeGenerator::initialize()
    cg->setSupportsCompactedLocals();
    if (!TR::Compiler->om.canGenerateArraylets())
       {
-      static const bool disableArrayCmp = feGetEnv("TR_aarch64DisableArrayCmp") != NULL;
+      static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
       if (!disableArrayCmp)
          {
          cg->setSupportsArrayCmp();
          }
-      static const bool disableArrayCmpLen = feGetEnv("TR_aarch64DisableArrayCmpLen") != NULL;
+      static const bool disableArrayCmpLen = feGetEnv("TR_DisableArrayCmpLen") != NULL;
       if (!disableArrayCmpLen)
          {
          cg->setSupportsArrayCmpLen();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -225,8 +225,20 @@ OMR::Power::CodeGenerator::initialize()
        {
        cg->setSupportsArraySet();
        }
-    cg->setSupportsArrayCmp();
-    cg->setSupportsArrayCmpLen();
+
+   if (!TR::Compiler->om.canGenerateArraylets())
+      {
+      static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
+      if (!disableArrayCmp)
+         {
+         cg->setSupportsArrayCmp();
+         }
+      static const bool disableArrayCmpLen = feGetEnv("TR_DisableArrayCmpLen") != NULL;
+      if (!disableArrayCmpLen)
+         {
+         cg->setSupportsArrayCmpLen();
+         }
+      }
 
     if (comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX))
        {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -379,8 +379,16 @@ OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
 
    if (!TR::Compiler->om.canGenerateArraylets())
       {
-      self()->setSupportsArrayCmp();
-      self()->setSupportsArrayCmpLen();
+      static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
+      if (!disableArrayCmp)
+         {
+         self()->setSupportsArrayCmp();
+         }
+      static const bool disableArrayCmpLen = feGetEnv("TR_DisableArrayCmpLen") != NULL;
+      if (!disableArrayCmpLen)
+         {
+         self()->setSupportsArrayCmpLen();
+         }
       self()->setSupportsPrimitiveArrayCopy();
       if (!comp->getOption(TR_DisableArraySetOpts))
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -502,9 +502,20 @@ OMR::Z::CodeGenerator::initialize()
       {
       cg->setSupportsArraySet();
       }
-   cg->setSupportsArrayCmp();
-   cg->setSupportsArrayCmpLen();
-   cg->setSupportsArrayCmpSign();
+   if (!TR::Compiler->om.canGenerateArraylets())
+      {
+      static const bool disableArrayCmp = feGetEnv("TR_DisableArrayCmp") != NULL;
+      if (!disableArrayCmp)
+         {
+         cg->setSupportsArrayCmp();
+         cg->setSupportsArrayCmpSign();
+         }
+      static const bool disableArrayCmpLen = feGetEnv("TR_DisableArrayCmpLen") != NULL;
+      if (!disableArrayCmpLen)
+         {
+         cg->setSupportsArrayCmpLen();
+         }
+      }
    if (!comp->compileRelocatableCode())
       {
       cg->setSupportsArrayTranslateTRxx();


### PR DESCRIPTION
For all platforms where `arraycmp` and `arraycmplen` are supported, do not call `setSupportsArrayCmp(Len)` when either
- arraylets can be generated
- the `TR_DisableArrayCmp(Len)` environment variable is set

See https://github.com/eclipse-openj9/openj9/pull/16662#discussion_r1317469710
Relies on https://github.com/eclipse/omr/pull/6983, leaving this as draft until that goes through