### PR TITLE
Off Heap Changes and lowering trees bug

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -157,7 +157,7 @@ OMR::SymbolReferenceTable::findOrCreateContiguousArrayDataAddrFieldShadowSymRef(
    {
    if (!element(contiguousArrayDataAddrFieldSymbol))
       {
-      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Address);
+      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Int64);
       sym->setContiguousArrayDataAddrFieldSymbol();
       element(contiguousArrayDataAddrFieldSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), contiguousArrayDataAddrFieldSymbol, sym);
       element(contiguousArrayDataAddrFieldSymbol)->setOffset(TR::Compiler->om.offsetOfContiguousDataAddrField());

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2605,6 +2605,15 @@ OMR::Options::jitPreProcess()
    _disabledOptimizations[IVTypeTransformation] = true;
    _disabledOptimizations[basicBlockHoisting] = true;
 
+#ifdef OMR_GC_SPARSE_HEAP_ALLOCATION
+   if (TR::Compiler->om.isOffHeapAllocationEnabled())
+      {
+      // Disable opts known to be broken for off heap
+      _disabledOptimizations[escapeAnalysis] = true;
+      _disabledOptimizations[idiomRecognition] = true;
+      }
+#endif
+
    self()->setOption(TR_DisableTreePatternMatching);
    self()->setOption(TR_DisableHalfSlotSpills);
 

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -436,3 +436,96 @@ OMR::TransformUtil::createConditionalAlternatePath(TR::Compilation* comp,
    cfg->addEdge(TR::CFGEdge::createEdge(ifBlock, thenBlock, comp->trMemory()));
    cfg->copyExceptionSuccessors(elseBlock, thenBlock);
    }
+
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+TR::Node *
+OMR::TransformUtil::generateDataAddrLoadTrees(TR::Compilation *comp, TR::Node *arrayObject)
+   {
+   TR_ASSERT_FATAL_WITH_NODE(arrayObject,
+      TR::Compiler->om.isOffHeapAllocationEnabled(),
+      "This helper shouldn't be called if off heap allocation is disabled.\n");
+
+   TR::SymbolReference *dataAddrFieldOffset = comp->getSymRefTab()->findOrCreateContiguousArrayDataAddrFieldShadowSymRef();
+   TR::Node *dataAddrField = TR::Node::createWithSymRef(TR::aloadi, 1, arrayObject, 0, dataAddrFieldOffset);
+   dataAddrField->setIsInternalPointer(true);
+
+   return dataAddrField;
+   }
+#endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
+
+TR::Node *
+OMR::TransformUtil::generateArrayElementAddressTrees(TR::Compilation *comp, TR::Node *arrayNode, TR::Node *offsetNode)
+   {
+   TR::Node *arrayAddressNode = NULL;
+   TR::Node *totalOffsetNode = NULL;
+
+   TR_ASSERT_FATAL_WITH_NODE(arrayNode,
+      !TR::Compiler->om.canGenerateArraylets(),
+      "This helper shouldn't be called if arraylets are enabled.\n");
+
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+   if (TR::Compiler->om.isOffHeapAllocationEnabled())
+      {
+      arrayAddressNode = generateDataAddrLoadTrees(comp, arrayNode);
+      if (offsetNode)
+         arrayAddressNode = TR::Node::create(TR::aladd, 2, arrayAddressNode, offsetNode);
+      }
+   else if (comp->target().is64Bit())
+#else
+   if (comp->target().is64Bit())
+#endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
+      {
+      totalOffsetNode = TR::Node::lconst(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+      if (offsetNode)
+         totalOffsetNode = TR::Node::create(TR::ladd, 2, offsetNode, totalOffsetNode);
+      arrayAddressNode = TR::Node::create(TR::aladd, 2, arrayNode, totalOffsetNode);
+      }
+   else
+      {
+      totalOffsetNode = TR::Node::iconst(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+      if (offsetNode)
+         totalOffsetNode = TR::Node::create(TR::iadd, 2, offsetNode, totalOffsetNode);
+      arrayAddressNode = TR::Node::create(TR::aiadd, 2, arrayNode, totalOffsetNode);
+      }
+
+   return arrayAddressNode;
+   }
+
+TR::Node *
+OMR::TransformUtil::generateFirstArrayElementAddressTrees(TR::Compilation *comp, TR::Node *arrayObject)
+   {
+   TR::Node *firstArrayElementNode = generateArrayElementAddressTrees(comp, arrayObject);
+   return firstArrayElementNode;
+   }
+
+TR::Node *
+OMR::TransformUtil::generateConvertArrayElementIndexToOffsetTrees(TR::Compilation *comp, TR::Node *indexNode, TR::Node *elementSizeNode, int32_t elementSize, bool useShiftOpCode)
+   {
+   TR::Node *offsetNode = indexNode->createLongIfNeeded();
+   TR::Node *strideNode = elementSizeNode;
+   if (strideNode)
+      strideNode = strideNode->createLongIfNeeded();
+
+   if (strideNode != NULL || elementSize > 1)
+      {
+      TR::ILOpCodes offsetOpCode = TR::BadILOp;
+      if (comp->target().is64Bit())
+         {
+         if (strideNode == NULL && elementSize > 1)
+            strideNode = TR::Node::lconst(indexNode, elementSize);
+
+         offsetOpCode = useShiftOpCode ? TR::lshl : TR::lmul;
+         }
+      else
+         {
+         if (strideNode == NULL && elementSize > 1)
+            strideNode = TR::Node::iconst(indexNode, elementSize);
+
+         offsetOpCode = useShiftOpCode ? TR::ishl : TR::imul;
+         }
+
+      offsetNode = TR::Node::create(offsetOpCode, 2, offsetNode, strideNode);
+      }
+
+   return offsetNode;
+   }

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -482,7 +482,7 @@ OMR::TransformUtil::generateArrayElementAddressTrees(TR::Compilation *comp, TR::
       }
    else
       {
-      totalOffsetNode = TR::Node::iconst(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+      totalOffsetNode = TR::Node::iconst(static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes()));
       if (offsetNode)
          totalOffsetNode = TR::Node::create(TR::iadd, 2, offsetNode, totalOffsetNode);
       arrayAddressNode = TR::Node::create(TR::aiadd, 2, arrayNode, totalOffsetNode);

--- a/compiler/optimizer/OMRTransformUtil.hpp
+++ b/compiler/optimizer/OMRTransformUtil.hpp
@@ -188,6 +188,91 @@ class OMR_EXTENSIBLE TransformUtil
                                               TR::Block* mergeBlock,
                                               TR::CFG *cfg,
                                               bool markCold = true);
+
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+   /**
+    * \brief
+    *    Generate IL to load dataAddr pointer from the array header
+    *
+    * \param comp
+    *    The compilation object
+    *
+    * \param arrayObject
+    *    The array object node
+    *
+    * \return
+    *    IL for loading dataAddr pointer
+    */
+   static TR::Node *generateDataAddrLoadTrees(TR::Compilation *comp, TR::Node *arrayObject);
+#endif /* OMR_GC_SPARSE_HEAP_ALLOCATION */
+
+   /**
+    * \brief
+    *    Generate array element access IL for on and off heap contiguous arrays
+    *
+    * \param comp
+    *    The compilation object
+    *
+    * \param arrayNode
+    *    The array object node
+    *
+    * \param offsetNode
+    *    The offset node (in bytes)
+    *
+    * \return
+    *    IL to access array element at offset provided by offsetNode or
+    *    first array element if no offset node is provided
+    */
+   static TR::Node *generateArrayElementAddressTrees(
+      TR::Compilation *comp,
+      TR::Node *arrayNode,
+      TR::Node *offsetNode = NULL);
+
+   /**
+    * \brief
+    *    Generate IL to access first array element
+    *
+    * \param comp
+    *    The compilation object
+    *
+    * \param arrayObject
+    *    The array object node
+    *
+    * \return
+    *    IL for accessing first array element
+    */
+   static TR::Node *generateFirstArrayElementAddressTrees(TR::Compilation *comp, TR::Node *arrayObject);
+
+   /**
+    * \brief
+    *    Generates IL to convert element index to offset in bytes using element
+    *    size (node or integer)
+    *
+    * \param comp
+    *    The compilation object
+    *
+    * \param indexNode
+    *    Array element index node
+    *
+    * \param elementSizeNode
+    *    Array element size tree (ex: const node containing element size)
+    *
+    * \param elementSize
+    *    Array element size
+    *
+    * \param useShiftOpCode
+    *    Use left shift instead of multiplication
+    *
+    * \return
+    *    IL to convert array element index to offset in bytes
+    */
+   static TR::Node *generateConvertArrayElementIndexToOffsetTrees(
+      TR::Compilation *comp,
+      TR::Node *indexNode,
+      TR::Node *elementSizeNode = NULL,
+      int32_t elementSize = 0,
+      bool useShiftOpCode = false);
+
    private:
 
    static uint32_t _widthToShift[];

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -289,6 +289,10 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
       TR::Node* base = NULL;
       TR::Node* index = NULL;
       TR::ILOpCodes addOp, subOp, constOp;
+      // Need to track if lowered trees are internal pointers
+      // For context: https://github.com/eclipse/omr/issues/4929
+      bool isInternalPointer = false;
+      TR::AutomaticSymbol *pinningArrayPointer = NULL;
 
       if (self()->comp()->target().is64Bit())
          {
@@ -304,14 +308,33 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
          }
 
       if (node->getFirstChild()->getOpCodeValue() == addOp)
+         {
          add1 = node->getFirstChild();
+         if (add1->isInternalPointer())
+            {
+            isInternalPointer = true;
+            pinningArrayPointer = add1->getPinningArrayPointer();
+            }
+         }
       if (add1 && add1->getFirstChild()->getOpCodeValue() == addOp)
          {
          add2 = add1->getFirstChild();
          base = add2->getFirstChild();
+         if (add2->isInternalPointer())
+            {
+            isInternalPointer = true;
+            pinningArrayPointer = add2->getPinningArrayPointer();
+            }
          }
       if (add1 && add1->getSecondChild()->getOpCodeValue() == subOp)
+         {
          sub = add1->getSecondChild();
+         if (add1->isInternalPointer())
+            {
+            isInternalPointer = true;
+            pinningArrayPointer = add1->getPinningArrayPointer();
+            }
+         }
       if (add2 && add2->getSecondChild()->getOpCode().isLoadConst())
          {
          const1 = add2->getSecondChild();
@@ -330,6 +353,11 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
             index = add2->getSecondChild();
             add2 = add2->getFirstChild();
             base = add2->getFirstChild();
+            if (add2->isInternalPointer())
+               {
+               isInternalPointer = true;
+               pinningArrayPointer = add2->getPinningArrayPointer();
+               }
             if (add2->getSecondChild()->getOpCode().isLoadConst())
                const2 = add2->getSecondChild();
             if (const2 && add1->getSecondChild()->getOpCode().isLoadConst())
@@ -363,6 +391,13 @@ OMR::Z::CodeGenerator::lowerTreeIfNeeded(
 
          TR::Node* newAdd2 = TR::Node::create(addOp, 2, base, index);
          TR::Node* newConst = TR::Node::create(constOp, 0);
+         if (isInternalPointer)
+            {
+            newAdd2->setIsInternalPointer(true);
+            if (pinningArrayPointer)
+               newAdd2->setPinningArrayPointer(pinningArrayPointer);
+            }
+
          if (self()->comp()->target().is64Bit())
             newConst->setLongInt(offset);
          else


### PR DESCRIPTION
A number of off-heap commits and a fix to lower trees bug on Z

Commit https://github.com/eclipse/omr/pull/7296/commits/5fea9955d0bc8286df5604b2fe774cb71f0d5078 copy the implementation of array access APIs from Openj9. Will be removed from OpenJ9 later.

