### PR TITLE
Move Forced Flags From Config to Extbase

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -483,13 +483,13 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 	 */
 
 	/* initialize packet lock splitting factor */
-	if (!_packetListSplitForced) {
+	if (!extensions->packetListSplitForced) {
 		extensions->packetListSplit = OMR_MAX(extensions->packetListSplit, splitAmount);
 	}
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/* initialize scan cache lock splitting factor */
-	if (!_cacheListSplitForced) {
+	if (!extensions->cacheListSplitForced) {
 		extensions->cacheListSplit = OMR_MAX(extensions->cacheListSplit, splitAmount);
 	}
 	if (extensions->scavengerEnabled) {
@@ -502,7 +502,7 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 	/* initialize default split freelist split amount */
-	if (!_splitFreeListAmountForced) {
+	if (!extensions->splitFreeListAmountForced) {
 		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 		uintptr_t freeListSplitAmount = (omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) - 1) / 8  +  1;
 #if defined(OMR_GC_MODRON_SCAVENGER)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -354,7 +354,8 @@ public:
 	OMR_VMThread* vmThreadAllocatedMost;
 
 	const char* gcModeString;
-	uintptr_t splitFreeListSplitAmount;
+	uintptr_t splitFreeListSplitAmount; /**< The number of split freelists in heap (or in tenure for gencon) */
+	bool splitFreeListAmountForced; /**< Flag to distinguish if splitFreeListAmount is externally enforced (for example, specified by command line) or determined heuristically */
 	uintptr_t splitFreeListNumberChunksPrepared; /**< Used in MPSAOL postProcess. Shared for all MPSAOLs. Do not overwrite during postProcess for any MPSAOL. */
 	bool enableHybridMemoryPool;
 
@@ -405,8 +406,8 @@ public:
 	bool useGCStartupHints; /**< Enabled/disable usage of heap sizing startup hints from Shared Cache */
 
 	uintptr_t workpacketCount; /**< this value is ONLY set if -Xgcworkpackets is specified - otherwise the workpacket count is determined heuristically */
-	uintptr_t packetListSplit; /**< the number of ways to split packet lists, set by -XXgc:packetListLockSplit=, or determined heuristically based on the number of GC threads */
-
+	uintptr_t packetListSplit; /**< the number of ways to split packet lists, set by command line option, or determined heuristically based on the number of GC threads */
+	bool packetListSplitForced;  /**< Flag to distinguish if packetListSplit is externally enforced (for example, specified by command line) */
 	uintptr_t markingArraySplitMaximumAmount; /**< maximum number of elements to split array scanning work in marking scheme */
 	uintptr_t markingArraySplitMinimumAmount; /**< minimum number of elements to split array scanning work in marking scheme */
 
@@ -500,7 +501,8 @@ public:
 	bool scvTenureStrategyHistory; /**< Flag for enabling the History scavenger tenure strategy. */
 	bool scavengerEnabled;
 	bool scavengerRsoScanUnsafe;
-	uintptr_t cacheListSplit; /**< the number of ways to split scanCache lists, set by -XXgc:cacheListLockSplit=, or determined heuristically based on the number of GC threads */
+	uintptr_t cacheListSplit; /**< the number of ways to split scanCache lists, set by command line option, or determined heuristically based on the number of GC threads */
+	bool cacheListSplitForced;/**< Flag to distinguish if cacheList is externally enforced (for example, specified by command line) */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool softwareRangeCheckReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS, complimentary to concurrentScavengerHWSupport with CS active */
 	bool softwareRangeCheckReadBarrierForced; /**< true if usage of softwareRangeCheckReadBarrier is requested explicitly */
@@ -1566,6 +1568,7 @@ public:
 		, vmThreadAllocatedMost(NULL)
 		, gcModeString(NULL)
 		, splitFreeListSplitAmount(0)
+		, splitFreeListAmountForced(false)
 		, splitFreeListNumberChunksPrepared(0)
 		, enableHybridMemoryPool(false)
 		, largeObjectArea(false)
@@ -1603,6 +1606,7 @@ public:
 		, useGCStartupHints(true)
 		, workpacketCount(0) /* only set if -Xgcworkpackets specified */
 		, packetListSplit(0)
+		, packetListSplitForced(false)
 		, markingArraySplitMaximumAmount(DEFAULT_ARRAY_SPLIT_MAXIMUM_SIZE)
 		, markingArraySplitMinimumAmount(DEFAULT_ARRAY_SPLIT_MINIMUM_SIZE)
 		, rootScannerStatsEnabled(false)
@@ -1681,6 +1685,7 @@ public:
 		, scavengerEnabled(false)
 		, scavengerRsoScanUnsafe(false)
 		, cacheListSplit(0)
+		, cacheListSplitForced(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, softwareRangeCheckReadBarrier(false)
 		, softwareRangeCheckReadBarrierForced(false)


### PR DESCRIPTION
move defs for packetlistsplit, cachelistsplit, and splitfreelistamount from config to extbase

Signed off by: Frank.Kang@ibm.com