### PR TITLE
Set Evaluation Priority Only For non-Treetop Nodes

### DIFF
--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -295,7 +295,13 @@ OMR::CodeGenerator::whichChildToEvaluate(TR::Node * node)
          }
       }
 
-   node->setEvaluationPriority(nodePriority);
+   // Do not set the evaluation priority of a treetop node, since evaluation priority
+   // is only meaningful for nodes yielding values, and treetops do not yield values.
+   if (!node->getOpCode().isTreeTop())
+      {
+      node->setEvaluationPriority(nodePriority);
+      }
+
    return bestChild;
    }
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -4492,6 +4492,11 @@ OMR::Node::getEvaluationPriority(TR::CodeGenerator * cg)
 int32_t
 OMR::Node::setEvaluationPriority(int32_t p)
    {
+   // Setting the evaluation priority of a treetop is not meaningful since they do not yield value
+   // In addition, _unionA is also used for guards (which are always treetops), and setting
+   // priorities for them would cause conflict.
+   TR_ASSERT(!self()->getOpCode().isTreeTop(), "cannot set evaluation priority of a treetop");
+
    if (_unionA._register == 0 ||            // not evaluated, priority unknown
        ((uintptr_t)(_unionA._register) & 1))  // not evaluated, priority known
       {


### PR DESCRIPTION
Set up an assertion to ensure OMR::Node::setEvaluationPriority is only called for nodes not at treetops, and guard against any calls made for nodes at treetops; prevent the assertion failure if the node is also a guard.