### PR TITLE
Refactor ARM64HelperCallSnippet 

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -2728,7 +2728,7 @@ void TR_Debug::printa64(OMR::Logger *log, TR::Snippet *snippet)
             break;
 #endif
         case TR::Snippet::IsHelperCall:
-            print(log, (TR::ARM64HelperCallSnippet *)snippet);
+            snippet->print(log, this);
             break;
         case TR::Snippet::IsUnresolvedData:
             print(log, (TR::UnresolvedDataSnippet *)snippet);

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.hpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.hpp
@@ -91,6 +91,15 @@ public:
      * @return Snippet length
      */
     virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+    /**
+     * @brief Prints the Snippet
+     */
+    virtual void print(OMR::Logger *log, TR_Debug *);
+
+protected:
+    uint8_t *emitSnippetBodyInner(uint8_t *cursor);
+    void printInner(OMR::Logger *log, TR_Debug *debug, uint8_t *cursor);
 };
 
 } // namespace TR

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1287,7 +1287,6 @@ public:
     void print(OMR::Logger *log, TR::ARM64RecompilationSnippet *);
     uint8_t *printARM64ArgumentsFlush(OMR::Logger *log, TR::Node *, uint8_t *, int32_t);
 #endif
-    void print(OMR::Logger *log, TR::ARM64HelperCallSnippet *);
 
 #endif
 #ifdef TR_TARGET_RISCV


### PR DESCRIPTION
Refactors ARM64HelperCallSnippet::emitSnippetBody so that the helper call emission logic can be used by downstream projects.

Removes deprecated TR_Debug::print for ARM64HelperCallSnippet and replaces with newer TR::ARM64HelperCallSnippet::print
	- TR::ARM64HelperCallSnippet::printInner to be used by downstream projects

must be merged before https://github.com/eclipse-openj9/openj9/pull/23085. This should not require a coordinated merge.