### PR TITLE
CheckpointGCthreadCount conflicts with gcThread Warning

### DIFF
--- a/example/glue/ConfigurationDelegate.hpp
+++ b/example/glue/ConfigurationDelegate.hpp
@@ -175,6 +175,18 @@ public:
 	 */
 	MM_GCPolicy getGCPolicy() { return _gcPolicy; }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * If checkpointGCthreadCount is specified by the user, it is verified
+	 * to be not larger than the number of gc threads, and throw a warning
+	 * if larger; if it is not specified by the user, it is adjusted to match
+	 * the number of gc threads.
+	 *
+	 * @param[in] env The environment for the calling thread
+	 */
+	void checkPointGCThreadCountVerifyAndAdjust(MM_EnvironmentBase *env) {}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	/**
 	 * Constructor.
 	 * @param gcPolicy The GC policy preselected for the GC configuration.

--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -450,6 +450,9 @@ MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase* env)
 	if (!extensions->gcThreadCountSpecified) {
 		extensions->gcThreadCount = defaultGCThreadCount(env);
 	}
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	_delegate.checkPointGCThreadCountVerifyAndAdjust(env);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 }
 
 uintptr_t


### PR DESCRIPTION
CheckpointGCthreadCount is expected to be no larger than
the number of gc threads.

We have two cases here:
1. If the user doesn't set the checkpointGCthreadCount,
the amount is adjusted to match the number of gc threads

2. If the user sets the checkpointGCthreadCount, a warning
is generated and the checkpointGCthreadCount is ignored

Signed off by: Frank.Kang@ibm.com