### PR TITLE
Add Options and Optimization plan flag for patchable JProfiling

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1300,6 +1300,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      "F" },
     { "enableParanoidRefCountChecks", "O\tenable extra reference count verification",
      SET_OPTION_BIT(TR_EnableParanoidRefCountChecks), "F" },
+    { "enablePatchableJProfiling", "O\tenable patchable JProfiling for low optimization compilations",
+     SET_OPTION_BIT(TR_EnablePatchableJProfiling), "F" },
     { "enablePerfAsserts", "O\tenable asserts for serious performance problems found during compilation",
      SET_OPTION_BIT(TR_EnablePerfAsserts), "F" },
     { "enableProfiledDevirtualization", "O\tenable devirtualization based on interpreter profiling",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -447,7 +447,7 @@ enum TR_CompilationOptions {
     TR_EnableSelectiveEnterExitHooks                         = 0x00000080 + 11,
     TR_EnableUseDefBasedVectorAPIExpansion                   = 0x00000100 + 11,
     TR_DisableDirectMemoryStore                              = 0x00000200 + 11,
-    // Available                                             = 0x00000400 + 11,
+    TR_EnablePatchableJProfiling                             = 0x00000400 + 11,
     TR_DisableConstProvenance                                = 0x00000800 + 11,
     TR_DisableITableIterationsAfterLastITableCacheCheck      = 0x00001000 + 11,
     TR_VerboseOptTransformations                             = 0x00002000 + 11,

--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -133,6 +133,11 @@ public:
 
     void setDowngradedDueToSamplingJProfiling(bool b) { _flags.set(DowngradedDueToSamplingJProfiling, b); }
 
+    // Insert JProfiling code that can be patched to turn on/off data collection
+    bool insertPatchableJProfiling() const { return _flags.testAny(InsertPatchableJProfiling); }
+
+    void setInsertPatchableJProfiling(bool b) { _flags.set(InsertPatchableJProfiling, b); }
+
     // Insert epilogue yieldpoints if the method is being sampled
     bool getInsertEpilogueYieldpoints() const { return _flags.testAny(UseSampling); }
 
@@ -281,6 +286,7 @@ public:
             = 0x00400000, // Compilation was downgraded to cold just because we wanted to do JProfiling
         InducedByDLT = 0x00800000, // Compilation that follows a DLT compilation
         DisableEDO = 0x01000000, // Do not insert EDO profiling trees for this compilation
+        InsertPatchableJProfiling = 0x02000000, // Insert patchable JProfiling trees for this compilation
     };
 
 private:


### PR DESCRIPTION
Changes in this PR adds JIT option to enable patchable JProfiling as well as an flag in the optimization plan to insert patchable JProfiling code in the method. These changes will be used to trigger patchable JProfiling.