### PR TITLE
omr_static_lib/makefile should not compile anything

### DIFF
--- a/omr_static_lib/makefile
+++ b/omr_static_lib/makefile
@@ -76,6 +76,7 @@ $(foreach lib,$(OMRLIBS), \
     $(shell MAKEFLAGS= $(MAKE) -s --no-print-directory -C $(lib) show-objects), \
     $(if $(filter /%,$(object)),$(object),$(lib)/$(object))))
 
-MODULE_INCLUDES += $(top_srcdir)/gc/startup
+$(OBJECTS) :
+	@echo "omr_static_lib: Assuming $(top_srcdir)/omr/makefile ensured that $@ is up to date"
 
 include $(top_srcdir)/omrmakefiles/rules.mk


### PR DESCRIPTION
Instead, it should assume that `omr/makefile` ensured all object files are up to date.

This reverts #7366 (which is unnecessary) and restores a rule for `$(OBJECTS)` (removed in #7177) that tolerates clock skew on build systems (it wasn't "useless" after all).

