### PR TITLE
Make default 4k pages GC memory allocation virtual on ZOS

### DIFF
--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -70,7 +70,7 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase *env, MM_MemoryH
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 
 	MM_VirtualMemory *instance = NULL;
-	uintptr_t mode = (OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE);
+	uintptr_t mode = (OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_VIRTUAL);
 	uintptr_t options = 0;
 	uint32_t memoryCategory = OMRMEM_CATEGORY_MM_RUNTIME_HEAP;
 
@@ -509,7 +509,7 @@ MM_MemoryManager::createVirtualMemoryForMetadata(MM_EnvironmentBase *env, MM_Mem
 			uintptr_t tailPadding = 0;
 			void *preferredAddress = NULL;
 			void *ceiling = NULL;
-			uintptr_t mode = (OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE);
+			uintptr_t mode = (OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_VIRTUAL);
 			uintptr_t options = 0;
 
 			uintptr_t pageSize = extensions->gcmetadataPageSize;

--- a/gc/base/SparseVirtualMemory.hpp
+++ b/gc/base/SparseVirtualMemory.hpp
@@ -80,7 +80,9 @@ protected:
 	void tearDown(MM_EnvironmentBase *env);
 
 	MM_SparseVirtualMemory(MM_EnvironmentBase *env, uintptr_t pageSize, uintptr_t pageFlags, MM_Heap *in_heap)
-		: MM_VirtualMemory(env, in_heap->getHeapRegionManager()->getRegionSize(), pageSize, pageFlags, 0, OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE)
+		: MM_VirtualMemory(
+				env, in_heap->getHeapRegionManager()->getRegionSize(), pageSize, pageFlags, 0,
+				OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_VIRTUAL)
 		, _heap(in_heap)
 		, _sparseDataPool(NULL)
 		, _largeObjectVirtualMemoryMutex(NULL)


### PR DESCRIPTION
There is missed flag OMRPORT_VMEM_MEMORY_MODE_VIRTUAL to be set for Object Heap, GC Metedata and Sparse Heap. This flag is recognized on ZOS only. As a result, if allocation on ZOS is using default 4k pages it uses malloc() instead of virtual memory allocation.