### PR TITLE
Update node uncommoning for offHeap

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1157,11 +1157,11 @@ static TR::SymbolReference * createSymRefForNode(TR::Compilation *comp, TR::Reso
          symRef = comp->getSymRefTab()->createTemporary(methodSymbol, TR::Address, true, 0);
          if (value->isNotCollected())
             symRef->getSymbol()->setNotCollected();
-         else if (value->getOpCode().isArrayRef())
+         else if (value->getOpCode().isArrayRef() || value->isDataAddrPointer())
             value->setIsInternalPointer(true);
 
          TR::AutomaticSymbol *pinningArray = NULL;
-         if (value->getOpCode().isArrayRef())
+         if (value->getOpCode().isArrayRef() || value->isDataAddrPointer())
             {
             TR::Node *valueChild = value->getFirstChild();
             if (valueChild->isInternalPointer() &&

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5214,7 +5214,7 @@ OMR::Node::getPinningArrayPointer()
    if (self()->getOpCode().hasPinningArrayPointer())
       return _unionPropertyA._pinningArrayPointer;
 
-   return _unionBase._extension.getExtensionPtr()->getElem<TR::AutomaticSymbol *>(5);
+   return _unionBase._extension.getNumElems() >= 6 ? _unionBase._extension.getExtensionPtr()->getElem<TR::AutomaticSymbol *>(5) : NULL;
    }
 
 TR::AutomaticSymbol*


### PR DESCRIPTION
Include dataAddr pointer check with ArrayRef check when unocmmoning
a node.

Previously, only aiadd or aladd could be used for array access but with
offHeap, dataAddr pointer nodes (aloadi) can also be used for array access.
Hence we must check for dataAddr pointer and ArrayRef when uncommoning a node.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>