### PR TITLE
Adds `yield` instruction for Power

### DIFF
--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -542,6 +542,7 @@
    xoris,            // XOR immediate shifted
    nop,              // NoOp (ori)
    genop,            // Group Ending NoOp (ori)
+   yield,            // Shared Resource Hint NoOp (or) (only on certain implementations, normal nop elsewhere)
    shdfence,         // Scheduling Fence
 // rxor,             // Rotate & XOR
    wrtbar,           // Write barrier directive

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -6308,6 +6308,21 @@
    /* .properties  = */ PPCOpProp_SyncSideEffectFree,
    },
 
+   /*
+    * yield is effective on Power 7 and Power 8 but may not be supported elsewhere.
+    * It is interpreted as a regular nop on unsupported implementations.
+    */
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::yield,
+   /* .name        = */ "yield",
+   /* .description =    "Shared Resource Hint NoOp (or)", */
+   /* .prefix      = */ 0x00000000,
+   /* .opcode      = */ 0x7F7BDB78,
+   /* .format      = */ FORMAT_DIRECT,
+   /* .minimumALS  = */ OMR_PROCESSOR_PPC_UNKNOWN,
+   /* .properties  = */ PPCOpProp_SyncSideEffectFree,
+   },
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::shdfence,
    /* .name        = */ "shdfence",

--- a/fvtest/compilerunittest/p/BinaryEncoder.cpp
+++ b/fvtest/compilerunittest/p/BinaryEncoder.cpp
@@ -1087,7 +1087,8 @@ INSTANTIATE_TEST_CASE_P(Special, PPCDirectEncodingTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::lwsync,   TRTest::BinaryInstruction("7c2004ac"), false),
     std::make_tuple(TR::InstOpCode::sync,     TRTest::BinaryInstruction("7c0004ac"), false),
     std::make_tuple(TR::InstOpCode::nop,      TRTest::BinaryInstruction("60000000"), false),
-    std::make_tuple(TR::InstOpCode::pnop,     TRTest::BinaryInstruction("0700000000000000"), true)
+    std::make_tuple(TR::InstOpCode::pnop,     TRTest::BinaryInstruction("0700000000000000"), true),
+    std::make_tuple(TR::InstOpCode::yield,    TRTest::BinaryInstruction("7f7bdb78"), false)
 ));
 
 INSTANTIATE_TEST_CASE_P(Special, PPCLabelEncodingTest, ::testing::Values(
@@ -1109,7 +1110,8 @@ INSTANTIATE_TEST_CASE_P(Special, PPCRecordFormSanityTest, ::testing::Values(
     std::make_tuple(TR::InstOpCode::label,    TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::lwsync,   TR::InstOpCode::bad, TRTest::BinaryInstruction()),
     std::make_tuple(TR::InstOpCode::sync,     TR::InstOpCode::bad, TRTest::BinaryInstruction()),
-    std::make_tuple(TR::InstOpCode::nop,      TR::InstOpCode::bad, TRTest::BinaryInstruction())
+    std::make_tuple(TR::InstOpCode::nop,      TR::InstOpCode::bad, TRTest::BinaryInstruction()),
+    std::make_tuple(TR::InstOpCode::yield,    TR::InstOpCode::bad, TRTest::BinaryInstruction())
 ));
 
 INSTANTIATE_TEST_CASE_P(Branch, PPCDirectEncodingTest, ::testing::Values(


### PR DESCRIPTION
Adds properties for the `yield` instruction on Power.

Also adds binary encoder tests for `yield`.