### PR TITLE
x86: Extend CPUID support

### DIFF
--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -42,6 +42,7 @@ struct TR_X86CPUIDBuffer
       uint32_t l3;
       } _cacheDescription;
    uint32_t _featureFlags8;
+   uint32_t _featureFlags10;
    };
 
 enum TR_X86ProcessorVendors
@@ -194,6 +195,48 @@ inline uint32_t getFeatureFlags8Mask()
          | TR_AVX512DQ
          | TR_AVX512CD;
    }
+
+enum TR_X86_CPUID_ecx_eax07_ecx00
+   {
+   TR_PREFETCHWT1         = 0x00000001,
+   TR_AVX512_VBMI         = 0x00000002,
+   TR_UMIP                = 0x00000004,
+   TR_PKU                 = 0x00000008,
+   TR_OSPKE               = 0x00000010,
+   TR_WAITPKG             = 0x00000020,
+   TR_AVX512_VBMI2        = 0x00000040,
+   TR_CET_SS              = 0x00000080,
+   TR_GFNI                = 0x00000100,
+   TR_VAES                = 0x00000200,
+   TR_VPCLMULQDQ          = 0x00000400,
+   TR_AVX512_VNNI         = 0x00000800,
+   TR_AVX512_BITALG       = 0x00001000,
+   TR_TME_EN              = 0x00002000,
+   TR_AVX512_VPOPCNTDQ    = 0x00004000,
+   // Reserved by Intel   = 0x00008000,
+   TR_LA57                = 0x00010000,
+   TR_MAWAU_0             = 0x00020000,
+   TR_MAWAU_1             = 0x00040000,
+   TR_MAWAU_2             = 0x00080000,
+   TR_MAWAU_3             = 0x00100000,
+   TR_MAWAU_4             = 0x00200000,
+   TR_RDPID               = 0x00400000,
+   TR_KL                  = 0x00800000,
+   TR_BUS_LOCK_DETECT     = 0x01000000,
+   TR_CLDEMOTE            = 0x02000000,
+   // Reserved by Intel   = 0x04000000,
+   TR_MOVDIRI             = 0x08000000,
+   TR_MOVDIR64B           = 0x10000000,
+   TR_ENQCMD              = 0x20000000,
+   TR_SGX_LC              = 0x40000000,
+   TR_PKS                 = 0x80000000,
+   };
+
+inline uint32_t getFeatureFlags10Mask()
+   {
+   return 0;
+   }
+
 
 enum TR_ProcessorDescription
    {

--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -51,7 +51,7 @@ enum TR_X86ProcessorVendors
    TR_UnknownVendor                 = 0x04
    };
 
-enum TR_X86ProcessorFeatures
+enum TR_X86_CPUID_edx_eax01
    {
    TR_BuiltInFPU                    = 0x00000001,
    TR_VirtualModeExtension          = 0x00000002,
@@ -98,7 +98,7 @@ inline uint32_t getFeatureFlagsMask()
          | TR_SSE2;
    }
 
-enum TR_X86ProcessorFeatures2
+enum TR_X86_CPUID_ecx_eax01
    {
    TR_SSE3                          = 0x00000001,
    TR_CLMUL                         = 0x00000002,
@@ -147,7 +147,7 @@ inline uint32_t getFeatureFlags2Mask()
          | TR_FMA;
    }
 
-enum TR_X86ProcessorFeatures8
+enum TR_X86_CPUID_ebx_eax07_ecx00
    {
    TR_FSGSBASE                = 0x00000001,
    TR_IA32_TSC_ADJUST         = 0x00000002,

--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -234,7 +234,9 @@ enum TR_X86_CPUID_ecx_eax07_ecx00
 
 inline uint32_t getFeatureFlags10Mask()
    {
-   return 0;
+   return  TR_AVX512_VBMI2
+         | TR_AVX512_BITALG
+         | TR_AVX512_VPOPCNTDQ;
    }
 
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -110,6 +110,7 @@ void TR_X86ProcessorInfo::reset()
    _featureFlags = 0;
    _featureFlags2 = 0;
    _featureFlags8 = 0;
+   _featureFlags10 = 0;
    _processorDescription = 0;
    }
 
@@ -130,6 +131,7 @@ void TR_X86ProcessorInfo::initialize(bool force)
    _featureFlags.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags());
    _featureFlags2.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags2());
    _featureFlags8.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags8());
+   _featureFlags10.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags10());
 
    // Determine the processor vendor.
    //

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -167,6 +167,9 @@ struct TR_X86ProcessorInfo
    bool supportsAVX512DQ()                 {return testFeatureFlags8(TR_AVX512DQ) && enabledXSAVE();}
    bool supportsAVX512CD()                 {return testFeatureFlags8(TR_AVX512CD) && enabledXSAVE();}
    bool supportsAVX512VL()                 {return testFeatureFlags8(TR_AVX512VL) && enabledXSAVE();}
+   bool supportsAVX512VBMI2()              {return testFeatureFlags10(TR_AVX512_VBMI2) && enabledXSAVE();}
+   bool supportsAVX512BITALG()             {return testFeatureFlags10(TR_AVX512_BITALG) && enabledXSAVE();}
+   bool supportsAVX512VPOPCNTDQ()          {return testFeatureFlags10(TR_AVX512_VPOPCNTDQ) && enabledXSAVE();}
    bool supportsBMI1()                     {return testFeatureFlags8(TR_BMI1) && enabledXSAVE();}
    bool supportsBMI2()                     {return testFeatureFlags8(TR_BMI2) && enabledXSAVE();}
    bool supportsFMA()                      {return testFeatureFlags2(TR_FMA) && enabledXSAVE();}

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -224,6 +224,7 @@ private:
    flags32_t  _featureFlags;   // cache feature flags for re-use
    flags32_t  _featureFlags2;  // cache feature flags 2 for re-use
    flags32_t  _featureFlags8;  // cache feature flags 8 for re-use
+   flags32_t  _featureFlags10; // cache feature flags 10 for re-use
 
    uint32_t _processorDescription;
 
@@ -302,6 +303,11 @@ private:
    bool testFeatureFlags8(uint32_t feature)
       {
       return testFlag(_featureFlags8, feature, getFeatureFlags8Mask());
+      }
+
+   bool testFeatureFlags10(uint32_t feature)
+      {
+      return testFlag(_featureFlags10, feature, getFeatureFlags10Mask());
       }
    };
 

--- a/compiler/x/codegen/OMRInstOpCode.hpp
+++ b/compiler/x/codegen/OMRInstOpCode.hpp
@@ -173,29 +173,41 @@ namespace TR { class Register; }
 #define X86FeatureProp_AVX512BW                  0x00040000
 #define X86FeatureProp_AVX512DQ                  0x00080000
 #define X86FeatureProp_AVX512CD                  0x00100000
+#define X86FeatureProp_AVX512VBMI2               0x00200000
+#define X86FeatureProp_AVX512BITALG              0x00400000
+#define X86FeatureProp_AVX512VPOPCNTDQ           0x00800000
 
 // VEX / EVEX forms (3-operands, except move instructions, etc.)
 // Alias old flags with new flags to avoid rewriting the Opcodes file
-#define X86FeatureProp_VEX128RequiresAVX         (X86FeatureProp_VEX128Supported  | X86FeatureProp_AVX      ) // VEX-128 encoded version requires AVX
-#define X86FeatureProp_VEX128RequiresAVX2        (X86FeatureProp_VEX128Supported  | X86FeatureProp_V128_AVX2) // VEX-128 encoded version requires AVX
-#define X86FeatureProp_VEX256RequiresAVX         (X86FeatureProp_VEX256Supported  | X86FeatureProp_AVX      ) // VEX-256 encoded version requires AVX
-#define X86FeatureProp_VEX256RequiresAVX2        (X86FeatureProp_VEX256Supported  | X86FeatureProp_V256_AVX2) // VEX-256 encoded version requires AVX2
-#define X86FeatureProp_EVEX128RequiresAVX512F    (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512F  ) // EVEX-128 encoded version requires AVX-512F
-#define X86FeatureProp_EVEX128RequiresAVX512VL   (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512VL ) // EVEX-128 encoded version requires AVX-512VL
-#define X86FeatureProp_EVEX128RequiresAVX512BW   (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512BW ) // EVEX-128 encoded version requires AVX-512BW
-#define X86FeatureProp_EVEX128RequiresAVX512DQ   (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512DQ ) // EVEX-128 encoded version requires AVX-512DQ
-#define X86FeatureProp_EVEX128RequiresAVX512CD   (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512CD ) // EVEX-128 encoded version requires AVX-512CD
-#define X86FeatureProp_EVEX256RequiresAVX512F    (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512F  ) // EVEX-256 encoded version requires AVX-512F
-#define X86FeatureProp_EVEX256RequiresAVX512VL   (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512VL ) // EVEX-256 encoded version requires AVX-512VL
-#define X86FeatureProp_EVEX256RequiresAVX512BW   (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512BW ) // EVEX-256 encoded version requires AVX-512BW
-#define X86FeatureProp_EVEX256RequiresAVX512DQ   (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512DQ ) // EVEX-256 encoded version requires AVX-512DQ
-#define X86FeatureProp_EVEX256RequiresAVX512CD   (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512CD ) // EVEX-256 encoded version requires AVX-512CD
-#define X86FeatureProp_EVEX512RequiresAVX512F    (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512F  ) // EVEX-512 encoded version requires AVX-512F
-#define X86FeatureProp_EVEX512RequiresAVX512BW   (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512BW ) // EVEX-512 encoded version requires AVX-512BW
-#define X86FeatureProp_EVEX512RequiresAVX512DQ   (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512DQ ) // EVEX-512 encoded version requires AVX-512DQ
-#define X86FeatureProp_EVEX512RequiresAVX512CD   (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512CD ) // EVEX-512 encoded version requires AVX-512CD
-#define X86FeatureProp_VEX128RequiresFMA         (X86FeatureProp_VEX128Supported  | X86FeatureProp_FMA      ) // VEX-128 encoded version requires AVX
-#define X86FeatureProp_VEX256RequiresFMA         (X86FeatureProp_VEX256Supported  | X86FeatureProp_FMA      ) // VEX-128 encoded version requires AVX
+#define X86FeatureProp_VEX128RequiresAVX              (X86FeatureProp_VEX128Supported  | X86FeatureProp_AVX            ) // VEX-128 encoded version requires AVX
+#define X86FeatureProp_VEX128RequiresAVX2             (X86FeatureProp_VEX128Supported  | X86FeatureProp_V128_AVX2      ) // VEX-128 encoded version requires AVX
+#define X86FeatureProp_VEX256RequiresAVX              (X86FeatureProp_VEX256Supported  | X86FeatureProp_AVX            ) // VEX-256 encoded version requires AVX
+#define X86FeatureProp_VEX256RequiresAVX2             (X86FeatureProp_VEX256Supported  | X86FeatureProp_V256_AVX2      ) // VEX-256 encoded version requires AVX2
+#define X86FeatureProp_EVEX128RequiresAVX512F         (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512F        ) // EVEX-128 encoded version requires AVX-512F
+#define X86FeatureProp_EVEX128RequiresAVX512VL        (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512VL       ) // EVEX-128 encoded version requires AVX-512VL
+#define X86FeatureProp_EVEX128RequiresAVX512BW        (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512BW       ) // EVEX-128 encoded version requires AVX-512BW
+#define X86FeatureProp_EVEX128RequiresAVX512DQ        (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512DQ       ) // EVEX-128 encoded version requires AVX-512DQ
+#define X86FeatureProp_EVEX128RequiresAVX512CD        (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512CD       ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX128RequiresAVX512VBMI2     (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512VBMI2    ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX128RequiresAVX512BITALG    (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512BITALG   ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX128RequiresAVX512VPOPCNTDQ (X86FeatureProp_EVEX128Supported | X86FeatureProp_AVX512VPOPCNTDQ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX256RequiresAVX512F         (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512F        ) // EVEX-256 encoded version requires AVX-512F
+#define X86FeatureProp_EVEX256RequiresAVX512VL        (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512VL       ) // EVEX-256 encoded version requires AVX-512VL
+#define X86FeatureProp_EVEX256RequiresAVX512BW        (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512BW       ) // EVEX-256 encoded version requires AVX-512BW
+#define X86FeatureProp_EVEX256RequiresAVX512DQ        (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512DQ       ) // EVEX-256 encoded version requires AVX-512DQ
+#define X86FeatureProp_EVEX256RequiresAVX512CD        (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512CD       ) // EVEX-256 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX256RequiresAVX512VBMI2     (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512VBMI2    ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX256RequiresAVX512BITALG    (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512BITALG   ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX256RequiresAVX512VPOPCNTDQ (X86FeatureProp_EVEX256Supported | X86FeatureProp_AVX512VPOPCNTDQ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX512RequiresAVX512F         (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512F        ) // EVEX-512 encoded version requires AVX-512F
+#define X86FeatureProp_EVEX512RequiresAVX512BW        (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512BW       ) // EVEX-512 encoded version requires AVX-512BW
+#define X86FeatureProp_EVEX512RequiresAVX512DQ        (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512DQ       ) // EVEX-512 encoded version requires AVX-512DQ
+#define X86FeatureProp_EVEX512RequiresAVX512CD        (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512CD       ) // EVEX-512 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX512RequiresAVX512VBMI2     (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512VBMI2    ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX512RequiresAVX512BITALG    (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512BITALG   ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_EVEX512RequiresAVX512VPOPCNTDQ (X86FeatureProp_EVEX512Supported | X86FeatureProp_AVX512VPOPCNTDQ) // EVEX-128 encoded version requires AVX-512CD
+#define X86FeatureProp_VEX128RequiresFMA              (X86FeatureProp_VEX128Supported  | X86FeatureProp_FMA            ) // VEX-128 encoded version requires AVX
+#define X86FeatureProp_VEX256RequiresFMA              (X86FeatureProp_VEX256Supported  | X86FeatureProp_FMA            ) // VEX-128 encoded version requires AVX
 
 typedef enum
    {
@@ -511,6 +523,12 @@ class InstOpCode: public OMR::InstOpCode
                   supported = target->supportsFeature(OMR_FEATURE_X86_AVX512DQ);
                if (supported && (flags & X86FeatureProp_AVX512CD))
                   supported = target->supportsFeature(OMR_FEATURE_X86_AVX512CD);
+               if (supported && (flags & X86FeatureProp_AVX512VBMI2))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VBMI2);
+               if (supported && (flags & X86FeatureProp_AVX512BITALG))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_BITALG);
+               if (supported && (flags & X86FeatureProp_AVX512VPOPCNTDQ))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VPOPCNTDQ);
 
                if (supported)
                     return OMR::X86::EVEX_L128;
@@ -553,6 +571,12 @@ class InstOpCode: public OMR::InstOpCode
                   supported = target->supportsFeature(OMR_FEATURE_X86_AVX512DQ);
                if (supported && (flags & X86FeatureProp_AVX512CD))
                   supported = target->supportsFeature(OMR_FEATURE_X86_AVX512CD);
+               if (supported && (flags & X86FeatureProp_AVX512VBMI2))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VBMI2);
+               if (supported && (flags & X86FeatureProp_AVX512BITALG))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_BITALG);
+               if (supported && (flags & X86FeatureProp_AVX512VPOPCNTDQ))
+                  supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VPOPCNTDQ);
 
                if (supported)
                   return OMR::X86::EVEX_L256;
@@ -578,12 +602,18 @@ class InstOpCode: public OMR::InstOpCode
 
             if (supported && (flags & X86FeatureProp_AVX512BW))
                supported = target->supportsFeature(OMR_FEATURE_X86_AVX512BW);
-
             if (supported && (flags & X86FeatureProp_AVX512DQ))
                supported = target->supportsFeature(OMR_FEATURE_X86_AVX512DQ);
-
+            if (supported && (flags & X86FeatureProp_AVX512DQ))
+               supported = target->supportsFeature(OMR_FEATURE_X86_AVX512DQ);
             if (supported && (flags & X86FeatureProp_AVX512CD))
                supported = target->supportsFeature(OMR_FEATURE_X86_AVX512CD);
+            if (supported && (flags & X86FeatureProp_AVX512VBMI2))
+               supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VBMI2);
+            if (supported && (flags & X86FeatureProp_AVX512BITALG))
+               supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_BITALG);
+            if (supported && (flags & X86FeatureProp_AVX512VPOPCNTDQ))
+               supported = target->supportsFeature(OMR_FEATURE_X86_AVX512_VPOPCNTDQ);
 
             if (supported)
                return OMR::X86::EVEX_L512;

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -42,7 +42,9 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
                                         OMR_FEATURE_X86_POPCNT, OMR_FEATURE_X86_AESNI, OMR_FEATURE_X86_OSXSAVE,
                                         OMR_FEATURE_X86_AVX, OMR_FEATURE_X86_AVX2, OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE,
                                         OMR_FEATURE_X86_RTM, OMR_FEATURE_X86_AVX512F, OMR_FEATURE_X86_AVX512VL,
-                                        OMR_FEATURE_X86_AVX512BW, OMR_FEATURE_X86_AVX512DQ, OMR_FEATURE_X86_AVX512CD
+                                        OMR_FEATURE_X86_AVX512BW, OMR_FEATURE_X86_AVX512DQ, OMR_FEATURE_X86_AVX512CD,
+                                        OMR_FEATURE_X86_AVX512_VBMI2, OMR_FEATURE_X86_AVX512_VPOPCNTDQ,
+                                        OMR_FEATURE_X86_AVX512_BITALG
                                         };
 
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);
@@ -397,6 +399,12 @@ OMR::X86::CPU::supports_feature_test(uint32_t feature)
          return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512DQ();
       case OMR_FEATURE_X86_AVX512CD:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512CD();
+      case OMR_FEATURE_X86_AVX512_VBMI2:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VBMI2();
+      case OMR_FEATURE_X86_AVX512_BITALG:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG();
+      case OMR_FEATURE_X86_AVX512_VPOPCNTDQ:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ();
       default:
          return false;
       }
@@ -601,6 +609,15 @@ OMR::X86::CPU::supports_feature_old_api(uint32_t feature)
          break;
       case OMR_FEATURE_X86_AVX512CD:
          supported = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512CD();
+         break;
+      case OMR_FEATURE_X86_AVX512_VBMI2:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VBMI2();
+         break;
+      case OMR_FEATURE_X86_AVX512_BITALG:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG();
+         break;
+      case OMR_FEATURE_X86_AVX512_VPOPCNTDQ:
+         supported = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ();
          break;
       case OMR_FEATURE_X86_FMA:
          supported = TR::CodeGenerator::getX86ProcessorInfo().supportsFMA();

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -141,6 +141,15 @@ OMR::X86::CPU::getX86ProcessorFeatureFlags8()
    return self()->_processorDescription.features[3];
    }
 
+uint32_t
+OMR::X86::CPU::getX86ProcessorFeatureFlags10()
+   {
+   if (TR::Compiler->omrPortLib == NULL)
+      return self()->queryX86TargetCPUID()->_featureFlags10;
+
+   return self()->_processorDescription.features[4];
+   }
+
 bool
 OMR::X86::CPU::getSupportsHardwareSQRT()
    {

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -67,6 +67,7 @@ public:
    uint32_t getX86ProcessorFeatureFlags();
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
+   uint32_t getX86ProcessorFeatureFlags10();
 
    bool getSupportsHardwareSQRT();
 

--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -84,7 +84,8 @@ inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
       pBuffer->_featureFlags2      = CPUInfo[ECX];
       // EAX = 7, ECX = 0
       cpuidex(CPUInfo, 7, 0);
-      pBuffer->_featureFlags8 = CPUInfo[EBX];
+      pBuffer->_featureFlags8      = CPUInfo[EBX];
+      pBuffer->_featureFlags10     = CPUInfo[ECX];
 
       // Check for XSAVE
       if(pBuffer->_featureFlags2 & TR_OSXSAVE)

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1766,6 +1766,42 @@ typedef struct OMRProcessorDesc {
 #define OMR_FEATURE_X86_AVX512BW            96 + 30 /* AVX512 Byte and Word */
 #define OMR_FEATURE_X86_AVX512VL            96 + 31 /* AVX512 Vector Length */
 
+/*
+ * Structured Feature Information Returned in the ECX Register by CPUID instruction when EAX = 7, ECX = 0
+ */
+#define OMR_FEATURE_X86_PREFETCHWT1         128 + 0
+#define OMR_FEATURE_X86_AVX512_VBMI         128 + 1
+#define OMR_FEATURE_X86_UMIP                128 + 2
+#define OMR_FEATURE_X86_PKU                 128 + 3
+#define OMR_FEATURE_X86_OSPKE               128 + 4
+#define OMR_FEATURE_X86_WAITPKG             128 + 5
+#define OMR_FEATURE_X86_AVX512_VBMI2        128 + 6
+#define OMR_FEATURE_X86_CET_SS              128 + 7
+#define OMR_FEATURE_X86_GFNI                128 + 8
+#define OMR_FEATURE_X86_VAES                128 + 9
+#define OMR_FEATURE_X86_VPCLMULQDQ          128 + 10
+#define OMR_FEATURE_X86_AVX512_VNNI         128 + 11
+#define OMR_FEATURE_X86_AVX512_BITALG       128 + 12
+#define OMR_FEATURE_X86_TME_EN              128 + 13
+#define OMR_FEATURE_X86_AVX512_VPOPCNTDQ    128 + 14
+#define OMR_FEATURE_X86_4_15                128 + 15 /* Reserved */
+#define OMR_FEATURE_X86_LA57                128 + 16
+#define OMR_FEATURE_X86_MAWAU_0             128 + 17
+#define OMR_FEATURE_X86_MAWAU_1             128 + 18
+#define OMR_FEATURE_X86_MAWAU_2             128 + 19
+#define OMR_FEATURE_X86_MAWAU_3             128 + 20
+#define OMR_FEATURE_X86_MAWAU_4             128 + 21
+#define OMR_FEATURE_X86_RDPID               128 + 22
+#define OMR_FEATURE_X86_KL                  128 + 23
+#define OMR_FEATURE_X86_BUS_LOCK_DETECT     128 + 24
+#define OMR_FEATURE_X86_CLDEMOTE            128 + 25
+#define OMR_FEATURE_X86_4_26                128 + 26 /* Reserved */
+#define OMR_FEATURE_X86_MOVDIRI             128 + 27
+#define OMR_FEATURE_X86_MOVDIR64B           128 + 28
+#define OMR_FEATURE_X86_ENQCMD              128 + 29
+#define OMR_FEATURE_X86_SGX_LC              128 + 30
+#define OMR_FEATURE_X86_PKS                 128 + 31
+
 /*  AArch64 Linux features
  *  See https://www.kernel.org/doc/html/latest/arm64/elf_hwcaps.html.
  */

--- a/port/common/omrsysinfo_helpers.c
+++ b/port/common/omrsysinfo_helpers.c
@@ -350,8 +350,8 @@ omrsysinfo_get_x86_description(struct OMRPortLibrary *portLibrary, OMRProcessorD
 	/* extended features */
 	omrsysinfo_get_x86_cpuid_ext(CPUID_STRUCTURED_EXTENDED_FEATURE_INFO, 0, CPUInfo); /* 0x0 is the only valid subleaf value for this leaf */
 	desc->features[3] = CPUInfo[CPUID_EBX]; /* Structured Extended Feature Flags in EBX */
+	desc->features[4] = CPUInfo[CPUID_ECX]; /* Structured Extended Feature Flags in ECX */
 
-	desc->features[4] = 0; /* reserved for future expansion */
 	return 0;
 }
 


### PR DESCRIPTION
- Process Structured Extended Feature Flags (from ECX) Enumeration Leaf (Initial EAX Value = 07H, ECX = 0)
- Enable AVX512-VBMI2, AVX512-BITALG, AVX512-VPOPCNTDQ

