### PR TITLE
Add check for ztpfSigShutdownMonitor before attempting to shut it down

### DIFF
--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -1321,12 +1321,15 @@ sig_full_shutdown(struct OMRPortLibrary *portLibrary)
 		}
 		omrthread_monitor_exit(asyncReporterShutdownMonitor);
 #endif	/* defined(OMR_PORT_ASYNC_HANDLER) */
-		omrthread_monitor_enter(ztpfSigShutdownMonitor);
-		shutdown_ztpf_sigpush = 1;
-		while (shutdown_ztpf_sigpush) {
-			omrthread_monitor_wait(ztpfSigShutdownMonitor);
+		/* Assume if zTPF signal monitor is gone no need to shut it down. */
+		if (NULL != ztpfSigShutdownMonitor) {
+			omrthread_monitor_enter(ztpfSigShutdownMonitor);
+			shutdown_ztpf_sigpush = 1;
+			while (0 != shutdown_ztpf_sigpush) {
+				omrthread_monitor_wait(ztpfSigShutdownMonitor);
+			}
+			omrthread_monitor_exit(ztpfSigShutdownMonitor);
 		}
-		omrthread_monitor_exit(ztpfSigShutdownMonitor);
 		/* destroy all of the remaining monitors */
 		destroySignalTools(portLibrary);
 	}


### PR DESCRIPTION
On z/TPF only, there exists a timing window where a signal monitor may be cleaned up before sig_full_shutdown completes processing.  This may lead to a GPF fault.

The fix is a simple check to make sure the monitor is not 0 before use.