### PR TITLE
Remove unused J9BITS_BITS_IN_SLOT definition

### DIFF
--- a/gc/base/Bits.hpp
+++ b/gc/base/Bits.hpp
@@ -28,10 +28,8 @@
 #include "modronbase.h"
 
 #if defined(OMR_ENV_DATA64)
-#define J9BITS_BITS_IN_SLOT 64
 #define OMRBITS_BITS_IN_SLOT 64
-#else
-#define J9BITS_BITS_IN_SLOT 32
+#else /* defined(OMR_ENV_DATA64) */
 #define OMRBITS_BITS_IN_SLOT 32
 #endif /* defined(OMR_ENV_DATA64) */
 


### PR DESCRIPTION
OMRBITS_BITS_IN_SLOT should be used instead, J9BITS_BITS_IN_SLOT can be removed now.