### PR TITLE
Optimize trivial branches obscured by goto blocks on the fall-through path

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -6695,6 +6695,15 @@ TR::Block *TR_BlockSplitter::splitBlock(TR::Block *pred, TR_LinkHeadAndTail<Bloc
           newBlock->append(TR::TreeTop::create(comp(), TR::Node::create(lastRealNode, TR::Goto, 0, nextTree)));
           cfg->addEdge(cloneEnd, newBlock);
           cfg->addEdge(newBlock, nextTree->getNode()->getBlock());
+          // The branch target may be the fall-through path. If so, since we're redirecting the fall-through path to a goto block
+          // and removing the single edge that represents both the fall-through and branch paths, we should also redirect the branch
+          // to the goto block.
+          if (lastRealNode->getBranchDestination()->getNode()->getBlock()->getNumber() == nextTree->getNode()->getBlock()->getNumber())
+             {
+             if (trace())
+                traceMsg(comp(), "   Redirecting branch %d->%d to %d\n", cloneEnd->getNumber(), nextTree->getNode()->getBlock()->getNumber(), newBlock->getNumber());
+             lastRealNode->setBranchDestination(newBlock->getEntry());
+             }
           cfg->removeEdge(cloneEnd, nextTree->getNode()->getBlock());
 
           if (trace())

--- a/compiler/optimizer/OMRSimplifierHelpers.hpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.hpp
@@ -173,6 +173,7 @@ void orderChildren(TR::Node * node, TR::Node * & firstChild, TR::Node * & second
 TR::Node *foldRedundantAND(TR::Node * node, TR::ILOpCodes andOpCode, TR::ILOpCodes constOpCode, int64_t andVal, TR::Simplifier * s);
 TR::Node* tryFoldAndWidened(TR::Simplifier* simplifier, TR::Node* node);
 bool branchToFollowingBlock(TR::Node * node, TR::Block * block, TR::Compilation *comp);
+bool fallthroughGoesToBranchBlock(TR::Node *node, TR::Block *block, TR::Compilation *comp);
 void makeConstantTheRightChild(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondChild, TR::Simplifier * s);
 void makeConstantTheRightChildAndSetOpcode(TR::Node * node, TR::Node * & firstChild, TR::Node * & secondChild, TR::Simplifier * s);
 TR::Node *replaceChild(int32_t childIndex, TR::Node* node, TR::Node* newChild, TR::Simplifier* s);


### PR DESCRIPTION
This PR contains the following 2 commits:

1 - Teach Simplifier to detect conditional branches that have fallthrough
blocks that are goto blocks to the same target.

For example:
```
n223n     BBStart <block_18> (freq 1) (cold)
n210n     ifacmpeq --> block_17 BBStart at n219n ()
n208n       aload  <temp slot 5>[#529  Auto] [flags 0x7 0x0 ]
n209n       aconst NULL (X==0 X>=0 X<=0 )
n224n     BBEnd </block_18> (cold) =====

n227n     BBStart <block_19> (freq 1) (cold)
n226n     goto --> block_17 BBStart at n219n ()
n228n     BBEnd </block_19> (cold) =====
```
This complements the symmetrical case where the conditional branch
goes to the fallthrough block, which is already detected and removed by
Simplifier.

2 - Make conditional branches with a fallthrough goto block to the branch
target unconditional so that they can be removed by later passes.