### PR TITLE
Set OMR_PLATFORM_THREAD_LIBRARY for openxl on AIX

### DIFF
--- a/cmake/modules/platform/toolcfg/openxl.cmake
+++ b/cmake/modules/platform/toolcfg/openxl.cmake
@@ -80,10 +80,10 @@ if(OMR_OS_ZOS)
 		-Wuninitialized
 		-mnocsect
 	)
-
-	# Configure the platform-dependent library for multithreading.
-	set(OMR_PLATFORM_THREAD_LIBRARY "")
 endif()
+
+# Configure the platform-dependent library for multithreading.
+set(OMR_PLATFORM_THREAD_LIBRARY "")
 
 set(SPP_CMD ${CMAKE_C_COMPILER})
 set(SPP_FLAGS -E -P)


### PR DESCRIPTION
It was set for z/OS but not AIX. FYI the AIX setting for xlc.
https://github.com/eclipse-omr/omr/blob/master/cmake/modules/platform/toolcfg/xlc.cmake#L209

If it's not set, there is an error.
https://github.com/eclipse-omr/omr/blob/master/cmake/modules/platform/toolcfg/verify.cmake#L24