### PR TITLE
Update verbosegc allocation stats for off-heap

### DIFF
--- a/example/glue/ArrayletObjectModel.hpp
+++ b/example/glue/ArrayletObjectModel.hpp
@@ -57,14 +57,6 @@ public:
 	{
 		/* No-op */
 	}
-
-	MMINLINE void
-	fixupDataAddr(MM_ForwardedHeader *forwardedHeader, omrobjectptr_t arrayPtr)
-	{
-#if defined(OMR_ENV_DATA64)
-		Assert_MM_unreachable();
-#endif /* defined(OMR_ENV_DATA64) */
-	}
 	
 	/**
 	 * Returns the size of an indexable object, in bytes, including the header.

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -894,8 +894,14 @@ MM_VerboseHandlerOutput::printAllocationStats(MM_EnvironmentBase* env)
 
 	if (_extensions->isVLHGC()) {
 #if defined(OMR_GC_VLHGC)
-		writer->formatAndOutput(env, 1, "<allocated-bytes non-tlh=\"%zu\" tlh=\"%zu\" arrayletleaf=\"%zu\"/>",
+		if (_extensions->isVirtualLargeObjectHeapEnabled) {
+			writer->formatAndOutput(env, 1, "<allocated-bytes non-tlh=\"%zu\" tlh=\"%zu\" offheap=\"%zu\"/>",
 				systemStats->nontlhBytesAllocated(), systemStats->tlhBytesAllocated(), systemStats->_arrayletLeafAllocationBytes);
+
+		} else {
+			writer->formatAndOutput(env, 1, "<allocated-bytes non-tlh=\"%zu\" tlh=\"%zu\" arrayletleaf=\"%zu\"/>",
+				systemStats->nontlhBytesAllocated(), systemStats->tlhBytesAllocated(), systemStats->_arrayletLeafAllocationBytes);
+		}
 #endif /* OMR_GC_VLHGC */
 	} else if (_extensions->isStandardGC()) {
 #if defined(OMR_GC_MODRON_STANDARD)

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -358,6 +358,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="non-tlh" type="integer" use="required" />
 		<attribute name="tlh" type="integer" use="optional" />
 		<attribute name="arrayletleaf" type="integer" use="optional" />
+		<attribute name="offheap" type="integer" use="optional" />
 	</complexType>
 
 	<complexType name="largest-consumer">


### PR DESCRIPTION
 - Report offheap bytes in <allocated-bytes> for off-heap enabled case vs arrayletleaf bytes for off-heap disabled case.
 - Remove unuse function fixupDataAddr in example/glue