### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# .git-blame-ignore-revs
+
+# Merge namespace declaration in class forward declaration
+bcfecedcb9c4cc49daaaeb9e33e96c63c1afdc7c
+
+# Format Compiler component
+d7f9acaf980f9fb85858694f647bfbd6990f3586


### PR DESCRIPTION
Add a git blame ignore-revs file; this file can be used by git blame via the `--ignore-revs-file` option, and it is also used by GitHub to ignore revisions when blaming.

This file contains the SHAs of the two commits introduced by the Compiler Code Formatting PR, specifically:

Merge namespace declaration in class forward declaration 
bcfecedcb9c4cc49daaaeb9e33e96c63c1afdc7c

Format Compiler component
d7f9acaf980f9fb85858694f647bfbd6990f3586

Closes https://github.com/eclipse-omr/omr/issues/7885