### PR TITLE
Merge Read Barrier copy stats

### DIFF
--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -563,31 +563,40 @@ public:
 
 	/**
 	 * Clear global (not thread local) stats for current phase/increment
-	 * @param firstIncrement true if first increment in a cycle
+	 * @param env[in] the current thread
+	 * @param firstIncrement[in] true if first increment in a cycle
 	 */
 	void clearIncrementGCStats(MM_EnvironmentBase *env, bool firstIncrement);
 	/**
-	 * Clear global (not thread local) cumulative cycle stats 
+	 * Clear global (not thread local) cumulative cycle stats
+	 * @param env[in] the current thread
 	 */
 	void clearCycleGCStats(MM_EnvironmentBase *env);
 	/**
 	 * Clear thread local stats for current phase/increment
-	 * @param firstIncrement true if first increment in a cycle
+	 * @param env[in] the current thread
+	 * @param firstIncrement[in] true if first increment in a cycle
 	 */
 	void clearThreadGCStats(MM_EnvironmentBase *env, bool firstIncrement);
 	/**
 	 * Merge thread local stats for current phase/increment in to global current increment stats
+	 * @param env[in] the current thread
 	 */	
 	void mergeThreadGCStats(MM_EnvironmentBase *env);
 	/**
 	 * Merge global current increment stats in to global cycle stats
-	 * @param firstIncrement true if last increment in a cycle
+	 * @param env[in] the current thread
+	 * @param firstIncrement[in] true if last increment in a cycle
 	 */		
 	void mergeIncrementGCStats(MM_EnvironmentBase *env, bool lastIncrement);
 	/**
 	 * Common merge logic used for both thread and increment level merges.
+	 * @param env[in] the current thread
+	 * @param finalGCStats[in/out] stats being added to
+	 * @param scavStats[in] stats being added from
 	 */
 	void mergeGCStatsBase(MM_EnvironmentBase *env, MM_ScavengerStats *finalGCStats, MM_ScavengerStats *scavStats);
+
 	bool canCalcGCStats(MM_EnvironmentStandard *env);
 	void calcGCStats(MM_EnvironmentStandard *env);
 
@@ -743,6 +752,14 @@ public:
 	virtual void preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats);
 	virtual uintptr_t mainThreadConcurrentCollect(MM_EnvironmentBase *env);
 	virtual void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned);
+
+	/**
+	 * Merge RB increment stats to general increment stats.
+	 * RB occasionally updates separate copy stats fields in the increment stats,
+	 * but eventually those values need to be added to the general copy increment stats.
+	 * @param env[in] the current thread
+	 */
+	void mergeReadBarrierStats(MM_EnvironmentBase *env);
 
 	/* main thread specific methods */
 	bool scavengeIncremental(MM_EnvironmentBase *env);

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -96,6 +96,8 @@ MM_ScavengerStats::MM_ScavengerStats()
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	,_readObjectBarrierCopy(0)
 	,_readObjectBarrierUpdate(0)
+	,_readObjectBarrierFlipBytes(0)
+	,_readObjectBarrierTenureBytes(0)
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	,_flipHistoryNewIndex(0)
 {
@@ -205,6 +207,8 @@ MM_ScavengerStats::clear(bool firstIncrement)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	_readObjectBarrierCopy = 0;
 	_readObjectBarrierUpdate = 0;
+	_readObjectBarrierFlipBytes = 0;
+	_readObjectBarrierTenureBytes = 0;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	_leafObjectCount = 0;

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -152,6 +152,8 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	uint64_t _readObjectBarrierCopy; /**< Number of objects copied by read barrier */
 	uint64_t _readObjectBarrierUpdate; /**< Number of reference slots updates, which may be (often is) preceded by object copy */ 
+	uint64_t _readObjectBarrierFlipBytes; /**< Bytes flipped through read barrier. Meaningful in the global-incremental stats struct, but not in a thread local. */
+	uint64_t _readObjectBarrierTenureBytes; /**< Bytes tenured through read barrier. Meaningful in the global-incremental stats struct, but not in a thread local. */
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 protected:


### PR DESCRIPTION
Introduce new separate copy stats fields where Read Barrier can accumulate its own values. Those stats fields are eventually appended to the general copy stats.

There are kept separate for future usage, to be able to monitor RB storms.

RB will incrementally update these new fields in a separate PR. For now, they are only updated  only a couple of times very close to end of the concurrent phase.