### PR TITLE
Remove unused macro: sig_handler_t

### DIFF
--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -44,9 +44,7 @@ typedef void (*sighandler_t)(int sig);
 typedef void (*sighandler_t)(int sig);
 #define __THROW
 #elif defined(OMR_OS_WINDOWS)
-/* Use sig_handler_t instead of sighandler_t for Windows. Define it for compatibility. */
-#define sig_handler_t sighandler_t
-typedef void (__cdecl *sighandler_t)(int signum);
+typedef void (__cdecl *sighandler_t)(int sig);
 #define __THROW
 #endif /* defined(OMR_OS_WINDOWS) */
 


### PR DESCRIPTION
The last uses are removed by https://github.com/eclipse-openj9/openj9/pull/19726.