### PR TITLE
Add missing attribute cpu-util/id

### DIFF
--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -458,6 +458,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	</complexType>
 
 	<complexType name="cpu-util">
+		<attribute name="id" type="integer" use="required" />
 		<attribute name="total" type="float" use="required" />
 		<attribute name="process" type="float" use="required" />
 	</complexType>


### PR DESCRIPTION
The element `<cpu-util`> was added in #7420, but without the `id` attribute generated by [VerboseHandlerOutput.cpp](https://github.com/eclipse/omr/blob/master/gc/verbose/VerboseHandlerOutput.cpp#L942).