### PR TITLE
Add TR_JProfiler object type in TR_Memory

### DIFF
--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -107,7 +107,7 @@ const char *objectName[] = { "Array", "Instruction", "ListElement", "Node", "Bit
 
     "TR_IPMethodTable", "TR_IPCCNode", "IPHashedCallSite", "Assumptions", "PatchSites",
 
-    "TR_ZHWProfiler", "TR_PPCHWProfiler", "TR_ZGuardedStorage",
+    "TR_ZHWProfiler", "TR_PPCHWProfiler", "TR_ZGuardedStorage", "TR_JProfiler",
 
     "CatchTable",
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -410,6 +410,7 @@ public:
         ZHWProfiler,
         PPCHWProfiler,
         ZGuardedStorage,
+        JProfiler,
 
         CatchTable,
 


### PR DESCRIPTION
This commit adds a TR_JProfiler object type in TR_Memory for persisten object related to JProfiler.