### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,27 @@
-# This .gitattributes file will cause all text files EXCEPT for
-# git's .gitattributes and .gitignore files to be encoded as EBCDIC
-# when cloned using git (from Rocket Software) on z/OS platform.
+###############################################################################
+# Copyright IBM Corp. and others 2018
 #
-# Selected binary files will not be translated at all.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+###############################################################################
 
-# Binary files
-*.jpg git-encoding=BINARY working-tree-encoding=BINARY
-*.png git-encoding=BINARY working-tree-encoding=BINARY
-*.gif git-encoding=BINARY working-tree-encoding=BINARY
-*.zip git-encoding=BINARY working-tree-encoding=BINARY
+# binary files
+*.gif binary
+*.jpg binary
+*.png binary
+*.zip binary


### PR DESCRIPTION
Encoding attributes are only applicable to text files.