### PR TITLE
Fix typo AIXPPCX -> AIXPPC

### DIFF
--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -743,14 +743,14 @@ upcall_handler(int signal, siginfo_t *siginfo, void *context_arg)
 	pid_t pid = getpid();
 	uintptr_t tid = omrthread_get_ras_tid();
 
-#if defined(AIXPPCX)
+#if defined(AIXPPC)
 	struct sigaction handler;
 
 	/* altering the signal handler doesn't affect already queued signals on AIX */
 	if ((-1 == sigaction(SUSPEND_SIG, NULL, &handler)) || (handler.sa_sigaction != upcall_handler)) {
 		return;
 	}
-#endif /* defined(AIXPPCX) */
+#endif /* defined(AIXPPC) */
 
 	/* check that this signal was queued by this process. */
 	if ((SI_QUEUE != siginfo->si_code)


### PR DESCRIPTION
On AIX, this typo disables code that prevents upcall_handler from
collecting thread data when upcall_handler is unregistered. Collecting
data after upcall_handler is unregistered might cause corrupt memory
to be passed through siginfo and lead to crashes.

**More context:**
On AIX, a signal can can be unavailable to sigpending/sigwait but
not yet have been delivered to a thread. As a result, it is not
guaranteed that SIG_SUSPEND won't be delivered after upcall_handler
is unregistered.