### PR TITLE
ValueTypes: Remove reference to 'Q' signature prefix

### DIFF
--- a/compiler/il/OMRSymbol.cpp
+++ b/compiler/il/OMRSymbol.cpp
@@ -118,7 +118,6 @@ OMR::Symbol::convertSigCharToType(char sigChar)
       case 'F': return TR::Float;
       case 'D': return TR::Double;
       case 'L':
-      case 'Q':
       case '[': return TR::Address;
       }
    TR_ASSERT(0, "unknown signature character");

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -781,12 +781,12 @@ TR::VPClassType *TR::VPUnresolvedClass::getArrayClass(OMR::ValuePropagation *vp)
 
 bool TR::VPUnresolvedClass::isReferenceArray(TR::Compilation *comp)
    {
-   return _sig[0] == '[' && (_sig[1] == '[' || _sig[1] == 'L' || _sig[1] == 'Q');
+   return _sig[0] == '[' && (_sig[1] == '[' || _sig[1] == 'L');
    }
 
 bool TR::VPUnresolvedClass::isPrimitiveArray(TR::Compilation *comp)
    {
-   return _sig[0] == '[' && _sig[1] != '[' && _sig[1] != 'L'  && _sig[1] != 'Q';
+   return _sig[0] == '[' && _sig[1] != '[' && _sig[1] != 'L';
    }
 
 bool TR::VPNullObject::isNullObject()
@@ -887,7 +887,6 @@ TR::VPConstraint *TR::VPConstraint::create(OMR::ValuePropagation *vp, const char
    switch (sig[0])
       {
       case 'L':
-      case 'Q':
       case '[':
          return TR::VPClassType::create(vp, sig, len, method, isFixedClass);
       case 'B':
@@ -3534,8 +3533,8 @@ TR::VPConstraint *TR::VPResolvedClass::intersect1(TR::VPConstraint *other, OMR::
             otherLen--;
             }
 
-         if (((*thisSig != 'L') && (*thisSig != '[') && (*thisSig != 'Q')) &&
-             ((*otherSig == 'L') || (*otherSig == '[') || (*otherSig == 'Q')))
+         if (((*thisSig != 'L') && (*thisSig != '[')) &&
+             ((*otherSig == 'L') || (*otherSig == '[')))
             return NULL;
 
          return this;
@@ -3628,7 +3627,7 @@ TR::VPConstraint *TR::VPFixedClass::intersect1(TR::VPConstraint *other, OMR::Val
             }
 
          // Test if thisSig is primitive or an array, and otherSig is any kind of reference type
-         if ((*thisSig != 'L') && (*thisSig != 'Q') && ((*otherSig == 'L') || (*otherSig == '[') || (*otherSig == 'Q')))
+         if ((*thisSig != 'L') && ((*otherSig == 'L') || (*otherSig == '[')))
             {
             // Test if thisSig is not an array, or otherSig is not a java/lang/Object array
             if (! ((*thisSig == '[') && (otherLen == 18 && !strncmp(otherSig, "Ljava/lang/Object;", 18))) )

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -273,7 +273,6 @@ static int32_t arrayElementSize(const char *signature, int32_t len, TR::Node *no
          case 'J': return 8;
          case 'Z': return static_cast<int32_t>(TR::Compiler->om.elementSizeOfBooleanArray());
          case 'L':
-         case 'Q':
          default :
             return TR::Compiler->om.sizeofReferenceField();
          }
@@ -1842,7 +1841,7 @@ TR::Node *constrainAload(OMR::ValuePropagation *vp, TR::Node *node)
                         {
                         int32_t len;
                         const char *sig = getFieldSignature(vp, node, len);
-                        if (sig && (len > 0) && (sig[0] == '[' || sig[0] == 'L' || sig[0] == 'Q'))
+                        if (sig && (len > 0) && (sig[0] == '[' || sig[0] == 'L'))
                            {
                            int32_t elementSize = arrayElementSize(sig, len, node, vp);
                            if (elementSize != 0)
@@ -1957,7 +1956,7 @@ TR::Node *constrainAload(OMR::ValuePropagation *vp, TR::Node *node)
                   if (classBlock != jlClass)
                      {
                      constraint = TR::VPClassType::create(vp, sig, len, owningMethod, isFixed, classBlock);
-                     if (*sig == '[' || sig[0] == 'L' || sig[0] == 'Q')
+                     if (*sig == '[' || sig[0] == 'L')
                         {
                         int32_t elementSize = arrayElementSize(sig, len, node, vp);
                         if (elementSize != 0)


### PR DESCRIPTION
Remove reference to `Q` signature prefix in the JIT

Similar change as https://github.com/eclipse-openj9/openj9/pull/19799

Related to: eclipse/openj9#18157