### PR TITLE
Update JBCodeCacheManager to allocate segment objects on mmaped memory

### DIFF
--- a/compiler/runtime/OMRCodeCacheMemorySegment.cpp
+++ b/compiler/runtime/OMRCodeCacheMemorySegment.cpp
@@ -21,6 +21,7 @@
 
 #include "runtime/CodeCacheMemorySegment.hpp"
 #include "runtime/CodeCacheManager.hpp"
+#include "thread_api.h"
 
 TR::CodeCacheMemorySegment*
 OMR::CodeCacheMemorySegment::self()
@@ -41,4 +42,38 @@ OMR::CodeCacheMemorySegment::free(TR::CodeCacheManager *manager)
    {
    manager->freeMemory(_base);
    new (static_cast<TR::CodeCacheMemorySegment *>(this)) TR::CodeCacheMemorySegment();
+   }
+
+void
+OMR::CodeCacheMemorySegment::setSegmentBase(uint8_t *newBase)
+   {
+   /*
+    * Assuming the code cache memory segment is allocated on the code cache memory,
+    * we need to modify the memory's permission before and after updating members.
+    */
+   omrthread_jit_write_protect_disable();
+   _base = newBase;
+   omrthread_jit_write_protect_enable();
+   }
+
+void OMR::CodeCacheMemorySegment::setSegmentAlloc(uint8_t *newAlloc)
+   {
+   /*
+    * Assuming the code cache memory segment is allocated on the code cache memory,
+    * we need to modify the memory's permission before and after updating members.
+    */
+   omrthread_jit_write_protect_disable();
+   _alloc = newAlloc;
+   omrthread_jit_write_protect_enable();
+   }
+
+void OMR::CodeCacheMemorySegment::setSegmentTop(uint8_t *newTop)
+   {
+   /*
+    * Assuming the code cache memory segment is allocated on the code cache memory,
+    * we need to modify the memory's permission before and after updating members.
+    */
+   omrthread_jit_write_protect_disable();
+   _top = newTop;
+   omrthread_jit_write_protect_enable();
    }

--- a/compiler/runtime/OMRCodeCacheMemorySegment.hpp
+++ b/compiler/runtime/OMRCodeCacheMemorySegment.hpp
@@ -63,9 +63,9 @@ public:
 
    void adjustAlloc(int64_t adjust);
 
-   void setSegmentBase(uint8_t *newBase)   { _base = newBase; }
-   void setSegmentAlloc(uint8_t *newAlloc) { _alloc = newAlloc; }
-   void setSegmentTop(uint8_t *newTop)     { _top = newTop; }
+   void setSegmentBase(uint8_t *newBase);
+   void setSegmentAlloc(uint8_t *newAlloc);
+   void setSegmentTop(uint8_t *newTop);
 
    // memory is backed by something else
    void free(TR::CodeCacheManager *manager);


### PR DESCRIPTION
This commit updates `JBCodeCacheManager` to allocate the `CodeCacheMemorySegment` object on the mmaped memory. The setter methods in `OMRCodeCacheMemorySegment` are also updated to guard the code updating members by `omrthread_jit_write_protect_disable/enable` calls.
