### PR TITLE
Add TR::vnolz and TR::vnotz evaluators in z/codegen

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4782,6 +4782,8 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
       case TR::vxor:
       case TR::vor:
       case TR::vand:
+      case TR::vnotz:
+      case TR::vnolz:
          if (et == TR::Int8 || et == TR::Int16 || et == TR::Int32 || et == TR::Int64)
             return true;
          else

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1660,19 +1660,7 @@ OMR::Z::TreeEvaluator::mcompressEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    }
 
 TR::Register*
-OMR::Z::TreeEvaluator::vnotzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
 OMR::Z::TreeEvaluator::vmnotzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
-   }
-
-TR::Register*
-OMR::Z::TreeEvaluator::vnolzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
    }
@@ -2336,6 +2324,18 @@ OMR::Z::TreeEvaluator::lbitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *c
    {
    return TR::TreeEvaluator::bitpermuteEvaluator(node, cg);
    }
+
+TR::Register*
+OMR::Z::TreeEvaluator::vnotzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+    {
+    return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VCTZ);
+    }
+
+ TR::Register*
+ OMR::Z::TreeEvaluator::vnolzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+    {
+    return inlineVectorUnaryOp(node, cg, TR::InstOpCode::VCLZ);
+    }
 
 static TR_ExternalRelocationTargetKind
 getRelocationTargetKindFromSymbol(TR::CodeGenerator* cg, TR::Symbol *sym)
@@ -14911,6 +14911,8 @@ OMR::Z::TreeEvaluator::inlineVectorUnaryOp(TR::Node * node,
          break;
       case TR::InstOpCode::VLC:
       case TR::InstOpCode::VLP:
+      case TR::InstOpCode::VCTZ:
+      case TR::InstOpCode::VCLZ:
          generateVRRaInstruction(cg, op, node, returnReg, sourceReg1, 0, 0, getVectorElementSizeMask(node));
          break;
       case TR::InstOpCode::VFPSO:


### PR DESCRIPTION
This PR introduces evaluators for the `TR::vnolz` and `TR::vnotz` IL in the z/codegen. Support is only enabled for architectures with vector instruction support.