### PR TITLE
Annotate failCompilation with OMR_NORETURN

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -863,7 +863,7 @@ public:
    const char *getHotnessName();
 
    template<typename Exception>
-   void failCompilation(const char *format, ...)
+   void OMR_NORETURN failCompilation(const char *format, ...)
       {
       char buffer[512];
 


### PR DESCRIPTION
This method reports the failed compilation and then unconditionally throws an Exception(), and hence never returns.