### PR TITLE
Don't version BNDCHK based on an IV if the loop test is backwards

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -7475,6 +7475,8 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(
             else
                incrementI = incrementJ;
 
+            bool isIncreasingI = incrementI > 0; // check before taking abs just below
+
             if (incrementI < 0)
                incrementI = -incrementI;
             if (incrementJ < 0)
@@ -7487,6 +7489,19 @@ void TR_LoopVersioner::buildBoundCheckComparisonsTree(
             TR::ILOpCode stayInLoopOp = _loopTestTree->getNode()->getOpCode();
             if (reverseBranch)
                stayInLoopOp = stayInLoopOp.getOpCodeForReverseBranch();
+
+            if (isIncreasingI == stayInLoopOp.isCompareTrueIfGreater())
+               {
+               dumpOptDetails(
+                  comp(),
+                  "Abandon versioning bound check because while condition %s "
+                  "is incompatible with %s loop driving IV\n",
+                  stayInLoopOp.getName(),
+                  isIncreasingI ? "an increasing" : "a decreasing");
+
+               nextTree = nextTree->getNextElement();
+               continue;
+               }
 
             bool strict = !stayInLoopOp.isCompareTrueIfEqual();
             if (strict)


### PR DESCRIPTION
For an increasing loop-driving IV, the loop test must impose an upper bound, e.g. `while (i < n)`, whereas for a decreasing loop-driving IV, the loop test must impose a lower bound instead, e.g. `while (i >= n)`. Otherwise, the predicted maximum iteration count will be wrong, which could allow a bound check to be incorrectly skipped.

Loop versioner will now check to ensure that the direction of the loop test agrees with the sign of the step of the loop-driving IV.

Fixes eclipse-openj9/openj9#18803