### PR TITLE
Revert "Replace redundant shifts and rotations of const 0 with const 0"

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -10259,12 +10259,7 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else if (secondChild->getOpCode().isLoadConst() &&
+   if (secondChild->getOpCode().isLoadConst() &&
        performTransformation(s->comp(), "%sChanged ishl by const into imul by const in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
       {
       // Normalize shift by a constant into multiply by a constant
@@ -10306,12 +10301,7 @@ TR::Node *lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else if (secondChild->getOpCode().isLoadConst())
+   if (secondChild->getOpCode().isLoadConst())
       {
       // Canonicalize shift by a constant into multiply by a constant
       //
@@ -10355,12 +10345,6 @@ TR::Node *bshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-
    return node;
    }
 
@@ -10380,12 +10364,6 @@ TR::Node *sshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
-
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
 
    return node;
    }
@@ -10413,13 +10391,7 @@ TR::Node *ishrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 31, s);
+   normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10443,13 +10415,7 @@ TR::Node *lshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 63, s);
+   normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10471,12 +10437,6 @@ TR::Node *bshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-
    return node;
    }
 
@@ -10496,12 +10456,6 @@ TR::Node *sshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
-
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
 
    return node;
    }
@@ -10595,13 +10549,7 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 31, s);
+   normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10743,13 +10691,7 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedLongInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 63, s);
+   normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10771,12 +10713,6 @@ TR::Node *bushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    if (identity)
       return identity;
 
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedByte() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-
    return node;
    }
 
@@ -10796,12 +10732,6 @@ TR::Node *sushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
-
-   // Replace shift of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedShortInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
 
    return node;
    }
@@ -10831,13 +10761,7 @@ TR::Node *irolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   // Replace rotate of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 31, s);
+   normalizeShiftAmount(node, 31, s);
    return node;
    }
 
@@ -10861,13 +10785,7 @@ TR::Node *lrolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   // Replace rotate of constant zero with constant zero
-   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
-      {
-      return s->replaceNode(node, firstChild, s->_curTree);
-      }
-   else
-      normalizeShiftAmount(node, 63, s);
+   normalizeShiftAmount(node, 63, s);
    return node;
    }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7027,13 +7027,6 @@ TR::Node *constrainIshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asIntConst()
-       && lhs->asIntConst()->getInt() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-
    checkForNonNegativeAndOverflowProperties(vp, node);
    return node;
    }
@@ -7057,13 +7050,7 @@ TR::Node *constrainLshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asLongConst()
-       && lhs->asLongConst()->getLong() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-   else if (lhs && lhs->asLongConst() &&
+   if (lhs && lhs->asLongConst() &&
        lhs->asLongConst()->getLong() == 1)
       {
       TR::VPConstraint *constraint = TR::VPLongRange::create(vp, TR::getMinSigned<TR::Int64>(), TR::getMaxSigned<TR::Int64>(), true);
@@ -7204,22 +7191,16 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool lhsGlobal, rhsGlobal;
-   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+   bool rhsGlobal;
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
-   lhsGlobal &= rhsGlobal;
-
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asIntConst()
-       && lhs->asIntConst()->getInt() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x01F;
+
+      bool lhsGlobal;
+      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+      lhsGlobal &= rhsGlobal;
 
       int32_t low, high;
       if (lhs)
@@ -7265,7 +7246,6 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       //lhs->decReferenceCount();
       //rhs->decReferenceCount();
       }
-
    // this handler is not called for unsigned shifts
    //#ifdef DEBUG
    //else if(!firstChild->getType().isSignedInt()) dumpOptDetails(vp->comp(), "FIXME: Need to support ishr opt for Unsigned datatypes!\n");
@@ -7283,22 +7263,16 @@ TR::Node *constrainLshr(OMR::ValuePropagation *vp, TR::Node *node)
 
    constrainChildren(vp, node);
 
-   bool lhsGlobal, rhsGlobal;
-   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+   bool rhsGlobal;
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
-   lhsGlobal &= rhsGlobal;
-
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asLongConst()
-       && lhs->asLongConst()->getLong() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x03F;
+
+      bool lhsGlobal;
+      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+      lhsGlobal &= rhsGlobal;
 
       int64_t low, high;
       if (lhs)
@@ -7366,18 +7340,8 @@ TR::Node *constrainIushr(OMR::ValuePropagation *vp, TR::Node *node)
    //if (parent && parent->getType().isUnsignedInt())
    //   isUnsigned = true;
 
-   bool lhsGlobal, rhsGlobal;
-   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+   bool rhsGlobal;
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
-   lhsGlobal &= rhsGlobal;
-
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asIntConst()
-       && lhs->asIntConst()->getInt() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
@@ -7453,18 +7417,8 @@ TR::Node *constrainLushr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool lhsGlobal, rhsGlobal;
-   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+   bool rhsGlobal;
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
-   lhsGlobal &= rhsGlobal;
-
-   // Replace shift of constant zero with constant zero
-   if (lhs && lhs->asLongConst()
-       && lhs->asLongConst()->getLong() == 0)
-      {
-      return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
-      }
-
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();


### PR DESCRIPTION
It turns out the calls to `replaceNode` for the Value Propagation portion of this change are causing use/def info. to become invalidated and deleted.  However, the use/def info. is cached by Value Propagation and continues to be used until a point at which the memory that was associated with the use/def info. is reused.  That results in a crash due to memory corruption.

Reverts eclipse/omr#7364

Fixes eclipse-openj9/openj9#19782

