### PR TITLE
Guard call to OMR::Node::setEvaluationPriority

### DIFF
--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -295,7 +295,10 @@ OMR::CodeGenerator::whichChildToEvaluate(TR::Node * node)
          }
       }
 
-   node->setEvaluationPriority(nodePriority);
+   if (!node->getOpCode().isIf())
+      {
+      node->setEvaluationPriority(nodePriority);
+      }
    return bestChild;
    }
 


### PR DESCRIPTION
Guard a call to OMR::Node::setEvaluationPriority to prevent it from being called on if nodes, since it doesn't make sense for them to have an evaluation priority.

Issue: [openj9 #17559](https://github.com/eclipse-openj9/openj9/issues/17559)