### PR TITLE
Add J9HookInterface.J9HookUnreserve() to clear flag J9HOOK_FLAG_RESERVED

### DIFF
--- a/include_core/omrhookable.h
+++ b/include_core/omrhookable.h
@@ -53,6 +53,7 @@ typedef struct J9HookInterface {
 	void (*J9HookDispatch)(struct J9HookInterface **hookInterface, uintptr_t eventNum, void *eventData);
 	intptr_t (*J9HookDisable)(struct J9HookInterface **hookInterface, uintptr_t eventNum);
 	intptr_t (*J9HookReserve)(struct J9HookInterface **hookInterface, uintptr_t eventNum);
+	void (*J9HookUnreserve)(struct J9HookInterface **hookInterface, uintptr_t eventNum);
 	intptr_t (*J9HookRegister)(struct J9HookInterface **hookInterface, uintptr_t eventNum, J9HookFunction function, void *userData, ...);
 	intptr_t (*J9HookRegisterWithCallSite)(struct J9HookInterface **hookInterface, uintptr_t eventNum, J9HookFunction function, const char *callsite, void *userData, ...);
 	void (*J9HookUnregister)(struct J9HookInterface **hookInterface, uintptr_t eventNum, J9HookFunction function, void *userData);


### PR DESCRIPTION
Add `J9HookInterface.J9HookUnreserve()` to clear flag `J9HOOK_FLAG_RESERVED`

`J9HookRegister()` sets flags `J9HOOK_FLAG_HOOKED | J9HOOK_FLAG_RESERVED`, `J9HookUnregister()` only clears `J9HOOK_FLAG_HOOKED`, add `J9HookUnreserve()` to clear `J9HOOK_FLAG_RESERVED`.
This supports an event to be `registered`, `unregistered`/`unreserved`, and `disabled`. Otherwise, an `unregistered` event can't be disabled by `J9HookDisable()` because of the presence of `J9HOOK_FLAG_RESERVED`.

Note: existing `J9HookUnregister()` only clears `J9HOOK_FLAG_HOOKED`, if it clears `J9HOOK_FLAG_RESERVED` as well, some tests such as [cmdLineTester_decompilationTests](https://github.com/eclipse-openj9/openj9/blob/5e3816d311ca2d4daeb315c8687d6d1d87e6234f/test/functional/cmdLineTests/jvmtitests/playlist.xml#L661) hangs.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>