### PR TITLE
Fix collection of object files for omr_static_lib

### DIFF
--- a/omr_static_lib/makefile
+++ b/omr_static_lib/makefile
@@ -67,13 +67,13 @@ endif
 
 # Prepend the path to the library for relative paths.
 # Absolute paths to object files must be left alone.
+# MAKEFLAGS is cleared below because it might contain '-w' which seems to
+# nullify the use of '--no-print-directory', or job-server context which
+# yields warnings that should not be mixed into the 'show-objects' output.
 OBJECTS := \
 $(foreach lib,$(OMRLIBS), \
   $(foreach object, \
-    $(shell $(MAKE) -s --no-print-directory -C $(lib) show-objects), \
+    $(shell MAKEFLAGS= $(MAKE) -s --no-print-directory -C $(lib) show-objects), \
     $(if $(filter /%,$(object)),$(object),$(lib)/$(object))))
-
-$(OBJECTS):
-	@echo $@
 
 include $(top_srcdir)/omrmakefiles/rules.mk


### PR DESCRIPTION
The behavior of GNU make seems to have changed between versions 4.2.1 and 4.3.

The latter appears to prioritize `MAKEFLAGS=` over (at least some) command-line options, with the effect being that `--no-print-directory` is ignored and included in the output of `show-objects`.

If invoked as part of a larger build where the make job server is enabled, there are also warnings that make unwanted contributions to the output of `show-objects`.

This fixes that, and removes the useless "echo" rule for the already existing objects.