### PR TITLE
Fix -Wnonnull warnings with GCC 11

### DIFF
--- a/compiler/infra/InterferenceGraph.cpp
+++ b/compiler/infra/InterferenceGraph.cpp
@@ -417,7 +417,7 @@ bool TR_InterferenceGraph::simplify()
                }
             }
 
-         TR_ASSERT(bestSpillNode, "Could not find a spill candidate.\n");
+         TR_ASSERT_FATAL(bestSpillNode, "Could not find a spill candidate.\n");
 
          virtualRemoveNodeFromIG(bestSpillNode);
          workingSet->reset(bestSpillNode->getIndex());

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1230,7 +1230,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
                if (origNode->getNumChildren() == 2)
                   {
                   twoChildrenCase = true;
-                  TR_ASSERT(0, "Only in WCode we can add extra children\n");
+                  TR_ASSERT_FATAL(0, "Only in WCode we can add extra children\n");
                   }
                else
                   {

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -2737,6 +2737,7 @@ bool TR_RegionStructure::changeContinueLoopsToNestedLoops(TR_RegionStructure *ro
                {
                diagnostic("Incoming [%p] edge %d->%d\n", incomingEdge, incomingEdge->getFrom()->asBlock()->getNumber(), incomingEdge->getTo()->asBlock()->getNumber());
                diagnostic("\tassuming it should be ->%d\n", entryBlock->getNumber());
+               TR_ASSERT_FATAL(newHeader, "New header must have been set by now");
                diagnostic("\tredirecting to ->%d\n", newHeader->getNumber());
                }
 


### PR DESCRIPTION
Version 11 and later of GCC consider the implicit `this` parameter of nonstatic member functions to be annotated with `nonnull` for the purposes of the `-Wnonnull` warning. This change generates new warnings that are resolved here with the use of `TR_ASSERT_FATAL` on the objects that the compiler thinks could be `NULL`. The macro `TR_ASSERT` is insufficient, as the `TR::assertion` method isn't (and cannot be) annotated with `OMR_NORETURN`.

Fixes: https://github.com/eclipse/omr/issues/7402