### PR TITLE
Remove trace-point that requires use-after-close reference

### DIFF
--- a/port/common/omrfilestream.c
+++ b/port/common/omrfilestream.c
@@ -293,12 +293,9 @@ omrfilestream_close(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStrea
 		Trc_PRT_filestream_close_invalidFileStream(fileStream);
 		rc = OMRPORT_ERROR_FILE_BADF;
 	} else {
-		/* copy handle to avoid "use-after-free(close)" warning */
-		void *fileTrace = fileStream;
 		rc = fclose(fileStream);
 		if (0 != rc) {
 			rc = portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
-			Trc_PRT_filestream_close_failedToClose(fileTrace, rc);
 		}
 	}
 

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -953,7 +953,7 @@ TraceException=Trc_PRT_filestream_open_invalidPath Group=omrfilestream Overhead=
 TraceEntry=Trc_PRT_filestream_close_Entry Group=omrfilestream Overhead=1 Level=5 NoEnv Template="omrfilestream_close fileStream = %p"
 TraceExit=Trc_PRT_filestream_close_Exit Group=j9filestrean Overhead=1 Level=5 NoEnv Template="omrfilestream_close returns code = %d"
 TraceException=Trc_PRT_filestream_close_invalidFileStream Group=omrfilestream Overhead=1 Level=5 NoEnv Template="omrfilestream_close Invalid fileStream. fileStream = %p"
-TraceException=Trc_PRT_filestream_close_failedToClose Group=omrfilestream Overhead=1 Level=5 NoEnv Template="omrfilestream_close Failed to close fileStream. fileStream = %p errorCode = %d"
+TraceException=Trc_PRT_filestream_close_failedToClose Obsolete Group=omrfilestream Overhead=1 Level=5 NoEnv Template="omrfilestream_close Failed to close fileStream. fileStream = %p errorCode = %d"
 
 TraceEntry=Trc_PRT_filestream_sync_Entry Group=omrfilestream Overhead=1 Level=5 NoEnv Template="omrfilestream_sync fileStream = %p"
 TraceExit=Trc_PRT_filestream_sync_Exit Group=j9filestrean Overhead=1 Level=5 NoEnv Template="omrfilestream_sync returns code = %d"

--- a/port/win32/omrfilestream.c
+++ b/port/win32/omrfilestream.c
@@ -245,7 +245,6 @@ omrfilestream_close(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStrea
 		rc = fclose(fileStream);
 		if (0 != rc) {
 			rc = portLibrary->error_set_last_error(portLibrary, errno, findErrorFromErrno(errno));
-			Trc_PRT_filestream_close_failedToClose(fileStream, rc);
 		}
 	}
 


### PR DESCRIPTION
It turns out that #7325 was ineffective: compilers see straight through that attempt to hide the use-after-close. The trace-point doesn't provide any information that isn't already available by other trace-points at the same level.