### PR TITLE
Expose alloc cache size API

### DIFF
--- a/gc/base/ObjectAllocationInterface.hpp
+++ b/gc/base/ObjectAllocationInterface.hpp
@@ -127,7 +127,23 @@ public:
 
 	virtual void flushCache(MM_EnvironmentBase *env);
 	virtual void restartCache(MM_EnvironmentBase *env);
-	
+	/**
+	 *  Return the size of currently remaining/unused part of the cache.
+	 *  With dual cache setup (pre-zeroed or non-pre-zeroed), both sizes can be obtained.
+	 *
+	 *  @param nonZero if true
+	 *  @return pre-zeroed remaining cache size, otherwise non-pre-zeroed one
+	 */
+	virtual uintptr_t getRemainingCacheSize(bool nonZero) { return 0; }
+	/**
+	 *  With dynamically sized caches, return the size of the cache on next refresh
+	 *  With dual cache setup (pre-zeroed or non-pre-zeroed), both sizes can be obtained.
+	 *
+	 *  @param nonZero if true
+	 *  @return pre-zeroed refresh cache size, otherwise non-pre-zeroed one
+	 */
+	virtual uintptr_t getRefreshCacheSize(bool nonZero) { return 0; }
+
 	virtual void enableCachedAllocations(MM_EnvironmentBase* env) {};
 	virtual void disableCachedAllocations(MM_EnvironmentBase* env) {};
 	virtual bool cachedAllocationsEnabled(MM_EnvironmentBase* env) { return true; }

--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -309,4 +309,30 @@ MM_TLHAllocationInterface::restartCache(MM_EnvironmentBase *env)
 #endif /* defined(OMR_GC_NON_ZERO_TLH) */
 }
 
+uintptr_t
+MM_TLHAllocationInterface::getRemainingCacheSize(bool nonZero)
+{
+#if defined(OMR_GC_NON_ZERO_TLH)
+	if (nonZero) {
+		return _tlhAllocationSupportNonZero.getRemainingSize();
+	} else
+#endif /* defined(OMR_GC_NON_ZERO_TLH) */
+	{
+		return _tlhAllocationSupport.getRemainingSize();
+	}
+}
+
+uintptr_t
+MM_TLHAllocationInterface::getRefreshCacheSize(bool nonZero)
+{
+#if defined(OMR_GC_NON_ZERO_TLH)
+	if (nonZero) {
+		return _tlhAllocationSupportNonZero.getRefreshSize();
+	} else
+#endif /* defined(OMR_GC_NON_ZERO_TLH) */
+	{
+		return _tlhAllocationSupport.getRefreshSize();
+	}
+}
+
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */

--- a/gc/base/TLHAllocationInterface.hpp
+++ b/gc/base/TLHAllocationInterface.hpp
@@ -77,6 +77,8 @@ public:
 
 	virtual void flushCache(MM_EnvironmentBase *env);
 	virtual void restartCache(MM_EnvironmentBase *env);
+	virtual uintptr_t getRemainingCacheSize(bool nonZero);
+	virtual uintptr_t getRefreshCacheSize(bool nonZero);
 	
 	/* BEN TODO: Collapse the env->enable/disableInlineTLHAllocate with these enable/disableCachedAllocations */
 	virtual void enableCachedAllocations(MM_EnvironmentBase* env) { _cachedAllocationsEnabled = true; }


### PR DESCRIPTION
Expose remaining and refresh size APIs for ObjectAllocationInterface,
and implement it for TLHAllocationInterface.

While this values are functionally needed only internally within the
class, they will be used for stats reporting purposes outisde the class,
hence need to be public.