### PR TITLE
Adjust arguments to Unsafe.setMemory() on PPC when offheap is enabled

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5902,14 +5902,35 @@ OMR::Power::TreeEvaluator::generateHelperBranchAndLinkInstruction(
 TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
+   TR::Node             *dstBaseAddrNode, *dstOffsetNode, *dstAddrNode, *lengthNode, *valueNode;
 
-   TR::Node *dstBaseAddrNode = node->getChild(0);
-   TR::Node *dstOffsetNode = node->getChild(1);
-   TR::Node *lengthNode = node->getChild(2);
-   TR::Node *valueNode = node->getChild(3);
+   bool arrayCheckNeeded;
 
-   TR::Register         *dstBaseAddrReg, *dstOffsetReg, *lengthReg, *valueReg;
-   bool stopUsingCopyReg1, stopUsingCopyReg2, stopUsingCopyReg3 = false, stopUsingCopyReg4 = false;
+   // IL tree structure depends on whether or not it's been determined that a runtime arrayCHK is needed:
+   // if node has four children (i.e.: object base address and offset are separate), need array check
+   // if node three children (i.e.: object base address and offset have already been added together), don't need array check
+   if (node->getNumChildren() == 4)
+      {
+      arrayCheckNeeded = true;
+
+      dstBaseAddrNode = node->getChild(0);
+      dstOffsetNode = node->getChild(1);
+      dstAddrNode = NULL;
+      lengthNode = node->getChild(2);
+      valueNode = node->getChild(3);
+      }
+   else //i.e.: node->getNumChildren() == 3
+      {
+      arrayCheckNeeded = false;
+
+      dstBaseAddrNode = NULL;
+      dstOffsetNode = NULL;
+      dstAddrNode = node->getChild(0);
+      lengthNode = node->getChild(1);
+      valueNode = node->getChild(2);
+      }
+
+   TR::Register         *dstBaseAddrReg, *dstOffsetReg, *dstAddrReg, *lengthReg, *valueReg;
 
    bool stopUsingCopyRegBase = dstBaseAddrNode ? TR::TreeEvaluator::stopUsingCopyReg(dstBaseAddrNode, dstBaseAddrReg, cg) : false;
    bool stopUsingCopyRegOffset = dstOffsetNode ? TR::TreeEvaluator::stopUsingCopyReg(dstOffsetNode, dstOffsetReg, cg) : false;
@@ -5923,16 +5944,16 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
 	   TR::Register *lenCopyReg = cg->allocateRegister();
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, lengthNode, lenCopyReg, lengthReg);
       lengthReg = lenCopyReg;
-      stopUsingCopyReg3 = true;
+      stopUsingCopyRegLen = true;
       }
 
    valueReg = cg->evaluate(valueNode);
    if (!cg->canClobberNodesRegister(valueNode))
       {
-	  TR::Register *valCopyReg = cg->allocateRegister();
+	   TR::Register *valCopyReg = cg->allocateRegister();
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, valueNode, valCopyReg, valueReg);
       valueReg = valCopyReg;
-      stopUsingCopyReg4 = true;
+      stopUsingCopyRegVal = true;
       }
 
    TR::LabelSymbol * residualLabel =  generateLabelSymbol(cg);
@@ -5944,48 +5965,46 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
    TR::LabelSymbol * label1aligned =  generateLabelSymbol(cg);
 
    TR::RegisterDependencyConditions *conditions;
-   int32_t numDeps = 7;
+   int32_t numDeps = arrayCheckNeeded ? 7 : 6;
    conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numDeps, numDeps, cg->trMemory());
    TR::Register *cndReg = cg->allocateRegister(TR_CCR);
    TR::addDependency(conditions, cndReg, TR::RealRegister::cr0, TR_CCR, cg);
-   TR::addDependency(conditions, dstBaseAddrReg, TR::RealRegister::NoReg, TR_GPR, cg);
-   TR::addDependency(conditions, dstOffsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
+
+   if (arrayCheckNeeded)
+      {
+      //dstBaseAddrReg holds the address of the object being written to, so need to exclude GPR0
+      TR::addDependency(conditions, dstBaseAddrReg, TR::RealRegister::NoReg, TR_GPR, cg);
+      conditions->getPostConditions()->getRegisterDependency(conditions->getAddCursorForPost() - 1)->setExcludeGPR0();
+
+      if (!useOffsetAsImmVal)
+         TR::addDependency(conditions, dstOffsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
+      }
+   else
+      {
+      //dstAddrReg holds the address of the object being written to, so need to exclude GPR0
+      TR::addDependency(conditions, dstAddrReg, TR::RealRegister::NoReg, TR_GPR, cg);
+      conditions->getPostConditions()->getRegisterDependency(1)->setExcludeGPR0();
+      }
+
    TR::addDependency(conditions, lengthReg, TR::RealRegister::NoReg, TR_GPR, cg);
    TR::addDependency(conditions, valueReg, TR::RealRegister::NoReg, TR_GPR, cg);
+
+   //temp1Reg will later be used to hold the J9Class flags for the object at dst, so need to exclude GPR0
    TR::Register * temp1Reg = cg->allocateRegister();
-   TR::Register * temp2Reg = cg->allocateRegister();
    TR::addDependency(conditions, temp1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
+   conditions->getPostConditions()->getRegisterDependency(conditions->getAddCursorForPost() - 1)->setExcludeGPR0();
+
+   TR::Register * temp2Reg = cg->allocateRegister();
    TR::addDependency(conditions, temp2Reg, TR::RealRegister::NoReg, TR_GPR, cg);
 
 
 #if defined (J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
-   // When using balanced GC policy with offheap allocation enabled, there are three possible cases:
-   // 1.) The object at dstBaseAddr is known to be a non-array object at compile time. In this scenario, no arrayCHK is
-   //     generated, and no adjustments are made to dstBaseAddr or dstOffset. The behavior in this case should be identical
-   //     to that under gencon GC policy.
-   // 2.) The object at dstBaseAddr is known to be an array at compile time. In this scenario, no arrayCHK is generated, but
-   //     the dstBaseAddr and dstOffset with be adjusted as needed for offheap.
-   // 3.) The type of the object at dstBaseAddr is unknown at compile time. In this scenario, a runtime arrayCHK will generated,
-   //     with two possible outcomes: if the object is an array, the dstBaseAddr and dstOffset will be adjusted, and if not,
-   //     no adjustments will be made.
 
-   //check dstBaseAddrNode type at compile time
-   int length;
-   const char *objTypeSig = dstBaseAddrNode->getSymbolReference()->getTypeSignature(length);
-
-   //generate arrayCHK in case (3) only
-   bool arrayCheckNeeded = TR::Compiler->om.isOffHeapAllocationEnabled() && comp->target().is64Bit() &&
-                           (objTypeSig == NULL || strstr(objTypeSig, "Ljava/lang/Object"));
-
-   //adjust dstBaseAddr and dstOffset in cases (2) and (3)
-   bool adjustmentNeeded = arrayCheckNeeded ||
-                           TR::Compiler->om.isOffHeapAllocationEnabled() && comp->target().is64Bit() && objTypeSig[0] == '[';
-
-   //generate array check if needed
-   TR::LabelSymbol *notArray = generateLabelSymbol(cg);
-
-   if (arrayCheckNeeded)
+   if (arrayCheckNeeded) // CASE (3)
    {
+      //generate array check if needed
+      TR::LabelSymbol *notArray = generateLabelSymbol(cg);
+
       TR::Register *dstClassInfoReg = temp1Reg;
       TR::Register *arrayFlagReg = temp2Reg;
 
@@ -5996,36 +6015,32 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
       else
          generateTrg1MemInstruction(cg,TR::InstOpCode::Op_load, node, dstClassInfoReg,
             TR::MemoryReference::createWithDisplacement(cg, dstBaseAddrReg, static_cast<int32_t>(TR::Compiler->om.offsetOfObjectVftField()), TR::Compiler->om.sizeofReferenceAddress()));
+      
       TR::TreeEvaluator::generateVFTMaskInstruction(cg, node, dstClassInfoReg);
 
       TR::MemoryReference *dstClassMR = TR::MemoryReference::createWithDisplacement(cg, dstClassInfoReg, offsetof(J9Class, classDepthAndFlags), TR::Compiler->om.sizeofReferenceAddress());
       generateTrg1MemInstruction(cg, TR::InstOpCode::Op_load, node, dstClassInfoReg, dstClassMR);
 
-      //generate arrayCHK
-      loadConstant(cg, node, comp->fej9()->getFlagValueForArrayCheck(), arrayFlagReg);
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::AND, node, arrayFlagReg, dstClassInfoReg, arrayFlagReg);
-      generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::cmpi8, node, cndReg, arrayFlagReg, 0);
+      //generate array check
+      int32_t arrayFlagValue = comp->fej9()->getFlagValueForArrayCheck();
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::andis_r, node, arrayFlagReg, dstClassInfoReg, arrayFlagValue >> 16);
 
       //if object is not an array (i.e.: temp1Reg & temp2Reg == 0), skip adjusting dstBaseAddr and dstOffset
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, notArray, cndReg);
-   }
 
-   //adjust dstBaseAddr if needed
-   if (adjustmentNeeded)
-   {
-      //load dataAddr
+      //load dataAddr if object is array:
       TR::MemoryReference *dataAddrSlotMR = TR::MemoryReference::createWithDisplacement(cg, dstBaseAddrReg, comp->fej9()->getOffsetOfContiguousDataAddrField(), TR::Compiler->om.sizeofReferenceAddress());
       generateTrg1MemInstruction(cg, TR::InstOpCode::Op_load, node, dstBaseAddrReg, dataAddrSlotMR);
+      
+      //arrayCHK will skip to here if object is not an array
+      generateLabelInstruction(cg, TR::InstOpCode::label, node, notArray);
+
+      //calculate dstAddr = dstBaseAddr + dstOffset
+      dstAddrReg = dstBaseAddrReg;
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dstAddrReg, dstBaseAddrReg, dstOffsetReg);
    }
 
-   //arrayCHK will skip to here if object is not an array
-   generateLabelInstruction(cg, TR::InstOpCode::label, node, notArray);
-
 #endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
-
-   //calculate dstAddr = dstBaseAddr + dstOffset
-   TR::Register *dstAddrReg = dstBaseAddrReg;
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dstAddrReg, dstBaseAddrReg, dstOffsetReg);
 
    // assemble the double word value from byte value
    generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwimi, node, valueReg, valueReg,  8, 0xff00);
@@ -6077,21 +6092,24 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
 
    generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
 
-   if (stopUsingCopyReg1)
+   if (stopUsingCopyRegBase)
       cg->stopUsingRegister(dstBaseAddrReg);
-   if (stopUsingCopyReg2)
+   if (stopUsingCopyRegOffset)
       cg->stopUsingRegister(dstOffsetReg);
-   if (stopUsingCopyReg3)
+   if (stopUsingCopyRegAddr)
+      cg->stopUsingRegister(dstAddrReg);
+   if (stopUsingCopyRegLen)
       cg->stopUsingRegister(lengthReg);
-   if (stopUsingCopyReg4)
+   if (stopUsingCopyRegVal)
       cg->stopUsingRegister(valueReg);
 
    cg->stopUsingRegister(cndReg);
    cg->stopUsingRegister(temp1Reg);
    cg->stopUsingRegister(temp2Reg);
 
-   cg->decReferenceCount(dstBaseAddrNode);
-   cg->decReferenceCount(dstOffsetNode);
+   if (dstBaseAddrNode) cg->decReferenceCount(dstBaseAddrNode);
+   if (dstOffsetNode) cg->decReferenceCount(dstOffsetNode);
+   if (dstAddrNode) cg->decReferenceCount(dstAddrNode);
    cg->decReferenceCount(lengthNode);
    cg->decReferenceCount(valueNode);
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5932,8 +5932,12 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
 
    TR::Register         *dstBaseAddrReg, *dstOffsetReg, *dstAddrReg, *lengthReg, *valueReg;
 
+   // if the offset is a constant value less than 16 bits, then we dont need a separate register for it
+   bool useOffsetAsImmVal = dstOffsetNode && dstOffsetNode->getOpCode().isLoadConst() &&
+                            (dstOffsetNode->getConstValue() >= LOWER_IMMED) && (dstOffsetNode->getConstValue() <= UPPER_IMMED);
+
    bool stopUsingCopyRegBase = dstBaseAddrNode ? TR::TreeEvaluator::stopUsingCopyReg(dstBaseAddrNode, dstBaseAddrReg, cg) : false;
-   bool stopUsingCopyRegOffset = dstOffsetNode ? TR::TreeEvaluator::stopUsingCopyReg(dstOffsetNode, dstOffsetReg, cg) : false;
+   bool stopUsingCopyRegOffset = (dstOffsetNode && !useOffsetAsImmVal) ? TR::TreeEvaluator::stopUsingCopyReg(dstOffsetNode, dstOffsetReg, cg) : false;
    bool stopUsingCopyRegAddr = dstAddrNode ? TR::TreeEvaluator::stopUsingCopyReg(dstAddrNode, dstAddrReg, cg) : false ;
 
    bool stopUsingCopyRegLen, stopUsingCopyRegVal;
@@ -5965,7 +5969,7 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
    TR::LabelSymbol * label1aligned =  generateLabelSymbol(cg);
 
    TR::RegisterDependencyConditions *conditions;
-   int32_t numDeps = arrayCheckNeeded ? 7 : 6;
+   int32_t numDeps = (!arrayCheckNeeded || useOffsetAsImmVal) ? 6 : 7;
    conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numDeps, numDeps, cg->trMemory());
    TR::Register *cndReg = cg->allocateRegister(TR_CCR);
    TR::addDependency(conditions, cndReg, TR::RealRegister::cr0, TR_CCR, cg);
@@ -6051,7 +6055,14 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
 
       //calculate dstAddr = dstBaseAddr + dstOffset
       dstAddrReg = dstBaseAddrReg;
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dstAddrReg, dstBaseAddrReg, dstOffsetReg);
+
+      if (useOffsetAsImmVal)
+      {
+         int offsetImmVal = dstOffsetNode->getConstValue();
+         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, dstAddrReg, dstBaseAddrReg, offsetImmVal);
+      }
+      else
+         generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dstAddrReg, dstBaseAddrReg, dstOffsetReg);
    }
 
 #endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */


### PR DESCRIPTION
Add runtime array check to generated assembly code for Unsafe.setMemory() on PPC and, when offheap/balanced GC policy is in use, generate assembly code to perform an arrayCHK and, if the object _is_ an array, adjust the arguments as follows:

- Load and pass in the dataAddr pointer as the base address of the object being operated on
- ~Subtract the array header size from the offset~ _no longer necessary due to this change_: https://github.com/eclipse-openj9/openj9/pull/19326

In addition, as a performance improvement for both the offheap and gencon cases on P8 and up, use vector instructions (`stxvd2x` and, on P10 only, `stxvl`) to reduce loop iterations when setting bytes in memory to specified value.

Depends on: https://github.com/eclipse-openj9/openj9/pull/18288