### PR TITLE
Add default cases to PPC switch statements

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2436,6 +2436,8 @@ OMR::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
          result = self()->comp()->target().is64Bit();
          break;
          }
+      default:
+         break;
       }
 
    return result;

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -90,8 +90,9 @@ static int32_t spillSizeForRegister(TR::Register *virtReg)
       case TR_VSX_VECTOR:
       case TR_VRF:
          return 16;
+      default:
+         TR_ASSERT(false, "Unexpected register kind");
       }
-   TR_ASSERT(false, "Unexpected register kind");
    return 0;
    }
 
@@ -251,6 +252,8 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
          break;
       case TR_VRF:
          maskI = TR::RealRegister::FirstVRF;
+         break;
+      default:
          break;
    }
 
@@ -493,6 +496,8 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
             maskI = first = TR::RealRegister::FirstVRF;
             last = TR::RealRegister::LastVRF;
             break;
+         default:
+            break;
          }
 
       int32_t  preference = 0, pref_favored = 0;
@@ -724,6 +729,8 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
             location = self()->cg()->allocateSpill(16, false, NULL);
             }
          break;
+      default:
+         break;
       }
 
    if (rk == TR_CCR)
@@ -843,6 +850,8 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
          tmemref->setLength(16);
          reloadInstr = generateTrg1MemInstruction(self()->cg(), opCode, currentNode, best, tmemref, currentInstruction);
          self()->cg()->stopUsingRegister(tempIndexRegister);
+         break;
+      default:
          break;
       }
 
@@ -1080,6 +1089,8 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction      *c
          tmemref->setLength(16);
          spillInstr = generateMemSrc1Instruction(self()->cg(), opCode, currentNode, tmemref, targetRegister, currentInstruction);
          self()->cg()->stopUsingRegister(tempIndexRegister);
+         break;
+      default:
          break;
       }
    self()->cg()->traceRAInstruction(spillInstr);
@@ -1755,6 +1766,8 @@ static void registerCopy(TR::Instruction     *precedingInstruction,
       case TR_VRF:
          instr = generateTrg1Src2Instruction(cg, TR::InstOpCode::vor, currentNode, targetReg, sourceReg, sourceReg, precedingInstruction);
          break;
+      default:
+         break;
       }
    cg->traceRAInstruction(instr);
    }
@@ -1779,23 +1792,25 @@ static void registerExchange(TR::Instruction     *precedingInstruction,
       {
       TR::InstOpCode::Mnemonic opCode;
       switch (rk)
-	 {
-	 case TR_GPR:
-	    opCode = TR::InstOpCode::XOR;
-	    break;
-	 case TR_FPR:
-	    opCode = TR::InstOpCode::xxlxor;
-	    break;
-	 case TR_VSX_SCALAR:
-	 case TR_VSX_VECTOR:
-	    opCode = TR::InstOpCode::xxlxor;
-	    break;
-	 case TR_VRF:
-	    opCode = TR::InstOpCode::vxor;
-	    break;
-	 case TR_CCR:
-	    TR_ASSERT(0, "Cannot exchange CCR without a third reg");
-	 }
+         {
+         case TR_GPR:
+            opCode = TR::InstOpCode::XOR;
+            break;
+         case TR_FPR:
+            opCode = TR::InstOpCode::xxlxor;
+            break;
+         case TR_VSX_SCALAR:
+         case TR_VSX_VECTOR:
+            opCode = TR::InstOpCode::xxlxor;
+            break;
+         case TR_VRF:
+            opCode = TR::InstOpCode::vxor;
+            break;
+         case TR_CCR:
+            TR_ASSERT(0, "Cannot exchange CCR without a third reg");
+         default:
+            break;
+         }
       cg->traceRAInstruction(generateTrg1Src2Instruction(cg, opCode, currentNode, targetReg, targetReg, sourceReg, precedingInstruction));
       cg->traceRAInstruction(generateTrg1Src2Instruction(cg, opCode, currentNode, sourceReg, targetReg, sourceReg, precedingInstruction));
       cg->traceRAInstruction(generateTrg1Src2Instruction(cg, opCode, currentNode, targetReg, targetReg, sourceReg, precedingInstruction));

--- a/compiler/p/codegen/OMRPeephole.cpp
+++ b/compiler/p/codegen/OMRPeephole.cpp
@@ -702,6 +702,8 @@ OMR::Power::Peephole::tryToRemoveRedundantMoveRegister()
                   }
                break;
                }
+            default:
+               break;
             }
          }
 

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -1088,6 +1088,8 @@ void OMR::Power::RegisterDependencyGroup::assignRegisters(TR::Instruction   *cur
             case TR_VRF:
                depsBlocked = haveSpareVRFs;
                break;
+            default:
+               break;
             }
          assignContendedRegisters(currentInstruction, &_dependencies[i], map, depsBlocked, cg);
          }

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -290,6 +290,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCLabelInstruction * instr)
             case TR::Snippet::IsArrayCopyCall:
                callSym = ((TR::PPCHelperCallSnippet *)snippet)->getDestination();
                break;
+            default:
+               break;
             }
          if (callSym)
             trfprintf(pOutFile, "\t; Call \"%s\"", getName(callSym));


### PR DESCRIPTION
Add missing default cases to switch statements which were causing "enumeration values not handled in switch" warnings on [ppc64_aix OpenJ9 builds](https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/18289/). These additions (along with a few corresponding additions in [OpenJ9](https://github.com/eclipse-openj9/openj9/pull/18178)) fix the warnings without changing the behaviour of the code. This, of course, assumes that there are no switch cases that should be handled but aren't.

This PR also fixes the indentation of one of the switch statements to make it consistent with our code indentation standard.

This PR contributes to (but does not close) [openj9 issue #14859](https://github.com/eclipse-openj9/openj9/issues/14859).