### PR TITLE
Fix maxSpinThreads enforcement in spinlock acquire

### DIFF
--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -74,14 +74,18 @@ omrthread_spinlock_acquire(omrthread_t self, omrthread_monitor_t monitor)
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
 	BOOLEAN spinning = TRUE;
 	if (OMRTHREAD_IGNORE_SPIN_THREAD_BOUND != lib->maxSpinThreads) {
-		if (monitor->spinThreads < lib->maxSpinThreads) {
-			VM_AtomicSupport::add(&monitor->spinThreads, 1);
-		} else {
-			spinCount1Init = 1;
-			spinCount2Init = 1;
-			spinCount3Init = 1;
-			spinning = FALSE;
-		}
+		uintptr_t oldSpinThreads = 0;
+		do {
+			oldSpinThreads = monitor->spinThreads;
+			if (oldSpinThreads >= lib->maxSpinThreads) {
+				spinCount1Init = 1;
+				spinCount2Init = 1;
+				spinCount3Init = 1;
+				spinning = FALSE;
+				break;
+			}
+		} while (oldSpinThreads != VM_AtomicSupport::lockCompareExchange(
+				&monitor->spinThreads, oldSpinThreads, oldSpinThreads + 1));
 	}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 
@@ -254,14 +258,18 @@ omrthread_mcs_lock(omrthread_t self, omrthread_monitor_t monitor, omrthread_mcs_
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
 		spinning = TRUE;
 		if (OMRTHREAD_IGNORE_SPIN_THREAD_BOUND != lib->maxSpinThreads) {
-			if (monitor->spinThreads < lib->maxSpinThreads) {
-				VM_AtomicSupport::add(&monitor->spinThreads, 1);
-			} else {
-				spinCount1Init = 1;
-				spinCount2Init = 1;
-				spinCount3Init = 1;
-				spinning = FALSE;
-			}
+			uintptr_t oldSpinThreads = 0;
+			do {
+				oldSpinThreads = monitor->spinThreads;
+				if (oldSpinThreads >= lib->maxSpinThreads) {
+					spinCount1Init = 1;
+					spinCount2Init = 1;
+					spinCount3Init = 1;
+					spinning = FALSE;
+					break;
+				}
+			} while (oldSpinThreads != VM_AtomicSupport::lockCompareExchange(
+					&monitor->spinThreads, oldSpinThreads, oldSpinThreads + 1));
 		}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 


### PR DESCRIPTION
Use a compare-and-swap loop when incrementing `spinThreads` so that the
`maxSpinThreads` limit is checked and updated atomically.

The previous check-then-increment sequence allowed multiple threads to
observe a value below the limit and increment it concurrently, causing
`spinThreads` to exceed `maxSpinThreads`.

Related: #7859