### PR TITLE
Ensure AOT-only relocations are not generated in a non-AOT compilation

### DIFF
--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1045,15 +1045,19 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                                                               TR_MethodEnterExitHookAddress, cg),
                                     __FILE__, __LINE__, node);
                             } else if (symbol->isCallSiteTableEntry()) {
-                                cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                              (uint8_t *)&self()->getSymbolReference(), NULL,
-                                                              TR_CallsiteTableEntryAddress, cg),
-                                    __FILE__, __LINE__, node);
+                                if (cg->comp()->compileRelocatableCode()) {
+                                    cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                                  (uint8_t *)&self()->getSymbolReference(), NULL,
+                                                                  TR_CallsiteTableEntryAddress, cg),
+                                        __FILE__, __LINE__, node);
+                                }
                             } else if (symbol->isMethodTypeTableEntry()) {
-                                cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                              (uint8_t *)&self()->getSymbolReference(), NULL,
-                                                              TR_MethodTypeTableEntryAddress, cg),
-                                    __FILE__, __LINE__, node);
+                                if (cg->comp()->compileRelocatableCode()) {
+                                    cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                                  (uint8_t *)&self()->getSymbolReference(), NULL,
+                                                                  TR_MethodTypeTableEntryAddress, cg),
+                                        __FILE__, __LINE__, node);
+                                }
                             } else {
                                 cg->addExternalRelocation(
                                     TR::ExternalRelocation::create(cursor, (uint8_t *)&self()->getSymbolReference(),

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -924,9 +924,9 @@ void TR::X86RegImmSymInstruction::autoSetReloKind()
         setReloKind(TR_RecompQueuedFlag);
     } else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress()) {
         setReloKind(TR_MethodEnterExitHookAddress);
-    } else if (symbol->isCallSiteTableEntry()) {
+    } else if (cg()->comp()->compileRelocatableCode() && symbol->isCallSiteTableEntry()) {
         setReloKind(TR_CallsiteTableEntryAddress);
-    } else if (symbol->isMethodTypeTableEntry()) {
+    } else if (cg()->comp()->compileRelocatableCode() && symbol->isMethodTypeTableEntry()) {
         setReloKind(TR_MethodTypeTableEntryAddress);
     }
 }
@@ -3196,9 +3196,11 @@ void TR::AMD64RegImm64SymInstruction::autoSetReloKind()
         setReloKind(TR_RecompQueuedFlag);
     else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress())
         setReloKind(TR_MethodEnterExitHookAddress);
-    else if (symbol->isCallSiteTableEntry() && !getSymbolReference()->isUnresolved())
+    else if (cg()->comp()->compileRelocatableCode() && symbol->isCallSiteTableEntry()
+        && !getSymbolReference()->isUnresolved())
         setReloKind(TR_CallsiteTableEntryAddress);
-    else if (symbol->isMethodTypeTableEntry() && !getSymbolReference()->isUnresolved())
+    else if (cg()->comp()->compileRelocatableCode() && symbol->isMethodTypeTableEntry()
+        && !getSymbolReference()->isUnresolved())
         setReloKind(TR_MethodTypeTableEntryAddress);
     else
         setReloKind(-1);

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1030,13 +1030,19 @@ void TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                                     NULL, TR_MethodEnterExitHookAddress, cg()),
                         __FILE__, __LINE__, getNode());
                 } else if (sym->isCallSiteTableEntry()) {
-                    cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
-                                                    NULL, TR_CallsiteTableEntryAddress, cg()),
-                        __FILE__, __LINE__, getNode());
+                    if (cg()->comp()->compileRelocatableCode()) {
+                        cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                        (uint8_t *)getSymbolReference(), NULL,
+                                                        TR_CallsiteTableEntryAddress, cg()),
+                            __FILE__, __LINE__, getNode());
+                    }
                 } else if (sym->isMethodTypeTableEntry()) {
-                    cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
-                                                    NULL, TR_MethodTypeTableEntryAddress, cg()),
-                        __FILE__, __LINE__, getNode());
+                    if (cg()->comp()->compileRelocatableCode()) {
+                        cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                        (uint8_t *)getSymbolReference(), NULL,
+                                                        TR_MethodTypeTableEntryAddress, cg()),
+                            __FILE__, __LINE__, getNode());
+                    }
                 } else {
                     cg()->addExternalRelocation(
                         TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
@@ -1702,15 +1708,19 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
         } break;
 
         case TR_CallsiteTableEntryAddress: {
-            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
-                                            TR_CallsiteTableEntryAddress, cg()),
-                __FILE__, __LINE__, getNode());
+            if (cg()->comp()->compileRelocatableCode()) {
+                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
+                                                NULL, TR_CallsiteTableEntryAddress, cg()),
+                    __FILE__, __LINE__, getNode());
+            }
         } break;
 
         case TR_MethodTypeTableEntryAddress: {
-            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
-                                            TR_MethodTypeTableEntryAddress, cg()),
-                __FILE__, __LINE__, getNode());
+            if (cg()->comp()->compileRelocatableCode()) {
+                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
+                                                NULL, TR_MethodTypeTableEntryAddress, cg()),
+                    __FILE__, __LINE__, getNode());
+            }
         } break;
 
         default:
@@ -2104,13 +2114,17 @@ void TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                         TR_MethodEnterExitHookAddress, cg()),
             __FILE__, __LINE__, getNode());
     } else if (symbol->isCallSiteTableEntry()) {
-        cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
-                                        TR_CallsiteTableEntryAddress, cg()),
-            __FILE__, __LINE__, getNode());
+        if (cg()->comp()->compileRelocatableCode()) {
+            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
+                                            TR_CallsiteTableEntryAddress, cg()),
+                __FILE__, __LINE__, getNode());
+        }
     } else if (symbol->isMethodTypeTableEntry()) {
-        cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
-                                        TR_MethodTypeTableEntryAddress, cg()),
-            __FILE__, __LINE__, getNode());
+        if (cg()->comp()->compileRelocatableCode()) {
+            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
+                                            TR_MethodTypeTableEntryAddress, cg()),
+                __FILE__, __LINE__, getNode());
+        }
     } else {
         cg()->addExternalRelocation(
             TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
@@ -2827,15 +2841,19 @@ void TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             } break;
 
             case TR_CallsiteTableEntryAddress: {
-                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
-                                                NULL, TR_CallsiteTableEntryAddress, cg()),
-                    __FILE__, __LINE__, getNode());
+                if (cg()->comp()->compileRelocatableCode()) {
+                    cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
+                                                    NULL, TR_CallsiteTableEntryAddress, cg()),
+                        __FILE__, __LINE__, getNode());
+                }
             } break;
 
             case TR_MethodTypeTableEntryAddress: {
-                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
-                                                NULL, TR_MethodTypeTableEntryAddress, cg()),
-                    __FILE__, __LINE__, getNode());
+                if (cg()->comp()->compileRelocatableCode()) {
+                    cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
+                                                    NULL, TR_MethodTypeTableEntryAddress, cg()),
+                        __FILE__, __LINE__, getNode());
+                }
             } break;
 
             default:;

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -246,17 +246,21 @@ void TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
         } break;
 
         case TR_CallsiteTableEntryAddress: {
-            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                            (uint8_t *)getNode()->getSymbolReference(), NULL,
-                                            TR_CallsiteTableEntryAddress, cg()),
-                __FILE__, __LINE__, getNode());
+            if (cg()->comp()->compileRelocatableCode()) {
+                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                (uint8_t *)getNode()->getSymbolReference(), NULL,
+                                                TR_CallsiteTableEntryAddress, cg()),
+                    __FILE__, __LINE__, getNode());
+            }
         } break;
 
         case TR_MethodTypeTableEntryAddress: {
-            cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                            (uint8_t *)getNode()->getSymbolReference(), NULL,
-                                            TR_MethodTypeTableEntryAddress, cg()),
-                __FILE__, __LINE__, getNode());
+            if (cg()->comp()->compileRelocatableCode()) {
+                cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
+                                                (uint8_t *)getNode()->getSymbolReference(), NULL,
+                                                TR_MethodTypeTableEntryAddress, cg()),
+                    __FILE__, __LINE__, getNode());
+            }
         } break;
 
         default:


### PR DESCRIPTION
In the downstream project OpenJ9, a change to how classes are laid out in memory resulted in some addresses no longer being in the sub-4G region. As a consequence, the code emitted by the compiler changed, causing some code paths to execute that rarely executed in a non-relocatable compilation. In a normal run, this did not change much because although the relocatable code paths created a relocation record, the compiler would not actually process them. However, when enabling the OpenJ9 JITServer feature, the compiler would process the relocation records.

The two relocation types that are guarded in this PR (`TR_CallsiteTableEntryAddress` and `TR_MethodTypeTableEntryAddress`) are normally only generated for a relocatable compilation when the SVM feature is enabled; however, under JITServer, it would also be generated for a JIT compilation. However, since these relocation records cannot be processed without the SVM, which is not used in a JIT compilation, it resulted in a compilation failure, ultimately impacting throughput performance.

This PR fixes this by ensuring that these relocation records are only generated under a relocatable compile.