### PR TITLE
Set termCharNodeIsHint correctly for VP converter intrinsic

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2373,7 +2373,7 @@ void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree, TR
         termCharNode = TR::Node::create(callNode, TR::iconst, 0, termchar);
     } else if (isSBCSEncoder || isEncodeFromLatin1) // only z
     {
-        arrayTranslateNode->setTermCharNodeIsHint(false);
+        arrayTranslateNode->setTermCharNodeIsHint(isEncodeFromLatin1);
         arrayTranslateNode->setSourceCellIsTermChar(false);
         arrayTranslateNode->setTableBackedByRawStorage(true);
         termCharNode = TR::Node::create(callNode, TR::iconst, 0, 0);


### PR DESCRIPTION

ValuePropagation accelerates an intrinsic (only on Z platform) sun_nio_cs_SingleByteEncoder_encodeFromLatin1Impl that performs a 1:1 translation using the arraytranslate IL via the TROO instruction and does not need a stop character. This commit prevents the instruction from testing for a stop character and hence avoids scenarios where we stop translation when a null terminator is encountered.