### PR TITLE
Enable boolean store simplification and disable other CFG simplifications

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -1107,15 +1107,6 @@ bool OMR::CFGSimplifier::simplifyBooleanStore(bool needToDuplicateTree)
         return false;
     logprintf(trace(), log, "   Successor block_%d is single store\n", _next2->getNumber());
 
-    // Store values cannot be internal pointers
-    //
-    int32_t valueIndex = store1->getOpCode().isIndirect() ? 1 : 0;
-    TR::Node *value1 = store1->getChild(valueIndex);
-    TR::Node *value2 = store2->getChild(valueIndex);
-    if (value1->isInternalPointer() || value2->isInternalPointer())
-        return false;
-    logprints(trace(), log, "   Store values are not internal pointers\n");
-
     // The stores must be integer stores to the same variable
     //
     if (store1->getOpCodeValue() != store2->getOpCodeValue())
@@ -1125,6 +1116,15 @@ bool OMR::CFGSimplifier::simplifyBooleanStore(bool needToDuplicateTree)
     if (store1->getSymbolReference()->getSymbol() != store2->getSymbolReference()->getSymbol())
         return false;
     logprints(trace(), log, "   Store nodes opcode and symref checks out\n");
+
+    // Store values cannot be internal pointers
+    //
+    int32_t valueIndex = store1->getOpCode().isIndirect() ? 1 : 0;
+    TR::Node *value1 = store1->getChild(valueIndex);
+    TR::Node *value2 = store2->getChild(valueIndex);
+    if (value1->isInternalPointer() || value2->isInternalPointer())
+        return false;
+    logprints(trace(), log, "   Store values are not internal pointers\n");
 
     // Indirect stores must have the same base
     //


### PR DESCRIPTION
This pull request is comprised of three changes related to the CFG Simplification optimization:

1) It re-enables the boolean store simplification of CFG Simplifier.

2) It fixes a bug in boolean store simplification in examining the values used in two stores on both sides of an if-then-else.  The code was testing whether either value that was being stored was an internal pointer.  However, it got the values of both stores based on whether the first of the two stores was indirect:  if it was indirect, the value of the store must be the child at index 1; otherwise, the value of the store must be the child at index 0.  However, if the first store was indirect, but the second was direct, it would access a non-existent child of the second store at index 1.  Fixed this by delaying retrieving the values until after comparing the opcodes of the two stores for equality, ensuring both are indirect stores or both are direct stores.

3) Several patterns and corresponding transformations in CFG Simplification have never been fully tested &mdash; in particular, `simplifyNullToException`, `simplifySimpleStore, simplifyCondStoreSequence`, `simplifyInstanceOfTestToCheckcast` and `simplifyBoundCheckWithThrowException`.  This change disables those transformations by default, allowing them to be enabled based on the settings of various environment variables.  The intention is that they should be more thoroughly tested and then re-enabled as that testing and any necessary bug fixes have been completed.
