### PR TITLE
Fix null restricted array related issues for value types

### DIFF
--- a/compiler/env/FrontEnd.cpp
+++ b/compiler/env/FrontEnd.cpp
@@ -188,6 +188,13 @@ TR_FrontEnd::getArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClas
    }
 
 TR_OpaqueClassBlock *
+TR_FrontEnd::getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClass)
+   {
+   TR_UNIMPLEMENTED();
+   return 0;
+   }
+
+TR_OpaqueClassBlock *
 TR_FrontEnd::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass)
    {
    TR_UNIMPLEMENTED();

--- a/compiler/env/FrontEnd.hpp
+++ b/compiler/env/FrontEnd.hpp
@@ -181,6 +181,16 @@ public:
 
    // VM+Shared
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClass);
+   /** \brief
+    *     Retrieves the nullRestrictedArrayClass from the array component class.
+    *
+    *  \param componentClass
+    *     The array component class
+    *
+    *  \return
+    *     A pointer to nullRestrictedArrayClass if it exists, otherwise NULL
+    */
+   virtual TR_OpaqueClassBlock * getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClass);
    virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool callSiteVettedForAOT=false);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool callSiteVettedForAOT=false);

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1690,7 +1690,7 @@ TR_YesNoMaybe OMR::ValuePropagation::isCastClassObject(TR::VPClassType *type)
    }
 
 
-TR_YesNoMaybe OMR::ValuePropagation::isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint)
+TR_YesNoMaybe OMR::ValuePropagation::isArrayNullRestricted(TR::VPConstraint *arrayConstraint)
    {
    return TR::Compiler->om.areFlattenableValueTypesEnabled() ? TR_maybe : TR_no;
    }

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -616,15 +616,16 @@ class ValuePropagation : public TR::Optimization
      {
      TR_ALLOC(TR_Memory::ValuePropagation)
 
-     TR_NeedRuntimeTestNullRestrictedArrayCopy(TR::Node *dstArrRef, TR::Node *srcArrRef,
+     TR_NeedRuntimeTestNullRestrictedArrayCopy(TR::SymbolReference *dstArrRefSymRef, TR::SymbolReference *srcArrRefSymRef,
                                                TR::TreeTop *ptt, TR::TreeTop *ntt,
                                                TR::Block *originBlock, TR::Block *slowBlock,
                                                bool testDstArray)
-        : _dstArrayRefNode(dstArrRef),  _srcArrayRefNode(srcArrRef), _prevTT(ptt), _nextTT(ntt), _originBlock(originBlock), _slowBlock(slowBlock), _needRuntimeTestDstArray(testDstArray)
+        : _dstArrRefSymRef(dstArrRefSymRef), _srcArrRefSymRef(srcArrRefSymRef), _prevTT(ptt), _nextTT(ntt),
+          _originBlock(originBlock), _slowBlock(slowBlock), _needRuntimeTestDstArray(testDstArray)
         {}
 
-     TR::Node *_dstArrayRefNode;
-     TR::Node *_srcArrayRefNode;
+     TR::SymbolReference * _dstArrRefSymRef;
+     TR::SymbolReference * _srcArrRefSymRef;
 
      TR::TreeTop *_prevTT;
      TR::TreeTop *_nextTT;

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -367,14 +367,14 @@ class ValuePropagation : public TR::Optimization
    TR_YesNoMaybe isCastClassObject(TR::VPClassType *type);
 
    /**
-    * Determine whether the component type of an array is, or might be, a primitive value
-    * type.
+    * Determine whether the array is, or might be, null-restricted
+    *
     * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
-    * \returns \c TR_yes if the array's component type is definitely a primitive value type;\n
-    *          \c TR_no if it is definitely not a primitive value type; or\n
+    * \returns \c TR_yes if the array is definitely a null-restricted array;\n
+    *          \c TR_no if it is definitely not a null-restricted array; or\n
     *          \c TR_maybe otherwise.
     */
-   virtual TR_YesNoMaybe isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint);
+   virtual TR_YesNoMaybe isArrayNullRestricted(TR::VPConstraint *arrayConstraint);
 
    /**
     * \brief

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -977,10 +977,10 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
 
    bool doRuntimeNullRestrictedTest = false;
    bool needRuntimeTestDstArray = true; // needRuntimeTestDstArray is used only if doRuntimeNullRestrictedTest is true
-   bool areBothArraysFlattenedPrimitiveValueType = false;
+   bool areBothArraysFlattenedNullRestrictedArray = false;
    bool isValueTypeArrayFlatteningEnabled = TR::Compiler->om.isValueTypeArrayFlatteningEnabled();
-   TR_YesNoMaybe isDstArrayCompTypePrimitiveValueType = TR_no;
-   TR_YesNoMaybe isSrcArrayCompTypePrimitiveValueType = TR_no;
+   TR_YesNoMaybe isDstArrayNullRestricted = TR_no;
+   TR_YesNoMaybe isSrcArrayNullRestricted = TR_no;
 
    if (trace() && comp()->generateArraylets())
       traceMsg(comp(), "Detected arraylet arraycopy: %p\n", node);
@@ -1311,7 +1311,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
 
       static char *disableNullRestrictedArrayCopyXForm = feGetEnv("TR_DisableNullRestrictedArraycopyXForm");
 
-      // JEP 401: If null restricted value type is enabled, we need to preform null check on the value being stored
+      // JEP 401: If null-restricted value type is enabled, we need to preform null check on the value being stored
       // in order to throw a NullPointerException if the array is null-restricted and the value to write is null.
       // If it is this case, System.arraycopy cannot be transformed into arraycopy instructions.
       //
@@ -1324,23 +1324,23 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
           !primitiveArray2 &&
           (copyLen != _constantZeroConstraint)) // Not zero length copy
          {
-         isDstArrayCompTypePrimitiveValueType = isArrayCompTypePrimitiveValueType(dstObject);
-         isSrcArrayCompTypePrimitiveValueType = isArrayCompTypePrimitiveValueType(srcObject);
+         isDstArrayNullRestricted = isArrayNullRestricted(dstObject);
+         isSrcArrayNullRestricted = isArrayNullRestricted(srcObject);
 
-         switch (isDstArrayCompTypePrimitiveValueType)
+         switch (isDstArrayNullRestricted)
             {
             case TR_yes:
                {
-               if (isSrcArrayCompTypePrimitiveValueType == TR_yes)
+               if (isSrcArrayNullRestricted == TR_yes)
                   {
                   // Array flattening is not enabled
-                  //    - If both source and destination arrays are primitive VT, they don't contain
+                  //    - If both source and destination arrays are null-restricted, they don't contain
                   //      NULL value. There is no need to check null store
                   //    - Also because flattening is not enabled, we don't need to concern about copying
                   //      between flattened arrays
                   //
                   // Array flattening is enabled
-                  //    - If both source and destination arrays are primitive VT
+                  //    - If both source and destination arrays are null-restricted
                   //        - (1) Both arrays are not flattened, there is no need to do anything
                   //        - (2) Both arrays are flattened, elementSize needs to be updated in order to
                   //          use arraycopy instructions
@@ -1356,7 +1356,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                      if ((isArrayElementFlattened(dstObject) == TR_yes) &&
                          (isArrayElementFlattened(srcObject) == TR_yes))
                         {
-                        areBothArraysFlattenedPrimitiveValueType = true;
+                        areBothArraysFlattenedNullRestrictedArray = true;
                         elementSize = TR::Compiler->cls.flattenedArrayElementSize(comp(), dstObject->getClass());
 
                         if (trace())
@@ -1369,10 +1369,10 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                         }
                      }
                   }
-               else // isSrcArrayCompTypePrimitiveValueType == TR_no or TR_maybe
+               else // isSrcArrayNullRestricted == TR_no or TR_maybe
                   {
-                  // The destination is primitive VT array and the source might or might not
-                  // be primitive VT array, do not transform because we need to do null store check and
+                  // The destination is null-restricted array and the source might or might not
+                  // be null-restricted array, do not transform because we need to do null store check and
                   // consider if the arrays are flattened
                   transformTheCall = false;
                   }
@@ -1380,16 +1380,16 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                }
             case TR_maybe:
                {
-               // If the destination array might or might not be primitive VT array at compile time,
+               // If the destination array might or might not be null-restricted array at compile time,
                // runtime tests are required regardless of the source array type.
                doRuntimeNullRestrictedTest = true;
                break;
                }
-            default: // TR_no == isDstArrayCompTypePrimitiveValueType
+            default: // TR_no == isDstArrayNullRestricted
                {
                if (isValueTypeArrayFlatteningEnabled)
                   {
-                  if (isSrcArrayCompTypePrimitiveValueType == TR_yes)
+                  if (isSrcArrayNullRestricted == TR_yes)
                      {
                      if (isArrayElementFlattened(srcObject) == TR_yes)
                         {
@@ -1400,16 +1400,16 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                         }
                      // else: As long as the source array is not flattened, no need to do anything here
                      }
-                  else if (isSrcArrayCompTypePrimitiveValueType == TR_maybe)
+                  else if (isSrcArrayNullRestricted == TR_maybe)
                      {
-                     // The source might or might not be a primitive VT array. If it is primitive VT array that is flattened,
+                     // The source might or might not be a null-restricted array. If it is null-restricted array that is flattened,
                      // the arraycopy instruction cannot handle copying from flattened array into non-flattened array since the
                      // destination array is identity type. Need to add runtime check here
                      doRuntimeNullRestrictedTest = true;
                      // We already know the destination array is identity type. No need to insert runtime test here
                      needRuntimeTestDstArray = false;
                      }
-                  // else: isSrcArrayCompTypePrimitiveValueType == TR_no, both destination and source arrays are
+                  // else: isSrcArrayNullRestricted == TR_no, both destination and source arrays are
                   // identity arrays. No need to do anything here
                   }
                // else: As long as array flattening is not enabled, no need to do anything here
@@ -1419,8 +1419,8 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          }
 
       if (trace())
-         traceMsg(comp(), "%s: n%dn %p transformTheCall %d isSrcArrayCompTypePrimitiveValueType %d isDstArrayCompTypePrimitiveValueType %d doRuntimeNullRestrictedTest %d\n", __FUNCTION__,
-         node->getGlobalIndex(), node, transformTheCall, isSrcArrayCompTypePrimitiveValueType, isDstArrayCompTypePrimitiveValueType, doRuntimeNullRestrictedTest);
+         traceMsg(comp(), "%s: n%dn %p transformTheCall %d isSrcArrayNullRestricted %d isDstArrayNullRestricted %d doRuntimeNullRestrictedTest %d\n", __FUNCTION__,
+         node->getGlobalIndex(), node, transformTheCall, isSrcArrayNullRestricted, isDstArrayNullRestricted, doRuntimeNullRestrictedTest);
       }
 #else
    bool isStringCompressedArrayCopy = false;
@@ -1436,7 +1436,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          {
          if (trace())
             {
-            comp()->dumpMethodTrees("Trees before modifying for null restricted array check");
+            comp()->dumpMethodTrees("Trees before modifying for null-restricted array check");
             comp()->getDebug()->print(comp()->getOutFile(), comp()->getFlowGraph());
             }
          /*
@@ -1551,7 +1551,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                                                                                                                      needRuntimeTestDstArray));
          if (trace())
             {
-            comp()->dumpMethodTrees("Trees after modifying for null restricted array check");
+            comp()->dumpMethodTrees("Trees after modifying for null-restricted array check");
             comp()->getDebug()->print(comp()->getOutFile(), comp()->getFlowGraph());
             }
          }
@@ -1731,7 +1731,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          else if (srcArrayInfo)
             stride = srcArrayInfo->elementSize();
 
-         stride = areBothArraysFlattenedPrimitiveValueType ? elementSize : stride;
+         stride = areBothArraysFlattenedNullRestrictedArray ? elementSize : stride;
 
          if (stride != 0)
             srcArrayLength->setArrayStride(stride);
@@ -1746,7 +1746,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
          else if (dstArrayInfo)
             stride = dstArrayInfo->elementSize();
 
-         stride = areBothArraysFlattenedPrimitiveValueType ? elementSize : stride;
+         stride = areBothArraysFlattenedNullRestrictedArray ? elementSize : stride;
 
          if (stride != 0)
             dstArrayLength->setArrayStride(stride);
@@ -3644,8 +3644,7 @@ void OMR::ValuePropagation::transformNullRestrictedArrayCopy(TR_NeedRuntimeTestN
     *     Array Flattening Is NOT Enabled:
     *    ================================
     *
-    *           Is dstArray primitive VT?
-    *                 (null restricted)
+    *           Is dstArray null-restricted?
     *                        |
     *              +---------+---------+
     *              |                   |
@@ -3660,15 +3659,14 @@ void OMR::ValuePropagation::transformNullRestrictedArrayCopy(TR_NeedRuntimeTestN
     *    Array Flattening IS Enabled:
     *    ================================
     *
-    *           Is dstArray primitive VT?
-    *                 (null restricted)
+    *           Is dstArray null-restricted?
     *                       |
     *             +---------+---------+
     *             |                   |
     *            Yes                  No
     *             |                   |
     *             v                   v
-    *     System.arrayCopy      Is srcArray primitive VT?
+    *     System.arrayCopy      Is srcArray null-restricted?
     *        (slowBlock)           (could be flattened)
     *                                       |
     *                             +---------+---------+
@@ -3683,7 +3681,7 @@ void OMR::ValuePropagation::transformNullRestrictedArrayCopy(TR_NeedRuntimeTestN
     *    No need to check dstArray(needTestDstArray=false):
     *    ================================
     *
-    *             Is srcArray primitive VT?
+    *             Is srcArray null-restricted?
     *               (could be flattened)
     *                        |
     *              +---------+---------+
@@ -3881,8 +3879,8 @@ slowBlock-> n39n      BBStart <block_10> (freq 0) (cold)
       prevBlock->split(ifDstTree->getNextTreeTop(), cfg, true, true);
       }
 
-   // If destination is not null restricted value type array and array flattening is enabled, we need to check
-   // the source array component type.  If it is null restricted value type, the current arraycopy instructions
+   // If destination is not null-restricted value type array and array flattening is enabled, we need to check
+   // the source array component type.  If it is null-restricted value type, the current arraycopy instructions
    // can't handle copying between flattened and non-flattened arrays.
    if (needTestSrcArray)
       {


### PR DESCRIPTION
(1) Add front end `getNullRestrictedArrayClassFromComponentClass`  to retrieve null restricted array class
(2) Rename `isArrayCompTypePrimitiveValueType` to `isArrayNullRestricted` to reflect the updated logic
(3) Fix array load in `transformNullRestrictedArrayCopy`

**Depends on** 
- [ ] https://github.com/eclipse-openj9/openj9/pull/20112

**Related:** https://github.com/eclipse-openj9/openj9/issues/19914, https://github.com/eclipse-openj9/openj9/issues/19913