### PR TITLE
x86: Require AVX support for bit compress/expand

### DIFF
--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -126,7 +126,7 @@ void OMR::X86::AMD64::CodeGenerator::initialize()
       _maxObjectSizeGuaranteedNotToOverflow = (uint32_t)INT_MAX;
       }
 
-   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2))
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2) && comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX))
       {
       static bool disableBitwiseCompress = feGetEnv("TR_disableBitwiseCompress") != NULL;
       if (!disableBitwiseCompress)

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -133,7 +133,7 @@ OMR::X86::I386::CodeGenerator::initialize()
    if (!dontConsiderAllAutosForGRA)
       cg->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
 
-   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2))
+   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_BMI2) && comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX))
       {
       static bool disableBitwiseCompress = feGetEnv("TR_disableBitwiseCompress") != NULL;
       if (!disableBitwiseCompress)


### PR DESCRIPTION
AVX support is required to generate VEX prefix for pext and pdep instructions.