### PR TITLE
WIP: Add JProfBFPatchSites for Patching Block Frequency Info

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1885,6 +1885,8 @@ public:
 
     void addCountersToEdges(TR::Block *block);
 
+    int32_t getMaxLengthOfIncMemoryInstruction() { return 0; }
+
     bool getSupportsBitOpCodes() { return false; }
 
     bool getMappingAutomatics() { return _flags1.testAny(MappingAutomatics); }

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -107,7 +107,7 @@ const char *objectName[] = { "Array", "Instruction", "ListElement", "Node", "Bit
 
     "TR_IPMethodTable", "TR_IPCCNode", "IPHashedCallSite", "Assumptions", "PatchSites",
 
-    "TR_ZHWProfiler", "TR_PPCHWProfiler", "TR_ZGuardedStorage", "TR_JProfiler",
+    "JProfBFPatchSites", "TR_ZHWProfiler", "TR_PPCHWProfiler", "TR_ZGuardedStorage", "TR_JProfiler",
 
     "CatchTable",
 

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -407,6 +407,7 @@ public:
         Assumption,
         PatchSites,
 
+        JProfBFPatchSites,
         ZHWProfiler,
         PPCHWProfiler,
         ZGuardedStorage,

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -142,3 +142,90 @@ void TR::PatchSites::reclaim(PatchSites *sites)
         TR_PersistentMemory::jitPersistentFree(sites);
     }
 }
+
+TR::JProfBFPatchSites::JProfBFPatchSites(TR_PersistentMemory *pm, size_t maxSize, size_t counterBumpInstructionLength)
+    : _maxSize(maxSize)
+    , _size(0)
+    , _refCount(0)
+    , _patchPoints(NULL)
+    , _firstLocation(NULL)
+    , _lastLocation(NULL)
+    , _counterBumpInstructionLength(counterBumpInstructionLength)
+    , _bumpInstructions(NULL)
+{
+    size_t bytes = sizeof(uint8_t *) * maxSize;
+    _patchPoints = (uint8_t **)pm->jitPersistentAlloc(bytes);
+    size_t bumpInstructionListSize = sizeof(uint8_t) * (1 + _counterBumpInstructionLength) * maxSize;
+    _bumpInstructions = (uint8_t *)pm->jitPersistentAlloc(bumpInstructionListSize);
+}
+
+void TR::JProfBFPatchSites::add(uint8_t *location, uint8_t instrLength)
+{
+    TR_ASSERT_FATAL(_size < _maxSize, "Cannot add more patch sites, max size is %d", _maxSize);
+    _patchPoints[_size] = location;
+    size_t bumpInstrIndex = _size * (1 + _counterBumpInstructionLength);
+#if defined(TR_TARGET_X86)
+    TR_ASSERT_FATAL(instrLength == 2 || instrLength == 3 || instrLength == 4, "Unexpected instruction length %d\n",
+        instrLength);
+#elif defined(TR_TARGET_S390)
+    TR_ASSERT_FATAL(instrLength == 6, "Unexpected instruction length %d\n", instrLength);
+#endif
+    *(uint8_t *)(_bumpInstructions + bumpInstrIndex) = (uint8_t)instrLength;
+    bumpInstrIndex += sizeof(uint8_t);
+
+    for (uint8_t index = 0; index < instrLength; index += sizeof(uint8_t)) {
+        *(uint8_t *)(_bumpInstructions + bumpInstrIndex + index) = *(uint8_t *)(location + index);
+    }
+
+    _size++;
+
+    if (_firstLocation == NULL || location < _firstLocation)
+        _firstLocation = location;
+    if (_lastLocation == NULL || location > _lastLocation)
+        _lastLocation = location;
+}
+
+uint8_t *TR::JProfBFPatchSites::getLocation(size_t index)
+{
+    TR_ASSERT_FATAL(index < _size, "Invalid index %d for patchSite with size %d", index, _size);
+    return _patchPoints[index];
+}
+
+uint8_t *TR::JProfBFPatchSites::getBumpInstructionPointer(size_t index)
+{
+    TR_ASSERT_FATAL(index < _size, "Invalid index %d for patchSite with size %d", index, _size);
+    return (uint8_t *)(_bumpInstructions + (index * (1 + _counterBumpInstructionLength)));
+}
+
+void TR::JProfBFPatchSites::reclaim(JProfBFPatchSites *sites)
+{
+    TR_ASSERT(sites->_refCount > 0, "Attempt to reclaim patch sites without a reference");
+    sites->_refCount--;
+
+    if (sites->_refCount == 0) {
+        TR_PersistentMemory::jitPersistentFree(sites->_patchPoints);
+        TR_PersistentMemory::jitPersistentFree(sites->_bumpInstructions);
+        TR_PersistentMemory::jitPersistentFree(sites);
+    }
+}
+
+void TR::JProfBFPatchSites::addReference()
+{
+    _refCount++;
+    TR_ASSERT(_refCount > 0, "Reference count overflow");
+}
+
+bool TR::JProfBFPatchSites::equals(JProfBFPatchSites *other)
+{
+    if (other->getSize() != _size)
+        return false;
+
+    if (_firstLocation != other->getFirstLocation() || _lastLocation != other->getLastLocation())
+        return false;
+
+    for (size_t i = 0; i < _size; ++i) {
+        if (getLocation(i) != other->getLocation(i))
+            return false;
+    }
+    return true;
+}

--- a/compiler/runtime/OMRRuntimeAssumptions.hpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.hpp
@@ -472,6 +472,48 @@ private:
     PatchSites *_patchSites;
 }; // TR::PatchMultipleNOPedGuardSites
 
+class JProfBFPatchSites {
+private:
+    size_t _refCount;
+    size_t _size;
+    size_t _maxSize;
+    size_t _counterBumpInstructionLength;
+
+    /**
+     * For each JProfiling body with the capability of patching, would contain this runtime assumption.
+     * Runtime Assumption for the JProfiling method contains the pointers to the
+     * instruction that increments counters for block frequency and the
+     * instruction value.
+     * Instruction at each location is cached in this assumption to allow
+     * patching the points back to enable JProfiling.
+     */
+    uint8_t **_patchPoints;
+    uint8_t *_bumpInstructions;
+
+    // Cache lower and upper bounds
+    uint8_t *_firstLocation;
+    uint8_t *_lastLocation;
+
+public:
+    TR_PERSISTENT_ALLOC_THROW(TR_Memory::JProfBFPatchSites);
+    JProfBFPatchSites(TR_PersistentMemory *pm, size_t maxSize, size_t counterBumpInstructionLength);
+
+    size_t getSize() { return _size; }
+
+    uint8_t *getFirstLocation() { return _firstLocation; }
+
+    uint8_t *getLastLocation() { return _lastLocation; }
+
+    uint8_t *getLocation(size_t index);
+    uint8_t *getBumpInstructionPointer(size_t index);
+
+    void add(uint8_t *location, uint8_t instrLength);
+
+    void addReference();
+    bool equals(JProfBFPatchSites *other);
+    static void reclaim(JProfBFPatchSites *sites);
+};
+
 } // namespace TR
 
 #endif

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -501,6 +501,8 @@ public:
 
     bool getSupportsBitOpCodes() { return true; }
 
+    int32_t getMaxLengthOfIncMemoryInstruction() { return 4; }
+
     static bool getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpCode opcode, bool supportsOpMaskRegs = false);
     bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -557,6 +557,8 @@ public:
 
     bool getSupportsBitOpCodes() { return true; }
 
+    int32_t getMaxLengthOfIncMemoryInstruction() { return 6; }
+
     bool getSupportsImplicitNullChecks() { return _cgFlags.testAny(S390CG_implicitNullChecks); }
 
     void setSupportsImplicitNullChecks(bool b) { _cgFlags.set(S390CG_implicitNullChecks, b); }


### PR DESCRIPTION
This PR adds infrastructure and helper functions for patching counter increment
instructions in the compiled method with JProfiling to turn-off / in profiling
data collection.