### PR TITLE
Remove deprecated BuildStructure codegen functionality

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -397,10 +397,6 @@ void OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator *cg, 
 void OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
 {
     TR::Compilation *comp = cg->comp();
-    if (cg->shouldBuildStructure() && (comp->getFlowGraph()->getStructure() != NULL)) {
-        TR_Structure *rootStructure = TR_RegionAnalysis::getRegions(comp);
-        comp->getFlowGraph()->setStructure(rootStructure);
-    }
 
     phase->reportPhase(SetupForInstructionSelectionPhase);
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1783,10 +1783,6 @@ public:
 
     TR::RealRegister **_unlatchedRegisterList; // dynamically allocated
 
-    bool shouldBuildStructure() { return _enabledFlags.testAny(ShouldBuildStructure); }
-
-    void setShouldBuildStructure() { _enabledFlags.set(ShouldBuildStructure); }
-
     bool enableRefinedAliasSets();
 
     void setEnableRefinedAliasSets() { _enabledFlags.set(EnableRefinedAliasSets); }
@@ -2411,7 +2407,7 @@ protected:
         // AVAILABLE                     = 0x0004,
         EnableRefinedAliasSets = 0x0008,
         // AVAILABLE                     = 0x0010,
-        ShouldBuildStructure = 0x0020,
+        // AVAILABLE                     = 0x0020,
         LockFreeSpillList = 0x0040, // TAROK only (until it matures)
         UseNonLinearRegisterAssigner = 0x0080, // TAROK only (until it matures)
         TrackRegisterUsage = 0x0100, // TAROK only (until it matures)


### PR DESCRIPTION
This functionality is no longer used in OMR or any downstream project.