### PR TITLE
Fix a performance regression in timed omrthread_park()

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -3331,22 +3331,20 @@ omrthread_park(int64_t millis, intptr_t nanos)
 				boundedMillis -= sleptMillis.quot;
 			}
 #endif /* defined(OMR_THR_YIELD_ALG) */
-			if (boundedMillis > 0) {
-				self->flags |= J9THREAD_FLAG_TIMER_SET;
+			self->flags |= J9THREAD_FLAG_TIMER_SET;
 
-				OMROSCOND_WAIT_IF_TIMEDOUT(self->condition, self->mutex, boundedMillis, nanos) {
-					rc = J9THREAD_TIMED_OUT;
-					break;
-				} else {
-					rc = omrthread_park_check_flags(self);
-					if (J9THREAD_UNPARKED == rc) {
-						self->flags &= ~J9THREAD_FLAG_UNPARKED;
-						rc = 0;
-					}
-					break;
+			OMROSCOND_WAIT_IF_TIMEDOUT(self->condition, self->mutex, boundedMillis, nanos) {
+				rc = J9THREAD_TIMED_OUT;
+				break;
+			} else {
+				rc = omrthread_park_check_flags(self);
+				if (J9THREAD_UNPARKED == rc) {
+					self->flags &= ~J9THREAD_FLAG_UNPARKED;
+					rc = 0;
 				}
-				OMROSCOND_WAIT_TIMED_LOOP();
+				break;
 			}
+			OMROSCOND_WAIT_TIMED_LOOP();
 		} else {
 			OMROSCOND_WAIT(self->condition, self->mutex);
 				rc = omrthread_park_check_flags(self);

--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -532,13 +532,13 @@ omrthread_park_spin(omrthread_t self, int64_t millis, intptr_t nanos, uintptr_t 
 	omrthread_library_t lib = self->library;
 	intptr_t rc = 0;
 	uintptr_t parkPolicy = lib->parkPolicy;
-	intptr_t totalSleepTime = 0;
 
 	if ((OMRTHREAD_PARK_POLICY_NONE != parkPolicy)) {
 		uintptr_t count = 0;
 		uintptr_t parkSleepTime = lib->parkSleepTime;
 		uintptr_t parkSleepMultiplier = lib->parkSleepMultiplier;
 		uintptr_t timeout = (millis * 1000) + (nanos / 1000);
+		intptr_t totalSleepTime = 0;
 
 		if (OMRTHREAD_PARK_POLICY_SPIN == parkPolicy) {
 			/* For now, spin is only supported if no timeout is specified. */
@@ -567,10 +567,12 @@ omrthread_park_spin(omrthread_t self, int64_t millis, intptr_t nanos, uintptr_t 
 				break;
 			}
 		}
+
+		if (NULL != sleptDuration) {
+			*sleptDuration = totalSleepTime;
+		}
 	}
-	if (NULL != sleptDuration) {
-		*sleptDuration = totalSleepTime;
-	}
+	
 	return rc;
 }
 #endif /* defined(OMR_THR_YIELD_ALG) */


### PR DESCRIPTION
The regression is mainly caused by the unintended if statement in https://github.com/eclipse-omr/omr/pull/7895