### PR TITLE
Specify unsupported features blocked by XLC v2r1

### DIFF
--- a/doc/SupportedC++Features.md
+++ b/doc/SupportedC++Features.md
@@ -73,11 +73,6 @@ The supported language and library features are set by the minimum compiler vers
 * Variadic macros: `#define m(p, ...)`, `__VA_ARGS__`
 * `__func__` macro
 * `long long`
-* Lambda expressions and closures: `[](int i) -> int { return i + 1; }`
-* Generalized attributes: `[[attribute]]`
-* Null pointer constant: `nullptr`
-* Alignment support: `alignas`, `alignof`
-* Explicit conversion operators
 
 ## Unsupported C++11 Features
 
@@ -104,3 +99,8 @@ The supported language and library features are set by the minimum compiler vers
 * New character types: `char16_t`, `char32_t` (MSVC 2010)
 * Extended sizeof (sizeof nested structures) (XLC 12.1)
 * ref qualifiers on member functions: `int my_member() &&;` (MSVC 2010)
+* Lambda expressions and closures: `[](int i) -> int { return i + 1; }` (XLC v2r1)
+* Generalized attributes: `[[attribute]]` (XLC v2r1)
+* Null pointer constant: `nullptr` (XLC v2r1)
+* Alignment support: `alignas`, `alignof` (XLC v2r1)
+* Explicit conversion operators (XLC v2r1)


### PR DESCRIPTION
Some features were moved from the unsupported list to the supported list because they were previously specified to be blocked by an older GCC version. They are actually blocked by the XLC version, and need to be re-added to the unsupported list.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>