### PR TITLE
Open XL segfault fix and workaround for si.cpp macro collision

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -42,6 +42,7 @@
 #include <direct.h>
 #endif /* defined(OMR_OS_WINDOWS) */
 #if !defined(OMR_OS_WINDOWS)
+#include <locale>
 #include <grp.h>
 #include <errno.h>
 #if defined(J9ZOS390)

--- a/thread/zos390/rasthrsup.c
+++ b/thread/zos390/rasthrsup.c
@@ -26,5 +26,6 @@
 uintptr_t
 omrthread_get_ras_tid(void)
 {
-	return (uintptr_t)(*(uint32_t *)pthread_self().__);
+	pthread_t id = pthread_self();
+	return (uintptr_t)*(unsigned long long *)&id;
 }


### PR DESCRIPTION
The omrthread_get_ras_tid() function in rasthrsup.c was causing a segmentation fault with Open XL as pthread_t is structured in a different manner. This fixes that while keeping support with XLC. The header grp.h used in si.cpp also has a macro collision with the native locale header from Open XL. The reordering of headers is a workaround for the core problem. A issue has also been created in order to use a better macro name __grp.

(This is one part of the multiple changes added for supporting Open XL compilation on OMR)