### PR TITLE
Simplify bit opcode VP handler templates

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -216,6 +216,53 @@ uint64_t TR::VPConstraint::getUnsignedHighLong()
    return TR::getMaxUnsigned<TR::Int64>();    // consumer beware! You don't want to assign this to a int64_t
    }
 
+TR::VPLongConst* TR::VPConstraint::createConst(OMR::ValuePropagation *vp, int64_t n)
+   {
+   return TR::VPLongConst::create(vp, n);
+   }
+
+TR::VPIntConst* TR::VPConstraint::createConst(OMR::ValuePropagation *vp, int32_t n)
+   {
+   return TR::VPIntConst::create(vp, n);
+   }
+
+TR::VPShortConst* TR::VPConstraint::createConst(OMR::ValuePropagation *vp, int16_t n)
+   {
+   return TR::VPShortConst::create(vp, n);
+   }
+
+TR::VPLongConstraint* TR::VPConstraint::createRange(OMR::ValuePropagation *vp, int64_t l, int64_t h)
+   {
+   return TR::VPLongRange::create(vp, l, h);
+   }
+
+TR::VPIntConstraint* TR::VPConstraint::createRange(OMR::ValuePropagation *vp, int32_t l, int32_t h)
+   {
+   return TR::VPIntRange::create(vp, l, h);
+   }
+
+TR::VPShortConstraint* TR::VPConstraint::createRange(OMR::ValuePropagation *vp, int16_t l, int16_t h)
+   {
+   return TR::VPShortRange::create(vp, l, h);
+   }
+
+template <>
+int64_t TR::VPConstraint::getConstValue<int64_t>()
+   {
+   return asLongConst()->getLong();
+   }
+
+template <>
+int32_t TR::VPConstraint::getConstValue<int32_t>()
+   {
+   return asIntConst()->getInt();
+   }
+
+template <>
+int16_t TR::VPConstraint::getConstValue<int16_t>()
+   {
+   return asShortConst()->getShort();
+   }
 
 bool TR::VPConstraint::isNullObject()
    {

--- a/compiler/optimizer/VPConstraint.hpp
+++ b/compiler/optimizer/VPConstraint.hpp
@@ -158,7 +158,28 @@ class VPConstraint
    virtual uint64_t getUnsignedLowLong();
    virtual uint64_t getUnsignedHighLong();
 
+   template <typename int_t> int_t getConstValue();
 
+   template <typename int_t> int_t getLow();
+   template <> virtual int64_t getLow<int64_t>() {return getLowLong();}
+   template <> virtual int32_t getLow<int32_t>() {return getLowInt();}
+   template <> virtual int16_t getLow<int16_t>() {return getLowShort();}
+
+   template <typename int_t> int_t getHigh();
+   template <> virtual int64_t getHigh<int64_t>() {return getLowLong();}
+   template <> virtual int32_t getHigh<int32_t>() {return getLowInt();}
+   template <> virtual int16_t getHigh<int16_t>() {return getLowShort();}
+
+   static TR::VPLongConst* createConst(OMR::ValuePropagation *vp, int64_t n);
+   static TR::VPIntConst* createConst(OMR::ValuePropagation *vp, int32_t n);
+   static TR::VPShortConst* createConst(OMR::ValuePropagation *vp, int16_t n);
+
+   static TR::VPLongConstraint* createRange(OMR::ValuePropagation *vp, int64_t l, int64_t h);
+   static TR::VPIntConstraint* createRange(OMR::ValuePropagation *vp, int32_t l, int32_t h);
+   static TR::VPShortConstraint* createRange(OMR::ValuePropagation *vp, int16_t l, int16_t h);
+
+   virtual bool isConst() {return false;}
+   virtual bool isRange() {return false;}
 
    // Class information
    //
@@ -320,6 +341,7 @@ class VPShortConst : public TR::VPShortConstraint
    virtual TR::VPShortConst *asShortConst();
    virtual int16_t getHigh() {return _low;}
    virtual bool mustBeEqual(TR::VPConstraint *other, OMR::ValuePropagation *vp);
+   virtual bool isConst() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();
@@ -336,6 +358,7 @@ class VPShortRange : public TR::VPShortConstraint
    static TR::VPShortConstraint *createWithPrecision(OMR::ValuePropagation *vp, int32_t precision, bool isNonNegative = false);
    virtual TR::VPShortRange *asShortRange();
    virtual int16_t getHigh() {return _high;}
+   virtual bool isRange() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();
@@ -399,6 +422,7 @@ class VPIntConst : public TR::VPIntConstraint
    virtual TR::VPIntConst *asIntConst();
    virtual int32_t getHigh() {return _low;}
    virtual bool mustBeEqual(TR::VPConstraint *other, OMR::ValuePropagation *vp);
+   virtual bool isConst() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();
@@ -416,6 +440,7 @@ class VPIntRange : public TR::VPIntConstraint
    static TR::VPIntConstraint *createWithPrecision(OMR::ValuePropagation *vp, TR::DataType dt, int32_t precision, TR_YesNoMaybe isUnsigned, bool isNonNegative = false);
    virtual TR::VPIntRange *asIntRange();
    virtual int32_t getHigh() {return _high;}
+   virtual bool isRange() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();
@@ -471,6 +496,7 @@ class VPLongConst : public TR::VPLongConstraint
    virtual TR::VPLongConst *asLongConst();
    virtual int64_t getHigh() {return _low;}
    virtual bool mustBeEqual(TR::VPConstraint *other, OMR::ValuePropagation *vp);
+   virtual bool isConst() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();
@@ -485,6 +511,7 @@ class VPLongRange : public TR::VPLongConstraint
    static TR::VPLongConstraint *create(OMR::ValuePropagation *vp, int64_t low, int64_t high, bool powerOfTwo = false, TR_YesNoMaybe canOverflow = TR_no);
    virtual TR::VPLongRange *asLongRange();
    virtual int64_t getHigh() {return _high;}
+   virtual bool isRange() {return true;}
 
    virtual void print(TR::Compilation *, TR::FILE *);
    virtual const char *name();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4588,36 +4588,6 @@ TR::Node *constrainMultiANewArray(OMR::ValuePropagation *vp, TR::Node *node)
 
 
 //bit opcode constraints start
-
-static TR::VPLongRange* getLongRange (TR::VPConstraint* c) {return c->asLongRange();}
-static TR::VPLongConst* getLongConst (TR::VPConstraint* c) {return c->asLongConst();}
-static TR::VPIntRange* getIntRange (TR::VPConstraint* c)   {return c->asIntRange();}
-static TR::VPIntConst* getIntConst (TR::VPConstraint* c)   {return c->asIntConst();}
-static void getLowHighInts (TR::VPIntRange* range, int32_t& low, int32_t& high)
-   {
-   low = range->getLowInt();
-   high = range->getHighInt();
-   }
-static void getInt (TR::VPIntConst* c, int32_t& n)
-   {
-   n = c->getInt();
-   }
-static void getLowHighLongs (TR::VPLongRange* range, int64_t& low, int64_t& high)
-   {
-   low = range->getLowLong();
-   high = range->getHighLong();
-   }
-static void getLong (TR::VPLongConst* c, int64_t& n)
-   {
-   n = c->getLong();
-   }
-
-static TR::VPConstraint* createIntConstConstraint(OMR::ValuePropagation *vp, int32_t n) {return TR::VPIntConst::create(vp, n); }
-template <typename T>
-static TR::VPConstraint* createIntRangeConstraint(OMR::ValuePropagation *vp, T l, T h) {return TR::VPIntRange::create(vp, static_cast<int32_t>(l), static_cast<int32_t>(h));}
-static TR::VPConstraint* createLongConstConstraint(OMR::ValuePropagation *vp, int64_t n) {return TR::VPLongConst::create(vp, n); }
-static TR::VPConstraint* createLongRangeConstraint(OMR::ValuePropagation *vp, int64_t l, int64_t h) {return TR::VPLongRange::create(vp, l, h);}
-
 static int32_t integerToPowerOf2 (int32_t n) {return (n==0) ? 0 : floorPowerOfTwo(n); }
 static int32_t integerNumberOfLeadingZeros (int32_t n) {return leadingZeroes (n);}
 static int32_t integerNumberOfTrailingZeros (int32_t n) {return trailingZeroes(n);}
@@ -4630,11 +4600,10 @@ static int32_t longBitCount (int64_t n) {return populationCount(n);}
 static int64_t longLowestOneBit (int64_t n) {return (n==0) ? 0 : 1 << longNumberOfTrailingZeros(n);}
 
 
-template <typename FUNC, typename FUNC2, typename T>
+template <typename T, typename FUNC>
 void addValidRangeBlockOrGlobalConstraint (OMR::ValuePropagation *vp,
                                                    TR::Node *node,
-                                                   FUNC createRange,
-                                                   FUNC2 processValue,
+                                                   FUNC processValue,
                                                    T low,
                                                    T high,
                                                    bool childGlobal)
@@ -4652,26 +4621,13 @@ void addValidRangeBlockOrGlobalConstraint (OMR::ValuePropagation *vp,
       }
 
 
-   vp->addBlockOrGlobalConstraint(node, createRange(vp, pLow, pHigh),childGlobal);
+   vp->addBlockOrGlobalConstraint(node, TR::VPConstraint::createRange(vp, pLow, pHigh), childGlobal);
    }
 
-template <typename A,
-         typename B,
-         typename C,
-         typename D,
-         typename E,
-         typename F,
-         typename G,
-         typename T>
+template <typename T, typename FUNC>
 static TR::Node* constrainHighestOneBitAndLeadingZerosHelper (OMR::ValuePropagation *vp,
                                                                      TR::Node *node,
-                                                                     A getConst,
-                                                                     B getRange,
-                                                                     C getValue,
-                                                                     D getValues,
-                                                                     E createConst,
-                                                                     F createRange,
-                                                                     G processValue,
+                                                                     FUNC processValue,
                                                                      T MIN_VALUE,
                                                                      T MAX_VALUE)
   {
@@ -4688,10 +4644,9 @@ static TR::Node* constrainHighestOneBitAndLeadingZerosHelper (OMR::ValuePropagat
 
    if (childConstraint)
       {
-      if (getConst(childConstraint))
+      if (childConstraint->isConst())
          {
-         T value = 0;
-         getValue (getConst(childConstraint), value);
+         T value = childConstraint->getConstValue<T>();
 
          //RangeConstraint with the same low and high should be folded into a const constraint
          MIN_VALUE = value;
@@ -4703,10 +4658,10 @@ static TR::Node* constrainHighestOneBitAndLeadingZerosHelper (OMR::ValuePropagat
             }
 
          }
-      else if (getRange(childConstraint))
+      else if (childConstraint->isRange())
          {
-         T low = 0, high = 0;
-         getValues(getRange(childConstraint) , low, high);
+         T low = childConstraint->getLow<T>();
+         T high = childConstraint->getHigh<T>();
          if (low < 0 && high < 0)
             {
             //RangeConstraint with the same low and high should be folded into a const constraint.
@@ -4726,27 +4681,14 @@ static TR::Node* constrainHighestOneBitAndLeadingZerosHelper (OMR::ValuePropagat
          }
       }
 
-   addValidRangeBlockOrGlobalConstraint (vp, node, createRange, processValue, MIN_VALUE, MAX_VALUE, childGlobal);
+   addValidRangeBlockOrGlobalConstraint (vp, node, processValue, MIN_VALUE, MAX_VALUE, childGlobal);
    return node;
    }
 
-template <typename A,
-         typename B,
-         typename C,
-         typename D,
-         typename E,
-         typename F,
-         typename G,
-         typename T>
+template <typename T, typename FUNC>
 static TR::Node* constrainLowestOneBitAndTrailingZerosHelper (OMR::ValuePropagation *vp,
                                                                      TR::Node *node,
-                                                                     A getConst,
-                                                                     B getRange,
-                                                                     C getValue,
-                                                                     D getValues,
-                                                                     E createConst,
-                                                                     F createRange,
-                                                                     G processValue,
+                                                                     FUNC processValue,
                                                                      T MIN_VALUE,
                                                                      T MAX_VALUE)
   {
@@ -4762,106 +4704,73 @@ static TR::Node* constrainLowestOneBitAndTrailingZerosHelper (OMR::ValuePropagat
 
    bool childGlobal;
    TR::VPConstraint *childConstraint = vp->getConstraint(node->getFirstChild(), childGlobal);
-   if (childConstraint && getConst(childConstraint))
+   if (childConstraint)
       {
-      T value = 0;
-      getValue (getConst(childConstraint), value);
-      MIN_VALUE = value;
-      MAX_VALUE = value;
+      if (childConstraint->isConst())
+         {
+         T value = childConstraint->getConstValue<T>();
+         MIN_VALUE = value;
+         MAX_VALUE = value;
+         }
       }
 
-   addValidRangeBlockOrGlobalConstraint (vp, node, createRange, processValue, MIN_VALUE, MAX_VALUE, childGlobal);
+   addValidRangeBlockOrGlobalConstraint (vp, node, processValue, MIN_VALUE, MAX_VALUE, childGlobal);
    return node;
    }
 
 TR::Node * constrainIntegerHighestOneBit(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainHighestOneBitAndLeadingZerosHelper (vp, node, getIntConst,
-                                                       getIntRange, getInt, getLowHighInts,
-                                                       createIntConstConstraint,
-                                                       //createIntRangeConstraint, integerToPowerOf2, (int32_t) 0, (int32_t) -1);
-                                                       createIntRangeConstraint<int32_t>, integerToPowerOf2, (int32_t) TR::getMaxSigned<TR::Int32>(), (int32_t) TR::getMinSigned<TR::Int32>());
+   return constrainHighestOneBitAndLeadingZerosHelper<int32_t>(vp, node, integerToPowerOf2, (int32_t) TR::getMaxSigned<TR::Int32>(), (int32_t) TR::getMinSigned<TR::Int32>());
    }
 
 
 TR::Node * constrainIntegerNumberOfLeadingZeros(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainHighestOneBitAndLeadingZerosHelper (vp, node, getIntConst,
-                                                       getIntRange, getInt, getLowHighInts,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int32_t>, integerNumberOfLeadingZeros, (int32_t) 0, (int32_t) -1);
-
-
+   return constrainHighestOneBitAndLeadingZerosHelper<int32_t>(vp, node, integerNumberOfLeadingZeros, (int32_t) 0, (int32_t) -1);
    }
 
 TR::Node * constrainLongHighestOneBit(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainHighestOneBitAndLeadingZerosHelper (vp, node, getLongConst,
-                                                       getLongRange, getLong, getLowHighLongs,
-                                                       createLongConstConstraint,
-                                                       //createLongRangeConstraint, longToPowerOf2, (int64_t) 0, (int64_t) -1);
-                                                       createLongRangeConstraint, longToPowerOf2, (int64_t) TR::getMaxSigned<TR::Int64>(), TR::getMinSigned<TR::Int64>());
-
+   return constrainHighestOneBitAndLeadingZerosHelper<int64_t>(vp, node, longToPowerOf2, (int64_t) TR::getMaxSigned<TR::Int64>(), TR::getMinSigned<TR::Int64>());
    }
 
 TR::Node * constrainLongNumberOfLeadingZeros(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainHighestOneBitAndLeadingZerosHelper (vp, node, getLongConst,
-                                                       getLongRange, getLong, getLowHighLongs,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int64_t>, longNumberOfLeadingZeros, (int64_t) 0, (int64_t) -1);
+   return constrainHighestOneBitAndLeadingZerosHelper<int64_t>(vp, node, longNumberOfLeadingZeros, (int64_t) 0, (int64_t) -1);
    }
 
 TR::Node * constrainIntegerLowestOneBit(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper (vp, node, getIntConst,
-                                                       getIntRange, getInt, getLowHighInts,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int32_t>, integerLowestOneBit, (int32_t) TR::getMaxSigned<TR::Int32>(), (int32_t) TR::getMinSigned<TR::Int32>());
+   return constrainLowestOneBitAndTrailingZerosHelper<int32_t>(vp, node, integerLowestOneBit, (int32_t) TR::getMaxSigned<TR::Int32>(), (int32_t) TR::getMinSigned<TR::Int32>());
    }
 
 
    TR::Node * constrainIntegerBitCount(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper (vp, node, getIntConst,
-                                                       getIntRange, getInt, getLowHighInts,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int32_t>, integerBitCount, (int32_t) 0, (int32_t) -1);
+   return constrainLowestOneBitAndTrailingZerosHelper<int32_t>(vp, node, integerBitCount, (int32_t) 0, (int32_t) -1);
    }
 
 
 TR::Node * constrainIntegerNumberOfTrailingZeros(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper (vp, node, getIntConst,
-                                                       getIntRange, getInt, getLowHighInts,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int32_t>, integerNumberOfTrailingZeros, (int32_t) 0, (int32_t) -1);
+   return constrainLowestOneBitAndTrailingZerosHelper<int32_t>(vp, node, integerNumberOfTrailingZeros, (int32_t) 0, (int32_t) -1);
    }
 
 TR::Node * constrainLongLowestOneBit(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper (vp, node, getLongConst,
-                                                       getLongRange, getLong, getLowHighLongs,
-                                                       createLongConstConstraint,
-                                                       createLongRangeConstraint, longLowestOneBit, (int64_t) TR::getMaxSigned<TR::Int64>(), (int64_t) TR::getMinSigned<TR::Int64>());
+   return constrainLowestOneBitAndTrailingZerosHelper<int64_t>(vp, node, longLowestOneBit, (int64_t) TR::getMaxSigned<TR::Int64>(), (int64_t) TR::getMinSigned<TR::Int64>());
    }
 
 
 TR::Node * constrainLongNumberOfTrailingZeros(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper (vp, node, getLongConst,
-                                                       getLongRange, getLong, getLowHighLongs,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int64_t>, longNumberOfTrailingZeros, (int64_t) 0, (int64_t) -1);
+   return constrainLowestOneBitAndTrailingZerosHelper<int64_t>(vp, node, longNumberOfTrailingZeros, (int64_t) 0, (int64_t) -1);
    }
 
 
    TR::Node * constrainLongBitCount(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   return constrainLowestOneBitAndTrailingZerosHelper  (vp, node, getLongConst,
-                                                       getLongRange, getLong, getLowHighLongs,
-                                                       createIntConstConstraint,
-                                                       createIntRangeConstraint<int64_t>, longBitCount, (int64_t) 0, (int64_t) -1);
+   return constrainLowestOneBitAndTrailingZerosHelper<int64_t>(vp, node, longBitCount, (int64_t) 0, (int64_t) -1);
    }
 
 


### PR DESCRIPTION
Get rid of passing functions for creating constraints and pulling values out of them, and replace with an API to select the correct functions based on type information.