### PR TITLE
Do not treat iconst node as unsigned long

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -12304,7 +12304,7 @@ TR::Node *removeArithmeticsUnderIntegralCompare(TR::Node *node, TR::Simplifier *
             // calling constNode->setConstValue()
             // Hence, creating a new node here and copy the old node's internal info.
             TR::Node *newConstNode = TR::Node::create(secondChild, secondChild->getOpCodeValue(), 0);
-            newConstNode->setUnsignedLongInt(newUConst);
+            newConstNode->setConstValue(newUConst);
             node->setAndIncChild(0, opNode->getFirstChild());
             node->setAndIncChild(1, newConstNode);
 


### PR DESCRIPTION
During simplification of integer compares, a new integer constant node might be created to simplify the arithmetic. Calling setUnsignedLongInt(...) to set a node's constant value has the possible side-effect of applying incorrect flags about an iconst node's value. It should not be possible for an iconst node with a negative integer constant to be marked as non-negative as this can lead to problems in future optimizations.

Issue: eclipse-openj9/openj9#22512