### PR TITLE
Add Cache Line Writeback Instruction

### DIFF
--- a/compiler/env/ProcessorInfo.hpp
+++ b/compiler/env/ProcessorInfo.hpp
@@ -188,6 +188,7 @@ inline uint32_t getFeatureFlags8Mask()
    {
    return  TR_HLE
          | TR_RTM
+         | TR_CLWB
          | TR_AVX2
          | TR_AVX512F
          | TR_AVX512VL

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -150,6 +150,7 @@ struct TR_X86ProcessorInfo
    bool has36BitPageSizeExtension()        {return testFeatureFlags(TR_36BitPageSizeExtension);}
    bool hasProcessorSerialNumber()         {return testFeatureFlags(TR_ProcessorSerialNumber);}
    bool supportsCLFLUSHInstruction()       {return testFeatureFlags(TR_CLFLUSHInstruction);}
+   bool supportsCLWBInstruction()          {return testFeatureFlags8(TR_CLWB);}
    bool supportsDebugTraceStore()          {return testFeatureFlags(TR_DebugTraceStore);}
    bool hasACPIRegisters()                 {return testFeatureFlags(TR_ACPIRegisters);}
    bool supportsMMXInstructions()          {return testFeatureFlags(TR_MMXInstructions);}

--- a/compiler/x/codegen/X86Ops.ins
+++ b/compiler/x/codegen/X86Ops.ins
@@ -5909,6 +5909,11 @@ INSTRUCTION(VFNMSUB231SDRegRegMem, vfnmsub231sd,
             PROPERTY0(IA32OpProp_ModifiesTarget | IA32OpProp_DoubleFP | IA32OpProp_UsesTarget),
             PROPERTY1(IA32OpProp1_XMMSource | IA32OpProp1_SourceIsMemRef | IA32OpProp1_XMMTarget),
             FEATURES(0)),
+INSTRUCTION(CLWBMem, clwb,
+            BINARY(VEX_L___, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F__, 0xae, 6, ModRM_RM__, Immediate_0),
+            PROPERTY0(0),
+            PROPERTY1(IA32OpProp1_SourceIsMemRef),
+            FEATURES(0)),
 
 // OpCodes beyond this point are pseudo instructions; they are for OMR internal usage only.
 INSTRUCTION(DQImm64, dq, // Define 8 bytes

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -44,7 +44,7 @@ OMR::X86::CPU::detect(OMRPortLibrary * const omrPortLib)
                                         OMR_FEATURE_X86_RTM, OMR_FEATURE_X86_AVX512F, OMR_FEATURE_X86_AVX512VL,
                                         OMR_FEATURE_X86_AVX512BW, OMR_FEATURE_X86_AVX512DQ, OMR_FEATURE_X86_AVX512CD,
                                         OMR_FEATURE_X86_AVX512_VBMI2, OMR_FEATURE_X86_AVX512_VPOPCNTDQ,
-                                        OMR_FEATURE_X86_AVX512_BITALG
+                                        OMR_FEATURE_X86_AVX512_BITALG, OMR_FEATURE_X86_CLWB,
                                         };
 
    OMRPORT_ACCESS_FROM_OMRPORT(omrPortLib);

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -349,6 +349,8 @@ OMR::X86::CPU::supports_feature_test(uint32_t feature)
          return TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber() == ans;
       case OMR_FEATURE_X86_CLFSH:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction() == ans;
+      case OMR_FEATURE_X86_CLWB:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsCLWBInstruction() == ans;
       case OMR_FEATURE_X86_DS:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore() == ans;
       case OMR_FEATURE_X86_ACPI:

--- a/fvtest/compilerunittest/x/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/x/BinaryEncoder.cpp
@@ -993,6 +993,21 @@ INSTANTIATE_TEST_CASE_P(XRegMaskRegEncTest, XRegMaskRegEncEncodingTest, ::testin
     std::make_tuple(TR::InstOpCode::MOVDQURegReg, TR::RealRegister::xmm8, TR::RealRegister::k6, TR::RealRegister::xmm6, OMR::X86::EVEX_L512, "62717e4e6fc6")
 )));
 
+class XMemEncEncodingTest : public TRTest::BinaryEncoderTest<>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int32_t, TRTest::BinaryInstruction>> {};
+
+TEST_P(XMemEncEncodingTest, encode) {
+    auto base = getRealRegister(std::get<1>(GetParam()), cg());
+    auto disp = std::get<2>(GetParam());
+
+    auto mr = generateX86MemoryReference(base, disp, cg());
+    auto instr = generateMemInstruction(std::get<0>(GetParam()), fakeNode, mr, cg());
+    ASSERT_EQ(std::get<3>(GetParam()), encodeInstruction(instr));
+}
+
+INSTANTIATE_TEST_CASE_P(X86MemEnc, XMemEncEncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, int32_t, TRTest::BinaryInstruction>>(
+    std::make_tuple(TR::InstOpCode::CLWBMem, TR::RealRegister::eax, 0, "660fae30")
+)));
+
 class XRegMaskMemEncEncodingTest : public TRTest::BinaryEncoderTest<>, public ::testing::WithParamInterface<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, TR::RealRegister::RegNum, TR::RealRegister::RegNum, int32_t, OMR::X86::Encoding, TRTest::BinaryInstruction>> {};
 
 TEST_P(XRegMaskMemEncEncodingTest, encode) {


### PR DESCRIPTION
This commit adds the `clwb` instruction motivated
by the writeback0 intrinsic available in the Unsafe Java library.

The intrinsic permits users to write back a cache line if cache line writeback is enabled by the underlying VM. This instruction maps 1-1 with the intrinsic method.

The CPUID feature flag OMR_FEATURE_X86_CLWB is already implemented and should be used to check whether the instruction is supported in the underlying hardware.