### PR TITLE
Add AArch64 to UtProcessorInfo

### DIFF
--- a/include_core/ute_dataformat.h
+++ b/include_core/ute_dataformat.h
@@ -117,6 +117,7 @@ typedef enum {
 	UT_TREX,
 	UT_OPTERON,
 	UT_RV64G,
+	UT_ARMV8A,
 	UT_SUBTYPE_FORCE_INTEGER = INT_MAX
 } UtSubtype;
 
@@ -147,6 +148,7 @@ typedef enum {
 	UT_S390X,
 	UT_AMD64,
 	UT_RISCV,
+	UT_AARCH64,
 	UT_ARCHITECTURE_FORCE_INTEGER = INT_MAX
 } UtArchitecture;
 

--- a/omrtrace/omrtracelog.cpp
+++ b/omrtrace/omrtracelog.cpp
@@ -1256,6 +1256,9 @@ getProcessorInfo(void)
 		} else if (0 == strcmp(osarch, OMRPORT_ARCH_RISCV)) {
 			ret->architecture = UT_RISCV;
 			ret->procInfo.subtype = UT_RV64G;
+		} else if (0 == strcmp(osarch, OMRPORT_ARCH_AARCH64)) {
+			ret->architecture = UT_AARCH64;
+			ret->procInfo.subtype = UT_ARMV8A;
 		} else {
 			ret->architecture = UT_UNKNOWN;
 		}


### PR DESCRIPTION
This commit adds AArch64 to UtArchitecture and Armv8-A to UtSubtype.