### PR TITLE
Move _offHeapCopyMemory delayedTransformation to OpenJ9

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7264,22 +7264,6 @@ void OMR::ValuePropagation::doDelayedTransformations()
       }
    _scalarizedArrayCopies.deleteAll();
 
-#if defined(J9_PROJECT_SPECIFIC) && defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
-   // Transform Unsafe.copyMemory in OffHeap
-   if (TR::Compiler->om.isOffHeapAllocationEnabled())
-      {
-      ListIterator<TR_TreeTopNodePair> copyMemoryIt(&_offHeapCopyMemory);
-      TR_TreeTopNodePair *copyMemoryPair;
-      for (copyMemoryPair = copyMemoryIt.getFirst();
-         copyMemoryPair; copyMemoryPair = copyMemoryIt.getNext())
-         {
-         if (performTransformation(comp(), "O^O Call arraycopy instead of Unsafe.copyMemory: %p\n", copyMemoryPair->_node))
-            TR::TransformUtil::transformUnsafeCopyMemorytoArrayCopyForOffHeap(self()->comp(), copyMemoryPair->_treetop, copyMemoryPair->_node);
-         }
-      _offHeapCopyMemory.deleteAll();
-      }
-#endif
-
    // NOTE: the array copy spine checks are processed before the reference, realtime, and
    //       unknown arraycopies because it refactors the CFG at a higher (outer) level
    //       than the others.  To simplify the CFG it should be run first.

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -994,7 +994,6 @@ class ValuePropagation : public TR::Optimization
    List<TR_ArrayCopySpineCheck> _arrayCopySpineCheck;
    List<TR::TreeTop> _multiLeafCallsToInline;
    List<TR_TreeTopNodePair> _scalarizedArrayCopies;
-   List<TR_TreeTopNodePair> _offHeapCopyMemory;
    List<TR::TreeTop> _converterCalls;
    List<TR::TreeTop> _objectCloneCalls;
    List<TR::TreeTop> _arrayCloneCalls;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -120,7 +120,6 @@ OMR::ValuePropagation::ValuePropagation(TR::OptimizationManager *manager)
      _javaLangClassGetComponentTypeCalls(trMemory()),
      _unknownTypeArrayCopyTrees(trMemory()),
      _scalarizedArrayCopies(trMemory()),
-     _offHeapCopyMemory(trMemory()),
      _predictedThrows(trMemory()),
      _prexClasses(trMemory()),
      _prexMethods(trMemory()),


### PR DESCRIPTION
Given that transformation is specific to OpenJ9 moving code to OpenJ9

https://github.com/eclipse-openj9/openj9/pull/19634 includes the OpenJ9 code.
https://github.com/eclipse-openj9/openj9/pull/19634#discussion_r1653189424