### PR TITLE
Allow Value Propagation to remove TR::new that creates a value type instance

### DIFF
--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -59,6 +59,8 @@ class ObjectModel
    bool mayRequireSpineChecks() { return false; }
 
    bool areValueTypesEnabled() { return false; }
+
+   bool areValueTypeInstancesCreatedWithBCNew() { return false; }
    /**
    * @brief: Returns true if flattenable value type is enabled
    */

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4202,14 +4202,21 @@ TR::Node *constrainNew(OMR::ValuePropagation *vp, TR::Node *node)
       else
          vp->addGlobalConstraint(node, classConstraint);
 
-      // If it's an abstract class, or an interface, or a value type, the allocation
+      // If it's an abstract class, an interface, or a value type (unless value
+      // type instances can be created by a new operation), the allocation
       // cannot be removed because InstantiationError could be thrown
       TR_OpaqueClassBlock *clazz = classConstraint->getClassType() ? classConstraint->getClassType()->getClass() : NULL;
       if (clazz &&
           TR::Compiler->cls.isConcreteClass(vp->comp(), clazz) &&
-          !TR::Compiler->cls.isValueTypeClass(clazz))
+          (!TR::Compiler->cls.isValueTypeClass(clazz) || TR::Compiler->om.areValueTypeInstancesCreatedWithBCNew()))
          {
          node->setAllocationCanBeRemoved(true);
+
+         // Instances of value classes have no identity
+         if (TR::Compiler->cls.isValueTypeClass(clazz))
+            {
+            node->setIdentityless(true);
+            }
          }
       }
 


### PR DESCRIPTION
Previously, value type instances created with the jitNewObject helper in a `TR::new` operation would result in an `InstantiationError`.  That prevented Value Propagation from removing a `TR::new` operation that was known to create an instance of a value type.  This change prepares for the possibility that a `TR::new` with a `jitNewObject` helper could be used to create an instance of a value type, which means the operation need not be kept just to allow for an `InstantiationError` to be thrown.

Whether a `TR::new` with `jitNewObject` can be used to create a value type instance is indicated by the method ObjectModel method `OMR::ObjectModel::areValueTypeInstancesCreatedWithBCNew`.  The default implementation returns false, but downstream uses might override that implementation.

This pull request will require a co-ordinated merge with OpenJ9 pull request eclipse-openj9/openj9#18790