### PR TITLE
Implement mAnyTrue and mmAnyTrue

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1890,6 +1890,12 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
             return true;
          else
             return false;
+      case TR::mAnyTrue:
+      case TR::mmAnyTrue:
+            if (cpu->isAtLeast(OMR_PROCESSOR_PPC_P8))
+               return true;
+            else
+               return false;
       case TR::vload:
       case TR::vloadi:
       case TR::vstore:


### PR DESCRIPTION
Implement PPC codegen for `mAnyTrue` and `mmAnyTrue` for Byte, Short, Int, and LongVectors on P8+

A brief summary of the opcode semantics: `mAnyTrue` takes a vector mask as input and returns true if at least one mask lanes are set (i.e.: if the mask is NOT all 0's). Otherwise, it returns false. `mmAnyTrue` is the same, but with a mask applied to the input beforehand. (See [VectorMask.anyTrue()](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorMask.html#anyTrue()))

