### PR TITLE
Final copy-scan history count update

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -2277,11 +2277,11 @@ MM_Scavenger::externalNotifyToYield(MM_EnvironmentBase *env)
 }
 
 MMINLINE void
-MM_Scavenger::flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env, bool finalFlush)
+MM_Scavenger::flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env)
 {
 	_delegate.flushReferenceObjects(env);
 	flushRememberedSet(env);
-	flushCopyScanCounts(env, finalFlush);
+	flushCopyScanCounts(env, false);
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavengeExhaustiveTermination && isCurrentPhaseConcurrent()) {
@@ -2423,9 +2423,10 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 
 		if(doneIndex == _doneIndex) {
 			if((env->_currentTask->getThreadCount() == _waitingCount) && (0 == _cachedEntryCount)) {
-				flushBuffersForGetNextScanCache(env, true);
+				flushBuffersForGetNextScanCache(env);
 
 				if (shouldDoFinalNotify(env)) {
+					flushCopyScanCounts(env, true);
 					_waitingCount = 0;
 					_doneIndex += 1;
 					uint64_t notifyStartTime = omrtime_hires_clock();

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -166,9 +166,8 @@ private:
 	 * This removes the requirement of a synchronization point after calls to completeScan when
 	 * it is followed by reference or remembered set processing.
 	 * @param env - current thread environment
-	 * @param finalFlush - lets the copy/scan flush know if it's the last thread performing the flush
 	 */
-	void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env, bool finalFlush = false);
+	void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env);
 	
 	void saveMainThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
 	void restoreMainThreadTenureTLHRemainders(MM_EnvironmentStandard *env);


### PR DESCRIPTION
In the history table of copy-scan counts, when the final update is done, in a simple STW Scavenge, it was not necessary to be atomic, since it was the only GC thread to do the update.

Even with Concurrent Scavenger, where the update would not necessarily be the final nor the only one (there could be a few attempts to converge the scanning cycle due to non-empty copy cashes associated with mutator threads), it would still not be a problem, since mutator threads would not even try to update these counts, and would not race with the GC thread doing the last few 'final' non-atomic updates.

With the introduction of taxation in Concurrent Scavenge, since mutator threads would do scan work they would start updating the counts. Even though their updates would be atomic, the GC thread doing non-atomic 'final' updates would create problems (like incrementing the size of the history table beyond its real maximum).

The fix is to defer the final update from the GC thread a bit later, when it's known the all mutator threads are done flushing.

An alternative solution is to leave the final flushes where there are, but make them atomic. However, that seemed to be a bit more complex/risky change (even though more future proof).