### PR TITLE
Remove binding of NULL to non-pointer variable

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -4089,7 +4089,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    bool        two_reg = isInt64 && cg->comp()->target().is32Bit();
    int32_t *dataTable = NULL;
    int64_t *dataTable64 = NULL;
-   intptr_t  address = NULL;
+   intptr_t  address = 0;
    if (isInt64)
       {
       dataTableSize *= 2;


### PR DESCRIPTION
Fix plinux warning concerning a conversion from NULL to intptr_t by removing the initial assignment of variable `address` to NULL. Since `address` is bound to a value immediately afterwards in both control flow paths through the if-else block which directly follows the variable definition, it's safe to not give it an initial value here.

The other instance of this warning will be fixed in [openj9 #18244](https://github.com/eclipse-openj9/openj9/pull/18244)

This PR contributes to (but does not close) [openj9 #14859](https://github.com/eclipse-openj9/openj9/issues/14859)