### PR TITLE
Add l2i case for TM reduction

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5685,6 +5685,7 @@ generateTestUnderMaskIfPossible(TR::Node * node, TR::CodeGenerator * cg, TR::Ins
       else if ((nonConstNode->getFirstChild()->getOpCodeValue() == TR::bu2i ||
             nonConstNode->getFirstChild()->getOpCodeValue() == TR::s2i ||
             nonConstNode->getFirstChild()->getOpCodeValue() == TR::b2i ||
+            nonConstNode->getFirstChild()->getOpCodeValue() == TR::l2i ||
             nonConstNode->getFirstChild()->getOpCodeValue() == TR::i2l)
             && nonConstNode->getFirstChild()->getReferenceCount() == 1)
          {


### PR DESCRIPTION
This draft PR updates the function `generateTestUnderMaskIfPossible` to add the case of **l2i** for pattern matching trees in order to reduce a specific set of instructions into `TM + BRC` in memory test.

The following is an example tree with a specific pattern with an **ificmpne** node against zero, with an **iand** child. The **iand** child with **l2i** first child, and constant second child. 

 ```
n22n     (  0)  ificmpne --> block_3 BBStart at n20n ()                                              [     0x3ff69802fe0] bci=[-1,4,180] rc=0 vc=538 vn=- li=2 udi=- nc=2 flg=0x20
 n17n     (  1)    iand (X>=0 cannotOverflow )                                                        [     0x3ff69802e50] bci=[-1,1,180] rc=1 vc=538 vn=- li=2 udi=- nc=2 flg=0x1100
 n14n     (  1)      l2i                                                                              [     0x3ff69802d60] bci=[-1,1,180] rc=1 vc=538 vn=- li=2 udi=- nc=1
 n13n     (  1)        lloadi  <isClassAndDepthFlags>[#319  Shadow +24] [flags 0x603 0x0 ] (cannotOverflow )  [     0x3ff69802d10] bci=[-1,1,180] rc=1 vc=538 vn=- li=2 udi=- nc=1 flg=0x1000
 n12n     (  1)          ==>aloadi (in GPR_0034) (X!=0 X>=0 )
 n16n     (  2)      iconst 0x10000 (X!=0 X>=0 )                                                      [     0x3ff69802e00] bci=[-1,1,180] rc=2 vc=538 vn=- li=2 udi=- nc=0 flg=0x104
 n16n     (  2)    ==>iconst 0x10000 (X!=0 X>=0 )
 
 ------------------------------
------------------------------
 n22n     (  0)  ificmpne --> block_3 BBStart at n20n ()                                              [     0x3ff69802fe0] bci=[-1,4,180] rc=0 vc=538 vn=- li=2 udi=- nc=2 flg=0x20
 n17n     (  0)    iand (in GPR_0038) (X>=0 cannotOverflow )                                          [     0x3ff69802e50] bci=[-1,1,180] rc=0 vc=538 vn=- li=2 udi=- nc=2 flg=0x1100
 n14n     (  0)      l2i (in GPR_0038)                                                                [     0x3ff69802d60] bci=[-1,1,180] rc=0 vc=538 vn=- li=2 udi=- nc=1
 n13n     (  0)        lloadi  <isClassAndDepthFlags>[#319  Shadow +24] [flags 0x603 0x0 ] (in GPR_0038) (cannotOverflow )  [     0x3ff69802d10] bci=[-1,1,180] rc=0 vc=538 vn=- li=2 udi=- nc=1 flg=0x1000
 n12n     (  0)          ==>aloadi (in GPR_0034) (X!=0 X>=0 )
 n16n     (  0)      iconst 0x10000 (X!=0 X>=0 )                                                      [     0x3ff69802e00] bci=[-1,1,180] rc=0 vc=538 vn=- li=2 udi=- nc=0 flg=0x104
 n16n     (  0)    ==>iconst 0x10000 (X!=0 X>=0 )
------------------------------

 [     0x3ff69a00e00]                          LG      GPR_0038, Shadow[<isClassAndDepthFlags>] 24(GPR_0034)
 [     0x3ff69a00ed0]                          NILF    GPR_0038,65536
 [     0x3ff69a00fe0]                          CFI     GPR_0038,65536
 [     0x3ff69a010f0]                          BRC     BNH(0x6), Label L0017
```

The variables `depth`, `refCountZero`, and the `memory reference node` are updated to capture the above pattern for the l2i node. The updated variables are later used for pattern matching when considering l2i node with a memory reference of depth 2.

The LOAD, AND, CMP instructions generated from this specific pattern are replaced by `TM + BRC` sequence, which uses the updated memory reference node.

Updated set of tress with TM reduction for l2i node, from an OpenJ9 trace log produced off a JLTF job:

```
------------------------------
 n22n     (  0)  ificmpne --> block_3 BBStart at n20n ()                                              [     0x3ff8cb66f10] bci=[-1,4,180] rc=0 vc=495 vn=- li=2 udi=- nc=2 flg=0x20
 n17n     (  1)    iand (X>=0 cannotOverflow )                                                        [     0x3ff8cb66d80] bci=[-1,1,180] rc=1 vc=495 vn=- li=2 udi=- nc=2 flg=0x1100
 n14n     (  1)      l2i                                                                              [     0x3ff8cb66c90] bci=[-1,1,180] rc=1 vc=495 vn=- li=2 udi=- nc=1
 n13n     (  1)        lloadi  <isClassAndDepthFlags>[#320  Shadow +24] [flags 0x603 0x0 ] (cannotOverflow )  [     0x3ff8cb66c40] bci=[-1,1,180] rc=1 vc=495 vn=- li=2 udi=- nc=1 flg=0x1000
 n12n     (  1)          ==>aloadi (in GPR_0034) (X!=0 X>=0 )
 n16n     (  2)      iconst 0x10000 (X!=0 X>=0 )                                                      [     0x3ff8cb66d30] bci=[-1,1,180] rc=2 vc=495 vn=- li=2 udi=- nc=0 flg=0x104
 n16n     (  2)    ==>iconst 0x10000 (X!=0 X>=0 )
------------------------------
------------------------------
 n22n     (  0)  ificmpne --> block_3 BBStart at n20n ()                                              [     0x3ff8cb66f10] bci=[-1,4,180] rc=0 vc=495 vn=- li=2 udi=- nc=2 flg=0x20
 n17n     (  0)    iand (X>=0 cannotOverflow )                                                        [     0x3ff8cb66d80] bci=[-1,1,180] rc=0 vc=495 vn=- li=2 udi=- nc=2 flg=0x1100
 n14n     (  0)      l2i                                                                              [     0x3ff8cb66c90] bci=[-1,1,180] rc=0 vc=495 vn=- li=2 udi=- nc=1
 n13n     (  0)        lloadi  <isClassAndDepthFlags>[#320  Shadow +24] [flags 0x603 0x0 ] (cannotOverflow )  [     0x3ff8cb66c40] bci=[-1,1,180] rc=0 vc=495 vn=- li=2 udi=- nc=1 flg=0x1000
 n12n     (  0)          ==>aloadi (in GPR_0034) (X!=0 X>=0 )
 n16n     (  0)      iconst 0x10000 (X!=0 X>=0 )                                                      [     0x3ff8cb66d30] bci=[-1,1,180] rc=0 vc=495 vn=- li=2 udi=- nc=0 flg=0x104
 n16n     (  0)    ==>iconst 0x10000 (X!=0 X>=0 )
------------------------------

 [     0x3ff8ce05580]                          TM       Shadow[<isClassAndDepthFlags>] 29(GPR_0034), 0x01
 [     0x3ff8ce05660]                          BRC     BNP(0xe), Label L0017
```

Tagging @r30shah for review and verification if more changes may be needed to the function.