### PR TITLE
Remove a redundant assignment in simplifySimpleStore()

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -826,7 +826,6 @@ bool OMR::CFGSimplifier::simplifySimpleStore(bool needToDuplicateTree)
         if (trace())
             traceMsg(comp(), "   Take side has an appropriate store as the first tree\n");
 
-        trueValue = treeCursor->getNode()->getFirstChild();
         if (treeCursor->getNode()->getFirstChild()->isInternalPointer())
             return false;
 


### PR DESCRIPTION
This PR removes a redundant assignment in
OMR::CFGSimplifier::simplifySimpleStore().

Two lines in the same block are assigning the same value to trueValue.