### PR TITLE
Z: Support NaN values w.r.t fmax/fmin/dmax/dmin on S390

### DIFF
--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -203,8 +203,7 @@ TEST_P(FloatMaxMin, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if (std::isnan(param.lhs) || std::isnan(param.rhs)) {
-       SKIP_ON_S390(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
-       SKIP_ON_S390X(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
+       SKIP_ON_ZOS(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
     }
 
     char inputTrees[1024] = {0};
@@ -238,8 +237,7 @@ TEST_P(FloatMaxMin, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     if (std::isnan(param.lhs) || std::isnan(param.rhs)) {
-       SKIP_ON_S390(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
-       SKIP_ON_S390X(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
+       SKIP_ON_ZOS(KnownBug) << "fmin / fmax returns wrong value for NaN on Z (see issue #5157)";
     }
 
     char inputTrees[1024] = {0};
@@ -281,8 +279,7 @@ TEST_P(DoubleMaxMin, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     if (std::isnan(param.lhs) || std::isnan(param.rhs)) {
-       SKIP_ON_S390(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
-       SKIP_ON_S390X(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
+       SKIP_ON_ZOS(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
     }
 
     char inputTrees[1024] = {0};
@@ -316,9 +313,7 @@ TEST_P(DoubleMaxMin, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     if (std::isnan(param.lhs) || std::isnan(param.rhs)) {
-       SKIP_ON_S390(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
-       SKIP_ON_S390X(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
-
+       SKIP_ON_ZOS(KnownBug) << "dmin / dmax returns wrong value for NaN on Z (see issue #5157)";
     }
 
     char inputTrees[1024] = {0};


### PR DESCRIPTION
This PR adds support to the S390 MaxMin evaluator to handle NaN operands for [fd]min/max opcodes.

- Add NaN checks and set return register to NaN if either operands are NaN
- Enable MaxMin tests for Float/Double on LoZ, and disable them on z/OS

Closes: #5157

Signed-off-by: Sarwat Shaheen sarwat.shaheen@yahoo.com