### PR TITLE
Add support for dispatchJ9Method for MethodHandles on Z

### DIFF
--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -52,6 +52,7 @@
 #include "z/codegen/S390Instruction.hpp"
 
 #define TR_S390_ARG_SLOT_SIZE 4
+#define OPCODE_SPACING 8
 
 uint8_t *TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, TR::RealRegister *reg,
     int32_t offset, TR::CodeGenerator *cg)
@@ -66,17 +67,12 @@ uint8_t *TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::Mnemonic op, uin
     return buffer + opCode.getInstructionLength();
 }
 
-uint8_t *TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
-    TR::CodeGenerator *cg)
+uint8_t *TR::S390CallSnippet::S390FlushArgumentsToStackHelper(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    TR::CodeGenerator *cg, int argStart, bool rightToLeft, TR::Linkage *linkage)
 {
     int32_t intArgNum = 0, floatArgNum = 0, offset;
     TR::Machine *machine = cg->machine();
-    TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
 
-    int32_t argStart = callNode->getFirstArgumentIndex();
-    bool rightToLeft = linkage->getRightToLeft() &&
-        // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
-        !callNode->getSymbolReference()->isOSRInductionHelper();
     if (rightToLeft) {
         offset = linkage->getOffsetToFirstParm();
     } else {
@@ -106,6 +102,7 @@ uint8_t *TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t *buffer, TR::Nod
                 if (!rightToLeft) {
                     offset -= cg->comp()->target().is64Bit() ? 8 : 4;
                 }
+
                 if (intArgNum < linkage->getNumIntegerArgumentRegisters()) {
                     buffer = storeArgumentItem(TR::InstOpCode::getStoreOpCode(), buffer,
                         machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
@@ -174,6 +171,17 @@ uint8_t *TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t *buffer, TR::Nod
     return buffer;
 }
 
+uint8_t *TR::S390CallSnippet::S390FlushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    TR::CodeGenerator *cg)
+{
+    TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
+
+    // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
+    bool rightToLeft = linkage->getRightToLeft() && !callNode->getSymbolReference()->isOSRInductionHelper();
+    return S390FlushArgumentsToStackHelper(buffer, callNode, argSize, cg, callNode->getFirstArgumentIndex(),
+        rightToLeft, linkage);
+}
+
 int32_t TR::S390CallSnippet::adjustCallOffsetWithTrampoline(uintptr_t targetAddr, uint8_t *currentInst,
     TR::SymbolReference *callSymRef, TR::Snippet *snippet)
 {
@@ -209,9 +217,14 @@ int32_t TR::S390CallSnippet::adjustCallOffsetWithTrampoline(uintptr_t targetAddr
  */
 int32_t TR::S390CallSnippet::instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg)
 {
+    return instructionCountForArgumentsInner(callNode, cg, callNode->getFirstArgumentIndex());
+}
+
+int32_t TR::S390CallSnippet::instructionCountForArgumentsInner(TR::Node *callNode, TR::CodeGenerator *cg,
+    int32_t argStart)
+{
     int32_t intArgNum = 0, floatArgNum = 0, count = 0;
     TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
-    int32_t argStart = callNode->getFirstArgumentIndex();
 
     for (int32_t i = argStart; i < callNode->getNumChildren(); i++) {
         TR::Node *child = callNode->getChild(i);
@@ -256,6 +269,107 @@ int32_t TR::S390CallSnippet::instructionCountForArguments(TR::Node *callNode, TR
     return count;
 }
 
+uint8_t *TR::S390CallSnippet::printS390ArgumentsFlush(OMR::Logger *log, TR::Node *node, uint8_t *bufferPos,
+    int32_t argSize, TR_Debug *debug, int32_t argStart, TR::Machine *machine, TR::Linkage *privateLinkage)
+{
+    int32_t offset = 0, intArgNum = 0, floatArgNum = 0;
+
+    TR::RealRegister *stackPtr = privateLinkage->getStackPointerRealRegister();
+
+    if (privateLinkage->getRightToLeft()) {
+        offset = privateLinkage->getOffsetToFirstParm();
+    } else {
+        offset = argSize + privateLinkage->getOffsetToFirstParm();
+    }
+
+    for (int i = argStart; i < node->getNumChildren(); i++) {
+        TR::Node *child = node->getChild(i);
+        switch (child->getDataType()) {
+            case TR::Int8:
+            case TR::Int16:
+            case TR::Int32:
+            case TR::Address:
+                if (!privateLinkage->getRightToLeft()) {
+                    offset -= comp()->target().is64Bit() ? 8 : 4;
+                }
+                if (intArgNum < privateLinkage->getNumIntegerArgumentRegisters()) {
+                    TR::InstOpCode::Mnemonic opcode
+                        = (comp()->target().is64Bit() && child->getDataType() == TR::Address) ? TR::InstOpCode::STG
+                                                                                              : TR::InstOpCode::ST;
+
+                    uint8_t opcodeSize = (comp()->target().is64Bit() && child->getDataType() == TR::Address) ? 6 : 4;
+                    bufferPos = printRXInstruction(log, debug, opcode,
+                        machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)), stackPtr,
+                        offset, bufferPos, opcodeSize);
+                }
+                intArgNum++;
+                if (privateLinkage->getRightToLeft()) {
+                    offset -= comp()->target().is64Bit() ? 8 : 4;
+                }
+                break;
+
+            case TR::Int64:
+                if (!privateLinkage->getRightToLeft()) {
+                    offset -= (comp()->target().is64Bit() ? 16 : 8);
+                }
+                if (intArgNum < privateLinkage->getNumIntegerArgumentRegisters()) {
+                    if (comp()->target().is64Bit()) {
+                        bufferPos = printRXInstruction(log, debug, TR::InstOpCode::STG,
+                            machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)), stackPtr,
+                            offset, bufferPos, 6);
+                    } else {
+                        bufferPos = printRXInstruction(log, debug, TR::InstOpCode::ST,
+                            machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)), stackPtr,
+                            offset, bufferPos, 4);
+
+                        if (intArgNum < privateLinkage->getNumIntegerArgumentRegisters() - 1) {
+                            bufferPos = printRXInstruction(log, debug, TR::InstOpCode::ST,
+                                machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum + 1)),
+                                stackPtr, offset, bufferPos, 4);
+                        }
+                    }
+                }
+                intArgNum += comp()->target().is64Bit() ? 1 : 2;
+                if (privateLinkage->getRightToLeft()) {
+                    offset += comp()->target().is64Bit() ? 16 : 8;
+                }
+                break;
+
+            case TR::Float:
+                if (!privateLinkage->getRightToLeft()) {
+                    offset -= 4;
+                }
+                if (floatArgNum < privateLinkage->getNumFloatArgumentRegisters()) {
+                    bufferPos = printRXInstruction(log, debug, TR::InstOpCode::STD,
+                        machine->getRealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)), stackPtr,
+                        offset, bufferPos, 4);
+                }
+                floatArgNum++;
+                if (privateLinkage->getRightToLeft()) {
+                    offset += 4;
+                }
+                break;
+
+            case TR::Double:
+                if (!privateLinkage->getRightToLeft()) {
+                    offset -= 8;
+                }
+                if (floatArgNum < privateLinkage->getNumFloatArgumentRegisters()) {
+                    bufferPos = printRXInstruction(log, debug, TR::InstOpCode::STE,
+                        machine->getRealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)), stackPtr,
+                        offset, bufferPos, 4);
+                }
+                floatArgNum++;
+                if (privateLinkage->getRightToLeft()) {
+                    offset += 8;
+                }
+                break;
+        }
+    }
+
+    return bufferPos;
+}
+
 uint8_t *TR::S390CallSnippet::getCallRA()
 {
     // Return Address is the address of the instr follows the branch instr
@@ -270,3 +384,35 @@ uint8_t *TR::S390CallSnippet::emitSnippetBody()
 }
 
 uint32_t TR::S390CallSnippet::getLength(int32_t estimatedSnippetStart) { return 0; }
+
+uint8_t *TR::S390CallSnippet::printRXInstruction(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode,
+    TR::RealRegister *targetReg, TR::RealRegister *baseReg, int32_t offset, uint8_t *cursor, uint8_t instrSize)
+{
+    printOpcode(log, debug, opcode, cursor, instrSize);
+    debug->print(log, targetReg);
+    log->printf(",%d(,", offset);
+    debug->print(log, baseReg);
+    log->printc(')');
+    cursor += instrSize;
+    return cursor;
+}
+
+uint8_t *TR::S390CallSnippet::printRRInstruction(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode,
+    TR::RealRegister *targetReg, TR::RealRegister *srcReg, uint8_t *cursor, uint8_t instrSize)
+{
+    printOpcode(log, debug, opcode, cursor, instrSize);
+    debug->print(log, targetReg);
+    log->printc(',');
+    debug->print(log, srcReg);
+    cursor += instrSize;
+    return cursor;
+}
+
+void TR::S390CallSnippet::printOpcode(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode,
+    uint8_t *cursor, uint8_t instrSize)
+{
+    debug->printPrefix(log, NULL, cursor, instrSize);
+    const char *mnemonicName = TR::InstOpCode::metadata[opcode].name;
+    log->printf("%-*s", OPCODE_SPACING, mnemonicName);
+}
+

--- a/compiler/z/codegen/CallSnippet.hpp
+++ b/compiler/z/codegen/CallSnippet.hpp
@@ -50,6 +50,9 @@ class S390CallSnippet : public TR::Snippet {
 protected:
     TR::SymbolReference *_realMethodSymbolReference;
 
+    static uint8_t *S390FlushArgumentsToStackHelper(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+        TR::CodeGenerator *cg, int argStart, bool rightToLeft, TR::Linkage *linkage);
+
 public:
     S390CallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s)
         : TR::Snippet(cg, c, lab, false)
@@ -88,9 +91,10 @@ public:
 
     static uint8_t *storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, TR::RealRegister *reg,
         int32_t offset, TR::CodeGenerator *cg);
-    static uint8_t *S390flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    static uint8_t *S390FlushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
         TR::CodeGenerator *cg);
     static int32_t instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg);
+    static int32_t instructionCountForArgumentsInner(TR::Node *callNode, TR::CodeGenerator *cg, int32_t argStart);
 
     /**
      * @brief For a given call from snippet (Usually helper calls) calculate the
@@ -105,6 +109,22 @@ public:
      */
     static int32_t adjustCallOffsetWithTrampoline(uintptr_t targetAddr, uint8_t *currentInst,
         TR::SymbolReference *callSymRef, TR::Snippet *snippet);
+
+    static uint8_t *printS390ArgumentsFlush(OMR::Logger *log, TR::Node *node, uint8_t *bufferPos, int32_t argSize,
+        TR_Debug *debug, int32_t argStart, TR::Machine *machine, TR::Linkage *privateLinkage);
+
+    /*
+     * prints a RX instruction given (for snippet debug logging).
+     */
+    static uint8_t *printRXInstruction(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode,
+        TR::RealRegister *targetReg, TR::RealRegister *baseReg, int32_t offset, uint8_t *cursor, uint8_t instrSize);
+
+    static uint8_t *printRRInstruction(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode,
+        TR::RealRegister *targetReg, TR::RealRegister *srcReg, uint8_t *cursor, uint8_t instrSize);
+
+private:
+    inline static void printOpcode(OMR::Logger *log, TR_Debug *debug, TR::InstOpCode::Mnemonic opcode, uint8_t *cursor,
+        uint8_t instrSize);
 };
 
 } // namespace TR

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -1560,44 +1560,25 @@ void OMR::Z::Linkage::doNotKillSpecialRegsForBuildArgs(TR::Linkage *linkage, boo
     }
 }
 
-/**
- * Build arguments for System routines
- */
 int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies, bool isFastJNI,
-    int64_t killMask, TR::Register *&vftReg, bool PassReceiver)
+    int64_t killMask, TR::Register *&vftReg, bool passReceiver, bool isRightToLeft)
 {
     TR::SystemLinkage *systemLinkage = (TR::SystemLinkage *)self()->cg()->getLinkage(TR_System);
 
-    int8_t gprSize = self()->machine()->getGPRSize();
-    TR::Register *tempRegister;
-    int32_t argIndex = 0, i, from, to, step, numChildren;
-    int32_t argSize = 0;
-    int32_t stackOffset = 0;
-    uint32_t numIntegerArgs = 0;
-    uint32_t numFloatArgs = 0;
-    uint32_t numVectorArgs = 0;
-    TR::Node *child;
-    void *smark;
-    uint32_t firstArgumentChild = callNode->getFirstArgumentIndex();
-    TR::DataType resType = callNode->getType();
-    TR::DataType resDataType = resType.getDataType();
-
-    const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
-
-    // Not kill special registers
     self()->doNotKillSpecialRegsForBuildArgs(self(), isFastJNI, killMask);
 
     // For the generated classObject argument, we didn't use them in the dispatch sequence.
     // Simply evaluating them would be enough. Care must be taken when we begin to use them,
     // in order not to spill in the dispatch sequence.
-    for (i = 0; i < firstArgumentChild; i++) {
+    uint32_t firstArgumentChild = callNode->getFirstArgumentIndex();
+    for (int i = 0; i < firstArgumentChild; i++) {
         TR::Node *child = callNode->getChild(i);
         vftReg = self()->cg()->evaluate(child);
         self()->cg()->decReferenceCount(child);
     }
 
     // Skip the first receiver argument if instructed.
-    if (!PassReceiver) {
+    if (!passReceiver) {
         // Force evaluation of child if necessary
         TR::Node *receiverChild = callNode->getChild(firstArgumentChild);
         if (receiverChild->getReferenceCount() > 1) {
@@ -1610,29 +1591,34 @@ int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyCon
         firstArgumentChild++;
     }
 
-    numChildren = callNode->getNumChildren() - 1;
-    if ((callNode->getNumChildren() >= 1) && (callNode->getChild(numChildren)->getOpCodeValue() == TR::GlRegDeps))
-        numChildren--;
+    int lastChildIndex = callNode->getNumChildren() - 1;
+    if ((callNode->getNumChildren() >= 1) && (callNode->getChild(lastChildIndex)->getOpCodeValue() == TR::GlRegDeps))
+        lastChildIndex--;
 
     // setup helper routine arguments in reverse order
-    bool rightToLeft = self()->isParmsInReverseOrder() &&
-        // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
-        !callNode->getSymbolReference()->isOSRInductionHelper();
+    // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
+    bool rightToLeft
+        = self()->isParmsInReverseOrder() && !callNode->getSymbolReference()->isOSRInductionHelper() && isRightToLeft;
+
+    int from = 0, to = 0, step = 0;
     if (rightToLeft) {
-        from = numChildren;
+        from = lastChildIndex;
         to = firstArgumentChild;
         step = -1;
     } else {
         from = firstArgumentChild;
-        to = numChildren;
+        to = lastChildIndex;
         step = 1;
     }
 
     // Add special argument register dependency
     self()->addSpecialRegDepsForBuildArgs(callNode, dependencies, from, step);
 
-    for (i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
-        child = callNode->getChild(i);
+    int32_t argSize = 0;
+    int8_t gprSize = self()->machine()->getGPRSize();
+    const bool enableVectorLinkage = self()->cg()->getSupportsVectorRegisters();
+    for (int i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
+        TR::Node *child = callNode->getChild(i);
         TR::DataType argType = child->getType();
         TR::DataType argDataType = argType.getDataType();
 
@@ -1644,9 +1630,10 @@ int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyCon
             argSize += gprSize;
     }
 
-    stackOffset = self()->isFirstParmAtFixedOffset() ? self()->getOffsetToFirstParm() : argSize;
+    int32_t stackOffset = self()->isFirstParmAtFixedOffset() ? self()->getOffsetToFirstParm() : argSize;
 
     // store env register
+    uint32_t numIntegerArgs = 0;
     stackOffset = self()->storeExtraEnvRegForBuildArgs(callNode, self(), dependencies, isFastJNI, stackOffset, gprSize,
         numIntegerArgs);
 
@@ -1655,10 +1642,12 @@ int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyCon
     //
 
     // Push args onto stack
-    for (i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
+    uint32_t numFloatArgs = 0;
+    uint32_t numVectorArgs = 0;
+    for (int i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
         TR::MemoryReference *mref = NULL;
         TR::Register *argRegister = NULL;
-        child = callNode->getChild(i);
+        TR::Node *child = callNode->getChild(i);
 
         switch (child->getDataType()) {
             case TR::Address:
@@ -1757,6 +1746,8 @@ int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyCon
     // Setup return register dependency
     TR::Register *resultReg = NULL;
     TR::Register *javaResultReg = NULL;
+    TR::DataType resType = callNode->getType();
+    TR::DataType resDataType = resType.getDataType();
     switch (resDataType) {
         case TR::NoType:
             break;
@@ -1828,7 +1819,7 @@ int32_t OMR::Z::Linkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyCon
     TR::Register *dummyReg;
     TR::RealRegister::RegNum last = TR::RealRegister::LastFPR;
 
-    for (i = TR::RealRegister::FirstGPR; i <= last; i++) {
+    for (int i = TR::RealRegister::FirstGPR; i <= last; i++) {
         if ((killMask & (0x1L << REGINDEX(i)))) {
             dummyReg = NULL;
             self()->killAndAssignRegister(killMask, dependencies, &dummyReg, REGNUM(i), self()->cg(), true, true);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -323,8 +323,20 @@ public:
         return killMask;
     }
 
+    /**
+     * @brief sets up registers and stack for a call
+     * @param callNode: the tree node representing the call
+     * @param dependencies: the register dependencies created in linkage. This will be modified
+     * @param isFastJNI: indicates if this is a JNI call
+     * @param killMask: a bit mask of the registers killed by the call
+     * @param vftReg: the register holdin the class object, for virtual calls
+     * @param passReceiver: default is true. When true, receiver object is passed as a paramter for the target method,
+     * and is not evaluted here
+     * @param isRightToLeft: to override the paramter order in special calls
+     * @return The total size (in bytes) of the arguments
+     */
     virtual int32_t buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies, bool isFastJNI,
-        int64_t killMask, TR::Register *&vftReg, bool PassReceiver = true);
+        int64_t killMask, TR::Register *&vftReg, bool passReceiver = true, bool isRightToLeft = true);
     TR::Instruction *storeArgumentOnStack(TR::Node *callNode, TR::InstOpCode::Mnemonic opCode, TR::Register *argReg,
         int32_t *stackOffsetPtr, TR::Register *stackRegister);
     TR::Instruction *storeLongDoubleArgumentOnStack(TR::Node *callNode, TR::DataType argType,

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -120,7 +120,7 @@ void TR_Debug::printz(OMR::Logger *log, TR::Snippet *snippet)
 {
     switch (snippet->getKind()) {
         case TR::Snippet::IsHelperCall:
-            print(log, (TR::S390HelperCallSnippet *)snippet);
+            snippet->print(log, this);
             break;
 #if J9_PROJECT_SPECIFIC
         case TR::Snippet::IsCall:

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -47,19 +47,8 @@ namespace TR {
 class Node;
 }
 
-uint8_t *TR::S390HelperCallSnippet::emitSnippetBody()
+uint8_t *TR::S390HelperCallSnippet::emitSnippetBodyInner(uint8_t *cursor, TR::SymbolReference *helperSymRef)
 {
-    uint8_t *cursor = cg()->getBinaryBufferCursor();
-    getSnippetLabel()->setCodeLocation(cursor);
-
-    TR::Node *callNode = getNode();
-    TR::SymbolReference *helperSymRef = getHelperSymRef();
-    bool jitInduceOSR = helperSymRef->isOSRInductionHelper();
-    if (jitInduceOSR) {
-        // Flush in-register arguments back to the stack for interpreter
-        cursor = TR::S390CallSnippet::S390flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
-    }
-
     uint32_t rEP = (uint32_t)cg()->getEntryPointRegister() - 1;
 
     // load vm thread into gpr13
@@ -108,7 +97,6 @@ uint8_t *TR::S390HelperCallSnippet::emitSnippetBody()
     // If MCC is supported, we will look up the appropriate trampoline, if
     //     necessary.
     intptr_t destAddr = (intptr_t)(helperSymRef->getSymbol()->castToMethodSymbol()->getMethodAddress());
-
 #if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
     if (cg()->comp()->getOption(TR_EnableRMODE64))
@@ -143,6 +131,22 @@ uint8_t *TR::S390HelperCallSnippet::emitSnippetBody()
     return cursor;
 }
 
+uint8_t *TR::S390HelperCallSnippet::emitSnippetBody()
+{
+    uint8_t *cursor = cg()->getBinaryBufferCursor();
+    getSnippetLabel()->setCodeLocation(cursor);
+
+    TR::Node *callNode = getNode();
+    TR::SymbolReference *helperSymRef = getHelperSymRef();
+    bool jitInduceOSR = helperSymRef->isOSRInductionHelper();
+    if (jitInduceOSR) {
+        // Flush in-register arguments back to the stack for interpreter
+        cursor = TR::S390CallSnippet::S390FlushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
+    }
+
+    return emitSnippetBodyInner(cursor, helperSymRef);
+}
+
 uint32_t TR::S390HelperCallSnippet::getLength(int32_t)
 {
     uint32_t length;
@@ -162,30 +166,46 @@ uint32_t TR::S390HelperCallSnippet::getLength(int32_t)
     return length;
 }
 
-void TR_Debug::print(OMR::Logger *log, TR::S390HelperCallSnippet *snippet)
+void TR::S390HelperCallSnippet::print(OMR::Logger *log, TR_Debug *debug)
 {
-    TR::SymbolReference *helperSymRef = snippet->getHelperSymRef();
+    if (log == NULL) {
+        return;
+    }
 
-    uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, "Helper Call Snippet", getName(helperSymRef));
+    TR::SymbolReference *helperSymRef = getHelperSymRef();
 
-    bufferPos = printLoadVMThreadInstruction(log, bufferPos);
+    uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
+    bool jitInduceOSR = helperSymRef->isOSRInductionHelper();
+    TR::Node *callNode = getNode();
+    TR::MethodSymbol *methodSymbol = helperSymRef->getSymbol()->castToMethodSymbol();
+    if (jitInduceOSR) {
+        // Flush in-register arguments back to the stack for interpreter
+        TR::S390CallSnippet::printS390ArgumentsFlush(log, callNode, bufferPos, getSizeOfArguments(), debug,
+            getNode()->getFirstArgumentIndex(), cg()->machine(),
+            cg()->getLinkage(methodSymbol->getLinkageConvention()));
+    }
+    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, "Helper Call Snippet", debug->getName(helperSymRef));
+    printInner(log, debug, bufferPos);
+}
 
-    bufferPos = printRuntimeInstrumentationOnOffInstruction(log, bufferPos, false); // RIOFF
+void TR::S390HelperCallSnippet::printInner(OMR::Logger *log, TR_Debug *debug, uint8_t *bufferPos)
+{
+    bufferPos = debug->printLoadVMThreadInstruction(log, bufferPos);
 
-    if (snippet->alwaysExcept()) {
-        printPrefix(log, NULL, bufferPos, 6);
-        log->printf("BRASL \tGPR14, <%p>\t# Branch to Helper Method %s", snippet->getSnippetDestAddr(),
-            snippet->usedTrampoline() ? "- Trampoline Used." : "");
+    bufferPos = debug->printRuntimeInstrumentationOnOffInstruction(log, bufferPos, false); // RIOFF
+
+    if (alwaysExcept()) {
+        debug->printPrefix(log, NULL, bufferPos, 6);
+        log->printf("BRASL \tGPR14, <%p>\t# Branch to Helper Method %s", getSnippetDestAddr(),
+            usedTrampoline() ? "- Trampoline Used." : "");
         bufferPos += 6;
     } else {
-        printPrefix(log, NULL, bufferPos, 6);
-        log->printf("LARL \tGPR14, <%p>\t# Return Addr of Main Line.",
-            (intptr_t)snippet->getReStartLabel()->getCodeLocation());
+        debug->printPrefix(log, NULL, bufferPos, 6);
+        log->printf("LARL \tGPR14, <%p>\t# Return Addr of Main Line.", (intptr_t)getReStartLabel()->getCodeLocation());
         bufferPos += 6;
-        printPrefix(log, NULL, bufferPos, 6);
-        log->printf("BRCL \t<%p>\t# Branch to Helper Method %s", snippet->getSnippetDestAddr(),
-            snippet->usedTrampoline() ? "- Trampoline Used." : "");
+        debug->printPrefix(log, NULL, bufferPos, 6);
+        log->printf("BRCL \t<%p>\t# Branch to Helper Method %s", getSnippetDestAddr(),
+            usedTrampoline() ? "- Trampoline Used." : "");
         bufferPos += 6;
     }
 }

--- a/compiler/z/codegen/S390HelperCallSnippet.hpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.hpp
@@ -78,7 +78,13 @@ public:
 
     virtual uint8_t *emitSnippetBody();
 
+    uint8_t *emitSnippetBodyInner(uint8_t *cursor, TR::SymbolReference *helperSymRef);
+
     virtual uint32_t getLength(int32_t);
+
+    virtual void print(OMR::Logger *log, TR_Debug *);
+
+    void printInner(OMR::Logger *log, TR_Debug *, uint8_t *);
 };
 
 } // namespace TR


### PR DESCRIPTION
Adds method to OMRNode to determine if node is jitDispatchJ9Method

flushArgs skips first argument for S390HelperCallSnippet call call is jitDipatchJ9Method

needed for https://github.com/eclipse-openj9/openj9/pull/22588. This should not require a coordinated merge since I left the old TR_Debug method in; it will be taken out in another PR.