### PR TITLE
Implement sysinfo_get_process_name for macOS

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -7934,6 +7934,17 @@ omrsysinfo_get_process_name(struct OMRPortLibrary *portLibrary, uintptr_t pid)
 			return exename;
 		}
 	}
+#elif defined(OSX) /* defined(LINUX) && !defined(OMRZTPF) */
+	char exebuf[PROC_PIDPATHINFO_MAXSIZE];
+	int pidpathrc = proc_pidpath((int)pid, exebuf, sizeof(exebuf));
+	if (pidpathrc > 0) {
+		uintptr_t alloclen = (uintptr_t)pidpathrc + 1;
+		char *exepath = portLibrary->mem_allocate_memory(portLibrary, alloclen, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+		if (NULL != exepath) {
+			memcpy(exepath, exebuf, alloclen);
+			return exepath;
+		}
+	}
 #endif /* defined(AIXPPC) */
 	return NULL;
 }


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/21609

Test build https://openj9-jenkins.osuosl.org/job/Pipeline-Build-Test-Personal/765/

Manual testing, the name comes from sysinfo_get_process_name()
aarch64: `1TISIGPID      Signalling process id 74296 name "/bin/bash"`
x86-64: `1TISIGPID      Signalling process id 91375 name "/usr/local/Cellar/bash/5.2.37/bin/bash"`