### PR TITLE
Support TR::Block in TR_RegionStructure::cleanupAfterNodeRemoval()

### DIFF
--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -994,8 +994,19 @@ void TR_RegionStructure::cleanupAfterNodeRemoval()
       {
       TR_RegionStructure::Cursor si(*this);
       TR_ASSERT(si.getFirst() == getEntry(),"bad structure found trying to remove a block");
-      if (getParent())
-         getParent()->replacePart(this, getEntry()->getStructure());
+
+      auto parent = getParent();
+      if (!parent)
+         return;
+
+      auto structure = getEntry()->getStructure();
+      if (!structure)
+         {
+         collapseIntoParent();
+         return;
+         }
+
+      parent->replacePart(this, structure);
       }
    }
 
@@ -1046,6 +1057,9 @@ TR_StructureSubGraphNode *TR_RegionStructure::subNodeFromStructure(
 
 void TR_RegionStructure::replacePart(TR_Structure *from, TR_Structure *to)
    {
+   TR_ASSERT(from != NULL, "target for structure replacement is null");
+   TR_ASSERT(to != NULL, "replacement for structure %d is null", from->getNumber());
+
    // Find the sub-graph node for the sub-structure
    //
    TR_StructureSubGraphNode *node;


### PR DESCRIPTION
This commit fixes an edge case in
TR_RegionStructure::cleanupAfterNodeRemoval() discovered by eclipse-openj9/openj9#17419. Previously, it was expected that a region structure could only collapsed into its parent iff the remaining sub node was also a structure.
This did not account for the case that the sub node could be a block.