### PR TITLE
Z: Change CPU support flag setters to return void

### DIFF
--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -267,12 +267,6 @@ OMR::Z::CPU::getSupportsArch(Architecture arch)
    }
 
 bool
-OMR::Z::CPU::setSupportsArch(Architecture arch)
-   {
-   return _supportedArch = _supportedArch >= arch ? _supportedArch : arch;
-   }
-
-bool
 OMR::Z::CPU::getSupportsHardwareSQRT()
    {
    return true;

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -284,7 +284,7 @@ OMR::Z::CPU::getSupportsHighWordFacility()
    return _flags.testAny(S390SupportsHPR);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsHighWordFacility(bool value)
    {
    if (value)
@@ -295,8 +295,6 @@ OMR::Z::CPU::setSupportsHighWordFacility(bool value)
       {
       _flags.reset(S390SupportsHPR);
       }
-
-   return value;
    }
 
 bool
@@ -305,7 +303,7 @@ OMR::Z::CPU::getSupportsDecimalFloatingPointFacility()
    return _flags.testAny(S390SupportsDFP);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsDecimalFloatingPointFacility(bool value)
    {
    if (value)
@@ -316,8 +314,6 @@ OMR::Z::CPU::setSupportsDecimalFloatingPointFacility(bool value)
       {
       _flags.reset(S390SupportsDFP);
       }
-
-   return value;
    }
 
 bool
@@ -326,7 +322,7 @@ OMR::Z::CPU::getSupportsFloatingPointExtensionFacility()
    return _flags.testAny(S390SupportsFPE);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsFloatingPointExtensionFacility(bool value)
    {
    if (value)
@@ -337,8 +333,6 @@ OMR::Z::CPU::setSupportsFloatingPointExtensionFacility(bool value)
       {
       _flags.reset(S390SupportsFPE);
       }
-
-   return value;
    }
 
 bool
@@ -354,7 +348,7 @@ OMR::Z::CPU::supportsTransactionalMemoryInstructions()
    }
 
 
-bool
+void
 OMR::Z::CPU::setSupportsTransactionalExecutionFacility(bool value)
    {
    if (value)
@@ -365,8 +359,6 @@ OMR::Z::CPU::setSupportsTransactionalExecutionFacility(bool value)
       {
       _flags.reset(OMR_FEATURE_S390_TRANSACTIONAL_EXECUTION_FACILITY);
       }
-
-   return value;
    }
 
 bool
@@ -375,7 +367,7 @@ OMR::Z::CPU::getSupportsConstrainedTransactionalExecutionFacility()
    return _flags.testAny(OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsConstrainedTransactionalExecutionFacility(bool value)
    {
    if (value)
@@ -386,8 +378,6 @@ OMR::Z::CPU::setSupportsConstrainedTransactionalExecutionFacility(bool value)
       {
       _flags.reset(OMR_FEATURE_S390_CONSTRAINED_TRANSACTIONAL_EXECUTION_FACILITY);
       }
-
-   return value;
    }
 
 bool
@@ -396,7 +386,7 @@ OMR::Z::CPU::getSupportsRuntimeInstrumentationFacility()
    return _flags.testAny(S390SupportsRI);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsRuntimeInstrumentationFacility(bool value)
    {
    if (value)
@@ -407,8 +397,6 @@ OMR::Z::CPU::setSupportsRuntimeInstrumentationFacility(bool value)
       {
       _flags.reset(S390SupportsRI);
       }
-
-   return value;
    }
 
 bool
@@ -417,7 +405,7 @@ OMR::Z::CPU::getSupportsVectorFacility()
    return _flags.testAny(S390SupportsVectorFacility);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorFacility(bool value)
    {
    if (value)
@@ -428,8 +416,6 @@ OMR::Z::CPU::setSupportsVectorFacility(bool value)
       {
       _flags.reset(S390SupportsVectorFacility);
       }
-
-   return value;
    }
 
 bool
@@ -438,7 +424,7 @@ OMR::Z::CPU::getSupportsVectorPackedDecimalFacility()
    return _flags.testAny(S390SupportsVectorPackedDecimalFacility);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorPackedDecimalFacility(bool value)
    {
    if (value)
@@ -449,8 +435,6 @@ OMR::Z::CPU::setSupportsVectorPackedDecimalFacility(bool value)
       {
       _flags.reset(S390SupportsVectorPackedDecimalFacility);
       }
-
-   return value;
    }
 
 bool
@@ -459,7 +443,7 @@ OMR::Z::CPU::getSupportsGuardedStorageFacility()
    return _flags.testAny(S390SupportsGuardedStorageFacility);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsGuardedStorageFacility(bool value)
    {
    if (value)
@@ -470,8 +454,6 @@ OMR::Z::CPU::setSupportsGuardedStorageFacility(bool value)
       {
       _flags.reset(S390SupportsGuardedStorageFacility);
       }
-
-   return value;
    }
 
 bool
@@ -480,7 +462,7 @@ OMR::Z::CPU::getSupportsMiscellaneousInstructionExtensions2Facility()
    return _flags.testAny(S390SupportsMIE2);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensions2Facility(bool value)
    {
    if (value)
@@ -491,8 +473,6 @@ OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensions2Facility(bool value)
       {
       _flags.reset(S390SupportsMIE2);
       }
-
-   return value;
    }
 
 bool
@@ -501,7 +481,7 @@ OMR::Z::CPU::getSupportsMiscellaneousInstructionExtensions3Facility()
    return _flags.testAny(S390SupportsMIE3);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensions3Facility(bool value)
    {
    if (value)
@@ -512,8 +492,6 @@ OMR::Z::CPU::setSupportsMiscellaneousInstructionExtensions3Facility(bool value)
       {
       _flags.reset(S390SupportsMIE3);
       }
-
-   return value;
    }
 
 bool
@@ -522,7 +500,7 @@ OMR::Z::CPU::getSupportsVectorFacilityEnhancement2()
    return _flags.testAny(S390SupportsVectorFacilityEnhancement2);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorFacilityEnhancement2(bool value)
    {
    if (value)
@@ -533,8 +511,6 @@ OMR::Z::CPU::setSupportsVectorFacilityEnhancement2(bool value)
       {
       _flags.reset(S390SupportsVectorFacilityEnhancement2);
       }
-
-   return value;
    }
 
 bool
@@ -543,7 +519,7 @@ OMR::Z::CPU::getSupportsVectorFacilityEnhancement1()
    return _flags.testAny(S390SupportsVectorFacilityEnhancement1);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorFacilityEnhancement1(bool value)
    {
    if (value)
@@ -554,8 +530,6 @@ OMR::Z::CPU::setSupportsVectorFacilityEnhancement1(bool value)
       {
       _flags.reset(S390SupportsVectorFacilityEnhancement1);
       }
-
-   return value;
    }
 
 bool
@@ -564,7 +538,7 @@ OMR::Z::CPU::getSupportsVectorPackedDecimalEnhancementFacility()
    return _flags.testAny(S390SupportsVectorPDEnhancementFacility);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility(bool value)
    {
    if (value)
@@ -575,8 +549,6 @@ OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility(bool value)
       {
       _flags.reset(S390SupportsVectorPDEnhancementFacility);
       }
-
-   return value;
    }
 
 bool
@@ -592,7 +564,7 @@ OMR::Z::CPU::getSupportsVectorPackedDecimalEnhancementFacility2()
    return _flags.testAny(S390SupportsVectorPDEnhancementFacility2);
    }
 
-bool
+void
 OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility2(bool value)
    {
    if (value)
@@ -603,6 +575,5 @@ OMR::Z::CPU::setSupportsVectorPackedDecimalEnhancementFacility2(bool value)
       {
       _flags.reset(S390SupportsVectorPDEnhancementFacility2);
       }
-   return value;
    }
 

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -77,8 +77,6 @@ public:
 
    bool getSupportsArch(Architecture arch);
 
-   bool setSupportsArch(Architecture arch);
-
    bool getSupportsHardwareSQRT();
 
    bool hasPopulationCountInstruction();

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -92,7 +92,7 @@ public:
     *  \param value
     *     Determines whether the High-Word facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsHighWordFacility(bool value);
+   void setSupportsHighWordFacility(bool value);
 
    /** \brief
     *     Determines whether the Decimal Floating Point (DFP) facility is available on the current processor.
@@ -105,7 +105,7 @@ public:
     *  \param value
     *     Determines whether the Decimal Floating Point facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsDecimalFloatingPointFacility(bool value);
+   void setSupportsDecimalFloatingPointFacility(bool value);
 
    /** \brief
     *     Determines whether the Floating Point Extension (FPE) facility is available on the current processor.
@@ -118,7 +118,7 @@ public:
     *  \param value
     *     Determines whether the Floating Point Extension facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsFloatingPointExtensionFacility(bool value);
+   void setSupportsFloatingPointExtensionFacility(bool value);
 
    /** \brief
     *     Determines whether the Transactional Execution (TX) facility is available on the current processor.
@@ -137,7 +137,7 @@ public:
     *  \param value
     *     Determines whether the Transactional Execution facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsTransactionalExecutionFacility(bool value);
+   void setSupportsTransactionalExecutionFacility(bool value);
 
    /** \brief
     *     Determines whether the Constrained Transactional Execution (TXC) facility is available on the current processor.
@@ -150,7 +150,7 @@ public:
     *  \param value
     *     Determines whether the Constrained Transactional Execution facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsConstrainedTransactionalExecutionFacility(bool value);
+   void setSupportsConstrainedTransactionalExecutionFacility(bool value);
 
    /** \brief
     *     Determines whether the Runtime Instrumentation (RI) facility is available on the current processor.
@@ -163,7 +163,7 @@ public:
     *  \param value
     *     Determines whether the Runtime Instrumentation facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsRuntimeInstrumentationFacility(bool value);
+   void setSupportsRuntimeInstrumentationFacility(bool value);
 
    /** \brief
     *     Determines whether the Vector facility is available on the current processor.
@@ -176,7 +176,7 @@ public:
     *  \param value
     *     Determines whether the Vector facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsVectorFacility(bool value);
+   void setSupportsVectorFacility(bool value);
 
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
@@ -189,7 +189,7 @@ public:
     *  \param value
     *     Determines whether the Vector Packed Decimal facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsVectorPackedDecimalFacility(bool value);
+   void setSupportsVectorPackedDecimalFacility(bool value);
 
    /** \brief
     *     Determines whether the Miscellaneous Instruction Extensions 2 (MIE2) facility is available on the current
@@ -205,7 +205,7 @@ public:
     *     Determines whether the Miscellaneous Instruction Extensions 2 facility is available (if \c true) or not (if
     *     \c false).
     */
-   bool setSupportsMiscellaneousInstructionExtensions2Facility(bool value);
+   void setSupportsMiscellaneousInstructionExtensions2Facility(bool value);
 
 
    /** \brief
@@ -222,7 +222,7 @@ public:
     *     Determines whether the Miscellaneous Instruction Extensions 3 facility is available (if \c true) or not (if
     *     \c false).
     */
-   bool setSupportsMiscellaneousInstructionExtensions3Facility(bool value);
+   void setSupportsMiscellaneousInstructionExtensions3Facility(bool value);
 
    /** \brief
     *     Determines whether the Vector Enhancement 2 facility is available on the current processor.
@@ -235,7 +235,7 @@ public:
     *  \param value
     *     Determines whether the Vector Enhancement 2 facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsVectorFacilityEnhancement2(bool value);
+   void setSupportsVectorFacilityEnhancement2(bool value);
 
    /** \brief
     *     Determines whether the Vector Enhancement 1 facility is available on the current processor.
@@ -248,7 +248,7 @@ public:
     *  \param value
     *     Determines whether the Vector Enhancement 1 facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsVectorFacilityEnhancement1(bool value);
+   void setSupportsVectorFacilityEnhancement1(bool value);
 
    /** \brief
     *     Determines whether the Vector Packed Decimal facility is available on the current processor.
@@ -261,7 +261,7 @@ public:
     *  \param value
     *     Determines whether the Vector Packed Decimal facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsVectorPackedDecimalEnhancementFacility(bool value);
+   void setSupportsVectorPackedDecimalEnhancementFacility(bool value);
 
    /** \brief
     *     Determines whether the Guarded Storage (GS) facility is available on the current processor.
@@ -274,7 +274,7 @@ public:
     *  \param value
     *     Determines whether the Guarded Storage facility is available (if \c true) or not (if \c false).
     */
-   bool setSupportsGuardedStorageFacility(bool value);
+   void setSupportsGuardedStorageFacility(bool value);
 
    /**
     * \brief Determines whether 32bit integer rotate is available
@@ -325,7 +325,7 @@ public:
     *  \param value
     *     \c true if the Vector Packed Decimal facility is available, and \c false otherwise.
     */
-   bool setSupportsVectorPackedDecimalEnhancementFacility2(bool value);
+   void setSupportsVectorPackedDecimalEnhancementFacility2(bool value);
 
 private:
 


### PR DESCRIPTION
Currently the `OMR::Z::CPU::setSupports*(bool value)` methods return the input `value`. The return value from these setters is not used anywhere, so there is no need to have a return value.