### PR TITLE
Accelerate Unsafe CAS Intrinsics on Z

### DIFF
--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -435,7 +435,7 @@ bool TR_RedundantAsyncCheckRemoval::callDoesAnImplicitAsyncCheck(TR::Node *callN
       return false;
 
    if (symbol->isNative() &&
-       (comp()->target().cpu.isPower() || comp()->target().cpu.isX86()) &&
+       (comp()->target().cpu.isPower() || comp()->target().cpu.isX86() || comp()->target().cpu.isZ()) &&
        ((symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeInt) ||
         (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeLong) ||
         (symbol->getRecognizedMethod()==TR::jdk_internal_misc_Unsafe_compareAndExchangeObject) ||


### PR DESCRIPTION
Support for acceleration of `compareAndExchange[Int|Long|Reference]` has been extended to Z. As a result, the check in
`callDoesAnImplicitAsyncCheck` needs to be updated as well.

Edit:
Should be checked in before: https://github.com/eclipse-openj9/openj9/pull/20308
 Ideally merged as a pair.