### PR TITLE
Add upstream support for avoiding AOT on specific methods

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1016,6 +1016,9 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      "M\tdo not activate another compilation thread when high priority request is blocked", RESET_OPTION_BIT(TR_ActivateCompThreadWhenHighPriReqIsBlocked), "F", NOT_IN_SUBSET },
     { "dontAddHWPDataToIProfiler", "O\tDont add HW Data to IProfiler", SET_OPTION_BIT(TR_DontAddHWPDataToIProfiler),
      "F", NOT_IN_SUBSET },
+    { "dontCompile=",
+     "D{regex}\t regex which specifies a subset of methods not to compile. If the option is passed via -Xaot, then"
+        " it is not AOT compiled, but may be jit compiled. The converse is true for -Xjit", TR::Options::setRegex, offsetof(OMR::Options, _dontCompile), 0, "F", NOT_IN_SUBSET },
     { "dontDisclaimMemoryOnSwap",
      "M\tIf memory disclaiming is enabled, prevent disclaiming on swap. Takes precedence over "
         "-Xjit:disclaimMemoryOnSwap", SET_OPTION_BIT(TR_DontDisclaimMemoryOnSwap), "F", NOT_IN_SUBSET },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1464,6 +1464,7 @@ public:
         _disabledIdiomPatterns = NULL;
         _suppressEA = NULL;
         _dontFoldStaticFinalFields = NULL;
+        _dontCompile = NULL;
         _gcCardSize = 0;
         _heapBase = 0;
         _heapTop = 0;
@@ -1889,6 +1890,8 @@ public:
     TR::SimpleRegex *getSuppressEARegex() { return _suppressEA; }
 
     TR::SimpleRegex *getDontFoldStaticFinalFields() { return _dontFoldStaticFinalFields; }
+
+    TR::SimpleRegex *getDontCompile() { return _dontCompile; }
 
     char *getInduceOSR() { return _induceOSR; }
 
@@ -2697,6 +2700,7 @@ protected:
     TR::SimpleRegex *_disabledIdiomPatterns;
     TR::SimpleRegex *_suppressEA;
     TR::SimpleRegex *_dontFoldStaticFinalFields;
+    TR::SimpleRegex *_dontCompile;
     uintptr_t _gcCardSize;
     uintptr_t _heapBase;
     uintptr_t _heapTop;


### PR DESCRIPTION
Add OMR support for the `-Xjit:dontCompile=` and `-Xaot:dontCompile=` command line options which avoid JIT and AOT compilation respectively.