### PR TITLE
Recognize DWARF tags used by XCode 14.0.3+

### DIFF
--- a/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
@@ -470,6 +470,7 @@ static const pair<const char *, Dwarf_Half> tagStrings[] = {
 	make_pair("namespace", DW_TAG_namespace),
 	make_pair("pointer_type", DW_TAG_pointer_type),
 	make_pair("ptr_to_member_type", DW_TAG_ptr_to_member_type),
+	make_pair("reference_type", DW_TAG_reference_type),
 	make_pair("restrict_type", DW_TAG_restrict_type),
 	make_pair("shared_type", DW_TAG_shared_type),
 	make_pair("structure_type", DW_TAG_structure_type),
@@ -478,6 +479,7 @@ static const pair<const char *, Dwarf_Half> tagStrings[] = {
 	make_pair("subroutine_type", DW_TAG_subroutine_type),
 	make_pair("typedef", DW_TAG_typedef),
 	make_pair("union_type", DW_TAG_union_type),
+	make_pair("unspecified_type", DW_TAG_unspecified_type),
 	make_pair("volatile_type", DW_TAG_volatile_type),
 };
 


### PR DESCRIPTION
XCode 14.0.3 uses these tags:
* `DW_TAG_reference_type`
* `DW_TAG_unspecified_type`

They must be recognized to be support elements whose type attribute targets them.

Fixes the problem mentioned in https://github.com/eclipse-openj9/openj9/issues/17493#issuecomment-1734447047.