### PR TITLE
Fix -Wwritable-strings in env

### DIFF
--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -136,7 +136,7 @@ TR::OptionTable OMR::Options::_feOptions[] =
 
 // S390 specific fucntion - FIXME: make this only be a problem when HOST is s390.  Also, use a better
 // name for this
-void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName,  TR::Compilation *comp) { TR_UNIMPLEMENTED(); }
+void setDllSlip(const char *CodeStart, const char *CodeEnd, const char *dllName, TR::Compilation *comp) { TR_UNIMPLEMENTED(); }
 
 // runtime assumptions
 #ifdef J9_PROJECT_SPECIFIC
@@ -146,7 +146,7 @@ void TR::PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *l
 void TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *) { TR_UNIMPLEMENTED(); }
 bool isOrderedPair(uint8_t recordType) { TR_UNIMPLEMENTED(); return false; }
 void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption** sentinel) { TR_UNIMPLEMENTED(); }
-void OMR::RuntimeAssumption::dumpInfo(char *subclassName) { TR_UNIMPLEMENTED(); }
+void OMR::RuntimeAssumption::dumpInfo(const char *subclassName) { TR_UNIMPLEMENTED(); }
 void TR_PatchJNICallSite::compensate(TR_FrontEnd*, bool, void *) { TR_UNIMPLEMENTED(); }
 void TR_PreXRecompile::compensate(TR_FrontEnd*, bool, void *) { TR_UNIMPLEMENTED(); }
 TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInitialize::make(TR_FrontEnd *fe, TR_PersistentMemory *, char*, unsigned int, unsigned char*, unsigned char*, OMR::RuntimeAssumption**) { TR_UNIMPLEMENTED(); return 0; }

--- a/compiler/env/FrontEnd.cpp
+++ b/compiler/env/FrontEnd.cpp
@@ -158,7 +158,7 @@ TR_FrontEnd::getFormattedName(
 
 
 TR_OpaqueMethodBlock*
-TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signature)
+TR_FrontEnd::getMethodFromName(const char *className, const char *methodName, const char *signature)
    {
    TR_UNIMPLEMENTED();
    return 0;

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -112,7 +112,7 @@ public:
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual OMR::MethodMetaDataPOD *createMethodMetaData(TR::Compilation *comp) { return NULL; }
 
-   virtual TR_OpaqueMethodBlock * getMethodFromName(char * className, char *methodName, char *signature);
+   virtual TR_OpaqueMethodBlock * getMethodFromName(const char *className, const char *methodName, const char *signature);
    virtual uint32_t offsetOfIsOverriddenBit();
 
    // Needs VMThread

--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -33,23 +33,23 @@ OMR::ClassEnv::self()
    return static_cast<TR::ClassEnv *>(this);
    }
 
-char *
-OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef, int32_t & len)
+const char *
+OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef, int32_t &len)
    {
-   char *name = "<no class name>";
+   const char *name = "<no class name>";
    len = static_cast<int32_t>(strlen(name));
    return name;
    }
 
 uintptr_t
-OMR::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass)
+OMR::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock *arrayClass)
    {
    TR_UNIMPLEMENTED();
    return 0;
    }
 
 intptr_t
-OMR::ClassEnv::getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock* clazz, int32_t offset)
+OMR::ClassEnv::getVFTEntry(TR::Compilation *comp, TR_OpaqueClassBlock *clazz, int32_t offset)
    {
    // There is no project-agnostic way to determine whether or not offset is a
    // valid VFT offset for clazz, so return 0 to be safe. If offset were valid,

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -156,8 +156,8 @@ public:
    int32_t flagValueForArrayCheck(TR::Compilation *comp) { return 0; }
    int32_t flagValueForFinalizerCheck(TR::Compilation *comp) { return 0; }
 
-   char *classNameChars(TR::Compilation *, TR::SymbolReference *symRef, int32_t & length);
-   char *classNameChars(TR::Compilation *, TR_OpaqueClassBlock * clazz, int32_t & length) { return NULL; }
+   const char *classNameChars(TR::Compilation *, TR::SymbolReference *symRef, int32_t &length);
+   const char *classNameChars(TR::Compilation *, TR_OpaqueClassBlock *clazz, int32_t &length) { return NULL; }
 
    char *classSignature_DEPRECATED(TR::Compilation *comp, TR_OpaqueClassBlock * clazz, int32_t & length, TR_Memory *) { return NULL; }
    char *classSignature(TR::Compilation *comp, TR_OpaqueClassBlock * clazz, TR_Memory *) { return NULL; }


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to (char *)) in env.

This PR contributes to (but does not close) [openj9 #14859](https://github.com/eclipse-openj9/openj9/issues/14859)

**This PR depends on:**

- **Step 1: [openj9 #18083](https://github.com/eclipse-openj9/openj9/pull/18083), [openj9 #18455](https://github.com/eclipse-openj9/openj9/pull/18455)**

**and must be merged in coordination with [openj9 #18467](https://github.com/eclipse-openj9/openj9/pull/18467)**