### PR TITLE
Add an alternative way to unmap heapProxyObject

### DIFF
--- a/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
+++ b/gc/base/SparseAddressOrderedFixedSizeDataPool.hpp
@@ -30,6 +30,8 @@
 #include "GCExtensionsBase.hpp"
 #include "SparseHeapLinkedFreeHeader.hpp"
 
+class GC_HashTableIterator;
+
 /**
  *
  * @ingroup GC_Base_Core
@@ -148,10 +150,12 @@ public:
 	 * @param dataPtr       void*       Data pointer
 	 * @param proxyObjPtr   void*       Proxy object associated with dataPtr
 	 * @param size          uintptr_t   Size of region consumed by dataPtr
+	 * @param sparseDataEntryIterator GC_HashTableIterator* if it is not NULL,
+	 * 		using the iterator for removing the entry instead of finding the entry from the hashtable
 	 *
 	 * @return true if key associated to dataPtr is removed successfully, false otherwise.
 	 */
-	bool unmapSparseDataPtrFromHeapProxyObjectPtr(void *dataPtr, void *proxyObjPtr, uintptr_t size);
+	bool unmapSparseDataPtrFromHeapProxyObjectPtr(void *dataPtr, void *proxyObjPtr, uintptr_t size, GC_HashTableIterator *sparseDataEntryIterator);
 
 	/**
 	 * Get MM_SparseDataTableEntry associated with data pointer

--- a/gc/base/SparseVirtualMemory.cpp
+++ b/gc/base/SparseVirtualMemory.cpp
@@ -29,6 +29,7 @@
 #include "EnvironmentBase.hpp"
 #include "Forge.hpp"
 #include "GCExtensionsBase.hpp"
+#include "HashTableIterator.hpp"
 #include "Math.hpp"
 #include "ModronAssertions.h"
 #include "SparseVirtualMemory.hpp"
@@ -166,7 +167,7 @@ MM_SparseVirtualMemory::allocateSparseFreeEntryAndMapToHeapObject(void *proxyObj
 }
 
 bool
-MM_SparseVirtualMemory::freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBase *env, void *dataPtr, void *proxyObjPtr, uintptr_t size)
+MM_SparseVirtualMemory::freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBase *env, void *dataPtr, void *proxyObjPtr, uintptr_t size, GC_HashTableIterator *sparseDataEntryIterator)
 {
 	uintptr_t dataSize = _sparseDataPool->findObjectDataSizeForSparseDataPtr(dataPtr);
 	bool ret = true;
@@ -176,7 +177,7 @@ MM_SparseVirtualMemory::freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBas
 		ret = decommitMemory(env, dataPtr, adjustedSize);
 		if (ret) {
 			omrthread_monitor_enter(_largeObjectVirtualMemoryMutex);
-			ret = (_sparseDataPool->returnFreeListEntry(dataPtr, adjustedSize) && _sparseDataPool->unmapSparseDataPtrFromHeapProxyObjectPtr(dataPtr, proxyObjPtr, size));
+			ret = (_sparseDataPool->returnFreeListEntry(dataPtr, adjustedSize) && _sparseDataPool->unmapSparseDataPtrFromHeapProxyObjectPtr(dataPtr, proxyObjPtr, size, sparseDataEntryIterator));
 			omrthread_monitor_exit(_largeObjectVirtualMemoryMutex);
 			Trc_MM_SparseVirtualMemory_decommitMemory_success(dataPtr, (void *)adjustedSize);
 		} else {

--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -38,6 +38,7 @@
 #include "HeapRegionManager.hpp"
 #include "VirtualMemory.hpp"
 
+class GC_HashTableIterator;
 class MM_GCExtensions;
 class MM_GCExtensionsBase;
 class MM_Heap;
@@ -124,10 +125,11 @@ public:
 	 * @param dataPtr       void*       Data pointer
 	 * @param proxyObjPtr   void*       Proxy object associated with dataPtr
 	 * @param size          uintptr_t   Size of region consumed by dataPtr
+ 	 * @param sparseDataEntryIterator GC_HashTableIterator*   if it is not NULL, For UnmapFromHeapObject
 	 *
 	 * @return true if region associated to object was decommited and freed successfully, false otherwise
 	 */
-	bool freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBase *env, void *dataPtr, void *proxyObjPtr, uintptr_t size);
+	bool freeSparseRegionAndUnmapFromHeapObject(MM_EnvironmentBase *env, void *dataPtr, void *proxyObjPtr, uintptr_t size, GC_HashTableIterator *sparseDataEntryIterator = NULL);
 	/**
 	 * Decommits/Releases memory, returning the associated pages to the OS
 	 *


### PR DESCRIPTION
sparseDataPool use the hashTable to map the heapProxyObject and the related allocated sparse heap address internally, for unmapping heapProxyObject need to get related entry from hashTable via hashTableFind() and remove it via hashTableRemove(), but if the heapProxyObjects are retrieved from iterator of the hashTable, hashTableFind() and hashTableRemove() could interfere the iterator, so add an alternative option to unmapping heapArrayObject via iterator to avoid conflict.