### PR TITLE
DDR: Emit proper base type for Type superclass

### DIFF
--- a/ddr/include/ddr/ir/ClassUDT.hpp
+++ b/ddr/include/ddr/ir/ClassUDT.hpp
@@ -29,7 +29,7 @@
 class ClassUDT : public ClassType
 {
 public:
-	ClassUDT *_superClass;
+	Type *_superClass;
 	bool _isClass;
 
 	explicit ClassUDT(size_t size, bool isClass = true, unsigned int lineNumber = 0);

--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -582,7 +582,11 @@ BlobBuildVisitor::visitClass(ClassUDT *cu) const
 				string superName;
 
 				if (NULL != cu->_superClass) {
-					superName = getBlobFullName(cu->_superClass);
+					Type *baseType = cu->_superClass->getOpaqueType();
+					if (NULL == baseType) {
+						baseType = cu->_superClass;
+					}
+					superName = getBlobFullName(baseType);
 				}
 
 				rc = _gen->addBlobStruct(nameFormatted, superName, constCount, fieldCount, (uint32_t)cu->_sizeOf);

--- a/ddr/lib/ddr-blobgen/java/genSuperset.cpp
+++ b/ddr/lib/ddr-blobgen/java/genSuperset.cpp
@@ -359,7 +359,11 @@ JavaSupersetGenerator::printType(Type *type, Type *superClass)
 	string superFormatted;
 
 	if (NULL != superClass) {
-		superFormatted = replaceAll(superClass->getFullName(), "::", "$");
+		Type *baseType = superClass->getOpaqueType();
+		if (NULL == baseType) {
+			baseType = superClass;
+		}
+		superFormatted = replaceAll(baseType->getFullName(), "::", "$");
 	}
 
 	_pendingTypeHeading = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|" + superFormatted + "\n";

--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -339,13 +339,13 @@ DDR_RC
 MergeVisitor::visitClass(ClassUDT *type) const
 {
 	if (NULL == type->_superClass) {
-		ClassUDT *otherSuper = ((ClassUDT *)_other)->_superClass;
+		Type *otherSuper = ((ClassUDT *)_other)->_superClass;
 
 		if (NULL != otherSuper) {
 			Type *thisSuper = _ir->findTypeInMap(otherSuper);
 
 			if (NULL != thisSuper) {
-				otherSuper = (ClassUDT *)thisSuper;
+				otherSuper = thisSuper;
 			} else {
 				_merged->push_back(otherSuper);
 			}

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -1667,10 +1667,11 @@ DwarfScanner::getSuperUDT(Dwarf_Die die, ClassUDT *udt)
 	Dwarf_Die superTypeDie = NULL;
 
 	if (DDR_RC_OK == getTypeTag(die, &superTypeDie, &tag)) {
-		ClassUDT *superUDT = NULL;
+		Type *superUDT = NULL;
 		/* Get the super udt. */
-		if ((DDR_RC_OK == addDieToIR(superTypeDie, tag, NULL, (Type **)&superUDT))
-				&& (NULL != superUDT)) {
+		if ((DDR_RC_OK == addDieToIR(superTypeDie, tag, NULL, &superUDT))
+			&& (NULL != superUDT)
+		) {
 			rc = DDR_RC_OK;
 			udt->_superClass = superUDT;
 		}


### PR DESCRIPTION
When dealing with (but perhaps not limited to) the split dwarf debug
files (.dwo) produced with Open XL on z/OS, there are instances where
the inheritance type points to a typedef Die. This updates the generator
classes (Superset and Blobgen) to look for the proper base type when
attempting to affix the supertypes.

Also changes ClassUDT::_superClass to `Type` to avoid casts.
