### PR TITLE
Adjust omrsysinfo_get_process_start_time traces

### DIFF
--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1631,5 +1631,5 @@ TraceException=Trc_PRT_retrieveLinuxMemoryStats_failedOpeningSwappinessFs Group=
 TraceException=Trc_PRT_retrieveLinuxMemoryStats_failedReadingSwappiness Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxMemoryStats: Failed to read /proc/sys/vm/swappiness. Error code = %d."
 TraceException=Trc_PRT_retrieveLinuxMemoryStats_unexpectedSwappinessFormat Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxMemoryStats: Expected %d items to read, but read %d items."
 
-TraceEntry=Trc_PRT_sysinfo_get_process_start_time_enter Group=sysinfo Overhead=1 Level=1 NoEnv Template="Enter omrsysinfo_get_process_start_time, pid=%llu."
-TraceExit=Trc_PRT_sysinfo_get_process_start_time_exit Group=sysinfo Overhead=1 Level=1 NoEnv Template="Exit omrsysinfo_get_process_start_time, pid=%llu, processStartTimeInNanoseconds=%llu, rc=%d."
+TraceEntry=Trc_PRT_sysinfo_get_process_start_time_enter Group=sysinfo Overhead=1 Level=1 NoEnv Template="Enter omrsysinfo_get_process_start_time, pid=%zu."
+TraceExit=Trc_PRT_sysinfo_get_process_start_time_exit Group=sysinfo Overhead=1 Level=1 NoEnv Template="Exit omrsysinfo_get_process_start_time, pid=%zu, processStartTimeInNanoseconds=%llu, rc=%d."

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -7383,7 +7383,7 @@ omrsysinfo_get_process_start_time(struct OMRPortLibrary *portLibrary, uintptr_t 
 {
 	int32_t rc = 0;
 	uint64_t computedProcessStartTimeInNanoseconds = 0;
-	Trc_PRT_sysinfo_get_process_start_time_enter((unsigned long long)pid);
+	Trc_PRT_sysinfo_get_process_start_time_enter(pid);
 	if (0 != omrsysinfo_process_exists(portLibrary, pid)) {
 #if defined(LINUX)
 		char procDir[OMRPORT_SYSINFO_PROC_DIR_BUFFER_SIZE] = {0};
@@ -7455,6 +7455,6 @@ omrsysinfo_get_process_start_time(struct OMRPortLibrary *portLibrary, uintptr_t 
 	}
 done:
 	*processStartTimeInNanoseconds = computedProcessStartTimeInNanoseconds;
-	Trc_PRT_sysinfo_get_process_start_time_exit((unsigned long long)pid, (unsigned long long)computedProcessStartTimeInNanoseconds, rc);
+	Trc_PRT_sysinfo_get_process_start_time_exit(pid, computedProcessStartTimeInNanoseconds, rc);
 	return rc;
 }

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1999,7 +1999,7 @@ omrsysinfo_get_process_start_time(struct OMRPortLibrary *portLibrary, uintptr_t 
 {
 	int32_t rc = 0;
 	uint64_t computedProcessStartTimeInNanoseconds = 0;
-	Trc_PRT_sysinfo_get_process_start_time_enter((unsigned long long)pid);
+	Trc_PRT_sysinfo_get_process_start_time_enter(pid);
 	if (0 != omrsysinfo_process_exists(portLibrary, pid)) {
 		double seconds = 0;
 		FILETIME createTime, exitTime, kernelTime, userTime;
@@ -2022,6 +2022,6 @@ cleanup:
 	}
 done:
 	*processStartTimeInNanoseconds = computedProcessStartTimeInNanoseconds;
-	Trc_PRT_sysinfo_get_process_start_time_exit((unsigned long long)pid, (unsigned long long)computedProcessStartTimeInNanoseconds, rc);
+	Trc_PRT_sysinfo_get_process_start_time_exit(pid, computedProcessStartTimeInNanoseconds, rc);
 	return rc;
 }


### PR DESCRIPTION
Adjust omrsysinfo_get_process_start_time traces to avoid 
casting.

Issue: https://github.com/eclipse/omr/issues/7201
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>