### PR TITLE
Make globalReg clobberable in Z iRegStoreEvaluator

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13787,7 +13787,7 @@ OMR::Z::TreeEvaluator::iRegStoreEvaluator(TR::Node * node, TR::CodeGenerator * c
 
    if (!useLGHI)
       {
-      globalReg = cg->evaluate(value);
+      globalReg = needsLGFR && noLGFgenerated ? cg->gprClobberEvaluate(value) : cg->evaluate(value);
       }
    else
       {


### PR DESCRIPTION
If the iRegStoreEvaluator generates an LGFR to sign extend, it is
incorrect to assume that the iRegStore's child is clobberable. We must
preserve the original value when sign extending. This commit fixes
this issue by using the gprClobberEvaluate routine so that the sign
extension is performed in a different register, and we don't potentially
overwrite the upper-half data in the original register.