### PR TITLE
Add -Xjit:disableWarmCallGraphTooBigHeuristic option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -984,6 +984,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      NOT_IN_SUBSET },
     { "disableVSSStackCompaction", "O\tdisable VariableSizeSymbol stack compaction",
      SET_OPTION_BIT(TR_DisableVSSStackCompaction), "F" },
+    { "disableWarmCallGraphTooBigHeuristic", "O\tdisable heuristic related to warm-call-graph-too-big logic",
+     SET_OPTION_BIT(TR_DisableWarmCallGraphTooBigHeuristic), "F" },
     { "disableWriteBarriersRangeCheck", "O\tdisable adding range check to write barriers",
      SET_OPTION_BIT(TR_DisableWriteBarriersRangeCheck), "F" },
     { "disableZ10", "O\tdisable z10 support", SET_OPTION_BIT(TR_DisableZ10), "F" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -462,7 +462,7 @@ enum TR_CompilationOptions {
     TR_DisablePrexistenceDuringGracePeriod                   = 0x02000000 + 11,
     TR_EnableITableIterationsAfterLastITableCacheCheckAtWarm = 0x04000000 + 11,
     TR_DisableInlineWriteBarriersRT                          = 0x08000000 + 11, // RTJ
-    // Available                                             = 0x10000000 + 11,
+    TR_DisableWarmCallGraphTooBigHeuristic                   = 0x10000000 + 11,
     TR_DisableNewInliningInfrastructure                      = 0x20000000 + 11,
     // Available                                             = 0x40000000 + 11,
     // Available                                             = 0x80000000 + 11,


### PR DESCRIPTION
This option will be used in a downstream project (OpenJ9) to disable an optimizer heuristic for diagnostic purposes.