### PR TITLE
Remove dead code from CopyPropagation and UseDefInfo

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -1159,9 +1159,7 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
       if (node->getOpCode().hasSymbolReference())
          {
          TR::SymbolReference *symRef = node->getSymbolReference();
-#ifndef PROPAGATE_GLOBALS
          if (symRef->getReferenceNumber() == copySymbolReference->getReferenceNumber())
-#endif
             {
             if (node->getOpCode().isLoadIndirect())
                {
@@ -1396,13 +1394,11 @@ void TR_CopyPropagation::replaceCopySymbolReferenceByOriginalIn(TR::SymbolRefere
             }
          }
 
-#ifndef PROPAGATE_GLOBALS
       for (int i = 0; i < node->getNumChildren(); i++)
          {
          TR::Node *child = node->getChild(i);
          replaceCopySymbolReferenceByOriginalIn(copySymbolReference, origNode, child, defNode);
          }
-#endif
       }
    }
 
@@ -1589,21 +1585,11 @@ TR::Node *TR_CopyPropagation::areAllDefsInCorrectForm(TR::Node *useNode, const T
 
       TR::SymbolReference *copySymbolReference = defNode->getSymbolReference();
 
-#ifdef PROPAGATE_GLOBALS
-      if (!defNode->getOpCode().isStore())
-         return NULL;
-#else
       if (!defNode->getOpCode().isStoreDirect())
          return NULL;
-#endif
 
-#ifdef PROPAGATE_GLOBALS
-      if (!useDefInfo->isPreciseDef(defNode, useNode))
-         return NULL;
-#else
       if (!defNode->getSymbolReference()->getSymbol()->isAutoOrParm())
          return NULL;
-#endif
 
       if (defNode->getDataType() != useNode->getDataType() ||
           defNode->getSize() != useNode->getSize())
@@ -1927,15 +1913,9 @@ bool TR_CopyPropagation::isCorrectToPropagate(TR::Node *useNode, TR::Node *store
          {
          return true;
          }
-#ifdef PROPAGATE_GLOBALS
-      else if (_lookForOriginalDefs &&
-               currentNode->getOpCode().isStore() &&
-               defs.ValueAt(currentNode->getUseDefIndex()-useDefInfo->getFirstDefIndex()))
-#else
       else if (_lookForOriginalDefs &&
               currentNode->getOpCode().isStoreDirect() &&
               currentNode->getSymbolReference() == storeNode->getSymbolReference())
-#endif
          {
          return true;
          }
@@ -2014,15 +1994,9 @@ bool TR_CopyPropagation::isRedefinedBetweenStoreTreeAnd(TR::list< TR::Node *> & 
             visitPredecessors = false;
             break;
             }
-#ifdef PROPAGATE_GLOBALS
-         else if (_lookForOriginalDefs &&
-                  currentNode->getOpCode().isStore() &&
-                  defs.ValueAt(currentNode->getUseDefIndex()-useDefInfo->getFirstDefIndex()))
-#else
          else if (_lookForOriginalDefs &&
                  currentNode->getOpCode().isStoreDirect() &&
                  currentNode->getSymbolReference() == storeNode->getSymbolReference())
-#endif
             {
             visitPredecessors = false;
             break;
@@ -2091,15 +2065,9 @@ bool TR_CopyPropagation::recursive_isRedefinedBetweenStoreTreeAnd(TR::list< TR::
          {
          return false;
          }
-#ifdef PROPAGATE_GLOBALS
-      else if (_lookForOriginalDefs &&
-               currentNode->getOpCode().isStore() &&
-               defs.ValueAt(currentNode->getUseDefIndex()-useDefInfo->getFirstDefIndex()))
-#else
       else if (_lookForOriginalDefs &&
               currentNode->getOpCode().isStoreDirect() &&
               currentNode->getSymbolReference() == storeNode->getSymbolReference())
-#endif
          {
          return false;
          }

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -211,7 +211,6 @@ class TR_UseDefInfo
 
    bool getUseDefIsZero(int32_t useIndex);
    bool getUseDef(BitVector &useDef, int32_t useIndex);
-   bool getUseDef_noExpansion(BitVector &useDef, int32_t useIndex);
    private:
    const BitVector &getUseDef_ref(int32_t useIndex, BitVector *defs = NULL);
    const BitVector &getUseDef_ref_body(int32_t useIndex, TR_BitVector *visitedDefs, TR_UseDefInfo::BitVector *defs = NULL);
@@ -243,9 +242,6 @@ class TR_UseDefInfo
 
    // For Languages where an auto can alias a volatile, extra care needs to be taken when setting up use-def
    // The conservative answer is to not index autos that have volatile aliases.
-
-   void setVolatileSymbolsIndexAndRecurse(TR::BitVector &volatileSymbols, int32_t symRefNum);
-   void findAndPopulateVolatileSymbolsIndex(TR::BitVector &volatileSymbols);
 
    bool shouldIndexVolatileSym(TR::SymbolReference *ref, AuxiliaryData &aux);
 
@@ -321,8 +317,6 @@ class TR_UseDefInfo
    public:
    int32_t getNumSymbols() { return _numSymbols; }
    int32_t getMemorySymbolIndex (TR::Node *);
-   bool isPreciseDef(TR::Node *def, TR::Node *use);
-   bool isChildUse(TR::Node *node, int32_t childIndex);
 
    public:
    bool     _useDefForRegs;


### PR DESCRIPTION
- Remove unused `PROPAGATE_GLOBALS` macro
- Remove unused `TR_UseDefInfo` methods
  - `getUseDef_noExpansion`
  - `setVolatileSymbolsIndexAndRecurse`
  - `findAndPopulateVolatileSymbolsIndex`
  - `isPreciseDef`
  - `isChildUse`