### PR TITLE
Guarantee new array will be zero initialized in transformArrayCloneCall

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -4120,7 +4120,7 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::
          }
       else
          {
-         TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateNewArrayNoZeroInitSymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
+         TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateNewArraySymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
          TR::Node::recreateWithoutProperties(callNode, TR::newarray, 2, lenNode, typeConst, symRef);
          callNode->setCanSkipZeroInitialization(true);
          }


### PR DESCRIPTION
Guarantee that `newarray`s generated from transformations of array clone calls will always be zero initialized, ensuring array allocation is done inline, whether `TR_disableSkipZeroInitInVP` is enabled or not.

While investigation and development into a fix for a bug caused by corruption of a TLH pointer forcing out of line array allocation when we skip zero initialization is ongoing, this PR will provide a temporary performance boost at the (rare and minor) expense of occasional zero initialization of arrays that don't need to be zero initialized.