### PR TITLE
AArch64: Disable Dual TLH by default

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2727,8 +2727,8 @@ OMR::Options::jitPreProcess()
          self()->setOption(TR_DisableZNext);
          }
 
-#if defined(TR_HOST_X86) || defined(TR_HOST_S390)
-      // Dual TLH disabled on default on X and Z
+#if defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_ARM64)
+      // Dual TLH disabled by default on X, Z, and AArch64
       self()->setOption(TR_DisableDualTLH);
 #endif
 


### PR DESCRIPTION
This commit disables Dual TLH on AArch64 by default.