### PR TITLE
New allocationContextArray in SparseVirtualMemory for reserved regions

### DIFF
--- a/gc/base/AllocateDescription.hpp
+++ b/gc/base/AllocateDescription.hpp
@@ -33,6 +33,7 @@
 #include "Base.hpp"
 #include "MemorySubSpace.hpp"
 
+class MM_AllocationContext;
 class MM_MemoryPool;
 class MM_MemorySpace;
 
@@ -66,6 +67,7 @@ protected:
 	omrarrayptr_t _spine; /**< field to store the arraylet spine allocated during an arraylet allocation */
 	bool _threadAtSafePoint;
 	MM_MemoryPool *_memoryPool;
+	MM_AllocationContext *_allocationContext; /**< resulting Allocation Context */
 		
 	/* The following fields are applicable to collectorAllocate requests only; ignored on other allocate requests */
 	bool _collectorAllocateExpandOnFailure; /**< if the allocation fails then expand heap if possible to satify the allocation */
@@ -74,7 +76,6 @@ protected:
 	bool  _collectAndClimb;
 	bool  _climb;				/* indicates that current attempt to allocate should try parent, if current subspace failed */
 	bool  _completedFromTlh;
-
 public:
 
 	/**
@@ -207,6 +208,8 @@ public:
 	MMINLINE bool isCompletedFromTlh() { return _completedFromTlh; }
 	MMINLINE void completedFromTlh() { _completedFromTlh = true; }
 
+	MMINLINE void setAllocationContext(MM_AllocationContext *allocationContext) {_allocationContext = allocationContext;}
+	MMINLINE MM_AllocationContext *getAllocationContext() {return _allocationContext;}
 	/**
 	 * Set whether the allocation succeeded
 	 * @param suceeded - true if the allocation succeeded, false otherwise
@@ -239,6 +242,7 @@ public:
 		,_spine(NULL)
 		,_threadAtSafePoint(threadAtSafePoint)
 		,_memoryPool(NULL)
+		,_allocationContext(NULL)
 		,_collectorAllocateExpandOnFailure(false)
 		,_collectorAllocateSatisfyAnywhere(false)
 		, _allocationType(MM_MemorySubSpace::ALLOCATION_TYPE_INVALID)

--- a/gc/base/AllocationContext.hpp
+++ b/gc/base/AllocationContext.hpp
@@ -97,6 +97,50 @@ public:
 		return NULL;
 	}
 
+	/**
+	 * Reserve (allocate) a non-region aligned fraction of an array from a shared reserved region.
+	 *
+	 * @param[in]		 env The calling thread
+	 * @param[in/out] 	allocateDescription The description of the requested allocation
+	 * @param[in] 		fraction  non-region aligned fraction
+	 * @param[in] 		shouldCollectOnFailure if true trigger GC on allocation failure
+	 *
+	 * @return The result of the allocation (NULL on failure or don't need to allocate new shared reserved region)
+	 */
+	virtual void *allocateFromSharedReservedRegion(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, uintptr_t fraction, bool shouldCollectOnFailure)
+	{
+		Assert_MM_unreachable();
+		return NULL;
+	}
+
+	/**
+	 * Recycle (free) a non-region aligned fraction of an array to shared reserved regions.
+	 *
+	 * @param[in] env The calling thread
+	 * @param[in] fraction  non-region aligned fraction
+	 * @param[in] needLock if true need common lock
+	 *
+	 * @return True if need to recycle shared reserved region
+	 */
+	virtual bool recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction, bool needLock = false)
+	{
+		Assert_MM_unreachable();
+		return false;
+	}
+
+	/**
+	 * Unreserve an array reserved region from the main heap and convert it to an ordinary free region.
+	 *
+	 * @param[in] env 					The calling thread
+	 * @param[in] reservedRegionCount	how many region need to be Unreserved
+	 * @param[in] needLock 				if true need common lock
+	 *
+	 */
+	virtual void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *env, uintptr_t reservedRegionCount, bool needLock)
+	{
+		Assert_MM_unreachable();
+	}
+
 protected:
 	virtual void tearDown(MM_EnvironmentBase *env);
 	bool initialize(MM_EnvironmentBase *env);

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -145,6 +145,7 @@ public:
 		ALLOCATION_TYPE_OBJECT,
 		ALLOCATION_TYPE_LEAF,
 		ALLOCATION_TYPE_TLH,
+		ALLOCATION_TYPE_SHARED_RESERVED
 	};
 
 	MMINLINE MM_PhysicalSubArena *getPhysicalSubArena() const { return _physicalSubArena; }

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -1034,3 +1034,7 @@ TraceEvent=Trc_MM_CPUUtilStats_processAndCpuUtilization_cpu_larger_than_elapsed 
 TraceEvent=Trc_MM_CPUUtilStats_processAndCpuUtilization_cpu_smaller_than_process Overhead=1 Level=1 Group=gclogger Template="cpu %lld smaller than process %lld; cpu adjusted to process"
 
 TraceEntry=Trc_MM_double_map_EntryNew Obsolete Overhead=1 Level=3 Group=arraylet Template="MM_IndexableObjectAllocationModel::doubleMapArraylets. originalDataSize: %p, adjustedDataSize: %p, spine: %p, leafSize: %p leavesCount: %zu"
+
+TraceException=Trc_MM_getSparseAddressAndDecommitLeaves_allocFailed Overhead=1 Level=1 Group=arraylet Template="Failed to allocate sparse memory sparseEntrySize: %zu"
+TraceException=Trc_MM_getSparseAddressAndDecommitLeaves_reserveFailed Overhead=1 Level=1 Group=arraylet Template="Failed to reserve region, ReservedRegionCount: %zu"
+


### PR DESCRIPTION
new _allocationContextArray in SparseVirtualMemory and related methods
to keep/retrieve the allocation context of off-heap related reserved
heap regions.

new AllocationType ALLOCATION_TYPE_SHARED_RESERVED for identifying the
allocation of shared reserved region after GC.

new _allocationContext in MM_AllocateDescription for passing back the
allocation context of shared reserved region for off-heap array.

new trace points for reserve region/allocate spare memory failures.

Add virtual Methods allocateFromSharedReservedRegion(),
recycleToSharedArrayReservedRegion(),
recycleReservedRegionsForVirtualLargeObjectHeap() in
MM_AllocationContext.
