### PR TITLE
WIP: Implement vectorized s2m on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1787,6 +1787,9 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::m2v:
             // only P9 has splat byte immediate, otherwise it's too expensive
             return cpu->isAtLeast(OMR_PROCESSOR_PPC_P9);
+        case TR::s2m:
+            TR_ASSERT_FATAL(et == TR::Int64, "Unsupported vector type %s for s2m (must be Int64)\n", et.toString());
+            return cpu->isAtLeast(OMR_PROCESSOR_PPC_P8);
         default:
             return false;
     }

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -802,7 +802,7 @@
    vupklsh,          // vector unpack low signed halfword
 // vupklsw,          // Vector Unpack Low Signed Word
 // vupklpx,          // Vector Unpack Low Pixel
-// vupkhsw,          // Vector Unpack High Signed Word
+   vupkhsw,          // Vector Unpack High Signed Word
 // vpksdss,          // Vector Pack Signed Dword Signed Saturate
 // vpksdus,          // Vector Pack Signed Dword Unsigned Saturate
    vpkuhum,          // vector pack unsigned half word unsigned modulo

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9055,17 +9055,16 @@
     /*                   PPCOpProp_SyncSideEffectFree, */
     /* }, */
 
-    /* { */
-    /* .mnemonic    =    OMR::InstOpCode::vupkhsw, */
-    /* .name        =    "vupkhsw", */
-    /* .description =    "Vector Unpack High Signed Word", */
-    /* .prefix      =    0x00000000, */
-    /* .opcode      =    0x1000064E, */
-    /* .format      =    FORMAT_UNKNOWN, */
-    /* .minimumALS  =    OMR_PROCESSOR_PPC_P8, */
-    /* .properties  =    PPCOpProp_IsVMX | */
-    /*                   PPCOpProp_SyncSideEffectFree, */
-    /* }, */
+    {
+        /* .mnemonic    = */ OMR::InstOpCode::vupkhsw,
+        /* .name        = */ "vupkhsw",
+        /* .description =    "Vector Unpack High Signed Word", */
+        /* .prefix      = */ 0x00000000,
+        /* .opcode      = */ 0x1000064E,
+        /* .format      = */ FORMAT_VRT_VRB,
+        /* .minimumALS  = */ OMR_PROCESSOR_PPC_P8,
+        /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
+    },
 
     /* { */
     /* .mnemonic    =    OMR::InstOpCode::vpksdss, */


### PR DESCRIPTION
Implement PPC codegen for `s2m` (Short to Mask) on P8+. This operation accepts two byte elements of a given boolean array (read from memory using a halfword load) and converts it into a two-element LongVector mask with the corresponding boolean values.

