### PR TITLE
Z: Implement vector mask to boolean array evaluators

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4454,6 +4454,11 @@ bool OMR::Z::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::ILOpC
         case TR::vcmple:
         case TR::vcmpgt:
         case TR::vcmpge:
+        case TR::m2v:
+        case TR::m2l:
+        case TR::m2i:
+        case TR::m2s:
+        case TR::m2b:
         case TR::v2m:
         case TR::b2m:
         case TR::s2m:


### PR DESCRIPTION
Implement m2b, m2s, m2i, m2l, m2v opcodes on IBM Z platform.

Related to: https://github.com/eclipse-omr/omr/pull/7927