### PR TITLE
Discarded bytes in Verbose GC

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -887,7 +887,7 @@ MM_VerboseHandlerOutput::printAllocationStats(MM_EnvironmentBase* env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
 	enterAtomicReportingBlock();
-	writer->formatAndOutput(env, 0, "<allocation-stats totalBytes=\"%zu\" >", systemStats->bytesAllocated());
+	writer->formatAndOutput(env, 0, "<allocation-stats totalBytes=\"%zu\" discardedBytes=\"%zu\" >", systemStats->bytesAllocated(), systemStats->_tlhDiscardedBytes);
 
 	if (_extensions->isVLHGC()) {
 #if defined(OMR_GC_VLHGC)

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -344,6 +344,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:largest-consumer" maxOccurs="1" minOccurs="0" />
 		</sequence>
 		<attribute name="totalBytes" type="integer" use="required" />
+		<attribute name="discardedBytes" type="integer" use="required" />
 	</complexType>
 
 	<complexType name="allocated-bytes">


### PR DESCRIPTION
Report existing cummulative discarded bytes in allocation stats section of VGC (reported as a part of GC-start increment).

At the present they are only TLH discards, although in theory there could be small discards from non-TLH allocations when remainder is less then min free entry, but we don't gather those stats. It's not specifically reported as TLH ones, since in future we might add non-TLH ones, too.

This is useful to report/check if TLH sizing is changed (via for example tlhMaximumSize paramter), to see if there is any negative sideeffect (increase of discards, which may potentially increase frequency of GCs).