### PR TITLE
AArch64: Stop generating instruction for adding 0

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -119,7 +119,7 @@ extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::
  * @param[in] srcReg : source register
  * @param[in] value : value to be added
  */
-TR::Instruction *addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value);
+void addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value);
 
 /**
  * @brief Generates instructions for adding 32-bit integer value to a register
@@ -129,7 +129,7 @@ TR::Instruction *addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Regist
  * @param[in] srcReg : source register
  * @param[in] value : value to be added
  */
-TR::Instruction *addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value);
+void addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value);
 
 /**
  * @brief Helper function for encoding immediate value of logic instructions.

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -5807,42 +5807,42 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
    return cursor;
    }
 
-TR::Instruction *addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value)
+void addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int64_t value)
    {
-   TR::Instruction *cursor;
-
-   if (constantIsUnsignedImm12(value))
+   if (value == 0)
       {
-      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, trgReg, srcReg, value);
+      // Do nothing
+      }
+   else if (constantIsUnsignedImm12(value))
+      {
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, trgReg, srcReg, value);
       }
    else
       {
       TR::Register *tempReg = cg->allocateRegister();
       loadConstant64(cg, node, value, tempReg);
-      cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, trgReg, srcReg, tempReg);
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, trgReg, srcReg, tempReg);
       cg->stopUsingRegister(tempReg);
       }
-
-   return cursor;
    }
 
-TR::Instruction *addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value)
+void addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t value)
    {
-   TR::Instruction *cursor;
-
-   if (constantIsUnsignedImm12(value))
+   if (value == 0)
       {
-      cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, trgReg, srcReg, value);
+      // Do nothing
+      }
+   else if (constantIsUnsignedImm12(value))
+      {
+      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, trgReg, srcReg, value);
       }
    else
       {
       TR::Register *tempReg = cg->allocateRegister();
       loadConstant32(cg, node, value, tempReg);
-      cursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::addw, node, trgReg, srcReg, tempReg);
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::addw, node, trgReg, srcReg, tempReg);
       cg->stopUsingRegister(tempReg);
       }
-
-   return cursor;
    }
 
 /**


### PR DESCRIPTION
This commit changes addConstant32() and addConstant64() for AArch64 so that they don't generate instructions when the value to be added is 0.