### PR TITLE
Add flag to indicate compile time is not that important

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -302,7 +302,7 @@ enum TR_CompilationOptions
    TR_DisableDelayRelocationForAOTCompilations   = 0x00000200 + 7,
    TR_DisableRecompDueToInlinedMethodRedefinition = 0x00000400 + 7,
    TR_DisableLoopReplicatorColdSideEntryCheck = 0x00000800 + 7,
-   // Available                           = 0x00001000 + 7,
+   TR_NotCompileTimeSensitive             = 0x00001000 + 7, // Can afford to spend more time compiling
    TR_DontDowgradeToColdDuringGracePeriod = 0x00002000 + 7,
    TR_EnableRecompilationPushing          = 0x00004000 + 7,
    TR_EnableJCLInline                     = 0x00008000 + 7, // enable JCL Integer and Long methods inline

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1551,6 +1551,12 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             doThisOptimization = true;
          }
          break;
+      case IfLoopsAndNotCompileTimeSensitive:
+         {
+         if (comp()->mayHaveLoops() && comp()->getOption(TR_NotCompileTimeSensitive))
+            doThisOptimization = true;
+         }
+         break;
       case MarkLastRun:
          doThisOptimization = true;
          TR_ASSERT(optNum < OMR::numOpts ,"No current support for marking groups as last (optNum=%d,numOpt=%d\n",optNum,OMR::numOpts); //make sure we didn't mark groups

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -135,6 +135,7 @@ enum
    IfAggressiveLiveness,
    IfVectorAPI,  // JEP414: Extra analysis required to optimize Vector API
    IfExceptionHandlers,
+   IfLoopsAndNotCompileTimeSensitive, // If loops and compile time is not that important
    MarkLastRun
    };
 


### PR DESCRIPTION
This commit adds a new option bit called TR_NotCompileTimeSensitive which will be turned on by an upstream project (OpenJ9) in situations where we favor throughput over compile time.
The commit also adds a new optimization qualifier, `IfLoopsAndNotCompileTimeSensitive`. An optimization pass flagged as such will be performed only if the method being compiled has loops and the `TR_NotCompileTimeSensitive` bit is turned on.