### PR TITLE
Commoning and InductionVariable changes for OffHeap

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2333,7 +2333,7 @@ OMR::Node::isNotCollected()
 bool
 OMR::Node::computeIsInternalPointer()
    {
-   TR_ASSERT(self()->getOpCode().hasPinningArrayPointer(), "Opcode %s is not supported, node is " POINTER_PRINTF_FORMAT, self()->getOpCode().getName(), self());
+   TR_ASSERT(self()->hasPinningArrayPointer(), "Opcode %s is not supported, node is " POINTER_PRINTF_FORMAT, self()->getOpCode().getName(), self());
    return self()->computeIsCollectedReference();
    }
 
@@ -3785,6 +3785,20 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
    TR::SymbolReference *newArrayRef = NULL;
    TR::TreeTop *newStoreTree = NULL;
 
+   if (self()->isDataAddrPointer())
+      {
+      TR::Node *firstChild = self()->getFirstChild();
+      TR::Node *arrayLoadNode = NULL;
+      TR::SymbolReference *newArrayRef = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), TR::Address);
+      TR::Node *newStore = TR::Node::createStore(newArrayRef, firstChild);
+      TR::TreeTop *newStoreTree = TR::TreeTop::create(comp, newStore);
+      insertBefore = origInsertBefore->insertBefore(newStoreTree);
+      arrayLoadNode = TR::Node::createLoad(firstChild, newArrayRef);
+      self()->setAndIncChild(0, arrayLoadNode);
+      firstChild->recursivelyDecReferenceCount();
+      return insertBefore;
+      }
+
    bool isInternalPointer = false;
    if ((self()->hasPinningArrayPointer() &&
         self()->computeIsInternalPointer()) ||
@@ -3807,7 +3821,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       }
 
    if (isInternalPointer &&
-       self()->getOpCode().isArrayRef() &&
+       (self()->getOpCode().isArrayRef() || self()->isDataAddrPointer())&&
        (comp->getSymRefTab()->getNumInternalPointers() >= (comp->maxInternalPointers()/2) ||
         comp->cg()->supportsComplexAddressing()) &&
        (self()->getReferenceCount() == 1))
@@ -3819,7 +3833,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       TR::Node *intOrLongNode = NULL;
 
 
-      if (!firstChild->getOpCode().isArrayRef() &&
+      if ( (!firstChild->getOpCode().isArrayRef() || self()->isDataAddrPointer()) &&
           !firstChild->isInternalPointer()  /* &&
              (!firstChild->getOpCode().isLoadVarDirect() ||
               !firstChild->getSymbolReference()->getSymbol()->isAuto()) */)
@@ -3874,10 +3888,10 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       if (isInternalPointer)
          {
          TR::AutomaticSymbol *pinningArray = NULL;
-         if (self()->getOpCode().isArrayRef())
+         if (self()->getOpCode().isArrayRef() || self()->isDataAddrPointer())
             {
             child = self()->getFirstChild();
-            if (child->isInternalPointer())
+            if (child->isInternalPointer() && !child->isDataAddrPointer())
                pinningArray = child->getPinningArrayPointer();
             else
                {
@@ -5885,14 +5899,14 @@ OMR::Node::chkCompressionSequence()
 bool
 OMR::Node::isInternalPointer()
    {
-   return _flags.testAny(internalPointer) && (self()->getOpCode().hasPinningArrayPointer() || self()->getOpCode().isArrayRef());
+   return _flags.testAny(internalPointer) && (self()->hasPinningArrayPointer() || self()->getOpCode().isArrayRef());
    }
 
 void
 OMR::Node::setIsInternalPointer(bool v)
    {
    TR::Compilation *c = TR::comp();
-   TR_ASSERT(self()->getOpCode().hasPinningArrayPointer() || self()->getOpCode().isArrayRef(),
+   TR_ASSERT(self()->hasPinningArrayPointer() || self()->getOpCode().isArrayRef(),
              "Opcode must be one that can have a pinningArrayPointer or must be an array reference");
    if (performNodeTransformation2(c, "O^O NODE FLAGS: Setting internalPointer flag on node %p to %d\n", self(), v))
       _flags.set(internalPointer, v);

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3821,7 +3821,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       }
 
    if (isInternalPointer &&
-       (self()->getOpCode().isArrayRef() || self()->isDataAddrPointer())&&
+       self()->getOpCode().isArrayRef() &&
        (comp->getSymRefTab()->getNumInternalPointers() >= (comp->maxInternalPointers()/2) ||
         comp->cg()->supportsComplexAddressing()) &&
        (self()->getReferenceCount() == 1))
@@ -3833,7 +3833,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       TR::Node *intOrLongNode = NULL;
 
 
-      if ( (!firstChild->getOpCode().isArrayRef() || self()->isDataAddrPointer()) &&
+      if (!firstChild->getOpCode().isArrayRef() &&
           !firstChild->isInternalPointer()  /* &&
              (!firstChild->getOpCode().isLoadVarDirect() ||
               !firstChild->getSymbolReference()->getSymbol()->isAuto()) */)
@@ -3888,7 +3888,7 @@ OMR::Node::createStoresForVar(TR::SymbolReference * &nodeRef, TR::TreeTop *inser
       if (isInternalPointer)
          {
          TR::AutomaticSymbol *pinningArray = NULL;
-         if (self()->getOpCode().isArrayRef() || self()->isDataAddrPointer())
+         if (self()->getOpCode().isArrayRef())
             {
             child = self()->getFirstChild();
             if (child->isInternalPointer() && !child->isDataAddrPointer())

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3362,11 +3362,11 @@ TR::TreeTop * OMR_InlinerUtil::storeValueInATemp(
          if (value->getOpCode().hasSymbolReference() && value->getSymbolReference()->getSymbol()->isNotCollected())
             valueRef->getSymbol()->setNotCollected();
 
-         else if (value->getOpCode().isArrayRef())
+         else if (value->getOpCode().isArrayRef() || value->isDataAddrPointer())
             value->setIsInternalPointer(true);
 
          TR::AutomaticSymbol *pinningArray = NULL;
-         if (value->getOpCode().isArrayRef())
+         if (value->getOpCode().isArrayRef() || value->isDataAddrPointer())
             {
             TR::Node *valueChild = value->getFirstChild();
             if (valueChild->isInternalPointer() &&

--- a/compiler/optimizer/LocalAnalysis.cpp
+++ b/compiler/optimizer/LocalAnalysis.cpp
@@ -136,6 +136,9 @@ bool TR_LocalAnalysis::isSupportedNodeForFunctionality(TR::Node *node, TR::Compi
         node->getSymbolReference()->isUnresolved()))
       return false;
 
+   if (node->isDataAddrPointer())
+      return false;
+
    if (isSupportedOpCode(node->getOpCode(), comp) || isSupportedStoreNode || node->getOpCode().isLoadConst())
        {
        if (node->getDataType() == TR::Address)

--- a/compiler/optimizer/OMRLocalCSE.cpp
+++ b/compiler/optimizer/OMRLocalCSE.cpp
@@ -111,7 +111,7 @@ bool OMR::LocalCSE::shouldCopyPropagateNode(TR::Node *parent, TR::Node *node, in
 
 bool OMR::LocalCSE::shouldCommonNode(TR::Node *parent, TR::Node *node)
    {
-   return isTreetopSafeToCommon();
+   return !node->isDataAddrPointer() && isTreetopSafeToCommon();
    }
 
 TR::Node * getRHSOfStoreDefNode(TR::Node * storeNode)

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -2573,8 +2573,8 @@ bool OMR::Optimizer::areNodesEquivalent(TR::Node *node1, TR::Node *node2,  TR::C
          // for some reason this tests hasPinningArrayPointer only when the node also is true on _flags.testAny(internalPointer)
          bool haveIPs =    node1->isInternalPointer() && node2->isInternalPointer();
          bool haveNoIPs = !node1->isInternalPointer() && !node2->isInternalPointer();
-         TR::AutomaticSymbol * pinning1 = node1->getOpCode().hasPinningArrayPointer() ? node1->getPinningArrayPointer() : NULL;
-         TR::AutomaticSymbol * pinning2 = node2->getOpCode().hasPinningArrayPointer() ? node2->getPinningArrayPointer() : NULL;
+         TR::AutomaticSymbol * pinning1 = node1->hasPinningArrayPointer() ? node1->getPinningArrayPointer() : NULL;
+         TR::AutomaticSymbol * pinning2 = node2->hasPinningArrayPointer() ? node2->getPinningArrayPointer() : NULL;
          if ((haveIPs && (pinning1 == pinning2)) || haveNoIPs)
             return true;
          else


### PR DESCRIPTION
Code disables localCSE for offheap and updates `createStoreForVar` to only store the baseArray (not the dataAddressPointer). Code to store pinningArray for offheap is in https://github.com/eclipse/omr/pull/7345 but not tested with commoning enabled yet.
Also changes to teach InductionVariable code on OffHeap tree structure. 
