### PR TITLE
OMR: Remove aarch64/arm cross compile and use aarch64/arm hosts for compile

### DIFF
--- a/buildenv/jenkins/omrbuild.groovy
+++ b/buildenv/jenkins/omrbuild.groovy
@@ -116,7 +116,9 @@ SPECS = [
                 'compile' : defaultCompile
             ]
         ],
-        'test' : false
+        'test' : true,
+        'testArgs' : '',
+        'junitPublish' : true
     ],
     'linux_arm' : [
         'alias': 'arm',
@@ -135,7 +137,9 @@ SPECS = [
                 'compile' : defaultCompile
             ]
         ],
-        'test' : false
+        'test' : true,
+        'testArgs' : '',
+        'junitPublish' : true
     ],
     'linux_ppc-64_le_gcc' : [
         'alias': 'plinux',


### PR DESCRIPTION
- related: https://github.ibm.com/runtimes/infrastructure/issues/11231
- remove aarch64/arm cross compile and use aarch64/arm hosts for aarch/arm compile

Signed-off-by: Aswin K R <aswinkr77@gmail.com>