### PR TITLE
Use correct simplifications after creating ifxcmpne

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -13145,9 +13145,12 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIficmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13289,9 +13292,12 @@ TR::Node *ificmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIficmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13338,9 +13344,12 @@ TR::Node *ificmpleSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIficmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13387,9 +13396,12 @@ TR::Node *ificmpgtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIficmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13436,9 +13448,12 @@ TR::Node *ificmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIficmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -14029,11 +14029,13 @@ TR::Node *ifacmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIfacmpneHelper(node, block, s);
 
    TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -13494,6 +13494,37 @@ TR::Node *ificmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    return node;
    }
 
+TR::Node *simplifyIflcmpneHelper(TR::Node * node, TR::Block * block, TR::Simplifier * s)
+   {
+   TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
+
+   if (firstChild == secondChild)
+      {
+      s->conditionalToUnconditional(node, block, false);
+      return node;
+      }
+
+   makeConstantTheRightChild(node, firstChild, secondChild, s);
+
+   if (firstChild->getOpCode().isLoadConst() && conditionalBranchFold((firstChild->getLongInt()!=secondChild->getLongInt()), node, firstChild, secondChild, block, s))
+      return node;
+
+   if (conditionalZeroComparisonBranchFold (node, firstChild, secondChild, block, s))
+      return node;
+
+   simplifyLongBranchArithmetic(node, firstChild, secondChild, s);
+
+   if (node->getOpCodeValue() == TR::iflcmpne)
+      {
+      longCompareNarrower(node, s, TR::ificmpne, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
+      }
+   addressCompareConversion(node, s);
+   removeArithmeticsUnderIntegralCompare(node, s);
+
+   partialRedundantCompareElimination(node, block, s);
+   return node;
+   }
+
 //---------------------------------------------------------------------
 // Long integer if compare equal (signed and unsigned)
 //
@@ -13503,9 +13534,12 @@ TR::Node *iflcmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIflcmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13553,33 +13587,7 @@ TR::Node *iflcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
-   TR::Node * firstChild = node->getFirstChild(), * secondChild = node->getSecondChild();
-
-   if (firstChild == secondChild)
-      {
-      s->conditionalToUnconditional(node, block, false);
-      return node;
-      }
-
-   makeConstantTheRightChild(node, firstChild, secondChild, s);
-
-   if (firstChild->getOpCode().isLoadConst() && conditionalBranchFold((firstChild->getLongInt()!=secondChild->getLongInt()), node, firstChild, secondChild, block, s))
-      return node;
-
-   if (conditionalZeroComparisonBranchFold (node, firstChild, secondChild, block, s))
-      return node;
-
-   simplifyLongBranchArithmetic(node, firstChild, secondChild, s);
-
-   if (node->getOpCodeValue() == TR::iflcmpne)
-      {
-      longCompareNarrower(node, s, TR::ificmpne, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
-      }
-   addressCompareConversion(node, s);
-   removeArithmeticsUnderIntegralCompare(node, s);
-
-   partialRedundantCompareElimination(node, block, s);
-   return node;
+   return simplifyIflcmpneHelper(node, block, s);
    }
 
 //---------------------------------------------------------------------
@@ -13591,9 +13599,12 @@ TR::Node *iflcmpltSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIflcmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13633,9 +13644,12 @@ TR::Node *iflcmpleSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIflcmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13675,9 +13689,12 @@ TR::Node *iflcmpgtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIflcmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 
@@ -13717,9 +13734,12 @@ TR::Node *iflcmpgeSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    // Perform a simplification for the case where an iselect is compared to a
    // constant. This is done before simplifyChildren because it may allow
    // further transformations to be done on the children.
-   simplifyISelectCompare(node, s);
+   bool opChangedToCmpNE = simplifyISelectCompare(node, s);
 
    s->simplifyChildren(node, block);
+   if (opChangedToCmpNE)
+      return simplifyIflcmpneHelper(node, block, s);
+
    if (removeIfToFollowingBlock(node, block, s) == NULL)
       return NULL;
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -2068,12 +2068,15 @@ static bool processSubTreeLeavesForISelectCompare(TR::NodeChecklist &visited, TR
  *
  * \param s
  *    The simplifier object.
+ *
+ * \return
+ *    True if a transformation was performed. False otherwise.
  */
-static void simplifyISelectCompare(TR::Node *compare, TR::Simplifier *s)
+static bool simplifyISelectCompare(TR::Node *compare, TR::Simplifier *s)
    {
    static char *disableISelectCompareSimplification = feGetEnv("TR_disableISelectCompareSimplification");
    if (disableISelectCompareSimplification)
-      return;
+      return false;
 
    if (compare->getOpCode().isBooleanCompare()
        && compare->getSecondChild()->getOpCode().isLoadConst()
@@ -2095,9 +2098,11 @@ static void simplifyISelectCompare(TR::Node *compare, TR::Simplifier *s)
             compare->setAndIncChild(1, TR::Node::createConstZeroValue(compare->getSecondChild(), compare->getSecondChild()->getDataType()));
             constVal->decReferenceCount();
             TR::Node::recreate(compare, TR::ILOpCode(TR::ILOpCode::compareOpCode(compare->getFirstChild()->getDataType(), TR_cmpNE, isUnsignedCompare)).convertCmpToIfCmp());
+            return true;
             }
          }
       }
+   return false;
    }
 
 // We handle two kind of cases here:


### PR DESCRIPTION
Creates ifxcmpne helper methods in the simplifier (taken from and now called by the body of the corresponding ifxcmpneSimplifier() function) and calls them after calling simplifyISelectCompare() from an ifxcmpxx simplifier when the iselect compare simplification causes the IL op of the ifxcmpxx node to become an ifxcmpne, making the rest of the handler's logic potentially incorrect due to the assumption that the op being simplified is still the same ifxcmpxx as it had been.

Corrects reversed logic observed in cases where an ifxcmpxx simplifier continued simplifying after simplifyISelectCompare() had caused the node to become an ifxcmpne. For example, an ificmpeq was simplified and transformed into an ificmpne during simplifyISelectCompare(), and then when the ificmpeqSimplifier() continued simplifying after simplifyISelectCompare(), the result was reversed logic producing incorrectly compiled code.