### PR TITLE
Refactor Binary Identity Simplification Macro

### DIFF
--- a/compiler/optimizer/OMRSimplifierHelpers.hpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.hpp
@@ -58,17 +58,6 @@ enum {XXCMP_EQ = 0, XXCMP_LT = 1, XXCMP_GT = 2};
     }                                                                   \
 }
 
-//**************************************
-// Binary identity operation
-//
-// If the second child is a constant that represents an identity operation,
-// replace this node with the first child.
-//
-#define BINARY_IDENTITY_OP(Type,NullValue)               \
-   if (secondChild->getOpCode().isLoadConst() && secondChild->get##Type() == NullValue) \
-      return s->replaceNode(node, firstChild, s->_curTree);
-
-
 /*
  * Helper functions needed by simplifier handlers across projects
  */


### PR DESCRIPTION
This commit cleans up the BINARY_IDENTITY_OP and
BIANRY_IDENTITY_OR_ZERO macros and replaces them
with inline equivalents by implementing a struct to replace template
instantions of the functions tryAndSimplifyBinaryOp*.

This change limits the number of template instantiations
potential call sites have to create as well as abstracts
some captured variables inside the struct to minimize
the number of arguments passed to actual calls.

A closure is emulated by the struct.
Through escape analysis, scalar replacement and inlining,
the overhead of creating this struct should be minimal
on -O3

Related: https://github.com/eclipse/omr/issues/7166

Signed-off-by: James You <james.you@protonmail.com>