### PR TITLE
Implement METHOD STATS verbose output

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1256,6 +1256,45 @@ public:
 
    TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition() { return &_snippetsToBePatchedOnClassRedefinition; }
 
+   /**
+   * \brief Calculates total size of all code snippets
+   *
+   * \return total size of all code snippets
+   */
+   uint32_t getCodeSnippetsSize();
+
+   /**
+   * \brief Calculates total size of all data snippets
+   *
+   * \return total size of all data snippets
+   */
+   uint32_t getDataSnippetsSize() { return 0; }
+
+   /**
+   * \brief Calculates total size of all out of line code
+   *
+   * \return total size of all out of line code
+   */
+   uint32_t getOutOfLineCodeSize() { return 0; }
+
+   struct MethodStats
+      {
+      uint32_t codeSize;
+      uint32_t warmBlocks;
+      uint32_t coldBlocks;
+      uint32_t prologue;
+      uint32_t snippets;
+      uint32_t outOfLine;
+      uint32_t unaccounted;
+      uint32_t blocksInColdCache;
+      uint32_t overestimateInColdCache;
+      };
+
+   /**
+   * \brief Fills in MethodStats structure with footprint data
+   */
+   void getMethodStats(MethodStats &methodStats);
+
    // --------------------------------------------------------------------------
    // Register pressure
    //

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -67,6 +67,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#FSD: ",
    "#VECTOR API: ",
    "#CHECKPOINT RESTORE: ",
+   "#METHOD STATS: "
    };
 
 void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -75,6 +75,7 @@ enum TR_VlogTag
    TR_Vlog_FSD,
    TR_Vlog_VECTOR_API,
    TR_Vlog_CHECKPOINT_RESTORE,
+   TR_Vlog_METHOD_STATS,
    TR_Vlog_numTags
    };
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -67,6 +67,17 @@ OMR::CFG::self() {
    return static_cast<TR::CFG*>(this);
 }
 
+const char*
+OMR::CFG::blockFrequencyNames[NUMBER_BLOCK_FREQUENCIES] =
+   {
+   "UNKNOWN_COLD_BLOCK_COUNT",
+   "VERSIONED_COLD_BLOCK_COUNT",
+   "UNRESOLVED_COLD_BLOCK_COUNT",
+   "CATCH_COLD_BLOCK_COUNT",
+   "INTERP_CALLEE_COLD_BLOCK_COUNT",
+   "REVERSE_ARRAYCOPY_COLD_BLOCK_COUNT"
+   };
+
 TR::CFGNode *
 OMR::CFG::addNode(TR::CFGNode *n, TR_RegionStructure *parent, bool isEntryInParent)
    {

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -73,6 +73,7 @@ template <class T> class TR_Array;
 #define INTERP_CALLEE_COLD_BLOCK_COUNT 4
 #define REVERSE_ARRAYCOPY_COLD_BLOCK_COUNT 5
 #define MAX_COLD_BLOCK_COUNT 5
+#define NUMBER_BLOCK_FREQUENCIES 6
 
 #define MAX_WARM_BLOCK_COUNT ((MAX_BLOCK_COUNT + MAX_COLD_BLOCK_COUNT)/10)
 #define MAX_HOT_BLOCK_COUNT (2*MAX_WARM_BLOCK_COUNT)
@@ -356,6 +357,8 @@ class CFG
       IsOrphanedNode,
       IsOrphanedRegion
       };
+
+   static const char *blockFrequencyNames[];
 
 protected:
    TR::Compilation *_compilation;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2363,6 +2363,19 @@ void OMR::X86::CodeGenerator::emitDataSnippets()
       }
    }
 
+uint32_t OMR::X86::CodeGenerator::getDataSnippetsSize()
+   {
+   uint32_t length = 0;
+
+   for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
+      {
+      length += (*iterator)->getLength(0);
+      }
+
+   return length;
+   }
+
+
 TR::X86ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c)
    {
    return self()->findOrCreateConstantDataSnippet(n, &c, 2);
@@ -3310,4 +3323,23 @@ OMR::X86::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
       {
       return true;
       }
+   }
+
+uint32_t
+OMR::X86::CodeGenerator::getOutOfLineCodeSize()
+   {
+   uint32_t totalSize = 0;
+
+   auto oiIterator = self()->getOutlinedInstructionsList().begin();
+   while (oiIterator != self()->getOutlinedInstructionsList().end())
+      {
+      auto start = (*oiIterator)->getFirstInstruction()->getBinaryEncoding();
+      auto end   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding();
+
+      totalSize += static_cast<uint32_t>(end - start);
+
+      ++oiIterator;
+      }
+
+   return totalSize;
    }

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -483,6 +483,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();
    bool hasDataSnippets() { return _dataSnippetList.empty() ? false : true; }
+   uint32_t getDataSnippetsSize();
 
    TR::list<TR::Register*> &getSpilledIntRegisters() {return _spilledIntRegisters;}
 
@@ -636,6 +637,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool considerTypeForGRA(TR::Node *node);
    bool considerTypeForGRA(TR::DataType dt);
    bool considerTypeForGRA(TR::SymbolReference *symRef);
+
+   uint32_t getOutOfLineCodeSize();
 
    /*
     * \brief create a data snippet.


### PR DESCRIPTION
- introduce new verbose tag: "#METHOD STATS"
- print "key=value" pairs for each method where "key" is an arbitrary string
- values can be agrregated across all methods by a parsing script
- this format can be used for an arbitrary info about a compiled method
- in particular, introduce a function that prints various footprint
      stats for a method
