### PR TITLE
Move out-of-line instructions to warm cache

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1002,6 +1002,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_minProfiledCheckcastFrequency, 0, "F%d", NOT_IN_SUBSET},
    {"minSleepTimeMsForCompThrottling=", "M<nnn>\tLower bound for sleep time during compilation throttling (ms)",
                                          TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_minSleepTimeMsForCompThrottling, 0, "F%d", NOT_IN_SUBSET },
+   {"moveOOLInstructionsToWarmCode", "M\tmove out-of-line instructions to after last warm instruction", SET_OPTION_BIT(TR_MoveOOLInstructionsToWarmCode), "F"},
    {"noAotSecondRunDetection", "M\tdo not do second run detection for AOT", SET_OPTION_BIT(TR_NoAotSecondRunDetection), "F", NOT_IN_SUBSET },
 #ifdef DEBUG
    {"noExceptions",       "C\tfail compilation for methods with exceptions",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -381,7 +381,7 @@ enum TR_CompilationOptions
    TR_BreakOnNew                          = 0x08000000 + 9,
    TR_DisableInliningUnrecognizedIntrinsics = 0x10000000 + 9,
    TR_EnableVectorAPIExpansion            = 0x20000000 + 9,
-   // Available                           = 0x40000000 + 9,
+   TR_MoveOOLInstructionsToWarmCode       = 0x40000000 + 9,
    // Available                           = 0x80000000 + 9,
 
    // Option word 10

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -654,6 +654,12 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool considerTypeForGRA(TR::DataType dt);
    bool considerTypeForGRA(TR::SymbolReference *symRef);
 
+   /*
+    * \brief move out-of-line instructions from cold code to warm
+    *
+    */
+   void moveOutOfLineInstructionsToWarm();
+
    uint32_t getOutOfLineCodeSize();
 
    /*

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -658,7 +658,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     * \brief move out-of-line instructions from cold code to warm
     *
     */
-   void moveOutOfLineInstructionsToWarm();
+   void moveOutOfLineInstructionsToWarmCode();
 
    uint32_t getOutOfLineCodeSize();
 


### PR DESCRIPTION
- during code cache disclaim, it's beneficial to move OOL code into warm code cache