### PR TITLE
Remove dead code in lookupScheme2

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1290,17 +1290,17 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       TR::ILOpCodes firstOp = firstChild->getOpCodeValue();
       if (firstChild->getReferenceCount() == 1 && src1Reg == NULL)
          {
-	 if (firstOp == TR::iu2l || firstOp == TR::su2l ||
-	     (firstOp == TR::lushr &&
-              firstChild->getSecondChild()->getOpCode().isLoadConst() &&
-              (firstChild->getSecondChild()->getInt() & LONG_SHIFT_MASK) == 32))
-	    {
-	    firstChild = firstChild->getFirstChild();
-	    if (firstOp == TR::lushr)
-	       {
-	       firstUseHighOrder = true;
-	       }
-	    }
+         if (firstOp == TR::iu2l || firstOp == TR::su2l ||
+            (firstOp == TR::lushr &&
+               firstChild->getSecondChild()->getOpCode().isLoadConst() &&
+               (firstChild->getSecondChild()->getInt() & LONG_SHIFT_MASK) == 32))
+            {
+            firstChild = firstChild->getFirstChild();
+            if (firstOp == TR::lushr)
+               {
+               firstUseHighOrder = true;
+               }
+            }
          }
       }
 
@@ -1310,17 +1310,17 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
       if (secondChild->getReferenceCount() == 1 && src2Reg == NULL)
          {
-	 if (secondOp == TR::iu2l || secondOp == TR::su2l ||
-	     (secondOp == TR::lushr &&
-              secondChild->getSecondChild()->getOpCode().isLoadConst() &&
-              (secondChild->getSecondChild()->getInt() & LONG_SHIFT_MASK) == 32))
-	    {
-	    secondChild = secondChild->getFirstChild();
-	    if (secondOp == TR::lushr)
-	       {
-	       secondUseHighOrder = true;
-	       }
-	    }
+         if (secondOp == TR::iu2l || secondOp == TR::su2l ||
+            (secondOp == TR::lushr &&
+               secondChild->getSecondChild()->getOpCode().isLoadConst() &&
+               (secondChild->getSecondChild()->getInt() & LONG_SHIFT_MASK) == 32))
+            {
+            secondChild = secondChild->getFirstChild();
+            if (secondOp == TR::lushr)
+               {
+               secondUseHighOrder = true;
+               }
+            }
          }
       }
 
@@ -1378,7 +1378,7 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
             {
             src2Low = src2Reg->getHighOrder();
             }
-	 else
+         else
             {
             src2Low = src2Reg->getLowOrder();
             }
@@ -1508,11 +1508,11 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
       TR::RegisterDependencyConditions *deps = NULL;
 
       if ((firstChild->isHighWordZero() || secondChild->isHighWordZero()) &&
-	  !(secondChild->getOpCode().isLoadConst() &&
-           secondChild->getRegister() == NULL))
-	 {
-	 return compareLongsForOrderWithAnalyser(branchOp, reversedBranchOp, condReg, dstLabel, deps, node, cg, isHint, likeliness);
-	 }
+            !(secondChild->getOpCode().isLoadConst() &&
+            secondChild->getRegister() == NULL))
+         {
+         return compareLongsForOrderWithAnalyser(branchOp, reversedBranchOp, condReg, dstLabel, deps, node, cg, isHint, likeliness);
+         }
 
       TR::Register *src2Reg;
       src1Reg = cg->evaluate(firstChild);
@@ -1533,7 +1533,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
          }
 
       if (deps == NULL)
-	    deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(4, 4, cg->trMemory());
+         deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(4, 4, cg->trMemory());
 
       fixDepsForLongCompare(deps, src1Reg->getHighOrder(), src1Reg->getLowOrder(), useImmed ? NULL : src2Reg->getHighOrder(), useImmed ? NULL : src2Reg->getLowOrder());
       TR::PPCControlFlowInstruction *cfop = (TR::PPCControlFlowInstruction *)
@@ -3693,19 +3693,19 @@ static void lookupScheme1(TR::Node *node, bool unbalanced, bool fromTableEval, T
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, cndRegister, selector, fromTableEval?(i-2):(int32_t)(child->getCaseConstant()));
          }
       if (unbalanced)
-	 {
+         {
          bcond = conditions;
          if (child->getNumChildren() > 0)
-	    {
+            {
             cg->evaluate(child->getFirstChild());
             bcond = bcond->clone(cg, generateRegisterDependencyConditions(cg, child->getFirstChild(), 0));
-	    }
+            }
          generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, child->getBranchDestination()->getNode()->getLabel(), cndRegister, bcond);
-	 }
+         }
       else
-	 {
+         {
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, child->getBranchDestination()->getNode()->getLabel(), cndRegister);
-	 }
+         }
       }
 
    if (two_reg)
@@ -3727,43 +3727,18 @@ static void lookupScheme2(TR::Node *node, bool unbalanced, bool fromTableEval, T
    TR::Register *cndRegister = cg->allocateRegister(TR_CCR);
    TR::Register *valRegister = NULL;
 
-   bool         isInt64 = false;
-   bool two_reg = (cg->comp()->target().is32Bit()) && isInt64;
    TR::LabelSymbol *toDefaultLabel = NULL;
-   if ( two_reg )
-      {
-      valRegister = cg->allocateRegisterPair(cg->allocateRegister(),cg->allocateRegister());
-      toDefaultLabel = generateLabelSymbol(cg);
-      }
-   else
-      {
-      valRegister = cg->allocateRegister();
-      }
+   valRegister = cg->allocateRegister();
 
    TR::RegisterDependencyConditions *acond, *bcond, *conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(5, 5, cg->trMemory());
    TR::Node     *secondChild = node->getSecondChild();
 
-   if(two_reg)
-      {
-      TR::addDependency(conditions, valRegister->getHighOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, valRegister->getLowOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, selector->getHighOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, selector->getLowOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
-      }
-   else
-      {
-      TR::addDependency(conditions, valRegister, TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, selector, TR::RealRegister::NoReg, TR_GPR, cg);
-      }
+   TR::addDependency(conditions, valRegister, TR::RealRegister::NoReg, TR_GPR, cg);
+   TR::addDependency(conditions, selector, TR::RealRegister::NoReg, TR_GPR, cg);
 
    TR::addDependency(conditions, cndRegister, TR::RealRegister::NoReg, TR_CCR, cg);
    conditions->getPreConditions()->getRegisterDependency(0)->setExcludeGPR0();
    conditions->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
-   if(two_reg)
-      {
-      conditions->getPreConditions()->getRegisterDependency(1)->setExcludeGPR0();
-      conditions->getPostConditions()->getRegisterDependency(1)->setExcludeGPR0();
-      }
 
    acond = conditions;
    if (secondChild->getNumChildren()>0 && !unbalanced)
@@ -3774,71 +3749,35 @@ static void lookupScheme2(TR::Node *node, bool unbalanced, bool fromTableEval, T
 
    int32_t   preInt = fromTableEval?0:node->getChild(2)->getCaseConstant();
 
-   if (isInt64)
-      {
-      if (two_reg)
-         {
-         loadConstant(cg, node, (int32_t)(preInt >> 32), valRegister->getHighOrder());
-         loadConstant(cg, node, (int32_t)preInt, valRegister->getLowOrder());
-         }
-      else
-         loadConstant(cg, node, preInt, valRegister);
-      }
-   else
-      {
-      loadConstant(cg, node, (int32_t) preInt, valRegister);
-      }
+   loadConstant(cg, node, preInt, valRegister);
 
    for (int i=2; i<total; i++)
       {
       TR::Node *child = node->getChild(i);
 
-      if (isInt64)
-         {
-         if (cg->comp()->target().is64Bit())
-            {
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp8, node, cndRegister, selector, valRegister);
-            }
-         else
-            {
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cndRegister, selector->getHighOrder(), valRegister->getHighOrder());
-            generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, toDefaultLabel, cndRegister);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cndRegister, selector->getLowOrder(), valRegister->getLowOrder());
-            }
-         }
-      else
-         {
-         generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cndRegister, selector, valRegister);
-         }
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp4, node, cndRegister, selector, valRegister);
 
       if (unbalanced)
-	 {
+         {
          bcond = conditions;
          if (child->getNumChildren() > 0)
-	    {
+            {
             cg->evaluate(child->getFirstChild());
             bcond = bcond->clone(cg, generateRegisterDependencyConditions(cg, child->getFirstChild(), 0));
-	    }
+            }
          generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, child->getBranchDestination()->getNode()->getLabel(), cndRegister, bcond);
-	 }
+         }
       else
-	 {
+         {
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, child->getBranchDestination()->getNode()->getLabel(), cndRegister);
-	 }
+         }
       if (i<total-1)
-	 {
+         {
          int32_t diff = fromTableEval?1:(node->getChild(i+1)->getCaseConstant()-preInt);
          preInt += diff;
-         if (!isInt64)
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, valRegister, valRegister, (int32_t)diff);
-         else
-            addConstantToLong(node, valRegister, diff, valRegister, cg);
-
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi2, node, valRegister, valRegister, (int32_t)diff);
          }
       }
-
-   if (two_reg)
-      generateLabelInstruction(cg, TR::InstOpCode::label, node, toDefaultLabel);
 
    if (secondChild->getNumChildren()>0 && unbalanced)
       {


### PR DESCRIPTION
Remove code in static function lookupScheme2 dependent on boolean variable isInt64 which was hard-coded to false.

This also removes code that was causing a warning, so this PR also contributes to (but does not close) [openj9 #14859](https://github.com/eclipse-openj9/openj9/issues/14859)