### PR TITLE
Enable sleep or spin in park() based on CPU utilization

### DIFF
--- a/include_core/thrtypes.h
+++ b/include_core/thrtypes.h
@@ -157,6 +157,8 @@ typedef struct J9ThreadLibrary {
 	uintptr_t parkSleepTime;
 	uintptr_t parkSpinCount;
 	uintptr_t parkSleepCount;
+	uintptr_t cpuUtilCache;
+	uintptr_t parkSleepCpuUtilThreshold;
 #endif /* defined(OMR_THR_YIELD_ALG) */
 } J9ThreadLibrary;
 


### PR DESCRIPTION
Experiments have been done using restCrud on Quarkus with wrk as the
load generator. With the current default configuration, we observed:
- ~20% throughput improvement on RHEL9 (Intel Skylake)
- ~8% improvement on RHEL10 (Intel Raptor Lake)
- ~11% improvement on pLinux

However, enabling sleep also causes regressions under lower loads. To
address this, a cutoff strategy was implemented to enable sleep only
when CPU utilization exceeds a given threshold. The observed break-even
point is around 80% CPU utilization, though this may vary depending on
the environment Java is running in.

This behaviour is only enabled for X86 and POWER currently.