### PR TITLE
WIP: Implement vectorized m2i on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1790,6 +1790,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::v2m:
         case TR::vblend:
             return true;
+        case TR::m2i:
+            return true;
         case TR::m2v:
             // only P9 has splat byte immediate, otherwise it's too expensive
             return cpu->isAtLeast(OMR_PROCESSOR_PPC_P9);

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -964,7 +964,7 @@
 // xvxsigsp,         // VSX Vector Extract Significand SP
 // xxbrd,            // VSX Vector Byte-Reverse Dword
 // xxbrh,            // VSX Vector Byte-Reverse Hword
-// xxbrw,            // VSX Vector Byte-Reverse Word
+   xxbrw,            // VSX Vector Byte-Reverse Word
    xxbrq,            // VSX Vector Byte-Reverse Qword
    fmrgew,           // Merge Even Word
    fmrgow,           // Merge Odd Word

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9097,7 +9097,7 @@
         /* .description =    "vector pack unsigned half word unsigned modulo", */
         /* .prefix      = */ 0x00000000,
         /* .opcode      = */ 0x1000000E,
-        /* .format      = */ FORMAT_UNKNOWN,
+        /* .format      = */ FORMAT_VRT_VRA_VRB,
         /* .minimumALS  = */ OMR_PROCESSOR_PPC_P6,
         /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
     },
@@ -9108,7 +9108,7 @@
         /* .description =    "vector pack unsigned word unsigned modulo", */
         /* .prefix      = */ 0x00000000,
         /* .opcode      = */ 0x1000004E,
-        /* .format      = */ FORMAT_UNKNOWN,
+        /* .format      = */ FORMAT_VRT_VRA_VRB,
         /* .minimumALS  = */ OMR_PROCESSOR_PPC_P6,
         /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
     },
@@ -10962,17 +10962,16 @@
     /*                   PPCOpProp_SyncSideEffectFree, */
     /* }, */
 
-    /* { */
-    /* .mnemonic    =    OMR::InstOpCode::xxbrw, */
-    /* .name        =    "xxbrw", */
-    /* .description =    "VSX Vector Byte-Reverse Word", */
-    /* .prefix      =    0x00000000, */
-    /* .opcode      =    0xF00F076C, */
-    /* .format      =    FORMAT_UNKNOWN, */
-    /* .minimumALS  =    OMR_PROCESSOR_PPC_P9, */
-    /* .properties  =    PPCOpProp_IsVSX | */
-    /*                   PPCOpProp_SyncSideEffectFree, */
-    /* }, */
+    {
+        /* .mnemonic    = */   OMR::InstOpCode::xxbrw,
+        /* .name        = */   "xxbrw",
+        /* .description =    "VSX Vector Byte-Reverse Word", */
+        /* .prefix      = */   0x00000000,
+        /* .opcode      = */   0xF00F076C,
+        /* .format      = */   FORMAT_XT_XB,
+        /* .minimumALS  = */   OMR_PROCESSOR_PPC_P9,
+        /* .properties  = */   PPCOpProp_IsVSX | PPCOpProp_SyncSideEffectFree,
+    },
 
     {
         /* .mnemonic    = */ OMR::InstOpCode::xxbrq,

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1074,7 +1074,48 @@ TR::Register *OMR::Power::TreeEvaluator::m2sEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::m2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    TR::Node *child = node->getFirstChild();
+
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *dstReg = cg->allocateRegister(TR_GPR);
+
+    TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
+
+    node->setRegister(dstReg);
+
+    // set all but least significant bit of each word element to 0
+    generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltisw, node, tmpReg, 1);
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::vand, node, tmpReg, srcReg, tmpReg);
+
+    // reverse element order if little endian (P8 or lower only due to availability fo xxbrw instruction)
+    if (cg->comp()->target().cpu.isLittleEndian() && !cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9)) {
+        TR::Register *shiftReg = cg->allocateRegister(TR_VRF);
+
+        generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxpermdi, node, tmpReg, tmpReg, tmpReg, 2);
+        generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltisw, node, shiftReg, -16);
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::vadduwm, node, shiftReg, shiftReg, shiftReg);
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::vrld, node, tmpReg, tmpReg, shiftReg);
+
+        cg->stopUsingRegister(shiftReg);
+    }
+
+    // pack word-length elements into halfword-length elements
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::vpkuwum, node, tmpReg, tmpReg, tmpReg);
+
+    // pack halfworld-length elements into byte-length elements
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::vpkuhum, node, tmpReg, tmpReg, tmpReg);
+
+    // if not done already (i.e.: P9+), reverse byte order if little endian
+    if (cg->comp()->target().cpu.isLittleEndian() && cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9))
+        generateTrg1Src1Instruction(cg, TR::InstOpCode::xxbrw, node, tmpReg, tmpReg);
+
+    // move to GPR
+    generateTrg1Src1Instruction(cg, TR::InstOpCode::mfvsrwz, node, dstReg, tmpReg);
+
+    cg->stopUsingRegister(tmpReg);
+    cg->decReferenceCount(child);
+
+    return dstReg;
 }
 
 TR::Register *OMR::Power::TreeEvaluator::m2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
Implement PPC codegen for m2i (Mask to Integer) on P8+. This operation accepts an IntVector mask (four elements) and converts it into four elements of a boolean array with the corresponding values.