### PR TITLE
Re-enable addKnownObjectConstraints() for JITServer

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1354,9 +1354,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      "F" },
     { "enableVectorAPIBoxing", "M\tenable boxing/unboxing during VectorAPIExpansion",
      SET_OPTION_BIT(TR_EnableVectorAPIBoxing), "F" },
-    { "enableVectorAPIExpansion",
-     "M\tenable expansion of Vector API, disableVectorAPIExpansion option takes precedence", SET_OPTION_BIT(TR_EnableVectorAPIExpansion), "F" },
-
     { "enableVirtualPersistentMemory", "M\tenable persistent memory to be allocated using virtual memory allocators",
      SET_OPTION_BIT(TR_EnableVirtualPersistentMemory), "F", NOT_IN_SUBSET },
     { "enableVpicForResolvedVirtualCalls", "O\tenable PIC for resolved virtual calls",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -404,7 +404,7 @@ enum TR_CompilationOptions {
     TR_DisableNoServerDuringStartup                           = 0x04000000 + 9, // set TR_NoOptServer during startup and insert GCR trees
     TR_BreakOnNew                                             = 0x08000000 + 9,
     TR_DisableInliningUnrecognizedIntrinsics                  = 0x10000000 + 9,
-    TR_EnableVectorAPIExpansion                               = 0x20000000 + 9,
+    // Available                                              = 0x20000000 + 9,
     TR_MoveOOLInstructionsToWarmCode                          = 0x40000000 + 9,
     TR_MoveSnippetsToWarmCode                                 = 0x80000000 + 9,
 


### PR DESCRIPTION
The functionality of addKnownObjectConstraints() was disabled for JITServer due to the large number of messages it generates to retrieve information related to "known objects". This problem has been solved to a large extent in OpenJ9 through the addition of caching (see https://github.com/eclipse-openj9/openj9/pull/23012). This commit re-enables addKnownObjectConstraints() for JITServer.