### PR TITLE
Clean up x86 supports_feature_test

### DIFF
--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -388,23 +388,23 @@ OMR::X86::CPU::supports_feature_test(uint32_t feature)
       case OMR_FEATURE_X86_AVX:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX() == ans;
       case OMR_FEATURE_X86_AVX2:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX2();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX2() == ans;
       case OMR_FEATURE_X86_AVX512F:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512F();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512F() == ans;
       case OMR_FEATURE_X86_AVX512VL:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VL();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VL() == ans;
       case OMR_FEATURE_X86_AVX512BW:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BW();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BW() == ans;
       case OMR_FEATURE_X86_AVX512DQ:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512DQ();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512DQ() == ans;
       case OMR_FEATURE_X86_AVX512CD:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512CD();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512CD() == ans;
       case OMR_FEATURE_X86_AVX512_VBMI2:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VBMI2();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VBMI2() == ans;
       case OMR_FEATURE_X86_AVX512_BITALG:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG() == ans;
       case OMR_FEATURE_X86_AVX512_VPOPCNTDQ:
-         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ();
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ() == ans;
       default:
          return false;
       }

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -405,6 +405,8 @@ OMR::X86::CPU::supports_feature_test(uint32_t feature)
          return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG() == ans;
       case OMR_FEATURE_X86_AVX512_VPOPCNTDQ:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ() == ans;
+      case OMR_FEATURE_X86_FMA:
+         return TR::CodeGenerator::getX86ProcessorInfo().supportsFMA() == ans;
       default:
          return false;
       }


### PR DESCRIPTION
- Some case branches in `supports_feature_test` did not check that the returned `supports*()` value matches the expected value, and instead directly return the `supports*()` value.
- `OMR_FEATURE_X86_FMA` was not included in `supports_feature_test`