### PR TITLE
Init allocation stats fields

### DIFF
--- a/gc/stats/AllocationStats.hpp
+++ b/gc/stats/AllocationStats.hpp
@@ -114,6 +114,7 @@ public:
 		_arrayletLeafAllocationBytes(0),
 		_allocationCount(0),
 		_allocationBytes(0),
+		_allocationBytesCumulative(0),
 		_ownableSynchronizerObjectCount(0),
 		_continuationObjectCount(0),
 		_discardedBytes(0),


### PR DESCRIPTION
This PR ensures that the cumulativeAllocationBytes field is initialized.