### PR TITLE
Make a minor correction to improved VPClass::mustBeNotEqual()

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -5213,7 +5213,7 @@ bool TR::VPClass::mustBeNotEqual(TR::VPConstraint *other, OMR::ValuePropagation 
          int32_t otherLo = otherArrayInfo->lowBound();
          int32_t otherHi = otherArrayInfo->highBound();
          if (thisHi < otherLo || otherHi < thisLo)
-            return false; // They're arrays with different lengths.
+            return true; // They're arrays with different lengths.
          }
       }
 


### PR DESCRIPTION
In 5aba990c724f7bd7 the improved `VPClass::mustBeNotEqual()` mistakenly returned false instead of true for arrays with different lengths. This commit corrects that case to return true as intended. This was not a functional problem because false is a conservative result.