### PR TITLE
Re-introduce makefile for pugixml-1.8

### DIFF
--- a/third_party/pugixml-1.8/makefile
+++ b/third_party/pugixml-1.8/makefile
@@ -1,0 +1,30 @@
+###############################################################################
+# Copyright IBM Corp. and others 2015
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+###############################################################################
+
+top_srcdir := ../..
+include $(top_srcdir)/omrmakefiles/configure.mk
+
+MODULE_NAME := pugixml
+ARTIFACT_TYPE := archive
+OBJECTS := pugixml$(OBJEXT)
+
+include $(top_srcdir)/omrmakefiles/rules.mk


### PR DESCRIPTION
Some downstream projects building with OMR do not use CMake.  When pugixml was updated to version 1.8 the makefile was omitted (it was actually a file ignored by git).  The 1.5 makefile builds 1.8 correctly.

This PR re-introduces that makefile for such downstream projects.