### PR TITLE
Clean-up code related to AlreadySignExtended register flag

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -2689,7 +2689,7 @@ TR::Register *OMR::Z::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGener
         cg->decReferenceCount(firstChild->getFirstChild());
 
         // Load Negative
-        if (cg->comp()->target().is64Bit() && targetRegister->alreadySignExtended())
+        if (cg->comp()->target().is64Bit())
             generateRRInstruction(cg, TR::InstOpCode::LNGR, node, targetRegister, sourceRegister);
         else
             generateRRInstruction(cg, TR::InstOpCode::LNR, node, targetRegister, sourceRegister);
@@ -2708,7 +2708,7 @@ TR::Register *OMR::Z::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGener
         sourceRegister = cg->evaluate(firstChild);
 
         // Do complement
-        if (cg->comp()->target().is64Bit() && targetRegister->alreadySignExtended())
+        if (cg->comp()->target().is64Bit())
             generateRRInstruction(cg, TR::InstOpCode::LCGR, node, targetRegister, sourceRegister);
         else
             generateRRInstruction(cg, TR::InstOpCode::LCR, node, targetRegister, sourceRegister);

--- a/compiler/z/codegen/OMRRegister.hpp
+++ b/compiler/z/codegen/OMRRegister.hpp
@@ -90,12 +90,6 @@ public:
     bool is64BitReg();
     void setIs64BitReg(bool b = true);
 
-    bool alreadySignExtended() { return _flags.testAny(AlreadySignExtended); }
-
-    void setAlreadySignExtended() { _flags.set(AlreadySignExtended); }
-
-    void resetAlreadySignExtended() { _flags.reset(AlreadySignExtended); }
-
     /*
      * Overriding Base Class Implementation of these methods
      */
@@ -124,8 +118,6 @@ private:
     enum {
         IsUsedInMemRef = 0x0800, // 390 cannot associate GPR0 to regs used in memrefs
         Is64Bit = 0x0002, // 390 flag indicates that this Register contained a 64-bit value
-
-        AlreadySignExtended = 0x1000, // determine whether i2l should be nops
     };
 
     // Both x and z have this field, but power has own specialization, may move to base


### PR DESCRIPTION
In https://github.com/eclipse-omr/omr/pull/8035 we introduced a new node flag to notify the code-gen that the node was sign extended when evaluated. This removes the the use of AlreadySignExtended register flag which can be propagated to other nodes if the register is reused through clobber evaluation of the node.
This commit includes the clean-up related AlreadySignExtended register flag.