### PR TITLE
Fix build error caused by unused variable in OSX

### DIFF
--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -299,7 +299,7 @@ TEST(PortTimeTest, time_test3)
 	uint64_t hiresTimeStart, hiresTimeStop;
 	uint64_t hiresDeltaAsMillis, hiresDeltaAsMicros;
 	uint64_t ntimeDeltaAsMillis;
-	uint32_t i, j;
+	uint32_t i;
 	int32_t millires;
 
 	reportTestEntry(OMRPORTLIB, testName);
@@ -314,7 +314,7 @@ TEST(PortTimeTest, time_test3)
 			/*change of millis*/
 			time = omrtime_current_time_millis();
 			oldTime = time;
-			for (j = 0; oldTime == time; j++) {
+			while (oldTime == time) {
 				oldTime = omrtime_current_time_millis();
 			}
 			millires = (int32_t)(oldTime - time);

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -500,7 +500,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 	J9SysinfoEnvElement element;
 	void *buffer = NULL;
 	uint32_t bufferSizeBytes = 0;
-	int l = 0;
 #undef SI_DEBUG
 
 	reportTestEntry(OMRPORTLIB, testName);
@@ -546,13 +545,11 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 
 	portTestEnv->log("Environment:\n\n");
 
-	l = 0;
 	while (omrsysinfo_env_iterator_hasNext(&state)) {
 		rc = omrsysinfo_env_iterator_next(&state, &element);
 
 		if (0 == rc) {
 			portTestEnv->log("%s\n", element.nameAndValue);
-			l++;
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_env_iterator_next returned: %i when 0 was expected\n", rc);
 			goto done;
@@ -586,7 +583,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 #endif
 	}
 
-	l = 0;
 	while (omrsysinfo_env_iterator_hasNext(&state)) {
 
 		rc = omrsysinfo_env_iterator_next(&state, &element);
@@ -596,7 +592,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 #endif
 
 		if (0 == rc) {
-			l++;
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_env_iterator_next returned: %i when 0 was expected\n", rc);
 			goto done;
@@ -629,7 +624,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 #endif
 	}
 
-	l = 0;
 	while (omrsysinfo_env_iterator_hasNext(&state)) {
 
 		rc = omrsysinfo_env_iterator_next(&state, &element);
@@ -639,7 +633,6 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_env_iterator)
 #endif
 
 		if (0 == rc) {
-			l++;
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "\tomrsysinfo_env_iterator_next returned: %i when 0 was expected\n", rc);
 			goto done;


### PR DESCRIPTION
Remove unused local variable in fvtest which will cause build error
In **omrtimeTest.cpp**
<img width="570" alt="Non used variable" src="https://github.com/eclipse/omr/assets/73817114/3483142c-db75-4d9a-babb-94d99d8cf762">
In **si.cpp**
<img width="570" alt="Non used variable2" src="https://github.com/eclipse/omr/assets/73817114/4f582184-2ce8-4b81-ba2b-e0c4af383baa">

Changes
 - omrtimeTest.cpp, replace for loop with while loop as variable 'j' isn't used
 - si.cpp, remove l that not use as any purpose