### PR TITLE
Replace redundant shifts and rotations of const 0 with const 0

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -10259,7 +10259,12 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   if (secondChild->getOpCode().isLoadConst() &&
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else if (secondChild->getOpCode().isLoadConst() &&
        performTransformation(s->comp(), "%sChanged ishl by const into imul by const in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
       {
       // Normalize shift by a constant into multiply by a constant
@@ -10301,7 +10306,12 @@ TR::Node *lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   if (secondChild->getOpCode().isLoadConst())
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else if (secondChild->getOpCode().isLoadConst())
       {
       // Canonicalize shift by a constant into multiply by a constant
       //
@@ -10345,6 +10355,12 @@ TR::Node *bshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10364,6 +10380,12 @@ TR::Node *sshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10391,7 +10413,13 @@ TR::Node *ishrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10415,7 +10443,13 @@ TR::Node *lshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10437,6 +10471,12 @@ TR::Node *bshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10456,6 +10496,12 @@ TR::Node *sshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10549,7 +10595,13 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10691,7 +10743,13 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10713,6 +10771,12 @@ TR::Node *bushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10732,6 +10796,12 @@ TR::Node *sushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10761,7 +10831,13 @@ TR::Node *irolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace rotate of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
    return node;
    }
 
@@ -10785,7 +10861,13 @@ TR::Node *lrolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace rotate of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
    return node;
    }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7109,6 +7109,13 @@ TR::Node *constrainIshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+
    checkForNonNegativeAndOverflowProperties(vp, node);
    return node;
    }
@@ -7132,7 +7139,13 @@ TR::Node *constrainLshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
-   if (lhs && lhs->asLongConst() &&
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+   else if (lhs && lhs->asLongConst() &&
        lhs->asLongConst()->getLong() == 1)
       {
       TR::VPConstraint *constraint = TR::VPLongRange::create(vp, TR::getMinSigned<TR::Int64>(), TR::getMaxSigned<TR::Int64>(), true);
@@ -7273,16 +7286,22 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x01F;
-
-      bool lhsGlobal;
-      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
-      lhsGlobal &= rhsGlobal;
 
       int32_t low, high;
       if (lhs)
@@ -7328,6 +7347,7 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       //lhs->decReferenceCount();
       //rhs->decReferenceCount();
       }
+
    // this handler is not called for unsigned shifts
    //#ifdef DEBUG
    //else if(!firstChild->getType().isSignedInt()) dumpOptDetails(vp->comp(), "FIXME: Need to support ishr opt for Unsigned datatypes!\n");
@@ -7345,16 +7365,22 @@ TR::Node *constrainLshr(OMR::ValuePropagation *vp, TR::Node *node)
 
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x03F;
-
-      bool lhsGlobal;
-      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
-      lhsGlobal &= rhsGlobal;
 
       int64_t low, high;
       if (lhs)
@@ -7422,8 +7448,18 @@ TR::Node *constrainIushr(OMR::ValuePropagation *vp, TR::Node *node)
    //if (parent && parent->getType().isUnsignedInt())
    //   isUnsigned = true;
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
@@ -7499,8 +7535,18 @@ TR::Node *constrainLushr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();


### PR DESCRIPTION
Since applying a shift or rotation to 0 simply produces 0 again, the optimizer can replace any shift or rotation for which the first child is a const 0 with a const 0.

Issue: [openj9 #19576](https://github.com/eclipse-openj9/openj9/issues/19576)