### PR TITLE
Add donated scratch regs to dependency list only when they are used

### DIFF
--- a/compiler/codegen/ScratchRegisterManager.hpp
+++ b/compiler/codegen/ScratchRegisterManager.hpp
@@ -33,9 +33,10 @@ namespace TR { class RegisterDependencyConditions; }
 
 enum TR_ManagedScratchRegisterStates
    {
-   msrUnassigned = 0x00,    // no register associated
-   msrAllocated  = 0x01,    // register has been allocated
-   msrDonated    = 0x02     // register was donated to the list (not allocated)
+   msrUnassigned  = 0x00,  // no register associated
+   msrAllocated   = 0x01,  // register has been allocated
+   msrDonated     = 0x02,  // register was donated to the list (not allocated)
+   msrUsedDonated = 0x04   // register was donated to the list has been used at least once
    };
 
 class TR_ManagedScratchRegister


### PR DESCRIPTION
Adds msrUsedDonated flag to mark that a donated scratch register has been used.

If using `findOrCreateScratchRegister` within ICF and there are no free registers, `cg->allocateRegister` is called causing a fatal assertion
`TR_ASSERT_FATAL(false, "Attempting to assign a register (%s) inside ICF", getRegisterName(targetRegister, self()->cg()));`
Thus, we have to donate registers before entering an internal control flow region where we request a scratch register.

For example, there are cases where we need at most 2 scratch registers, and the use of the second register is guarded by an if statement (i.e. in the java superclass test on Z):
```
void genSuperclassTest(..., ScratchRegisterManager *srm, ...) {
    ...
    TR::Register *castClassDepthReg = NULL;
    if (castClassDepth == -1) { // we do not know the depth at compile time
        castClassDepthReg = srm->findOrCreateScratchRegister();
    }
    ....
    TR::Register *objClassDepthReg = srm->findOrCreateScratchRegister();
}
```
Since the superclass test is generated inside an ICF region, we need to allocate the 2 registers before entering the region. But when `castClassDepth != -1`, we never use one of the donated registers. Adding this unused register to the dependency list results in an extra real register being allocated.

This change allows the Scratch Register Manager to treat donated and non-donated registers in the same way: `they are only added to the dependency list if they are actually used`. This way, we allow the user to set the capacity of the scratch register manager to the maximum amount they need, and donate how ever many they want (up to the maximum), without worrying about whether all donated registers are used in all cases.