### PR TITLE
x86: remove supports_feature_test

### DIFF
--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -294,11 +294,6 @@ bool OMR::X86::CPU::supportsFeature(uint32_t feature)
     if (TR::Compiler->omrPortLib == NULL)
         return self()->supports_feature_old_api(feature);
 
-    static bool disableOldVersionCPUDetectionTest = feGetEnv("TR_DisableOldVersionCPUDetectionTest") != NULL;
-    if (!disableOldVersionCPUDetectionTest)
-        TR_ASSERT_FATAL(self()->supports_feature_test(feature), "old api and new api did not match, feature %d",
-            feature);
-
     OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
     return TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature);
 }
@@ -354,118 +349,6 @@ bool OMR::X86::CPU::is_test(OMRProcessorArchitecture p)
             return TR::CodeGenerator::getX86ProcessorInfo().isAMDOpteron() == (_processorDescription.processor == p);
         case OMR_PROCESSOR_X86_AMD_FAMILY15H:
             return TR::CodeGenerator::getX86ProcessorInfo().isAMD15h() == (_processorDescription.processor == p);
-        default:
-            return false;
-    }
-    return false;
-}
-
-bool OMR::X86::CPU::supports_feature_test(uint32_t feature)
-{
-    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
-    bool ans = (TRUE == omrsysinfo_processor_has_feature(&_processorDescription, feature));
-
-    switch (feature) {
-        case OMR_FEATURE_X86_OSXSAVE:
-            return TR::CodeGenerator::getX86ProcessorInfo().enabledXSAVE() == ans;
-        case OMR_FEATURE_X86_FPU:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasBuiltInFPU() == ans;
-        case OMR_FEATURE_X86_VME:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsVirtualModeExtension() == ans;
-        case OMR_FEATURE_X86_DE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsDebuggingExtension() == ans;
-        case OMR_FEATURE_X86_PSE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsPageSizeExtension() == ans;
-        case OMR_FEATURE_X86_TSC:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsRDTSCInstruction() == ans;
-        case OMR_FEATURE_X86_MSR:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasModelSpecificRegisters() == ans;
-        case OMR_FEATURE_X86_PAE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsPhysicalAddressExtension() == ans;
-        case OMR_FEATURE_X86_MCE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsMachineCheckException() == ans;
-        case OMR_FEATURE_X86_CX8:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG8BInstruction() == ans;
-        case OMR_FEATURE_X86_CMPXCHG16B:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCMPXCHG16BInstruction() == ans;
-        case OMR_FEATURE_X86_APIC:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasAPICHardware() == ans;
-        case OMR_FEATURE_X86_MTRR:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasMemoryTypeRangeRegisters() == ans;
-        case OMR_FEATURE_X86_PGE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsPageGlobalFlag() == ans;
-        case OMR_FEATURE_X86_MCA:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasMachineCheckArchitecture() == ans;
-        case OMR_FEATURE_X86_CMOV:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCMOVInstructions() == ans;
-        case OMR_FEATURE_X86_PAT:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasPageAttributeTable() == ans;
-        case OMR_FEATURE_X86_PSE_36:
-            return TR::CodeGenerator::getX86ProcessorInfo().has36BitPageSizeExtension() == ans;
-        case OMR_FEATURE_X86_PSN:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasProcessorSerialNumber() == ans;
-        case OMR_FEATURE_X86_CLFSH:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCLFLUSHInstruction() == ans;
-        case OMR_FEATURE_X86_CLWB:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCLWBInstruction() == ans;
-        case OMR_FEATURE_X86_DS:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsDebugTraceStore() == ans;
-        case OMR_FEATURE_X86_ACPI:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasACPIRegisters() == ans;
-        case OMR_FEATURE_X86_MMX:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsMMXInstructions() == ans;
-        case OMR_FEATURE_X86_FXSR:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsFastFPSavesRestores() == ans;
-        case OMR_FEATURE_X86_SSE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE() == ans;
-        case OMR_FEATURE_X86_SSE2:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE2() == ans;
-        case OMR_FEATURE_X86_SSE3:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE3() == ans;
-        case OMR_FEATURE_X86_SSSE3:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSSE3() == ans;
-        case OMR_FEATURE_X86_SSE4_1:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() == ans;
-        case OMR_FEATURE_X86_SSE4_2:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_2() == ans;
-        case OMR_FEATURE_X86_PCLMULQDQ:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsCLMUL() == ans;
-        case OMR_FEATURE_X86_AESNI:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAESNI() == ans;
-        case OMR_FEATURE_X86_POPCNT:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsPOPCNT() == ans;
-        case OMR_FEATURE_X86_SS:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsSelfSnoop() == ans;
-        case OMR_FEATURE_X86_RTM:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsTM() == ans;
-        case OMR_FEATURE_X86_HTT:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsHyperThreading() == ans;
-        case OMR_FEATURE_X86_HLE:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsHLE() == ans;
-        case OMR_FEATURE_X86_TM:
-            return TR::CodeGenerator::getX86ProcessorInfo().hasThermalMonitor() == ans;
-        case OMR_FEATURE_X86_AVX:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX() == ans;
-        case OMR_FEATURE_X86_BMI2:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2() == ans;
-        case OMR_FEATURE_X86_AVX2:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX2();
-        case OMR_FEATURE_X86_AVX512F:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512F();
-        case OMR_FEATURE_X86_AVX512VL:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VL();
-        case OMR_FEATURE_X86_AVX512BW:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BW();
-        case OMR_FEATURE_X86_AVX512DQ:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512DQ();
-        case OMR_FEATURE_X86_AVX512CD:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512CD();
-        case OMR_FEATURE_X86_AVX512_VBMI2:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VBMI2();
-        case OMR_FEATURE_X86_AVX512_BITALG:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512BITALG();
-        case OMR_FEATURE_X86_AVX512_VPOPCNTDQ:
-            return TR::CodeGenerator::getX86ProcessorInfo().supportsAVX512VPOPCNTDQ();
         default:
             return false;
     }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -157,7 +157,6 @@ public:
 
     bool supportsFeature(uint32_t feature);
     bool supports_feature_old_api(uint32_t feature);
-    bool supports_feature_test(uint32_t feature);
 
     bool isFeatureDisabledByOption(uint32_t feature);
 


### PR DESCRIPTION
The `supports_feature_test` function is broken and the check is unnecessary.