### PR TITLE
Tidy up thread API

### DIFF
--- a/fvtest/threadtest/createTest.cpp
+++ b/fvtest/threadtest/createTest.cpp
@@ -1246,7 +1246,7 @@ TEST_F(ThreadCreateTest, DISABLED_SetAttrThreadWeight)
 
 	initDefaultExpected(&expected);
 
-	weight = (const char **)omrthread_global((char *)"thread_weight");
+	weight = (const char **)omrthread_global("thread_weight");
 
 	*weight = "heavy";
 	expected.osThreadweight = OS_HEAVY_WEIGHT;

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -139,7 +139,7 @@ omrthread_get_flags(omrthread_t thread, omrthread_monitor_t *blocker);
  * @return void
  */
 void
-omrthread_get_state(omrthread_t thread, omrthread_state_t *const state);
+omrthread_get_state(omrthread_t thread, omrthread_state_t *state);
 
 /**
 * @brief
@@ -521,8 +521,7 @@ omrthread_exit(omrthread_monitor_t monitor);
 * @return uintptr_t*
 */
 uintptr_t *
-omrthread_global(char *name);
-
+omrthread_global(const char *name);
 
 /**
 * @brief
@@ -614,7 +613,7 @@ omrthread_jlm_init(uintptr_t flags);
  */
 intptr_t
 jlm_adaptive_spin_init(void);
-#endif
+#endif /* defined(OMR_THR_ADAPTIVE_SPIN) */
 
 /**
 * @brief
@@ -716,7 +715,7 @@ omrthread_lib_postForkParent(void);
  */
 void
 omrthread_lib_preFork(void);
-#endif /* !defined(OMR_THR_FORK_SUPPORT) */
+#endif /* defined(OMR_THR_FORK_SUPPORT) */
 
 /**
 * @brief

--- a/include_core/thrtypes.h
+++ b/include_core/thrtypes.h
@@ -85,7 +85,7 @@ typedef struct J9ThreadMonitorPool {
 
 typedef struct J9ThreadGlobal {
 	struct J9ThreadGlobal *next;
-	char *name;
+	const char *name;
 	uintptr_t data;
 } J9ThreadGlobal;
 


### PR DESCRIPTION
* don't require a non-const name
* remove useless const qualifier
* remove (now) unnecessary casts
* fix comments
* improve adherence to coding standard

In draft mode until downstream projects have prepared.