### PR TITLE
Replace shifts and rotations of constant 0 with constant 0

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -10259,7 +10259,12 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   if (secondChild->getOpCode().isLoadConst() &&
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else if (secondChild->getOpCode().isLoadConst() &&
        performTransformation(s->comp(), "%sChanged ishl by const into imul by const in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
       {
       // Normalize shift by a constant into multiply by a constant
@@ -10301,7 +10306,12 @@ TR::Node *lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   if (secondChild->getOpCode().isLoadConst())
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else if (secondChild->getOpCode().isLoadConst())
       {
       // Canonicalize shift by a constant into multiply by a constant
       //
@@ -10345,6 +10355,12 @@ TR::Node *bshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10364,6 +10380,12 @@ TR::Node *sshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10391,7 +10413,13 @@ TR::Node *ishrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10415,7 +10443,13 @@ TR::Node *lshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10437,6 +10471,12 @@ TR::Node *bshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10456,6 +10496,12 @@ TR::Node *sshrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10549,7 +10595,13 @@ TR::Node *iushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
 
    return node;
    }
@@ -10691,7 +10743,13 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
          }
       }
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
 
    return node;
    }
@@ -10713,6 +10771,12 @@ TR::Node *bushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    if (identity)
       return identity;
 
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedByte() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+
    return node;
    }
 
@@ -10732,6 +10796,12 @@ TR::Node *sushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    auto identity = binOpSimplifier.tryToSimplifyIdentityOp(node, 0);
    if (identity)
       return identity;
+
+   // Replace shift of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getUnsignedShortInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
 
    return node;
    }
@@ -10761,7 +10831,13 @@ TR::Node *irolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   normalizeShiftAmount(node, 31, s);
+   // Replace rotate of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 31, s);
    return node;
    }
 
@@ -10785,7 +10861,13 @@ TR::Node *lrolSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       return s->replaceNode(node, firstChild, s->_curTree);
       }
 
-   normalizeShiftAmount(node, 63, s);
+   // Replace rotate of constant zero with constant zero
+   if (firstChild->getOpCode().isLoadConst() && firstChild->getLongInt() == 0)
+      {
+      return s->replaceNode(node, firstChild, s->_curTree);
+      }
+   else
+      normalizeShiftAmount(node, 63, s);
    return node;
    }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7027,6 +7027,14 @@ TR::Node *constrainIshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+
    checkForNonNegativeAndOverflowProperties(vp, node);
    return node;
    }
@@ -7050,7 +7058,14 @@ TR::Node *constrainLshl(OMR::ValuePropagation *vp, TR::Node *node)
       vp->replaceByConstant(node, constraint, lhsGlobal);
       }
 
-   if (lhs && lhs->asLongConst() &&
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+   else if (lhs && lhs->asLongConst() &&
        lhs->asLongConst()->getLong() == 1)
       {
       TR::VPConstraint *constraint = TR::VPLongRange::create(vp, TR::getMinSigned<TR::Int64>(), TR::getMaxSigned<TR::Int64>(), true);
@@ -7191,16 +7206,23 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x01F;
-
-      bool lhsGlobal;
-      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
-      lhsGlobal &= rhsGlobal;
 
       int32_t low, high;
       if (lhs)
@@ -7246,6 +7268,7 @@ TR::Node *constrainIshr(OMR::ValuePropagation *vp, TR::Node *node)
       //lhs->decReferenceCount();
       //rhs->decReferenceCount();
       }
+
    // this handler is not called for unsigned shifts
    //#ifdef DEBUG
    //else if(!firstChild->getType().isSignedInt()) dumpOptDetails(vp->comp(), "FIXME: Need to support ishr opt for Unsigned datatypes!\n");
@@ -7263,16 +7286,23 @@ TR::Node *constrainLshr(OMR::ValuePropagation *vp, TR::Node *node)
 
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
       int32_t shiftAmount = rhsConst & 0x03F;
-
-      bool lhsGlobal;
-      TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
-      lhsGlobal &= rhsGlobal;
 
       int64_t low, high;
       if (lhs)
@@ -7340,8 +7370,19 @@ TR::Node *constrainIushr(OMR::ValuePropagation *vp, TR::Node *node)
    //if (parent && parent->getType().isUnsignedInt())
    //   isUnsigned = true;
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asIntConst()
+       && lhs->asIntConst()->getInt() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();
@@ -7417,8 +7458,19 @@ TR::Node *constrainLushr(OMR::ValuePropagation *vp, TR::Node *node)
       return node;
    constrainChildren(vp, node);
 
-   bool rhsGlobal;
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
    TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   lhsGlobal &= rhsGlobal;
+
+   // Replace shift of constant zero with constant zero
+   if (lhs && lhs->asLongConst()
+       && lhs->asLongConst()->getLong() == 0)
+      {
+      vp->replaceByConstant(node, lhs, lhsGlobal);
+      return node;
+      }
+
    if (rhs && rhs->asIntConst())
       {
       int32_t rhsConst = rhs->asIntConst()->getInt();


### PR DESCRIPTION
Since applying a shift or rotation to 0 simply produces 0 again, the optimizer can replace any shift or rotation for which the first child is a constant 0 with that constant 0.