### PR TITLE
Disable JitBuilder API generator tests on macOS on x86

### DIFF
--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -144,7 +144,7 @@ if(OMR_JITBUILDER AND OMR_ENV_DATA64)
 	add_subdirectory(release)
 endif()
 
-if(OMR_JITBUILDER_TEST)
+if(OMR_JITBUILDER_TEST AND NOT (OMR_OS_OSX AND OMR_ARCH_X86))
 	add_test(
 		NAME TestJitBuilderAPIGenerator
 		COMMAND ${PYTHON_EXECUTABLE} run_tests.py


### PR DESCRIPTION
The Azure CI macOS nodes on x86 have a version of Python later than 3.1
installed where the `assertRegexpMatches` function has been deprecated (and
replaced) in favour of `assertRegex`.

Ideally, this API would be replaced with the newer version.  However, some
nodes on the OMR CI farm have older versions of Python installed that need to
be upgraded first.

Until that happens, since x86 macOS is the only platform affected, the
JitBuilder API tests will be disabled  on that platform only.  There should be
adequate test coverage on the other x86 platforms.

Other alternatives considered were to sprinkle Python version checks throughout
the code to guard each API usage (which is messy), or downgrading the Python
version on the Azure builds.  However, I believe the right path forward is to
ensure all our build nodes have a consistent, modern version of Python
installed.  Once the build nodes are upgraded then this test will be modified
to use the new API and it will be reenabled on all platforms that support it.