### PR TITLE
Fix encoding of numbers within Type names in DDR

### DIFF
--- a/ddr/include/ddr/blobgen/java/genBinaryBlob.hpp
+++ b/ddr/include/ddr/blobgen/java/genBinaryBlob.hpp
@@ -123,13 +123,14 @@ private:
 	};
 
 	BuildBlobInfo _buildInfo;
-	bool _printEmptyTypes;
+	OMRPortLibrary * const _portLibrary;
+	bool const _printEmptyTypes;
 
 	void copyStringTable();
 	DDR_RC stringTableOffset(BlobHeader *blobHeader, J9HashTable *stringTable, const char *cString, uint32_t *offset);
 	DDR_RC countStructsAndStrings(Symbol_IR *ir);
 	DDR_RC addFieldAndConstCount(bool addStructureCount, size_t fieldCount, size_t constCount);
-	DDR_RC buildBlobData(OMRPortLibrary *portLibrary, Symbol_IR *ir);
+	DDR_RC buildBlobData(Symbol_IR *ir);
 	DDR_RC addBlobField(Field *field, uint32_t *fieldCount, size_t baseOffset, const string &prefix);
 	DDR_RC addBlobConst(const string &name, long long value, uint32_t *constCount);
 	DDR_RC addBlobStruct(const string &name, const string &superName, uint32_t constCount, uint32_t fieldCount, uint32_t size);
@@ -139,7 +140,12 @@ private:
 	friend class BlobEnumerateVisitor;
 
 public:
-	explicit JavaBlobGenerator(bool printEmptyTypes) : _printEmptyTypes(printEmptyTypes) {}
+	JavaBlobGenerator(struct OMRPortLibrary *portLibrary, bool printEmptyTypes)
+		: _buildInfo()
+		, _portLibrary(portLibrary)
+		, _printEmptyTypes(printEmptyTypes)
+	{
+	}
 	DDR_RC genBinaryBlob(struct OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *blobFile);
 };
 

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -31,7 +31,7 @@ genBlob(struct OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *supersetF
 	DDR_RC rc = DDR_RC_OK;
 
 	if (NULL != blobFile) {
-		JavaBlobGenerator blobGenerator(printEmptyTypes);
+		JavaBlobGenerator blobGenerator(portLibrary, printEmptyTypes);
 
 		rc = blobGenerator.genBinaryBlob(portLibrary, ir, blobFile);
 

--- a/ddr/lib/ddr-blobgen/java/genSuperset.cpp
+++ b/ddr/lib/ddr-blobgen/java/genSuperset.cpp
@@ -27,12 +27,9 @@
 #include "ddr/ir/Symbol_IR.hpp"
 #include "ddr/ir/TypedefUDT.hpp"
 #include "ddr/ir/UnionUDT.hpp"
-#include "ddr/std/sstream.hpp"
 
 #include <assert.h>
 #include <stdio.h>
-
-using std::stringstream;
 
 static string
 replaceAll(string str, const string &subStr, const string &newStr)
@@ -94,11 +91,11 @@ JavaSupersetGenerator::replaceBaseTypedef(Type *type, string *name)
 	 * types such as "U_32" are replaced with "U32".
 	 */
 	if (Type::isStandardType(name->c_str() + start, (size_t)length, &isSigned, &bitWidth)) {
-		stringstream ss;
+		OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+		char newType[32];
 
-		ss << (isSigned ? "I" : "U") << bitWidth;
-
-		name->replace(start, length, ss.str());
+		omrstr_printf(newType, sizeof(newType), "%c%zu", isSigned ? 'I' : 'U', bitWidth);
+		name->replace(start, length, newType);
 	}
 }
 
@@ -259,10 +256,11 @@ JavaSupersetGenerator::getFieldType(Field *field, string *assembledTypeName, str
 	string bitField;
 
 	if ((DDR_RC_OK == rc) && (0 != field->_bitField)) {
-		stringstream ss;
+		OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+		char width[32];
 
-		ss << ":" << field->_bitField;
-		bitField = ss.str();
+		omrstr_printf(width, sizeof(width), ":%zu", field->_bitField);
+		bitField = width;
 	}
 
 	/* Assemble the type name. */


### PR DESCRIPTION
Type names were being badly encoded when building with Open XL on z/OS.
The numbers were being affixed in EBCDIC which resulted in problems.
This was owing to stringstream insertion operator (<<) not respecting
the compile-time charset for integers. This replaces the usages with
omrstr_printf() which does.