### PR TITLE
Add JIT option to control feature in downstream project

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -634,6 +634,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      SET_OPTION_BIT(TR_DisablePersistIProfile), "F" },
     { "disableIsolatedSE", "O\tdisable isolated store elimination", TR::Options::disableOptimization,
      isolatedStoreElimination, 0, "P" },
+    { "disableITableIterationsAfterLastITableCacheCheck", "O\tdisable iterating the iTable after last cache check",
+     SET_OPTION_BIT(TR_DisableITableIterationsAfterLastITableCacheCheck), "F" },
     { "disableIterativeSA", "O\trevert back to a recursive version of Structural Analysis",
      SET_OPTION_BIT(TR_DisableIterativeSA), "P" },
     { "disableIVTT", "O\tdisable IV Type transformation", TR::Options::disableOptimization, IVTypeTransformation, 0,

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -446,7 +446,7 @@ enum TR_CompilationOptions {
     // Available                                             = 0x00000200 + 11,
     // Available                                             = 0x00000400 + 11,
     TR_DisableConstProvenance                                = 0x00000800 + 11,
-    // Available                                             = 0x00001000 + 11,
+    TR_DisableITableIterationsAfterLastITableCacheCheck      = 0x00001000 + 11,
     TR_VerboseOptTransformations                             = 0x00002000 + 11,
     TR_DisableEnhancedClobberEval                            = 0x00004000 + 11,
     TR_Enable39064Epilogue                                   = 0x00008000 + 11,


### PR DESCRIPTION
This commit adds a new JIT option called
-Xjit:disableITableIterationsAfterLastITableCacheCheck, which will be used in a downstream project (OpenJ9) to control the Java interface dispatch sequence in the code generator.