### PR TITLE
Combine bu2i comparison optimization in z/codegen

### DIFF
--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -163,22 +163,19 @@ void TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node *root, TR::InstO
     bool adjustDiplacementOnSecondChild = false;
 
     if (root->getOpCode().isBooleanCompare() || nonClobberingDestination) {
-        if (firstChild->getOpCodeValue() == TR::bu2i && firstChild->getReferenceCount() == 1
-            && firstChild->getRegister() == NULL
-            && (firstChild->getFirstChild()->getOpCodeValue() == TR::bload
-                || firstChild->getFirstChild()->getOpCodeValue() == TR::bloadi)) {
+        if ((firstChild->getOpCodeValue() == TR::bu2i && firstChild->getReferenceCount() == 1
+                && firstChild->getRegister() == NULL
+                && (firstChild->getFirstChild()->getOpCodeValue() == TR::bload
+                    || firstChild->getFirstChild()->getOpCodeValue() == TR::bloadi))
+            && (secondChild->getOpCodeValue() == TR::bu2i && secondChild->getReferenceCount() == 1
+                && secondChild->getRegister() == NULL
+                && (secondChild->getFirstChild()->getOpCodeValue() == TR::bload
+                    || secondChild->getFirstChild()->getOpCodeValue() == TR::bloadi))) {
             initFirstChild = firstChild;
-
             firstChild = firstChild->getFirstChild();
             cg()->evaluate(firstChild);
-        }
 
-        if (secondChild->getOpCodeValue() == TR::bu2i && secondChild->getReferenceCount() == 1
-            && secondChild->getRegister() == NULL
-            && (secondChild->getFirstChild()->getOpCodeValue() == TR::bload
-                || secondChild->getFirstChild()->getOpCodeValue() == TR::bloadi)) {
             initSecondChild = secondChild;
-
             secondChild = secondChild->getFirstChild();
             cg()->evaluate(secondChild);
         }


### PR DESCRIPTION
The z/codegen skips evaluation of a comparison operation if the first OR second child is a bu2i node and its grandchild is a bloadi. This condition needs to be modified from OR to AND (i.e so that both children of the comparison operation satisfy all conditions). This fixes a bug where the second comparison child has an
incompatible type with the bu2i node.