### PR TITLE
Fix build errors using gcc 13

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -3248,7 +3248,7 @@ static void decomposeMultiply(TR::Node *node, TR::Simplifier *s, bool isLong)
    int count = 0;
    int i;
    char bitPosition[64];
-   char operationType[64];
+   char operationType[128];
    char temp;
 
    count = decomposeConstant(bitPosition, operationType, isLong?secondChild->getLongInt():secondChild->getInt(), isLong?64:32);

--- a/port/common/omrfilestream.c
+++ b/port/common/omrfilestream.c
@@ -293,10 +293,12 @@ omrfilestream_close(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStrea
 		Trc_PRT_filestream_close_invalidFileStream(fileStream);
 		rc = OMRPORT_ERROR_FILE_BADF;
 	} else {
+		/* copy handle to avoid "use-after-free(close)" warning */
+		void *fileTrace = fileStream;
 		rc = fclose(fileStream);
 		if (0 != rc) {
 			rc = portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
-			Trc_PRT_filestream_close_failedToClose(fileStream, rc);
+			Trc_PRT_filestream_close_failedToClose(fileTrace, rc);
 		}
 	}
 


### PR DESCRIPTION
* fix a use-after-free problem in `omrfilestream.c`
* fix a stringop-overflow error in `OMRSimplifierHandlers.cpp`