### PR TITLE
Set live local index bit vector only when register candidate is created

### DIFF
--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -2733,11 +2733,12 @@ void TR_GlobalRegisterAllocator::offerAllAutosAndRegisterParmAsCandidates(TR::Bl
             if (paramCursor->getLinkageRegisterIndex() >= 0)
                rc->addAllBlocks();
             }
+
+         i = paramCursor->getLiveLocalIndex();
+         autoAndParmLiveLocalIndex.set(i);
+         registerCandidateByIndex[i] = rc;
          }
 
-      i = paramCursor->getLiveLocalIndex();
-      autoAndParmLiveLocalIndex.set(i);
-      registerCandidateByIndex[i] = rc;
       paramCursor = paramIterator.getNext();
       }
 


### PR DESCRIPTION
Set live local index bit vector only when register candidate is created

Fixes: eclipse-openj9/openj9#19329