### PR TITLE
Reverts omrsigcompat artifact type to c_shared

### DIFF
--- a/omrsigcompat/makefile
+++ b/omrsigcompat/makefile
@@ -24,7 +24,7 @@ top_srcdir := ..
 include $(top_srcdir)/omrmakefiles/configure.mk
 
 MODULE_NAME := omrsig
-ARTIFACT_TYPE := cxx_shared
+ARTIFACT_TYPE := c_shared
 OBJECTS := omrsig
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 ifeq (win,$(OMR_HOST_OS))


### PR DESCRIPTION
Reverts changes from https://github.com/eclipse/omr/pull/7435 