### PR TITLE
Remove unnecessary include

### DIFF
--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -33,7 +33,6 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstdio>
-#include "ddr/std/sstream.hpp"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
`DwarfScanner.cpp` does not use `stringstream`.