### PR TITLE
Add reinitializeForRestore to GCExtBase

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -323,6 +323,14 @@ MM_GCExtensionsBase::computeDefaultMaxHeap(MM_EnvironmentBase* env)
 	memoryMax = MM_Math::roundToFloor(heapAlignment, (uintptr_t)memoryToRequest);
 }
 
+void
+MM_GCExtensionsBase::reinitializeForRestore(MM_EnvironmentBase* env)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	usablePhysicalMemory = omrsysinfo_get_addressable_physical_memory();
+	parSweepChunkSize = 0;
+}
+
 bool
 MM_GCExtensionsBase::isSATBBarrierActive()
 {

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -894,7 +894,7 @@ protected:
 	virtual bool initialize(MM_EnvironmentBase* env);
 	virtual void tearDown(MM_EnvironmentBase* env);
 	virtual void computeDefaultMaxHeap(MM_EnvironmentBase* env);
-
+	virtual void reinitializeForRestore(MM_EnvironmentBase* env);
 public:
 	static MM_GCExtensionsBase* newInstance(MM_EnvironmentBase* env);
 	virtual void kill(MM_EnvironmentBase* env);

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -362,6 +362,7 @@ MM_VerboseHandlerOutput::outputInitializedStanza(MM_EnvironmentBase *env, MM_Ver
 	buffer->formatAndOutput(env, 1, "<system>");
 	buffer->formatAndOutput(env, 2, "<attribute name=\"physicalMemory\" value=\"%llu\" />", omrsysinfo_get_physical_memory());
 	buffer->formatAndOutput(env, 2, "<attribute name=\"numCPUs\" value=\"%zu\" />", omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE));
+	buffer->formatAndOutput(env, 2, "<attribute name=\"numCPUs active\" value=\"%zu\" />", omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_TARGET));
 	buffer->formatAndOutput(env, 2, "<attribute name=\"architecture\" value=\"%s\" />", omrsysinfo_get_CPU_architecture());
 	buffer->formatAndOutput(env, 2, "<attribute name=\"os\" value=\"%s\" />", omrsysinfo_get_OS_type());
 	buffer->formatAndOutput(env, 2, "<attribute name=\"osVersion\" value=\"%s\" />", omrsysinfo_get_OS_version());


### PR DESCRIPTION
Introduce reinitializeForRestore() method to GCExtBase, so that
during restore we can simply call this method rather than access
the GCExt members. This is done similar to other components which
need to reinit such as Configuration.

Also, add print in verboseGC for number of active cpus.

Signed-off-by: Frank Kang frank.kang@ibm.com