### PR TITLE
Clear `_curDefinedOnAllPaths` after processing an outermost loop in GVP

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -4014,6 +4014,14 @@ void TR::GlobalValuePropagation::processNaturalLoop(TR_StructureSubGraphNode *no
         printStructureInfo(node->getStructure(), false, lastTimeThrough);
 
     _loopInfo = parentLoopInfo;
+    if (!insideLoop) {
+        // _curDefinedOnAllPaths is meant to tell us whether it's safe to ignore
+        // back-edge constraints when considering a load within a loop. For code
+        // outside of any loop, it's not kept up to date correctly, and if it's
+        // left in place, stale information from loop processing can interfere
+        // with optimization outside.
+        _curDefinedOnAllPaths = NULL;
+    }
 }
 
 void TR::GlobalValuePropagation::processImproperLoop(TR_StructureSubGraphNode *node, bool lastTimeThrough,


### PR DESCRIPTION
Here is an example in Java where a stale `_curDefinedOnAllPaths` would have prevented a transformation outside of a loop. The last use of `answer` (after the loop) can be folded to 42, but previously GVP would fail to do so.

        if (x == null) {
            throw new NullPointerException();
        }

        int answer = 42;
        int i;
        for (i = 0; i < x.length; i++) {
            x[i] = 0;
            if (x == null) {
                answer++; // dead path
            }
        }

        ... answer ...