### PR TITLE
Define isPowerOf2 utility methods for unsigned

### DIFF
--- a/compiler/infra/Bit.hpp
+++ b/compiler/infra/Bit.hpp
@@ -394,10 +394,31 @@ static inline bool isNonPositivePowerOf2(int32_t input)
    return (input & -input) == -input;
    }
 
+/**
+ * \brief Tests whether the operand is a power of 2
+ *
+ * \param input The 32-bit signed integer value to be tested
+ *
+ * \return \c true, if the operand is a power of 2;
+ *         \c false, otherwise
+ */
 static inline bool isPowerOf2(int32_t input)
    {
    input = input < 0 ? -input : input;
    return (input & -input) == input;
+   }
+
+/**
+ * \brief Tests whether the operand is a power of 2
+ *
+ * \param input The 32-bit unsigned integer value to be tested
+ *
+ * \return \c true, if the operand is a power of 2;
+ *         \c false, otherwise
+ */
+static inline bool isPowerOf2(uint32_t input)
+   {
+   return (input != 0) && (input & (input-1)) == 0;
    }
 
 static inline bool isNonNegativePowerOf2(int64_t input)
@@ -417,10 +438,31 @@ static inline bool isNonPositivePowerOf2(int64_t input)
    return (input & -input) == -input;
    }
 
+/**
+ * \brief Tests whether the operand is a power of 2
+ *
+ * \param input The 64-bit signed integer value to be tested
+ *
+ * \return \c true, if the operand is a power of 2;
+ *         \c false, otherwise
+ */
 static inline bool isPowerOf2(int64_t input)
    {
    input = input < 0 ? -input : input;
    return (input & -input) == input;
+   }
+
+/**
+ * \brief Tests whether the operand is a power of 2
+ *
+ * \param input The 64-bit unsigned integer value to be tested
+ *
+ * \return \c true, if the operand is a power of 2;
+ *         \c false, otherwise
+ */
+static inline bool isPowerOf2(uint64_t input)
+   {
+   return (input != 0) && (input & (input-1)) == 0;
    }
 
 #if defined(OSX)


### PR DESCRIPTION
There are `isPowerOf2` methods defined in `Bit.hpp` for `int32_t` and `int64_t` values.  This change defines new `isPowerOf2` methods for values of type `uint32_t` and `uint64_t`.

Also added Doxygen comments for the various `isPowerOf2` methods.

This change doesn't introduce any uses of these methods in OMR, but I will be able to take advantage of them in a downstream project.