### PR TITLE
Fix -Wshift-negative-value Open XL warning in OMRCodeGenerator.hpp

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -237,7 +237,7 @@ public:
     */
    bool materializesLargeConstants() { return true; }
    bool shouldValueBeInACommonedNode(int64_t value);
-   int64_t getLargestNegConstThatMustBeMaterialized() {return ((-1ll) << 31) - 1;}   // min 32bit signed integer minus 1
+   int64_t getLargestNegConstThatMustBeMaterialized() { return (int64_t)(((~(uint64_t)0) << 31) - 1); } // min 32bit signed integer minus 1
    int64_t getSmallestPosConstThatMustBeMaterialized() {return ((int64_t)0x000000007FFFFFFF) + 1;}   // max 32bit signed integer plus 1
 
    void beginInstructionSelection();


### PR DESCRIPTION
warning: shifting a negative signed value is undefined [-Wshift-negative-value]
return ((-1ll) << 31) - 1;}   // min 32bit signed integer minus 1

Changes here attempt to resolve this to a more correct approach.

@keithc-ca Not sure if we settled on something specific for this item, but creating a placeholder PR for it from what I had retained with and to continue discussions/suggestions here.