### PR TITLE
Correct typos mentioning classDepthAndFlags field

### DIFF
--- a/compiler/compile/OMRNonHelperSymbols.enum
+++ b/compiler/compile/OMRNonHelperSymbols.enum
@@ -50,6 +50,7 @@
    componentClassSymbol,
    isArraySymbol,
    isClassAndDepthFlagsSymbol,
+   isClassDepthAndFlagsSymbol = isClassAndDepthFlagsSymbol,
    isClassFlagsSymbol,
    vftSymbol,
    currentThreadSymbol,

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -312,6 +312,12 @@ OMR::SymbolReferenceTable::findClassIsArraySymbolRef()
 
 
 TR::SymbolReference *
+OMR::SymbolReferenceTable::findClassDepthAndFlagsSymbolRef()
+   {
+   return element(isClassDepthAndFlagsSymbol);
+   }
+
+TR::SymbolReference *
 OMR::SymbolReferenceTable::findClassAndDepthFlagsSymbolRef()
    {
    return element(isClassAndDepthFlagsSymbol);
@@ -2142,7 +2148,7 @@ const char *OMR::SymbolReferenceTable::_commonNonHelperSymbolNames[] =
    "<addressOfClassOfMethod>",
    "<componentClass>",
    "<isArray>",
-   "<isClassAndDepthFlags>",
+   "<isClassDepthAndFlags>",
    "<isClassFlags>",
    "<vft>",
    "<currentThread>",

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -114,6 +114,7 @@ class SymbolReferenceTable
       componentClassAsPrimitiveSymbol,
       isArraySymbol,
       isClassAndDepthFlagsSymbol,
+      isClassDepthAndFlagsSymbol = isClassAndDepthFlagsSymbol,
       initializeStatusFromClassSymbol,
       isClassFlagsSymbol,
       vftSymbol,
@@ -773,6 +774,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findDescriptionWordFromPtrSymbolRef();
    TR::SymbolReference * findClassFlagsSymbolRef();
    TR::SymbolReference * findClassAndDepthFlagsSymbolRef();
+   TR::SymbolReference * findClassDepthAndFlagsSymbolRef();
    TR::SymbolReference * findArrayComponentTypeSymbolRef();
    TR::SymbolReference * findClassIsArraySymbolRef();
    TR::SymbolReference * findHeaderFlagsSymbolRef() { return element(headerFlagsSymbol); }

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -8105,7 +8105,7 @@ bool TR_LoopVersioner::suppressInvarianceAndPrivatization(TR::SymbolReference *s
          return true;
 
       // Class flags are mutable.
-      case TR::SymbolReferenceTable::isClassAndDepthFlagsSymbol:
+      case TR::SymbolReferenceTable::isClassDepthAndFlagsSymbol:
          return true;
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1521,7 +1521,7 @@ bool simplifyJ9ClassFlags(OMR::ValuePropagation *vp, TR::Node *node, bool isLong
    TR::VPConstraint *base = vp->getConstraint(node->getFirstChild(), isGlobal);
    TR::SymbolReference *symRef = node->getSymbolReference();
 
-   if (symRef == vp->comp()->getSymRefTab()->findClassAndDepthFlagsSymbolRef() &&
+   if (symRef == vp->comp()->getSymRefTab()->findClassDepthAndFlagsSymbolRef() &&
          base &&
          base->isJ9ClassObject() == TR_yes &&
          base->getClassType() &&
@@ -7647,7 +7647,7 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
                firstChild = firstChild->getChild(0);
 
             if ((firstChild->getOpCodeValue() == TR::iloadi || firstChild->getOpCodeValue() == TR::lloadi) &&
-                (firstChild->getSymbolReference() == vp->comp()->getSymRefTab()->findClassAndDepthFlagsSymbolRef()) &&
+                (firstChild->getSymbolReference() == vp->comp()->getSymRefTab()->findClassDepthAndFlagsSymbolRef()) &&
                 (rhs->getLowInt() == TR::Compiler->cls.flagValueForArrayCheck(vp->comp())))
                {
                if (vp->trace())

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2078,7 +2078,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<componentClass>",
    "<componentClassAsPrimitive>",
    "<isArray>",
-   "<isClassAndDepthFlags>",
+   "<isClassDepthAndFlags>",
    "<initializeStatusFromClass>",
    "<isClassFlags>",
    "<vft>",


### PR DESCRIPTION
Code in OMR supports the JIT compiler in generating IL to access the `J9Class` field `classDepthAndFlags` in the downstream OpenJ9 project. In many cases, that compiler code incorrectly refers to the field as `classAndDepthFlags`.

This commit adds new duplicate definitions of the methods and enum values to use the correct name.  Once the downstream project removes references to the obsolete methods, the obsolete definitions will be removed.