### PR TITLE
Accelerate Unsafe CAS Intrinsics on Power and X

### DIFF
--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -431,8 +431,15 @@ bool TR_RedundantAsyncCheckRemoval::callDoesAnImplicitAsyncCheck(TR::Node *callN
    if (symbol->isNative() &&
        ((symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z) ||
        (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z) ||
-       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z))
-      )
+       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z)))
+      return false;
+
+   if (symbol->isNative() &&
+       (comp()->target().cpu.isPower() || comp()->target().cpu.isX86()) &&
+       ((symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeInt) ||
+        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeLong) ||
+        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeObject) ||
+        (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeReference)))
       return false;
 #endif
    return true;

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -226,6 +226,7 @@
    fsubs,            // Floating subtract single
    isync,            // Instruction synchronize
    lbz,              // Load byte and zero extend
+   lbarx,            // Load byte and reserve indexed
    lbzu,             // Load byte and zero extend with update
    lbzux,            // Load byte and zero extend with update indexed
    lbzx,             // Load byte and zero extend indexed
@@ -247,6 +248,7 @@
    lfsux,            // Load floating short with update indexed
    lfsx,             // Load floating short indexed
    lha,              // Load half word algebraic
+   lharx,            // Load half word and reserve indexed
    lhau,             // Load half word algebraic
    lhaux,            // Load half word algebraic
    lhax,             // Load half word algebraic
@@ -390,11 +392,12 @@
    srw,              // Shift right word
    srw_r,            // Shift right word Rc=1
    stb,              // Store byte
+   stbcx_r,          // Store byte conditional indexed
    stbu,             // Store byte with update
    stbux,            // Store byte with update indexed
    stbx,             // Store byte indexed
    std,              // Store dword
-   stdcx_r,          // Store word conditional indexed
+   stdcx_r,          // Store dword conditional indexed
    stdu,             // Store dword with update
    stdux,            // Store dword with update indexed
    stdx,             // Store dword indexed
@@ -411,6 +414,7 @@
    stfsx,            // Store float single indexed
    sth,              // Store half word
    sthbrx,           // Store half word byte reversed indexed
+   sthcx_r,          // Store half word conditional indexed
    sthu,             // Store half word with update
    sthux,            // Store half word with update indexed
    sthx,             // Store half word indexed

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -2507,6 +2507,18 @@
    },
 
    {
+   /* .mnemonic    = */ OMR::InstOpCode::lbarx,
+   /* .name        = */ "lbarx",
+   /* .description =    "Load byte and reserve indexed", */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7C000068,
+   /* .format      = */ FORMAT_RT_RA_RB_MEM,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P7,
+   /* .properties  = */ PPCOpProp_IsLoad |
+                        PPCOpProp_ExcludeR0ForRA,
+   },
+
+   {
    /* .mnemonic    = */ OMR::InstOpCode::lbzu,
    /* .name        = */ "lbzu",
    /* .description =    "Load byte and zero extend with update", */
@@ -2776,6 +2788,18 @@
    /* .opcode      = */ 0xA8000000,
    /* .format      = */ FORMAT_RT_D16_RA,
    /* .minimumALS  = */ OMR_PROCESSOR_PPC_RIOS1,
+   /* .properties  = */ PPCOpProp_IsLoad |
+                        PPCOpProp_ExcludeR0ForRA,
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::lharx,
+   /* .name        = */ "lharx",
+   /* .description =    "Load half word and reserve indexed", */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7C0000E8,
+   /* .format      = */ FORMAT_RT_RA_RB_MEM,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P7,
    /* .properties  = */ PPCOpProp_IsLoad |
                         PPCOpProp_ExcludeR0ForRA,
    },
@@ -4461,6 +4485,19 @@
    },
 
    {
+   /* .mnemonic    = */ OMR::InstOpCode::stbcx_r,
+   /* .name        = */ "stbcx.",
+   /* .description =    "Store byte conditional indexed", */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7C00056D,
+   /* .format      = */ FORMAT_RS_RA_RB_MEM,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P7,
+   /* .properties  = */ PPCOpProp_IsStore |
+                        PPCOpProp_ExcludeR0ForRA |
+                        PPCOpProp_IsRecordForm,
+   },
+
+   {
    /* .mnemonic    = */ OMR::InstOpCode::stbu,
    /* .name        = */ "stbu",
    /* .description =    "Store byte with update", */
@@ -4514,7 +4551,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::stdcx_r,
    /* .name        = */ "stdcx.",
-   /* .description =    "Store word conditional indexed", */
+   /* .description =    "Store dword conditional indexed", */
    /* .prefix      = */ 0x00000000,
    /* .opcode      = */ 0x7C0001AD,
    /* .format      = */ FORMAT_RS_RA_RB_MEM,
@@ -4731,6 +4768,19 @@
    /* .minimumALS  = */ OMR_PROCESSOR_PPC_RIOS1,
    /* .properties  = */ PPCOpProp_IsStore |
                         PPCOpProp_ExcludeR0ForRA,
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::sthcx_r,
+   /* .name        = */ "sthcx.",
+   /* .description =    "Store half word conditional indexed", */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7C0005AD,
+   /* .format      = */ FORMAT_RS_RA_RB_MEM,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_P7,
+   /* .properties  = */ PPCOpProp_IsStore |
+                        PPCOpProp_ExcludeR0ForRA |
+                        PPCOpProp_IsRecordForm,
    },
 
    {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -761,12 +761,16 @@ bool OMR::X86::CodeGenerator::willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR:
    TR::MethodSymbol *methodSymbol = callSymRef->getSymbol()->castToMethodSymbol();
    switch (methodSymbol->getRecognizedMethod())
       {
-      case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
-         return willNotInlineCompareAndSwapNative(node, 8, comp);
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
+      case TR::jdk_internal_misc_Unsafe_compareAndExchangeInt:
          return willNotInlineCompareAndSwapNative(node, 4, comp);
+      case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
+      case TR::jdk_internal_misc_Unsafe_compareAndExchangeLong:
+         return willNotInlineCompareAndSwapNative(node, 8, comp);
       case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
-         return willNotInlineCompareAndSwapNative(node, (comp->target().is64Bit() && !comp->useCompressedPointers()) ? 8 : 4, comp);
+      case TR::jdk_internal_misc_Unsafe_compareAndExchangeObject:
+      case TR::jdk_internal_misc_Unsafe_compareAndExchangeReference:
+         return willNotInlineCompareAndSwapNative(node, TR::Compiler->om.sizeofReferenceField(), comp);
 
       default:
          break;

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -3918,6 +3918,10 @@ INSTANTIATE_TEST_CASE_P(LoadDisp, PPCRecordFormSanityTest, ::testing::Values(
 ));
 
 INSTANTIATE_TEST_CASE_P(LoadIndex, PPCTrg1MemEncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, TR::RealRegister::RegNum, MemoryReference, TRTest::BinaryInstruction, bool>>(
+    std::make_tuple(TR::InstOpCode::lbarx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c000068"), false),
+    std::make_tuple(TR::InstOpCode::lbarx,   TR::RealRegister::gr31,  MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7fe00068"), false),
+    std::make_tuple(TR::InstOpCode::lbarx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c1f0068"), false),
+    std::make_tuple(TR::InstOpCode::lbarx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TRTest::BinaryInstruction("7c00f868"), false),
     std::make_tuple(TR::InstOpCode::lbzux,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c0100ee"), false),
     std::make_tuple(TR::InstOpCode::lbzux,   TR::RealRegister::gr31,  MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7fe100ee"), false),
     std::make_tuple(TR::InstOpCode::lbzux,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c1f00ee"), false),
@@ -3966,6 +3970,10 @@ INSTANTIATE_TEST_CASE_P(LoadIndex, PPCTrg1MemEncodingTest, ::testing::ValuesIn(*
     std::make_tuple(TR::InstOpCode::lfsx,    TR::RealRegister::fp31,  MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7fe0042e"), false),
     std::make_tuple(TR::InstOpCode::lfsx,    TR::RealRegister::fp0,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c1f042e"), false),
     std::make_tuple(TR::InstOpCode::lfsx,    TR::RealRegister::fp0,   MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TRTest::BinaryInstruction("7c00fc2e"), false),
+    std::make_tuple(TR::InstOpCode::lharx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c0000e8"), false),
+    std::make_tuple(TR::InstOpCode::lharx,   TR::RealRegister::gr31,  MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7fe000e8"), false),
+    std::make_tuple(TR::InstOpCode::lharx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c1f00e8"), false),
+    std::make_tuple(TR::InstOpCode::lharx,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TRTest::BinaryInstruction("7c00f8e8"), false),
     std::make_tuple(TR::InstOpCode::lhaux,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c0102ee"), false),
     std::make_tuple(TR::InstOpCode::lhaux,   TR::RealRegister::gr31,  MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7fe102ee"), false),
     std::make_tuple(TR::InstOpCode::lhaux,   TR::RealRegister::gr0,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TRTest::BinaryInstruction("7c1f02ee"), false),
@@ -4070,6 +4078,7 @@ INSTANTIATE_TEST_CASE_P(LoadIndex, PPCTrg1MemEncodingTest, ::testing::ValuesIn(*
 )));
 
 INSTANTIATE_TEST_CASE_P(LoadIndex, PPCRecordFormSanityTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::lbarx,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lbzux,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lbzx,    TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::ldarx,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
@@ -4082,6 +4091,7 @@ INSTANTIATE_TEST_CASE_P(LoadIndex, PPCRecordFormSanityTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::lfiwzx,  TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lfsux,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lfsx,    TR::InstOpCode::bad, TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::lharx,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lhaux,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lhax,    TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lhbrx,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
@@ -4482,6 +4492,10 @@ INSTANTIATE_TEST_CASE_P(StoreDisp, PPCRecordFormSanityTest, ::testing::Values(
 ));
 
 INSTANTIATE_TEST_CASE_P(StoreIndex, PPCMemSrc1EncodingTest, ::testing::ValuesIn(*TRTest::MakeVector<std::tuple<TR::InstOpCode::Mnemonic, MemoryReference, TR::RealRegister::RegNum, TRTest::BinaryInstruction, bool>>(
+    std::make_tuple(TR::InstOpCode::stbcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c00056d"), false),
+    std::make_tuple(TR::InstOpCode::stbcx_r, MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c1f056d"), false),
+    std::make_tuple(TR::InstOpCode::stbcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c00fd6d"), false),
+    std::make_tuple(TR::InstOpCode::stbcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TR::RealRegister::gr31,  TRTest::BinaryInstruction("7fe0056d"), false),
     std::make_tuple(TR::InstOpCode::stbux,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c0101ee"), false),
     std::make_tuple(TR::InstOpCode::stbux,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c1f01ee"), false),
     std::make_tuple(TR::InstOpCode::stbux,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr31), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c01f9ee"), false),
@@ -4526,6 +4540,10 @@ INSTANTIATE_TEST_CASE_P(StoreIndex, PPCMemSrc1EncodingTest, ::testing::ValuesIn(
     std::make_tuple(TR::InstOpCode::sthbrx,  MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c1f072c"), false),
     std::make_tuple(TR::InstOpCode::sthbrx,  MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c00ff2c"), false),
     std::make_tuple(TR::InstOpCode::sthbrx,  MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TR::RealRegister::gr31,  TRTest::BinaryInstruction("7fe0072c"), false),
+    std::make_tuple(TR::InstOpCode::sthcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c0005ad"), false),
+    std::make_tuple(TR::InstOpCode::sthcx_r, MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c1f05ad"), false),
+    std::make_tuple(TR::InstOpCode::sthcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr31), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c00fdad"), false),
+    std::make_tuple(TR::InstOpCode::sthcx_r, MemoryReference(TR::RealRegister::gr0,  TR::RealRegister::gr0 ), TR::RealRegister::gr31,  TRTest::BinaryInstruction("7fe005ad"), false),
     std::make_tuple(TR::InstOpCode::sthux,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c01036e"), false),
     std::make_tuple(TR::InstOpCode::sthux,   MemoryReference(TR::RealRegister::gr31, TR::RealRegister::gr0 ), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c1f036e"), false),
     std::make_tuple(TR::InstOpCode::sthux,   MemoryReference(TR::RealRegister::gr1,  TR::RealRegister::gr31), TR::RealRegister::gr0,   TRTest::BinaryInstruction("7c01fb6e"), false),
@@ -4608,6 +4626,7 @@ INSTANTIATE_TEST_CASE_P(StoreIndex, PPCMemSrc1EncodingTest, ::testing::ValuesIn(
 )));
 
 INSTANTIATE_TEST_CASE_P(StoreIndex, PPCRecordFormSanityTest, ::testing::Values(
+    std::make_tuple(TR::InstOpCode::bad,     TR::InstOpCode::stbcx_r, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::stbux,   TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::stbx,    TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::bad,     TR::InstOpCode::stdcx_r, TRTest::BinaryInstruction()),
@@ -4619,6 +4638,7 @@ INSTANTIATE_TEST_CASE_P(StoreIndex, PPCRecordFormSanityTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::stfsux,  TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::stfsx,   TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::sthbrx,  TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::bad,     TR::InstOpCode::sthcx_r, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::sthux,   TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::sthx,    TR::InstOpCode::bad,     TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::stvx,    TR::InstOpCode::bad,     TRTest::BinaryInstruction()),


### PR DESCRIPTION
Adds lbarx, lharx, stbcx_r and sthcx_r instruction support for Power. These instructions are not currently in use but will be needed for future enhancements targetting CAS on byte and short length data.

Updates willBeEvaluatedAsCallByCodeGen to reflect the new acceleration of Unsafe compareAndExchange methods on X.

Edit:
X changes are dependent on this OpenJ9 PR:
https://github.com/eclipse-openj9/openj9/pull/19991
Behavior of `inlineCompareAndSwapNative` and `inlineCompareAndSwapObjectNative` in `J9TreeEvaluator.cpp` must match behavior in `willBeEvaluatedAsCallByCodeGen` in `OMRCodeGenerator.cpp`