### PR TITLE
Check TR_DisableUnsafe before transforming Unsafe copyMemory & setMemory

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1674,6 +1674,7 @@ bool OMR::Compilation::canTransformUnsafeCopyToArrayCopy()
    {
    if (!self()->getOptions()->realTimeGC() &&
        !TR::Compiler->om.canGenerateArraylets() &&
+       !self()->getOption(TR_DisableUnsafe) &&
        self()->cg()->canTransformUnsafeCopyToArrayCopy())
       return true;
 
@@ -1684,6 +1685,7 @@ bool OMR::Compilation::canTransformUnsafeSetMemory()
    {
    if (!self()->getOptions()->realTimeGC() &&
        !TR::Compiler->om.canGenerateArraylets() &&
+       !self()->getOption(TR_DisableUnsafe) &&
        self()->cg()->canTransformUnsafeSetMemory())
       return true;
 


### PR DESCRIPTION
Transforming `Unsafe.copyMemory()` or `Unsafe.setMemory()` are considered Unsafe related transformation and should check `TR_DisableUnsafe` before performing the transformation.
