### PR TITLE
Off-Heap related update

### DIFF
--- a/gc/base/SparseAddressOrderedFixedSizeDataPool.cpp
+++ b/gc/base/SparseAddressOrderedFixedSizeDataPool.cpp
@@ -270,6 +270,7 @@ MM_SparseAddressOrderedFixedSizeDataPool::findFreeListEntry(uintptr_t size)
 		Assert_MM_true(NULL != returnAddr);
 		_approximateFreeMemorySize -= size;
 		_freeListPoolAllocBytes += size;
+		_allocObjectCount += 1;
 
 		Trc_MM_SparseAddressOrderedFixedSizeDataPool_freeListEntryFoundForData_success(returnAddr, (void *)size, _freeListPoolFreeNodesCount, (void *)_approximateFreeMemorySize, (void *)_freeListPoolAllocBytes);
 	}
@@ -356,6 +357,7 @@ MM_SparseAddressOrderedFixedSizeDataPool::returnFreeListEntry(void *dataAddr, ui
 
 	_approximateFreeMemorySize += size;
 	_freeListPoolAllocBytes -= size;
+	_allocObjectCount -= 1;
 	_lastFreeBytes = size;
 
 	Trc_MM_SparseAddressOrderedFixedSizeDataPool_returnFreeListEntry_success(dataAddr, (void *)size, _freeListPoolFreeNodesCount, (void *)_approximateFreeMemorySize, (void *)_freeListPoolAllocBytes);

--- a/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
+++ b/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
@@ -86,6 +86,7 @@ protected:
 	uintptr_t _lastFreeBytes; /**< Number of bytes free at end of last GC */
 	uintptr_t _freeListPoolFreeNodesCount; /**< Number of free list nodes. There's always at least one node in list therefore >= 1 */
 	uintptr_t _freeListPoolAllocBytes; /**< Byte amount allocated from sparse heap */
+	uintptr_t _allocObjectCount; /**< Object count allocated from sparse heap */
 
 	MM_GCExtensionsBase *_extensions; /**< GC Extensions for this JVM */
 	J9Pool *_freeListPool; /**< Memory pool to be used to create MM_SparseHeapLinkedFreeHeader nodes */
@@ -195,6 +196,14 @@ public:
 	}
 
 	/**
+	 * Get the total count of the allocated objects
+	 */
+	MMINLINE uintptr_t getAllocObjectCount()
+	{
+		return _allocObjectCount;
+	}
+
+	/**
 	 * Update the proxyObjPtr after an object has moved for the sparse data entry associated with the given dataPtr.
 	 *
 	 * @param dataPtr		void*	Data pointer
@@ -216,6 +225,7 @@ protected:
 		, _lastFreeBytes(0)
 		, _freeListPoolFreeNodesCount(0)
 		, _freeListPoolAllocBytes(0)
+		, _allocObjectCount(0)
 		, _extensions(env->getExtensions())
 		, _freeListPool(NULL)
 		, _heapFreeList(NULL)

--- a/gc/include/RootScannerTypes.h
+++ b/gc/include/RootScannerTypes.h
@@ -64,7 +64,7 @@ typedef enum RootScannerEntity {
 	RootScannerEntity_MonitorLookupCachesComplete,
 	RootScannerEntity_MonitorReferenceObjectsComplete,
 	RootScannerEntity_DoubleMappedObjects, /* Obsolete */
-	RootScannerEntity_DoubleMappedOrVirtualLargeObjectHeapObjects,
+	RootScannerEntity_virtualLargeObjectHeapObjects,
 
 	/* Must be last, do not use this entity! */
 	RootScannerEntity_Count

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -34,6 +34,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="arraylet-unknown" type="vgc:arraylet-unknown" />
 	<element name="cpu-util" type="vgc:cpu-util" />
 	<element name="numa" type="vgc:numa" />
+	<element name="offheap-objects" type="vgc:offheap-objects" />
 	<element name="vmarg" type="vgc:vmarg" />
 	<element name="vmargs" type="vgc:vmargs" />
 	<element name="attribute" type="vgc:attribute" />
@@ -72,6 +73,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<element name="finalization" type="vgc:finalization" />
 	<element name="ownableSynchronizers" type="vgc:ownableSynchronizers" />
 	<element name="continuations" type="vgc:continuations" />
+	<element name="offheap" type="vgc:offheap" />
 	<element name="stringconstants" type="vgc:stringconstants" />
 	<element name="object-monitors" type="vgc:object-monitors" />
 	<element name="classunload-info" type="vgc:classunload-info" />
@@ -176,6 +178,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:arraylet-primitive" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:arraylet-unknown" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:numa" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:offheap-objects" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:pending-finalizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:continuation-objects" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:remembered-set" maxOccurs="1" minOccurs="0" />
@@ -491,6 +494,11 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 
 	<complexType name="continuations">
 		<attribute name="candidates" type="integer" use="optional" />
+		<attribute name="cleared" type="integer" use="required" />
+	</complexType>
+
+	<complexType name="offheap">
+		<attribute name="candidates" type="integer" use="required" />
 		<attribute name="cleared" type="integer" use="required" />
 	</complexType>
 
@@ -810,6 +818,11 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="non-local-percent" type="integer" use="required" />
 	</complexType>
 
+	<complexType name="offheap-objects">
+		<attribute name="objects" type="integer" use="required" />
+		<attribute name="bytes" type="integer" use="required" />
+	</complexType>
+
 	<group name="gc-op-mark">
 		<sequence>
 			<element ref="vgc:trace-info" maxOccurs="1" minOccurs="1" />
@@ -818,6 +831,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:finalization" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:ownableSynchronizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:continuations" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:offheap" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:references" maxOccurs="unbounded" minOccurs="0" />
 			<element ref="vgc:stringconstants" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:object-monitors" maxOccurs="1" minOccurs="0" />
@@ -881,6 +895,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 			<element ref="vgc:finalization" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:ownableSynchronizers" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:continuations" maxOccurs="1" minOccurs="0" />
+			<element ref="vgc:offheap" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:references" maxOccurs="unbounded" minOccurs="0" />
 			<element ref="vgc:stringconstants" maxOccurs="1" minOccurs="0" />
 			<element ref="vgc:object-monitors" maxOccurs="1" minOccurs="0" />


### PR DESCRIPTION
 - Remove double mapping related entities.
 - Record allocObjectCount in Sparse Heap.
 - Update verbosegc schema for new off heap related elements \
    New sub element\<offheap-objects objects=nnn allocatedBytes=nnn\> in \<mem-info\> .
  New element \<offheap candidates=nnn cleared=nnn\> in group \<gc-op-copy-forward\> and group  \<gc-op-mark\>.