### PR TITLE
Introduce conversion size to index in integers

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -885,6 +885,10 @@ public:
 
 	bool shouldForceLowMemoryHeapCeilingShiftIfPossible; /**< Whether we should force compressed reference shift to 3 **/
 	MM_CPUUtilStats cpuUtilStats; /**< CPU/process util between any STW GC increments, hence not part of any Collector Stats */
+
+	bool shouldUseIntegerSizeToIndex; /**< Use conversion size to index and index to size in integers */
+
+
 	/* Function Members */
 private:
 
@@ -1992,6 +1996,7 @@ public:
 		, shouldForceLowMemoryHeapCeilingShiftIfPossible(false)
 		, cpuUtilStats()
 #endif /* defined(OMR_VALGRIND_MEMCHECK) */
+		, shouldUseIntegerSizeToIndex(true)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/MemoryPoolSplitAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedList.cpp
@@ -1330,7 +1330,7 @@ MM_MemoryPoolSplitAddressOrderedList::reinitializeForRestore(MM_EnvironmentBase 
 				return false;
 			}
 
-			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(env);
+			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(_extensions);
 
 			if (!_largeObjectAllocateStatsForFreeList[i].initialize(
 					env, (uint16_t)_extensions->largeObjectAllocationProfilingTopK,

--- a/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
@@ -183,7 +183,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::initialize(MM_EnvironmentBase* env)
 		return false;
 	} else {
 		for (uintptr_t i = 0; i < _heapFreeListCount; ++i) {
-			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(env);
+			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(_extensions);
 
 			/* set multiple factor = 2 for doubling _maxVeryLargeEntrySizes to avoid run out of _veryLargeEntryPool (minus count during decrement) */
 			if (!_largeObjectAllocateStatsForFreeList[i].initialize(env, (uint16_t)extensions->largeObjectAllocationProfilingTopK, extensions->largeObjectAllocationProfilingThreshold, extensions->largeObjectAllocationProfilingVeryLargeObjectThreshold, (float)extensions->largeObjectAllocationProfilingSizeClassRatio / (float)100.0,

--- a/gc/stats/LargeObjectAllocateStats.hpp
+++ b/gc/stats/LargeObjectAllocateStats.hpp
@@ -33,7 +33,7 @@
 #include "FreeEntrySizeClassStats.hpp"
 
 class MM_EnvironmentBase;
-class MM_FreeEntrySizeClassStats;
+class MM_GCExtensionsBase;
 
 /*
  * Keeps track of the most frequent large allocations
@@ -41,7 +41,7 @@ class MM_FreeEntrySizeClassStats;
 class MM_LargeObjectAllocateStats : public MM_Base {
 public:
 private:
-	MM_EnvironmentBase *_env;				/**< cached thread environment */
+	MM_GCExtensionsBase *_ext;				/**< cached GC Extensions*/
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	uintptr_t _tlhMaximumSize;				/**< cached value of _tlhMaximumSize */
 	uintptr_t _tlhMinimumSize;				/**< cached value of _tlhMinimumSize */
@@ -222,9 +222,12 @@ public:
 	uintptr_t getFreeMemory(){return _freeEntrySizeClassStats.getFreeMemory(_sizeClassSizes);}
 	uintptr_t getPageAlignedFreeMemory(uintptr_t pageSize) {return _freeEntrySizeClassStats.getPageAlignedFreeMemory(_sizeClassSizes, pageSize);}
 
+	MMINLINE static uintptr_t sizeToIndexFP(uintptr_t size, float ratioInversed);
+	MMINLINE static uintptr_t indexToSizeFP(uintptr_t index, float ratio);
 
-	MM_LargeObjectAllocateStats(MM_EnvironmentBase* env) :
-		_env(env),
+	MM_LargeObjectAllocateStats(MM_GCExtensionsBase* ext) :
+		MM_Base(),
+		_ext(ext),
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 		_tlhMaximumSize(0),
 		_tlhMinimumSize(0),
@@ -237,7 +240,7 @@ public:
 		_maxAllocateSizes(0),
 		_largeObjectThreshold(0),
 		_veryLargeEntrySizeClass(0),
-		_sizeClassRatio(0.0),
+		_sizeClassRatio(0.0f),
 		_sizeClassRatioLogInversed(0.0f),
 		_averageBytesAllocated(0),
 		_timeEstimateFragmentation(0),


### PR DESCRIPTION
Introducing simplified size-to-index and index-to-size functions using calculations in integers and making it enabled by default. Old calculation in Float Point math is preserved and can be activated is necessary.
Calculation in integers using hardcoded log base ~1.189 instead of 1.2 for FP. This hardcoded log base can not be changed, so log base parameter is ignored.