### PR TITLE
Check array-shadow symbol and DataType for refineArrayAliasing

### DIFF
--- a/compiler/optimizer/GeneralLoopUnroller.hpp
+++ b/compiler/optimizer/GeneralLoopUnroller.hpp
@@ -137,6 +137,7 @@ class TR_LoopUnroller
    struct IntrnPtr;
    IntrnPtr *findIntrnPtr(int32_t symRefNum);
    bool haveIdenticalOffsets(IntrnPtr *intrnPtr1, IntrnPtr *intrnPtr2);
+   bool isSymRefSameTypeArrayShadow(TR::Node *node);
    void examineArrayAccesses();
    void refineArrayAliasing();
 


### PR DESCRIPTION
This is to check that the array access is an array-shadow symbol and that the symbol DataType matches the node DataType before performing `TR_LoopUnroller::refineArrayAliasing` on that list of accesses.