### PR TITLE
Implement mloadiFromArrayEvaluator on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1787,6 +1787,12 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::m2v:
             // only P9 has splat byte immediate, otherwise it's too expensive
             return cpu->isAtLeast(OMR_PROCESSOR_PPC_P9);
+        case TR::mloadiFromArray:
+            if ((et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P9)) || et == TR::Int16 || et == TR::Int32
+                || et == TR::Int64 || et == TR::Float || et == TR::Double)
+                return true;
+            else
+                return false;
         default:
             return false;
     }

--- a/compiler/p/codegen/OMRInstOpCode.enum
+++ b/compiler/p/codegen/OMRInstOpCode.enum
@@ -800,9 +800,9 @@
    vupkhsh,          // vector unpack high signed halfword
    vupklsb,          // vector unpack low signed byte
    vupklsh,          // vector unpack low signed halfword
-// vupklsw,          // Vector Unpack Low Signed Word
+   vupklsw,          // Vector Unpack Low Signed Word
 // vupklpx,          // Vector Unpack Low Pixel
-// vupkhsw,          // Vector Unpack High Signed Word
+   vupkhsw,          // Vector Unpack High Signed Word
 // vpksdss,          // Vector Pack Signed Dword Signed Saturate
 // vpksdus,          // Vector Pack Signed Dword Unsigned Saturate
    vpkuhum,          // vector pack unsigned half word unsigned modulo

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -9031,17 +9031,16 @@
         /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
     },
 
-    /* { */
-    /* .mnemonic    =    OMR::InstOpCode::vupklsw, */
-    /* .name        =    "vupklsw", */
-    /* .description =    "Vector Unpack Low Signed Word", */
-    /* .prefix      =    0x00000000, */
-    /* .opcode      =    0x100006CE, */
-    /* .format      =    FORMAT_UNKNOWN, */
-    /* .minimumALS  =    OMR_PROCESSOR_PPC_P8, */
-    /* .properties  =    PPCOpProp_IsVMX | */
-    /*                   PPCOpProp_SyncSideEffectFree, */
-    /* }, */
+    {
+        /* .mnemonic    = */ OMR::InstOpCode::vupklsw,
+        /* .name        = */ "vupklsw",
+        /* .description =    "Vector Unpack Low Signed Word", */
+        /* .prefix      = */ 0x00000000,
+        /* .opcode      = */ 0x100006CE,
+        /* .format      = */ FORMAT_VRT_VRB,
+        /* .minimumALS  = */ OMR_PROCESSOR_PPC_P8,
+        /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
+    },
 
     /* { */
     /* .mnemonic    =    OMR::InstOpCode::vupklpx, */
@@ -9055,17 +9054,16 @@
     /*                   PPCOpProp_SyncSideEffectFree, */
     /* }, */
 
-    /* { */
-    /* .mnemonic    =    OMR::InstOpCode::vupkhsw, */
-    /* .name        =    "vupkhsw", */
-    /* .description =    "Vector Unpack High Signed Word", */
-    /* .prefix      =    0x00000000, */
-    /* .opcode      =    0x1000064E, */
-    /* .format      =    FORMAT_UNKNOWN, */
-    /* .minimumALS  =    OMR_PROCESSOR_PPC_P8, */
-    /* .properties  =    PPCOpProp_IsVMX | */
-    /*                   PPCOpProp_SyncSideEffectFree, */
-    /* }, */
+    {
+        /* .mnemonic    = */ OMR::InstOpCode::vupkhsw,
+        /* .name        = */ "vupkhsw",
+        /* .description =    "Vector Unpack High Signed Word", */
+        /* .prefix      = */ 0x00000000,
+        /* .opcode      = */ 0x1000064E,
+        /* .format      = */ FORMAT_VRT_VRB,
+        /* .minimumALS  = */ OMR_PROCESSOR_PPC_P8,
+        /* .properties  = */ PPCOpProp_IsVMX | PPCOpProp_SyncSideEffectFree,
+    },
 
     /* { */
     /* .mnemonic    =    OMR::InstOpCode::vpksdss, */


### PR DESCRIPTION
Implement PPC codegen for `mloadiFromArray` for all Integral Vector Mask types 