### PR TITLE
Fix some inconsistencies with GC IDs

### DIFF
--- a/gc/base/Collector.cpp
+++ b/gc/base/Collector.cpp
@@ -289,7 +289,7 @@ MM_Collector::checkForExcessiveGC(MM_EnvironmentBase* env, MM_Collector *collect
 	Assert_MM_true(extensions->excessiveGCEnabled._valueSpecified);
 
 	/* Get gc count now collect has happened */
-	UDATA gcCount = extensions->getUniqueGCCycleCount();
+	uintptr_t gcCount = extensions->getUniqueGCCycleCount();
 
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	TRIGGER_J9HOOK_MM_PRIVATE_EXCESSIVEGC_CHECK_GC_ACTIVITY(extensions->privateHookInterface,

--- a/gc/base/CycleState.hpp
+++ b/gc/base/CycleState.hpp
@@ -74,6 +74,8 @@ public:
 	} _pgcData;
 
 	uintptr_t _currentIncrement; /**< The index of the current increment within the cycle, starting at 0 (used for event reporting) */
+	uintptr_t _currentCycleID; /**< The index of the current cycle (used for event reporting) */
+
 	bool _shouldRunCopyForward; /**< True if this cycle is to run a copy-forward-based attempt at reclaiming memory, false if mark-compact is to be used */
 
 	enum ReasonForMarkCompactPGC {
@@ -112,6 +114,7 @@ public:
 		, _markDelegateState(state_mark_idle)
 		, _collectionReason(gc_reason_other)
 		, _currentIncrement(0)
+		, _currentCycleID(0)
 		, _shouldRunCopyForward(false)
 		, _reasonForMarkCompactPGC(reason_not_exceptional)
 		, _externalCycleState(NULL)

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -360,10 +360,10 @@ MM_GCExtensionsBase::usingSATBBarrier()
 	return false;
 }
 
-UDATA
+uintptr_t
 MM_GCExtensionsBase::getUniqueGCCycleCount()
 {
-	UDATA result = 0;
+	uintptr_t result = 0;
 
 	switch (configurationOptions._gcPolicy) {
 	case OMR_GC_POLICY_OPTTHRUPUT:

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1466,7 +1466,7 @@ public:
 	 *
 	 * @return unique GC ID count
 	 */
-	UDATA getUniqueGCCycleCount();
+	uintptr_t getUniqueGCCycleCount();
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	/**

--- a/gc/base/segregated/SegregatedGC.cpp
+++ b/gc/base/segregated/SegregatedGC.cpp
@@ -176,8 +176,6 @@ bool
 MM_SegregatedGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription)
 {
 	env->_cycleState->_activeSubSpace->reset();
-	_extensions->globalGCStats.clear();
-	_extensions->globalGCStats.gcCount++;
 
 	/*
 	 * Marking
@@ -258,6 +256,9 @@ MM_SegregatedGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 	env->_cycleState->_gcCode = MM_GCCode(gcCode);
 	env->_cycleState->_type = _cycleType;
 	env->_cycleState->_activeSubSpace = subSpace;
+	_extensions->globalGCStats.clear();
+	_extensions->globalGCStats.gcCount++;
+	env->_cycleState->_currentCycleID = env->getExtensions()->getUniqueGCCycleCount();
 
 	MM_MemoryPoolSegregated *memoryPool = (MM_MemoryPoolSegregated *) env->getDefaultMemorySubSpace()->getMemoryPool();
 

--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -819,7 +819,7 @@ MM_ConcurrentCardTable::cleanCards(MM_EnvironmentBase *env, bool isMutator, uint
 		currentCleaningPhase = _cardCleanPhase;
 	}
 
-	if (gcCount != _extensions->globalGCStats.gcCount) {
+	if ((gcCount != _extensions->globalGCStats.gcCount) || (CONCURRENT_INIT_COMPLETE >= _collector->getConcurrentGCStats()->getExecutionMode())) {
 		/* A gc has occured while attempting to acquire exclusive access to the card table */
 		return false;
 	}

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1589,6 +1589,8 @@ MM_ConcurrentGC::acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(
 			_concurrentCycleState._type = _cycleType;
 			env->_cycleState = &_concurrentCycleState;
 			env->_cycleState->_collectionStatistics = &_collectionStatistics;
+			_extensions->globalGCStats.gcCount += 1;
+			env->_cycleState->_currentCycleID = _extensions->getUniqueGCCycleCount();
 			reportGCCycleStart(env);
 			env->_cycleState = previousCycleState;
 
@@ -1601,9 +1603,7 @@ MM_ConcurrentGC::acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(
 			_callback->cancelCallback(env);
 
 			env->releaseExclusiveVMAccessForGC();
-		}
-
-		if (gcCount != _extensions->globalGCStats.gcCount) {
+		} else if (gcCount != _extensions->globalGCStats.gcCount) {
 			break;
 		}
 	}
@@ -2069,8 +2069,6 @@ MM_ConcurrentGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *
 bool
 MM_ConcurrentGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription)
 {
-	_extensions->globalGCStats.gcCount += 1;
-
 	mainThreadGarbageCollect(env, static_cast<MM_AllocateDescription*>(allocDescription), _initializeMarkMap, false);
 
 	/* Restore normal allocation rules.

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1085,6 +1085,8 @@ MM_ParallelGlobalGC::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpa
 	env->_cycleState->_type = _cycleType;
 	env->_cycleState->_activeSubSpace = subSpace;
 	env->_cycleState->_collectionStatistics = &_collectionStatistics;
+	_extensions->globalGCStats.gcCount += 1;
+	env->_cycleState->_currentCycleID = _extensions->getUniqueGCCycleCount();
 
 	/* If we are in an excessiveGC level beyond normal then an aggressive GC is
 	 * conducted to free up as much space as possible
@@ -1270,8 +1272,6 @@ MM_ParallelGlobalGC::setupForGC(MM_EnvironmentBase *env)
 bool
 MM_ParallelGlobalGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription)
 {
-	_extensions->globalGCStats.gcCount += 1;
-
 	/* only try to expand heap instead of garbage collection in -Xgcpolicy:nogc */
 	if (_disableGC) {
 		env->_cycleState->_activeSubSpace->checkResize(env, allocDescription, false);

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4320,7 +4320,7 @@ MM_Scavenger::mainThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_AllocateD
 		if (_extensions->processLargeAllocateStats) {
 			processLargeAllocateStatsBeforeGC(env);
 		}
-
+		env->_cycleState->_currentCycleID = _extensions->getUniqueGCCycleCount();
 		reportGCCycleStart(env);
 		_cycleTimes.cycleStart = omrtime_hires_clock();
 		mainSetupForGC(env);


### PR DESCRIPTION
Before this change the IDs were being retrieved from the current count. This lead to duplicate IDs due to the counts being retrieved and updated
 non sequentially. Another field to store the ID at the start of the
cycle is introduced. There were some inconsistencies with the increase in count as well, due to it being updated at varying places. The count increase is re-ordered to fix the inconsistencies. Moving the counts created an issue on PPC with some race conditions. Additional conditions had to be added to some logic to account for the changes in counts.