### PR TITLE
Add contiguous array dataAddr field shadow symbol reference for off heap technology

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -151,6 +151,26 @@ OMR::SymbolReferenceTable::findOrCreateContiguousArraySizeSymbolRef()
    return element(contiguousArraySizeSymbol);
    }
 
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateContiguousArrayDataAddrFieldShadowSymRef()
+   {
+   if (!element(contiguousArrayDataAddrFieldSymbol))
+      {
+      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Address);
+      sym->setContiguousArrayDataAddrFieldSymbol();
+      element(contiguousArrayDataAddrFieldSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), contiguousArrayDataAddrFieldSymbol, sym);
+      element(contiguousArrayDataAddrFieldSymbol)->setOffset(TR::Compiler->om.offsetOfContiguousDataAddrField());
+      }
+   return element(contiguousArrayDataAddrFieldSymbol);
+   }
+#endif // defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findContiguousArrayDataAddrFieldShadowSymRef()
+   {
+   return element(contiguousArrayDataAddrFieldSymbol);
+   }
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateVftSymbolRef()
@@ -2152,6 +2172,7 @@ const char *OMR::SymbolReferenceTable::_commonNonHelperSymbolNames[] =
    "<osrScratchBuffer>",
    "<osrFrameIndex>",
    "<osrReturnAddress>",
+   "<contiguousArrayDataAddrField>",
    "<potentialOSRPointHelper>",
    "<osrFearPointHelper>",
    "<eaEscapeHelper>",

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -148,6 +148,7 @@ class SymbolReferenceTable
       osrScratchBufferSymbol,    //osrScratchBuffer slot on  j9vmthread
       osrFrameIndexSymbol,       // osrFrameIndex slot on j9vmthread
       osrReturnAddressSymbol,       // osrFrameIndex slot on j9vmthread
+      contiguousArrayDataAddrFieldSymbol, // dataAddr field symbol used to track data portion of the array
 
       /** \brief
        *
@@ -803,6 +804,10 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateTemporaryWithKnowObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::KnownObjectTable::Index knownObjectIndex);
    TR::SymbolReference * findOrCreateThisRangeExtensionSymRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateContiguousArraySizeSymbolRef();
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+   TR::SymbolReference * findOrCreateContiguousArrayDataAddrFieldShadowSymRef();
+#endif // defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+   TR::SymbolReference * findContiguousArrayDataAddrFieldShadowSymRef();
    TR::SymbolReference * findOrCreateNewArrayNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateNewObjectSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateNewObjectNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5899,6 +5899,14 @@ OMR::Node::setIsInternalPointer(bool v)
    }
 
 bool
+OMR::Node::isDataAddrPointer()
+   {
+   return self()->getOpCodeValue() == TR::aloadi
+       && self()->getOpCode().hasSymbolReference()
+       && self()->getSymbolReference() == TR::comp()->getSymRefTab()->findContiguousArrayDataAddrFieldShadowSymRef();
+   }
+
+bool
 OMR::Node::isArrayTRT()
    {
    TR_ASSERT(self()->getOpCodeValue() == TR::arraytranslateAndTest, "Opcode must be arraytranslateAndTest");

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1152,6 +1152,9 @@ public:
    bool isInternalPointer();
    void setIsInternalPointer(bool v);
 
+   // Flag used by TR::aloadi
+   bool isDataAddrPointer();
+
    // Flags used by TR::arraytranslate and TR::arraytranslateAndTest
    bool isArrayTRT();
    void setArrayTRT(bool v);

--- a/compiler/il/OMRSymbol.hpp
+++ b/compiler/il/OMRSymbol.hpp
@@ -382,6 +382,9 @@ public:
    inline void setArrayShadowSymbol();
    inline bool isArrayShadowSymbol();
 
+   inline void setContiguousArrayDataAddrFieldSymbol();
+   inline bool isContiguousArrayDataAddrFieldSymbol();
+
    inline bool isRecognizedShadow();
 
    inline bool isRecognizedKnownObjectShadow();
@@ -515,7 +518,7 @@ public:
                                               ///< to behave as regular locals to
                                               ///< preserve floating point semantics
       PinningArrayPointer       = 0x10000000,
-      // Available              = 0x00020000,
+      contiguousArrayDataAddrField = 0x00020000,
       AutoAddressTaken          = 0x04000000, ///< a loadaddr of this auto exists
       SpillTempLoaded           = 0x04000000, ///< share bit with loadaddr because spill temps will never have their address taken. Used to remove store to spill if never loaded
       // Available              = 0x02000000,

--- a/compiler/il/OMRSymbol_inlines.hpp
+++ b/compiler/il/OMRSymbol_inlines.hpp
@@ -427,6 +427,19 @@ OMR::Symbol::isArrayShadowSymbol()
    return self()->isShadow() && _flags.testAny(ArrayShadow);
    }
 
+
+void
+OMR::Symbol::setContiguousArrayDataAddrFieldSymbol()
+   {
+   _flags.set(contiguousArrayDataAddrField);
+   }
+
+bool
+OMR::Symbol::isContiguousArrayDataAddrFieldSymbol()
+   {
+   return _flags.testAny(contiguousArrayDataAddrField);
+   }
+
 bool
 OMR::Symbol::isRecognizedShadow()
    {

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1667,6 +1667,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<storeFlattenableArrayElementNonHelper>";
          case TR::SymbolReferenceTable::J9JNIMethodIDvTableIndexFieldSymbol:
              return "<J9JNIMethodIDvTableIndexFieldSymbol>";
+         case TR::SymbolReferenceTable::contiguousArrayDataAddrFieldSymbol:
+             return "<contiguousArrayDataAddrFieldSymbol>";
          case TR::SymbolReferenceTable::defaultValueSymbol:
              return "<defaultValue>";
          case TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol:
@@ -2111,6 +2113,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<osrScratchBuffer>",
    "<osrFrameIndex>",
    "<osrReturnAddress>",
+   "<contiguousArrayDataAddrField>",
    "<potentialOSRPointHelper>",
    "<osrFearPointHelper>",
    "<eaEscapeHelper>",


### PR DESCRIPTION
Add ContiguousArrayDataAddrFieldShadowSymRef along with needed getter and setter. This is minimum set of off heap changes needed for https://github.com/eclipse-openj9/openj9/pull/18303.