### PR TITLE
WIP: Implement vectorized m2l on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1790,6 +1790,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::v2m:
         case TR::vblend:
             return true;
+        case TR::m2l:
+            return true;
         case TR::m2v:
             // only P9 has splat byte immediate, otherwise it's too expensive
             return cpu->isAtLeast(OMR_PROCESSOR_PPC_P9);

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9097,7 +9097,7 @@
         /* .description =    "vector pack unsigned half word unsigned modulo", */
         /* .prefix      = */ 0x00000000,
         /* .opcode      = */ 0x1000000E,
-        /* .format      = */ FORMAT_UNKNOWN,
+        /* .format      = */ FORMAT_VRT_VRA_VRB,
         /* .minimumALS  = */ OMR_PROCESSOR_PPC_P6,
         /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
     },

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1079,7 +1079,46 @@ TR::Register *OMR::Power::TreeEvaluator::m2iEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::m2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    TR::Node *child = node->getFirstChild();
+
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *dstReg = cg->allocateRegister(TR_GPR);
+
+    TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
+
+    node->setRegister(dstReg);
+
+    // set all but least significant bit of each halfword element to 0
+    generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltish, node, tmpReg, 1);
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::vand, node, tmpReg, srcReg, tmpReg);
+
+    // reverse element order if little endian (P8 or lower only due to availability fo xxbrw instruction)
+    if (cg->comp()->target().cpu.isLittleEndian() && !cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9)) {
+        TR::Register *shiftReg = cg->allocateRegister(TR_VRF);
+
+        generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxpermdi, node, tmpReg, tmpReg, tmpReg, 2);
+        generateTrg1ImmInstruction(cg, TR::InstOpCode::vspltisw, node, shiftReg, -16);
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::vrld, node, tmpReg, tmpReg, shiftReg);
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::vrld, node, tmpReg, tmpReg, shiftReg);
+        generateTrg1Src2Instruction(cg, TR::InstOpCode::vrlw, node, tmpReg, tmpReg, shiftReg);
+
+        cg->stopUsingRegister(shiftReg);
+    }
+
+    // pack halfworld-length elements into byte-length elements
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::vpkuhum, node, tmpReg, tmpReg, tmpReg);
+
+    // if not done already (i.e.: P9+), reverse byte order if little endian
+    if (cg->comp()->target().cpu.isLittleEndian() && cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P9))
+        generateTrg1Src1Instruction(cg, TR::InstOpCode::xxbrq, node, tmpReg, tmpReg);
+
+    // move to GPR
+    generateTrg1Src1Instruction(cg, TR::InstOpCode::mfvsrd, node, dstReg, tmpReg);
+
+    cg->stopUsingRegister(tmpReg);
+    cg->decReferenceCount(child);
+
+    return dstReg;
 }
 
 TR::Register *OMR::Power::TreeEvaluator::m2vEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
Implement PPC codegen for m2l (Mask to Long) on P8+. This operation accepts a ShortVector mask (eight elements) and converts it into eight elements of a boolean array with the corresponding values.