### PR TITLE
AArch64: Remove generateConditionalBranchInstruction() with opcode

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -116,21 +116,6 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
         TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cond, cg);
 }
 
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::Instruction *preced)
-{
-    TR_ASSERT_FATAL(op == TR::InstOpCode::b_cond, "Unsupported opcode for Conditional branch");
-    return generateConditionalBranchInstruction(cg, node, sym, cc, preced);
-}
-
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced)
-{
-    TR_ASSERT_FATAL(op == TR::InstOpCode::b_cond, "Unsupported opcode for Conditional branch");
-    return generateConditionalBranchInstruction(cg, node, sym, cc, cond, preced);
-}
-
 TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
     TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced)
 {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -161,34 +161,6 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
     TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
 /*
- * @brief Generates conditional branch instruction
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] sym : label symbol
- * @param[in] cc : branch condition code
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
-
-/*
- * @brief Generates conditional branch instruction with register dependency
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] sym : label symbol
- * @param[in] cc : branch condition code
- * @param[in] cond : register dependency condition
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced = NULL);
-
-/*
  * @brief Generates compare and branch instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode


### PR DESCRIPTION
This commit removes generateConditionalBranchInstruction() functions that are no longer used.