### PR TITLE
Add const provenance edges in a few `J9_PROJECT_SPECIFIC` sections

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -102,6 +102,7 @@
 #include "runtime/J9Profiler.hpp"
 #include "env/CHTable.hpp"
 #include "env/ClassTableCriticalSection.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/RuntimeAssumptionTable.hpp"
 #include "env/VMJ9.h"
@@ -6528,8 +6529,12 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
 
         {
             TR::ClassTableCriticalSection setClass(comp()->fe());
-            receiverInfo->setClass(TR::Compiler->cls.objectClass(comp(),
-                knot->getPointer(receiver->getSymbolReference()->getKnownObjectIndex())));
+            TR::KnownObjectTable::Index koi = receiver->getSymbolReference()->getKnownObjectIndex();
+            TR_OpaqueClassBlock *clazz = TR::Compiler->cls.objectClass(comp(), knot->getPointer(koi));
+            receiverInfo->setClass(clazz);
+
+            J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+            cpg->addEdge(cpg->knownObject(koi), clazz);
         }
     }
 

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -26,6 +26,7 @@
 #include "compile/Compilation.hpp"
 #ifdef J9_PROJECT_SPECIFIC
 #include "env/VMAccessCriticalSection.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #endif
 #include "optimizer/Inliner.hpp"
 
@@ -59,6 +60,9 @@ TR_PrexArgument::TR_PrexArgument(TR::KnownObjectTable::Index knownObjectIndex, T
         if (prexArgumentCriticalSection.hasVMAccess()) {
             _class = TR::Compiler->cls.objectClass(comp, comp->getKnownObjectTable()->getPointer(knownObjectIndex));
             _classKind = ClassIsFixed;
+
+            J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
+            cpg->addEdge(cpg->knownObject(knownObjectIndex), _class);
         }
     }
 #endif

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -50,6 +50,7 @@
 #include "optimizer/ValuePropagation.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
 #include "env/VMJ9.h"
@@ -1082,6 +1083,10 @@ TR::VPConstraint *TR::VPClass::create(OMR::ValuePropagation *vp, TR::VPClassType
         uintptr_t objRefOffs = fej9->getOffsetOfJavaLangClassFromClassField();
         uintptr_t *objRef = (uintptr_t *)(type->getClass() + objRefOffs);
         TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt(objRef);
+
+        J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+        cpg->addEdge(type->getClass(), cpg->knownObject(index));
+
         type = TR::VPKnownObject::createForJavaLangClass(vp, index);
     }
 #endif


### PR DESCRIPTION
These changes are necessary in order for OpenJ9 to keep track in certain cases of where certain classes or known objects were found at compile time.