### PR TITLE
Change arraycmp length child to 64 bits

### DIFF
--- a/compiler/il/OMROpcodes.enum
+++ b/compiler/il/OMROpcodes.enum
@@ -7196,7 +7196,7 @@ OPCODE_MACRO(\
    /* .properties4          = */ 0, \
    /* .dataType             = */ TR::Int32, \
    /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer, \
-   /* .childProperties      = */ THREE_CHILD(TR::Address, TR::Address, TR::Int32), \
+   /* .childProperties      = */ THREE_CHILD(TR::Address, TR::Address, TR::Int64), \
    /* .swapChildrenOpCode   = */ TR::BadILOp, \
    /* .reverseBranchOpCode  = */ TR::BadILOp, \
    /* .booleanCompareOpCode = */ TR::BadILOp, \

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1151,7 +1151,15 @@ TR::Register *OMR::X86::TreeEvaluator::SSE2ArraycmpEvaluator(TR::Node *node, TR:
 
    TR::Register *s1Reg = cg->gprClobberEvaluate(s1AddrNode, TR::InstOpCode::MOVRegReg());
    TR::Register *s2Reg = cg->gprClobberEvaluate(s2AddrNode, TR::InstOpCode::MOVRegReg());
-   TR::Register *strLenReg = cg->gprClobberEvaluate(lengthNode, TR::InstOpCode::MOVRegReg());
+   TR::Register *strLenReg = cg->longClobberEvaluate(lengthNode);
+
+   if (cg->comp()->target().is32Bit() && strLenReg->getRegisterPair())
+      {
+      // On 32-bit, the length is guaranteed to fit into the bottom 32 bits
+      cg->stopUsingRegister(strLenReg->getHighOrder());
+      strLenReg = strLenReg->getLowOrder();
+      }
+
    TR::Register *deltaReg = cg->allocateRegister(TR_GPR);
    TR::Register *equalTestReg = cg->allocateRegister(TR_GPR);
    TR::Register *s2ByteVer1Reg = cg->allocateRegister(TR_GPR);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -10759,7 +10759,9 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
 
       bool lengthCanBeZero = true;
       bool lenMinusOne = false;
-      bool needs64BitOpCode = false;
+
+      // Length is specified to be 64 bits, however on 32 bit target the length is guaranteed to fit in 32 bits
+      bool needs64BitOpCode = cg->comp()->target().is64Bit();
 
       TR::LabelSymbol *cFlowRegionStart = generateLabelSymbol(cg);
       TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
@@ -10769,15 +10771,6 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
       TR::Register *lengthCopyReg = NULL;
       TR::RegisterPair *source1Pair = NULL;
       TR::RegisterPair *source2Pair = NULL;
-
-      if (lengthNode)
-         {
-         needs64BitOpCode = lengthNode->getSize() > 4;
-         }
-      else
-         {
-         needs64BitOpCode =  cg->comp()->target().is64Bit();
-         }
 
       if (maxLenIn256)
          {

--- a/fvtest/compilertriltest/ArrayTest.cpp
+++ b/fvtest/compilertriltest/ArrayTest.cpp
@@ -32,7 +32,7 @@ static const int32_t returnValueForArraycmpEqual = 0;
  * @details Used for arraycmp test with the arrays with same data.
  * The parameter is the length parameter for the arraycmp evaluator.
  */
-class ArraycmpEqualTest : public TRTest::JitTest, public ::testing::WithParamInterface<int32_t> {};
+class ArraycmpEqualTest : public TRTest::JitTest, public ::testing::WithParamInterface<int64_t> {};
 /**
  * @brief TestFixture class for arraycmp test
  *
@@ -40,7 +40,7 @@ class ArraycmpEqualTest : public TRTest::JitTest, public ::testing::WithParamInt
  * The first parameter is the length parameter for the arraycmp evaluator.
  * The second parameter is the offset of the mismatched element in the arrays.
  */
-class ArraycmpNotEqualTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<int32_t, int32_t>> {};
+class ArraycmpNotEqualTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<int64_t, int64_t>> {};
 
 TEST_P(ArraycmpEqualTest, ArraycmpSameArray) {
     SKIP_ON_ARM(MissingImplementation);
@@ -58,7 +58,7 @@ TEST_P(ArraycmpEqualTest, ArraycmpSameArray) {
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iconst %d)))))",
+      "        (lconst %" OMR_PRId64 ")))))",
       length
       );
     auto trees = parseString(inputTrees);
@@ -87,7 +87,7 @@ TEST_P(ArraycmpEqualTest, ArraycmpEqualConstLen) {
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iconst %d)))))",
+      "        (lconst %" OMR_PRId64 ")))))",
       length
       );
     auto trees = parseString(inputTrees);
@@ -111,13 +111,13 @@ TEST_P(ArraycmpEqualTest, ArraycmpEqualVariableLen) {
     auto length = GetParam();
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-      "(method return=Int32 args=[Address, Address, Int32]"
+      "(method return=Int32 args=[Address, Address, Int64]"
       "  (block"
       "    (ireturn"
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iload parm=2)))))"
+      "        (lload parm=2)))))"
       );
     auto trees = parseString(inputTrees);
 
@@ -129,11 +129,11 @@ TEST_P(ArraycmpEqualTest, ArraycmpEqualVariableLen) {
 
     std::vector<unsigned char> s1(length, 0x5c);
     std::vector<unsigned char> s2(length, 0x5c);
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int32_t)>();
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int64_t)>();
     EXPECT_EQ(returnValueForArraycmpEqual, entry_point(&s1[0], &s2[0], length));
 }
 
-INSTANTIATE_TEST_CASE_P(ArraycmpTest, ArraycmpEqualTest, ::testing::Range(1, 128));
+INSTANTIATE_TEST_CASE_P(ArraycmpTest, ArraycmpEqualTest, ::testing::Range(static_cast<int64_t>(1), static_cast<int64_t>(128)));
 
 TEST_P(ArraycmpNotEqualTest, ArraycmpGreaterThanConstLen) {
     SKIP_ON_ARM(MissingImplementation);
@@ -149,7 +149,7 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpGreaterThanConstLen) {
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iconst %d)))))",
+      "        (lconst %" OMR_PRId64 ")))))",
       length
       );
     auto trees = parseString(inputTrees);
@@ -176,13 +176,13 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpGreaterThanVariableLen) {
     auto offset = std::get<1>(GetParam());
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-      "(method return=Int32 args=[Address, Address, Int32]"
+      "(method return=Int32 args=[Address, Address, Int64]"
       "  (block"
       "    (ireturn"
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iload parm=2)))))"
+      "        (lload parm=2)))))"
       );
     auto trees = parseString(inputTrees);
 
@@ -196,7 +196,7 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpGreaterThanVariableLen) {
     std::vector<unsigned char> s2(length, 0x5c);
     s1[offset] = 0x81;
 
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int32_t)>();
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int64_t)>();
     EXPECT_EQ(returnValueForArraycmpGreaterThan, entry_point(&s1[0], &s2[0], length));
 }
 
@@ -214,7 +214,7 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpLessThanConstLen) {
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iconst %d)))))",
+      "        (lconst %" OMR_PRId64 ")))))",
       length
       );
     auto trees = parseString(inputTrees);
@@ -241,13 +241,13 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpLessThanVariableLen) {
     auto offset = std::get<1>(GetParam());
     char inputTrees[1024] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
-      "(method return=Int32 args=[Address, Address, Int32]"
+      "(method return=Int32 args=[Address, Address, Int64]"
       "  (block"
       "    (ireturn"
       "      (arraycmp address=0 args=[Address, Address]"
       "        (aload parm=0)"
       "        (aload parm=1)"
-      "        (iload parm=2)))))"
+      "        (lload parm=2)))))"
       );
     auto trees = parseString(inputTrees);
 
@@ -261,13 +261,12 @@ TEST_P(ArraycmpNotEqualTest, ArraycmpLessThanVariableLen) {
     std::vector<unsigned char> s2(length, 0x5c);
     s1[offset] = 0x21;
 
-    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int32_t)>();
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(unsigned char *, unsigned char *, int64_t)>();
     EXPECT_EQ(returnValueForArraycmpLessThan, entry_point(&s1[0], &s2[0], length));
 }
 
-template <typename intXX_t>
-static std::vector<std::tuple<intXX_t, intXX_t>> createArraycmpNotEqualParam() {
-  std::vector<std::tuple<intXX_t, intXX_t>> v;
+static std::vector<std::tuple<int64_t, int64_t>> createArraycmpNotEqualParam() {
+  std::vector<std::tuple<int64_t, int64_t>> v;
   /* Small arrays */
   for (int i = 1; i < 32; i++) {
     for (int j = 0; j < i; j++) {
@@ -290,7 +289,7 @@ static std::vector<std::tuple<intXX_t, intXX_t>> createArraycmpNotEqualParam() {
   }
   return v;
 }
-INSTANTIATE_TEST_CASE_P(ArraycmpTest, ArraycmpNotEqualTest, ::testing::ValuesIn(createArraycmpNotEqualParam<int32_t>()));
+INSTANTIATE_TEST_CASE_P(ArraycmpTest, ArraycmpNotEqualTest, ::testing::ValuesIn(createArraycmpNotEqualParam()));
 
 
 /**
@@ -467,4 +466,4 @@ TEST_P(ArraycmplenNotEqualTest, ArraycmpLenNotEqualVariableLen) {
     EXPECT_EQ(offset, entry_point(&s1[0], &s2[0], length));
 }
 
-INSTANTIATE_TEST_CASE_P(ArraycmplenTest, ArraycmplenNotEqualTest, ::testing::ValuesIn(createArraycmpNotEqualParam<int64_t>()));
+INSTANTIATE_TEST_CASE_P(ArraycmplenTest, ArraycmplenNotEqualTest, ::testing::ValuesIn(createArraycmpNotEqualParam()));


### PR DESCRIPTION
Previously the arraycmp IL opcode's length child  was specified as 32 bits but was inconsistent in its use. This commit changes the specification of the length child to 64 bits, and normalizes the use to 64 bits.

Closes: #6992