### PR TITLE
Add a couple of border frequency threshold options

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1473,6 +1473,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
         "heuristic kicks in", TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerArgumentHeuristicFractionUpToWarm), 0, "F%d" },
     { "inlinerBorderFrequency=", "O<nnn>\tblock frequency threshold for not inlining at warm",
      TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerBorderFrequency), 0, "F%d" },
+    { "inlinerBorderFrequencyServer=", "O<nnn>\tblock frequency threshold for not inlining in server configurations",
+     TR::Options::set32BitNumeric, offsetof(OMR::Options, _serverInlinerBorderFrequency), 0, "F%d" },
     { "inlinerCGBorderFrequency=", "O<nnn>\tblock frequency threshold for not inlining at warm",
      TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerCGBorderFrequency), 0, "F%d" },
     { "inlinerCGColdBorderFrequency=", "O<nnn>\tblock frequency threshold for not inlining at warm",
@@ -1487,6 +1489,9 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerVeryColdBorderFrequency), 0, "F%d" },
     { "inlinerVeryColdBorderFrequencyAtCold=", "O<nnn>\tblock frequency threshold for not inlining at cold",
      TR::Options::set32BitNumeric, offsetof(OMR::Options, _inlinerVeryColdBorderFrequencyAtCold), 0, "F%d" },
+    { "inlinerVeryColdBorderFrequencyServer=",
+     "O<nnn>\tblock frequency threshold for not inlining in server configurations", TR::Options::set32BitNumeric,
+     offsetof(OMR::Options, _serverInlinerVeryColdBorderFrequency), 0, "F%d" },
     { "inlinerVeryLargeCompiledMethodAdjustFactor=", "O<nnn>\tFactor to multiply the perceived size of the method",
      TR::Options::setStaticNumeric, (intptr_t)&OMR::Options::_inlinerVeryLargeCompiledMethodAdjustFactor, 0, "F%d",
      NOT_IN_SUBSET },
@@ -3372,6 +3377,9 @@ void OMR::Options::jitPreProcess()
     _blockShufflingSequence = (char *)"S";
     _delayCompileWithCPUBurn = 0;
     _largeNumberOfLoops = 6500;
+
+    _serverInlinerBorderFrequency = -1;
+    _serverInlinerVeryColdBorderFrequency = -1;
 
     // The entry block is under this threshold in methods containing a block
     // expected to run >=100 times per method entry, which should be sure to

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1523,6 +1523,8 @@ public:
         _inlinerCGColdBorderFrequency = 0;
         _inlinerCGVeryColdBorderFrequency = 0;
         _alwaysWorthInliningThreshold = 0;
+        _serverInlinerBorderFrequency = 0;
+        _serverInlinerVeryColdBorderFrequency = 0;
         _initialSCount = 0;
         _enableSCHintFlags = 0;
         _insertGCRTrees = false;
@@ -2068,6 +2070,10 @@ public:
     int32_t getMaxLimitedGRARegs() { return _maxLimitedGRARegs; }
 
     int32_t getNumLimitedGRARegsWithheld();
+
+    int32_t getServerInlinerBorderFrequency() { return _serverInlinerBorderFrequency; }
+
+    int32_t getServerInlinerVeryColdBorderFrequency() { return _serverInlinerVeryColdBorderFrequency; }
 
     int32_t getProfilingCompNodecountThreshold() { return _profilingCompNodecountThreshold; }
 
@@ -2776,6 +2782,9 @@ protected:
     int32_t _inlinerCGColdBorderFrequency;
     int32_t _inlinerCGVeryColdBorderFrequency;
     int32_t _alwaysWorthInliningThreshold;
+
+    int32_t _serverInlinerBorderFrequency;
+    int32_t _serverInlinerVeryColdBorderFrequency;
 
     int32_t _initialSCount;
     int32_t _enableSCHintFlags;


### PR DESCRIPTION
This PR adds two inliner threshold options
* `_smallInlinerBorderFrequency`
* `_smallInlinerVeryColdBorderFrequency`

which are needed for the OpenJ9 downstream project. See [this explanation](https://github.com/eclipse-openj9/openj9/pull/22560) for why this can't be done downstream.