### PR TITLE
Fix string literal conversion warnings in codegen, p, il, infra, optimizer

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -2829,7 +2829,7 @@ OMR::CodeGenerator::simulateNodeEvaluation(TR::Node *node, TR_RegisterPressureSt
    // don't properly account for cases where one child's result must live
    // across the evaluation of another child.
    //
-   char *tag = NULL;
+   const char *tag = NULL;
    if (  nodeGotFoldedIntoMemref(node, state, self())
       && self()->simulatedNodeState(node)._willBeRematerialized == 0 // remat nodes have already had their children incremented, so we must decrement them
       ){

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1192,21 +1192,21 @@ public:
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
    void addProjectSpecializedPairRelocation(uint8_t *location1,
                                           uint8_t *location2,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
    void addProjectSpecializedRelocation(TR::Instruction *instr,
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
-                                          char *generatingFileName,
+                                          const char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
 

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -497,7 +497,7 @@ uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =
    0           // TR_HeapSizeForBarrierRange0
    };
 
-char *TR::ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
+const char *TR::ExternalRelocation::_globalValueNames[TR_NumGlobalValueItems] =
    {
    "not used (0)",
    "TR_CountForRecompile (1)",

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -424,17 +424,17 @@ class ExternalRelocation : public TR::Relocation
    virtual bool isExternalRelocation() { return true; }
 
    static const char *getName(TR_ExternalRelocationTargetKind k) {return _externalRelocationTargetKindNames[k];}
-   static uintptr_t    getGlobalValue(uint32_t g)
+   static uintptr_t   getGlobalValue(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          return _globalValueList[g];
          }
-   static void         setGlobalValue(uint32_t g, uintptr_t v)
+   static void        setGlobalValue(uint32_t g, uintptr_t v)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          _globalValueList[g] = v;
          }
-   static char *       nameOfGlobal(uint32_t g)
+   static const char *nameOfGlobal(uint32_t g)
          {
          TR_ASSERT(g >= 0 && g < TR_NumGlobalValueItems, "invalid index for global item");
          return _globalValueNames[g];
@@ -443,12 +443,12 @@ class ExternalRelocation : public TR::Relocation
    private:
    uint8_t                         *_targetAddress;
    uint8_t                         *_targetAddress2;
-   TR::IteratedExternalRelocation   *_relocationRecord;
+   TR::IteratedExternalRelocation  *_relocationRecord;
    TR_ExternalRelocationTargetKind  _kind;
    static const char               *_externalRelocationTargetKindNames[TR_NumExternalRelocationKinds];
    static uintptr_t                 _globalValueList[TR_NumGlobalValueItems];
    static uint8_t                   _globalValueSizeList[TR_NumGlobalValueItems];
-   static char                     *_globalValueNames[TR_NumGlobalValueItems];
+   static const char                *_globalValueNames[TR_NumGlobalValueItems];
    };
 
 class ExternalOrderedPair32BitRelocation: public TR::ExternalRelocation

--- a/compiler/codegen/StorageInfo.cpp
+++ b/compiler/codegen/StorageInfo.cpp
@@ -35,7 +35,7 @@
 #include "il/SymbolReference.hpp"
 #include "infra/Assert.hpp"
 
-char *TR_StorageInfo::TR_StorageClassNames[TR_NumStorageClassTypes] =
+const char *TR_StorageInfo::TR_StorageClassNames[TR_NumStorageClassTypes] =
    {
    "<unknown_class>",
    "<direct_mapped_auto>",
@@ -44,7 +44,7 @@ char *TR_StorageInfo::TR_StorageClassNames[TR_NumStorageClassTypes] =
    "<private_static_base_address>",
    };
 
-char *TR_StorageInfo::TR_StorageOverlapKindNames[TR_NumOverlapTypes] =
+const char *TR_StorageInfo::TR_StorageOverlapKindNames[TR_NumOverlapTypes] =
    {
    "NoOverlap",
    "MayOverlap",

--- a/compiler/codegen/StorageInfo.hpp
+++ b/compiler/codegen/StorageInfo.hpp
@@ -81,12 +81,12 @@ public:
 
    void print();
 
-   char *getName() { return getName(_class); }
+   const char *getName() { return getName(_class); }
 
-   static char *getName(TR_StorageClass klass)
+   static const char *getName(TR_StorageClass klass)
       { return ((klass < TR_NumStorageClassTypes) ? TR_StorageClassNames[klass] : (char*)"invalid_class"); }
 
-   static char *getName(TR_StorageOverlapKind overlapType)
+   static const char *getName(TR_StorageOverlapKind overlapType)
       { return ((overlapType < TR_NumOverlapTypes) ? TR_StorageOverlapKindNames[overlapType] : (char*)"invalid_overlap_type"); }
 
    TR::Compilation *comp() { return _comp; }
@@ -100,8 +100,8 @@ private:
    size_t                _length;
    TR_StorageClass       _class;
    TR::Compilation *     _comp;
-   static char *TR_StorageClassNames[TR_NumStorageClassTypes];
-   static char *TR_StorageOverlapKindNames[TR_NumOverlapTypes];
+   static const char *TR_StorageClassNames[TR_NumStorageClassTypes];
+   static const char *TR_StorageOverlapKindNames[TR_NumOverlapTypes];
 
    };
 

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -502,9 +502,9 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    struct StandardException
       {
-      int32_t  length;
-      char    *name;
-      uint32_t exceptions;
+      int32_t     length;
+      const char *name;
+      uint32_t    exceptions;
       };
 
    static StandardException _standardExceptions[];

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -707,11 +707,11 @@ OMR_InlinerPolicy::inlineRecognizedMethod(TR::RecognizedMethod method)
 
 // only dumbinliner uses this and includes checking for variable initialization
 bool
-TR_DumbInliner::tryToInline(char *message, TR_CallTarget *calltarget)
+TR_DumbInliner::tryToInline(const char *message, TR_CallTarget *calltarget)
    {
    TR_ResolvedMethod *method = calltarget->_calleeSymbol->getResolvedMethod();
 
-   if (getPolicy()->tryToInline(calltarget,NULL,true))
+   if (getPolicy()->tryToInline(calltarget, NULL, true))
       {
       if (comp()->trace(OMR::inlining))
          traceMsg(comp(), "tryToInline pattern matched; %s for %s\n", message, method->signature(comp()->trMemory()));
@@ -6152,7 +6152,7 @@ const char * TR_InlinerTracer::getGuardTypeString(TR_VirtualGuardSelection *guar
       return "???Test";
    }
 
-TR_InlinerDelimiter::TR_InlinerDelimiter(TR_InlinerTracer *tracer, char * tag)
+TR_InlinerDelimiter::TR_InlinerDelimiter(TR_InlinerTracer *tracer, const char *tag)
    :_tracer(tracer),_tag(tag)
    {
    debugTrace(tracer,"<%s>",_tag);

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -156,12 +156,12 @@ class TR_InlinerDelimiter
    {
 
    public:
-   TR_InlinerDelimiter(TR_InlinerTracer * tracer, char * tag);
+   TR_InlinerDelimiter(TR_InlinerTracer *tracer, const char *tag);
    ~TR_InlinerDelimiter();
 
    protected:
-   TR_InlinerTracer * _tracer;
-   char *_tag;
+   TR_InlinerTracer *_tracer;
+   const char *_tag;
    };
 
 class TR_Inliner : public TR::Optimization
@@ -435,7 +435,7 @@ class TR_DumbInliner : public TR_InlinerBase
    public:
       TR_DumbInliner(TR::Optimizer *, TR::Optimization *, uint32_t initialSize, uint32_t dumbReductionIncrement = 5);
       virtual bool inlineCallTargets(TR::ResolvedMethodSymbol *, TR_CallStack *, TR_InnerPreexistenceInfo *);
-      bool tryToInline(char *message, TR_CallTarget *calltarget);
+      bool tryToInline(const char *message, TR_CallTarget *calltarget);
    protected:
       virtual bool analyzeCallSite(TR_CallStack *, TR::TreeTop *, TR::Node *, TR::Node *);
 

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -8970,7 +8970,7 @@ TR_BlockManipulator::breakFallThrough(TR::Block *faller, TR::Block *fallee, bool
 
 // used by trivialDeadTreeRemoval opt pass and during CodeGenPrep to remove nodes treetops that have no intervening def
 void
-TR_TrivialDeadTreeRemoval::preProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp)
+TR_TrivialDeadTreeRemoval::preProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp)
    {
    TR::Node *ttNode = treeTop->getNode();
    if (ttNode->getOpCodeValue() == TR::treetop &&
@@ -9017,7 +9017,7 @@ TR_TrivialDeadTreeRemoval::preProcessTreetop(TR::TreeTop *treeTop, List<TR::Tree
    }
 
 void
-TR_TrivialDeadTreeRemoval::postProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp)
+TR_TrivialDeadTreeRemoval::postProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp)
    {
    if (treeTop->isPossibleDef())
       {
@@ -9028,7 +9028,7 @@ TR_TrivialDeadTreeRemoval::postProcessTreetop(TR::TreeTop *treeTop, List<TR::Tre
    }
 
 void
-TR_TrivialDeadTreeRemoval::processCommonedChild(TR::Node *child, TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp)
+TR_TrivialDeadTreeRemoval::processCommonedChild(TR::Node *child, TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp)
    {
    if (child->getReferenceCount() > 1)
       {

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -858,9 +858,9 @@ class TR_TrivialDeadTreeRemoval : public TR::Optimization
    void transformBlock(TR::TreeTop * entryTree, TR::TreeTop * exitTree);
    void examineNode(TR::Node *node, vcount_t visitCount);
 
-   void preProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp);
-   void postProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp);
-   void processCommonedChild(TR::Node *child, TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, char *optDetails, TR::Compilation *comp);
+   void preProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp);
+   void postProcessTreetop(TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp);
+   void processCommonedChild(TR::Node *child, TR::TreeTop *treeTop, List<TR::TreeTop> &commonedTreeTopList, const char *optDetails, TR::Compilation *comp);
    private:
    TR_ScratchList<TR::TreeTop> _commonedTreeTopList;
    TR::TreeTop *_currentTreeTop;

--- a/compiler/optimizer/LoopReplicator.cpp
+++ b/compiler/optimizer/LoopReplicator.cpp
@@ -65,7 +65,7 @@ TR_LoopReplicator::TR_LoopReplicator(TR::OptimizationManager *manager)
 
 
 //Add static debug counter for a given replication failure
-static void countReplicationFailure(char *failureReason, int32_t regionNum)
+static void countReplicationFailure(const char *failureReason, int32_t regionNum)
    {
    TR::Compilation *comp = TR::comp();
 

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4989,7 +4989,7 @@ void OMR::ValuePropagation::setUnreachablePath(TR::CFGEdge *edge)
 void OMR::ValuePropagation::printStructureInfo(TR_Structure *s, bool starting, bool lastTimeThrough)
    {
    traceMsg(comp(), "\n%s ", starting ? "Starting " : "Stopping ");
-   char *type;
+   const char *type;
    bool isLoop = false;
    if (s->asRegion())
       {

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1002,7 +1002,7 @@ void TR_OrderBlocks::addRemainingSuccessorsToListHWProfile(TR::CFGNode *block, T
 // pattern: block has goto to fall-through block
 //   block assumed to end in a goto
 // returns TRUE if the pattern was found and replaced
-bool TR_OrderBlocks::peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title)
+bool TR_OrderBlocks::peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, const char *title)
    {
    // pattern: block has goto to fall-through block
    TR::Node *gotoNode = block->getLastRealTreeTop()->getNode();
@@ -1024,7 +1024,7 @@ bool TR_OrderBlocks::peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR:
 // pattern: block contains goto to a block that only contains a goto
 //   block assumed to end in a goto
 // returns TRUE if the pattern was found and replaced
-bool TR_OrderBlocks::peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title,
+bool TR_OrderBlocks::peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, const char *title,
                                         TR::BitVector &skippedGotoBlocks)
    {
    if (comp()->getProfilingMode() == JitProfiling)
@@ -1066,7 +1066,7 @@ bool TR_OrderBlocks::peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node
 // pattern: block contains a goto to an empty block
 //   block assumed to end in a goto
 // returns TRUE if the pattern was found and replaced
-bool TR_OrderBlocks::peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title)
+bool TR_OrderBlocks::peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, const char *title)
    {
    if (comp()->getProfilingMode() == JitProfiling)
       return false;
@@ -1098,7 +1098,7 @@ bool TR_OrderBlocks::peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Nod
    return false;
    }
 
-static bool peepHoleGotoToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *dest, char *title)
+static bool peepHoleGotoToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *dest, const char *title)
    {
    // try to peephole the following:
    // dest:      loopHeader
@@ -1162,7 +1162,7 @@ static bool peepHoleGotoToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *
 // assume block->endsInGoto()
 // returns TRUE if block was removed
 //   currently always returns false because this code can't remove block itself
-void TR_OrderBlocks::peepHoleGotoBlock(TR::CFG *cfg, TR::Block *block, char *title)
+void TR_OrderBlocks::peepHoleGotoBlock(TR::CFG *cfg, TR::Block *block, const char *title)
    {
    TR_ASSERT(block->endsInGoto(), "peepHoleGotoBlock called on block that doesn't end in a goto!");
    bool madeAChange;
@@ -1215,7 +1215,7 @@ void TR_OrderBlocks::removeRedundantBranch(TR::CFG *cfg, TR::Block *block, TR::N
    }
 
 
-bool TR_OrderBlocks::peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *fallThrough, TR::Block *dest, char *title)
+bool TR_OrderBlocks::peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *fallThrough, TR::Block *dest, const char *title)
    {
    bool success = false;
    TR_Structure *destStructure = dest->getStructureOf();
@@ -1254,9 +1254,9 @@ bool TR_OrderBlocks::peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, 
    }
 
 // apply peephole optimizations to blocks that end in a branch and branch around a single goto
-void TR_OrderBlocks::peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *block, char *title)
+void TR_OrderBlocks::peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *block, const char *title)
    {
-   TR_ASSERT(block->endsInBranch(), "peepHoleBranchBlock called on block that doesn't end in a branch!");
+   TR_ASSERT(block->endsInBranch(), "peepHoleBranchAroundSingleGoto called on block that doesn't end in a branch!");
    TR::Node *branchNode = block->getLastRealTreeTop()->getNode();
    TR::TreeTop *takenEntry = branchNode->getBranchDestination();
    TR::Block *takenBlock = takenEntry->getNode()->getBlock();
@@ -1328,7 +1328,7 @@ void TR_OrderBlocks::peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *blo
 // apply peephole optimizations to blocks that end in a branch
 // no looping here because there are only two possible optimizations done but we know which order to try them in
 // assume block->endsInBranch()
-void TR_OrderBlocks::peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, char *title)
+void TR_OrderBlocks::peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, const char *title)
    {
    TR_ASSERT(block->endsInBranch(), "peepHoleBranchBlock called on block that doesn't end in a branch!");
    TR::Node *branchNode = block->getLastRealTreeTop()->getNode();
@@ -1400,7 +1400,7 @@ void TR_OrderBlocks::peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, char *t
    }
 
 // look for a branch with taken block same as fall-through block
-bool TR_OrderBlocks::peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title)
+bool TR_OrderBlocks::peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, const char *title)
    {
    TR_ASSERT(block->endsInBranch(), "peepHoleBranchToFollowing called on block that doesn't end in a branch!");
    TR::Node *branchNode = block->getLastRealTreeTop()->getNode();
@@ -1419,7 +1419,7 @@ bool TR_OrderBlocks::peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, T
    return false;
    }
 
-void TR_OrderBlocks::removeEmptyBlock(TR::CFG *cfg, TR::Block *block, char *title)
+void TR_OrderBlocks::removeEmptyBlock(TR::CFG *cfg, TR::Block *block, const char *title)
    {
    TR_ASSERT(block->getExceptionPredecessors().empty(), "removeEmpty block doesn't deal with empty catch blocks properly");
 
@@ -1487,7 +1487,7 @@ void TR_OrderBlocks::removeEmptyBlock(TR::CFG *cfg, TR::Block *block, char *titl
 // apply a small set of transformations to try to clean up blocks before ordering
 //  repeatedly apply these transformations until none apply
 //  returns TRUE if block still exists after peepholing
-bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
+bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, const char *title)
    {
    TR::CFG *cfg             = comp()->getFlowGraph();
 
@@ -1557,7 +1557,7 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
 
 // go through the blocks looking for peephole optimization opportunities
 // return TRUE if blocks were removed during the analysis
-bool TR_OrderBlocks::lookForPeepHoleOpportunities(char *title)
+bool TR_OrderBlocks::lookForPeepHoleOpportunities(const char *title)
    {
    static bool doPeepHoling=(feGetEnv("TR_noBlockOrderPeepholing") == NULL);
    if (!doPeepHoling)
@@ -1586,7 +1586,7 @@ bool TR_OrderBlocks::lookForPeepHoleOpportunities(char *title)
       TR::TreeTop *nextBlockTT = block->getExit()->getNextTreeTop();
       if (trace()) traceMsg(comp(), "\tBlock %d:\n", block->getNumber());
 
-      bool blockStillExists = doPeepHoleBlockCorrections(block,title);
+      bool blockStillExists = doPeepHoleBlockCorrections(block, title);
       tt = nextBlockTT;
       if (!blockStillExists)
          blocksWereRemoved = true;
@@ -2198,9 +2198,9 @@ void checkOrderingConsistency(TR::Compilation *comp)
          {
          if (seenColdBlock)
             {
-            char *fmt= "Non-cold block_%d found after a cold block in method %s\n";
+            const char *fmt = "Non-cold block_%d found after a cold block in method %s\n";
             char *buffer = (char *) comp->trMemory()->allocateStackMemory((strlen(fmt) + strlen(comp->signature()) + 15) * sizeof(char));
-            sprintf(buffer, fmt, block->getNumber(), comp->signature());
+            sprintf(buffer, const_cast<char *>(fmt), block->getNumber(), comp->signature());
             //TR_ASSERT(0, buffer);
             }
          }
@@ -2248,7 +2248,7 @@ void checkOrderingConsistency(TR::Compilation *comp)
    }
 
 
-void TR_BlockOrderingOptimization::dumpBlockOrdering(TR::TreeTop *tt, char *title)
+void TR_BlockOrderingOptimization::dumpBlockOrdering(TR::TreeTop *tt, const char *title)
    {
    traceMsg(comp(), "%s:\n", title? title : "Block ordering");
    unsigned numberOfColdBlocks = 0;
@@ -2289,7 +2289,7 @@ void TR_BlockShuffling::traceBlocks(TR::Block **blocks)
    const int32_t BLOCKS_PER_LINE=30;
    if (trace())
       {
-      char *sep = "";
+      const char *sep = "";
       for (int32_t i = 0; i < _numBlocks; i++)
          {
          traceMsg(comp(), "%s%d", sep, blocks[i]->getNumber());

--- a/compiler/optimizer/OrderBlocks.hpp
+++ b/compiler/optimizer/OrderBlocks.hpp
@@ -47,7 +47,7 @@ class TR_BlockOrderingOptimization : public TR::Optimization
    {
    public:
 
-   void dumpBlockOrdering(TR::TreeTop *tt, char *title=NULL); // This is called from other opts!
+   void dumpBlockOrdering(TR::TreeTop *tt, const char *title=NULL); // This is called from other opts!
 
    protected:
    TR_BlockOrderingOptimization(TR::OptimizationManager *manager)
@@ -93,7 +93,7 @@ class TR_OrderBlocks : public TR_BlockOrderingOptimization
    void            dontReorderBlocks()       { _reorderBlocks = false; }
    void            extendBlocks()            { _extendBlocks = true; }
    void            dontExtendBlocks()        { _extendBlocks = false; }
-   bool            lookForPeepHoleOpportunities(char *title);
+   bool            lookForPeepHoleOpportunities(const char *title);
    void            doReordering();
 
    void            invalidateStructure() { _needInvalidateStructure = true; }
@@ -114,17 +114,17 @@ class TR_OrderBlocks : public TR_BlockOrderingOptimization
    void            removeFromOrderedBlockLists(TR::CFGNode *block);
    void            addRemainingSuccessorsToList(TR::CFGNode *block, TR::CFGNode *excludeBlock);
 
-   bool            peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title);
-   bool            peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title, TR::BitVector &skippedGotoBlocks);
-   bool            peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title);
-   void            peepHoleGotoBlock(TR::CFG *cfg, TR::Block *block, char *title);
+   bool            peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, const char *title);
+   bool            peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, const char *title, TR::BitVector &skippedGotoBlocks);
+   bool            peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, const char *title);
+   void            peepHoleGotoBlock(TR::CFG *cfg, TR::Block *block, const char *title);
    void            removeRedundantBranch(TR::CFG *cfg, TR::Block *block, TR::Node *branchNode, TR::Block *takenBlock);
-   void            peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, char *title);
-   void            peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *block, char *title);
-   bool            peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, char *title);
-   bool            peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *fallThrough, TR::Block *dest, char *title);
-   void            removeEmptyBlock(TR::CFG *cfg, TR::Block *block, char *title);
-   bool            doPeepHoleBlockCorrections(TR::Block *block, char *title);
+   void            peepHoleBranchBlock(TR::CFG *cfg, TR::Block *block, const char *title);
+   void            peepHoleBranchAroundSingleGoto(TR::CFG *cfg, TR::Block *block, const char *title);
+   bool            peepHoleBranchToFollowing(TR::CFG *cfg, TR::Block *block, TR::Block *followingBlock, const char *title);
+   bool            peepHoleBranchToLoopHeader(TR::CFG *cfg, TR::Block *block, TR::Block *fallThrough, TR::Block *dest, const char *title);
+   void            removeEmptyBlock(TR::CFG *cfg, TR::Block *block, const char *title);
+   bool            doPeepHoleBlockCorrections(TR::Block *block, const char *title);
    void            addRemainingSuccessorsToListHWProfile(TR::CFGNode *block, TR::CFGNode *excludeBlock);
    void            insertBlocksToList();
    bool            hasValidCandidate(List<TR::CFGNode> & list, TR::CFGNode *prevBlock);

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1093,7 +1093,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
           !comp()->getOption(TR_DisableMultiLeafArrayCopy))
          {
          TR_ResolvedMethod *caller = node->getSymbolReference()->getOwningMethod(comp());
-         char *sig = "multiLeafArrayCopy";
+         const char *sig = "multiLeafArrayCopy";
          if (caller && strncmp(caller->nameChars(), sig, strlen(sig)) == 0)
             {
             if (trace())

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -73,8 +73,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCHelperCallSnippet * snippet)
       printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Helper Call Snippet");
       }
 
-   char    *info = "";
-   int32_t  distance;
+   const char *info = "";
+   int32_t     distance;
    if (isBranchToTrampoline(snippet->getDestination(), cursor, distance))
       info = " Through trampoline";
 


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to `(char *)`) in codegen, p, il, and optimizer.

This PR contributes to (but does not close) https://github.com/eclipse-openj9/openj9/issues/14859