### PR TITLE
Use gcThreadCountSpecified

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -447,8 +447,7 @@ MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 
-	/* to be checked against gcThreadCountSpecified, once downstream projects properly set it */
-	if (!extensions->gcThreadCountForced) {
+	if (!extensions->gcThreadCountSpecified) {
 		extensions->gcThreadCount = defaultGCThreadCount(env);
 	}
 }

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -701,7 +701,6 @@ MM_ParallelDispatcher::contractThreadPool(MM_EnvironmentBase *env, uintptr_t new
 
 		Assert_MM_true(_threadShutdownCount == expectedThreadShutdownThread);
 
-		_extensions->gcThreadCount = newThreadCount;
 		_activeThreadCount = newThreadCount;
 		_threadCount = newThreadCount;
 		_threadCountMaximum = newThreadCount;
@@ -748,7 +747,6 @@ MM_ParallelDispatcher::expandThreadPool(MM_EnvironmentBase *env)
 				newThreadCount = _threadShutdownCount + 1;
 			}
 
-			_extensions->gcThreadCount = newThreadCount;
 			_threadCount = newThreadCount;
 			_threadCountMaximum = newThreadCount;
 		}


### PR DESCRIPTION
Make use of newly introduced gcThreadCountSpecified flag so that when command line options (such as Java's -Xgcthreads or -Xgcmaxthreads) are specified, GC thread count overrides the default count calculation.

Old gcThreadCountForced flag is still used, butin ParallelDispatcher to distinguish between force/fixed or adaptive count of threads, bufore deciding how many threads to use for a ParallelTask.

Another change is that during the snapshot VM creation when thread count is reduced to checkpointGCthreadCount, we don't adjust GCExtensions gcThreadCount anymore (only ParallelDispatcher is affected). This is to be able to carry over the original count (from snapshot VM) to restore VM, so that options that specify that count can be obeyed even on restore side.