### PR TITLE
Print assertion failure to log and flush even if DEBUG is not defined

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2483,17 +2483,14 @@ TR_Debug * OMR::Compilation::findOrCreateDebug()
 
 void OMR::Compilation::diagnosticImpl(const char *s, ...)
    {
-#if defined(DEBUG)
    va_list ap;
    va_start(ap, s);
    self()->diagnosticImplVA(s, ap);
    va_end(ap);
-#endif
    }
 
 void OMR::Compilation::diagnosticImplVA(const char *s, va_list ap)
    {
-#if defined(DEBUG)
    if (self()->getOutFile() != NULL)
       {
       va_list copy;
@@ -2504,7 +2501,6 @@ void OMR::Compilation::diagnosticImplVA(const char *s, va_list ap)
       trfflush(self()->getOutFile());
       va_end(copy);
       }
-#endif
    }
 
 


### PR DESCRIPTION
`TR_ASSERT_FATAL()` could fail in any build, and in particular in builds without `DEBUG`. Previously, if such a failure occurred with tracing enabled, the process would crash without printing the failure to the log, and more importantly, without flushing previously written trace output, which was confusing and impeded debugging.