### PR TITLE
Introduce flag gcThreadsCountSpecified

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -447,13 +447,14 @@ MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
+	/* to be checked against gcThreadCountSpecified, once downstream projects properly set it */
 	if (!extensions->gcThreadCountForced) {
-		extensions->gcThreadCount = supportedGCThreadCount(env);
+		extensions->gcThreadCount = defaultGCThreadCount(env);
 	}
 }
 
 uintptr_t
-MM_Configuration::supportedGCThreadCount(MM_EnvironmentBase* env)
+MM_Configuration::defaultGCThreadCount(MM_EnvironmentBase* env)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	uintptr_t threadCount = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_TARGET);

--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -144,8 +144,8 @@ public:
 
 	virtual void kill(MM_EnvironmentBase* env);
 
-	/* Number of GC threads supported based on hardware and dispatcher's max. */
-	virtual uintptr_t supportedGCThreadCount(MM_EnvironmentBase* env);
+	/* Default number of GC threads based on h/w, os and container limits */
+	virtual uintptr_t defaultGCThreadCount(MM_EnvironmentBase* env);
 
 	/**
 	 * Sets the number of gc threads

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -465,9 +465,9 @@ public:
 #endif /* defined(OMR_GC_BATCH_CLEAR_TLH) */
 	omrthread_monitor_t gcStatsMutex;
 	uintptr_t gcThreadCount; /**< Initial number of GC threads - chosen default or specified in java options*/
-	bool gcThreadCountForced; /**< true if number of GC threads is specified in java options. Currently we have a few ways to do this:
-										-Xgcthreads		-Xthreads= (RT only)	-XthreadCount= */
-	uintptr_t dispatcherHybridNotifyThreadBound; /** Bound for determining hybrid notification type (Individual notifies for count < MIN(bound, maxThreads/2), otherwise notify_all) */
+	bool gcThreadCountSpecified; /**< true if number of GC threads is specified in command line options. */
+	bool gcThreadCountForced; /**< true if user forced a fixed number of GC threads. Default is false, but a command line option could set it if not wanting adaptive threading */
+	uintptr_t dispatcherHybridNotifyThreadBound; /**< Bound for determining hybrid notification type (Individual notifies for count < MIN(bound, maxThreads/2), otherwise notify_all) */
 
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	enum ScavengerScanOrdering {
@@ -1657,6 +1657,7 @@ public:
 		, batchClearTLH(0)
 #endif /* defined(OMR_GC_BATCH_CLEAR_TLH) */
 		, gcThreadCount(0)
+		, gcThreadCountSpecified(false)
 		, gcThreadCountForced(false)
 		, dispatcherHybridNotifyThreadBound(16)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -494,7 +494,7 @@ MM_ParallelDispatcher::adjustThreadCount(uintptr_t maxThreadCount)
 {
 	uintptr_t toReturn = maxThreadCount;
 	
-	/* Did user specify number of gc threads? */
+	/* Did user force a fixed number of gc threads? */
 	if (!_extensions->gcThreadCountForced) {
 		/* No ...Use a sensible number of threads for current heap size. Using too many 
 		 * can lead to unacceptable pause times due to insufficient parallelism. Additionally,
@@ -733,7 +733,7 @@ MM_ParallelDispatcher::expandThreadPool(MM_EnvironmentBase *env)
 
 	Trc_MM_ParallelDispatcher_expandThreadPool_params(
 			newThreadCount, _poolMaxCapacity,
-			_extensions->configuration->supportedGCThreadCount(env), preExpandThreadCount);
+			_extensions->configuration->defaultGCThreadCount(env), preExpandThreadCount);
 
 	result = reinitializeThreadPool(env, newThreadCount);
 

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1007,7 +1007,7 @@ TraceEntry=Trc_MM_DoFixHeapForCompact_Entry Overhead=1 Level=1 Template="Trc_MM_
 TraceExit=Trc_MM_DoFixHeapForCompact_Exit Overhead=1 Level=1 Template="Trc_MM_DoFixHeapForCompact Exit after fixing up %zu objects"
 
 TraceEntry=Trc_MM_ParallelDispatcher_expandThreadPool_Entry noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool Entry"
-TraceEvent=Trc_MM_ParallelDispatcher_expandThreadPool_params noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool_params: newThreadCount: %zu, _threadCountMaximumAtCheckpointStartup: %zu, supportedGCThreadCount: %zu, preExpandThreadCount: %zu"
+TraceEvent=Trc_MM_ParallelDispatcher_expandThreadPool_params noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool_params: newThreadCount: %zu, _threadCountMaximumAtCheckpointStartup: %zu, defaultGCThreadCount: %zu, preExpandThreadCount: %zu"
 TraceExit=Trc_MM_ParallelDispatcher_expandThreadPool_Exit noEnv Overhead=1 Level=1 Group=dispatcher Template="expandThreadPool Exit: preExpandThreadCount: %zu, gcThreadCount: %zu, _threadShutdownCount: %zu"
 
 TraceEntry=Trc_MM_ParallelDispatcher_contractThreadPool_Entry noEnv Overhead=1 Level=1 Group=dispatcher Template="contractThreadPool Entry: gcThreadCount: %zu, requested newThreadCount: %zu"


### PR DESCRIPTION
This flag is to be used along existing gcThreadCountForced. Specified
flag will be used to distinguish between GC thread count calculated by
default or specified by a command line option. Forced flag
will to be used for a subset of options that force a fixed number of
threads.

Currently Forced is used as Specified, but we need both to distinguish
among 3 posibilities, specifically in Java: default, Xgcthreads and
Xgcmaxthreads.

Changes that will make that behavior effective will follow up later,
once downstream projects properly adjust command line parsing and
setting these flags.