### PR TITLE
Update Port.cpp and omrsharedhelper.c to fix gcc11 compilation

### DIFF
--- a/port/unix/omrsharedhelper.c
+++ b/port/unix/omrsharedhelper.c
@@ -416,7 +416,7 @@ omr_unlinkControlFile(struct OMRPortLibrary* portLibrary, const char *controlFil
 	if (msgLen + 1 > sizeof(originalErrMsg)) {
 		msgLen = sizeof(originalErrMsg) - 1;
 	}
-	strncpy(originalErrMsg, currentErrMsg, msgLen);
+	memcpy(originalErrMsg, currentErrMsg, msgLen);
 	originalErrMsg[msgLen] = '\0';
 	if (-1 == omrfile_unlink(portLibrary, controlFile)) {
 		/* If an error occurred during unlinking, store the unlink error code in 'controlFileStatus' if available,

--- a/tools/tracegen/Port.cpp
+++ b/tools/tracegen/Port.cpp
@@ -684,11 +684,11 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 	if (statfs(path, &statfsbuf)) {
 		return RC_FAILED;
 	}
-	switch (statfsbuf.f_type) {
+	switch ((unsigned int)statfsbuf.f_type) {
 	/* Detect remote filesystem types */
-	case 0x6969: /* NFS_SUPER_MAGIC */
-	case 0x517B: /* SMB_SUPER_MAGIC */
-	case 0xFF534D42: /* CIFS_MAGIC_NUMBER */
+	case 0x6969u: /* NFS_SUPER_MAGIC */
+	case 0x517Bu: /* SMB_SUPER_MAGIC */
+	case 0xFF534D42u: /* CIFS_MAGIC_NUMBER */
 		buf->isRemote = 1;
 		break;
 	default:


### PR DESCRIPTION
The code fails to compile on zlinux with gcc 11.2 without fixes.
```
Port.cpp: In static member function 'static RCType
Port::omrfile_stat(const char*, unsigned int, J9FileStat*)':
Port.cpp:691:14: error: narrowing conversion of '4283649346' from
'unsigned int' to 'int'
[https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wnarrowing]
  691 |         case 0xFF534D42: /* CIFS_MAGIC_NUMBER */
      |              ^~~~~~~~~~
```

This one fails to compile on 32-bit.
```
In file included from /usr/include/string.h:637,
                 from ./unix/omrsharedhelper.c:34:
./unix/omrsharedhelper.c: In function 'omr_unlinkControlFile':
./unix/omrsharedhelper.c:419:9: error: '__builtin_strncpy' specified
bound depends on the length of the source argument
[https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation]
  419 |         strncpy(originalErrMsg, currentErrMsg, msgLen);
      |         ^~~~~~~
./unix/omrsharedhelper.c:413:26: note: length computed here
  413 |         int32_t msgLen = strlen(currentErrMsg);
      |                          ^~~~~~~~~~~~~~~~~~~~~
```