### PR TITLE
Use fallocate instead of ftruncate

### DIFF
--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1164,8 +1164,8 @@ reserve_memory_with_mmap(struct OMRPortLibrary *portLibrary, void *address, uint
 			fd = mkostemp(filename, 0);
 			if (OMRPORT_INVALID_FD != fd) {
 				unlink(filename);
-				/* Set the file size with ftruncate. */
-				if (OMRPORT_INVALID_FD == ftruncate(fd, byteAmount)) {
+				/* Set the file size with fallocate . */
+				if (OMRPORT_INVALID_FD == fallocate(fd, 0, 0, byteAmount)) {
 					close(fd);
 					fd = OMRPORT_INVALID_FD;
 				}


### PR DESCRIPTION
Even if the ftruncate() system call succeeds, this does not guarantee that the underlying filesystem has enough free blocks to support whatever increase in file size that was requested. This can cause SIGBUS errors if writes are attempted in the file.

The fallocate() call does guarantee that there is enough space available.

Fixes: https://github.com/eclipse-openj9/openj9/issues/20239