### PR TITLE
Avoid division operation using _sizeCalssRatioLog

### DIFF
--- a/gc/stats/LargeObjectAllocateStats.hpp
+++ b/gc/stats/LargeObjectAllocateStats.hpp
@@ -56,7 +56,7 @@ private:
 	uintptr_t _largeObjectThreshold;	/**< Threshold to consider an object large enough to keep track of */
 	uintptr_t _veryLargeEntrySizeClass; /**< index of sizeClass for minimum veryLargeEntry, the cache value of GCExtensions.largeObjectAllocationProfilingVeryLargeObjectSizeClass */
 	float _sizeClassRatio;			/**< ratio of lower and upper boundary of a size class */
-	float _sizeClassRatioLog;		/**< log value of the above ratio */
+	float _sizeClassRatioLogInversed;	/**< 1.0 / (log value of the above ratio) */
 	uintptr_t _averageBytesAllocated;   /**< history average of total allocated bytes for each of the updates */
 
 	MM_FreeEntrySizeClassStats _freeEntrySizeClassStats; /**< global (still per pool) statistics structure for heap free entry size (sizeClass) distribution */
@@ -238,7 +238,7 @@ public:
 		_largeObjectThreshold(0),
 		_veryLargeEntrySizeClass(0),
 		_sizeClassRatio(0.0),
-		_sizeClassRatioLog(0.0),
+		_sizeClassRatioLogInversed(0.0f),
 		_averageBytesAllocated(0),
 		_timeEstimateFragmentation(0),
 		_cpuTimeEstimateFragmentation(0),


### PR DESCRIPTION
_sizeCalssRatioLog is used to calculate log value for desired base: _sizeCalssRatioLog = logf(base);
log_base_for_value = logf(value) / _sizeCalssRatioLog. Division operation can be expensive so code can be optimized by using multiplication operation instead of division. Also I renamed precalculated variable name to _sizeCalssRatioLogInversed to reflect this change:
 _sizeCalssRatioLogInversed = 1.0f / logf(base);
 log_base_for_value = logf(value) / _sizeCalssRatioLogInversed.