### PR TITLE
Fix omrgenerate_ieat_dump.s assembly instruction to load 64 bit

### DIFF
--- a/port/zos390/omrgenerate_ieat_dump.s
+++ b/port/zos390/omrgenerate_ieat_dump.s
@@ -44,7 +44,7 @@ _TDUMP   EDCXPRLG BASEREG=8
 .JMP1    ANOP
 _TDUMP   CELQPRLG BASEREG=8
 * IEATDUMP macro will toast R1, so keep it in R3
-         LR    3,1
+         LGR   3,1
          USING IOPARMS,3
          CALL  BPX4ENV,                                                +
                (=A(ENV_TOGGLE_SEC),                                    +


### PR DESCRIPTION
During Open XL bring up of OMR, a segmentation fault was seen while running the `omrporttest` target.

One of the load register instructions was meant to be loading the 64-bit address over which was not apparent while compiling with XLC. The problem manifested itself as a segmentation fault with Open XL, and this addresses that issue while keeping XLC working the same way.