### PR TITLE
UMA: add missing include path

### DIFF
--- a/omr_static_lib/makefile
+++ b/omr_static_lib/makefile
@@ -76,4 +76,6 @@ $(foreach lib,$(OMRLIBS), \
     $(shell MAKEFLAGS= $(MAKE) -s --no-print-directory -C $(lib) show-objects), \
     $(if $(filter /%,$(object)),$(object),$(lib)/$(object))))
 
+MODULE_INCLUDES += $(top_srcdir)/gc/startup
+
 include $(top_srcdir)/omrmakefiles/rules.mk


### PR DESCRIPTION
If make decides to build `OMR_VM.o` for `omr_static_lib`, it will not be able to find `mminitcore.h` because `$(top_srcdir)/gc/startup` is not on the include path (like it is in `omr/makefile`).