### PR TITLE
Correct references to github repository

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    if: github.repository == 'eclipse/omr'
+    if: github.repository == 'eclipse-omr/omr'
     runs-on: ubuntu-latest
     steps:
     - uses: fjeremic/cron-first-interaction@0.2.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    if: github.repository == 'eclipse/omr'
+    if: github.repository == 'eclipse-omr/omr'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3


### PR DESCRIPTION
The repository was moved from "eclipse" organization to the "eclipse-omr" organization some time ago.