### PR TITLE
Implement RSSReport class

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4983,7 +4983,9 @@ const char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "vectorAPI",
    "iprofilerPersistence",
    "CheckpointRestore",
-   "CheckpointRestoreDetails"
+   "CheckpointRestoreDetails",
+   "RSSReport",
+   "RSSReportDetailed"
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1072,6 +1072,8 @@ enum TR_VerboseFlags
    TR_VerboseIProfilerPersistence,
    TR_VerboseCheckpointRestore,
    TR_VerboseCheckpointRestoreDetails,
+   TR_VerboseRSSReport,
+   TR_VerboseRSSReportDetailed,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -35,6 +35,7 @@
 #include "env/PersistentInfo.hpp"
 #include "env/jittypes.h"
 #include "env/StackMemoryRegion.hpp"
+#include "env/VerboseLog.hpp"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
 #include "il/Node.hpp"
@@ -459,6 +460,36 @@ void TR::DebugCounterAggregation::accumulate()
    for (CounterDelta *counterDelta = it.getFirst(); counterDelta; counterDelta = it.getNext())
       {
       counterDelta->counter->accumulate(increment * counterDelta->delta);
+      }
+   }
+
+
+int64_t TR::DebugCounterAggregation::getCount()
+   {
+   int64_t count = 0;
+   ListIterator<CounterDelta> it(_counterDeltas);
+
+   for (CounterDelta *counterDelta = it.getFirst(); counterDelta; counterDelta = it.getNext())
+      {
+      count += counterDelta->counter->getCount();
+      }
+
+   return count;
+   }
+
+void TR::DebugCounterAggregation::printCounters(bool printZeroCounters)
+   {
+   ListIterator<CounterDelta> it(_counterDeltas);
+
+   for (CounterDelta *counterDelta = it.getFirst(); counterDelta; counterDelta = it.getNext())
+      {
+      TR::DebugCounter *counter = counterDelta->counter;
+      int64_t count = counter->getCount();
+
+      if (count || printZeroCounters)
+         {
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Counter count=%d %s", count, counter->getName());
+         }
       }
    }
 

--- a/compiler/ras/DebugCounter.hpp
+++ b/compiler/ras/DebugCounter.hpp
@@ -265,6 +265,8 @@ public:
    TR::SymbolReference *getBumpCountSymRef(TR::Compilation *comp);
 
    void accumulate();
+   int64_t getCount();
+   void printCounters(bool printZeroCounters = true);
    };
 
 class DebugCounterGroup

--- a/compiler/runtime/CMakeLists.txt
+++ b/compiler/runtime/CMakeLists.txt
@@ -27,4 +27,5 @@ compiler_library(runtime
 	${CMAKE_CURRENT_LIST_DIR}/OMRCodeCacheManager.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRCodeCacheMemorySegment.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRCodeCacheConfig.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRRSSReport.cpp
 )

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -1553,6 +1553,7 @@ OMR::CodeCache::allocateCodeMemory(size_t warmCodeSize,
    uint8_t * cacheHeapAlloc;
    bool warmIsFreeBlock = false;
    bool coldIsFreeBlock = false;
+   uint8_t *oldColdAlloc = _coldCodeAlloc;
 
    size_t warmSize = warmCodeSize;
    size_t coldSize = coldCodeSize;
@@ -1678,6 +1679,37 @@ OMR::CodeCache::allocateCodeMemory(size_t warmCodeSize,
       *coldCode = coldCodeAddress;
    else
       *coldCode = warmCodeAddress;
+
+   if (OMR::RSSReport::instance() &&
+       !coldIsFreeBlock &&
+       !needsToBeContiguous &&
+       _coldCodeRSSRegion)
+      {
+      _coldCodeRSSRegion->_size = _coldCodeRSSRegion->_start - _coldCodeAlloc;
+
+      int32_t padding = static_cast<int32_t>(oldColdAlloc - coldCodeAddress - coldCodeSize);
+      TR_ASSERT_FATAL(padding >= 0, "Cold code padding should be >= 0");
+
+      if (padding > 0)
+         {
+         OMR::RSSItem *rssItem = new (TR::Compiler->persistentMemory()) OMR::RSSItem(OMR::RSSItem::alignment,
+                                                                                     oldColdAlloc - padding, padding,
+                                                                                     NULL /* counters */);
+         _coldCodeRSSRegion->addRSSItem(rssItem, self()->getReservingCompThreadID());
+         }
+
+      int32_t header = static_cast<uint32_t>(coldCodeAddress - _coldCodeAlloc);
+      TR_ASSERT_FATAL(header >= 0, "Cold code header should be >= 0");
+
+      if (header > 0)
+         {
+         OMR::RSSItem *rssItem = new (TR::Compiler->persistentMemory()) OMR::RSSItem(OMR::RSSItem::header,
+                                                                                     coldCodeAddress - header, header,
+                                                                                     NULL /* counters */);
+         _coldCodeRSSRegion->addRSSItem(rssItem, self()->getReservingCompThreadID());
+         }
+      }
+
    return warmCodeAddress;
    }
 

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -40,6 +40,7 @@ namespace OMR { typedef CodeCache CodeCacheConnector; }
 #include "runtime/CodeCacheConfig.hpp"
 #include "runtime/Runtime.hpp"
 #include "runtime/CodeCacheTypes.hpp"
+#include "runtime/OMRRSSReport.hpp"
 #include "OMR/Bytes.hpp"
 
 class TR_OpaqueMethodBlock;
@@ -57,7 +58,7 @@ class OMR_EXTENSIBLE CodeCache
    TR::CodeCache *self();
 
 public:
-   CodeCache() { }
+   CodeCache() : _coldCodeRSSRegion(NULL) { }
 
    void *operator new(size_t s, TR::CodeCache *cache) { return cache; }
    void operator delete(void *p, TR::CodeCache *cache) { /* do nothing */ }
@@ -416,6 +417,11 @@ public:
 
    CodeCacheFreeCacheBlock *_freeBlockList;
 
+   /**
+   * @brief Returns pointer to the cold code RSS Region
+   */
+   OMR::RSSRegion *getColdCodeRSSRegion() { return _coldCodeRSSRegion; }
+
    // This is used in an attempt to enforce mutually exclusive ownership.
    // flag accessed under mutex <== This is deceiving! There are two different monitors we may hold (not at the same time!) when we write to this.
    // We can either be holding the code cache monitor *OR* the manager's code cache list monitor.
@@ -450,6 +456,8 @@ public:
 
    TR_YesNoMaybe _almostFull;
    CodeCacheMethodHeader *_lastAllocatedBlock; // used for error detection (RAS)
+
+   OMR::RSSRegion   *_coldCodeRSSRegion;
    };
 
 } // namespace OMR

--- a/compiler/runtime/OMRRSSReport.cpp
+++ b/compiler/runtime/OMRRSSReport.cpp
@@ -1,0 +1,403 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2000
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+#include "compiler/infra/String.hpp"
+#include "runtime/OMRRSSReport.hpp"
+
+OMR::RSSReport *OMR::RSSReport::_instance = NULL;
+
+const char *OMR::RSSItem::itemNames [] =
+      {
+      "Unknown",
+      "HEADER",
+      "ALIGNMENT",
+      "COLD BLOCKS",
+      "OVERESTIMATE",
+      "OOL",
+      "SNIPPET"
+      };
+
+void
+OMR::RSSRegion::addRSSItem(OMR::RSSItem *item, int32_t threadId, const char* methodName)
+   {
+#ifdef DEBUG_RSS_REPORT
+   TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS adding item addr=%p size=%zu type=%s thread=%d method=%s", item->_addr, item->_size,
+                                  OMR::RSSItem::itemNames[item->_type], threadId,
+                                  methodName ? methodName : "no method");
+#endif
+
+   uint8_t *address = item->_addr;
+   TR_PersistentList<TR::DebugCounterAggregation> *counters = item->_counters;
+
+   TR_ASSERT_FATAL(address, "Address should not be null");
+   TR_ASSERT_FATAL(_pageSize > 0, "Page size should be set");
+
+   size_t addressPage = (uintptr_t)address / _pageSize;
+   size_t startPage = (uintptr_t)_start / _pageSize;
+   int32_t offset = static_cast<int32_t>((_grows == lowToHigh) ? addressPage - startPage : startPage - addressPage);
+
+   TR_ASSERT_FATAL(offset >= 0, "Offset should be >= 0\n");
+
+   size_t tillPageEnd = _pageSize - ((uintptr_t)address % _pageSize);
+   size_t remainingSize = item->_size;
+
+   if (remainingSize > tillPageEnd)
+      item->_size = tillPageEnd;
+
+   addToListSorted(&_pageMap[offset], item);
+
+   remainingSize -= item->_size;
+   address += tillPageEnd;  // next address in case it's needed, points to the beginning of the next page
+
+   while (remainingSize > 0)
+      {
+      size_t  newSize = remainingSize;
+
+      if (newSize > _pageSize)
+         newSize = _pageSize;
+
+      OMR::RSSItem *newItem = new (TR::Compiler->persistentMemory()) OMR::RSSItem(item->_type, address, newSize, counters);
+      offset = (_grows == lowToHigh) ? ++offset : --offset;
+
+      TR_ASSERT_FATAL(offset >= 0, "Got negative offset %d for addr=%p size=%zu type=%s\n", offset,
+                      newItem->_addr, newItem->_size, OMR::RSSItem::itemNames[newItem->_type]);
+
+#ifdef DEBUG_RSS_REPORT
+      TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS adding overflow item addr=%p size=%zu type=%s thread=%d method=%s",
+                                     newItem->_addr, newItem->_size,
+                                     OMR::RSSItem::itemNames[newItem->_type], threadId,
+                                     methodName ? methodName : "no method");
+#endif
+
+      addToListSorted(&_pageMap[offset], newItem);
+      address += _pageSize;
+      remainingSize -= newSize;
+      }
+   }
+
+void
+OMR::RSSRegion::addToListSorted(TR_PersistentList<OMR::RSSItem> *itemList, OMR::RSSItem *item)
+   {
+   ListElement<OMR::RSSItem> *prevElement = NULL;
+   ListElement<OMR::RSSItem> *newElement = NULL;
+   uint8_t *itemStart = item->_addr;
+   uint8_t *itemEnd = item->_addr + item->_size;
+   OMR::RSSItem *next = NULL;
+
+   ListIterator<OMR::RSSItem> it(itemList);
+
+   for (next = it.getFirst(); next; next = it.getNext())
+      {
+      uint8_t *nextEnd = next->_addr + next->_size;
+
+      if (itemStart < nextEnd)
+         {
+         newElement = itemList->addAfter(item, prevElement);
+         break;
+         }
+
+      prevElement = it.getCurrentElement();
+      }
+
+   if (!next)
+      newElement = itemList->addAfter(item, prevElement);
+
+   // Remove all subsequent overlaping items
+   // Due to the way we inserted the item above, all ovelaping items will be next
+   //
+   for (ListElement<OMR::RSSItem> * nextElement = newElement->getNextElement(); nextElement; nextElement = nextElement->getNextElement())
+      {
+      OMR::RSSItem *nextItem = nextElement->getData();
+      uint8_t *nextStart = nextItem->_addr;
+      uint8_t *nextEnd = nextStart + nextItem->_size;
+
+      if (itemStart >= nextStart || itemEnd > nextStart)
+         {
+         itemList->removeNext(newElement);
+         }
+      else
+         {
+         break;
+         }
+      }
+   }
+
+#ifdef LINUX
+typedef struct __attribute__ ((__packed__))
+   {
+   union
+      {
+      uint64_t _pmd; // page memory descriptor
+      uint64_t _pageFrameNumber : 55; // bits 0..54 represent the page frame number (PFN) if present
+                                      // if not present, they represent the swap type and offset
+      struct
+         {
+         uint64_t _swapType: 5;    // swap type if swapped
+         uint64_t _swapOffset: 50; // swap offset if swapped
+         uint64_t _softDirty: 1;   // bit 55: pte is soft dirty
+         uint64_t _exclusive: 1;   // bit 56: page exclussively mapped
+         uint64_t _wp:1;           // bit 57: pte is uffd-wp write-protected (since 5.13)
+         uint64_t _zero: 3;        // bits 58..60 are zero
+         uint64_t _filePage: 1;    // bit 61: page is file-page or shared-anon
+         uint64_t _swapped: 1;     // bit 62: page is swapped
+         uint64_t _present: 1;     // bit 63: page is present
+         };
+       };
+   } pmd_t;
+#endif
+
+size_t
+OMR::RSSReport::countResidentPages(int fd, OMR::RSSRegion *rssRegion, char *pagesInfo)
+   {
+   size_t  rss = 0;
+
+#ifdef LINUX
+   uint8_t *start = rssRegion->_start;
+   size_t size = rssRegion->_size;
+
+   if (rssRegion->_grows == OMR::RSSRegion::highToLow)
+      start = start - size;
+
+   uint8_t *end = start + size;
+   size_t  pageCount = 0;
+   size_t  pageSize = rssRegion->_pageSize;
+
+   TR_ASSERT_FATAL(pageSize >=0, "Page size should be set");
+
+   for (uint8_t *addr = start; addr < end; addr += pageSize)
+      {
+      pmd_t pmd;
+      uint64_t index = ((uint64_t)addr / pageSize) * sizeof(pmd._pmd);
+
+      if (pread(fd, &pmd._pmd, sizeof(pmd._pmd), index) != sizeof(pmd))
+         {
+         perror("cannot read from pagemap file");
+         break;
+         }
+
+      size_t resident = pmd._present;
+      rss += resident;
+
+      if (!_detailed) continue;
+
+      // Print RSS items and debug counters for each resident page
+      //
+#ifdef DEBUG_RSS_REPORT // printing RSS bit for every page is rarely used
+      if (pagesInfo)
+         {
+         size_t offset = pageCount * PAGE_PRINT_WIDTH;
+
+         if ((offset + PAGE_PRINT_WIDTH + 1) < MAX_RSS_LINE)
+            {
+            // Note: In addition to the pafgesInfo limit, TR_VerboseLog will truncate the line to some maximum
+            // PAGE_PRINT_WIDTH+1 ensures each field will not take more than expected by the check above
+            //
+            TR::snprintfTrunc(pagesInfo + offset, PAGE_PRINT_WIDTH+1, "%1zu ", resident);
+            }
+          else
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS: The following line is incomplete");
+            }
+         }
+#endif
+
+      TR_PersistentList<OMR::RSSItem> itemList = rssRegion->getRSSItemList(addr);
+
+      if (resident == 1 &&
+          itemList.isEmpty())
+         {
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS: Resident page at addr %p has no RSS items", addr);
+         }
+      else if (resident == 1)
+         {
+         ListIterator<OMR::RSSItem> it(&itemList);
+
+         size_t totalItemSize = 0;
+         int32_t countItems = 0;
+         uint8_t *prevEnd = (addr == start) ? addr : (uint8_t *)(((uintptr_t)addr / pageSize) * pageSize);  // current page start
+         OMR::RSSItem *prevItem = NULL;
+
+         uint64_t pageDebugCount = 0;
+
+         // print RSS items
+         for (OMR::RSSItem *item = it.getFirst(); item; item = it.getNext())
+            {
+            uint64_t itemDebugCount = 0;
+
+            if (item->_counters)
+               {
+               ListIterator<TR::DebugCounterAggregation> aggrIt(item->_counters);
+
+               // print debug counters
+               for (TR::DebugCounterAggregation *aggr = aggrIt.getFirst(); aggr; aggr = aggrIt.getNext())
+                  {
+                  uint64_t count = aggr->getCount();
+
+                  itemDebugCount += count;
+                  pageDebugCount += count;
+                  if (count > 0) aggr->printCounters(false /*printZeroCounters*/);
+                  }
+               }
+
+            int32_t gap = item->_addr - prevEnd;
+
+            TR_ASSERT_FATAL(gap >= 0, "Item at addr %p in page %p is out of order, prevAddr=%p", item->_addr, addr,
+                            prevItem->_addr);
+
+            if (gap != 0)
+               {
+               TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS: gap at addr=%p size=%zu in %s region", prevEnd, gap, rssRegion->_name);
+               }
+
+            totalItemSize += item->_size + gap;
+
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS item at addr=%p size=%zu itemDebugCount=%zu %s",
+                                           item->_addr, item->_size, itemDebugCount, OMR::RSSItem::itemNames[item->_type]);
+
+            countItems++;
+            prevEnd = item->_addr + item->_size;
+            prevItem = item;
+            }
+
+         TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS: Page at addr %p has %zu bytes of %d items pageDebugCount=%zu",
+                                        addr, totalItemSize, countItems, pageDebugCount);
+
+         TR_ASSERT_FATAL(totalItemSize <= pageSize, "Total size of items within page %p > page size\n", addr);
+         }
+
+      pageCount++;
+      }
+#endif
+
+   return rss;
+   }
+
+void
+OMR::RSSReport::printTitle()
+   {
+   int32_t regionNum = 0;
+   char rssLine[MAX_RSS_LINE];
+
+   ListIterator<OMR::RSSRegion> it(&_regions);
+   for (OMR::RSSRegion *rssRegion = it.getFirst(); rssRegion; rssRegion = it.getNext())
+      {
+      size_t offset = regionNum * REGION_PRINT_WIDTH;
+
+      if ((offset + REGION_PRINT_WIDTH + 1) < MAX_RSS_LINE)
+         {
+         // Note: In addition to the rssLine limit, TR_VerboseLog will truncate the line to some maximum
+         // REGION_PRINT_WIDTH+1 ensures each field will not take more than expected by the check above
+         //
+         TR::snprintfTrunc(rssLine + offset, REGION_PRINT_WIDTH+1, "%*.*s", REGION_PRINT_WIDTH, REGION_PRINT_WIDTH, rssRegion->_name);
+         }
+      else
+         {
+         break;
+         }
+      regionNum++;
+      }
+
+   TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS Region name:    %s", rssLine);
+
+   it.reset();
+   regionNum = 0;
+   for (OMR::RSSRegion *rssRegion = it.getFirst(); rssRegion; rssRegion = it.getNext())
+      {
+      size_t offset = regionNum * REGION_PRINT_WIDTH;
+
+      if ((offset + REGION_PRINT_WIDTH + 1) < MAX_RSS_LINE)
+         {
+         // Note: In addition to the rssLine limit, TR_VerboseLog will truncate the line to some maximum
+         // REGION_PRINT_WIDTH+1 ensures each field will not take more than expected by the check above
+         //
+         TR::snprintfTrunc(rssLine + offset, REGION_PRINT_WIDTH+1, "%*p", REGION_PRINT_WIDTH, rssRegion->_start);
+         }
+      else
+         {
+         break;
+         }
+
+      regionNum++;
+      }
+
+   TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS Region start:     %s", rssLine);
+   _printTitle = false;
+   }
+
+void
+OMR::RSSReport::printRegions()
+   {
+   size_t totalKb = 0;
+   size_t totalRSSKb = 0;
+   int32_t regionNum = 0;
+   char rssLine[MAX_RSS_LINE];
+
+#ifdef DEBUG_RSS_REPORT
+   char pagesInfo[MAX_RSS_LINE];
+#else
+   char *pagesInfo = NULL;
+#endif
+
+   static const char *pagemapPath = "/proc/self/pagemap";
+   int fd = 0;
+
+#ifdef LINUX
+   fd = open(pagemapPath, O_RDONLY);
+   if (fd < 0)
+      {
+      perror("cannot open pagemap file");
+      return;
+      }
+#endif
+
+   if (_printTitle) printTitle();
+
+   ListIterator<OMR::RSSRegion> it(&_regions);
+
+   for (OMR::RSSRegion *rssRegion = it.getFirst(); rssRegion; rssRegion = it.getNext())
+      {
+      size_t pageSize = rssRegion->_pageSize;
+
+      TR_ASSERT_FATAL(pageSize >=0, "Page size should be set");
+
+      size_t rssPages = countResidentPages(fd, rssRegion, pagesInfo);
+      size_t rssSizeKb  = rssPages * pageSize / 1024;
+      size_t sizeKb  = rssRegion->_size / 1024;
+      size_t offset = regionNum * REGION_PRINT_WIDTH;
+
+      if ((offset + REGION_PRINT_WIDTH + 1) < MAX_RSS_LINE)
+         {
+         // Note: In addition to the rssLine limit, TR_VerboseLog will truncate the line to some maximum
+         // REGION_PRINT_WIDTH+1 ensures each field will not take more than expected by the check above
+         //
+         TR::snprintfTrunc(rssLine + offset, REGION_PRINT_WIDTH+1, " %5zu/%5zu(%3.0f%%)", rssSizeKb, sizeKb, (float)rssSizeKb*100.0/sizeKb);
+         }
+
+      totalKb += sizeKb;
+      totalRSSKb += rssSizeKb;
+      regionNum++;
+      }
+
+#ifdef LINUX
+   close(fd);
+#endif
+
+   TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "RSS Region rss/size:    %s  all %u regions %5zu/%5zu(%3.0f%%) KB", rssLine, regionNum, totalRSSKb, totalKb, (float)totalRSSKb*100.0/totalKb);
+   }

--- a/compiler/runtime/OMRRSSReport.hpp
+++ b/compiler/runtime/OMRRSSReport.hpp
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2000
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef OMR_RSSREPORT_INCL
+#define OMR_RSSREPORT_INCL
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#ifdef LINUX
+#include <unistd.h>
+#endif
+#include "env/TRMemory.hpp"
+#include "infra/Array.hpp"
+#include "infra/CriticalSection.hpp"
+#include "infra/List.hpp"
+#include "env/VerboseLog.hpp"
+#include "ras/DebugCounter.hpp"
+
+namespace TR { class Monitor; }
+
+namespace OMR
+{
+
+/*
+ * RSSItem describes content of some memory given address and size.
+ * RSSItem can be added to RSSRegion. It is possible to associate
+ * debug counters with each item.
+ */
+class RSSItem
+   {
+   public:
+   TR_ALLOC(TR_Memory::Inliner);  // TODO: add new type
+
+   enum Type
+      {
+      unknown,
+      header,
+      alignment,
+      coldBlocks,
+      overEstimate,
+      OOL,
+      snippet
+      };
+
+   static const char *itemNames[];
+
+   RSSItem() : _type(unknown), _addr(NULL), _size(0), _counters(NULL) {}
+   RSSItem(Type type, uint8_t *addr, size_t size, TR_PersistentList<TR::DebugCounterAggregation> *counters)
+           : _type(type), _addr(addr), _size(size), _counters(counters){}
+   private:
+   enum Type _type;
+   uint8_t *_addr;
+   size_t _size;
+   TR_PersistentList<TR::DebugCounterAggregation> *_counters;
+   friend class RSSRegion;
+   friend class RSSReport;
+   };
+
+/*
+ * RSSRegion represents a region of memory that has starting address, size,
+ * name, and RSSItems associated with it. Regions can be added to RSSReport.
+ * Region's size can be updatee after it was added to the report.
+ * Regions can grow low to high, as well as high to low addresses.
+ */
+class RSSRegion
+   {
+public:
+   TR_ALLOC(TR_Memory::UnknownType);  // TODO: add new type
+
+   enum Grows
+      {
+      lowToHigh,
+      highToLow
+      };
+
+   RSSRegion(const char *name, uint8_t *start, uint32_t size, Grows grows, size_t pageSize) :
+             _name(name), _start(start), _size(size), _grows(grows), _pageSize(pageSize),
+             _pageMap(TR::Compiler->persistentMemory()) { }
+
+   /**
+    * \brief
+    *  Returns region's start
+    *
+    * \returns
+    *  Lowest address for regions that grow low to high and highest addres otherwise
+    */
+   uint8_t *getStart() {return _start;}
+
+   /**
+    * \brief Adds RSSItem to the region. If the item overlaps with any existing items
+    *        those items get removed.
+    *
+    * \param item
+    *        Item to add
+    * \param thredId
+    *        Thread id that adds the item
+    * \param methodName
+    *        Name of the method that adds the item
+    */
+   void addRSSItem(RSSItem *item, int32_t threadId, const char* methodName = NULL);
+
+   /**
+    * \brief
+    *      Adds item to a sorted list
+    *
+    * \param itemList
+    *        List to add to
+    * \param item
+    *        Item to add
+    */
+   void addToListSorted(TR_PersistentList<RSSItem> *itemList, RSSItem *item);
+
+   /**
+    * \brief
+    *        Returns list of RSSItems for the page given address belongs to
+    *
+    * \param address
+    *        Address
+    *
+    * \return
+    *        Items list
+    */
+   TR_PersistentList<RSSItem> getRSSItemList(uint8_t *address)
+         {
+         TR_ASSERT_FATAL(_pageSize > 0, "Page size should be set");
+
+         size_t addressPage = (uintptr_t)address / _pageSize;
+         size_t startPage = (uintptr_t)_start / _pageSize;
+         int32_t offset = static_cast<uint32_t>((_grows == lowToHigh) ?
+                                                 addressPage - startPage : startPage - addressPage);
+
+         TR_ASSERT_FATAL (offset >= 0, "Offset should be >= 0\n");
+         return _pageMap[offset];
+         }
+
+   const char* _name;
+   uint8_t *_start;
+   size_t _size;
+   Grows _grows;
+   size_t _pageSize;
+   TR_PersistentArray<TR_PersistentList<RSSItem>> _pageMap;
+   };
+
+/*
+ * A singleton class that maintains a global list of RSSRegions.
+ * Prints either a summary of RSS status for each RSSRegion
+ * or a detailed report per page.
+ *
+ * Note: using this class is relatively expensive for both time and memory.
+ */
+class RSSReport
+   {
+   static RSSReport *_instance; // singleton
+
+   static int32_t const MAX_RSS_LINE = 10000;
+   static int32_t const PAGE_PRINT_WIDTH = 2;
+   static int32_t const REGION_PRINT_WIDTH = 18;
+
+   public:
+   RSSReport(bool detailed) : _detailed(detailed), _lastRegion(NULL), _printTitle(true)
+      {
+      _instance = this;
+      _mutex = TR::Monitor::create("RSSReport-Monitor");
+      if (!_mutex)
+         _instance = NULL;
+      }
+
+   class RSSReportCriticalSection : public CriticalSection
+      {
+      public:
+      RSSReportCriticalSection(RSSReport *rssReport) : CriticalSection(rssReport->_mutex) { }
+      };
+
+   /**
+    * \brief
+    *         Returns single instance of the class
+    *
+    * \return
+    *         Single instance
+    */
+   static RSSReport *instance() { return _instance; }
+
+
+   /**
+    * \brief Counts number of resident pages in the region
+    *
+    * \param fd
+    *        File descriptor for opened /proc/self/pagemap
+    * \param rssRegion
+    *        Region
+    * \param pagesInfo
+    *        String where to print page info
+    * \return
+    *        Number of resident pages
+    */
+   size_t countResidentPages(int fd, RSSRegion *rssRegion, char *pagesInfo);
+
+   /**
+    * \brief
+    *        Prints region names
+    */
+   void printTitle();
+
+   /**
+    * \brief
+    *        Prints region summary
+    */
+   void printRegions();
+
+   /**
+    * \brief
+    *        Adds RSSRegion to the list
+    *
+    * \param region
+    *        Region to add
+    */
+   void addRegion(RSSRegion *region)
+         {
+         _printTitle = true;
+
+         RSSReportCriticalSection addRegionToList(this);
+         _lastRegion = _regions.addAfter(region, _lastRegion);
+         }
+
+   /**
+    * \brief
+    *        Creates and adds new RSSRegion to the list
+    */
+   void addNewRegion(const char *name, uint8_t *start, uint32_t size, RSSRegion::Grows grows, size_t pageSize)
+         {
+         RSSRegion *region = new (PERSISTENT_NEW) RSSRegion(name, start, size, grows, pageSize);
+
+         _printTitle = true;
+
+         RSSReportCriticalSection addRegionToList(this);
+         _lastRegion = _regions.addAfter(region, _lastRegion);
+         }
+
+
+   private:
+   bool _detailed;
+   bool _printTitle;
+   TR_PersistentList<RSSRegion> _regions;
+   ListElement<RSSRegion>       *_lastRegion;
+   TR::Monitor *_mutex;
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_RSSREPORT_INCL)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -91,6 +91,7 @@
 #include "optimizer/RegisterCandidate.hpp"
 #include "ras/Debug.hpp"
 #include "ras/DebugCounter.hpp"
+#include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "x/codegen/DataSnippet.hpp"
 #include "x/codegen/OutlinedInstructions.hpp"
@@ -1891,6 +1892,83 @@ struct DescendingSortX86DataSnippetByDataSize
       return a->getDataSize() > b->getDataSize();
       }
    };
+
+
+void OMR::X86::CodeGenerator::addItemsToRSSReport(uint8_t *coldCode)
+   {
+   // calculate size and collect counters for all cold blocks in the cold cache
+   TR_PersistentList<TR::DebugCounterAggregation> *coldBlockCountersList = NULL;
+   bool insideColdCode = false;
+   size_t blocksInsideColdCodeSize = 0;
+   TR::Compilation *comp = self()->comp();
+   const char* methodName = comp->signature();
+
+   for (TR::TreeTop *tt = comp->getMethodSymbol()->getFirstTreeTop(); tt ; tt = tt->getNextTreeTop())
+      {
+      TR::Node *node = tt->getNode();
+
+      if (node->getOpCodeValue() != TR::BBStart) continue;
+
+      TR::Block *block = node->getBlock();
+
+      if (insideColdCode)
+         {
+         uint8_t *startCursor = block->getFirstInstruction()->getBinaryEncoding();
+         uint8_t *endCursor = block->getLastInstruction()->getBinaryEncoding();
+         size_t blockSize = endCursor - startCursor;
+         blocksInsideColdCodeSize += blockSize;
+
+         if (!coldBlockCountersList)
+            coldBlockCountersList = new (comp->trPersistentMemory()) TR_PersistentList<TR::DebugCounterAggregation> ();
+
+         coldBlockCountersList->add(block->getDebugCounters());
+         }
+
+      if (block->isLastWarmBlock())
+         insideColdCode = true;
+
+      }
+
+   // create one RSSItem for all cold blocks
+   if (self()->getEstimatedColdLength() &&
+       OMR::RSSReport::instance())
+      {
+      TR::CodeCache *codeCache = TR::CodeCacheManager::instance()->findCodeCacheFromPC(coldCode);
+      OMR::RSSRegion *rssRegion = codeCache->getColdCodeRSSRegion();
+
+      if (rssRegion)
+         {
+         size_t actualColdLength = getBinaryBufferCursor() - coldCode;
+         int32_t overEstimate = static_cast<int32_t>(getEstimatedColdLength() - actualColdLength);
+
+         TR_ASSERT_FATAL(overEstimate >= 0, "Estimated cold code length should not be less than actual\n");
+
+         if (blocksInsideColdCodeSize != actualColdLength)
+            {
+            if (comp->getOption(TR_TraceCG))
+               {
+               traceMsg(comp, "RSS: blocksInsideColdCodeSize=%zu actualColdLength=%zu coldCode=%p coldCodeEnd=%p\n",
+                              blocksInsideColdCodeSize, actualColdLength, coldCode, coldCode+actualColdLength);
+               }
+            }
+
+         OMR::RSSItem *rssItem;
+
+         if (overEstimate > 0)
+            {
+            rssItem = new (comp->trPersistentMemory()) OMR::RSSItem(OMR::RSSItem::overEstimate, getBinaryBufferCursor(),
+                                                                           overEstimate, NULL);
+            rssRegion->addRSSItem(rssItem, codeCache->getReservingCompThreadID(), methodName);
+            }
+
+         rssItem = new (comp->trPersistentMemory()) OMR::RSSItem(OMR::RSSItem::coldBlocks, coldCode, actualColdLength,
+                                                                        coldBlockCountersList);
+
+         rssRegion->addRSSItem(rssItem, codeCache->getReservingCompThreadID(), methodName);
+         }
+      }
+   }
+
 void OMR::X86::CodeGenerator::doBinaryEncoding()
    {
    LexicalTimer pt1("code generation", self()->comp()->phaseTimer());
@@ -2206,6 +2284,9 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
       cursorInstruction = cursorInstruction->getNext();
       }
+
+   if (OMR::RSSReport::instance())
+       addItemsToRSSReport(coldCode);
 
    // Create exception table entries for outlined instructions.
    //

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -385,6 +385,17 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
 
+
+   /*
+    * \brief
+    *        Adds items describing cold code cache to RSSReport
+    *
+    * \param coldCode
+    *        Starting address of the cold code cache
+    *
+    */
+   void addItemsToRSSReport(uint8_t *coldCode);
+
    void doBackwardsRegisterAssignment(TR_RegisterKinds kindsToAssign, TR::Instruction *startInstruction, TR::Instruction *appendInstruction = NULL);
 
    bool hasComplexAddressingMode() { return true; }

--- a/doc/compiler/debug/RSSReport.md
+++ b/doc/compiler/debug/RSSReport.md
@@ -1,0 +1,55 @@
+<!--
+Copyright IBM Corp. and others 2018
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# RSSReport
+
+**RSSReport** is a singleton class that prints resident set sizes (RSS) for an arbitrary number of memory regions.
+
+# RSSRegion
+
+**RSSRegion** represents a memory region for which RSS data will be printed. **RSSRegion** can be added to **RSSReport** using the `addRegion()` method. **RSSRegion** has starting address, size, and name. The size of the region can be updated after it was created. A region can grow from low to high or from high to low addresses, which can be specified in its constructor.
+
+# RSSItem
+
+**RSSItem** is a way to describe some part of **RSSRegion**. When **RSSItem** is added to **RSSRegion** and it overlaps with an existing item the latter will be removed. When a detailed RSS report is printed, it detects if there are gaps between the items. It is also possible to attach debug counters to **RSSItem**. This might be useful if you would like to find out why some page is in RSS.
+
+# Options
+`-Xjit:verbose={RSSReport|RSSReportDetailed}`
+
+# Example
+For example, `-Xjit:verbose={RSSReport}` may print:
+
+```
+#PERF:  RSS Region name:             cold code         cold code
+#PERF:  RSS Region start:          0x7f90895ff1a0    0x7f90897ff1a0
+#PERF:  RSS Region rss/size:       580/  591( 98%)   360/  356(101%)  all 2 regions   940/  947( 99%) KB
+```
+
+`-Xjit:verbose={RSSReportDetailed}` may print:
+
+```
+#PERF:  RSS item at addr=00007F1A6B969FC0 size=16 itemDebugCount=0 HEADER
+#PERF:  RSS item at addr=00007F1A6B969FD0 size=15 itemDebugCount=0 COLD BLOCKS
+#PERF:  RSS item at addr=00007F1A6B969FDF size=24 itemDebugCount=0 OVERESTIMATE
+#PERF:  RSS item at addr=00007F1A6B969FF7 size=9 itemDebugCount=0 ALIGNMENT
+#PERF:  RSS: Page at addr 00007F1A6B969FC0 has 64 bytes of 4 items pageDebugCount=0
+```


### PR DESCRIPTION
- Implement a class that can monitor RSS status of any number of arbitry memory regions
- In addition to start address and size, region can have name, as well as a list of items describing its content