### PR TITLE
Add option to enforce IProfiler during startup phase

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -122,6 +122,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
       "narrower than 32-bits (boolean, byte, char, short) are in-range",
       SET_OPTION_BIT(TR_AllowVPRangeNarrowingBasedOnDeclaredType), "F" },
    {"alwaysFatalAssert",       "I\tAlways execute fatal assertion for testing purposes",           SET_OPTION_BIT(TR_AlwaysFatalAssert), "F"},
+   {"alwaysIProfileDuringStartupPhase", "R\t enforce iprofiler during startup phase, overrides noIProfilerDuringStartupPhase", SET_OPTION_BIT(TR_AlwaysIProfileDuringStartupPhase), "F", NOT_IN_SUBSET},
    {"alwaysSafeFatalAssert", "I\tAlways issue a safe fatal assertion for testing purposes",      SET_OPTION_BIT(TR_AlwaysSafeFatal), "F"},
    {"alwaysWorthInliningThreshold=", "O<nnn>\t", TR::Options::set32BitNumeric, offsetof(OMR::Options, _alwaysWorthInliningThreshold), 0, "F%d" },
    {"aotOnlyFromBootstrap", "O\tahead-of-time compilation allowed only for methods from bootstrap classes",
@@ -2091,6 +2092,13 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          OMR::Options::getAOTCmdLineOptions()->setDisabled(rematerialization, true);
          }
       }
+
+   static const char *dnipdsp = feGetEnv("TR_DisableNoIprofilerDuringStartupPhase");
+   if (dnipdsp)
+      self()->setOption(TR_AlwaysIProfileDuringStartupPhase);
+
+   if (self()->getOption(TR_AlwaysIProfileDuringStartupPhase))
+      self()->setOption(TR_NoIProfilerDuringStartupPhase, false);
 
    static const char *ipm = feGetEnv("TR_IProfileMore");
    if (ipm)

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -548,7 +548,7 @@ enum TR_CompilationOptions
    TR_DoNotUseFastStackwalk                           = 0x00100000 + 15,
    TR_DisableOSRLiveRangeAnalysis                     = 0x00200000 + 15,
    TR_DisableOSRGuardMerging                         = 0x00400000 + 15,
-   // Available                                       = 0x00800000 + 15,
+   TR_AlwaysIProfileDuringStartupPhase                = 0x00800000 + 15,
    // Available                                       = 0x01000000 + 15,
    // Available                                       = 0x02000000 + 15,
    TR_DisableDowngradeToColdOnVMPhaseStartup          = 0x04000000 + 15,


### PR DESCRIPTION
Making a JIT option that has the same effect of the `TR_DisableNoIProfilerDuringStartupPhase` environment variable.

Named `alwaysIProfileDuringStartupPhase` and it "enforce iprofiler during startup phase". It will override `TR_NoIProfilerDuringStartupPhase`.
This option will be used in `populate_scc` scripts to ensure more IProfiler information are being collected to be stored in the SCC.

Few points:
* Naming is open for suggestion
* I'm aiming for the effect when the option is used with either `-Xjit` or `-Xaot`
* I see `TR_IProfileMore` being another environment variable. While its different, it might be a good candidate to be alongside `alwaysProfileDuringStartup` for a more general "buildSCC" (cold-run) option that can be used when a setup is doing a `populate_scc` run.

Subsequent OpenJ9 change: https://github.com/eclipse-openj9/openj9/pull/18352