### PR TITLE
Add API to recognize methods that do not access flattened arrays

### DIFF
--- a/compiler/il/OMRMethodSymbol.hpp
+++ b/compiler/il/OMRMethodSymbol.hpp
@@ -193,6 +193,7 @@ public:
    bool safeToSkipCheckCasts() { return false; }
    bool safeToSkipArrayStoreChecks() { return false; }
    bool safeToSkipNonNullableArrayNullStoreCheck() { return false; }
+   bool safeToSkipFlattenableArrayElementNonHelperCall() { return false; }
    bool safeToSkipZeroInitializationOnNewarrays() { return false; }
    bool safeToSkipChecksOnArrayCopies() { return false; }
 

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -194,14 +194,15 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    self()->setParameterList();
 
-   _properties.set(CanSkipNullChecks                    , self()->safeToSkipNullChecks());
-   _properties.set(CanSkipBoundChecks                   , self()->safeToSkipBoundChecks());
-   _properties.set(CanSkipCheckCasts                    , self()->safeToSkipCheckCasts());
-   _properties.set(CanSkipDivChecks                     , self()->safeToSkipDivChecks());
-   _properties.set(CanSkipArrayStoreChecks              , self()->safeToSkipArrayStoreChecks());
-   _properties.set(CanSkipNonNullableArrayNullStoreCheck, self()->safeToSkipNonNullableArrayNullStoreCheck());
-   _properties.set(CanSkipChecksOnArrayCopies           , self()->safeToSkipChecksOnArrayCopies());
-   _properties.set(CanSkipZeroInitializationOnNewarrays , self()->safeToSkipZeroInitializationOnNewarrays());
+   _properties.set(CanSkipNullChecks                          , self()->safeToSkipNullChecks());
+   _properties.set(CanSkipBoundChecks                         , self()->safeToSkipBoundChecks());
+   _properties.set(CanSkipCheckCasts                          , self()->safeToSkipCheckCasts());
+   _properties.set(CanSkipDivChecks                           , self()->safeToSkipDivChecks());
+   _properties.set(CanSkipArrayStoreChecks                    , self()->safeToSkipArrayStoreChecks());
+   _properties.set(CanSkipNonNullableArrayNullStoreCheck      , self()->safeToSkipNonNullableArrayNullStoreCheck());
+   _properties.set(CanSkipFlattenableArrayElementNonHelperCall, self()->safeToSkipFlattenableArrayElementNonHelperCall());
+   _properties.set(CanSkipChecksOnArrayCopies                 , self()->safeToSkipChecksOnArrayCopies());
+   _properties.set(CanSkipZeroInitializationOnNewarrays       , self()->safeToSkipZeroInitializationOnNewarrays());
    }
 
 

--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -263,14 +263,15 @@ public:
    bool canReplaceWithHWInstr()              { return _properties.testAny(CanReplaceWithHWInstr); }
    void setCanReplaceWithHWInstr(bool b)     { _properties.set(CanReplaceWithHWInstr,b); }
 
-   bool skipNullChecks()                     { return _properties.testAny(CanSkipNullChecks); }
-   bool skipBoundChecks()                    { return _properties.testAny(CanSkipBoundChecks); }
-   bool skipCheckCasts()                     { return _properties.testAny(CanSkipCheckCasts); }
-   bool skipDivChecks()                      { return _properties.testAny(CanSkipDivChecks); }
-   bool skipArrayStoreChecks()               { return _properties.testAny(CanSkipArrayStoreChecks); }
-   bool skipNonNullableArrayNullStoreCheck() { return _properties.testAny(CanSkipNonNullableArrayNullStoreCheck); }
-   bool skipChecksOnArrayCopies()            { return _properties.testAny(CanSkipChecksOnArrayCopies); }
-   bool skipZeroInitializationOnNewarrays()  { return _properties.testAny(CanSkipZeroInitializationOnNewarrays); }
+   bool skipNullChecks()                           { return _properties.testAny(CanSkipNullChecks); }
+   bool skipBoundChecks()                          { return _properties.testAny(CanSkipBoundChecks); }
+   bool skipCheckCasts()                           { return _properties.testAny(CanSkipCheckCasts); }
+   bool skipDivChecks()                            { return _properties.testAny(CanSkipDivChecks); }
+   bool skipArrayStoreChecks()                     { return _properties.testAny(CanSkipArrayStoreChecks); }
+   bool skipNonNullableArrayNullStoreCheck()       { return _properties.testAny(CanSkipNonNullableArrayNullStoreCheck); }
+   bool skipFlattenableArrayElementNonHelperCall() { return _properties.testAny(CanSkipFlattenableArrayElementNonHelperCall); }
+   bool skipChecksOnArrayCopies()                  { return _properties.testAny(CanSkipChecksOnArrayCopies); }
+   bool skipZeroInitializationOnNewarrays()        { return _properties.testAny(CanSkipZeroInitializationOnNewarrays); }
 
    bool hasSnapshots()                       { return _properties.testAny(HasSnapshots); }
    void setHasSnapshots(bool v=true)         { _properties.set(HasSnapshots,v); }
@@ -329,23 +330,24 @@ public:
 protected:
    enum Properties
       {
-      CanSkipNullChecks                         = 1 << 0,
-      CanSkipBoundChecks                        = 1 << 1,
-      CanSkipCheckCasts                         = 1 << 2,
-      CanSkipDivChecks                          = 1 << 3,
-      CanSkipChecksOnArrayCopies                = 1 << 4,
-      CanSkipZeroInitializationOnNewarrays      = 1 << 5,
-      CanSkipArrayStoreChecks                   = 1 << 6,
-      HasSnapshots                              = 1 << 7,
-      CanSkipNonNullableArrayNullStoreCheck     = 1 << 8,
-      CanDirectNativeCall                       = 1 << 9,
-      CanReplaceWithHWInstr                     = 1 << 10,
-      IsSideEffectFree                          = 1 << 12,
-      IsLeaf                                    = 1 << 13,
-      FoundThrow                                = 1 << 14,
-      HasExceptionHandlers                      = 1 << 15,
-      MayHaveVirtualCallProfileInfo             = 1 << 16,
-      AggressivelyInlineThrows                  = 1 << 18,
+      CanSkipNullChecks                           = 1 << 0,
+      CanSkipBoundChecks                          = 1 << 1,
+      CanSkipCheckCasts                           = 1 << 2,
+      CanSkipDivChecks                            = 1 << 3,
+      CanSkipChecksOnArrayCopies                  = 1 << 4,
+      CanSkipZeroInitializationOnNewarrays        = 1 << 5,
+      CanSkipArrayStoreChecks                     = 1 << 6,
+      HasSnapshots                                = 1 << 7,
+      CanSkipNonNullableArrayNullStoreCheck       = 1 << 8,
+      CanDirectNativeCall                         = 1 << 9,
+      CanReplaceWithHWInstr                       = 1 << 10,
+      CanSkipFlattenableArrayElementNonHelperCall = 1 << 11,
+      IsSideEffectFree                            = 1 << 12,
+      IsLeaf                                      = 1 << 13,
+      FoundThrow                                  = 1 << 14,
+      HasExceptionHandlers                        = 1 << 15,
+      MayHaveVirtualCallProfileInfo               = 1 << 16,
+      AggressivelyInlineThrows                    = 1 << 18,
       LastProperty = AggressivelyInlineThrows,
       };
 


### PR DESCRIPTION
Add `CanSkipFlattenableArrayElementNonHelperCall` to `ResolvedMethodSymbol`.