### PR TITLE
Assert if ScratchRegisterManager is unable to provide a register

### DIFF
--- a/compiler/codegen/ScratchRegisterManager.cpp
+++ b/compiler/codegen/ScratchRegisterManager.cpp
@@ -97,7 +97,7 @@ TR::Register *TR_ScratchRegisterManager::findOrCreateScratchRegister(TR_Register
 
    if (_cursor >= _capacity)
       {
-      traceMsg(_cg->comp(), "ERROR: cannot allocate any more scratch registers\n");
+      TR_ASSERT_FATAL(false, "ERROR: cannot allocate any more scratch registers");
       return NULL;
       }
 


### PR DESCRIPTION
The ScratchRegisterManager quietly returns NULL if it is unable to provide a scratch register.  This is actually a serious problem and the logic should assert fatally rather than return NULL.