### PR TITLE
Tweak a2e header wrappers for Open XL compliance

### DIFF
--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -43,7 +43,11 @@ list(APPEND CMAKE_INCLUDE_PATH "/usr/lpp/cbclib/include")
 # Create helper targets for specifying ascii/ebcdic options
 add_library(omr_ascii INTERFACE)
 target_compile_definitions(omr_ascii INTERFACE -DIBM_ATOE)
-target_compile_options(omr_ascii INTERFACE "-Wc,convlit(ISO8859-1),nose,se(${CMAKE_CURRENT_LIST_DIR}/../../../../util/a2e/headers)")
+if(CMAKE_C_COMPILER_IS_OPENXL)
+	target_compile_options(omr_ascii INTERFACE -fexec-charset=ISO8859-1 -isystem ${CMAKE_CURRENT_LIST_DIR}/../../../../util/a2e/headers)
+else()
+	target_compile_options(omr_ascii INTERFACE "-Wc,convlit(ISO8859-1),nose,se(${CMAKE_CURRENT_LIST_DIR}/../../../../util/a2e/headers)")
+endif()
 target_link_libraries(omr_ascii INTERFACE j9a2e)
 
 add_library(omr_ebcdic INTERFACE)

--- a/port/zos390/omrtty.c
+++ b/port/zos390/omrtty.c
@@ -40,6 +40,7 @@
 
 #if !defined(OMR_EBCDIC)
 #include "atoe.h"
+#include "omriconvhelpers.h"
 #endif /* !defined(OMR_EBCDIC) */
 
 void WRITE_TTY(int fileno, char *b, int bcount);

--- a/util/a2e/headers/_Ccsid.h
+++ b/util/a2e/headers/_Ccsid.h
@@ -35,8 +35,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   
 #include <//'PP.ADLE370.OS39028.SCEEH.H(Ccsid)'>                   
 #else                                                              
-#include "prefixpath.h"
-#include PREFIXPATH(_Ccsid.h)                                    
+#include_next <_Ccsid.h>
 #endif                                                             
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/arpa/inet.h
+++ b/util/a2e/headers/arpa/inet.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.ARPA.H(inet)'>               /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(arpa/inet.h)                                /*ibm@28725*/
+#include_next <arpa/inet.h>                                        /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/atoe.h
+++ b/util/a2e/headers/atoe.h
@@ -36,7 +36,9 @@
 extern "C" {
 #endif /* __cplusplus */
 /* CMVC 162573 include the header file that includes the prototype for malloc used in functions/macros below*/
-	#include <stdlib.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <sys/types.h>
 
     #pragma map(sysTranslateASM, "SYSXLATE")
     extern char* sysTranslateASM(const char *source, int length, char *trtable, char* xlate_buf);
@@ -66,7 +68,8 @@ extern "C" {
 
     void atoe_enableFileTagging(void);
     void atoe_setFileTaggingCcsid(void *pccsid);
-    int  atoe_open_notag(const char *fname, int options, ...);
+    int atoe_open_notag(const char *fname, int options, ...);
+    struct passwd *etoa_passwd(struct passwd *e_passwd);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/util/a2e/headers/ctype.h
+++ b/util/a2e/headers/ctype.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(ctype)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(ctype.h)                                    /*ibm@28725*/
+#include_next <ctype.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/dirent.h
+++ b/util/a2e/headers/dirent.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(dirent)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(dirent.h)                                   /*ibm@28725*/
+#include_next <dirent.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/dll.h
+++ b/util/a2e/headers/dll.h
@@ -35,12 +35,11 @@
  * The compiler will find this header file in preference to the system one.
  * ===========================================================================
  */
-
+#include <dlfcn.h>
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(dll)'>                     /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(dll.h)                                      /*ibm@28725*/
+#include_next <dll.h>                                              /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)
@@ -51,7 +50,7 @@
 		#ifdef __cplusplus
                   extern "C" {
 		#endif
-	        dllhandle* atoe_dllload(char *);
+	        dllhandle* atoe_dllload(const char *);
 		#ifdef __cplusplus
                   }
 		#endif
@@ -67,7 +66,7 @@
                 #ifdef __cplusplus
                   extern "C" {
                 #endif 
-                void (*atoe_dllqueryfn(dllhandle* dllHandle, char* funcName)) ();
+                void (*atoe_dllqueryfn(dllhandle* dllHandle, const char* funcName)) ();
                 #ifdef __cplusplus
                   }
                 #endif

--- a/util/a2e/headers/fcntl.h
+++ b/util/a2e/headers/fcntl.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(fcntl)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(fcntl.h)                                    /*ibm@28725*/
+#include_next <fcntl.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/grp.h
+++ b/util/a2e/headers/grp.h
@@ -38,8 +38,7 @@
 #if __TARGET_LIB__ == 0X22080000
 #include <//'PP.ADLE370.OS39028.SCEEH.H(grp)'>
 #else
-#include "prefixpath.h"
-#include PREFIXPATH(grp.h)
+#include_next <grp.h>
 #endif
 
 #if !defined(IBM_ATOE_GRP)

--- a/util/a2e/headers/langinfo.h
+++ b/util/a2e/headers/langinfo.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(langinfo)'>                /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(langinfo.h)                                 /*ibm@28725*/
+#include_next <langinfo.h>                                         /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/locale.h
+++ b/util/a2e/headers/locale.h
@@ -35,8 +35,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(locale)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(locale.h)                                   /*ibm@28725*/
+#include_next <locale.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/netdb.h
+++ b/util/a2e/headers/netdb.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(netdb)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(netdb.h)                                    /*ibm@28725*/
+#include_next <netdb.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/old-stdio.h
+++ b/util/a2e/headers/old-stdio.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(stdio)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(stdio.h)                                    /*ibm@28725*/
+#include_next <stdio.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/old-stdlib.h
+++ b/util/a2e/headers/old-stdlib.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(stdlib)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(stdlib.h)                                   /*ibm@28725*/
+#include_next <stdlib.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/pwd.h
+++ b/util/a2e/headers/pwd.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(pwd)'>                     /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(pwd.h)                                      /*ibm@28725*/
+#include_next <pwd.h>                                              /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/spawn.h
+++ b/util/a2e/headers/spawn.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(spawn)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(spawn.h)                                    /*ibm@28725*/
+#include_next <spawn.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/stdio.h
+++ b/util/a2e/headers/stdio.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(stdio)'>                   /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(stdio.h)                                    /*ibm@28725*/
+#include_next <stdio.h>                                            /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/stdlib.h
+++ b/util/a2e/headers/stdlib.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(stdlib)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(stdlib.h)                                   /*ibm@28725*/
+#include_next <stdlib.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/string.h
+++ b/util/a2e/headers/string.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(string)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(string.h)                                   /*ibm@28725*/
+#include_next <string.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/strings.h
+++ b/util/a2e/headers/strings.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(strings)'>                 /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(strings.h)                                  /*ibm@28725*/
+#include_next <strings.h>                                          /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/sys/ipc.h
+++ b/util/a2e/headers/sys/ipc.h
@@ -37,8 +37,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.SYS.H(ipc)'>                 /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(sys/ipc.h)                                  /*ibm@28725*/
+#include_next <sys/ipc.h>                                          /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/sys/stat.h
+++ b/util/a2e/headers/sys/stat.h
@@ -36,8 +36,7 @@
 #if !defined(IBM_STAT_INCLUDED)  /*ibm@39757*/
 #define IBM_STAT_INCLUDED        /*ibm@39757*/
 
-#include "prefixpath.h"
-#include PREFIXPATH(sys/stat.h)                          /*ibm@39429*/
+#include_next <sys/stat.h>                          /*ibm@39429*/
 
 #if defined(IBM_ATOE)
 
@@ -51,6 +50,7 @@
         int atoe_mkdir (const char*, mode_t);
         int atoe_remove (const char*);                     /*ibm@4838*/
         int atoe_chmod (const char*, mode_t);             /*ibm@11596*/
+        int atoe_lstat(const char *pathname, struct stat *sbuf);
         int atoe_stat (const char*, struct stat*);
         int atoe_statvfs (const char*, struct statvfs *buf);
 

--- a/util/a2e/headers/sys/time.h
+++ b/util/a2e/headers/sys/time.h
@@ -43,8 +43,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.SYS.H(time)'>                /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(sys/time.h)                                 /*ibm@28725*/
+#include_next <sys/time.h>                                         /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if !defined(IBM_ATOE_SYS_TIME)

--- a/util/a2e/headers/sys/utsname.h
+++ b/util/a2e/headers/sys/utsname.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.SYS.H(utsname)'>             /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(sys/utsname.h)                              /*ibm@28725*/
+#include_next <sys/utsname.h>                                      /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/time.h
+++ b/util/a2e/headers/time.h
@@ -38,8 +38,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(time)'>                    /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(time.h)                                     /*ibm@28725*/
+#include_next <time.h>                                             /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if defined(IBM_ATOE)

--- a/util/a2e/headers/unistd.h
+++ b/util/a2e/headers/unistd.h
@@ -36,8 +36,7 @@
 #if __TARGET_LIB__ == 0X22080000                                   /*ibm@28725*/
 #include <//'PP.ADLE370.OS39028.SCEEH.H(unistd)'>                  /*ibm@28725*/
 #else                                                              /*ibm@28725*/
-#include "prefixpath.h"
-#include PREFIXPATH(unistd.h)                                   /*ibm@28725*/
+#include_next <unistd.h>                                           /*ibm@28725*/
 #endif                                                             /*ibm@28725*/
 
 #if !defined(IBM_ATOE_UNISTD)


### PR DESCRIPTION
When compiling with omr_ascii option, there is an alternative notation to pass in the a2e header wrappers with Open XL using the -isystem option. While making this work, it was also suggested to cleanup the PREFIXPATH(header) notation to simply use #include_next which supports and works with both XLC and Open XL on z/OS.
