### PR TITLE
Add OMR_ISSPACE macro for Open XL

### DIFF
--- a/ddr/lib/ddr-ir/Type.cpp
+++ b/ddr/lib/ddr-ir/Type.cpp
@@ -309,14 +309,14 @@ Type::isStandardType(const char *type, size_t typeLen, bool *isSigned, size_t *b
 	 * occurrences of each word to verify the combination is reasonable.
 	 */
 	for (const char * cursor = type; cursor < typeEnd;) {
-		if (isspace(*cursor)) {
+		if (OMR_ISSPACE(*cursor)) {
 			cursor += 1;
 			continue;
 		}
 
 		const char * const word = cursor;
 
-		while ((cursor < typeEnd) && !isspace(*cursor)) {
+		while ((cursor < typeEnd) && !OMR_ISSPACE(*cursor)) {
 			cursor += 1;
 		}
 

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -615,8 +615,10 @@ typedef struct U_128 {
 
 #if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #define OMR_ISDIGIT(x) __isdigit_a(x)
+#define OMR_ISSPACE(x) __isspace_a(x)
 #else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 #define OMR_ISDIGIT(x) isdigit(x)
+#define OMR_ISSPACE(x) isspace(x)
 #endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 #endif /* OMRCOMP_H */

--- a/omrtrace/omrtracecomponent.cpp
+++ b/omrtrace/omrtracecomponent.cpp
@@ -761,7 +761,7 @@ parseAndSetTracePointsInRange(const char *componentName,
 
 		ret = 0;
 		temp = p;
-		while (isdigit((int)*temp)) {
+		while (OMR_ISDIGIT((int)*temp)) {
 			ret++;
 			temp++;
 		}
@@ -774,11 +774,11 @@ parseAndSetTracePointsInRange(const char *componentName,
 			p += ret + 1;
 			length++; /* plus one for the dash */
 			ret = 0;
-			if (!isdigit(*temp)) {
+			if (!OMR_ISDIGIT(*temp)) {
 				reportCommandLineError(suppressMessages, "Expecting tracepoint range specified as tpnid{componentName.offset1-offset2} e.g. tpnid{j9trc.2-6}");
 				return OMR_ERROR_ILLEGAL_ARGUMENT;
 			}
-			while (isdigit(*temp)) {
+			while (OMR_ISDIGIT(*temp)) {
 				ret++;
 				temp++;
 			}
@@ -940,7 +940,7 @@ setTracePointsToParsed(const char *componentName, UtComponentList *componentList
 
 		if (0 == j9_cmdla_strnicmp(tempstr, UT_LEVEL_KEYWORD, strlen(UT_LEVEL_KEYWORD))  ||
 			*tempstr == 'l' || *tempstr == 'L') {
-			while (!isdigit(*tempstr)) {
+			while (!OMR_ISDIGIT(*tempstr)) {
 				if (*tempstr == ',' || *tempstr == '}' || *tempstr == '\0') {
 					reportCommandLineError(suppressMessages, "Trace level required without an integer level specifier");
 					return OMR_ERROR_ILLEGAL_ARGUMENT;

--- a/omrtrace/omrtraceoptions.cpp
+++ b/omrtrace/omrtraceoptions.cpp
@@ -152,7 +152,7 @@ parseBufferSize(const char *const str, const int argSize, BOOLEAN atRuntime)
 	const char *p = str;
 
 	while (*p) {
-		if (isdigit(*p)) {
+		if (OMR_ISDIGIT(*p)) {
 			if (-1 == firstDigit) {
 				firstDigit = p - str;
 			}


### PR DESCRIPTION
Replaces usage of `isspace()` with `OMR_ISSPACE()`
This conditionally  uses `__isspace_a()` on z/OS platforms, to properly handle ASCII input.