### PR TITLE
AArch64: Improve some unary evaluators

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -101,22 +101,24 @@ TR::Register *OMR::ARM64::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::Node *firstChild = node->getFirstChild();
-    TR::Register *reg = cg->gprClobberEvaluate(firstChild);
-    generateNegInstruction(cg, node, reg, reg);
-    node->setRegister(reg);
-    cg->decReferenceCount(firstChild);
-    return reg;
+    TR::Node *child = node->getFirstChild();
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+    generateNegInstruction(cg, node, trgReg, srcReg);
+    node->setRegister(trgReg);
+    cg->decReferenceCount(child);
+    return trgReg;
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::Node *firstChild = node->getFirstChild();
-    TR::Register *tempReg = cg->gprClobberEvaluate(firstChild);
-    generateNegInstruction(cg, node, tempReg, tempReg, true);
-    node->setRegister(tempReg);
-    cg->decReferenceCount(firstChild);
-    return tempReg;
+    TR::Node *child = node->getFirstChild();
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
+    generateNegInstruction(cg, node, trgReg, srcReg, true);
+    node->setRegister(trgReg);
+    cg->decReferenceCount(child);
+    return trgReg;
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg,
@@ -487,11 +489,15 @@ static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mne
 TR::Register *OMR::ARM64::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
-    TR::Register *trgReg = cg->gprClobberEvaluate(child);
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
     if (child->getOpCodeValue() == TR::bload || child->getOpCodeValue() == TR::bloadi) {
         // No sign extension needed.
+        if (trgReg != srcReg) {
+            generateMovInstruction(cg, node, trgReg, srcReg);
+        }
     } else {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, trgReg, 7);
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg, 7);
     }
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
@@ -501,11 +507,15 @@ TR::Register *OMR::ARM64::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::ARM64::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
-    TR::Register *trgReg = cg->gprClobberEvaluate(child);
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
     if (child->getOpCodeValue() == TR::sload || child->getOpCodeValue() == TR::sloadi) {
         // No sign extension needed.
+        if (trgReg != srcReg) {
+            generateMovInstruction(cg, node, trgReg, srcReg);
+        }
     } else {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, trgReg, 15);
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg, 15);
     }
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
@@ -574,12 +584,16 @@ TR::Register *OMR::ARM64::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::ARM64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
-    TR::Register *trgReg = cg->gprClobberEvaluate(child);
+    TR::Register *srcReg = cg->evaluate(child);
+    TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
 
     if (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi) {
         // No need for zero extension
+        if (trgReg != srcReg) {
+            generateMovInstruction(cg, node, trgReg, srcReg);
+        }
     } else {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, node, trgReg, trgReg, 31);
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, node, trgReg, srcReg, 31);
     }
     node->setRegister(trgReg);
     cg->decReferenceCount(child);


### PR DESCRIPTION
This commit improves code generation of some unary evaluators for AArch64 by removing unnecessary mov instruction when the reference count of the child node > 1.