### PR TITLE
Refactor PPCHelperCallSnippet Debug Printing

### DIFF
--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -1035,10 +1035,6 @@ void TR_Debug::printp(OMR::Logger *log, TR::Snippet *snippet)
             print(log, (TR::PPCRecompilationSnippet *)snippet);
             break;
 #endif
-        case TR::Snippet::IsArrayCopyCall:
-        case TR::Snippet::IsHelperCall:
-            print(log, (TR::PPCHelperCallSnippet *)snippet);
-            break;
         case TR::Snippet::IsUnresolvedData:
             print(log, (TR::UnresolvedDataSnippet *)snippet);
             break;
@@ -1051,6 +1047,8 @@ void TR_Debug::printp(OMR::Logger *log, TR::Snippet *snippet)
         case TR::Snippet::IsLockReservationExit:
         case TR::Snippet::IsAllocPrefetch:
         case TR::Snippet::IsNonZeroAllocPrefetch:
+        case TR::Snippet::IsHelperCall:
+        case TR::Snippet::IsArrayCopyCall:
             snippet->print(log, this);
             break;
         default:

--- a/compiler/p/codegen/PPCHelperCallSnippet.hpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.hpp
@@ -67,6 +67,11 @@ public:
     virtual uint8_t *emitSnippetBody();
 
     virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+    void print(OMR::Logger *log, TR_Debug *debug);
+
+protected:
+    void printInner(OMR::Logger *log, TR_Debug *debug, uint8_t *cursor);
 };
 
 class PPCArrayCopyCallSnippet : public TR::PPCHelperCallSnippet {


### PR DESCRIPTION
Removes old TR_Debug::print overload for PPCHelperCallSnippet and replaces with TR::PPCHelperCallSnippet::print

Adds printInner so core printing logic can be used by downstream projects.

must be merged before https://github.com/eclipse-openj9/openj9/pull/22938