### PR TITLE
Initialize the array variable in generateArrayAddressTree to null

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2122,7 +2122,7 @@ TR::Node *generateArrayAddressTree(
 
    bool is64BitTarget = comp->target().is64Bit() ? true : false;
 
-   TR::Node *array;
+   TR::Node *array = NULL;
 
 #if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
    if (TR::Compiler->om.isOffHeapAllocationEnabled())


### PR DESCRIPTION
The code populates the `TR::Node* array` variable if a non-zero offset exist.

The variable is passed to `generateArrayElementAddressTrees` which depends on if the variable is null to indicate a zero offset.

Given that the variable is not initialized to null a value may be passed causing wrong generated trees.