### PR TITLE
Remove no longer valid assert in OMRMemoryReference

### DIFF
--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1003,7 +1003,6 @@ OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
 
       case 5:
          displacement = self()->getDisplacement();
-         TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          if (displacement == 0 &&
              !base->needsDisp() &&
              !base->needsSIB() &&
@@ -1033,7 +1032,6 @@ OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
 
       case 7:
          displacement = self()->getDisplacement();
-         TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          if (displacement >= -128 &&
              displacement <= 127  &&
              !self()->isForceWideDisplacement())


### PR DESCRIPTION
The assert on IS_32BIT_SIGNED for displacement in estimateBinaryLength() no longer accurately reflects expected behavior. When using a debug build, coming from the caller in [OMR::X86::AMD64::MemoryReference::estimateBinaryLength()](https://github.com/eclipse/omr/blob/13d47ea4def377422793a23813b6b25c76bbd56d/compiler/x/amd64/codegen/OMRMemoryReference.cpp#L382), it is possible to hit this assert with a non-null _addressRegister and a displacement that is > 0x7FFFFFFF (for example, displacement=0x80000000, which is not a valid signed 32-bit int) since the control flow changed in https://github.com/eclipse/omr/pull/6937. The code appears to function correctly, except for hitting the assert (and, indeed, with the assert disabled or in a non-debug build there is no problem). The scenario described in the following issue from OpenJ9 recounts a fairly similar situation to what we have seen: https://github.com/eclipse-openj9/openj9/issues/20066. Based on these observations, it seems to me the assert itself is no longer valid and can be removed.