### PR TITLE
Clear Inactive Objects at Checkpoint

### DIFF
--- a/gc/base/GCCode.cpp
+++ b/gc/base/GCCode.cpp
@@ -262,3 +262,13 @@ MM_GCCode::isRASDumpGC() const
 {
 	return J9MMCONSTANT_EXPLICIT_GC_RASDUMP_COMPACT == _gcCode;
 }
+
+/**
+ * Determine if the GC should clear bits for objects marked as deleted.
+ * @return true if we should clear the heap (currently only at snapshot)
+ */
+bool
+MM_GCCode::shouldClearHeap() const
+{
+	return J9MMCONSTANT_EXPLICIT_GC_PREPARE_FOR_CHECKPOINT == _gcCode;
+}

--- a/gc/base/GCCode.hpp
+++ b/gc/base/GCCode.hpp
@@ -85,6 +85,12 @@ public:
 	 * @return true if OOM can be thrown at the end of this GC
 	 */
 	bool isOutOfMemoryGC() const;
+
+	/**
+	 * Determine if the GC should clear bits for objects marked as deleted.
+	 * @return true if we should clear the heap (currently only at snapshot)
+	 */
+	bool shouldClearHeap() const;
 };
 
 #endif /* GCCODE_HPP_ */

--- a/gc/base/ParallelHeapWalker.cpp
+++ b/gc/base/ParallelHeapWalker.cpp
@@ -147,7 +147,7 @@ MM_ParallelHeapWalker::allObjectsDoParallel(MM_EnvironmentBase *env, MM_HeapWalk
  * otherwise walk all objects in the heap in a single threaded linear fashion.
  */
 void
-MM_ParallelHeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk)
+MM_ParallelHeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk, bool includeDeadObjects)
 {
 	if (parallel) {
 		GC_OMRVMInterface::flushCachesForWalk(env->getOmrVM());
@@ -158,7 +158,7 @@ MM_ParallelHeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObject
 		MM_ParallelObjectDoTask objectDoTask(env, this, function, userData, walkFlags, parallel);
 		env->getExtensions()->dispatcher->run(env, &objectDoTask);
 	} else {
-		MM_HeapWalker::allObjectsDo(env, function, userData, walkFlags, parallel, prepareHeapForWalk);
+		MM_HeapWalker::allObjectsDo(env, function, userData, walkFlags, parallel, prepareHeapForWalk, includeDeadObjects);
 	}
 }
 

--- a/gc/base/ParallelHeapWalker.hpp
+++ b/gc/base/ParallelHeapWalker.hpp
@@ -59,7 +59,7 @@ public:
 	 * If parallel is set to true, task is dispatched to GC threads and walks the heap segments in parallel,
 	 * otherwise walk all objects in the heap in a single threaded linear fashion.
 	 */
-	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk);
+	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk, bool includeDeadObjects);
 
 	MM_MarkMap *getMarkMap() {
 		return _markMap;

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1025,3 +1025,5 @@ TraceEvent=Trc_MM_MSSSS_flip_backout Overhead=1 Level=1 Group=scavenger Template
 TraceEvent=Trc_MM_MSSSS_flip_restore_tilt_after_percolate Overhead=1 Level=1 Group=scavenger Template="MSSSS::flip restore_tilt_after_percolate last free entry %zx size %zu"
 TraceEvent=Trc_MM_MSSSS_flip_restore_tilt_after_percolate_with_stats Overhead=1 Level=1 Group=scavenge Template="MSSSS::flip restore_tilt_after_percolate heapAlignedLastFreeEntry %zu section (%zu) aligned size %zu"
 TraceEvent=Trc_MM_MSSSS_flip_restore_tilt_after_percolate_current_status Overhead=1 Level=1 Group=scavenge Template="MSSSS::flip restore_tilt_after_percolate %sallocateSize %zu survivorSize %zu"
+
+TraceEvent=Trc_MM_clearheap Overhead=1 Level=1 Template="clearheap with free memory size: %zu, object size: %zu"

--- a/gc/base/standard/HeapWalker.cpp
+++ b/gc/base/standard/HeapWalker.cpp
@@ -189,7 +189,7 @@ MM_HeapWalker::allObjectSlotsDo(MM_EnvironmentBase *env, MM_HeapWalkerSlotFunc f
 		modifiedWalkFlags &= ~J9_MU_WALK_NEW_AND_REMEMBERED_ONLY;
 	}
 
-	allObjectsDo(env, heapWalkerObjectSlotsDo, (void *)&slotObjectDoUserData, modifiedWalkFlags, parallel, prepareHeapForWalk);
+	allObjectsDo(env, heapWalkerObjectSlotsDo, (void *)&slotObjectDoUserData, modifiedWalkFlags, parallel, prepareHeapForWalk, false);
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/* If J9_MU_WALK_NEW_AND_REMEMBERED_ONLY is specified, allObjectsDo will only walk
@@ -205,7 +205,7 @@ MM_HeapWalker::allObjectSlotsDo(MM_EnvironmentBase *env, MM_HeapWalkerSlotFunc f
  * Walk all objects in the heap in a single threaded linear fashion.
  */
 void
-MM_HeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk)
+MM_HeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk, bool includeDeadObjects)
 {
 	uintptr_t typeFlags = 0;
 
@@ -225,7 +225,7 @@ MM_HeapWalker::allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc fun
 		if (typeFlags == (region->getTypeFlags() & typeFlags)) {
 			/* Optimization to avoid virtual dispatch for every slot in the system */
 			omrobjectptr_t object = NULL;
-			GC_ObjectHeapIteratorAddressOrderedList liveObjectIterator(extensions, region, false);
+			GC_ObjectHeapIteratorAddressOrderedList liveObjectIterator(extensions, region, includeDeadObjects);
 
 			while (NULL != (object = liveObjectIterator.nextObject())) {
 				function(omrVMThread, region, object, userData);

--- a/gc/base/standard/HeapWalker.hpp
+++ b/gc/base/standard/HeapWalker.hpp
@@ -51,7 +51,7 @@ protected:
 
 public:
 	virtual void allObjectSlotsDo(MM_EnvironmentBase *env, MM_HeapWalkerSlotFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk);
-	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk);
+	virtual void allObjectsDo(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc function, void *userData, uintptr_t walkFlags, bool parallel, bool prepareHeapForWalk, bool includeDeadObjects);
 
 	static MM_HeapWalker *newInstance(MM_EnvironmentBase *env); 	
 	virtual void kill(MM_EnvironmentBase *env);

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -285,6 +285,7 @@ public:
 	 */
 	uintptr_t fixHeapForWalk(MM_EnvironmentBase *env, UDATA walkFlags, uintptr_t walkReason, MM_HeapWalkerObjectFunc walkFunction);
 	MM_HeapWalker *getHeapWalker() { return _heapWalker; }
+	void clearHeap(MM_EnvironmentBase *env, MM_HeapWalkerObjectFunc walkFunction);
 	virtual void prepareHeapForWalk(MM_EnvironmentBase *env);
 
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -279,6 +279,8 @@ MM_VerboseHandlerOutput::getHeapFixupReasonString(uintptr_t reason)
 			return "class unloading";
 		case FIXUP_DEBUG_TOOLING:
 			return "debug tooling";
+		case FIXUP_AND_CLEAR_HEAP:
+			return "fixup and clear heap";
 		default:
 			return "unknown";
 	}

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -465,7 +465,8 @@ typedef enum {
 typedef enum {
 	FIXUP_NONE = 0,
 	FIXUP_CLASS_UNLOADING,
-	FIXUP_DEBUG_TOOLING
+	FIXUP_DEBUG_TOOLING,
+	FIXUP_AND_CLEAR_HEAP
 } FixUpReason;
 
 typedef enum {


### PR DESCRIPTION
When a checkpoint is taken, the entire contents of the process is serialized, and someone can inspect the serialized state to capture some sensitive info.

Solution:
If a data is no longer referenced, the entire memory chunk is zeroed at snapshot time.

Implementation detail:
After the initial snapshot GC, 2 passes are done to fix-up, identify, and clear all unused free memory chunks (including both linked and unlinked multi-slot free entries). The first pass performs a fix-up to the current heap which converts dark matter to holes, while the second pass clears all free entries.

Note here this implementation only works for standard GC but not balanced GC and metronome.

Signed off by: Frank.Kang@ibm.com