### PR TITLE
Z: Split flag for transactional execution facility

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -532,7 +532,7 @@ OMR::Z::CodeGenerator::initialize()
 
    if (comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_ZEC12))
       {
-      if (comp->target().cpu.supportsFeature(OMR_FEATURE_S390_TE) && !comp->getOption(TR_DisableTM))
+      if (comp->target().cpu.supportsTransactionalMemoryInstructions() && !comp->getOption(TR_DisableTM))
          cg->setSupportsTM();
       }
 

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -53,7 +53,8 @@ OMR::Z::CPU::detect(OMRPortLibrary * const omrPortLib)
 
    if (processorDescription.processor < OMR_PROCESSOR_S390_ZEC12)
       {
-      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_TE, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY, FALSE);
+      omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY, FALSE);
       omrsysinfo_processor_set_feature(&processorDescription, OMR_FEATURE_S390_RI, FALSE);
       }
 
@@ -168,9 +169,11 @@ OMR::Z::CPU::supportsFeatureOldAPI(uint32_t feature)
       case OMR_FEATURE_S390_FPE:
          supported = self()->getSupportsFloatingPointExtensionFacility();
          break;
-      case OMR_FEATURE_S390_TE:
-         supported = self()->getSupportsTransactionalMemoryFacility();
+      case OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY:
+         supported = self()->getSupportsConstrainedTransactionalExecutionFacility();
          break;
+      case OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY:
+         supported = self()->getSupportsTransactionalExecutionFacility();
       case OMR_FEATURE_S390_RI:
          supported = self()->getSupportsRuntimeInstrumentationFacility();
          break;
@@ -345,28 +348,49 @@ OMR::Z::CPU::setSupportsFloatingPointExtensionFacility(bool value)
    }
 
 bool
-OMR::Z::CPU::getSupportsTransactionalMemoryFacility()
+OMR::Z::CPU::getSupportsTransactionalExecutionFacility()
    {
-   return _flags.testAny(S390SupportsTM);
+   return _flags.testAny(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
    }
 
 bool
 OMR::Z::CPU::supportsTransactionalMemoryInstructions()
    {
-   return self()->supportsFeature(OMR_FEATURE_S390_TE);
+   return self()->supportsFeature(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
    }
 
 
 bool
-OMR::Z::CPU::setSupportsTransactionalMemoryFacility(bool value)
+OMR::Z::CPU::setSupportsTransactionalExecutionFacility(bool value)
    {
    if (value)
       {
-      _flags.set(S390SupportsTM);
+      _flags.set(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
       }
    else
       {
-      _flags.reset(S390SupportsTM);
+      _flags.reset(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
+      }
+
+   return value;
+   }
+
+bool
+OMR::Z::CPU::getSupportsConstrainedTransactionalExecutionFacility()
+   {
+   return _flags.testAny(OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY);
+   }
+
+bool
+OMR::Z::CPU::setSupportsConstrainedTransactionalExecutionFacility(bool value)
+   {
+   if (value)
+      {
+      _flags.set(OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY);
+      }
+   else
+      {
+      _flags.reset(OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY);
       }
 
    return value;

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -82,7 +82,7 @@ public:
    bool getSupportsHardwareSQRT();
 
    bool hasPopulationCountInstruction();
-   
+
    /** \brief
     *     Determines whether the High-Word facility is available on the current processor.
     */
@@ -95,12 +95,12 @@ public:
     *     Determines whether the High-Word facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsHighWordFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Decimal Floating Point (DFP) facility is available on the current processor.
     */
    bool getSupportsDecimalFloatingPointFacility();
-   
+
    /** \brief
     *     Determines whether the Decimal Floating Point (DFP) facility is available on the current processor.
     *
@@ -108,12 +108,12 @@ public:
     *     Determines whether the Decimal Floating Point facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsDecimalFloatingPointFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Floating Point Extension (FPE) facility is available on the current processor.
     */
    bool getSupportsFloatingPointExtensionFacility();
-   
+
    /** \brief
     *     Determines whether the Floating Point Extension (FPE) facility is available on the current processor.
     *
@@ -121,31 +121,44 @@ public:
     *     Determines whether the Floating Point Extension facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsFloatingPointExtensionFacility(bool value);
-   
-   /** \brief
-    *     Determines whether the Transactional Memory (TM) facility is available on the current processor.
-    */
-   bool getSupportsTransactionalMemoryFacility();
 
    /** \brief
-    *     Determines whether the Transactional Memory (TM) facility is available on the current processor.
-    *     Alias of supportsFeature(OMR_FEATURE_S390_TE) as a platform agnostic query.
+    *     Determines whether the Transactional Execution (TX) facility is available on the current processor.
+    */
+   bool getSupportsTransactionalExecutionFacility();
+
+   /** \brief
+    *     Determines whether the Transactional Execution (TX) facility is available on the current processor.
+    *     Alias of supportsFeature(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY) as a platform agnostic query.
     */
    bool supportsTransactionalMemoryInstructions();
-   
+
    /** \brief
-    *     Determines whether the Transactional Memory (TM) facility is available on the current processor.
+    *     Determines whether the Transactional Execution (TX) facility is available on the current processor.
     *
     *  \param value
-    *     Determines whether the Transactional Memory facility is available (if \c true) or not (if \c false).
+    *     Determines whether the Transactional Execution facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsTransactionalMemoryFacility(bool value);
-   
+   bool setSupportsTransactionalExecutionFacility(bool value);
+
+   /** \brief
+    *     Determines whether the Constrained Transactional Execution (TXC) facility is available on the current processor.
+    */
+   bool getSupportsConstrainedTransactionalExecutionFacility();
+
+   /** \brief
+    *     Determines whether the Constrained Transactional Execution (TXC) facility is available on the current processor.
+    *
+    *  \param value
+    *     Determines whether the Constrained Transactional Execution facility is available (if \c true) or not (if \c false).
+    */
+   bool setSupportsConstrainedTransactionalExecutionFacility(bool value);
+
    /** \brief
     *     Determines whether the Runtime Instrumentation (RI) facility is available on the current processor.
     */
    bool getSupportsRuntimeInstrumentationFacility();
-   
+
    /** \brief
     *     Determines whether the Runtime Instrumentation (RI) facility is available on the current processor.
     *
@@ -153,12 +166,12 @@ public:
     *     Determines whether the Runtime Instrumentation facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsRuntimeInstrumentationFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Vector facility is available on the current processor.
     */
    bool getSupportsVectorFacility();
-   
+
    /** \brief
     *     Determines whether the Vector facility is available on the current processor.
     *
@@ -166,12 +179,12 @@ public:
     *     Determines whether the Vector facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsVectorFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
     */
    bool getSupportsVectorPackedDecimalFacility();
-   
+
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
     *
@@ -179,7 +192,7 @@ public:
     *     Determines whether the Vector Packed Decimal facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsVectorPackedDecimalFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Miscellaneous Instruction Extensions 2 (MIE2) facility is available on the current
     *     processor.
@@ -202,22 +215,22 @@ public:
     *     processor.
     */
    bool getSupportsMiscellaneousInstructionExtensions3Facility();
-   
+
    /** \brief
     *     Determines whether the Miscellaneous Instruction Extensions 3 (MIE3) facility is available on the current
     *     processor.
     *
     *  \param value
-    *     Determines whether the Miscellaneous Instruction Extensions 3 facility is available (if \c true) or not (if 
+    *     Determines whether the Miscellaneous Instruction Extensions 3 facility is available (if \c true) or not (if
     *     \c false).
     */
    bool setSupportsMiscellaneousInstructionExtensions3Facility(bool value);
-   
+
    /** \brief
     *     Determines whether the Vector Enhancement 2 facility is available on the current processor.
     */
    bool getSupportsVectorFacilityEnhancement2();
-   
+
    /** \brief
     *     Determines whether the Vector Enhancement 2 facility is available on the current processor.
     *
@@ -230,7 +243,7 @@ public:
     *     Determines whether the Vector Enhancement 1 facility is available on the current processor.
     */
    bool getSupportsVectorFacilityEnhancement1();
-   
+
    /** \brief
     *     Determines whether the Vector Enhancement 1 facility is available on the current processor.
     *
@@ -238,12 +251,12 @@ public:
     *     Determines whether the Vector Enhancement 1 facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsVectorFacilityEnhancement1(bool value);
-   
+
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
     */
    bool getSupportsVectorPackedDecimalEnhancementFacility();
-   
+
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
     *
@@ -251,12 +264,12 @@ public:
     *     Determines whether the Vector Packed Decimal facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsVectorPackedDecimalEnhancementFacility(bool value);
-   
+
    /** \brief
     *     Determines whether the Guarded Storage (GS) facility is available on the current processor.
     */
    bool getSupportsGuardedStorageFacility();
-   
+
    /** \brief
     *     Determines whether the Guarded Storage (GS) facility is available on the current processor.
     *
@@ -264,7 +277,7 @@ public:
     *     Determines whether the Guarded Storage facility is available (if \c true) or not (if \c false).
     */
    bool setSupportsGuardedStorageFacility(bool value);
-   
+
    /**
     * \brief Determines whether 32bit integer rotate is available
     *

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1526,7 +1526,6 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_S390_MSA        3 /* STFLE bit 17 */
 #define OMR_FEATURE_S390_DFP        6 /* STFLE bit 42 & 44 */
 #define OMR_FEATURE_S390_HPAGE      7
-#define OMR_FEATURE_S390_TE        10 /* STFLE bit 50 & 73 */
 #define OMR_FEATURE_S390_MSA_EXTENSION3                      11 /* STFLE bit 76 */
 #define OMR_FEATURE_S390_MSA_EXTENSION4                      12 /* STFLE bit 77 */
 
@@ -1571,6 +1570,11 @@ typedef struct OMRProcessorDesc {
 /* STFLE bit 49 - Miscellaneous-instruction-extension facility */
 #define OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION 49
 
+/* STFLE bit 50 - Constrained transactional-execution facility */
+#define OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY 50
+/* STFLE bit 73 - Transactional-execution facility */
+#define OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY 73
+
 /* z13 facilities */
 
 /* STFLE bit 53 - Load/store-on-condition facility 2 */
@@ -1610,7 +1614,7 @@ typedef struct OMRProcessorDesc {
 
 /* z15 facilities */
 
-/* STFLE bit 61 - Miscellaneous-instruction-extensions facility 3 */ 
+/* STFLE bit 61 - Miscellaneous-instruction-extensions facility 3 */
 #define OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_3 61
 
 /* STFLE bit 148 - Vector enhancements facility 2 */


### PR DESCRIPTION
Previously both constrained and non-constrained transactional memory facility support were indicated with the `OMR_FEATURE_S390_TE` flag. This commit removes the `OMR_FEATURE_S390_TE` flag and adds a separate flag for constrained and non-constrained transactional execution facilities.