### PR TITLE
Add code cache kind to TR_PrintCompMem printout

### DIFF
--- a/compiler/control/OptionsUtil.hpp
+++ b/compiler/control/OptionsUtil.hpp
@@ -205,8 +205,8 @@ private:
 };
 
 // An enum to indcate the type of code cache a compiled body will be placed into
-// If you add a new value to this enum, make sure to update CodeCacheKindStrings
-// in compiler/runtime/OMRCodeCacheManager.cpp
+// If you add a new value to this enum, make sure to update getCodeCacheKindString
+// in compiler/runtime/OMRCodeCache.cpp
 enum CodeCacheKind {
     DEFAULT_CC = 0,
     TRANSIENT_CODE_CC, // To prevent fragmentation, we allow the user to indicate that certain classes are

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -140,6 +140,20 @@ uint8_t *OMR::CodeCache::getCodeBase() { return _segment->segmentBase(); }
 
 uint8_t *OMR::CodeCache::getCodeTop() { return _segment->segmentTop(); }
 
+const char *OMR::CodeCache::getCodeCacheKindString()
+{
+    switch (_kind) {
+        case TR::CodeCacheKind::DEFAULT_CC:
+            return "DEFAULT_CC";
+        case TR::CodeCacheKind::TRANSIENT_CODE_CC:
+            return "TRANSIENT_CODE_CC";
+        case TR::CodeCacheKind::FILE_BACKED_CC:
+            return "FILE_BACKED_CC";
+        default:
+            return "UNKNOWN";
+    }
+}
+
 void OMR::CodeCache::reserve(int32_t reservingCompThreadID)
 {
     _reserved = true;
@@ -1150,7 +1164,9 @@ void OMR::CodeCache::dumpCodeCache()
 
 void OMR::CodeCache::printOccupancyStats()
 {
-    fprintf(stderr, "Code Cache @%p flags=0x%x almostFull=%d\n", this, _flags, _almostFull);
+    fprintf(stderr, "Code Cache @%p flags=0x%x almostFull=%d codeCacheKind=%s\n", this, _flags, _almostFull,
+        getCodeCacheKindString());
+    fprintf(stderr, "   range: " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT "\n", getCodeBase(), getCodeTop());
     fprintf(stderr, "   cold-warm hole size        = %8" OMR_PRIuSIZE " bytes\n", self()->getFreeContiguousSpace());
     fprintf(stderr, "   warmCodeAlloc=%p coldCodeAlloc=%p\n", (void *)_warmCodeAlloc, (void *)_coldCodeAlloc);
     size_t warmCodeSize = _warmCodeAlloc - _segment->segmentBase();

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -80,6 +80,8 @@ public:
     uint8_t *getCodeBase();
     uint8_t *getCodeTop();
 
+    const char *getCodeCacheKindString();
+
     uint8_t *getHelperBase() { return _helperBase; }
 
     uint8_t *getHelperTop() { return _helperTop; }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -1066,10 +1066,6 @@ void OMR::CodeCacheManager::initializeExecutableELFGenerator(void)
 }
 #endif // HOST_OS==OMR_LINUX
 
-// Should be in correspondance with the enum defined in
-// compiler/control/OptionsUtil.hpp
-const char *CodeCacheKindStrings[] = { "DEFAULT_CC", "TRANSIENT_CODE_CC", "FILE_BACKED_CC" };
-
 TR::CodeCache *OMR::CodeCacheManager::allocateCodeCacheFromNewSegment(size_t segmentSizeInBytes,
     int32_t reservingCompilationTID, TR::CodeCacheKind kind)
 {
@@ -1098,7 +1094,7 @@ TR::CodeCache *OMR::CodeCacheManager::allocateCodeCacheFromNewSegment(size_t seg
                     "CodeCache allocated %p @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT
                     " HelperBase:" POINTER_PRINTF_FORMAT " CodeCacheKind=%s",
                     codeCache, codeCache->getCodeBase(), codeCache->getCodeTop(), codeCache->_helperBase,
-                    CodeCacheKindStrings[codeCache->_kind]);
+                    codeCache->getCodeCacheKindString());
             }
 
             return codeCache;


### PR DESCRIPTION
The TR_PrintCompMem printout displays various statistics about code cache usage for each code cache. This pr simply adds code cache kind to those statistics