### PR TITLE
Remove unused cpIndex parameter of vTableSlot(), virtualCallSelector()

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1528,7 +1528,7 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
    if (!resolvedMethod)
       symRef->setUnresolved();
    else if (callKind == TR::MethodSymbol::Virtual && cpIndex != -1)
-      symRef->setOffset(resolvedMethod->virtualCallSelector(cpIndex));
+      symRef->setOffset(resolvedMethod->virtualCallSelector());
 
    aliasBuilder.methodSymRefs().set(symRef->getReferenceNumber());
 

--- a/compiler/compile/ResolvedMethod.cpp
+++ b/compiler/compile/ResolvedMethod.cpp
@@ -391,11 +391,11 @@ char *       TR_ResolvedMethod::fieldNameChars(int32_t, int32_t &)         { TR_
 char *       TR_ResolvedMethod::fieldSignatureChars(int32_t, int32_t &)    { TR_UNIMPLEMENTED(); return 0; }
 char *       TR_ResolvedMethod::staticSignatureChars(int32_t, int32_t &)   { TR_UNIMPLEMENTED(); return 0; }
 void * &     TR_ResolvedMethod::addressOfClassOfMethod()                   { TR_UNIMPLEMENTED(); throw std::exception(); }
-uint32_t     TR_ResolvedMethod::vTableSlot(uint32_t)                       { TR_UNIMPLEMENTED(); return 0; }
+uint32_t     TR_ResolvedMethod::vTableSlot()                               { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::virtualMethodIsOverridden()                { TR_UNIMPLEMENTED(); return false; }
 void         TR_ResolvedMethod::setVirtualMethodIsOverridden()             { TR_UNIMPLEMENTED(); }
 void *       TR_ResolvedMethod::addressContainingIsOverriddenBit()         { TR_UNIMPLEMENTED(); return 0; }
-int32_t     TR_ResolvedMethod::virtualCallSelector(uint32_t)               { TR_UNIMPLEMENTED(); return 0; }
+int32_t     TR_ResolvedMethod::virtualCallSelector()                       { TR_UNIMPLEMENTED(); return 0; }
 uint32_t     TR_ResolvedMethod::numberOfExceptionHandlers()                { TR_UNIMPLEMENTED(); return 0; }
 uint8_t *    TR_ResolvedMethod::allocateException(uint32_t,TR::Compilation*){ TR_UNIMPLEMENTED(); return 0; }
 

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -218,7 +218,7 @@ public:
    virtual uint32_t classCPIndexOfMethod(uint32_t);
    virtual void * & addressOfClassOfMethod();
 
-   virtual uint32_t vTableSlot(uint32_t);
+   virtual uint32_t vTableSlot();
 
    virtual TR_OpaqueClassBlock *getResolvedInterfaceMethod(int32_t cpIndex, uintptr_t * pITableIndex);
 
@@ -236,7 +236,7 @@ public:
    virtual bool virtualMethodIsOverridden();
    virtual void setVirtualMethodIsOverridden();
    virtual void *addressContainingIsOverriddenBit();
-   virtual int32_t virtualCallSelector(uint32_t cpIndex);
+   virtual int32_t virtualCallSelector();
 
    virtual int32_t exceptionData(int32_t exceptionNumber, int32_t * startIndex, int32_t * endIndex, int32_t * catchType);
    virtual uint32_t numberOfExceptionHandlers();


### PR DESCRIPTION
...in `TR_ResolvedMethod`.