### PR TITLE
Prevent commoning conversion to address operations in LocalCSE

### DIFF
--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -1186,7 +1186,7 @@ bool OMR::LocalCSE::canBeAvailable(TR::Node *parent, TR::Node *node, TR_BitVecto
    if (node->getOpCodeValue() == TR::allocationFence)
       return false;
 
-   if (node->getOpCodeValue() == TR::l2a)
+   if (node->getOpCode().isConversion() && node->getOpCode().isRef())
       return false;
 
    if (node->getOpCode().isLoadReg() || node->getOpCode().isStoreReg() || (node->getOpCodeValue() == TR::PassThrough && parent->getOpCodeValue() != TR::GlRegDeps) || (node->getOpCodeValue() == TR::GlRegDeps))


### PR DESCRIPTION
`OMR::LocalCSE::canBeAvailable` was restricting `l2a` operations from being commoned to reduce the likelihood that a register holding the result of such an operation would be marked as a collected reference and kept live across a GC point by l2aEvaluator.  To be safest, all conversion to address types should be similarly prevented from being commoned.

This change generalizes the change delivered under pull request #7217.