### PR TITLE
Add can skip null value store check

### DIFF
--- a/compiler/il/OMRMethodSymbol.hpp
+++ b/compiler/il/OMRMethodSymbol.hpp
@@ -192,6 +192,7 @@ public:
    bool safeToSkipDivChecks() { return false; }
    bool safeToSkipCheckCasts() { return false; }
    bool safeToSkipArrayStoreChecks() { return false; }
+   bool safeToSkipNonNullableArrayNullStoreCheck() { return false; }
    bool safeToSkipZeroInitializationOnNewarrays() { return false; }
    bool safeToSkipChecksOnArrayCopies() { return false; }
 

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -194,13 +194,14 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    self()->setParameterList();
 
-   _properties.set(CanSkipNullChecks                   , self()->safeToSkipNullChecks());
-   _properties.set(CanSkipBoundChecks                  , self()->safeToSkipBoundChecks());
-   _properties.set(CanSkipCheckCasts                   , self()->safeToSkipCheckCasts());
-   _properties.set(CanSkipDivChecks                    , self()->safeToSkipDivChecks());
-   _properties.set(CanSkipArrayStoreChecks             , self()->safeToSkipArrayStoreChecks());
-   _properties.set(CanSkipChecksOnArrayCopies          , self()->safeToSkipChecksOnArrayCopies());
-   _properties.set(CanSkipZeroInitializationOnNewarrays, self()->safeToSkipZeroInitializationOnNewarrays());
+   _properties.set(CanSkipNullChecks                    , self()->safeToSkipNullChecks());
+   _properties.set(CanSkipBoundChecks                   , self()->safeToSkipBoundChecks());
+   _properties.set(CanSkipCheckCasts                    , self()->safeToSkipCheckCasts());
+   _properties.set(CanSkipDivChecks                     , self()->safeToSkipDivChecks());
+   _properties.set(CanSkipArrayStoreChecks              , self()->safeToSkipArrayStoreChecks());
+   _properties.set(CanSkipNonNullableArrayNullStoreCheck, self()->safeToSkipNonNullableArrayNullStoreCheck());
+   _properties.set(CanSkipChecksOnArrayCopies           , self()->safeToSkipChecksOnArrayCopies());
+   _properties.set(CanSkipZeroInitializationOnNewarrays , self()->safeToSkipZeroInitializationOnNewarrays());
    }
 
 

--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -268,6 +268,7 @@ public:
    bool skipCheckCasts()                     { return _properties.testAny(CanSkipCheckCasts); }
    bool skipDivChecks()                      { return _properties.testAny(CanSkipDivChecks); }
    bool skipArrayStoreChecks()               { return _properties.testAny(CanSkipArrayStoreChecks); }
+   bool skipNonNullableArrayNullStoreCheck() { return _properties.testAny(CanSkipNonNullableArrayNullStoreCheck); }
    bool skipChecksOnArrayCopies()            { return _properties.testAny(CanSkipChecksOnArrayCopies); }
    bool skipZeroInitializationOnNewarrays()  { return _properties.testAny(CanSkipZeroInitializationOnNewarrays); }
 
@@ -336,7 +337,7 @@ protected:
       CanSkipZeroInitializationOnNewarrays      = 1 << 5,
       CanSkipArrayStoreChecks                   = 1 << 6,
       HasSnapshots                              = 1 << 7,
-      // AVAILABLE                              = 1 << 8,
+      CanSkipNonNullableArrayNullStoreCheck     = 1 << 8,
       CanDirectNativeCall                       = 1 << 9,
       CanReplaceWithHWInstr                     = 1 << 10,
       IsSideEffectFree                          = 1 << 12,


### PR DESCRIPTION
Add `CanSkipNonNullableArrayNullStoreCheck` for recognized method.

This change is used by the change in:
- [ ] https://github.com/eclipse-openj9/openj9/pull/18464