### PR TITLE
Update differenceInAdditiveConstants as int64_t

### DIFF
--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -2175,9 +2175,9 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
          seenInductionVariableComputation = true;
          examineChildren = false;
 
-         int32_t differenceInAdditiveConstants = 0;
+         int64_t differenceInAdditiveConstants = 0;
          if (isAdditiveTermConst(index))
-            differenceInAdditiveConstants = (int32_t)(-1*getAdditiveTermConst(index));
+            differenceInAdditiveConstants = (-1*getAdditiveTermConst(index));
 
          examineOpCodesForInductionVariableUse(node, parent, childNum, index, originalNode, replacingNode, linearTerm, mulTerm, newSymbolReference, loopInvariantBlock, pinningArrayPointer, differenceInAdditiveConstants, isInternalPointer, downcastNode, usingAladd);
 


### PR DESCRIPTION
`differenceInAdditiveConstants` is expected to be a 64 bit integer. `examineOpCodesForInductionVariableUse` takes care of casting it into `int32_t` if it does not use aladd and the adjustment or the replacing node is not a 64-bit value.

Fixes: eclipse-openj9/openj9#19220