### PR TITLE
Reuse OMRPORT_TIME_DELTA_IN_NANOSECONDS in omrtime.c

### DIFF
--- a/port/aix/omrtime.c
+++ b/port/aix/omrtime.c
@@ -34,7 +34,6 @@
 
 /* Frequency is nanoseconds / second */
 #define OMRTIME_HIRES_CLOCK_FREQUENCY J9CONST_U64(1000000000)
-#define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_U64(1000000000)
 
 extern int64_t __getNanos(void);
 extern int64_t __getMillis(void);
@@ -83,7 +82,7 @@ omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *succes
 	uint64_t nsec = 0;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
-		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+		nsec = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
 	return nsec;

--- a/port/linuxppc64/omrtime.c
+++ b/port/linuxppc64/omrtime.c
@@ -57,7 +57,6 @@ extern int64_t __getNanos(void);
 /* Frequency is nanoseconds / second */
 #define OMRTIME_HIRES_CLOCK_FREQUENCY J9CONST_U64(1000000000)
 
-#define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
 static const clockid_t OMRTIME_NANO_CLOCK = CLOCK_MONOTONIC;
 
 /*
@@ -113,7 +112,7 @@ omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *succes
 	uint64_t nsec = 0;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
-		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+		nsec = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
 	return nsec;
@@ -148,7 +147,7 @@ omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 	int64_t hiresTime = 0;
 
 	if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
-		hiresTime = ((int64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)ts.tv_nsec;
+		hiresTime = ((int64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (int64_t)ts.tv_nsec;
 	}
 
 	return hiresTime;
@@ -171,7 +170,7 @@ omrtime_hires_clock(struct OMRPortLibrary *portLibrary)
 	} else {
 		struct timespec ts;
 		if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
-			ret = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+			ret = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 		}
 	}
 	return ret;

--- a/port/linuxs390/omrtime.c
+++ b/port/linuxs390/omrtime.c
@@ -36,7 +36,6 @@
 
 #define OMRTIME_CLOCK_DELTA_ADJUSTMENT_INTERVAL_USEC J9CONST_I64(60 * 1000 * 1000)
 
-#define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
 static const clockid_t OMRTIME_NANO_CLOCK = CLOCK_MONOTONIC;
 
 extern int64_t maxprec();
@@ -121,7 +120,7 @@ omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *succes
 	uint64_t nsec = 0;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
-		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+		nsec = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
 	return nsec;

--- a/port/unix/omrtime.c
+++ b/port/unix/omrtime.c
@@ -43,8 +43,6 @@
 #define OMRTIME_HIRES_CLOCK_FREQUENCY J9CONST_U64(1000000)
 #endif /* defined(OSX) || defined(LINUX) */
 
-#define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
-
 #if defined(OSX)
 static clock_serv_t cs_t;
 #else /* defined(OSX) */
@@ -97,14 +95,14 @@ omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *succes
 	struct timeval ts;
 	*success = 0;
 	if (0 == gettimeofday(&ts, NULL)) {
-		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)(ts.tv_usec * 1000);
+		nsec = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)(ts.tv_usec * 1000);
 		*success = 1;
 	}
 #else /* defined(OSX) */
 	struct timespec ts;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
-		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+		nsec = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
 #endif /* defined(OSX) */
@@ -118,13 +116,13 @@ omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 #if defined(OSX)
 	mach_timespec_t mt;
 	if (KERN_SUCCESS == clock_get_time(cs_t, &mt)) {
-		hiresTime = ((int64_t)mt.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)mt.tv_nsec;
+		hiresTime = ((int64_t)mt.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (int64_t)mt.tv_nsec;
 	}
 #else /* defined(OSX) */
 	struct timespec ts;
 
 	if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
-		hiresTime = ((int64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)ts.tv_nsec;
+		hiresTime = ((int64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (int64_t)ts.tv_nsec;
 	}
 #endif /* defined(OSX) */
 
@@ -165,7 +163,7 @@ omrtime_hires_clock(struct OMRPortLibrary *portLibrary)
 	uint64_t ret = 0;
 	struct timespec ts;
 	if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
-		ret = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
+		ret = ((uint64_t)ts.tv_sec * OMRPORT_TIME_DELTA_IN_NANOSECONDS) + (uint64_t)ts.tv_nsec;
 	}
 	return ret;
 #else /* defined(LINUX) */

--- a/port/win32/omrtime.c
+++ b/port/win32/omrtime.c
@@ -29,7 +29,6 @@
 void shutdown_timer(void);
 int32_t init_timer(void);
 
-#define OMRTIME_NANOSECONDS_PER_SECOND ((long double) 1000000000)
 #define UNIX_EPOCH_TIME_DELTA J9CONST_I64(116444736000000000)
 /**
  * Query OS for timestamp.
@@ -178,12 +177,12 @@ omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 		ticks = (int64_t)GetTickCount();
 	}
 
-	if (PPG_time_hiresClockFrequency == OMRTIME_NANOSECONDS_PER_SECOND) {
+	if (OMRPORT_TIME_DELTA_IN_NANOSECONDS == PPG_time_hiresClockFrequency) {
 		nanos = ticks;
-	} else if (PPG_time_hiresClockFrequency < OMRTIME_NANOSECONDS_PER_SECOND) {
-		nanos = (int64_t)(ticks * (OMRTIME_NANOSECONDS_PER_SECOND / PPG_time_hiresClockFrequency));
+	} else if (PPG_time_hiresClockFrequency < OMRPORT_TIME_DELTA_IN_NANOSECONDS) {
+		nanos = (int64_t)(ticks * ((long double)OMRPORT_TIME_DELTA_IN_NANOSECONDS / PPG_time_hiresClockFrequency));
 	} else {
-		nanos = (int64_t)(ticks / (PPG_time_hiresClockFrequency / OMRTIME_NANOSECONDS_PER_SECOND));
+		nanos = (int64_t)(ticks / (PPG_time_hiresClockFrequency / (long double)OMRPORT_TIME_DELTA_IN_NANOSECONDS));
 	}
 
 	return nanos;


### PR DESCRIPTION
Reuse OMRPORT_TIME_DELTA_IN_NANOSECONDS in omrtime.c 
instead of OMRTIME_NANOSECONDS_PER_SECOND for consistency 
across the different platforms.

Issue: https://github.com/eclipse/omr/issues/7219
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>