### PR TITLE
Add OMRRSSReport.cpp to UMA build configs

### DIFF
--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -277,6 +277,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheManager.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheMemorySegment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheConfig.cpp \
+    $(JIT_OMR_DIRTY_DIR)/runtime/OMRRSSReport.cpp \
     $(JIT_PRODUCT_DIR)/compile/ResolvedMethod.cpp \
     $(JIT_PRODUCT_DIR)/control/TestJit.cpp \
     $(JIT_PRODUCT_DIR)/env/FrontEnd.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -246,6 +246,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheManager.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheMemorySegment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCacheConfig.cpp \
+    $(JIT_OMR_DIRTY_DIR)/runtime/OMRRSSReport.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRCompilerEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/PersistentAllocator.cpp \
     $(JIT_PRODUCT_DIR)/compile/ResolvedMethod.cpp \


### PR DESCRIPTION
https://github.com/eclipse/omr/pull/7349 added the new file OMRRSSReport.cpp. However, it did not add this to the jitbuilder and compilertest UMA build file list. This PR adds it to ensure that UMA builds of OMR are not broken.