### PR TITLE
Integrate GC Restore With Delegate Reinit APIs

### DIFF
--- a/example/glue/ConfigurationDelegate.hpp
+++ b/example/glue/ConfigurationDelegate.hpp
@@ -165,7 +165,7 @@ public:
 	 * allow the heap to grow to a stable operational size. Frequent transitions true->false will limit the quality
 	 * of heap fragmentation stats.
 	 *
-	 * @param[in] env The environment for the calling thread.
+	 * @param[in] env The environment for the calling thread
 	 * @return true to allow heap fragmentation tracking to start or continue
 	 */
 	bool canCollectFragmentationStats(MM_EnvironmentBase *env) { return false; }
@@ -174,6 +174,16 @@ public:
 	 * Return the GC policy preselected for the GC configuration.
 	 */
 	MM_GCPolicy getGCPolicy() { return _gcPolicy; }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Reinitialize the language specific configuration structures.
+	 *
+	 * @param[in] env The environment for the calling thread
+	 * @return boolean indicating whether configuration reinitialization was successful
+	 */
+	bool reinitializeForRestore(MM_EnvironmentBase *env) { return true; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	/**
@@ -189,7 +199,7 @@ public:
 
 	/**
 	 * Constructor.
-	 * @param gcPolicy The GC policy preselected for the GC configuration.
+	 * @param gcPolicy The GC policy preselected for the GC configuration
 	 */
 	MM_ConfigurationDelegate(MM_GCPolicy gcPolicy)
 		: _gcPolicy(gcPolicy)

--- a/example/glue/EnvironmentDelegate.hpp
+++ b/example/glue/EnvironmentDelegate.hpp
@@ -277,6 +277,15 @@ public:
 	uintptr_t getAllocatedSizeInsideTLH() { return 0; }
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Reinitialize the env's language specific structures.
+	 *
+	 * @return boolean indicating whether the thread env was successfully reinitialized
+	 */
+	bool reinitializeForRestore() { return true; }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 	MM_EnvironmentDelegate()
 		: _env(NULL)
 	{ }

--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -51,20 +51,20 @@
 #endif /* defined(OMR_GC_SEGREGATED_HEAP) */
 
 void
-MM_Configuration::kill(MM_EnvironmentBase* env)
+MM_Configuration::kill(MM_EnvironmentBase *env)
 {
 	tearDown(env);
 	env->getForge()->free(this);
 }
 
 bool
-MM_Configuration::initialize(MM_EnvironmentBase* env)
+MM_Configuration::initialize(MM_EnvironmentBase *env)
 {
 	bool result = false;
 
 	if (initializeRegionSize(env) && initializeArrayletLeafSize(env)) {
 		if (_delegate.initialize(env, _writeBarrierType, _allocationType)) {
-			MM_GCExtensionsBase* extensions = env->getExtensions();
+			MM_GCExtensionsBase *extensions = env->getExtensions();
 			/* excessivegc is enabled by default */
 			if (!extensions->excessiveGCEnabled._wasSpecified) {
 				extensions->excessiveGCEnabled._valueSpecified = true;
@@ -84,7 +84,7 @@ MM_Configuration::initialize(MM_EnvironmentBase* env)
 void
 MM_Configuration::tearDown(MM_EnvironmentBase* env)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	/* DefaultMemorySpace needs to be killed before
 	 * ext->heap is freed in MM_Configuration::tearDown. */
@@ -152,8 +152,8 @@ MM_Configuration::tearDown(MM_EnvironmentBase* env)
 void
 MM_Configuration::destroyCollectors(MM_EnvironmentBase* env)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
-	MM_Collector* collector = extensions->getGlobalCollector();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
+	MM_Collector *collector = extensions->getGlobalCollector();
 
 	if (NULL != collector) {
 		collector->kill(env);
@@ -170,9 +170,9 @@ MM_Configuration::destroyCollectors(MM_EnvironmentBase* env)
  * @return env The newly allocated env or NULL
  */
 MM_EnvironmentBase*
-MM_Configuration::createEnvironment(MM_GCExtensionsBase* extensions, OMR_VMThread* omrVMThread)
+MM_Configuration::createEnvironment(MM_GCExtensionsBase *extensions, OMR_VMThread *omrVMThread)
 {
-	MM_EnvironmentBase* env = allocateNewEnvironment(extensions, omrVMThread);
+	MM_EnvironmentBase *env = allocateNewEnvironment(extensions, omrVMThread);
 	if (NULL != env) {
 		if (!initializeEnvironment(env)) {
 			env->kill();
@@ -191,7 +191,7 @@ MM_Configuration::createEnvironment(MM_GCExtensionsBase* extensions, OMR_VMThrea
  * @param env The environment to initialize
  */
 bool
-MM_Configuration::initializeEnvironment(MM_EnvironmentBase* env)
+MM_Configuration::initializeEnvironment(MM_EnvironmentBase *env)
 {
 	bool result = false;
 
@@ -221,15 +221,15 @@ MM_Configuration::initializeEnvironment(MM_EnvironmentBase* env)
 }
 
 void
-MM_Configuration::defaultMemorySpaceAllocated(MM_GCExtensionsBase* extensions, void* defaultMemorySpace)
+MM_Configuration::defaultMemorySpaceAllocated(MM_GCExtensionsBase *extensions, void *defaultMemorySpace)
 {
 	/* do nothing */
 }
 
 MM_Heap*
-MM_Configuration::createHeap(MM_EnvironmentBase* env, uintptr_t heapBytesRequested)
+MM_Configuration::createHeap(MM_EnvironmentBase *env, uintptr_t heapBytesRequested)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	if (NULL == extensions->memoryManager) {
 		extensions->memoryManager = MM_MemoryManager::newInstance(env);
@@ -245,7 +245,7 @@ MM_Configuration::createHeap(MM_EnvironmentBase* env, uintptr_t heapBytesRequest
 		}
 	}
 
-	MM_Heap* heap = createHeapWithManager(env, heapBytesRequested, extensions->heapRegionManager);
+	MM_Heap *heap = createHeapWithManager(env, heapBytesRequested, extensions->heapRegionManager);
 	if (NULL != heap) {
 		if (!heap->initializeHeapRegionManager(env, extensions->heapRegionManager)) {
 			heap->kill(env);
@@ -276,10 +276,10 @@ MM_Configuration::createHeap(MM_EnvironmentBase* env, uintptr_t heapBytesRequest
 }
 
 bool
-MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase* env, MM_Heap* heap)
+MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase *env, MM_Heap *heap)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
-	OMR_VM* omrVM = env->getOmrVM();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
+	OMR_VM *omrVM = env->getOmrVM();
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 	if (env->compressObjectReferences()) {
@@ -334,7 +334,7 @@ MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase*
 }
 
 void
-MM_Configuration::prepareParameters(OMR_VM* omrVM,
+MM_Configuration::prepareParameters(OMR_VM *omrVM,
 									uintptr_t minimumSpaceSize,
 									uintptr_t minimumNewSpaceSize,
 									uintptr_t initialNewSpaceSize,
@@ -344,10 +344,10 @@ MM_Configuration::prepareParameters(OMR_VM* omrVM,
 									uintptr_t maximumTenureSpaceSize,
 									uintptr_t memoryMax,
 									uintptr_t tenureFlags,
-									MM_InitializationParameters* parameters)
+									MM_InitializationParameters *parameters)
 {
-	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(omrVM);
-	MM_Heap* heap = extensions->heap;
+	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVM);
+	MM_Heap *heap = extensions->heap;
 	uintptr_t alignment = getAlignment(extensions, _alignmentType);
 
 	uintptr_t maximumHeapSize = MM_Math::roundToFloor(alignment, heap->getMaximumMemorySize());
@@ -381,7 +381,7 @@ MM_Configuration::prepareParameters(OMR_VM* omrVM,
 }
 
 uintptr_t
-MM_Configuration::getAlignment(MM_GCExtensionsBase* extensions, MM_AlignmentType type)
+MM_Configuration::getAlignment(MM_GCExtensionsBase *extensions, MM_AlignmentType type)
 {
 	uintptr_t result = 0;
 
@@ -399,10 +399,10 @@ MM_Configuration::getAlignment(MM_GCExtensionsBase* extensions, MM_AlignmentType
 }
 
 bool
-MM_Configuration::initializeRegionSize(MM_EnvironmentBase* env)
+MM_Configuration::initializeRegionSize(MM_EnvironmentBase *env)
 {
 	bool result = true;
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 	uintptr_t regionSize = extensions->regionSize;
 	if (0 == regionSize) {
 		regionSize = _defaultRegionSize;
@@ -422,10 +422,10 @@ MM_Configuration::initializeRegionSize(MM_EnvironmentBase* env)
 }
 
 bool
-MM_Configuration::initializeArrayletLeafSize(MM_EnvironmentBase* env)
+MM_Configuration::initializeArrayletLeafSize(MM_EnvironmentBase *env)
 {
 	bool result = true;
-	OMR_VM* omrVM = env->getOmrVM();
+	OMR_VM *omrVM = env->getOmrVM();
 	if (UDATA_MAX != _defaultArrayletLeafSize) {
 		uintptr_t arrayletLeafSize = (0 != _defaultArrayletLeafSize) ? _defaultArrayletLeafSize : env->getExtensions()->regionSize;
 		uintptr_t shift = calculatePowerOfTwoShift(env, arrayletLeafSize);
@@ -443,9 +443,9 @@ MM_Configuration::initializeArrayletLeafSize(MM_EnvironmentBase* env)
 }
 
 void
-MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase* env)
+MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase *env)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	if (!extensions->gcThreadCountSpecified) {
 		extensions->gcThreadCount = defaultGCThreadCount(env);
@@ -456,7 +456,7 @@ MM_Configuration::initializeGCThreadCount(MM_EnvironmentBase* env)
 }
 
 uintptr_t
-MM_Configuration::defaultGCThreadCount(MM_EnvironmentBase* env)
+MM_Configuration::defaultGCThreadCount(MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	uintptr_t threadCount = omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_TARGET);
@@ -470,7 +470,7 @@ MM_Configuration::defaultGCThreadCount(MM_EnvironmentBase* env)
 }
 
 void
-MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
+MM_Configuration::initializeGCParameters(MM_EnvironmentBase *env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 	
@@ -518,22 +518,22 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 }
 
 bool
-MM_Configuration::initializeNUMAManager(MM_EnvironmentBase* env)
+MM_Configuration::initializeNUMAManager(MM_EnvironmentBase *env)
 {
 	return env->getExtensions()->_numaManager.recacheNUMASupport(env);
 }
 
 MM_ParallelDispatcher *
-MM_Configuration::createParallelDispatcher(MM_EnvironmentBase* env, omrsig_handler_fn handler, void* handler_arg, uintptr_t defaultOSStackSize)
+MM_Configuration::createParallelDispatcher(MM_EnvironmentBase *env, omrsig_handler_fn handler, void *handler_arg, uintptr_t defaultOSStackSize)
 {
 	return MM_ParallelDispatcher::newInstance(env, handler, handler_arg, defaultOSStackSize);
 }
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 bool
-MM_Configuration::reinitializeForRestore(MM_EnvironmentBase* env)
+MM_Configuration::reinitializeForRestore(MM_EnvironmentBase *env)
 {
-	MM_GCExtensionsBase* extensions = env->getExtensions();
+	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	/* The initialization of the GC thread count can only happen if it is not enforced by the user. */
 	initializeGCThreadCount(env);
@@ -548,6 +548,19 @@ MM_Configuration::reinitializeForRestore(MM_EnvironmentBase* env)
 			extensions->gcThreadCount);
 
 	initializeGCParameters(env);
+
+	if (!_delegate.reinitializeForRestore(env)) {
+		return false;
+	}
+
+	OMR_VMThread *walkThread = NULL;
+	GC_OMRVMThreadListIterator threadListIterator(env->getOmrVM());
+	while (NULL != (walkThread = threadListIterator.nextOMRVMThread())) {
+		MM_EnvironmentBase *walkEnv = MM_EnvironmentBase::getEnvironment(walkThread);
+		if (!walkEnv->reinitializeForRestore()) {
+			return false;
+		}
+	}
 
 	return true;
 }

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -206,7 +206,7 @@ public:
 
 	/**
 	 * Get the Core Environment.
-	 * @return Pointer to the core environment.
+	 * @return Pointer to the core environment
 	 */
 	MMINLINE static MM_EnvironmentBase *getEnvironment(OMR_VMThread *omrVMThread) { return (MM_EnvironmentBase *)omrVMThread->_gcOmrVMThreadExtensions; }
 	virtual void kill();
@@ -255,7 +255,7 @@ public:
 
 	/**
 	 * Get a pointer to the J9VMThread structure.
-	 * @return Pointer to the J9VMThread structure.
+	 * @return Pointer to the J9VMThread structure
 	 */
 	MMINLINE OMR_VMThread *getOmrVMThread() { return _omrVMThread; }
 	
@@ -296,7 +296,7 @@ public:
 
 	/**
 	 * Get a pointer to the port library.
-	 * @return Pointer to the port library.
+	 * @return Pointer to the port library
 	 */
 	MMINLINE OMRPortLibrary *getPortLibrary() { return _portLibrary; }
 	
@@ -308,13 +308,13 @@ public:
 
 	/**
 	 * Get the thread's priority.
-	 * @return The thread's priority.
+	 * @return The thread's priority
 	 */
 	MMINLINE uintptr_t getPriority() { return omrthread_get_priority(_omrVMThread->_os_thread); }
 	
 	/**
 	 * Set the the thread's priority.
-	 * @param priority The priority to set the thread to.
+	 * @param priority The priority to set the thread to
 	 * @returns 0 on success or negative value on failure (priority wasn't changed)
 	 */
 	MMINLINE intptr_t setPriority(uintptr_t priority) { return omrthread_set_priority(_omrVMThread->_os_thread, priority); }
@@ -350,7 +350,7 @@ public:
 		
 	/**
 	 * Get the threads worker id.
-	 * @return The threads worker id.
+	 * @return The threads worker id
 	 */
 	MMINLINE uintptr_t getWorkerID() { return _workerID; }
 
@@ -367,13 +367,13 @@ public:
 
 	/**
 	 * Gets the threads type.
-	 * @return The type of thread.
+	 * @return The type of thread
 	 */
 	MMINLINE ThreadType getThreadType() { return _threadType; } ;
 
 	/**
 	 * Sets the threads type.
-	 * @param threadType The thread type to set thread to.
+	 * @param threadType The thread type to set thread to
 	 */
 	MMINLINE void
 	setThreadType(ThreadType threadType)
@@ -384,7 +384,7 @@ public:
 
 	/**
 	 * Gets the id used for calculating work packet sublist indexes.
-	 * @return The environment's packet sublist id.
+	 * @return The environment's packet sublist id
 	 */
 	MMINLINE uintptr_t getEnvironmentId() { return _environmentId; }
 
@@ -459,8 +459,8 @@ public:
 	/**
 	 * Acquire exclusive access to request a gc.
 	 * The calling thread will acquire exclusive access for Gc regardless if other threads beat it to exclusive for the same purposes.
-	 * @param collector gc intended to be used for collection.
-	 * @return boolean indicating whether the thread cleanly won exclusive access for its collector or if it had been beaten already.
+	 * @param collector gc intended to be used for collection
+	 * @return boolean indicating whether the thread cleanly won exclusive access for its collector or if it had been beaten already
 	 *
 	 * @note this call should be considered a safe-point as the thread may release VM access to allow the other threads to acquire exclusivity.
 	 * @note this call supports recursion.
@@ -505,7 +505,7 @@ public:
 
 	/**
 	 * Checks to see if any thread has requested exclusive access
-	 * @return true if a thread is waiting on exclusive access, false if not.
+	 * @return true if a thread is waiting on exclusive access, false if not
 	 */
 	bool isExclusiveAccessRequestWaiting();
 
@@ -513,7 +513,7 @@ public:
 	 * Get the time taken to acquire exclusive access.
 	 * Time is stored in raw format (no units).  Output routines
 	 * are responsible for converting to the desired resolution (msec, usec)
-	 * @return The time taken to acquire exclusive access.
+	 * @return The time taken to acquire exclusive access
 	 */
 	uint64_t getExclusiveAccessTime() { return _exclusiveAccessTime; };
 
@@ -521,7 +521,7 @@ public:
 	 * Get the time average threads were idle while acquiring exclusive access.
 	 * Time is stored in raw format (no units).  Output routines
 	 * are responsible for converting to the desired resolution (msec, usec)
-	 * @return The mean idle time during exclusive access acquisition.
+	 * @return The mean idle time during exclusive access acquisition
 	 */
 	uint64_t getMeanExclusiveAccessIdleTime() { return _meanExclusiveAccessIdleTime; };
 
@@ -539,7 +539,7 @@ public:
 
 	/**
 	 * Enquire whether we were beaten to exclusive access by another thread.
-	 * @return true if we were beaten, false otherwise.
+	 * @return true if we were beaten, false otherwise
 	 */
 	bool exclusiveAccessBeatenByOtherThread() { return _exclusiveAccessBeatenByOtherThread; }
 	
@@ -688,6 +688,15 @@ public:
 	MMINLINE MM_HeapRegionQueue *getRegionLocalFree() const { return _regionLocalFree; }
 	MMINLINE MM_HeapRegionQueue *getRegionLocalFull() const { return _regionLocalFull; }
 #endif /* OMR_GC_SEGREGATED_HEAP */
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	/**
+	 * Reinitialize the env's language specific object buffers based on the the number of restore GC threads.
+	 *
+	 * @return boolean indicating whether thread buffers were reinitialized successfully
+	 */
+	MMINLINE bool reinitializeForRestore() { return _delegate.reinitializeForRestore(this); }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 	/**
 	 * Create an EnvironmentBase object.


### PR DESCRIPTION
Integrate with downstream delegate restore reinit APIs:

- Thread Local (env) Obj Buffers
- Region Extensions Object Lists

Continue Salman's work, after fixing https://github.com/eclipse-openj9/openj9/issues/17731
Also fix some comments.

Signed-off-by: frank.kang@ibm.com