### PR TITLE
Client Request Cached Methods List from JIT Server

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1082,6 +1082,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"regmap",             "C\tgenerate GC maps with register maps", SET_OPTION_BIT(TR_RegisterMaps), "F", NOT_IN_SUBSET},
    {"reportEvents",       "C\tcompile event reporting hooks into code", SET_OPTION_BIT(TR_ReportMethodEnter | TR_ReportMethodExit)},
    {"reportMethodEnterExit", "D\treport method enter and exit",                   SET_OPTION_BIT(TR_ReportMethodEnter | TR_ReportMethodExit), "F"},
+   {"requestJITServerCachedMethods", "O\trequest the list of methods cached at the server on bootstrap, and prioritise the compilation requests for them", SET_OPTION_BIT(TR_RequestJITServerCachedMethods), "F"},
    {"reserveAllLocks",    "O\tenable reserving locks for all classes and methods (DEBUG Only)", SET_OPTION_BIT(TR_ReserveAllLocks), "F"},
    {"reservingLocks",     "O\tenable reserving locks for hot methods on classes that can be reserved", SET_OPTION_BIT(TR_ReservingLocks), "F"},
    {"restrictInlinerDuringStartup", "O\trestrict trivial inliner during startup", SET_OPTION_BIT(TR_RestrictInlinerDuringStartup), "F", NOT_IN_SUBSET },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -392,7 +392,7 @@ enum TR_CompilationOptions
    TR_FirstLevelProfiling                 = 0x00000100 + 10,
    TR_EnableCodeCacheDisclaiming          = 0x00000200 + 10,
    // Available                           = 0x00000400 + 10,
-   // Available                           = 0x00000800 + 10,
+   TR_RequestJITServerCachedMethods       = 0x00000800 + 10,
    // Available                           = 0x00001000 + 10,
    TR_DisableNewMethodOverride            = 0x00002000 + 10,
    // Available                           = 0x00004000 + 10,


### PR DESCRIPTION
Added an option that makes the client request a list of cached methods from the server on bootstrap, and set the count for those methods as scount to improve rampup