### PR TITLE
Cast pid_t to int64_t for use in format specifiers

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4952,8 +4952,8 @@ void TR_Debug::setupDebugger(void *addr)
          char * Argv[20];
 
          yield();
-         sprintf(cfname, "_%ld_", getpid());
-         sprintf(pp,"%ld", ppid);
+         sprintf(cfname, "_%" OMR_PRId64 "_", (int64_t)getpid());
+         sprintf(pp, "%" OMR_PRId64, (int64_t)ppid);
          Argv[1] = "-a";
          Argv[2] = pp;
          Argv[3] = NULL;


### PR DESCRIPTION
Fix AIX warnings concerning incorrect format specifiers for variables with type `pid_t` by casting them to `int64_t` since `pid_t` is not guaranteed to be a long integer on every platform.

This PR contributes to (but does not close) [openj9 #14859](https://github.com/eclipse-openj9/openj9/issues/14859)