### PR TITLE
Move snippets to warm code

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -251,7 +251,20 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
    TR::LexicalMemProfiler mp("Emit Snippets", comp->phaseMemProfiler());
    LexicalTimer pt("Emit Snippets", comp->phaseTimer());
 
-   cg->emitSnippets();
+   if (cg->getLastWarmInstruction() &&
+       comp->getOption(TR_MoveSnippetsToWarmCode))
+      {
+      // Snippets will follow warm blocks
+      uint8_t * oldCursor = cg->getBinaryBufferCursor();
+      cg->setBinaryBufferCursor(cg->getWarmCodeEnd());
+      cg->emitSnippets();
+      cg->setWarmCodeEnd(cg->getBinaryBufferCursor());
+      cg->setBinaryBufferCursor(oldCursor);
+      }
+   else
+      {
+      cg->emitSnippets();
+      }
 
    if (comp->getOption(TR_EnableOSR))
       {

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -363,6 +363,78 @@ OMR::CodeGenerator::generateCodeFromIL()
    return false;
    }
 
+void
+OMR::CodeGenerator::insertGotoIntoLastBlock(TR::Block *lastBlock)
+   {
+   // If the last tree in the last block is not a TR_goto, insert a goto tree
+   // at the end of the block.
+   // If there is a following block the goto will branch to it so that when the
+   // code is split any fall-through will go to the right place.
+   // If there is no following block the goto will branch to the first block; in
+   // this case the goto should never be reached, it is there only to
+   // make sure that the instruction following the last real treetop will be in
+   // method's code, so if it is a helper call (e.g. for a throw) the return address
+   // is in this method's code.
+   //
+   TR::Compilation *comp = self()->comp();
+   TR::TreeTop * tt;
+   TR::Node * node;
+
+   if (lastBlock->getNumberOfRealTreeTops() == 0)
+      tt = lastBlock->getEntry();
+   else
+      tt = lastBlock->getLastRealTreeTop();
+
+   node = tt->getNode();
+
+   if (!(node->getOpCode().isGoto() ||
+         node->getOpCode().isJumpWithMultipleTargets() ||
+         node->getOpCode().isReturn()))
+      {
+
+      if (comp->getOption(TR_TraceCG))
+         {
+         traceMsg(comp, "%s Inserting goto at the end of block_%d\n", SPLIT_WARM_COLD_STRING, lastBlock->getNumber());
+         }
+
+      // Find the block to be branched to
+      //
+      TR::TreeTop * targetTreeTop = lastBlock->getExit()->getNextTreeTop();
+
+      if (targetTreeTop)
+         // Branch to following block. Make sure it is not marked as an
+         // extension block so that it will get a label generated.
+         //
+         targetTreeTop->getNode()->getBlock()->setIsExtensionOfPreviousBlock(false);
+      else
+         // Branch to the first block. This will not be marked as an extension
+         // block.
+         //
+         targetTreeTop = comp->getStartBlock()->getEntry();
+
+      // Generate the goto and insert it into the end of the last warm block.
+      //
+      TR::TreeTop *gotoTreeTop = TR::TreeTop::create(comp, TR::Node::create(node, TR::Goto, 0, targetTreeTop));
+
+      // Move reg deps from BBEnd to goto
+      //
+      TR::Node *bbEnd = lastBlock->getExit()->getNode();
+
+      if (bbEnd->getNumChildren() > 0)
+         {
+         TR::Node *glRegDeps = bbEnd->getChild(0);
+
+         gotoTreeTop->getNode()->setNumChildren(1);
+         gotoTreeTop->getNode()->setChild(0, glRegDeps);
+
+         bbEnd->setChild(0,NULL);
+         bbEnd->setNumChildren(0);
+         }
+
+      tt->insertAfter(gotoTreeTop);
+      }
+   }
+
 void OMR::CodeGenerator::findLastWarmBlock()
    {
    TR::Compilation *comp = self()->comp();
@@ -457,62 +529,18 @@ void OMR::CodeGenerator::findLastWarmBlock()
                            (numColdBlocks - numNonOutlinedColdBlocks)*100/numColdBlocks);
       }
 
-   // If the last tree in the last warm block is not a TR_goto, insert a goto tree
-   // at the end of the block.
-   // If there is a following block the goto will branch to it so that when the
-   // code is split any fall-through will go to the right place.
-   // If there is no following block the goto will branch to the first block; in
-   // this case the goto should never be reached, it is there only to
-   // make sure that the instruction following the last real treetop will be in
-   // warm code, so if it is a helper call (e.g. for a throw) the return address
-   // is in this method's code.
+
+   insertGotoIntoLastBlock(lastWarmBlock);
+   TR::Block *lastBlock = comp->findLastTree()->getNode()->getBlock();
+
+   // If disclaim is enabled, it may happen that nothing follows mainline code
+   // (no snippets or OOL). Then, we need to insert a goto at the end for the
+   // reasons described in insertGotoIntoLastBlock()
    //
-   if (lastWarmBlock->getNumberOfRealTreeTops() == 0)
-      tt = lastWarmBlock->getEntry();
-   else
-      tt = lastWarmBlock->getLastRealTreeTop();
-
-   node = tt->getNode();
-
-   if (!(node->getOpCode().isGoto() ||
-         node->getOpCode().isJumpWithMultipleTargets() ||
-         node->getOpCode().isReturn()))
+   if (TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming) &&
+       lastBlock != lastWarmBlock)
       {
-      // Find the block to be branched to
-      //
-      TR::TreeTop * targetTreeTop = lastWarmBlock->getExit()->getNextTreeTop();
-
-      if (targetTreeTop)
-         // Branch to following block. Make sure it is not marked as an
-         // extension block so that it will get a label generated.
-         //
-         targetTreeTop->getNode()->getBlock()->setIsExtensionOfPreviousBlock(false);
-      else
-         // Branch to the first block. This will not be marked as an extension
-         // block.
-         //
-         targetTreeTop = comp->getStartBlock()->getEntry();
-
-      // Generate the goto and insert it into the end of the last warm block.
-      //
-      TR::TreeTop *gotoTreeTop = TR::TreeTop::create(comp, TR::Node::create(node, TR::Goto, 0, targetTreeTop));
-
-      // Move reg deps from BBEnd to goto
-      //
-      TR::Node *bbEnd = lastWarmBlock->getExit()->getNode();
-
-      if (bbEnd->getNumChildren() > 0)
-         {
-         TR::Node *glRegDeps = bbEnd->getChild(0);
-
-         gotoTreeTop->getNode()->setNumChildren(1);
-         gotoTreeTop->getNode()->setChild(0, glRegDeps);
-
-         bbEnd->setChild(0,NULL);
-         bbEnd->setNumChildren(0);
-         }
-
-      tt->insertAfter(gotoTreeTop);
+      insertGotoIntoLastBlock(lastBlock);
       }
    }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -435,7 +435,7 @@ OMR::CodeGenerator::insertGotoIntoLastBlock(TR::Block *lastBlock)
       }
    }
 
-void OMR::CodeGenerator::findLastWarmBlock()
+void OMR::CodeGenerator::prepareLastWarmBlockForCodeSplitting()
    {
    TR::Compilation *comp = self()->comp();
    TR::TreeTop * tt;
@@ -598,7 +598,7 @@ void OMR::CodeGenerator::postLowerTrees()
    if (comp()->getOption(TR_SplitWarmAndColdBlocks) &&
        !comp()->compileRelocatableCode())
       {
-      self()->findLastWarmBlock();
+      self()->prepareLastWarmBlockForCodeSplitting();
       }
    }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -349,7 +349,11 @@ public:
     */
    void insertGotoIntoLastBlock(TR::Block *lastBlock);
 
-   void findLastWarmBlock();
+   /**
+    * @brief Finds last warm block and inserts necessary gotos
+    *        for splitting code into warm and cold
+    */
+   void prepareLastWarmBlockForCodeSplitting();
 
    void setUpForInstructionSelection();
    void doInstructionSelection();

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -344,6 +344,11 @@ public:
 
    void lowerTreesPropagateBlockToNode(TR::Node *node);
 
+   /**
+    * @brief Inserts goto into the last block if necessary
+    */
+   void insertGotoIntoLastBlock(TR::Block *lastBlock);
+
    void findLastWarmBlock();
 
    void setUpForInstructionSelection();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1004,7 +1004,9 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"minSleepTimeMsForCompThrottling=", "M<nnn>\tLower bound for sleep time during compilation throttling (ms)",
                                          TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_minSleepTimeMsForCompThrottling, 0, "F%d", NOT_IN_SUBSET },
    {"moveOOLInstructionsToWarmCode", "M\tmove out-of-line instructions to after last warm instruction", SET_OPTION_BIT(TR_MoveOOLInstructionsToWarmCode), "F"},
+   {"moveSnippetsToWarmCode",           "M\tmove snippets to after last warm instruction", SET_OPTION_BIT(TR_MoveSnippetsToWarmCode), "F"},
    {"noAotSecondRunDetection", "M\tdo not do second run detection for AOT", SET_OPTION_BIT(TR_NoAotSecondRunDetection), "F", NOT_IN_SUBSET },
+
 #ifdef DEBUG
    {"noExceptions",       "C\tfail compilation for methods with exceptions",
         TR::Options::setDebug, (intptr_t)"noExceptions"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -382,7 +382,7 @@ enum TR_CompilationOptions
    TR_DisableInliningUnrecognizedIntrinsics = 0x10000000 + 9,
    TR_EnableVectorAPIExpansion            = 0x20000000 + 9,
    TR_MoveOOLInstructionsToWarmCode       = 0x40000000 + 9,
-   // Available                           = 0x80000000 + 9,
+   TR_MoveSnippetsToWarmCode              = 0x80000000 + 9,
 
    // Option word 10
    //


### PR DESCRIPTION
- during code cache disclaim, it's beneficial to move snippets into warm code cache
- controlled by -Xjit:moveSnippetsToWarmCode option