### PR TITLE
Split warm and cold blocks

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -206,6 +206,10 @@ OMR::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
       _binaryBufferStart(NULL),
       _binaryBufferCursor(NULL),
       _largestOutgoingArgSize(0),
+      _warmCodeEnd(NULL),
+      _coldCodeStart(NULL),
+      _estimatedWarmCodeLength(0),
+      _estimatedColdCodeLength(0),
       _estimatedCodeLength(0),
       _estimatedSnippetStart(0),
       _accumulatedInstructionLengthError(0),
@@ -227,6 +231,7 @@ OMR::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
       _globalFPRPartitionLimit(0),
       _firstInstruction(NULL),
       _appendInstruction(NULL),
+      _lastWarmInstruction(NULL),
       _firstGlobalVRF(-1),
       _lastGlobalVRF(-1),
       _firstOverlappedGlobalVRF(-1),
@@ -358,6 +363,159 @@ OMR::CodeGenerator::generateCodeFromIL()
    return false;
    }
 
+void OMR::CodeGenerator::findLastWarmBlock()
+   {
+   TR::Compilation *comp = self()->comp();
+   TR::TreeTop * tt;
+   TR::Node * node;
+
+   TR::Block * block = NULL;
+   TR::Block * firstColdBlock = NULL, * firstColdExtendedBlock = NULL;
+   int32_t numColdBlocks = 0, numNonOutlinedColdBlocks = 0;
+
+   for (tt = comp->getStartTree(); tt; tt = tt->getNextTreeTop())
+      {
+      node = tt->getNode();
+
+      if (node->getOpCodeValue() == TR::BBStart)
+         {
+         block = node->getBlock();
+
+         // If this is the first cold block, remember where the warm blocks ended.
+         // If it is a warm block and cold blocks have already been found, they
+         // are treated as warm.
+         //
+         if (block->isCold())
+            {
+            if (!firstColdBlock)
+               firstColdBlock = block;
+
+            numColdBlocks++;
+            }
+         else if (firstColdBlock)
+            {
+            firstColdBlock = NULL;
+            firstColdExtendedBlock = NULL;
+            numNonOutlinedColdBlocks = numColdBlocks;
+            }
+
+         if (!block->isExtensionOfPreviousBlock())
+            {
+            if (firstColdBlock &&
+                !firstColdExtendedBlock)
+               {
+               if (!block->getPrevBlock() ||
+                   !block->getPrevBlock()->canFallThroughToNextBlock())
+                  {
+                  firstColdExtendedBlock = block;
+                  }
+               else
+                  {
+                  firstColdBlock = NULL;
+                  numNonOutlinedColdBlocks = numColdBlocks;
+                  }
+               }
+            }
+         }
+      }
+
+   // Mark the split point between warm and cold blocks, so they can be
+   // allocated in different code sections.
+   //
+   TR::Block *lastWarmBlock;
+
+   if (firstColdExtendedBlock)
+      {
+      lastWarmBlock = firstColdExtendedBlock->getPrevBlock();
+
+      if (!lastWarmBlock)
+         {
+         // All the blocks are cold: insert a new goto block ahead of real blocks
+         //
+         lastWarmBlock = comp->insertNewFirstBlock();
+         }
+      }
+   else
+      {
+      // All the blocks are warm - the split point is between the last
+      // instruction and the snippets.
+      //
+      lastWarmBlock = block;
+      }
+
+   lastWarmBlock->setIsLastWarmBlock();
+
+   if (comp->getOption(TR_TraceCG))
+      {
+      traceMsg(comp, "%s Last warm block is block_%d\n", SPLIT_WARM_COLD_STRING, lastWarmBlock->getNumber());
+
+      if (numColdBlocks > 0)
+         traceMsg(comp, "%s Moved to cold code cache %d out of %d cold blocks (%d%%)\n",
+                           SPLIT_WARM_COLD_STRING,
+                           numColdBlocks - numNonOutlinedColdBlocks,
+                           numColdBlocks,
+                           (numColdBlocks - numNonOutlinedColdBlocks)*100/numColdBlocks);
+      }
+
+   // If the last tree in the last warm block is not a TR_goto, insert a goto tree
+   // at the end of the block.
+   // If there is a following block the goto will branch to it so that when the
+   // code is split any fall-through will go to the right place.
+   // If there is no following block the goto will branch to the first block; in
+   // this case the goto should never be reached, it is there only to
+   // make sure that the instruction following the last real treetop will be in
+   // warm code, so if it is a helper call (e.g. for a throw) the return address
+   // is in this method's code.
+   //
+   if (lastWarmBlock->getNumberOfRealTreeTops() == 0)
+      tt = lastWarmBlock->getEntry();
+   else
+      tt = lastWarmBlock->getLastRealTreeTop();
+
+   node = tt->getNode();
+
+   if (!(node->getOpCode().isGoto() ||
+         node->getOpCode().isJumpWithMultipleTargets() ||
+         node->getOpCode().isReturn()))
+      {
+      // Find the block to be branched to
+      //
+      TR::TreeTop * targetTreeTop = lastWarmBlock->getExit()->getNextTreeTop();
+
+      if (targetTreeTop)
+         // Branch to following block. Make sure it is not marked as an
+         // extension block so that it will get a label generated.
+         //
+         targetTreeTop->getNode()->getBlock()->setIsExtensionOfPreviousBlock(false);
+      else
+         // Branch to the first block. This will not be marked as an extension
+         // block.
+         //
+         targetTreeTop = comp->getStartBlock()->getEntry();
+
+      // Generate the goto and insert it into the end of the last warm block.
+      //
+      TR::TreeTop *gotoTreeTop = TR::TreeTop::create(comp, TR::Node::create(node, TR::Goto, 0, targetTreeTop));
+
+      // Move reg deps from BBEnd to goto
+      //
+      TR::Node *bbEnd = lastWarmBlock->getExit()->getNode();
+
+      if (bbEnd->getNumChildren() > 0)
+         {
+         TR::Node *glRegDeps = bbEnd->getChild(0);
+
+         gotoTreeTop->getNode()->setNumChildren(1);
+         gotoTreeTop->getNode()->setChild(0, glRegDeps);
+
+         bbEnd->setChild(0,NULL);
+         bbEnd->setNumChildren(0);
+         }
+
+      tt->insertAfter(gotoTreeTop);
+      }
+   }
+
 void OMR::CodeGenerator::lowerTrees()
    {
 
@@ -393,7 +551,6 @@ void OMR::CodeGenerator::lowerTrees()
 
       self()->lowerTreesPreTreeTopVisit(tt, visitCount);
 
-
       // First lower the children
       //
       self()->lowerTreesWalk(node, tt, visitCount);
@@ -408,6 +565,14 @@ void OMR::CodeGenerator::lowerTrees()
    self()->postLowerTrees();
    }
 
+void OMR::CodeGenerator::postLowerTrees()
+   {
+   if (comp()->getOption(TR_SplitWarmAndColdBlocks) &&
+       !comp()->compileRelocatableCode())
+      {
+      self()->findLastWarmBlock();
+      }
+   }
 
 void
 OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount)
@@ -3424,7 +3589,7 @@ OMR::CodeGenerator::getMethodStats(MethodStats &methodStats)
    outOfLine = 0;
    unaccounted = 0;
    blocksInColdCache = 0;
-   overestimateInColdCache = 0;  // TODO: implement
+   overestimateInColdCache = self()->getEstimatedColdLength() - self()->getColdCodeLength();
 
    uint32_t allBlocks = 0;
    uint32_t sizeBeforeFirstBlock = 0;
@@ -3432,13 +3597,10 @@ OMR::CodeGenerator::getMethodStats(MethodStats &methodStats)
    bool insideColdCache = false;
    uint32_t cold_frequence_size[NUMBER_BLOCK_FREQUENCIES] = {0};
 
-   codeSize = (uint32_t)(self()->getCodeEnd() - self()->getCodeStart());
+   codeSize = static_cast<uint32_t>(self()->getCodeEnd() - self()->getCodeStart());
 
-#if 0
-   // enable when splitting warm  and cold blocks is enabled
    if (self()->getLastWarmInstruction())
-      codeSize = codeSize + self()->getWarmCodeEnd() - self()->getColdCodeStart();
-#endif
+      codeSize = codeSize - static_cast<uint32_t>(self()->getColdCodeStart() - self()->getWarmCodeEnd());
 
    for (TR::TreeTop *tt = self()->comp()->getMethodSymbol()->getFirstTreeTop(); tt ; tt = tt->getNextTreeTop())
       {
@@ -3473,11 +3635,9 @@ OMR::CodeGenerator::getMethodStats(MethodStats &methodStats)
             sizeBeforeFirstBlock = (uint32_t)(startCursor - self()->getCodeStart());
             firstBlock = false;
             }
-#if 0
-         /// enable when splitting warm  and cold blocks is enabled
+
          if (block->isLastWarmBlock())
             insideColdCache = true;
-#endif
          }
       }
 

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -218,6 +218,21 @@ class OMR_EXTENSIBLE Instruction
    bool needsAOTRelocation() { return (_index & TO_MASK(NeedsAOTRelocation)) != 0; }
    void setNeedsAOTRelocation(bool v = true) { v ? _index |= TO_MASK(NeedsAOTRelocation) : _index &= ~TO_MASK(NeedsAOTRelocation); }
 
+   /**
+    * @brief Indicates instruction after which binary encoding should switch to a cold cache
+    *
+    * @returns true iff instruction is a last warm instruction
+    */
+   bool isLastWarmInstruction() { return (_index & TO_MASK(LastWarmInstruction)) != 0; }
+
+   /**
+    * @brief Identifies instruction as a last warm instruction.
+    *        Instructions after that will be placed into a cold cache.
+    *        Code that sets it is responsible for maintaining the correct value
+    *        in case the instruction is removed or a new instruction is appended
+    */
+   void setLastWarmInstruction(bool v = true) { v ? _index |= TO_MASK(LastWarmInstruction) : _index &= ~TO_MASK(LastWarmInstruction); }
+
    TR_GCStackMap *getGCMap() { return _gc._GCMap; }
    TR_GCStackMap *setGCMap(TR_GCStackMap *map) { return (_gc._GCMap = map); }
    TCollectableReferenceMask getGCRegisterMask() { return _gc._GCRegisterMask; }

--- a/compiler/codegen/OMRInstructionFlagEnum.hpp
+++ b/compiler/codegen/OMRInstructionFlagEnum.hpp
@@ -31,3 +31,7 @@ NeedsGCMapBit,
 // Instruction requires an AOT relocation
 //
 NeedsAOTRelocation,
+
+// Last warm instruction
+//
+LastWarmInstruction,

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2732,3 +2732,25 @@ OMR::Compilation::getSnippetsToBePatchedOnClassRedefinition()
    {
    return self()->cg()->getSnippetsToBePatchedOnClassRedefinition();
    }
+
+TR::Block *
+OMR::Compilation::insertNewFirstBlock()
+   {
+   TR::Node *oldBBStart = self()->getStartTree()->getNode();
+   TR::Block *oldFirstBlock = self()->getStartTree()->getNode()->getBlock();
+   TR::Node *glRegDeps=NULL;
+   if (oldBBStart->getNumChildren() == 1)
+      glRegDeps = oldBBStart->getChild(0);
+
+   TR::CFG *cfg = self()->getFlowGraph();
+   TR::Block *newFirstBlock = TR::Block::createEmptyBlock(oldBBStart, self(), oldFirstBlock->getFrequency());
+
+   newFirstBlock->takeGlRegDeps(self(), glRegDeps);
+   cfg->addNode(newFirstBlock, (TR_RegionStructure *)cfg->getStructure());
+   cfg->join(newFirstBlock, oldFirstBlock);
+   cfg->addEdge(cfg->getStart(), newFirstBlock);
+   cfg->removeEdge(cfg->getStart(), oldFirstBlock);
+   self()->setStartTree(newFirstBlock->getEntry());
+
+   return newFirstBlock;
+   }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -575,6 +575,17 @@ public:
 
    TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition();
 
+  /*
+   * \brief
+   *    Inserts new first block into the IL
+   *
+   * \note
+   *    Inserts an empty block before the current first block
+   *    Moves glRegDeps from the current first block to the new one
+   *
+   */
+   TR::Block *insertNewFirstBlock();
+
    TR::RegisterCandidates *getGlobalRegisterCandidates() { return _globalRegisterCandidates; }
    void setGlobalRegisterCandidates(TR::RegisterCandidates *t) { _globalRegisterCandidates = t; }
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1096,6 +1096,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"slipTrap=",                          "O{regex}\trecord entry/exit for slit/trap for methods listed",
                                           TR::Options::setRegex, offsetof(OMR::Options, _slipTrap), 0, "P"},
    {"softFailOnAssume",   "M\tfail the compilation quietly and use the interpreter if an assume fails", SET_OPTION_BIT(TR_SoftFailOnAssume), "P"},
+   {"splitWarmAndColdBlocks",       "M\tplace cold blocks into cold part of code cache", SET_OPTION_BIT(TR_SplitWarmAndColdBlocks), "F"},
    {"stackPCDumpNumberOfBuffers=",            "O<nnn>\t The number of gc cycles for which we collect top stack pcs", TR::Options::setCount, offsetof(OMR::Options,_stackPCDumpNumberOfBuffers), 0, "F%d"},
    {"stackPCDumpNumberOfFrames=",            "O<nnn>\t The number of top stack pcs we collect during each cycle", TR::Options::setCount, offsetof(OMR::Options,_stackPCDumpNumberOfFrames), 0, "F%d"},
    {"startThrottlingTime=", "M<nnn>\tTime when compilation throttling should start (ms since JVM start)",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -356,7 +356,7 @@ enum TR_CompilationOptions
 
    // Option word 9
    //
-   // Available                           = 0x00000020 + 9,
+   TR_SplitWarmAndColdBlocks              = 0x00000020 + 9,
    // Available                           = 0x00000040 + 9,
    TR_DisableTLHPrefetch                  = 0x00000080 + 9,
    TR_DisableJProfilerThread              = 0x00000100 + 9,

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -448,6 +448,8 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    bool wasHeaderOfCanonicalizedLoop()                { return _flags.testAny(_wasHeaderOfCanonicalizedLoop); }
    void setWasHeaderOfCanonicalizedLoop(bool b)       { _flags.set(_wasHeaderOfCanonicalizedLoop, b); }
 
+   bool isLastWarmBlock()                             { return _flags.testAny(_isLastWarmBlock); }
+   void setIsLastWarmBlock(bool b = true)             { _flags.set(_isLastWarmBlock, b); }
 
    bool isSyntheticHandler()                          { return  _catchBlockExtension && _catchBlockExtension->_isSyntheticHandler; }
    void setIsSyntheticHandler();
@@ -534,6 +536,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _isCreatedByVersioning                = 0x02000000,
       _isEntryOfShortRunningLoop            = 0x04000000,
       _wasHeaderOfCanonicalizedLoop         = 0x08000000,
+      _isLastWarmBlock                      = 0x10000000,
       };
 
    TR::TreeTop *                         _pEntry;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -98,6 +98,13 @@
 #include "x/codegen/X86Instruction.hpp"
 #include "codegen/InstOpCode.hpp"
 
+// Amount to be added to the estimated code size to ensure that there are long
+// branches between warm and cold code sections (must be multiple of 8 bytes).
+//
+#define MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE 512
+
+static_assert(MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE % 8 == 0, "MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE should be multiple of 8");
+
 namespace OMR { class RegisterUsage; }
 namespace TR { class RegisterDependencyConditions; }
 
@@ -1897,6 +1904,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
    TR::Instruction * estimateCursor = self()->getFirstInstruction();
    int32_t estimate = 0;
+   int32_t warmEstimate = 0;
 
    // Estimate the binary length up to TR::InstOpCode::proc
    //
@@ -2037,6 +2045,19 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       if (self()->comp()->getOption(TR_TraceCG))
          self()->getDebug()->dumpInstructionWithVFPState(estimateCursor, &prevState);
 
+      // If this is the last warm instruction, remember the estimated size up to
+      // this point and add a buffer to the estimated size so that branches
+      // between warm and cold instructions will be forced to be long branches.
+      // The size is rounded up to a multiple of 8 so that double-alignments in
+      // the cold section will have the same amount of padding for the estimate
+      // and the actual code allocation.
+      //
+      if (estimateCursor->isLastWarmInstruction())
+         {
+         warmEstimate = (estimate+7) & ~7;
+         estimate = warmEstimate + MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE;
+         }
+
       if (estimateCursor == _vfpResetInstruction)
          self()->generateDebugCounter(estimateCursor, "cg.prologues:#instructionBytes", estimate - estimatedPrologueStartOffset, TR::DebugCounter::Expensive);
 
@@ -2047,6 +2068,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       traceMsg(self()->comp(), "\n</instructions>\n");
 
    estimate = self()->setEstimatedLocationsForSnippetLabels(estimate);
+
    // When using copyBinaryToBuffer() to copy the encoding of an instruction we
    // indiscriminatelly copy a whole integer, even if the size of the encoding
    // is less than that. This may cause the write to happen beyond the allocated
@@ -2054,8 +2076,20 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // block, then the write could potentially destroy data that resides in the
    // adjacent block. For this reason it is better to overestimate
    // the allocated size by 4.
+   //
    #define OVER_ESTIMATION 4
-   self()->setEstimatedCodeLength(estimate+OVER_ESTIMATION);
+   self()->setEstimatedCodeLength(estimate + OVER_ESTIMATION);
+
+   if (warmEstimate)
+      {
+      self()->setEstimatedWarmLength(warmEstimate + OVER_ESTIMATION);
+      self()->setEstimatedColdLength(estimate - warmEstimate - MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE + OVER_ESTIMATION);
+      }
+   else
+      {
+      self()->setEstimatedWarmLength(estimate + OVER_ESTIMATION);
+      self()->setEstimatedColdLength(0);
+      }
 
    if (self()->comp()->getOption(TR_TraceCG))
       {
@@ -2073,7 +2107,9 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       }
 
    uint8_t * coldCode = NULL;
-   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
+   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(),
+                                               self()->getEstimatedColdLength(),
+                                               &coldCode);
    TR_ASSERT(temp, "Failed to allocate primary code area.");
 
    if (self()->comp()->target().is64Bit() && self()->hasCodeCacheSwitched() && self()->getPicSlotCount() != 0)
@@ -2128,6 +2164,29 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          }
 
       self()->addToAtlas(cursorInstruction);
+
+      // If this is the last warm instruction, save info about the warm code range
+      // and set up to generate code in the cold code range.
+      //
+      if (cursorInstruction->isLastWarmInstruction())
+         {
+         self()->setWarmCodeEnd(self()->getBinaryBufferCursor());
+         self()->setColdCodeStart(coldCode);
+         self()->setBinaryBufferCursor(coldCode);
+
+         if (self()->comp()->getOption(TR_TraceCG))
+            {
+            traceMsg(self()->comp(), "%s warmCodeEnd = %p, lastWarmInstruction = %p coldCodeStart = %p\n",
+                                                           SPLIT_WARM_COLD_STRING,
+                                                           self()->getWarmCodeEnd(), cursorInstruction, coldCode);
+            }
+
+         // Adjust the accumulated length error so that distances within the cold
+         // code are calculated properly using the estimated code locations.
+         //
+         self()->setAccumulatedInstructionLengthError(static_cast<uint32_t>(self()->getBinaryBufferStart() + self()->getEstimatedWarmLength() + MIN_DISTANCE_BETWEEN_WARM_AND_COLD_CODE - coldCode));
+         }
+
       cursorInstruction = cursorInstruction->getNext();
       }
 


### PR DESCRIPTION
OMR already provides warm and cold code cache and some platforms already
place some code into the cold cache, but not cold blocks. The goal is to
provide a capability of placing cold blocks into the cold cache. This can
help with the future footprint reduction work:

- find last warm block during tree lowering
- identify last warm instruction during instruction selection (currently, only in openj9)
- switch to the cold code cache after last warm instruction during binary encoding (currently, only on x platform)
- the code is only enabled if -Xjit:splitWarmAndColdBlocks option is on