### PR TITLE
Add VGC output for softmax

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -310,6 +310,9 @@ MM_VerboseHandlerOutput::outputInitializedStanza(MM_EnvironmentBase *env, MM_Ver
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	buffer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", _extensions->memoryMax);
+	if (0 < _extensions->softMx) {
+		buffer->formatAndOutput(env, 1, "<attribute name=\"softMx\" value=\"0x%zx\" />", _extensions->softMx);
+	}
 	buffer->formatAndOutput(env, 1, "<attribute name=\"initialHeapSize\" value=\"0x%zx\" />", _extensions->initialMemorySize);
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)


### PR DESCRIPTION
Add softmax stats to verbose:gc between maxHeapSize
and initialHeapSize

Signed-off-by: Frank Kang frank.kang@ibm.com