### PR TITLE
Add missing default cases to switch statements

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1695,6 +1695,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
                break;
             case TR::InstOpCode::addsimmw:
                mnemonic = "cmnimmw";
+               break;
+            default:
+               break;
             }
          trfprintf(pOutFile, "%s \t", mnemonic);
          print(pOutFile, instr->getSource1Register(), TR_WordReg);

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -980,6 +980,8 @@ OMR::ARM64::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
          result = true;
          break;
          }
+      default:
+         break;
       }
 
    return result;


### PR DESCRIPTION
Add missing default cases to switch statements which were causing "enumeration values not handled in switch" warnings on [`aarch64_mac` OpenJ9 builds](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/18194/). These additions (along with a few corresponding additions in [OpenJ9](https://github.com/eclipse-openj9/openj9/pull/18174)) fix the warnings without changing the behaviour of the code. This, of course, assumes that there are no switch cases that should be handled but aren't.

This PR contributes to (but does not close) [openj9 issue #14859](https://github.com/eclipse-openj9/openj9/issues/14859).