### PR TITLE
Add the correct address as ClassUnloading PicSite in POWER LE

### DIFF
--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -300,8 +300,11 @@ OMR::ConstantDataSnippet::emitAddressConstant(PPCConstant<intptr_t> *acursor, ui
          {
          // Register an unload assumption on the lower 32bit of the class constant.
          // The patching code thinks it's low bit tagging an instruction not a class pointer!!
+         int PICOffset = 0; // For LE or BE 32-bit
+         if (cg()->comp()->target().cpu.isBigEndian() && cg()->comp()->target().is64Bit())
+            PICOffset = 4;
          cg()->
-         jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+((cg()->comp()->target().is64Bit())?4:0)) );
+         jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+PICOffset));
          }
       }
 


### PR DESCRIPTION
POWER patches class unload constants by `value |= 1` of a 32bit value given it might be an instruction, to correctly invalidate the constant we offset the `acursor` differently for LE and BE to overwrite the least-significant bit in the constant.

Closes eclipse-openj9/openj9#20263
Maybe eclipse-openj9/openj9#20261
Maybe eclipse-openj9/openj9#19884