### PR TITLE
Disable PortSockTest tests that fail on Azure MacOSX

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,6 +196,7 @@ jobs:
       vmImage: 'macOS-latest'
     variables:
       CCACHE_DIR: $(Pipeline.Workspace)/ccache
+      GTEST_FILTER: -*.poll_functionality_basic:*poll_functionality_many_sockets
     steps:
       - script: |
           brew install ccache


### PR DESCRIPTION
These tests pass on the Jenkins MacOSX machines, but intermittently
fail on Azure MacOSX due to machine/network issues.

Related: #6516