### PR TITLE
Adaptive CS taxation headroom

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -519,7 +519,8 @@ public:
 	float concurrentScavengerAllocAverageBoost; /**< boost factor for allocate rate, used for tilt calculation in CS - similar to Slack but expressed in relative rather than absolute terms */
 	float concurrentScavengerAllocDeviationBoost; /**< boost factor for allocate rate deviation, used for tilt calculation in CS - increase when frequent small deviations in allocation are expected */
 	bool concurrentScavengeExhaustiveTermination; /**< control flag to enable/disable concurrent phase termination optimization using involving async mutator callbacks */
-	float concurrentScavengerTaxationHeadroom; /**< Threshold of allocation progress allowed ahead of copying before taxation is activated */
+	float concurrentScavengeTaxationHeadroomLow; /**< Threshold of allocation progress allowed ahead of copying before taxation is activated, low bound */
+	float concurrentScavengeTaxationHeadroomHigh; /**< Threshold of allocation progress allowed ahead of copying before taxation is activated, high bound */
 #endif	/* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1719,7 +1720,8 @@ public:
 		, concurrentScavengerAllocAverageBoost(1.5)
 		, concurrentScavengerAllocDeviationBoost(5.0)
 		, concurrentScavengeExhaustiveTermination(true)
-		, concurrentScavengerTaxationHeadroom(0.00f)
+		, concurrentScavengeTaxationHeadroomLow(-0.1f)
+		, concurrentScavengeTaxationHeadroomHigh(0.2f)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)


### PR DESCRIPTION
During concurrent phase the headroom will gradually increase from low to high.

This is for two reasons:
- ignore early fluctuations in allocate and copy progress. We don't want to panic too early and activate the taxation if the copy progress might eventually catch up,
- compensate for read barrier activity that is already a form of taxation, also early in the concurrent phase.