### PR TITLE
New element is added in vgc:mem-info

### DIFF
--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -65,6 +65,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="gc-op" type="vgc:gc-op" />
 	<element name="references" type="vgc:references" />
 	<element name="pending-finalizers" type="vgc:pending-finalizers" />
+	<element name="continuation-objects" type="vgc:continuation-objects" />
 	<element name="trace-info" type="vgc:trace-info" />
 	<element name="cardclean-info" type="vgc:cardclean-info" />
 	<element name="finalization" type="vgc:finalization" />
@@ -174,6 +175,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:arraylet-unknown" maxOccurs="1" minOccurs="0" />			
 			<element ref="vgc:numa" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:continuation-objects" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:remembered-set" maxOccurs="1" minOccurs="0" />
 		</sequence>
 		<attribute name="id" type="integer" use="required" />
@@ -450,6 +452,11 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="default" type="integer" use="required" />
 		<attribute name="reference" type="integer" use="required" />
 		<attribute name="classloader" type="integer" use="required" />
+	</complexType>
+
+	<complexType name="continuation-objects">
+		<attribute name="total" type="integer" use="required" />
+		<attribute name="started" type="integer" use="required" />
 	</complexType>
 
 	<complexType name="trace-info">


### PR DESCRIPTION
new element "vgc:continuation-objects" is added in vgc:mem-info, 
the element with two integer addributes "total" and "started"

Signed-off-by: hulin <linhu@ca.ibm.com>