### PR TITLE
Fix string literal conversion warnings in compile, runtime, control, ras, infra

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -712,11 +712,12 @@ OMR::SymbolReferenceTable::createKnownStaticDataSymbolRef(void *dataAddress, TR:
 TR::SymbolReference *
 OMR::SymbolReferenceTable::createKnownStaticReferenceSymbolRef(void *dataAddress, TR::KnownObjectTable::Index knownObjectIndex)
    {
-   char *name = "<known-static-reference>";
+   const char *name = "<known-static-reference>";
    if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
       {
-      name = (char*)trMemory()->allocateMemory(25, heapAlloc);
-      sprintf(name, "<known-obj%d>", knownObjectIndex);
+      char *nameBuffer = (char *)trMemory()->allocateMemory(25, heapAlloc);
+      sprintf(nameBuffer, "<known-obj%d>", knownObjectIndex);
+      name = nameBuffer;
       }
    TR::StaticSymbol * sym = TR::StaticSymbol::createNamed(trHeapMemory(), TR::Address, dataAddress,name);
    return TR::SymbolReference::create(self(), sym, knownObjectIndex);
@@ -950,7 +951,7 @@ OMR::SymbolReferenceTable::findOrCreateMonitorEntrySymbolRef(TR::ResolvedMethodS
  */
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::methodSymRefFromName(TR::ResolvedMethodSymbol * owningMethodSymbol, char *className, char *methodName, char *methodSignature, TR::MethodSymbol::Kinds kind, int32_t cpIndex)
+OMR::SymbolReferenceTable::methodSymRefFromName(TR::ResolvedMethodSymbol * owningMethodSymbol, const char *className, const char *methodName, const char *methodSignature, TR::MethodSymbol::Kinds kind, int32_t cpIndex)
    {
    // Check _methodsBySignature to see if we've already created a symref for this one
    //

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -720,7 +720,7 @@ class SymbolReferenceTable
 
    int32_t getNumInternalPointers() { return _numInternalPointers; }
 
-   TR::SymbolReference * methodSymRefFromName(TR::ResolvedMethodSymbol *owningMethodSymbol, char *className, char *methodName, char *signature, TR::MethodSymbol::Kinds kind, int32_t cpIndex=-1);
+   TR::SymbolReference *methodSymRefFromName(TR::ResolvedMethodSymbol *owningMethodSymbol, const char *className, const char *methodName, const char *signature, TR::MethodSymbol::Kinds kind, int32_t cpIndex=-1);
 
    TR::SymbolReference *createSymbolReference(TR::Symbol *sym, intptr_t o = 0);
 

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -190,7 +190,7 @@ int32_t init_options(TR::JitConfig *jitConfig, char *cmdLineOptions)
       if (*cmdLineOptions == ':') cmdLineOptions++; // also skip :
       }
 
-   char *endOptions = TR::Options::processOptionsJIT(cmdLineOptions, jitConfig, fe);
+   const char *endOptions = TR::Options::processOptionsJIT(cmdLineOptions, jitConfig, fe);
    if (*endOptions)
       {
       fprintf(stderr, "JIT: fatal error: invalid command line at %s\n", endOptions);

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -92,7 +92,7 @@ using namespace OMR;
 #define TR_PERFORM_INLINE_BLOCK_EXPANSION 0
 
 
-static char * EXCLUDED_METHOD_OPTIONS_PREFIX = "ifExcluded";
+static const char *EXCLUDED_METHOD_OPTIONS_PREFIX = "ifExcluded";
 
 #if defined(LINUX)
 #pragma GCC diagnostic push
@@ -1325,7 +1325,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 #endif
 
 int64_t
-OMR::Options::getNumericValue(char * & option)
+OMR::Options::getNumericValue(const char *& option)
    {
    /* The natural way to implement operations might be to recurse to process
     * the right-hand number.  However, in a sequence of operations, that would
@@ -1340,7 +1340,7 @@ OMR::Options::getNumericValue(char * & option)
       int64_t current = 0;
       while (isdigit(*option))
          {
-         current = 10*current + *option - '0';
+         current = 10 * current + *option - '0';
          option++;
          }
       switch (pendingOperation)
@@ -1369,41 +1369,41 @@ OMR::Options::getNumericValue(char * & option)
    }
 
 
-static uintptr_t getHexadecimalValue(char * & option)
+static uintptr_t getHexadecimalValue(const char *& option)
    {
-   uintptr_t value=0;
+   uintptr_t value = 0;
    char *endLocation;
-   value = strtol((const char *)option, &endLocation, 16);
+   value = strtol(option, &endLocation, 16);
    option = endLocation;
    return value;
    }
 
 
-char *
-OMR::Options::setNumeric(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setNumeric(const char *option, void *base, TR::OptionTable *entry)
    {
    *((intptr_t*)((char*)base+entry->parm1)) = (intptr_t)TR::Options::getNumericValue(option);
    return option;
    }
 
 
-char *
-OMR::Options::set32BitNumeric(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set32BitNumeric(const char *option, void *base, TR::OptionTable *entry)
    {
    *((int32_t*)((char*)base+entry->parm1)) = (int32_t)TR::Options::getNumericValue(option);
    return option;
    }
 
 
-char *
-OMR::Options::set32BitNumericInJitConfig(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set32BitNumericInJitConfig(const char *option, void *base, TR::OptionTable *entry)
    {
    return TR::Options::set32BitNumeric(option, _feBase, entry);
    }
 
 
-char *
-OMR::Options::set64BitSignedNumeric(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set64BitSignedNumeric(const char *option, void *base, TR::OptionTable *entry)
    {
    int64_t sign = 1;
    if (*option == '-')
@@ -1416,16 +1416,16 @@ OMR::Options::set64BitSignedNumeric(char *option, void *base, TR::OptionTable *e
    }
 
 
-char *
-OMR::Options::set32BitHexadecimal(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set32BitHexadecimal(const char *option, void *base, TR::OptionTable *entry)
    {
    *((int32_t*)((char*)base+entry->parm1)) = static_cast<int32_t>(getHexadecimalValue(option));
    return option;
    }
 
 
-char *
-OMR::Options::set32BitSignedNumeric(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set32BitSignedNumeric(const char *option, void *base, TR::OptionTable *entry)
    {
    int32_t sign = 1;
    if (*option == '-')
@@ -1438,44 +1438,44 @@ OMR::Options::set32BitSignedNumeric(char *option, void *base, TR::OptionTable *e
    }
 
 
-char *
-OMR::Options::setStaticNumeric(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticNumeric(const char *option, void *base, TR::OptionTable *entry)
    {
    *((int32_t*)entry->parm1) = (int32_t)TR::Options::getNumericValue(option);
    return option;
    }
 
 
-char *
-OMR::Options::setStaticNumericKBAdjusted(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticNumericKBAdjusted(const char *option, void *base, TR::OptionTable *entry)
    {
    *((size_t*)entry->parm1) = (size_t) (TR::Options::getNumericValue(option) * 1024);
    return option;
    }
 
 
-char *
-OMR::Options::setStaticHexadecimal(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticHexadecimal(const char *option, void *base, TR::OptionTable *entry)
    {
    *((uintptr_t*)entry->parm1) = getHexadecimalValue(option);
    return option;
    }
 
 
-char *
-OMR::Options::setStatic32BitValue(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStatic32BitValue(const char *option, void *base, TR::OptionTable *entry)
    {
    *((int32_t*)((char*)entry->parm1)) = (int32_t)entry->parm2;
    return option;
    }
 
 
-static char *dummy_string = "dummy";
+static const char *dummy_string = "dummy";
 
-char *
-OMR::Options::setString(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setString(const char *option, void *base, TR::OptionTable *entry)
    {
-   char *p;
+   const char *p;
    int32_t parenNest = 0;
    for (p = option; *p; p++)
       {
@@ -1490,26 +1490,26 @@ OMR::Options::setString(char *option, void *base, TR::OptionTable *entry)
          }
       }
    int32_t len = static_cast<int32_t>(p - option);
-   p = (char *)TR::Options::jitPersistentAlloc(len+1);
-   if (p)
+   char *pBuffer = (char *)TR::Options::jitPersistentAlloc(len+1);
+   if (pBuffer)
       {
-      memcpy(p, option, len);
-      p[len] = 0;
-      *((char**)((char*)base+entry->parm1)) = p;
+      memcpy(pBuffer, option, len);
+      pBuffer[len] = 0;
+      *((char**)((char*)base+entry->parm1)) = pBuffer;
       return option+len;
       }
 
    return dummy_string;
    }
 
-char *
-OMR::Options::setStringInJitConfig(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStringInJitConfig(const char *option, void *base, TR::OptionTable *entry)
    {
    return TR::Options::setString(option, _feBase, entry);
    }
 
-char *
-OMR::Options::setStringForPrivateBase(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStringForPrivateBase(const char *option, void *base, TR::OptionTable *entry)
    {
 #ifdef J9_PROJECT_SPECIFIC
    base = TR_J9VMBase::getPrivateConfig(_feBase);
@@ -1520,15 +1520,15 @@ OMR::Options::setStringForPrivateBase(char *option, void *base, TR::OptionTable 
    }
 
 
-char *
-OMR::Options::setStaticString(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticString(const char *option, void *base, TR::OptionTable *entry)
    {
    return TR::Options::setString(option, 0, entry);
    }
 
 
-char *
-OMR::Options::setDebug(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setDebug(const char *option, void *base, TR::OptionTable *entry)
    {
    if(strcmp((char*)entry->name,"trdebug="))
       {
@@ -1537,7 +1537,7 @@ OMR::Options::setDebug(char *option, void *base, TR::OptionTable *entry)
       }
    else
       {
-      char * position = option;
+      char *position = (char *)option;
       if(*position == '{')
          {
          for(;*position;++position)
@@ -1569,8 +1569,8 @@ OMR::Options::setDebug(char *option, void *base, TR::OptionTable *entry)
    }
 
 
-char *
-OMR::Options::setRegex(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setRegex(const char *option, void *base, TR::OptionTable *entry)
    {
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
    *((TR::SimpleRegex**)((char*)base+entry->parm1)) = regex;
@@ -1580,8 +1580,8 @@ OMR::Options::setRegex(char *option, void *base, TR::OptionTable *entry)
    }
 
 
-char *
-OMR::Options::setStaticRegex(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticRegex(const char *option, void *base, TR::OptionTable *entry)
    {
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
    *((TR::SimpleRegex**)entry->parm1) = regex;
@@ -1656,8 +1656,8 @@ int32_t       OMR::Options::_highCodeCacheOccupancyPercentage = 75; // in the ra
 int32_t       OMR::Options::_queueWeightThresholdForAppThreadYield = -1; // not yet set
 int32_t       OMR::Options::_queueWeightThresholdForStarvation = -1; // not yet set
 
-uint32_t       OMR::Options::_memExpensiveCompThreshold = 0; // not initialized
-uint32_t       OMR::Options::_cpuExpensiveCompThreshold = 0; // not initialized
+uint32_t      OMR::Options::_memExpensiveCompThreshold = 0; // not initialized
+uint32_t      OMR::Options::_cpuExpensiveCompThreshold = 0; // not initialized
 int32_t       OMR::Options::_deterministicMode = -1; // -1 means we're not in any deterministic mode
 int32_t       OMR::Options::_maxPeekedBytecodeSize = 100000;
 
@@ -1690,7 +1690,7 @@ int32_t       OMR::Options::_highCodeCacheOccupancyBCount = 10000;
 bool          OMR::Options::_sharedClassCache=false;
 
 TR::OptionSet *OMR::Options::_currentOptionSet = NULL;
-char *        OMR::Options::_compilationStrategyName = "default";
+const char *   OMR::Options::_compilationStrategyName = "default";
 
 bool          OMR::Options::_optionsTablesValidated = false;
 
@@ -1953,7 +1953,7 @@ OMR::Options::realTimeGC()
    return self()->getOption(TR_RealTimeGC);
    }
 
-char *
+const char *
 OMR::Options::latePostProcessJIT(void *jitConfig)
    {
    if (_jitCmdLineOptions)
@@ -1962,7 +1962,7 @@ OMR::Options::latePostProcessJIT(void *jitConfig)
    }
 
 
-char *
+const char *
 OMR::Options::latePostProcessAOT(void *jitConfig)
    {
    if (_aotCmdLineOptions)
@@ -1971,7 +1971,7 @@ OMR::Options::latePostProcessAOT(void *jitConfig)
    }
 
 
-char *
+const char *
 OMR::Options::latePostProcess(TR::Options *options, void *jitConfig, bool isAOT)
    {
    char * rc = 0;
@@ -1997,7 +1997,7 @@ OMR::Options::latePostProcess(TR::Options *options, void *jitConfig, bool isAOT)
       // Get the option string before clobbering it with the options object
       //
       _currentOptionSet = optionSet;
-      char *subOpts = optionSet->getOptionString();
+      const char *subOpts = optionSet->getOptionString();
       TR::Options *newOptions = new (PERSISTENT_NEW) TR::Options(*options);
       if (newOptions)
          {
@@ -2435,8 +2435,8 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
 
 
 // The string passed in as options should be from the -Xjit option
-char *
-OMR::Options::processOptionsJIT(char *jitOptions, void *feBase, TR_FrontEnd *fe)
+const char *
+OMR::Options::processOptionsJIT(const char *jitOptions, void *feBase, TR_FrontEnd *fe)
    {
    // Create the default JIT command line options object
    // only do this if this the first time around we're processing options
@@ -2468,7 +2468,7 @@ OMR::Options::processOptionsJIT(char *jitOptions, void *feBase, TR_FrontEnd *fe)
 
       _jitCmdLineOptions->jitPreProcess();
 
-      char *rc = TR::Options::processOptions(jitOptions, envOptions, feBase, fe, _jitCmdLineOptions);
+      const char *rc = TR::Options::processOptions(jitOptions, envOptions, feBase, fe, _jitCmdLineOptions);
 
       _processOptionsStatus |= (NULL == rc)?TR_JITProcessedOK : TR_JITProcessErrorJITOpts;
       return rc;
@@ -2480,8 +2480,8 @@ OMR::Options::processOptionsJIT(char *jitOptions, void *feBase, TR_FrontEnd *fe)
 
 
 // The string passed in as options should be from the -Xaot option
-char *
-OMR::Options::processOptionsAOT(char *aotOptions, void *feBase, TR_FrontEnd *fe)
+const char *
+OMR::Options::processOptionsAOT(const char *aotOptions, void *feBase, TR_FrontEnd *fe)
    {
    // Create the default AOT command line options object
    // only do this if this the first time around we're processing options
@@ -2506,7 +2506,7 @@ OMR::Options::processOptionsAOT(char *aotOptions, void *feBase, TR_FrontEnd *fe)
       _aotCmdLineOptions->jitPreProcess();
 
       static char *envOptions = feGetEnv("TR_OptionsAOT");
-      char* rc = TR::Options::processOptions(aotOptions, envOptions, feBase, fe, _aotCmdLineOptions);
+      const char *rc = TR::Options::processOptions(aotOptions, envOptions, feBase, fe, _aotCmdLineOptions);
 
       _processOptionsStatus |= (NULL == rc)?TR_AOTProcessedOK : TR_AOTProcessErrorAOTOpts;
       return rc;
@@ -2681,7 +2681,7 @@ OMR::Options::jitPreProcess()
    _lastIpaOptTransformationIndex = INT_MAX;
    _jProfilingMethodRecompThreshold = 4000;
    _jProfilingLoopRecompThreshold = 2000;
-   _blockShufflingSequence = "S";
+   _blockShufflingSequence = (char *)"S";
    _delayCompileWithCPUBurn = 0;
    _largeNumberOfLoops = 6500;
 
@@ -3127,11 +3127,11 @@ void OMR::Options::setOptionInAllOptionSets(uint32_t mask, bool b)
    }
 
 
-char *
+const char *
 OMR::Options::getDefaultOptions()
    {
    if (TR::Compiler->target.cpu.isX86() || TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM() || TR::Compiler->target.cpu.isARM64())
-      return (char *) ("samplingFrequency=2");
+      return "samplingFrequency=2";
 
    if (TR::Compiler->target.cpu.isZ())
       return "samplingFrequency=2,numInterfaceCallCacheSlots=4";
@@ -3217,10 +3217,10 @@ OMR::Options::validateOptionsTables(void *feBase, TR_FrontEnd *fe)
    }
 
 
-char *
+const char *
 OMR::Options::processOptions(
-      char *options,
-      char *envOptions,
+      const char *options,
+      const char *envOptions,
       void *feBase,
       TR_FrontEnd *fe,
       TR::Options *cmdLineOptions)
@@ -3243,8 +3243,8 @@ OMR::Options::processOptions(
    }
 
 
-char *
-OMR::Options::processOptions(char * options, char * envOptions, TR::Options *cmdLineOptions)
+const char *
+OMR::Options::processOptions(const char *options, const char *envOptions, TR::Options *cmdLineOptions)
    {
    // Process the main options - option sets found will be skipped and their
    // addresses saved in the following array, then processed after the main
@@ -3278,10 +3278,10 @@ OMR::Options::processOptions(char * options, char * envOptions, TR::Options *cmd
    }
 
 
-char *
+const char *
 OMR::Options::processOptionSet(
-      char *options,
-      char *envOptions,
+      const char *options,
+      const char *envOptions,
       TR::Options *jitBase,
       bool isAOT)
    {
@@ -3293,10 +3293,10 @@ OMR::Options::processOptionSet(
    }
 
 
-char *
+const char *
 OMR::Options::processOptionSet(
-      char *options,
-      char *envOptions,
+      const char *options,
+      const char *envOptions,
       TR::OptionSet *optionSet)
    {
    TR::Options *jitBase = optionSet ? optionSet->getOptions() : _cmdLineOptions;
@@ -3309,17 +3309,17 @@ OMR::Options::processOptionSet(
    }
 
 
-char *
+const char *
 OMR::Options::processOptionSet(
-      char *options,
+      const char *options,
       TR::OptionSet *optionSet,
       void *jitBase,
       bool isAOT)
    {
    while (*options && *options != ')')
       {
-      char *endOpt = NULL;
-      char *filterHeader = NULL;
+      const char *endOpt = NULL;
+      const char *filterHeader = NULL;
       TR::SimpleRegex *methodRegex = NULL, *optLevelRegex = NULL;
       int32_t startLine = 0, endLine = 0;
 
@@ -3335,6 +3335,7 @@ OMR::Options::processOptionSet(
             filterHeader = options;
             // Option subset represented by a regular expression
             endOpt = options;
+
 
             methodRegex = TR::SimpleRegex::create(endOpt);
             if (!methodRegex)
@@ -3373,7 +3374,7 @@ OMR::Options::processOptionSet(
             value=0;
             while (isdigit(*options))
                {
-               value = 10*value + *options - '0';
+               value = 10 * value + *options - '0';
                options++;
                }
 
@@ -3403,7 +3404,7 @@ OMR::Options::processOptionSet(
             endLine=value;
 
             //assume this is the ending ']';
-            endOpt = options+1;
+            endOpt = options + 1;
             }
          else if (!strnicmp_ignore_locale(options, EXCLUDED_METHOD_OPTIONS_PREFIX, strlen(EXCLUDED_METHOD_OPTIONS_PREFIX)))
             {
@@ -3418,7 +3419,7 @@ OMR::Options::processOptionSet(
             filterHeader = options;
             // Option subset represented by an index (used in limitfiles)
             //
-            endOpt = options+1;
+            endOpt = options + 1;
             }
          }
 
@@ -3429,7 +3430,7 @@ OMR::Options::processOptionSet(
          {
          if (*endOpt != '(')
             return options;
-         char *startOptString = ++endOpt;
+         const char *startOptString = ++endOpt;
          int32_t parenNest = 1;
          for (; *endOpt; endOpt++)
             {
@@ -3488,7 +3489,7 @@ OMR::Options::processOptionSet(
       //
       else
          {
-         endOpt = TR::Options::processOption(options, _jitOptions, jitBase, _numJitEntries, optionSet);
+         endOpt = (char *)TR::Options::processOption(options, _jitOptions, jitBase, _numJitEntries, optionSet);
 
          if (!endOpt)
             {
@@ -3496,7 +3497,7 @@ OMR::Options::processOptionSet(
             return options;
             }
 
-         char *feEndOpt = TR::Options::processOption(options, TR::Options::_feOptions, _feBase, _numVmEntries, optionSet);
+         const char *feEndOpt = TR::Options::processOption(options, TR::Options::_feOptions, _feBase, _numVmEntries, optionSet);
 
          if (!feEndOpt)
             {
@@ -3515,7 +3516,7 @@ OMR::Options::processOptionSet(
             }
 
          if (feEndOpt > endOpt)
-            endOpt = feEndOpt;
+            endOpt = (char *)feEndOpt;
          if (endOpt == options)
             {
             return options; // Unrecognized option
@@ -3539,8 +3540,8 @@ OMR::Options::processOptionSet(
    return options;
    }
 
-char *
-OMR::Options::processOptionSetPostRestore(void *jitConfig, char *options, TR::Options *optBase, bool isAOT)
+const char *
+OMR::Options::processOptionSetPostRestore(void *jitConfig, const char *options, TR::Options *optBase, bool isAOT)
    {
    _postRestoreProcessing = true;
 
@@ -3555,7 +3556,7 @@ OMR::Options::processOptionSetPostRestore(void *jitConfig, char *options, TR::Op
    // Process option sets
    for (TR::OptionSet *optionSet = optBase->_postRestoreOptionSets; optionSet; optionSet = optionSet->getNext())
       {
-      char *subOpts = optionSet->getOptionString();
+      const char *subOpts = optionSet->getOptionString();
 
       TR::Options *newOptions = new (PERSISTENT_NEW) TR::Options(*optBase);
       optionSet->setOptions(newOptions);
@@ -3598,15 +3599,15 @@ OMR::Options::compareOptionsForBinarySearch(const TR::OptionTable &a, const TR::
    return (strnicmp_ignore_locale(a.name, b.name, lengthOfTableEntry) < 0);
    }
 
-char *
+const char *
 OMR::Options::processOption(
-      char *startOption,
+      const char *startOption,
       TR::OptionTable *table,
       void *base,
       int32_t numEntries,
       TR::OptionSet *optionSet)
    {
-   char * option = startOption;
+   const char *option = startOption;
    bool negate = false;
    if (*option == '!')
       {
@@ -3695,7 +3696,7 @@ OMR::Options::processOption(
 
    // Process this entry
    //
-   return processingMethod(option+opt->length, base, opt);
+   return processingMethod(option + opt->length, base, opt);
    }
 
 
@@ -3897,7 +3898,7 @@ void OMR::Options::openLogFile(int32_t idSuffix)
          std::swap(destBuf, otherBuf);
          }
 
-      char *fmodeString = "wb+";
+      const char *fmodeString = "wb+";
       if (self()->getOption(TR_EnablePIDExtension))
          {
          if (!_suffixLogsFormat)
@@ -3958,9 +3959,9 @@ void OMR::Options::closeLogFile(TR_FrontEnd *fe, TR::FILE *file)
 
 
 void
-OMR::Options::printOptions(char *options, char *envOptions)
+OMR::Options::printOptions(const char *options, const char *envOptions)
    {
-   char *optionsType = "JIT";
+   const char *optionsType = "JIT";
    if (this == TR::Options::getAOTCmdLineOptions())
       optionsType = "AOT";
    TR_Debug::dumpOptions(optionsType, options, envOptions, self(), _jitOptions, TR::Options::_feOptions, _feBase, _fe);
@@ -4168,7 +4169,7 @@ OMR::Options::mergePostRestoreOptionSets()
    _postRestoreOptionSets = NULL;
    }
 
-char*
+const char *
 OMR::Options::setCounts()
    {
    if (_countString)
@@ -4470,7 +4471,7 @@ OMR::Options::getInitialHotnessLevel(bool methodHasLoops)
    }
 
 
-char *
+const char *
 OMR::Options::getDefaultCountString()
    {
    TR_ASSERT(this == _jitCmdLineOptions || this == _aotCmdLineOptions, "assertion failure");
@@ -4479,7 +4480,7 @@ OMR::Options::getDefaultCountString()
    //
    bool bcountFirst = false;
 
-   char * str = 0;
+   const char *str = 0;
 
    if (self()->getFixedOptLevel() == -1) // Not a fixed opt level
       {
@@ -4582,8 +4583,8 @@ OMR::Options::getDefaultCountString()
 #pragma report(disable, "CCN6281")
 #endif
 
-char *
-OMR::Options::setCount(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setCount(const char *option, void *base, TR::OptionTable *entry)
    {
    int32_t offset = static_cast<int32_t>(entry->parm1);
    int32_t countValue = (int32_t)TR::Options::getNumericValue(option);
@@ -4710,24 +4711,24 @@ OMR::Options::checkDisableFlagForAllMethods(OMR::Optimizations o, bool b)
    }
 
 
-char *
-OMR::Options::setStaticBool(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setStaticBool(const char *option, void *base, TR::OptionTable *entry)
    {
    *((bool*)entry->parm1) = (entry->parm2 != 0);
    return option;
    }
 
 
-char *
-OMR::Options::setBit(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setBit(const char *option, void *base, TR::OptionTable *entry)
    {
    *((uint32_t*)((char*)base+entry->parm1)) |= entry->parm2;
    return option;
    }
 
 
-char *
-OMR::Options::setAddressEnumerationBits(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setAddressEnumerationBits(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!_debug)
       TR::Options::createDebug();
@@ -4798,8 +4799,8 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 };
 
 
-char *
-OMR::Options::setBitsFromStringSet(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setBitsFromStringSet(const char *option, void *base, TR::OptionTable *entry)
    {
    int i;
    if (!_debug)
@@ -4834,7 +4835,8 @@ OMR::Options::setBitsFromStringSet(char *option, void *base, TR::OptionTable *en
    }
 
 
-char *OMR::Options::clearBitsFromStringSet(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::clearBitsFromStringSet(const char *option, void *base, TR::OptionTable *entry)
    {
    int i;
 
@@ -4866,8 +4868,8 @@ char *OMR::Options::clearBitsFromStringSet(char *option, void *base, TR::OptionT
 
 
 
-char *
-OMR::Options::configureOptReporting(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::configureOptReporting(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!_debug)
       TR::Options::createDebug();
@@ -4899,7 +4901,7 @@ OMR::Options::configureOptReporting(char *option, void *base, TR::OptionTable *e
    }
 
 
-char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
+const char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    {
    "options",
    "compileStart",
@@ -4959,8 +4961,8 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    };
 
 
-char *
-OMR::Options::setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setVerboseBitsInJitPrivateConfig(const char *option, void *base, TR::OptionTable *entry)
    {
 #ifdef J9_PROJECT_SPECIFIC
    TR_JitPrivateConfig *privateConfig = *(TR_JitPrivateConfig**)((char*)_feBase+entry->parm1);
@@ -4973,16 +4975,16 @@ OMR::Options::setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::Opt
    }
 
 
-char *
-OMR::Options::setVerboseBits(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setVerboseBits(const char *option, void *base, TR::OptionTable *entry)
    {
    VerboseOptionFlagArray *verboseOptionFlags = (VerboseOptionFlagArray*)((char*)_feBase+entry->parm1);
    return TR::Options::setVerboseBitsHelper(option, verboseOptionFlags, entry->parm2);
    }
 
 
-char *
-OMR::Options::setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptr_t defaultVerboseFlags)
+const char *
+OMR::Options::setVerboseBitsHelper(const char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptr_t defaultVerboseFlags)
    {
    if (defaultVerboseFlags != 0) // This is used for -Xjit:verbose without any options
       {
@@ -5029,56 +5031,56 @@ bool OMR::Options::isVerboseFileSet()
    }
 
 
-char *
-OMR::Options::resetBit(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::resetBit(const char *option, void *base, TR::OptionTable *entry)
    {
    *((uint32_t*)((char*)base+entry->parm1)) &= ~entry->parm2;
    return option;
    }
 
 
-char *
-OMR::Options::setValue(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setValue(const char *option, void *base, TR::OptionTable *entry)
    {
    *((intptr_t*)((char*)base+entry->parm1)) = entry->parm2;
    return option;
    }
 
 
-char *
-OMR::Options::set32BitValue(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::set32BitValue(const char *option, void *base, TR::OptionTable *entry)
    {
    *((int32_t*)((char*)base+entry->parm1)) = (int32_t)entry->parm2;
    return option;
    }
 
 
-char *
-OMR::Options::enableOptimization(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::enableOptimization(const char *option, void *base, TR::OptionTable *entry)
    {
    ((TR::Options *)base)->_disabledOptimizations[entry->parm1] = false;
    return option;
    }
 
 
-char *
-OMR::Options::dontTraceOptimization(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::dontTraceOptimization(const char *option, void *base, TR::OptionTable *entry)
    {
    ((TR::Options *)base)->_traceOptimizations[entry->parm1] = false;
    return option;
    }
 
 
-char *
-OMR::Options::disableOptimization(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::disableOptimization(const char *option, void *base, TR::OptionTable *entry)
    {
    ((TR::Options *)base)->_disabledOptimizations[entry->parm1] = true;
    return option;
    }
 
 
-char *
-OMR::Options::traceOptimization(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::traceOptimization(const char *option, void *base, TR::OptionTable *entry)
    {
    ((TR::Options *)base)->_traceOptimizations[entry->parm1] = true;
    ((TR::Options *)base)->_tracingOptimization = true;
@@ -5086,8 +5088,8 @@ OMR::Options::traceOptimization(char *option, void *base, TR::OptionTable *entry
    }
 
 
-char *
-OMR::Options::helpOption(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::helpOption(const char *option, void *base, TR::OptionTable *entry)
    {
    if (!_debug)
       TR::Options::createDebug();
@@ -5116,7 +5118,7 @@ OMR::Options::helpOption(char *option, void *base, TR::OptionTable *entry)
    return option;
    }
 
-char *OMR::Options::_samplingJProfilingOptionNames[TR_NumSamplingJProfilingFlags] =
+const char *OMR::Options::_samplingJProfilingOptionNames[TR_NumSamplingJProfilingFlags] =
    {
    "invokevirtual",
    "invokeinterface",
@@ -5126,7 +5128,8 @@ char *OMR::Options::_samplingJProfilingOptionNames[TR_NumSamplingJProfilingFlags
    "instanceof",
    };
 
-char *OMR::Options::setSamplingJProfilingBits(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::setSamplingJProfilingBits(const char *option, void *base, TR::OptionTable *entry)
    {
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
 
@@ -5147,14 +5150,15 @@ char *OMR::Options::setSamplingJProfilingBits(char *option, void *base, TR::Opti
    return option;
    }
 
-char *OMR::Options::_hotFieldReductionAlgorithmNames[TR_NumReductionAlgorithms] =
+const char *
+OMR::Options::_hotFieldReductionAlgorithmNames[TR_NumReductionAlgorithms] =
    {
    "sum",
    "average",
    "max",
    };
 
-char *OMR::Options::setHotFieldReductionAlgorithm(char *option, void *base, TR::OptionTable *entry)
+const char *OMR::Options::setHotFieldReductionAlgorithm(const char *option, void *base, TR::OptionTable *entry)
    {
    TR::SimpleRegex * regex = TR::SimpleRegex::create(option);
    bool foundMatch = false;
@@ -5177,8 +5181,8 @@ char *OMR::Options::setHotFieldReductionAlgorithm(char *option, void *base, TR::
    return option;
    }
 
-char *
-OMR::Options::breakOnLoad(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::breakOnLoad(const char *option, void *base, TR::OptionTable *entry)
    {
    TR::Compiler->debug.breakPoint();
    return option;
@@ -5375,7 +5379,8 @@ bool OMR::Options::useCompressedPointers()
    }
 
 
-char *OMR::Options::limitOption(char *option, void *base, TR::OptionTable *entry)
+const char *
+OMR::Options::limitOption(const char *option, void *base, TR::OptionTable *entry)
    {
    // TODO: this is identical to the J9 frontend
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
@@ -5384,7 +5389,8 @@ char *OMR::Options::limitOption(char *option, void *base, TR::OptionTable *entry
    }
 
 
-char *OMR::Options::limitfileOption(char* option, void* base, TR::OptionTable* entry)
+const char *
+OMR::Options::limitfileOption(const char *option, void *base, TR::OptionTable* entry)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return 0;
@@ -5392,7 +5398,8 @@ char *OMR::Options::limitfileOption(char* option, void* base, TR::OptionTable* e
    }
 
 
-char *OMR::Options::inlinefileOption(char* option, void* base, TR::OptionTable* entry)
+const char *
+OMR::Options::inlinefileOption(const char *option, void *base, TR::OptionTable* entry)
    {
    if (!TR::Options::getDebug() && !TR::Options::createDebug())
       return 0;
@@ -5446,7 +5453,8 @@ bool  OMR::Options::fePostProcessJIT(void *base)
    }
 
 
-char *OMR::Options::versionOption(char * option, void * base, TR::OptionTable *entry)
+const char *
+OMR::Options::versionOption(const char *option, void * base, TR::OptionTable *entry)
    {
    fprintf(stdout, "JIT version: %s\n", TR_BUILD_NAME);
    return  option;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1518,27 +1518,27 @@ public:
    static void       setIsFullyInitialized()           { _fullyInitialized = true; }
    static bool       isFullyInitialized()              { return _fullyInitialized; }
 
-   static TR::OptionSet * findOptionSet(TR_Memory *, int32_t index, int32_t lineNum, TR_ResolvedMethod *, TR_Hotness, bool);
-   static TR::OptionSet * findOptionSet(TR_Memory *, TR_ResolvedMethod *, bool);
-   static TR::OptionSet * findOptionSet(int32_t index, int32_t lineNum, const char *, TR_Hotness, bool);
+   static TR::OptionSet *findOptionSet(TR_Memory *, int32_t index, int32_t lineNum, TR_ResolvedMethod *, TR_Hotness, bool);
+   static TR::OptionSet *findOptionSet(TR_Memory *, TR_ResolvedMethod *, bool);
+   static TR::OptionSet *findOptionSet(int32_t index, int32_t lineNum, const char *, TR_Hotness, bool);
 
-   static char       *getDefaultOptions();
-   static char       *validateOptions(void *feBase, TR_FrontEnd *fe);
-   static char       *processOptionsJIT(char *jitOptions, void *feBase, TR_FrontEnd *fe);
-   static char       *processOptionsAOT(char *aotOptions, void *feBase, TR_FrontEnd *fe);
-   static char       *processOptions(char *options, char *envOptions, void *feBase, TR_FrontEnd *fe, TR::Options *cmdLineOptions);
-   static char       *latePostProcessJIT(void *jitConfig);
-   static char       *latePostProcessAOT(void *jitConfig);
-   static char       *latePostProcess(TR::Options *options, void *jitConfig, bool isAOT);
-   static char       *processOptions(char *options, char *moreOptions, TR::Options *cmdLineOptions);
+   static const char  *getDefaultOptions();
+   static char        *validateOptions(void *feBase, TR_FrontEnd *fe);
+   static const char  *processOptionsJIT(const char *jitOptions, void *feBase, TR_FrontEnd *fe);
+   static const char  *processOptionsAOT(const char *aotOptions, void *feBase, TR_FrontEnd *fe);
+   static const char  *processOptions(const char *options, const char *envOptions, void *feBase, TR_FrontEnd *fe, TR::Options *cmdLineOptions);
+   static const char  *latePostProcessJIT(void *jitConfig);
+   static const char  *latePostProcessAOT(void *jitConfig);
+   static const char  *latePostProcess(TR::Options *options, void *jitConfig, bool isAOT);
+   static const char  *processOptions(const char *options, const char *moreOptions, TR::Options *cmdLineOptions);
    static TR::Options *getCmdLineOptions();
    static TR::Options *getAOTCmdLineOptions();
-   static void        setAOTCmdLineOptions(TR::Options *options);
+   static void         setAOTCmdLineOptions(TR::Options *options);
    static TR::Options *getJITCmdLineOptions();
-          void        saveOptionSet(TR::OptionSet *o);
-          void        mergePostRestoreOptionSets();
-          bool        hasOptionSets() {return _optionSets != NULL;}
-   char*              setCounts();
+          void         saveOptionSet(TR::OptionSet *o);
+          void         mergePostRestoreOptionSets();
+          bool         hasOptionSets() {return _optionSets != NULL;}
+          const char  *setCounts();
 
    static bool     useCompressedPointers();
 
@@ -1546,7 +1546,7 @@ public:
    void            setLogFile(TR::FILE * f)  {_logFile = f;}
    char *          getLogFileName()      {return _logFileName;}
 
-   char *          getBlockShufflingSequence(){ return _blockShufflingSequence; }
+   char *    getBlockShufflingSequence(){ return _blockShufflingSequence; }
 
    int32_t         getRandomSeed(){ return _randomSeed; }
 
@@ -1593,7 +1593,7 @@ public:
    static void  setVerboseOption(TR_VerboseFlags op)     { _verboseOptionFlags.set(op); }
    static void  setVerboseOptions(uint64_t mask)         { _verboseOptionFlags.maskWord(0, mask); }
    static void  resetVerboseOption(TR_VerboseFlags op)   { _verboseOptionFlags.reset(op); }
-   static char *getVerboseOptionName(TR_VerboseFlags op) { return _verboseOptionNames[op]; }
+   static const char *getVerboseOptionName(TR_VerboseFlags op) { return _verboseOptionNames[op]; }
    static bool  isAnyVerboseOptionSet()                  { return !_verboseOptionFlags.isEmpty(); }
    static bool  isAnyVerboseOptionSet(TR_VerboseFlags op1);
    static bool  isAnyVerboseOptionSet(TR_VerboseFlags op1, TR_VerboseFlags op2);
@@ -2004,7 +2004,7 @@ public:
    static TR_Hotness getInitialHotnessLevel(bool methodHasLoops);
 
    bool getOptLevelDowngraded() const { return _optLevelDowngraded; }
-   static char *getCompilationStrategyName() { return _compilationStrategyName; }
+   static const char *getCompilationStrategyName() { return _compilationStrategyName; }
 
 /**   \brief Returns a threshold on the profiling method invocations to trip recompilation
  */
@@ -2029,7 +2029,7 @@ public:
     *
     * \return pointer to the end of the options string if success, or to the invalid option
     */
-   static char *processOptionSetPostRestore(void *jitConfig, char *options, TR::Options *optBase, bool isAOT);
+   static const char *processOptionSetPostRestore(void *jitConfig, const char *options, TR::Options *optBase, bool isAOT);
 
 protected:
    void  jitPreProcess();
@@ -2086,11 +2086,11 @@ private:
 
    static bool compareOptionsForBinarySearch(const TR::OptionTable &a, const TR::OptionTable &b);
 
-   static char *processOptionSet(char *options, char *envOptions, TR::Options *jitBase, bool isAOT);
-   static char *processOptionSet(char *options, char *envOptions, TR::OptionSet *optionSet);
-   static char *processOptionSet(char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT);
-   static char *processOption(char *option, TR::OptionTable *table, void *base, int32_t numEntries, TR::OptionSet *optionSet);
-          void  printOptions(char *options, char *envOptions);
+   static const char *processOptionSet(const char *options, const char *envOptions, TR::Options *jitBase, bool isAOT);
+   static const char *processOptionSet(const char *options, const char *envOptions, TR::OptionSet *optionSet);
+   static const char *processOptionSet(const char *options, TR::OptionSet *optionSet, void *jitBase, bool isAOT);
+   static const char *processOption(const char *option, TR::OptionTable *table, void *base, int32_t numEntries, TR::OptionSet *optionSet);
+          void  printOptions(const char *options, const char *envOptions);
 
           bool  showOptionsInEffect();
           bool  showPID();
@@ -2114,54 +2114,54 @@ private:
 
    // Set bit(s) defined by "mask" at offset "offset" from the base
    //
-   static char *setBit(char *option, void *base, TR::OptionTable *entry);
+   static const char *setBit(const char *option, void *base, TR::OptionTable *entry);
 
    // Set verbose bits
    //
-   static char *setVerboseBits(char *option, void *base, TR::OptionTable *entry);
-   static char *setVerboseBitsInJitPrivateConfig(char *option, void *base, TR::OptionTable *entry);
+   static const char *setVerboseBits(const char *option, void *base, TR::OptionTable *entry);
+   static const char *setVerboseBitsInJitPrivateConfig(const char *option, void *base, TR::OptionTable *entry);
    // Helper method used by the two methods above
-   static char *setVerboseBitsHelper(char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptr_t defaultVerboseFlags);
+   static const char *setVerboseBitsHelper(const char *option, VerboseOptionFlagArray *verboseOptionFlags, uintptr_t defaultVerboseFlags);
 
    //set hot field reduction algorithm for dynamicBreadthFirstScanOrdering
    //
-   static char *setHotFieldReductionAlgorithm(char *option, void *base, TR::OptionTable *entry);
+   static const char *setHotFieldReductionAlgorithm(const char *option, void *base, TR::OptionTable *entry);
 
    // Set samplingjprofiling bits
    //
-   static char *setSamplingJProfilingBits(char* option, void *base, TR::OptionTable *entry);
+   static const char *setSamplingJProfilingBits(const char* option, void *base, TR::OptionTable *entry);
 
    // Reset bit(s) defined by "mask" at offset "offset" from the base
    //
-   static char *resetBit(char *option, void *base, TR::OptionTable *entry);
+   static const char *resetBit(const char *option, void *base, TR::OptionTable *entry);
 
    // Set (pointer-sized) word at offset "offset" from the base to "value"
    //
-   static char *setValue(char *option, void *base, TR::OptionTable *entry);
+   static const char *setValue(const char *option, void *base, TR::OptionTable *entry);
 
    // Set 32-bit word at offset "offset" from the base to "value"
    //
-   static char *set32BitValue(char *option, void *base, TR::OptionTable *entry);
+   static const char *set32BitValue(const char *option, void *base, TR::OptionTable *entry);
 
    // Disable an optimization
    //
-   static char *disableOptimization(char *option, void *base, TR::OptionTable *entry);
-   static char *enableOptimization(char *option, void *base, TR::OptionTable *entry);
+   static const char *disableOptimization(const char *option, void *base, TR::OptionTable *entry);
+   static const char *enableOptimization(const char *option, void *base, TR::OptionTable *entry);
 
    // Trace an optimization
    //
-   static char *traceOptimization(char *option, void *base, TR::OptionTable *entry);
-   static char *dontTraceOptimization(char *option, void *base, TR::OptionTable *entry);
+   static const char *traceOptimization(const char *option, void *base, TR::OptionTable *entry);
+   static const char *dontTraceOptimization(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a numeric value and set word at offset "offset"
    // from the base to that value. That "word" is of 32bit or 64bit, depending on JIT.
    //
-   static char *setNumeric(char *option, void *base, TR::OptionTable *entry);
+   static const char *setNumeric(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a numeric value and set 32bit word at offset "offset"
    // from the base to that value.
    //
-   static char *set32BitNumeric(char *option, void *base, TR::OptionTable *entry);
+   static const char *set32BitNumeric(const char *option, void *base, TR::OptionTable *entry);
 
   /**
    * \brief Option processing function for 32 bit numeric fields stored in JitConfig
@@ -2175,53 +2175,53 @@ private:
    *                     32-bit that needs to be set
    * \return A pointer to the option parameter
    */
-   static char *set32BitNumericInJitConfig(char *option, void *base, TR::OptionTable *entry);
+   static const char *set32BitNumericInJitConfig(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a hexadecimal value and set 32bit word at offset "offset"
    // from the base to that value.
    //
-   static char *set32BitHexadecimal(char *option, void *base, TR::OptionTable *entry);
+   static const char *set32BitHexadecimal(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a numeric value and set 32bit word at offset "offset"
    // from the 'private' base (derived from the 'base' passed in) to that value.
    //
-   static char *setStaticNumericKBAdjusted(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStaticNumericKBAdjusted(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a string and set the value at offset "offset"
    // from the 'private' base (derived from the 'base' passed in) to that value.
    //
-   static char *setStringForPrivateBase(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStringForPrivateBase(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a (possibly negative) numeric value and set 32bit
    // word at offset "offset" from the base to that value.
    //
-   static char *set32BitSignedNumeric(char *option, void *base, TR::OptionTable *entry);
+   static const char *set32BitSignedNumeric(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a (possibly negative) numeric value and set 32bit
    // word at offset "offset" from the base to that value.
    //
-   static char *set64BitSignedNumeric(char *option, void *base, TR::OptionTable *entry);
+   static const char *set64BitSignedNumeric(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a numeric value and set word at parm1 to that value
    //
-   static char *setStaticNumeric(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStaticNumeric(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a hexadecimal value and set word at parm1 to that value
    //
-   static char *setStaticHexadecimal(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStaticHexadecimal(const char *option, void *base, TR::OptionTable *entry);
 
    // Set word at parm1 to 32-bit value at parm2
    //
-   static char *setStatic32BitValue(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStatic32BitValue(const char *option, void *base, TR::OptionTable *entry);
 
    // Set bool at parm1 to value at parm2
    //
-   static char *setStaticBool(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStaticBool(const char *option, void *base, TR::OptionTable *entry);
 
    // Scan the option for a string value and copy the string to the address
    // given by entry->parm1
    //
-   static char *setStaticString(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStaticString(const char *option, void *base, TR::OptionTable *entry);
 
    /**
    * \brief Option processing function for strings
@@ -2236,7 +2236,7 @@ private:
    *                     string field that needs to be set
    * \return A pointer to the option parameter
    */
-   static char *setString(char *option, void *base, TR::OptionTable *entry);
+   static const char *setString(const char *option, void *base, TR::OptionTable *entry);
 
    /**
    * \brief Option processing function for string fields stored in JitConfig
@@ -2250,47 +2250,47 @@ private:
    *                     field (a char pointer) that needs to be set
    * \return A pointer to the option parameter
    */
-   static char *setStringInJitConfig(char *option, void *base, TR::OptionTable *entry);
+   static const char *setStringInJitConfig(const char *option, void *base, TR::OptionTable *entry);
 
 
    // Add "debugString" to the JIT debug strings
    //
-   static char *setDebug(char *option, void *, TR::OptionTable *entry);
+   static const char *setDebug(const char *option, void *, TR::OptionTable *entry);
 
-   static char *setRegex(char *option, void *, TR::OptionTable *entry);
-   static char *setStaticRegex(char *option, void *, TR::OptionTable *entry);
+   static const char *setRegex(const char *option, void *, TR::OptionTable *entry);
+   static const char *setStaticRegex(const char *option, void *, TR::OptionTable *entry);
 
    // Set address enumeration bits
    //
-   static char *setAddressEnumerationBits(char *option, void *base, TR::OptionTable *entry);
+   static const char *setAddressEnumerationBits(const char *option, void *base, TR::OptionTable *entry);
 
    // Set bits from a set of string options
    //
-   typedef struct { char *bitName; int32_t bitValue; } TR_OptionStringToBit;
+   typedef struct { const char *bitName; int32_t bitValue; } TR_OptionStringToBit;
    private:
    static TR_OptionStringToBit _optionStringToBitMapping[];
    public:
-   static char *setBitsFromStringSet(char *option, void *base, TR::OptionTable *entry);
-   static char *clearBitsFromStringSet(char *option, void *base, TR::OptionTable *entry);
+   static const char *setBitsFromStringSet(const char *option, void *base, TR::OptionTable *entry);
+   static const char *clearBitsFromStringSet(const char *option, void *base, TR::OptionTable *entry);
 
-   static char *configureOptReporting(char *option, void *base, TR::OptionTable *entry);
+   static const char *configureOptReporting(const char *option, void *base, TR::OptionTable *entry);
 
    // Option processing helper functions
    //
-   static int64_t getNumericValue(char * &option);
+   static int64_t getNumericValue(const char *&option);
 
    // Display help information
    //
-   static char *helpOption(char *option, void *, TR::OptionTable *entry);
+   static const char *helpOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *limitOption(char *option, void *, TR::OptionTable *entry);
-   static char *inlinefileOption(char *option, void *, TR::OptionTable *entry);
-   static char *limitfileOption(char *option, void *, TR::OptionTable *entry);
-   static char *versionOption(char *option, void *, TR::OptionTable *entry);
+   static const char *limitOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *inlinefileOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *limitfileOption(const char *option, void *, TR::OptionTable *entry);
+   static const char *versionOption(const char *option, void *, TR::OptionTable *entry);
 
-   static char *breakOnLoad(char *option, void *, TR::OptionTable *entry);
-   static char *setCount(char *option, void *base, TR::OptionTable *entry);
-   char *getDefaultCountString();
+   static const char *breakOnLoad(const char *option, void *, TR::OptionTable *entry);
+   static const char *setCount(const char *option, void *base, TR::OptionTable *entry);
+   const char *getDefaultCountString();
 
    bool counterIsEnabled(const char *name, int8_t fidelity, TR::SimpleRegex *nameRegex);
 
@@ -2315,9 +2315,9 @@ protected:
    static int32_t        _numJitEntries;
    static int32_t        _numVmEntries;
    static TR::OptionSet  *_currentOptionSet;
-          char *         _startOptions;
-          char *         _envOptions;
-   static char *         _compilationStrategyName;
+          const char *   _startOptions;
+          const char *   _envOptions;
+   static const char *   _compilationStrategyName;
 
    // Option flag words
    //
@@ -2338,7 +2338,7 @@ protected:
    //
    int32_t                     _optLevel;
    int32_t                     _initialOptLevel; // opt level for first time compilations
-   char *                      _countString;
+   const char *                _countString;
    int32_t                     _initialCount;
    int32_t                     _initialBCount;
    int32_t                     _initialMILCount;
@@ -2407,16 +2407,16 @@ protected:
    // If countsAreProvidedByUser, then this flag is undefined
 
    static VerboseOptionFlagArray  _verboseOptionFlags;
-   static char                   *_verboseOptionNames[TR_NumVerboseOptions];
+   static const char          *_verboseOptionNames[TR_NumVerboseOptions];
    static bool                 _quickstartDetected; // set when Quickstart was specified on the command line
 
    typedef OptionFlagArray<TR_SamplingJProfilingFlags, TR_NumSamplingJProfilingFlags> SamplingJProfilingOptionFlagArray;
    static SamplingJProfilingOptionFlagArray _samplingJProfilingOptionFlags;
-   static char                     *_samplingJProfilingOptionNames[TR_NumSamplingJProfilingFlags];
+   static const char          *_samplingJProfilingOptionNames[TR_NumSamplingJProfilingFlags];
 
    typedef OptionFlagArray<TR_ReductionAlgorithms, TR_NumReductionAlgorithms> HotFieldReductionAlgorithmArray;
    static HotFieldReductionAlgorithmArray  _hotFieldReductionAlgorithms;
-   static char                   *_hotFieldReductionAlgorithmNames[TR_NumReductionAlgorithms];
+   static const char          *_hotFieldReductionAlgorithmNames[TR_NumReductionAlgorithms];
    // Miscellaneous options
    //
    char *                      _osVersionString;
@@ -2488,7 +2488,7 @@ protected:
 
    int32_t                     _jProfilingMethodRecompThreshold;
    int32_t                     _jProfilingLoopRecompThreshold;
-   char *                      _blockShufflingSequence;
+   char *                _blockShufflingSequence;
    int32_t                     _randomSeed;
    TR_MCTLogs *                _logListForOtherCompThreads;
    static bool                 _dualLogging;    // a log file is used in two different option sets, or in

--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -37,7 +37,7 @@ class Options;
 
 // Shape of an option processing method
 //
-typedef char * (* OptionFunctionPtr)(char *option, void *base, OptionTable *entry);
+typedef const char * (* OptionFunctionPtr)(const char *option, void *base, OptionTable *entry);
 
 // Flags used for the msgInfo field in TR::OptionTable
 //
@@ -146,9 +146,9 @@ public:
 
    TR_ALLOC(TR_Memory::OptionSet)
 
-   OptionSet(char *s) { init(s); }
+   OptionSet(const char *s) { init(s); }
 
-   void init(char *s) { _optionString = s; _next = 0; _methodRegex = 0; _optLevelRegex = 0; _start=0; _end=0; _options = NULL; }
+   void init(const char *s) { _optionString = s; _next = 0; _methodRegex = 0; _optLevelRegex = 0; _start=0; _end=0; _options = NULL; }
 
    OptionSet *getNext() {return _next;}
 
@@ -157,7 +157,7 @@ public:
    TR::SimpleRegex *getOptLevelRegex() {return _optLevelRegex; }
    bool match(const char *s) { TR_ASSERT(false, "should be unreachable"); return false; }
    TR::Options *getOptions() {return _options;}
-   char *getOptionString() {return _optionString;}
+   const char *getOptionString() {return _optionString;}
    int32_t getStart() {return _start;}
    int32_t getEnd() {return  _end;}
 
@@ -177,7 +177,7 @@ private:
    int32_t _start;
    int32_t _end;
    TR::Options *_options;
-   char *_optionString;
+   const char *_optionString;
    };
 
 }

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -268,7 +268,7 @@ bcIndexForFakeInduce(TR::Compilation* comp, int16_t* callSiteInsertionPoint,
       if (!p) break;
       strncpy(signatureRegex, p, temp - p);
       signatureRegex[temp-p] = '\0';
-      char* tempRegex = signatureRegex;
+      const char *tempRegex = (const char *)signatureRegex;
       TR::SimpleRegex* regex = TR::SimpleRegex::create(tempRegex);
       if (regex)
          {

--- a/compiler/infra/InterferenceGraph.cpp
+++ b/compiler/infra/InterferenceGraph.cpp
@@ -503,7 +503,7 @@ bool TR_InterferenceGraph::select()
 
 
 #ifdef DEBUG
-void TR_InterferenceGraph::dumpIG(char *msg)
+void TR_InterferenceGraph::dumpIG(const char *msg)
    {
    if (msg)
       {

--- a/compiler/infra/InterferenceGraph.hpp
+++ b/compiler/infra/InterferenceGraph.hpp
@@ -144,9 +144,9 @@ class TR_InterferenceGraph : public TR_IGBase
    IGNodeColour findMinimumChromaticNumber();
 
 #ifdef DEBUG
-   void dumpIG(char *msg = NULL);
+   void dumpIG(const char *msg = NULL);
 #else
-   void dumpIG(char *msg = NULL) {}
+   void dumpIG(const char *msg = NULL) {}
 #endif
    };
 #endif

--- a/compiler/infra/SimpleRegex.cpp
+++ b/compiler/infra/SimpleRegex.cpp
@@ -55,11 +55,11 @@
 namespace TR
 {
 
-SimpleRegex *SimpleRegex::create(char *&s)
+SimpleRegex *SimpleRegex::create(const char *& s)
    {
    if (s == NULL || s[0] != '{')
       return NULL;
-   char *origStr = s;
+   const char *origStr = s;
    ++s;
    bool negate = (s[0] == '^');
    if (negate)
@@ -78,7 +78,7 @@ SimpleRegex *SimpleRegex::create(char *&s)
    }
 
 
-SimpleRegex::Regex *SimpleRegex::processRegex(char *&s, bool &foundError)
+SimpleRegex::Regex *SimpleRegex::processRegex(const char *&s, bool &foundError)
    {
    // First get rid of all + and |
    //
@@ -108,10 +108,10 @@ void *SimpleRegex::Component::operator new (size_t size, PERSISTENT_NEW_DECLARE,
 
 // Process a simple_pattern: a sequence of components
 //
-SimpleRegex::Simple *SimpleRegex::processSimple(char *&s, TR_YesNoMaybe allowAlternates, bool &foundError)
+SimpleRegex::Simple *SimpleRegex::processSimple(const char *&s, TR_YesNoMaybe allowAlternates, bool &foundError)
    {
    int32_t i,lo,hi;
-   char *startSimple = s;
+   const char *startSimple = s;
 
    if (s[0] == '\0' || s[0] == ',' || s[0] == '|' || s[0] == '}')
       return NULL;

--- a/compiler/infra/SimpleRegex.hpp
+++ b/compiler/infra/SimpleRegex.hpp
@@ -50,7 +50,7 @@ class SimpleRegex
 
    // Create a new regular expression
    //
-   static SimpleRegex *create(char *&s);
+   static SimpleRegex *create(const char *& s);
 
    // Check whether a string matches this regular expression
    //
@@ -139,15 +139,15 @@ class SimpleRegex
 
    private:
 
-   static Regex  *processRegex(char *&s, bool &foundError);
-   static Simple *processSimple(char *&s, TR_YesNoMaybe allowAlternates, bool &foundError);
+   static Regex  *processRegex(const char *&s, bool &foundError);
+   static Simple *processSimple(const char *&s, TR_YesNoMaybe allowAlternates, bool &foundError);
 
    Regex *_regex;
    bool   _negate;
 
    // Length and pointer to the original string that the regex was parsed from
    size_t _regexStrLen;
-   char *_regexStr;
+   const char *_regexStr;
    };
 
 }

--- a/compiler/infra/Statistics.hpp
+++ b/compiler/infra/Statistics.hpp
@@ -272,13 +272,13 @@ class TR_StatsEvents
    public:
    enum {NAME_LEN=31};
    TR_StatsEvents() {}
-   TR_StatsEvents(const char *name, char **binNames, int minEventId)
+   TR_StatsEvents(const char *name, const char **binNames, int minEventId)
       {
       init(name, binNames, minEventId);
       }
    // the init method can be used if we want to declare an array of stats
    // that are initialized later (in a for loop)
-   void init(const char *name, char **binNames, int minEventId)
+   void init(const char *name, const char **binNames, int minEventId)
       {
       strncpy(_name, name, NAME_LEN);
       _name[NAME_LEN] = 0; // just in case name is longer than _name
@@ -341,12 +341,12 @@ class TR_StatsEvents
       }
    unsigned samples() const {return _numSamples;}
    protected:
-   char     _name[NAME_LEN+1];
-   int      _bins[N];
-   char**   _binNames;
-   int      _minEventId;  // value of smallest bin
-   int      _numSamples;
-   int      _numInvalidSamples;
+   char         _name[NAME_LEN+1];
+   int          _bins[N];
+   const char **_binNames;
+   int          _minEventId;  // value of smallest bin
+   int          _numSamples;
+   int          _numInvalidSamples;
    };
 
 #endif

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4258,11 +4258,11 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
 
 static bool traceIfMatchesPattern(TR::Compilation* comp)
    {
-   static char* cRegex = feGetEnv ("TR_printIfRegex");
+   static const char *cRegex = feGetEnv ("TR_printIfRegex");
 
    if (cRegex && comp->getOptions() && comp->getOptions()->getDebug())
       {
-      static TR::SimpleRegex * regex = TR::SimpleRegex::create(cRegex);
+      static TR::SimpleRegex *regex = TR::SimpleRegex::create(cRegex);
       if (TR::SimpleRegex::match(regex, comp->signature(), false))
          {
          return true;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2562,9 +2562,9 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree,TR:
          comp()->getSymRefTab()->methodSymRefFromName(
             comp()->getMethodSymbol(),
             "com/ibm/jit/JITHelpers",
-            const_cast<char*> (TR::sun_nio_cs_UTF_16_Encoder_encodeUTF16Big == rm ?
+            TR::sun_nio_cs_UTF_16_Encoder_encodeUTF16Big == rm ?
                "transformedEncodeUTF16Big" :
-               "transformedEncodeUTF16Little"),
+               "transformedEncodeUTF16Little",
             "(JJI)I",
             TR::MethodSymbol::Static
             );
@@ -3962,15 +3962,15 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
          comp()->getSymRefTab()->methodSymRefFromName(
             comp()->getMethodSymbol(),
             "com/ibm/jit/JITHelpers",
-            const_cast<char*>("jitHelpers"),
-            const_cast<char*>("()Lcom/ibm/jit/JITHelpers;"),
+            "jitHelpers",
+            "()Lcom/ibm/jit/JITHelpers;",
             TR::MethodSymbol::Static);
    TR::SymbolReference* objCopySymRef =
          comp()->getSymRefTab()->methodSymRefFromName(
             comp()->getMethodSymbol(),
             "com/ibm/jit/JITHelpers",
-            const_cast<char*>(comp()->target().is64Bit() ? "unsafeObjectShallowCopy64" : "unsafeObjectShallowCopy32"),
-            const_cast<char*>(comp()->target().is64Bit() ? "(Ljava/lang/Object;Ljava/lang/Object;J)V" : "(Ljava/lang/Object;Ljava/lang/Object;I)V"),
+            comp()->target().is64Bit() ? "unsafeObjectShallowCopy64" : "unsafeObjectShallowCopy32",
+            comp()->target().is64Bit() ? "(Ljava/lang/Object;Ljava/lang/Object;J)V" : "(Ljava/lang/Object;Ljava/lang/Object;I)V",
             TR::MethodSymbol::Static);
    TR::Node *getHelpers = TR::Node::createWithSymRef(callNode, TR::acall, 0, helperAccessor);
    callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, getHelpers)));

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -764,7 +764,7 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction *instr, uint8_t *curso
       }
    else if (_registerAssignmentTraceFlags & TRACERA_IN_PROGRESS)
       {
-      char *spaces = "                                        ";
+      const char *spaces = "                                        ";
       int16_t padding = 30 - _registerAssignmentTraceCursor;
 
       if (padding < 0)
@@ -1803,7 +1803,7 @@ TR_Debug::getAutoName(TR::SymbolReference * symRef)
    else if (slot < getOwningMethodSymbol(symRef)->getFirstJitTempIndex())
       {
       int debugNameLen;
-      char *debugName = getOwningMethod(symRef)->localName(slot, 0, debugNameLen, comp()->trMemory()); // TODO: Proper bcIndex somehow; TODO: proper length
+      const char *debugName = getOwningMethod(symRef)->localName(slot, 0, debugNameLen, comp()->trMemory()); // TODO: Proper bcIndex somehow; TODO: proper length
       if (!debugName)
          {
          debugName = "";
@@ -1850,8 +1850,8 @@ TR_Debug::getParmName(TR::SymbolReference * symRef)
    int32_t debugNameLen, signatureLen;
    int32_t slot = symRef->getCPIndex();
    const char * s = symRef->getSymbol()->castToParmSymbol()->getTypeSignature(signatureLen);
-   char *debugName = getOwningMethod(symRef)->localName(slot, 0, debugNameLen, comp()->trMemory()); // TODO: Proper bcIndex somehow; TODO: proper length
-   char * buf;
+   const char *debugName = getOwningMethod(symRef)->localName(slot, 0, debugNameLen, comp()->trMemory()); // TODO: Proper bcIndex somehow; TODO: proper length
+   char *buf;
 
    if (!debugName)
       {
@@ -1937,7 +1937,7 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
          TR::StackMemoryRegion stackMemoryRegion(*comp()->trMemory());
          char *contents = NULL;
          intptr_t length = 0, prefixLength = 0, suffixOffset = 0;
-         char *etc = "";
+         const char *etc = "";
          const intptr_t LENGTH_LIMIT=80;
          const intptr_t PIECE_LIMIT=20;
 
@@ -4949,18 +4949,18 @@ void TR_Debug::setupDebugger(void *addr)
          char cfname[20];
          FILE *cf;
          char pp[20];
-         char * Argv[20];
+         char *Argv[20];
 
          yield();
          sprintf(cfname, "_%" OMR_PRId64 "_", (int64_t)getpid());
          sprintf(pp, "%" OMR_PRId64, (int64_t)ppid);
-         Argv[1] = "-a";
+         Argv[1] = (char *)"-a";
          Argv[2] = pp;
          Argv[3] = NULL;
 
          if ((Argv[0] = ::feGetEnv("TR_DEBUGGER")) == NULL)
             {
-            Argv[0] = "/usr/bin/dbx";
+            Argv[0] = (char *)"/usr/bin/dbx";
             if ((cf = fopen(cfname, "wb+")) == 0)
               cfname[0] = '\0';
             else
@@ -4972,7 +4972,7 @@ void TR_Debug::setupDebugger(void *addr)
                fprintf(cf, "cont SIGCONT\n");
                fclose(cf);
 
-               Argv[3] = "-c";
+               Argv[3] = (char *)"-c";
                Argv[4] = cfname;
                Argv[5] = NULL;
               }

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -481,10 +481,10 @@ public:
    virtual void            clearFilters(TR::CompilationFilters *);
    void                    clearFilters(bool loadLimit);
    virtual bool            scanInlineFilters(FILE *, int32_t &, TR::CompilationFilters *);
-   virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, TR::CompilationFilters *);
-   virtual TR_FilterBST *  addFilter(char * &, int32_t, int32_t, int32_t, bool loadLimit);
+   virtual TR_FilterBST *  addFilter(const char *&, int32_t, int32_t, int32_t, TR::CompilationFilters *);
+   virtual TR_FilterBST *  addFilter(const char *&, int32_t, int32_t, int32_t, bool loadLimit);
    virtual TR_FilterBST *  addExcludedMethodFilter(bool loadLimit);
-   virtual int32_t         scanFilterName(char *, TR_FilterBST *);
+   virtual int32_t         scanFilterName(const char *, TR_FilterBST *);
    virtual void            printFilters(TR::CompilationFilters *);
    virtual void            printFilters();
    virtual void            print(TR_FilterBST * filter);

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -463,11 +463,11 @@ public:
    virtual int32_t         findLogFile(const char *logFileName, TR::Options *aotCmdLineOptions, TR::Options *jitCmdLineOptions, TR::Options **optionsArray, int32_t arraySize);
    virtual void            dumpOptionHelp(TR::OptionTable *jitOptions, TR::OptionTable *feOptions, TR::SimpleRegex *nameFilter);
 
-   static void dumpOptions(char *optionsType, char *options, char *envOptions, TR::Options *cmdLineOptions, TR::OptionTable *jitOptions, TR::OptionTable *feOptions, void *, TR_FrontEnd *);
-   virtual char *          limitfileOption(char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr = 0);
-   virtual char *          inlinefileOption(char *, void *, TR::OptionTable *, TR::Options *);
-   virtual char *          limitOption(char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit);
-   char *                  limitOption(char *, void *, TR::OptionTable *, TR::Options *, TR::CompilationFilters * &);
+   static void dumpOptions(const char *optionsType, const char *options, const char *envOptions, TR::Options *cmdLineOptions, TR::OptionTable *jitOptions, TR::OptionTable *feOptions, void *, TR_FrontEnd *);
+   virtual const char *    limitfileOption(const char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr = 0);
+   virtual const char *    inlinefileOption(const char *, void *, TR::OptionTable *, TR::Options *);
+   virtual const char *    limitOption(const char *, void *, TR::OptionTable *, TR::Options *, bool loadLimit);
+   const char *            limitOption(const char *, void *, TR::OptionTable *, TR::Options *, TR::CompilationFilters * &);
    virtual int32_t *       loadCustomStrategy(char *optFileName);
    virtual bool            methodCanBeCompiled(TR_Memory *mem, TR_ResolvedMethod *, TR_FilterBST * &);
    virtual bool            methodCanBeRelocated(TR_Memory *mem, TR_ResolvedMethod *, TR_FilterBST * &);

--- a/compiler/ras/ILValidationRules.cpp
+++ b/compiler/ras/ILValidationRules.cpp
@@ -269,7 +269,7 @@ void TR::ValidateLivenessBoundaries::updateNodeState(TR::Node *node,
       if (!liveNodes.isEmpty())
          {
          traceMsg(comp(), "    -- Live nodes: {");
-         char *separator = "";
+         const char *separator = "";
          for (TR::LiveNodeWindow::Iterator lnwi(liveNodes); lnwi.currentNode(); ++lnwi)
             {
             traceMsg(comp(), "%sn%dn", separator,

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -322,12 +322,12 @@ TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::Compila
  *     The unmodified parameter option if there is a problem with the file, aborting JIT initialization.
  *     Otherwise a pointer to the next comma or NULL.
  */
-char *
-TR_Debug::inlinefileOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions)
+const char *
+TR_Debug::inlinefileOption(const char *option, void *base, TR::OptionTable *entry, TR::Options *cmdLineOptions)
    {
-   char *endOpt = option;
-   char *name = option;
-   char *fail = option;
+   const char *endOpt = option;
+   const char *name = option;
+   const char *fail = option;
 
    // move to the end of this option
    for (; *endOpt && *endOpt != ','; endOpt++)
@@ -406,12 +406,12 @@ TR_Debug::inlinefileOption(char *option, void *base, TR::OptionTable *entry, TR:
  *     The unmodified parameter option if there is a problem with the file, aborting JIT initialization.
  *     Otherwise a pointer to the next comma or NULL.
  */
-char *
-TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr)
+const char *
+TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr)
    {
-   char *endOpt = option;
-   char *name = option;
-   char *fail = option;
+   char *endOpt = (char *)option;
+   const char *name = option;
+   const char *fail = option;
 
    bool range = false;
    if (*endOpt == '(')
@@ -611,10 +611,10 @@ TR_Debug::limitfileOption(char *option, void *base, TR::OptionTable *entry, TR::
    return endOpt;
    }
 
-char *
-TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, TR::CompilationFilters *&filters)
+const char *
+TR_Debug::limitOption(const char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, TR::CompilationFilters *&filters)
    {
-   char *p = option;
+   char *p = (char *)option;
 
    filters = findOrCreateFilters(filters);
    TR_FilterBST *filter = addFilter(p, static_cast<int32_t>(entry->parm1), 0, 0, filters);
@@ -682,8 +682,8 @@ TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Opti
    return p;
    }
 
-char *
-TR_Debug::limitOption(char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit)
+const char *
+TR_Debug::limitOption(const char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit)
    {
    if (loadLimit)
       {

--- a/compiler/ras/LimitFile.cpp
+++ b/compiler/ras/LimitFile.cpp
@@ -102,7 +102,7 @@ TR_Debug::findOrCreateFilters(bool loadLimit)
    }
 
 TR_FilterBST *
-TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, TR::CompilationFilters * anyFilters)
+TR_Debug::addFilter(const char *& filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, TR::CompilationFilters * anyFilters)
    {
    uint32_t filterType = scanningExclude ? TR_FILTER_EXCLUDE_NAME_ONLY : TR_FILTER_NAME_ONLY;
 
@@ -115,7 +115,7 @@ TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t opti
    int32_t nameLength;
    if (*filterString == '{')
       {
-      char *filterCursor = filterString;
+      const char *filterCursor = filterString;
       filterType = scanningExclude ? TR_FILTER_EXCLUDE_REGEX : TR_FILTER_REGEX;
       filterBST->setFilterType(filterType);
 
@@ -184,7 +184,7 @@ TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t opti
    }
 
 TR_FilterBST *
-TR_Debug::addFilter(char * & filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, bool loadLimit)
+TR_Debug::addFilter(const char *& filterString, int32_t scanningExclude, int32_t optionSetIndex, int32_t lineNum, bool loadLimit)
    {
    if (loadLimit)
       {
@@ -254,7 +254,7 @@ TR_Debug::scanInlineFilters(FILE * inlineFile, int32_t & lineNumber, TR::Compila
          }
       else if (includeFlag == '+' || includeFlag == '-')
          {
-         char *p = limitReadBuffer+1;
+         const char *p = limitReadBuffer + 1;
          int32_t optionSet;
          if (*p >= '0' && *p <= '9')
             optionSet = *(p++) - '0';
@@ -409,7 +409,7 @@ TR_Debug::inlinefileOption(const char *option, void *base, TR::OptionTable *entr
 const char *
 TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, bool loadLimit, TR_PseudoRandomNumbersListElement **pseudoRandomListHeadPtr)
    {
-   char *endOpt = (char *)option;
+   const char *endOpt = option;
    const char *name = option;
    const char *fail = option;
 
@@ -470,7 +470,7 @@ TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry
          char includeFlag = limitReadBuffer[0];
          if (strncmp(limitReadBuffer,"-precompileMethod",17) == 0)
             {
-            char *p = limitReadBuffer+18;
+            const char *p = limitReadBuffer + 18;
             if (!addFilter(p, 0, 0, lineNumber, loadLimit))
                {
                limitFileError = true;
@@ -479,7 +479,7 @@ TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry
             }
          else if (strncmp(limitReadBuffer,"-noprecompileMethod",19) == 0)
             {
-            char *p = limitReadBuffer+20;
+            const char *p = limitReadBuffer + 20;
             if (!addFilter(p, 1, 0, lineNumber, loadLimit))
                {
                limitFileError = true;
@@ -488,7 +488,7 @@ TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry
             }
          else if (includeFlag == '+' || includeFlag == '-')
             {
-            char *p = limitReadBuffer+1;
+            const char *p = limitReadBuffer + 1;
             int32_t optionSet;
             if (*p >= '0' && *p <= '9')
                optionSet = *(p++) - '0';
@@ -614,7 +614,7 @@ TR_Debug::limitfileOption(const char *option, void *base, TR::OptionTable *entry
 const char *
 TR_Debug::limitOption(const char *option, void *base, TR::OptionTable *entry, TR::Options * cmdLineOptions, TR::CompilationFilters *&filters)
    {
-   char *p = (char *)option;
+   const char *p = option;
 
    filters = findOrCreateFilters(filters);
    TR_FilterBST *filter = addFilter(p, static_cast<int32_t>(entry->parm1), 0, 0, filters);
@@ -651,7 +651,7 @@ TR_Debug::limitOption(const char *option, void *base, TR::OptionTable *entry, TR
       // If an option subset was found, save the information for later
       // processing
       //
-      char *startOptString = ++p;
+      const char *startOptString = ++p;
       int32_t parenNest = 1;
       for (; *p; p++)
          {
@@ -931,7 +931,7 @@ TR_Debug::printFilterTree(TR_FilterBST *root)
    }
 
 int32_t
-TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
+TR_Debug::scanFilterName(const char *string, TR_FilterBST *filter)
    {
    // help for OMR parsing
    bool seenFileName = false;
@@ -941,11 +941,11 @@ TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
    // Walk the filter to determine the type.
    //
    //TR_VerboseLog::writeLine("filterName: %s", string);
-   char *nameChars = NULL;
+   const char *nameChars = NULL;
    int32_t nameLen = 0;
-   char *classChars = NULL;
+   const char *classChars = NULL;
    int32_t classLen = 0;
-   char *signatureChars = string;
+   const char *signatureChars = string;
    int32_t signatureLen = 0;
    char  filterType = filter->getFilterType();
    if (*string == '/' || *string == '.') // hack that works for linux
@@ -1027,7 +1027,7 @@ TR_Debug::scanFilterName(char *string, TR_FilterBST *filter)
    if (omrPattern)
       {
       // need to swap name and signature, since name is currently the line number
-      char *tempChars = nameChars;
+      const char *tempChars = nameChars;
       int32_t tempLen = nameLen;
       nameChars = signatureChars;
       nameLen = signatureLen;

--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -50,16 +50,16 @@
 #define DEFAULT_OPTION_LINE_WIDTH  80
 
 static char  optionCategories[] = {' ','C','O','L','D','R','I','M',0}; // Must match categories[] in codegen.dev/Options.cpp
-static char *optionCategoryNames[] = {"\nGeneral options:\n",
-                                      "\nCode generation options:\n",
-                                      "\nOptimization options:\n",
-                                      "\nLogging and display options:\n",
-                                      "\nDebugging options:\n",
-                                      "\nRecompilation and profiling options:\n",
-                                      "\nInternal options:\n",
-                                      "\nOther options:\n",
-                                      0 // Fail quickly if we run past the end of this array
-                                      };
+static const char *optionCategoryNames[] = {"\nGeneral options:\n",
+                                            "\nCode generation options:\n",
+                                            "\nOptimization options:\n",
+                                            "\nLogging and display options:\n",
+                                            "\nDebugging options:\n",
+                                            "\nRecompilation and profiling options:\n",
+                                            "\nInternal options:\n",
+                                            "\nOther options:\n",
+                                            0 // Fail quickly if we run past the end of this array
+                                           };
 
 
 
@@ -280,9 +280,9 @@ void TR_Debug::dumpOptionHelp(TR::OptionTable * firstOjit, TR::OptionTable * fir
 
 void
 TR_Debug::dumpOptions(
-      char *optionsType,
-      char *options,
-      char *envOptions,
+      const char *optionsType,
+      const char *options,
+      const char *envOptions,
       TR::Options *cmdLineOptions,
       TR::OptionTable *ojit,
       TR::OptionTable *ofe,
@@ -493,7 +493,7 @@ TR_Debug::dumpOptions(
             //since java uses different function, we need to check for that to get our verbose options printed
             TR_VerboseLog::write("{");
             base = (char*)cmdLineOptions;
-            char *sep = "";
+            const char *sep = "";
             for (int i=0; i < TR_NumVerboseOptions; i++)
                {
                TR_VerboseFlags flag = (TR_VerboseFlags)i;

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1729,7 +1729,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          {
          output.appends("   ; array type is ");
 
-         char *typeStr;
+         const char *typeStr;
          switch (node->getInt())
             {
             case 4:

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -955,7 +955,7 @@ OMR::CodeCache::addFreeBlock(void * metaData)
 bool
 OMR::CodeCache::addFreeBlock2WithCallSite(uint8_t *start,
                                         uint8_t *end,
-                                        char *file,
+                                        const char *file,
                                         uint32_t lineNumber)
    {
    TR::CodeCacheConfig &config = _manager->codeCacheConfig();

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -229,7 +229,7 @@ private:
 public:
    bool                       addFreeBlock2WithCallSite(uint8_t *start,
                                                         uint8_t *end,
-                                                        char *file,
+                                                        const char *file,
                                                         uint32_t lineNumber);
 
    /**

--- a/compiler/runtime/OMRRuntimeAssumptions.hpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.hpp
@@ -243,7 +243,7 @@ class RuntimeAssumption
    virtual TR_UnloadedClassPicSite  *asUCPSite() { return 0; }
    virtual TR_RedefinedClassPicSite *asRCPSite() { return 0; }
    virtual TR_PatchJNICallSite      *asPJNICSite() { return 0; }
-   void dumpInfo(char *subclassName);
+   void dumpInfo(const char *subclassName);
    virtual void dumpInfo() = 0;
    virtual TR_RuntimeAssumptionKind getAssumptionKind() = 0;
    virtual RuntimeAssumptionCategory getAssumptionCategory() = 0;


### PR DESCRIPTION
Work towards fixing AIX warnings about assigning string literals to non-const char pointers by adding 'const' qualifiers to some string variables and parameters (or worst case scenario, casting to (char *)) in compile, runtime, control, ras, and infra.

This PR contributes to (but does not close) https://github.com/eclipse-openj9/openj9/issues/14859

**This PR depends on:**

- **Step 1:**
    - https://github.com/eclipse-openj9/openj9/pull/18083
    - https://github.com/eclipse-openj9/openj9/pull/18455
- **Step 2:**
    - https://github.com/eclipse-openj9/openj9/pull/18467
    - https://github.com/eclipse/omr/pull/7186

**and must be merged in coordination with https://github.com/eclipse-openj9/openj9/pull/18470**