### PR TITLE
Allocate TreeInfo objects using TR::Region of containing List

### DIFF
--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -73,7 +73,7 @@ static OMR::TreeInfo *findOrCreateTreeInfo(TR::TreeTop *treeTop, List<OMR::TreeI
          return t;
       }
 
-   t = new (comp->trStackMemory()) OMR::TreeInfo(treeTop, 0);
+   t = new (targetTrees->getRegion()) OMR::TreeInfo(treeTop, 0);
    targetTrees->add(t);
    return t;
    }
@@ -433,8 +433,7 @@ TR::Optimization *TR::DeadTreesElimination::create(TR::OptimizationManager *mana
 
 
 TR::DeadTreesElimination::DeadTreesElimination(TR::OptimizationManager *manager)
-   : TR::Optimization(manager),
-     _targetTrees(manager->trMemory())
+   : TR::Optimization(manager)
    {
    _cannotBeEliminated = false;
    _delayedRegStores = false;
@@ -473,8 +472,6 @@ void TR::DeadTreesElimination::prePerformOnBlocks()
    {
    _cannotBeEliminated = false;
    _delayedRegStores = false;
-
-   _targetTrees.deleteAll();
 
    /*
     * Walk through all the blocks to remove trivial dead trees in the following forms:
@@ -759,6 +756,9 @@ static bool treeCanPossiblyBeRemoved(TR::Node *node)
 int32_t TR::DeadTreesElimination::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
    {
    TR::StackMemoryRegion stackRegion(*comp()->trMemory());
+
+   List<OMR::TreeInfo> targetTrees(stackRegion);
+
    LongestPathMap longestPaths(std::less<TR::Node*>(), stackRegion);
 
    typedef TR::typed_allocator<CRAnchor, TR::Region&> CRAnchorAlloc;
@@ -894,7 +894,7 @@ int32_t TR::DeadTreesElimination::process(TR::TreeTop *startTree, TR::TreeTop *e
                   visitCount,
                   comp(),
                   this,
-                  &_targetTrees,
+                  &targetTrees,
                   _cannotBeEliminated,
                   longestPaths);
                }

--- a/compiler/optimizer/DeadTreesElimination.hpp
+++ b/compiler/optimizer/DeadTreesElimination.hpp
@@ -103,7 +103,6 @@ class DeadTreesElimination : public TR::Optimization
 
    int32_t process(TR::TreeTop *, TR::TreeTop *);
 
-   List<OMR::TreeInfo> _targetTrees;
    bool _cannotBeEliminated;
    bool _delayedRegStores;
    };


### PR DESCRIPTION
If the [`findOrCreateTreeInfo`](https://github.com/eclipse/omr/blob/8037ccd0406c017f6a8043a8d04e19ac68f626f2/compiler/optimizer/DeadTreesElimination.cpp#L66) function fails to find a `TreeInfo` object that refers to a particular `TR::TreeTop` in the `targetTrees` `List`, it allocates a new `TreeTop` instance using `trStackMemory`.  However, `findOrCreateTreeInfo` is called within a call tree from [`DeadTreesElimination::process`](https://github.com/eclipse/omr/blob/8037ccd0406c017f6a8043a8d04e19ac68f626f2/compiler/optimizer/DeadTreesElimination.cpp#L759).  The `process` method [creates a new `TR::StackMemoryRegion`](https://github.com/eclipse/omr/blob/8037ccd0406c017f6a8043a8d04e19ac68f626f2/compiler/optimizer/DeadTreesElimination.cpp#L761) on entry to the method, but the `targetTrees` `List` has a lifetime that extends for the duration of the optimization.  (The `_targetTrees` is first constructed in the [`DeadTreesElimination` constructor](https://github.com/eclipse/omr/blob/8037ccd0406c017f6a8043a8d04e19ac68f626f2/compiler/optimizer/DeadTreesElimination.cpp#L435-L437) and is only cleared in the [`prePerformOnBlocks`](https://github.com/eclipse/omr/blob/8037ccd0406c017f6a8043a8d04e19ac68f626f2/compiler/optimizer/DeadTreesElimination.cpp#L477) method.

The `TreeInfo` objects should be allocated from the same `TR::Region` that the `List` uses for allocation of its nodes to ensure that their lifetime is as long as that of the containing `List` object.

Fixes:  Issue eclipse-openj9/openj9#19197