### PR TITLE
Adding more info to CodeCache::printOccupancyStats()

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -1321,6 +1321,9 @@ OMR::CodeCache::printOccupancyStats()
    fprintf(stderr, "Code Cache @%p flags=0x%x almostFull=%d\n", this, _flags, _almostFull);
    fprintf(stderr, "   cold-warm hole size        = %8" OMR_PRIuSIZE " bytes\n", self()->getFreeContiguousSpace());
    fprintf(stderr, "   warmCodeAlloc=%p coldCodeAlloc=%p\n", (void*)_warmCodeAlloc, (void*)_coldCodeAlloc);
+   size_t warmCodeSize = _warmCodeAlloc - _segment->segmentBase();
+   size_t coldCodeSize = _trampolineBase - _coldCodeAlloc;
+   fprintf(stderr, "   warmCodeSize= %zu coldCodeSize= %zu\n", warmCodeSize, coldCodeSize);
    size_t totalReclaimed = 0;
    if (_freeBlockList)
       {


### PR DESCRIPTION
OMR::CodeCache::printOccupancyStats() prints to stderr various information about the code cache usage such as:
- Whether it's full or not
- The values for the warmCodeAlloc and coldCodeAlloc pointers
- How much space is available in the hole between warmCodeAlloc and coldCodeAlloc
- The list of freed blocks that are available for reuse

This commit adds a new line of output that shows the sizes of warm and cold sections of the code cache.