### PR TITLE
Remove redundant newline in verbose log

### DIFF
--- a/compiler/ras/OptionsDebug.cpp
+++ b/compiler/ras/OptionsDebug.cpp
@@ -513,7 +513,6 @@ TR_Debug::dumpOptions(
 #ifdef J9_PROJECT_SPECIFIC
    if (fej9->generateCompressedPointers())
       {
-      TR_VerboseLog::writeLine("");
       TR_VerboseLog::writeLine(TR_Vlog_INFO, "     compressedRefs shiftAmount=%d", TR::Compiler->om.compressedReferenceShift());
       }
 #endif


### PR DESCRIPTION
The `writeLine("")` that is removed by this commit appears to be redundant - the most recent thing written to the log before the compressed refs message will either come from this:

https://github.com/eclipse/omr/blob/a74c0935b40f9e40b4be65004a8d0e711e16e6f2/compiler/ras/OptionsDebug.cpp#L335

or this, in the loop that prints the options:

https://github.com/eclipse/omr/blob/a74c0935b40f9e40b4be65004a8d0e711e16e6f2/compiler/ras/OptionsDebug.cpp#L509

In both cases the extra line is redundant.

Before this change:

```
#INFO:  _______________________________________
#INFO:  JIT 
#INFO:  options specified:
#INFO:       verbose={compilePerformance|JITServer},vlog=clientvlog.txt
#INFO:  
#INFO:  options in effect:
#INFO:       verbose={options|compilePerformance|JITServer}
#INFO:       vlog=clientvlog.txt

#INFO:       compressedRefs shiftAmount=3
#INFO:  aggressivenessLevel=5
```

After this change:

```
#INFO:  _______________________________________
#INFO:  JIT 
#INFO:  options specified:
#INFO:       verbose={compilePerformance|JITServer},vlog=clientvlog.txt
#INFO:  
#INFO:  options in effect:
#INFO:       verbose={options|compilePerformance|JITServer}
#INFO:       vlog=clientvlog.txt
#INFO:       compressedRefs shiftAmount=3
#INFO:  aggressivenessLevel=5
```