### PR TITLE
Remove generateBreakOnDFSet instruction generator

### DIFF
--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -3208,30 +3208,6 @@ void TR::AMD64RegImm64SymInstruction::autoSetReloKind()
 // Generate methods
 ////////////////////////////////////////////////////////////////////////////////
 
-TR::Instruction *generateBreakOnDFSet(TR::CodeGenerator *cg, TR::Instruction *cursor)
-{
-    if (!cursor)
-        cursor = cg->getAppendInstruction();
-
-    TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
-    cursor = generateInstruction(cursor, TR::InstOpCode::PUSHFD, cg);
-    TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
-    TR::LabelSymbol *endLabel = generateLabelSymbol(cg);
-    begLabel->setStartInternalControlFlow();
-    endLabel->setEndInternalControlFlow();
-
-    const int32_t dfMask = 0x400;
-    cursor = generateLabelInstruction(cursor, TR::InstOpCode::label, begLabel, cg);
-    cursor = generateMemImmInstruction(cursor, TR::InstOpCode::TEST2MemImm2, generateX86MemoryReference(espReal, 0, cg),
-        dfMask, cg);
-    cursor = generateLabelInstruction(cursor, TR::InstOpCode::JE1, endLabel, cg);
-    cursor = generateInstruction(cursor, TR::InstOpCode::INT3, cg);
-    cursor = generateLabelInstruction(cursor, TR::InstOpCode::label, endLabel, cg);
-    cursor = generateInstruction(cursor, TR::InstOpCode::POPFD, cg);
-
-    return cursor;
-}
-
 TR::Instruction *generateInstruction(TR::Instruction *prev, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg,
     OMR::X86::Encoding encoding)
 {

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -2743,21 +2743,6 @@ TR::X86RegMemInstruction *generateRegMemInstruction(TR::Instruction *, TR::InstO
 TR::X86RegRegInstruction *generateRegRegInstruction(TR::Instruction *, TR::InstOpCode::Mnemonic op, TR::Register *reg1,
     TR::Register *reg2, TR::CodeGenerator *cg, OMR::X86::Encoding encoding = OMR::X86::Default);
 
-/** \brief
- *   Insert instructions to check DF flag is in the right state (zero) and trap if not
- *
- *  \param cg
- *   The Code Generator
- *
- *  \param cursor
- *   The instruction the generated sequence to be inserted after. If is NULL, the check
- *   will be inserted after the most recently generated instruction
- *
- *  \return
- *   Return the last instruction of the sequence
- */
-TR::Instruction *generateBreakOnDFSet(TR::CodeGenerator *cg, TR::Instruction *cursor = NULL);
-
 TR::Instruction *generateInstruction(TR::InstOpCode::Mnemonic, TR::Node *, TR::RegisterDependencyConditions *cond,
     TR::CodeGenerator *cg, OMR::X86::Encoding encoding = OMR::X86::Default);
 TR::Instruction *generateInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg,


### PR DESCRIPTION
These instructions were part of a diagnostic feature in a downstream project that has been eliminated.