### PR TITLE
Fix `PassThrough` handling for commoning fix-up when splitting blocks

### DIFF
--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -869,7 +869,9 @@ public:
 
 private:
     void printNodesWithMultipleReferences();
+    void collectNodesWithMultipleReferences(TR::TreeTop *storeInsertionPoint, TR::TreeTop *start, TR::TreeTop *end);
     void collectNodesWithMultipleReferences(TR::TreeTop *, TR::Node *, TR::Node *);
+    void uncommonPassThroughNodes(TR::Node *, TR::NodeChecklist &);
     void replaceNodesReferencedFromAbove(TR::Block *, TR::NodeChecklist &visitedNodes);
     void replaceNodesReferencedFromAbove(TR::TreeTop *, TR::Node *, TR::Node *, uint32_t,
         TR::NodeChecklist &visitedNodes);


### PR DESCRIPTION
Commoning fix-up avoids storing/reloading the values of `PassThrough` nodes because `PassThrough` is untyped. It does this by replacing commoned `PassThrough` nodes with fresh uncommoned ones, causing the child to be commoned instead. So far this has been done interleaved with the analysis that determines which nodes are live at each point, i.e. in `collectNodesWithMultipleReferences()`, but doing so can interfere with that analysis because it can introduce new occurrences of the child after its refcount has been observed.

Commoned `PassThrough` nodes are now handled in a separate walk over the trees so that all refcounts seen by `collectNodesWithMultipleReferences()` will be accurate.