### PR TITLE
Named virtual registers

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -586,13 +586,13 @@ void OMR::CodeGenerator::jettisonAllSpills()
     _internalPointerSpillFreeList.clear();
 }
 
-TR::Register *OMR::CodeGenerator::allocateRegister(TR_RegisterKinds rk)
+TR::Register *OMR::CodeGenerator::allocateRegister(TR_RegisterKinds rk, const char *name)
 {
     TR_ASSERT(rk != TR_SSR, "use allocatePseudoRegister for TR_SSR registers\n");
     TR::Register *temp = new (self()->trHeapMemory()) TR::Register(rk);
     self()->addAllocatedRegister(temp);
     if (self()->getDebug())
-        self()->getDebug()->newRegister(temp);
+        self()->getDebug()->newRegister(temp, name);
 
     return temp;
 }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1173,16 +1173,16 @@ int32_t OMR::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *b
     return self()->getMaximumNumberOfGPRsAllowedAcrossEdge(node);
 }
 
-TR::Register *OMR::CodeGenerator::allocateCollectedReferenceRegister()
+TR::Register *OMR::CodeGenerator::allocateCollectedReferenceRegister(const char *name)
 {
-    TR::Register *temp = self()->allocateRegister();
+    TR::Register *temp = self()->allocateRegister(name);
     temp->setContainsCollectedReference();
     return temp;
 }
 
-TR::Register *OMR::CodeGenerator::allocateSinglePrecisionRegister(TR_RegisterKinds rk)
+TR::Register *OMR::CodeGenerator::allocateSinglePrecisionRegister(TR_RegisterKinds rk, const char *name)
 {
-    TR::Register *temp = self()->allocateRegister(rk);
+    TR::Register *temp = self()->allocateRegister(rk, name);
     temp->setIsSinglePrecision();
     return temp;
 }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1397,9 +1397,17 @@ public:
     // --------------------------------------------------------------------------
     // Virtual register allocation
     //
-    TR::Register *allocateRegister(TR_RegisterKinds rk = TR_GPR);
-    TR::Register *allocateCollectedReferenceRegister();
-    TR::Register *allocateSinglePrecisionRegister(TR_RegisterKinds rk = TR_FPR);
+    TR::Register *allocateRegister(TR_RegisterKinds rk = TR_GPR, const char *name = NULL);
+
+    TR::Register *allocateRegister(const char *name) { return allocateRegister(TR_GPR, name); }
+
+    TR::Register *allocateCollectedReferenceRegister(const char *name = NULL);
+    TR::Register *allocateSinglePrecisionRegister(TR_RegisterKinds rk = TR_FPR, const char *name = NULL);
+
+    TR::Register *allocateSinglePrecisionRegister(const char *name)
+    {
+        return allocateSinglePrecisionRegister(TR_FPR, name);
+    }
 
     TR::RegisterPair *allocateRegisterPair(TR::Register *lo = 0, TR::Register *ho = 0);
     TR::RegisterPair *allocateSinglePrecisionRegisterPair(TR::Register *lo = 0, TR::Register *ho = 0);

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -466,7 +466,7 @@ public:
     virtual void resetDebugData();
     virtual void newNode(TR::Node *);
     virtual void newLabelSymbol(TR::LabelSymbol *);
-    virtual void newRegister(TR::Register *);
+    virtual void newRegister(TR::Register *, const char *name = NULL);
     virtual void newVariableSizeSymbol(TR::AutomaticSymbol *sym);
     virtual void newInstruction(TR::Instruction *);
     virtual void addInstructionComment(TR::Instruction *, char *, ...);


### PR DESCRIPTION
Add support to associate names with virtual registers in debug prints. Registers that don't have associated names are still printed with the original behaviour.

Example from jit log:
Before
```
 [0x7a02d18d1b00]       mov     qword ptr [GPR_0000+0x60], GPR_0029             # S8MemReg, SymRef [#439 +96]
 [0x7a02d18d1b90]       xor     GPR_0018, GPR_0018              # XOR1RegReg
 [0x7a02d18d1c20]       mov     GPR_0019, GPR_0028              # MOV8RegReg
 [0x7a02d18d1cb0]       sub     GPR_0029, GPR_0028              # SUB8RegReg
```
After
```
 [0x7ddf9c8d1b00]       mov     qword ptr [GPR_0000+0x60], GPR_multianewarray.allocEnd          # S8MemReg, SymRef [#439 +96]
 [0x7ddf9c8d1b90]       xor     GPR_multianewarray.zeroReg, GPR_multianewarray.zeroReg          # XOR1RegReg
 [0x7ddf9c8d1c20]       mov     GPR_multianewarray.nDims, GPR_multianewarray.leafArr            # MOV8RegReg
 [0x7ddf9c8d1cb0]       sub     GPR_multianewarray.allocEnd, GPR_multianewarray.leafArr         # SUB8RegReg
```
