### PR TITLE
Update the compiler target to zOSV3R1 for Open XL

### DIFF
--- a/cmake/modules/platform/toolcfg/openxl.cmake
+++ b/cmake/modules/platform/toolcfg/openxl.cmake
@@ -21,9 +21,14 @@
 
 if(OMR_OS_ZOS)
 	set(OMR_ZOS_COMPILE_ARCHITECTURE "arch10" CACHE STRING "z/OS compile machine architecture" FORCE)
-	set(OMR_ZOS_COMPILE_TARGET "ZOSV2R5" CACHE STRING "z/OS compile target operating system" FORCE)
+	if(JAVA_SPEC_VERSION GREATER_EQUAL 25)
+		set(OMR_ZOS_COMPILE_TARGET "ZOSV3R1" CACHE STRING "z/OS compile target operating system" FORCE)
+		set(OMR_ZOS_LINK_COMPAT "ZOSV3R1" CACHE STRING "z/OS link compatible operating system" FORCE)
+	else()
+		set(OMR_ZOS_COMPILE_TARGET "ZOSV2R5" CACHE STRING "z/OS compile target operating system" FORCE)
+		set(OMR_ZOS_LINK_COMPAT "ZOSV2R5" CACHE STRING "z/OS link compatible operating system" FORCE)
+	endif()
 	set(OMR_ZOS_COMPILE_TUNE "12" CACHE STRING "z/OS compile machine architecture tuning" FORCE)
-	set(OMR_ZOS_LINK_COMPAT "ZOSV2R5" CACHE STRING "z/OS link compatible operating system" FORCE)
 	set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "--shared")
 	set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "--shared")
 


### PR DESCRIPTION
Open XL 2.2 on z/OS requires z/OS 3.1+
This updates the target level as a result of this requirement.