### PR TITLE
x86: Support BMI2 instructions

### DIFF
--- a/compiler/x/codegen/OMRInstOpCode.cpp
+++ b/compiler/x/codegen/OMRInstOpCode.cpp
@@ -86,7 +86,7 @@ template <typename TBuffer> typename TBuffer::cursor_t OMR::X86::InstOpCode::OpC
 
    if (encoding == OMR::X86::Default)
       {
-      enc = comp->target().cpu.supportsAVX() ? vex_l : OMR::X86::Legacy;
+      enc = (comp->target().cpu.supportsAVX() || vex_l == VEX_LZ) ? vex_l : OMR::X86::Legacy;
       }
 
    TBuffer buffer(cursor);
@@ -107,7 +107,7 @@ template <typename TBuffer> typename TBuffer::cursor_t OMR::X86::InstOpCode::OpC
 
    if (enc != VEX_L___)
       {
-      if (enc >> 2)
+      if (enc >> 2 && enc != VEX_LZ)
          {
          TR::Instruction::EVEX vex(rex, modrm_opcode);
          vex.mm = escape;

--- a/compiler/x/codegen/OMRInstOpCode.hpp
+++ b/compiler/x/codegen/OMRInstOpCode.hpp
@@ -248,6 +248,7 @@ class InstOpCode: public OMR::InstOpCode
       EVEX_L128 = 0x4,
       EVEX_L256 = 0x5,
       EVEX_L512 = 0x6,
+      VEX_LZ    = 0x8, // L bits are 0; Skip 0x7 to keep two low bits 0
       };
    enum TR_OpCodeVEX_v : uint8_t
       {
@@ -293,7 +294,7 @@ class InstOpCode: public OMR::InstOpCode
       };
    struct OpCode_t
       {
-      uint8_t vex_l : 3;
+      uint8_t vex_l : 4;
       uint8_t vex_v : 1;
       uint8_t prefixes : 3;
       uint8_t rex_w : 1;

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -4951,7 +4951,6 @@ TR::X86RegRegRegInstruction  *
 generateRegRegRegInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * reg1, TR::Register * reg2, TR::Register * reg3, TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
    {
    TR_ASSERT_FATAL(encoding != OMR::X86::Legacy, "Cannot use legacy SSE encoding for 3-operand instruction");
-   TR_ASSERT_FATAL(encoding == OMR::X86::Default ? cg->comp()->target().cpu.supportsAVX() : true, "Cannot use legacy SSE encoding for 3-operand instruction");
 
    return new (cg->trHeapMemory()) TR::X86RegRegRegInstruction(op, node, reg1, reg2, reg3, cg, encoding);
    }
@@ -5132,7 +5131,7 @@ generateRegRegRegInstruction(TR::InstOpCode::Mnemonic            op,
                              OMR::X86::Encoding               encoding)
    {
    TR_ASSERT_FATAL(encoding != OMR::X86::Legacy, "Cannot use legacy SSE encoding for 3-operand instruction");
-   TR_ASSERT_FATAL(encoding == OMR::X86::Default ? cg->comp()->target().cpu.supportsAVX() : true, "Cannot use legacy SSE encoding for 3-operand instruction");
+
    return new (cg->trHeapMemory()) TR::X86RegRegRegInstruction(op, node, reg1, reg2, reg3, cond, cg, encoding);
    }
 
@@ -5140,7 +5139,7 @@ TR::X86RegRegMemInstruction  *
 generateRegRegMemInstruction(TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * reg1, TR::Register * reg2, TR::MemoryReference  * mr, TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
    {
    TR_ASSERT_FATAL(encoding != OMR::X86::Legacy, "Cannot use legacy SSE encoding for 3-operand instruction");
-   TR_ASSERT_FATAL(encoding == OMR::X86::Default ? cg->comp()->target().cpu.supportsAVX() : true, "Cannot use legacy SSE encoding for 3-operand instruction");
+
    return new (cg->trHeapMemory()) TR::X86RegRegMemInstruction(op, node, reg1, reg2, mr, cg, encoding);
    }
 
@@ -5155,7 +5154,7 @@ generateRegRegMemInstruction(TR::InstOpCode::Mnemonic                     op,
                              OMR::X86::Encoding encoding)
    {
    TR_ASSERT_FATAL(encoding != OMR::X86::Legacy, "Cannot use legacy SSE encoding for 3-operand instruction");
-   TR_ASSERT_FATAL(encoding == OMR::X86::Default ? cg->comp()->target().cpu.supportsAVX() : true, "Cannot use legacy SSE encoding for 3-operand instruction");
+
    return new (cg->trHeapMemory()) TR::X86RegRegMemInstruction(op, node, reg1, reg2, mr, cond, cg, encoding);
    }
 


### PR DESCRIPTION
We discovered an issue when trying to add BMI2 instructions which are non-vector instructions using the VEX prefix. BMI2 instructions could not be correctly generated if AVX is unavailable.