### PR TITLE
Don't use non-ASCII characters in text files

### DIFF
--- a/gc/base/standard/ConcurrentGCSATB.cpp
+++ b/gc/base/standard/ConcurrentGCSATB.cpp
@@ -577,7 +577,7 @@ MM_ConcurrentGCSATB::reportConcurrentCollectionStart(MM_EnvironmentBase *env)
 /**
  * TLH is about to be cleared, we must premark it if SATB is active. This is
  * non-trival to do, we must know the start of the last object to mark the proper range of the TLH.
- * Arbitrary bits at the end of the TLH can’t be marked, this is problematic for sweep.
+ * Arbitrary bits at the end of the TLH can't be marked, this is problematic for sweep.
  *
  * To get around this issue we seal the TLH with a bogus/dummy obj at the
  * end of the TLH (done before call to this method). With this, we know the precise addr to batch mark to. We have

--- a/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
@@ -157,7 +157,7 @@ MM_VerboseWriterFileLoggingBuffered::outputString(MM_EnvironmentBase *env, const
 	if(NULL == _logFileStream) {
 		/**
 		 * Under normal circumstances, new file should be opened during endOfCycle call.
-		 * This path works as one backup, in case we failed to open the file,  we’ll attempt to open it again before outputting the string.
+		 * This path works as one backup, in case we failed to open the file,  we'll attempt to open it again before outputting the string.
 		 */
 		openFile(env);
 	}

--- a/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
@@ -159,7 +159,7 @@ MM_VerboseWriterFileLoggingSynchronous::outputString(MM_EnvironmentBase *env, co
 	if(-1 == _logFileDescriptor) {
 		/**
 		 * Under normal circumstances, new file should be opened during endOfCycle call.
-		 * This path works as one backup, in case we failed to open the file,  we’ll attempt to open it again before outputting the string.
+		 * This path works as one backup, in case we failed to open the file,  we'll attempt to open it again before outputting the string.
 		 */
 		openFile(env);
 	}

--- a/include_core/omrportsocktypes.h
+++ b/include_core/omrportsocktypes.h
@@ -82,7 +82,7 @@
 #if defined(OMR_OS_WINDOWS)
 typedef SOCKET omr_os_socket;
 typedef struct sockaddr_storage omr_os_sockaddr_storage; /* For IPv4 or IPv6 addresses */
-typedef struct addrinfoW omr_os_addrinfo;  /* addrinfo structure – Unicode, for IPv4 or IPv6 */
+typedef struct addrinfoW omr_os_addrinfo; /* addrinfo structure - Unicode, for IPv4 or IPv6 */
 #else /* defined(OMR_OS_WINDOWS) */
 typedef int omr_os_socket;
 typedef struct sockaddr_storage omr_os_sockaddr_storage; /* For IPv4 or IPv6 addresses */

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -552,8 +552,8 @@ intptr_t
 omrthread_monitor_get_acquired_count(omrthread_monitor_t monitor);
 
 /**
- * Return thread that currently owns the monitor. Null 
- * will be returned if monitor is not owned.
+ * Return thread that currently owns the monitor.
+ * Null will be returned if monitor is not owned.
  * @param monitor
  * @return omrthread_t
  */


### PR DESCRIPTION
They are problematic on z/OS where conversion to EBCDIC will fail.