### PR TITLE
AArch64: Add new overloads of generateConditionalBranchInstruction()

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -249,9 +249,9 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
         cg->evaluate(thirdChild);
 
         deps = generateRegisterDependencyConditions(cg, thirdChild, 0);
-        result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc, deps);
+        result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
     } else {
-        result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
+        result = generateConditionalBranchInstruction(cg, node, dstLabel, cc);
     }
 
     cg->decReferenceCount(firstChild);
@@ -595,8 +595,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
             cg->evaluate(child->getFirstChild());
             cond = cond->clone(cg, generateRegisterDependencyConditions(cg, child->getFirstChild(), 0));
         }
-        generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node,
-            child->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, cond);
+        generateConditionalBranchInstruction(cg, node, child->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ,
+            cond);
     }
 
     // Branch to default
@@ -643,7 +643,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
     if (5 > numBranchTableEntries) {
         for (i = 0; i < numBranchTableEntries; i++) {
             generateCompareImmInstruction(cg, node, selectorReg, i);
-            generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node,
+            generateConditionalBranchInstruction(cg, node,
                 node->getChild(2 + i)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ);
         }
 
@@ -657,8 +657,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
             generateCompareImmInstruction(cg, node, selectorReg, numBranchTableEntries);
         }
 
-        generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node,
-            defaultChild->getBranchDestination()->getNode()->getLabel(), TR::CC_CS);
+        generateConditionalBranchInstruction(cg, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
+            TR::CC_CS);
         generateTrg1ImmInstruction(cg, TR::InstOpCode::adr, node, tmpRegister,
             12); // distance between this instruction to the jump table
         generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, tmpRegister, tmpRegister, selectorReg,

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -540,33 +540,32 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
 
         TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(cg, thirdChild, 0);
         if (!needsExplicitUnorderedCheck) {
-            result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc, deps);
+            result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
         } else {
             if (cc == TR::CC_NE) {
                 /* iffcmpne/ifdcmpne: false if CC_VS is set */
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_VS);
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc, deps);
+                generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
+                generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
                 result = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
             } else {
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
-                result
-                    = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, TR::CC_VS, deps);
+                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
+                result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS, deps);
             }
         }
     } else {
         if (!needsExplicitUnorderedCheck) {
-            result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
+            result = generateConditionalBranchInstruction(cg, node, dstLabel, cc);
         } else {
             if (cc == TR::CC_NE) {
                 /* iffcmpne/ifdcmpne: false if CC_VS is set */
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_VS);
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
+                generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
+                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
                 result = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
             } else {
-                generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc);
-                result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, TR::CC_VS);
+                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
+                result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS);
             }
         }
     }
@@ -770,7 +769,7 @@ static TR::Register *floatThreeWayCompareHelper(TR::Node *node, bool isDouble, b
 
     generateSrc2Instruction(cg, cmpOp, node, src1Reg, src2Reg); // compare
     generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, trgReg, 0);
-    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_EQ);
+    generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
     generateTrg1ImmInstruction(cg, movOp, node, trgReg, movVal); // 1 or -1
     generateCondTrg1Src2Instruction(cg, TR::InstOpCode::csnegx, node, trgReg, trgReg, trgReg, cc);
     generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -97,21 +97,38 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
     return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cond, cg);
 }
 
+TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+    TR::ARM64ConditionCode cc, TR::Instruction *preced)
+{
+    if (preced)
+        return new (cg->trHeapMemory())
+            TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, preced, cg);
+    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cg);
+}
+
+TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+    TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+{
+    if (preced)
+        return new (cg->trHeapMemory())
+            TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cond, preced, cg);
+    return new (cg->trHeapMemory())
+        TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cond, cg);
+}
+
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
     TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::Instruction *preced)
 {
-    if (preced)
-        return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cg);
+    TR_ASSERT_FATAL(op == TR::InstOpCode::b_cond, "Unsupported opcode for Conditional branch");
+    return generateConditionalBranchInstruction(cg, node, sym, cc, preced);
 }
 
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
     TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
     TR::Instruction *preced)
 {
-    if (preced)
-        return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cond, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cond, cg);
+    TR_ASSERT_FATAL(op == TR::InstOpCode::b_cond, "Unsupported opcode for Conditional branch");
+    return generateConditionalBranchInstruction(cg, node, sym, cc, cond, preced);
 }
 
 TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -138,6 +138,31 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
 /*
  * @brief Generates conditional branch instruction
  * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sym : label symbol
+ * @param[in] cc : branch condition code
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+    TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates conditional branch instruction with register dependency
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sym : label symbol
+ * @param[in] cc : branch condition code
+ * @param[in] cond : register dependency condition
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+    TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates conditional branch instruction
+ * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode
  * @param[in] node : node
  * @param[in] sym : label symbol

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -4767,8 +4767,7 @@ static TR::Instruction *compareIntsAndBranchForArrayCopyBNDCHK(TR::ARM64Conditio
 
     TR_ASSERT_FATAL_WITH_NODE(node, sr, "Must provide an ArrayCopyBNDCHK symref");
     cg->addSnippet(new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, snippetLabel, sr));
-    TR::Instruction *instr
-        = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, snippetLabel, branchCond);
+    TR::Instruction *instr = generateConditionalBranchInstruction(cg, node, snippetLabel, branchCond);
 
     cg->machine()->setLinkRegisterKilled(true);
     cg->decReferenceCount(firstChild);
@@ -6010,7 +6009,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                         generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node,
                             TR::MemoryReference::createWithDisplacement(cg, dstReg, 256), vectorValueReg,
                             vectorValueReg);
-                        generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, loopLabel, TR::CC_GT);
+                        generateConditionalBranchInstruction(cg, node, loopLabel, TR::CC_GT);
                         srm->reclaimScratchRegister(countReg);
                     }
                     int64_t remainingLength = useLoop ? ((length - 32) % constLoopLen) : (length - 32);
@@ -6181,8 +6180,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstEndReg, dstReg, lengthReg);
         TR::LabelSymbol *lessThan32Label = generateLabelSymbol(cg);
         generateCompareImmInstruction(cg, node, lengthReg, 32, true);
-        auto branchToLessThan32LabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, lessThan32Label, TR::CC_CC);
+        auto branchToLessThan32LabelInstr = generateConditionalBranchInstruction(cg, node, lessThan32Label, TR::CC_CC);
 
         generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node,
             TR::MemoryReference::createWithDisplacement(cg, dstReg, 0), vectorValueReg, vectorValueReg);
@@ -6190,7 +6188,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         TR::LabelSymbol *lessThanOrEqual96Label = generateLabelSymbol(cg);
         generateCompareImmInstruction(cg, node, lengthReg, 96, true);
         auto branchToLessThanOrEqual96LabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, lessThanOrEqual96Label, TR::CC_LS);
+            = generateConditionalBranchInstruction(cg, node, lessThanOrEqual96Label, TR::CC_LS);
         if (debugObj) {
             debugObj->addInstructionComment(branchToLessThan32LabelInstr, "Jumps to lessThan32Label if length < 32.");
             debugObj->addInstructionComment(branchToLessThanOrEqual96LabelInstr,
@@ -6224,8 +6222,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             TR::MemoryReference::createWithDisplacement(cg, dstReg, 32), vectorValueReg, vectorValueReg);
         generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node,
             TR::MemoryReference::createWithDisplacement(cg, dstReg, 64), vectorValueReg, vectorValueReg);
-        auto branchBackToMainLoopLabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, mainLoopLabel, TR::CC_HI);
+        auto branchBackToMainLoopLabelInstr = generateConditionalBranchInstruction(cg, node, mainLoopLabel, TR::CC_HI);
         auto adjustDstRegInstr = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstReg, dstReg, lengthReg);
         generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node,
             TR::MemoryReference::createWithDisplacement(cg, dstReg, 32), vectorValueReg, vectorValueReg);
@@ -6301,7 +6298,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             generateMemSrc1Instruction(cg, strOpCode, node,
                 TR::MemoryReference::createWithDisplacement(cg, dstReg, elementSize), valueReg);
             auto branchBackToElementLoopLabelInstr
-                = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, elementLoopLabel, TR::CC_HI);
+                = generateConditionalBranchInstruction(cg, node, elementLoopLabel, TR::CC_HI);
             if (debugObj) {
                 debugObj->addInstructionComment(lessThan16LabelInstr, "lessThan16Label");
                 debugObj->addInstructionComment(elementLoopLabelInstr, "elementLoopLabel");
@@ -6476,8 +6473,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
                 "Compares lengthReg with 0 if src1 and src2 are not the same array. Otherwise, sets EQ flag.");
         }
     }
-    auto branchToDoneLabelInstr
-        = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_EQ);
+    auto branchToDoneLabelInstr = generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
     if (debugObj) {
         debugObj->addInstructionComment(branchToDoneLabelInstr,
             "Done if src1 and src2 are the same array or length is 0.");
@@ -6493,8 +6489,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     TR::Register *data4Reg = srm->findOrCreateScratchRegister();
     if (!isLengthGreaterThan15) {
         generateCompareImmInstruction(cg, node, lengthReg, 16, /* is64bit */ true);
-        auto branchToLessThan16LabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, lessThan16Label, TR::CC_CC);
+        auto branchToLessThan16LabelInstr = generateConditionalBranchInstruction(cg, node, lessThan16Label, TR::CC_CC);
         if (debugObj) {
             debugObj->addInstructionComment(branchToLessThan16LabelInstr, "Jumps to lessThan16Label if length < 16.");
         }
@@ -6514,12 +6509,10 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
             generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
         }
         generateConditionalCompareInstruction(cg, node, data3Reg, data4Reg, 0, TR::CC_EQ, true);
-        auto branchToNotEqual16LabelInstr2
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, notEqual16Label, TR::CC_NE);
+        auto branchToNotEqual16LabelInstr2 = generateConditionalBranchInstruction(cg, node, notEqual16Label, TR::CC_NE);
         auto subtractLengthInstr
             = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, lengthReg, lengthReg, 16);
-        auto branchBacktoLoop16LabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, loop16Label, TR::CC_CS);
+        auto branchBacktoLoop16LabelInstr = generateConditionalBranchInstruction(cg, node, loop16Label, TR::CC_CS);
         if (debugObj) {
             debugObj->addInstructionComment(loop16LabelInstr, "loop16Label");
             debugObj->addInstructionComment(branchToNotEqual16LabelInstr2,
@@ -6530,8 +6523,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
     if (isLengthGreaterThan15) {
         generateCompareImmInstruction(cg, node, lengthReg, -16, true);
-        auto branchToDoneLabelInstr3
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, done0Label, TR::CC_EQ);
+        auto branchToDoneLabelInstr3 = generateConditionalBranchInstruction(cg, node, done0Label, TR::CC_EQ);
         auto adjustSrc1RegInstr
             = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, src1Reg, src1Reg, lengthReg);
         generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, src2Reg, src2Reg, lengthReg);
@@ -6615,7 +6607,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
             TR::MemoryReference::createWithDisplacement(cg, src2Reg, 1));
         generateConditionalCompareInstruction(cg, node, data1Reg, data2Reg, 0, TR::CC_HI);
         auto branchBacktoLessThan16LabelInstr
-            = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, lessThan16Label, TR::CC_EQ);
+            = generateConditionalBranchInstruction(cg, node, lessThan16Label, TR::CC_EQ);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDone0LabelInstr, "Jumps to done0Label.");
             debugObj->addInstructionComment(lessThan16LabelInstr, "lessThan16Label");
@@ -6978,20 +6970,20 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
 
     const int32_t inlineThresholdBytes = 63;
     generateCompareImmInstruction(cg, node, lengthReg, inlineThresholdBytes, true);
-    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, oolArraycopyLabel, TR::CC_HI);
+    generateConditionalBranchInstruction(cg, node, oolArraycopyLabel, TR::CC_HI);
 
     generateTrg1Src2Instruction(cg, TR::InstOpCode::subsx, node, x3ScratchReg, dstAddrReg, srcAddrReg);
 
     // Skip if src and dest are the same
     //
-    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_EQ);
+    generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
 
     if (!node->isForwardArrayCopy()) {
         // Check for forward arraycopy dynamically if not known.  Forward arraycopies should be
         // the more common case and are optimized inline.
         //
         generateCompareInstruction(cg, node, lengthReg, x3ScratchReg, true);
-        generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, oolArraycopyLabel, TR::CC_HI);
+        generateConditionalBranchInstruction(cg, node, oolArraycopyLabel, TR::CC_HI);
     }
 
     // Copy 32 bytes


### PR DESCRIPTION
This commit adds new function overloads of generateConditionalBranchInstruction() for AArch64 that don't take opcode as one of the parameters, because it must always be TR::InstOpCode::b_cond.