### PR TITLE
Do not restore comp phase during comp exception

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2466,7 +2466,11 @@ OMR::Compilation::CompilationPhaseScope::CompilationPhaseScope(TR::Compilation *
     , _savedPhase(comp->saveCompilationPhase())
 {}
 
-OMR::Compilation::CompilationPhaseScope::~CompilationPhaseScope() { _comp->restoreCompilationPhase(_savedPhase); }
+OMR::Compilation::CompilationPhaseScope::~CompilationPhaseScope()
+{
+    if (!std::uncaught_exception())
+        _comp->restoreCompilationPhase(_savedPhase);
+}
 
 TR::Region &OMR::Compilation::aliasRegion() { return self()->_aliasRegion; }
 

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1640,6 +1640,7 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             delete opt;
             return 0;
         }
+        comp()->reportOptimizationPhase(optNum);
 
         if (comp()->getOption(TR_TraceOptDetails)) {
             if (comp()->isOutermostMethod())
@@ -1947,7 +1948,6 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
             }
         }
 
-        comp()->reportOptimizationPhase(optNum);
         breakForTesting(optNum);
         if (!doThisOptimizationIfEnabled
             || manager->getRequestedBlocks()->find(toBlock(comp()->getFlowGraph()->getStart()))


### PR DESCRIPTION
In `OMR::Optimizer::optimize()` the JIT saves the "compilation phase"
into a stack allocated object of type `TR::Compilation::CompilationPhaseScope`.
This happens in the constructor of the object. The destructor of the
object restores the previously saved state. This ensures that that if we
leave the scope of the `OMR::Optimizer::optimize()` routine, the compilation
phase is properly restored.
However, if the optimizer throws an exception, the stack is unwound, the
destructor of the CompilationPhaseScope object is called and the compilation
phase is restored (most likely showing as ILgen). This is not want we want.
For exceptions, we want to retain the compilation phase (namely the optimization)
that produced the exception, so that it can be properly reported at higher
levels, when the exception is caught.
This commit changes the destructor of the CompilationPhaseScope object so that
the compilation phase is restored only if there isn't an exception in progress.
This ensures that the compilation phase at the time when the exception was
thrown is reported correctly.
This commit also moves the `comp()->reportOptimizationPhase(optNum);`
statement from `performOptimization()` routine to an earlier location,
as soon as we determine that the current optimization is a proper optimization
and not an optimization group. This ensures that the "analysisPhase" reported
in case of a crash or exception is shown in the context of the current optimization
and not the previous one.