### PR TITLE
Enable CS taxation

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -519,6 +519,7 @@ public:
 	float concurrentScavengerAllocAverageBoost; /**< boost factor for allocate rate, used for tilt calculation in CS - similar to Slack but expressed in relative rather than absolute terms */
 	float concurrentScavengerAllocDeviationBoost; /**< boost factor for allocate rate deviation, used for tilt calculation in CS - increase when frequent small deviations in allocation are expected */
 	bool concurrentScavengeExhaustiveTermination; /**< control flag to enable/disable concurrent phase termination optimization using involving async mutator callbacks */
+	float concurrentScavengerTaxationHeadroom; /**< Threshold of allocation progress allowed ahead of copying before taxation is activated */
 #endif	/* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1718,6 +1719,7 @@ public:
 		, concurrentScavengerAllocAverageBoost(1.5)
 		, concurrentScavengerAllocDeviationBoost(5.0)
 		, concurrentScavengeExhaustiveTermination(true)
+		, concurrentScavengerTaxationHeadroom(0.00f)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -27,6 +27,7 @@
 #define OMR_SCAVENGER_TRACE_BACKOUT
 #define OMR_SCAVENGER_TRACE_COPY
 #define OMR_SCAVENGER_TRACK_COPY_DISTANCE
+#define OMR_SCAVENGER_TRACE_TAX
 #endif
 
 #include <math.h>
@@ -2300,24 +2301,26 @@ MM_Scavenger::shouldDoFinalNotify(MM_EnvironmentStandard *env)
 		 * Activate Async Signal handler which will force Mutator threads to flush their copy caches for scanning. */
 		_delegate.signalThreadsToFlushCaches(env);
 
-		/* If no work has been created and no one requested to yeild meanwhile, go and wait for new work */
+		/* If no work has been created and no yield was requested, wait for new work. */
 		if (!checkAndSetShouldYieldFlag(env)) {
-			if (0 == _cachedEntryCount) {
-				Assert_MM_true(!_scavengeCacheFreeList.areAllCachesReturned());
+			/* Meanwhile, mutator might have raced and released caches - check again. */
+			if (!_scavengeCacheFreeList.areAllCachesReturned()) {
+				if (0 == _cachedEntryCount)  {
 
-				/* The only known reason for timeout is a rare case if Exclusive VM Access request came from a nonGC party. If we did not have a timeout,
-				 * we would end up wating for mutator threads that hold Copy Caches, but they would not respond if they already released VM access
-				 * and blocked due to ongoing Exclusive, hence creating deadlock. Timeout of 1ms gives a chance to check if we should yield and release VM access.
-				 * Alternative solutions to providing timeout to consider in future:
-				 * 1) notify (via hook) GC that Exclusive is requested (proven to work, but breaks general async nature of how Exclusive Request is requested)
-				 * 2) release VM access prior to blocking (tricky since thread that blocks is not necessarily Main, which is the one that holds VM access)
-				 */
-				omrthread_monitor_wait_timed(_scanCacheMonitor, 1, 0);
-			}
-			/* We know there is more work - can't do the final notify yet. Need to help with work and eventually re-evaulate if it's really the end */
-			return false;
+					/* The only known reason for timeout is a rare case if Exclusive VM Access request came from a non-GC party. Without a timeout,
+					 * we would end up waiting for mutator threads that hold Copy Caches. If those threads had already released VM access
+					 * and are blocked on an ongoing Exclusive request, they would not respond, leading to a deadlock. Timeout of 1ms gives a chance to check if we should yield and release VM access.
+					 * Alternative solutions to consider in future:
+					 * 1) Notify GC (via hook) that Exclusive is requested (proven to work, but breaks general async nature of Exclusive requests).
+					 * 2) Release VM access prior to blocking (tricky since the blocking thread is not necessarily the Main thread, which typically holds VM access).
+					 */
+					omrthread_monitor_wait_timed(_scanCacheMonitor, 1, 0);
+				}
+				/* More work is pending, so the final notify cannot be sent yet. Help with work and eventually re-evaluate if it's really the end. */
+				return false;
+			} 
 		}
-		/* If we have to yield, we do need to notify worker threads to unblock and temporarily completely scan loop */
+		/* If yielding, notify worker threads to unblock and temporarily complete scan loop. */
 	}
 #endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	return true;
@@ -6008,17 +6011,28 @@ MM_Scavenger::payAllocationTax(MM_EnvironmentBase *envBase, MM_MemorySubSpace *s
 		/* Progress of how much objects have been flipped since the start of concurrent phase of this cycle relative to historically averaged amount. */
 		float flipBytesRatio = (float)flipBytes / _extensions->scavengerStats._avgExpectedFlipBytes;
 
-		/* If flip progress is too low (too small Nursery, background GC threads starved by CPU overloading,...)
+		/* If flip progress is too low (due to small Nursery, background GC threads starved by CPU overloading, ...)
 		 * mutator threads need to be taxed to slow down their heap allocation and CPU consumption.
+		 * Activate taxation when flip progress is less than used memory plus some headroom (for example, up to 20%, possibly even negative).
+		 * Apply it in small increments (for example, 1-2ms), although individual caches may take longer unless yielded mid-way.
 		 */
-		uint64_t totalScanTime = 0;
+		uint64_t totalScanTimeUs = 0;
 		bool workDone = false;
+#if defined(OMR_SCAVENGER_TRACE_TAX)
+		uintptr_t iteration = 0;
+		uintptr_t iterationFromList = 0;
+#endif /* defined(OMR_SCAVENGER_TRACE_TAX) */
 
-		/* Yet to provide a meaningful heuristic (current one should never trigger). */
-		while (((1.0f + flipBytesRatio) < usedMemoryRatio) && (totalScanTime < 1000)) {
+		while ((flipBytesRatio < (usedMemoryRatio + _extensions->concurrentScavengerTaxationHeadroom)) && (totalScanTimeUs < 2000)) {
+#if defined(OMR_SCAVENGER_TRACE_TAX)
+			iteration += 1;
+#endif /* defined(OMR_SCAVENGER_TRACE_TAX) */
 			MM_CopyScanCacheStandard *scanCache = getNextScanCacheFromThread(env);
 
 			if (NULL == scanCache) {
+#if defined(OMR_SCAVENGER_TRACE_TAX)
+				iterationFromList += 1;
+#endif /* defined(OMR_SCAVENGER_TRACE_TAX) */
 				scanCache = getNextScanCacheFromList(env);
 			}
 
@@ -6047,14 +6061,30 @@ MM_Scavenger::payAllocationTax(MM_EnvironmentBase *envBase, MM_MemorySubSpace *s
 					break;
 				}
 
-				uint64_t intervalTime = omrtime_hires_delta(startTime, omrtime_hires_clock(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
-				totalScanTime += intervalTime;
+				totalScanTimeUs += omrtime_hires_delta(startTime, omrtime_hires_clock(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
 			} else {
 				break;
 			}
 		}
 
 		if (workDone) {
+
+#if defined(OMR_SCAVENGER_TRACE_TAX)
+			omrtty_printf(
+					"{SCAV: payAllocationTax envID %zu iteration %zu/%zu free/total mem %zu/%zu used bytes %.3f flipped global %zu bytes %zu%% of total mem; %.3f of average expected flipped %zu total scan %zuus}\n",
+					env->getEnvironmentId(),
+					iteration,
+					iterationFromList,
+					freeMemory,
+					totalMemory,
+					usedMemoryRatio,
+					flipBytes,
+					flipBytes / (totalMemory / 100),
+					flipBytesRatio,
+					_extensions->scavengerStats._avgExpectedFlipBytes,
+					totalScanTimeUs);
+#endif /* defined(OMR_SCAVENGER_TRACE_TAX) */
+
 			_delegate.flushReferenceObjects(env);
 
 			Assert_MM_true(env->_cycleState == &_cycleState);


### PR DESCRIPTION
Heuristic headroom threshold is reduced, so that taxation will activate as soon as copy-flip progress is slower than allocate space consumption.

This is a mildly aggressive. Will not be enough in tight scenarios (small nursery etc), but is enough for now for the logic to be tested for stability.

This will further evolve to be dynamic, in future. We probably want this threshold be slightly negative early in a cycle (do not panic too early), but increase it to a slightly positive later in a cycle.