### PR TITLE
Add Xjit option to control feature in downstream project

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1208,6 +1208,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
     { "enableInterfaceCallCachingSingleDynamicSlot",
      "O\tenable interfaceCall caching with one slot storing J9MethodPtr   ", SET_OPTION_BIT(TR_enableInterfaceCallCachingSingleDynamicSlot), "F" },
     { "enableIprofilerChanges", "O\tenable iprofiler changes", SET_OPTION_BIT(TR_EnableIprofilerChanges), "F" },
+    { "enableITableIterationsAfterLastITableCacheCheckAtWarm",
+     "O\tenable iterating the iTable after last cache check for warm compilations", SET_OPTION_BIT(TR_EnableITableIterationsAfterLastITableCacheCheckAtWarm), "F" },
     { "enableIVTT", "O\tenable IV Type Transformation", TR::Options::enableOptimization, IVTypeTransformation, 0, "P" },
     { "enableJCLInline", "O\tenable JCL Integer and Long methods inlining", SET_OPTION_BIT(TR_EnableJCLInline), "F" },
     { "enableJITHelpershashCodeImpl", "O\tenable java version of object hashCode()",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -459,7 +459,7 @@ enum TR_CompilationOptions {
     TR_DisableHighWordRA                                     = 0x00800000 + 11, // zGryphon
     TR_DisableZImplicitNullChecks                            = 0x01000000 + 11,
     TR_DisablePrexistenceDuringGracePeriod                   = 0x02000000 + 11,
-    // Available                                             = 0x04000000 + 11,
+    TR_EnableITableIterationsAfterLastITableCacheCheckAtWarm = 0x04000000 + 11,
     TR_DisableInlineWriteBarriersRT                          = 0x08000000 + 11, // RTJ
     // Available                                             = 0x10000000 + 11,
     TR_DisableNewInliningInfrastructure                      = 0x20000000 + 11,


### PR DESCRIPTION
This commit adds a new JIT option called
`-Xjit:enableITableIterationsAfterLastITableCacheCheckAtWarm`, which will be used in a downstream project (OpenJ9) to control the Java interface dispatch sequence for compilations performed at warm opt level (or below).