### PR TITLE
Revert "Add Xgc options for suballocator heap size and quick allocation"

### DIFF
--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -56,8 +56,8 @@ extern PortTestEnvironment *portTestEnv;
 #endif
 
 #if defined(OMR_ENV_DATA64)
-/* This macro corresponds to SUBALLOCATOR_INCREMENT_SIZE defined in omrgcconsts.h. */
-#define HEAP_SIZE_BYTES (8 * 1024 * 1024)
+/* this macro corresponds to the one defined in omrmem32helpers */
+#define HEAP_SIZE_BYTES 8*1024*1024
 #endif
 
 #define COMPLETE_LARGE_REGION 1

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -745,8 +745,6 @@ public:
 	bool scavengerAlignHotFields; /**< True if the scavenger is to check the hot field description for an object in order to better cache align it when tenuring (enabled with the -Xgc:hotAlignment option) */
 	uintptr_t suballocatorInitialSize; /**< the initial chunk size in bytes for the J9Heap suballocator (enabled with the -Xgc:suballocatorInitialSize option) */
 	uintptr_t suballocatorCommitSize; /**< the commit size in bytes for the J9Heap suballocator (enabled with the -Xgc:suballocatorCommitSize option) */
-	uintptr_t suballocatorIncrementSize; /**< the increment size in bytes for the J9Heap suballocator (enabled with the -Xgc:suballocatorIncrementSize option) */
-	bool suballocatorQuickAlloc; /**< use OMRPORT_VMEM_ALLOC_QUICK for the J9Heap suballocator (disabled with the -Xgc:suballocatorQuickAllocDisable option) */
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 	bool shouldAllowShiftingCompression; /**< temporary option to enable compressed reference scaling by shifting pointers */
@@ -1872,8 +1870,6 @@ public:
 		, scavengerAlignHotFields(true) /* VM Design 1774: hot field alignment is on by default */
 		, suballocatorInitialSize(SUBALLOCATOR_INITIAL_SIZE) /* default for J9Heap suballocator initial size is 200 MB */
 		, suballocatorCommitSize(SUBALLOCATOR_COMMIT_SIZE) /* default for J9Heap suballocator commit size is 50 MB */
-		, suballocatorIncrementSize(SUBALLOCATOR_INCREMENT_SIZE) /* default for J9Heap suballocator commit size is 8 MB or 256 MB for AIX */
-		, suballocatorQuickAlloc(true) /* use mmap-based allocation by default for the J9Heap suballoctor */
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 		, shouldAllowShiftingCompression(true) /* VM Design 1810: shifting compression enabled, by default, for compressed refs */
 		, shouldForceSpecifiedShiftingCompression(0)

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -174,12 +174,6 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase *env, MM_MemoryH
 			/* Set the commit size for the sub allocator. This needs to be completed before the call to omrmem_ensure_capacity32 */
 			omrport_control(OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, extensions->suballocatorCommitSize);
 
-			/* Set the increment size for the sub allocator. This needs to be completed before the call to omrmem_ensure_capacity32 */
-			omrport_control(OMRPORT_CTLDATA_ALLOCATE32_INCREMENT_SIZE, extensions->suballocatorIncrementSize);
-
-			/* Set if the sub allocator should use ALLOC_QUICK. This needs to be completed before the call to omrmem_ensure_capacity32 */
-			omrport_control(OMRPORT_CTLDATA_ALLOCATE32_QUICK_ALLOC, extensions->suballocatorQuickAlloc ? 1 : 0);
-
 			if (!shouldHeapBeAllocatedFirst) {
 				if (OMRPORT_ENSURE_CAPACITY_FAILED == omrmem_ensure_capacity32(extensions->suballocatorInitialSize)) {
 					extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE;

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -555,25 +555,14 @@ typedef enum {
 #define PREFERRED_HEAP_BASE 0x0
 #endif
 
-#define SUBALLOCATOR_INITIAL_SIZE (200 * 1024 * 1024)
-#define SUBALLOCATOR_COMMIT_SIZE (50 * 1024 * 1024)
+#define SUBALLOCATOR_INITIAL_SIZE (200*1024*1024)
+#define SUBALLOCATOR_COMMIT_SIZE (50*1024*1024)
 #if defined(AIXPPC)
 /* virtual memory is assigned in segment of 256M, so grab the entire segment */
-#define SUBALLOCATOR_ALIGNMENT (256 * 1024 * 1024)
+#define SUBALLOCATOR_ALIGNMENT (256*1024*1024)
 #else /* defined(AIXPPC) */
-#define SUBALLOCATOR_ALIGNMENT (8 * 1024 * 1024)
+#define SUBALLOCATOR_ALIGNMENT (8*1024*1024)
 #endif /* defined(AIXPPC) */
-
-/* VMDESIGN 1761 The size of a suballocation heap.
- * See VMDESIGN 1761 for the rationale behind the selection of this size.
- * We use a 8MB heap to give us more room in case an application loads a larger amount of classes than usual.
- * For testing purposes, this value is mirrored in port library test. If we tune this value, we should also adjust it in omrmemTest.cpp
- */
-#if defined(AIXPPC) && defined(OMR_GC_COMPRESSED_POINTERS)
-#define SUBALLOCATOR_INCREMENT_SIZE (256 * 1024 * 1024)
-#else /* defined(AIXPPC) && defined(OMR_GC_COMPRESSED_POINTERS) */
-#define SUBALLOCATOR_INCREMENT_SIZE (8 * 1024 * 1024)
-#endif /* defined(AIXPPC) && defined(OMR_GC_COMPRESSED_POINTERS) */
 
 #define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_COMPRESSEDREFS            ((U_64)57 * 1024 * 1024 * 1024)
 #define MAXIMUM_HEAP_SIZE_RECOMMENDED_FOR_3BIT_SHIFT_COMPRESSEDREFS ((U_64)25 * 1024 * 1024 * 1024)

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -877,8 +877,6 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_CTLDATA_MEM_CATEGORIES_SET  "MEM_CATEGORIES_SET"
 #define OMRPORT_CTLDATA_AIX_PROC_ATTR  "AIX_PROC_ATTR"
 #define OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE  "ALLOCATE32_COMMIT_SIZE"
-#define OMRPORT_CTLDATA_ALLOCATE32_INCREMENT_SIZE  "ALLOCATE32_INCREMENT_SIZE"
-#define OMRPORT_CTLDATA_ALLOCATE32_QUICK_ALLOC  "ALLOCATE32_QUICK_ALLOC"
 #define OMRPORT_CTLDATA_NOSUBALLOC32BITMEM  "NOSUBALLOC32BITMEM"
 #define OMRPORT_CTLDATA_VMEM_ADVISE_OS_ONFREE  "VMEM_ADVISE_OS_ONFREE"
 #define OMRPORT_CTLDATA_VECTOR_REGS_SUPPORT_ON  "VECTOR_REGS_SUPPORT_ON"
@@ -2485,10 +2483,6 @@ typedef struct OMRPortLibrary {
 	int32_t (*port_startup_library)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrport.c::omrport_create_library "omrport_create_library"*/
 	int32_t (*port_create_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
-#if defined(OMR_ENV_DATA64)
-	/** see @ref omrport.c::omrport_copy_suballocator_heap_globals "omrport_copy_suballocator_heap_globals" */
-	void (*port_copy_suballocator_heap_globals)(struct OMRPortLibrary *destPortLibrary, struct OMRPortLibrary *srcPortLibrary) ;
-#endif /* defined(OMR_ENV_DATA64) */
 	/** see @ref omrsyslog.c::omrsyslog_write "omrsyslog_write"*/
 	uintptr_t (*syslog_write)(struct OMRPortLibrary *portLibrary, uintptr_t flags, const char *message) ;
 	/** see @ref omrintrospect.c::omrintrospect_startup "omrintrospect_startup"*/

--- a/port/common/omrmem32struct.h
+++ b/port/common/omrmem32struct.h
@@ -41,8 +41,6 @@ typedef struct J9SubAllocateHeapMem32 {
 	J9HeapWrapper *subCommitHeapWrapper;
 	uintptr_t suballocator_initialSize;
 	uintptr_t suballocator_commitSize;
-	uintptr_t suballocator_incrementSize;
-	BOOLEAN suballocator_quickAlloc;
 } J9SubAllocateHeapMem32;
 
 #endif	/* omrmem32struct_h */

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -339,9 +339,6 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */
-#if defined(OMR_ENV_DATA64)
-	omrport_copy_suballocator_heap_globals, /* port_copy_suballocator_heap_globals */
-#endif /* defined(OMR_ENV_DATA64) */
 	omrsyslog_write, /* syslog_write */
 	omrintrospect_startup, /* introspect_startup */
 	omrintrospect_shutdown, /* introspect_shutdown */
@@ -591,28 +588,6 @@ omrport_create_library(struct OMRPortLibrary *portLibrary, uintptr_t size)
 
 	return 0;
 }
-
-#if defined(OMR_ENV_DATA64)
-/**
- * Copy the subAllocHeapMem32 values from a source OMRPortLibrary to a destination OMRPortLibrary.
- *
- * This is a helper for ensuring memCheckPortLib picks up the subAllocHeapMem32 default and/or -Xgc
- * specified values.
- *
- * @param[in,out] destPortLibrary The port library to copy the port globals to.
- * @param[in,out] sourcePortLibrary The port library to copy the port globals from.
- *
- */
-void
-omrport_copy_suballocator_heap_globals(struct OMRPortLibrary *destPortLibrary, struct OMRPortLibrary *srcPortLibrary)
-{
-	J9SubAllocateHeapMem32 subAllocGlobals = srcPortLibrary->portGlobals->platformGlobals.subAllocHeapMem32;
-	omrport_control(destPortLibrary, OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, subAllocGlobals.suballocator_commitSize);
-	omrport_control(destPortLibrary, OMRPORT_CTLDATA_ALLOCATE32_INCREMENT_SIZE, subAllocGlobals.suballocator_incrementSize);
-	omrport_control(destPortLibrary, OMRPORT_CTLDATA_ALLOCATE32_QUICK_ALLOC, subAllocGlobals.suballocator_quickAlloc ? 1 : 0);
-	return;
-}
-#endif /* defined(OMR_ENV_DATA64) */
 
 /**
  * PortLibrary startup.

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -54,11 +54,11 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		return 0;
 	}
 #if defined(OMR_ENV_DATA64)
-	if (0 == strcmp(OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, key)) {
+	if (!strcmp(OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, key)) {
 		if (0 != value) {
 			/* CommitSize is immutable. It can only be set once. */
 			if (0 == PPG_mem_mem32_subAllocHeapMem32.suballocator_commitSize) {
-				/* Round up the commit size to the page size and set it to global variable. */
+				/* Round up the commit size to the page size and set it to global variable */
 				uintptr_t pageSize = portLibrary->vmem_supported_page_sizes(portLibrary)[0];
 				uintptr_t roundedCommitSize = pageSize * (value / pageSize);
 				if (roundedCommitSize < value) {
@@ -72,29 +72,8 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 			return (int32_t)PPG_mem_mem32_subAllocHeapMem32.suballocator_commitSize;
 		}
 		return 0;
-	} else if (0 == strcmp(OMRPORT_CTLDATA_ALLOCATE32_INCREMENT_SIZE, key)) {
-		if (0 != value) {
-			/* IncrementSize is immutable. It can only be set once. */
-			if (0 == PPG_mem_mem32_subAllocHeapMem32.suballocator_incrementSize) {
-				/* Round up the increment size to the page size and set it to global variable. */
-				uintptr_t pageSize = portLibrary->vmem_supported_page_sizes(portLibrary)[0];
-				uintptr_t roundedIncrementSize = pageSize * (value / pageSize);
-				if (roundedIncrementSize < value) {
-					roundedIncrementSize += pageSize;
-				}
-				PPG_mem_mem32_subAllocHeapMem32.suballocator_incrementSize = roundedIncrementSize;
-			} else {
-				return 1;
-			}
-		} else {
-			return (int32_t)PPG_mem_mem32_subAllocHeapMem32.suballocator_incrementSize;
-		}
-		return 0;
-	} else if (0 == strcmp(OMRPORT_CTLDATA_ALLOCATE32_QUICK_ALLOC, key)) {
-		PPG_mem_mem32_subAllocHeapMem32.suballocator_quickAlloc = (0 != value) ? TRUE : FALSE;
-		return 0;
 	}
-#endif /* defined(OMR_ENV_DATA64) */
+#endif
 
 #if defined(OMR_RAS_TDF_TRACE)
 	if (!strcmp(OMRPORT_CTLDATA_TRACE_START, key) && value) {

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -931,10 +931,6 @@ extern J9_CFUNC int32_t
 omrport_startup_library(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC int32_t
 omrport_create_library(struct OMRPortLibrary *portLibrary, uintptr_t size);
-#if defined(OMR_ENV_DATA64)
-extern J9_CFUNC void
-omrport_copy_suballocator_heap_globals(struct OMRPortLibrary *destPortLibrary, struct OMRPortLibrary *srcPortLibrary);
-#endif /* defined(OMR_ENV_DATA64) */
 
 /* J9Syslog */
 extern J9_CFUNC uintptr_t


### PR DESCRIPTION
Reverts eclipse/omr#7414

See https://github.com/eclipse/omr/pull/7414#issuecomment-2265837658