### PR TITLE
Fixes documentation of disableGLU Xjit option

### DIFF
--- a/doc/compiler/CompilerOptions.md
+++ b/doc/compiler/CompilerOptions.md
@@ -132,10 +132,10 @@ options, etc).
 | disableCFGSimplification                         | disable Control Flow Graph simplification                                       |
 | disableDeadTreeElimination                       | disable dead tree elimination                                                   |
 | disableGlobalDSE                                 | disable global dead store elimination                                           |
+| disableGLU                                       | disable general loop unroller                                                   |
 | disableGRA                                       | disable IL based global register allocator                                      |
 | disableInlining                                  | disable IL inlining                                                             |
 | disableLiveRegisterAnalysis                      | disable live register analysis                                                  |
-| disableLoopUnroller                              | disable loop unroller                                                           |
 | disableOpts={<em>regex</em>}                     | list of optimizations to disable                                                |
 | disableOptTransformations={<em>regex</em>}       | list of optimizer transformations to disable                                    |
 | disableTreeCleansing                             | disable tree cleansing                                                          |


### PR DESCRIPTION
The documentation incorrectly lists "disableLoopUnroller" as the option to disable loop unroller. This option does not exist and will result in an unrecognized option error.

The correct Xjit option name is "disableGLU" and the documentation has been updated to reflect this.

The "disableGLU" option is defined here:
https://github.com/eclipse/omr/blob/0e07ad19c1f3a7ce41cebd121fde5756fa32fd0c/compiler/control/OMROptions.cpp#L343