### PR TITLE
WIP: Check for Mask type whenever we check for Vector type

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -236,7 +236,7 @@ void TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
     while (localCursor != NULL) {
         if (localCursor->getGCMapIndex() < 0 && localCursor->getDataType() != TR::Int64
             && localCursor->getDataType() != TR::Double && localCursor->getDataType() != TR::Address
-            && !localCursor->getDataType().isVector()) {
+            && !localCursor->getDataType().isVectorOrMask()) {
             localCursor->setOffset(stackIndex);
             stackIndex += (localCursor->getSize() + 3) & (~3);
             frameNeeded = true;
@@ -265,7 +265,7 @@ void TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
 
     // map vector automatics
     while (localCursor != NULL) {
-        if (localCursor->getDataType().isVector()) {
+        if (localCursor->getDataType().isVectorOrMask()) {
             localCursor->setOffset(stackIndex);
             stackIndex += (localCursor->getSize() + 15) & (~15);
             frameNeeded = true;
@@ -867,4 +867,3 @@ intptr_t TR::ARM64SystemLinkage::entryPointFromInterpretedMethod()
 {
     return reinterpret_cast<intptr_t>(cg()->getCodeStart());
 }
-

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -121,7 +121,7 @@ static uint32_t countIntegerAndAddressTypesInGlRegDeps(TR::Node *glRegDepsNode, 
             child = child->getFirstChild();
         }
 
-        if (!(child->getDataType().isFloatingPoint() || child->getDataType().isVector())) {
+        if (!(child->getDataType().isFloatingPoint() || child->getDataType().isVectorOrMask())) {
             numIntNodes++;
         }
     }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -756,7 +756,7 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
 
 bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::Node *node) { return !node->getOpCode().isVectorOpCode(); }
 
-bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !(dt.isVector() || dt.isMask()); }
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !dt.isVectorOrMask(); }
 
 bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
 {

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1043,7 +1043,7 @@ TR_GlobalRegisterNumber OMR::CodeGenerator::pickRegister(TR::RegisterCandidate *
 
         const bool usesFPR = (dtype == TR::Float || dtype == TR::Double);
 
-        const bool usesVRF = dtype.isVector() || dtype.isMask();
+        const bool usesVRF = dtype.isVectorOrMask();
 
         if (terseSimulateTreeEvaluation) {
             log->printf("         { Picking register for %s%s candidate #%d %s\n",

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -46,7 +46,7 @@ TR_RegisterKinds OMR::Linkage::argumentRegisterKind(TR::Node *argumentNode)
 {
     if (argumentNode->getOpCode().isFloatingPoint())
         return TR_FPR;
-    else if (argumentNode->getOpCode().isVectorResult())
+    else if (argumentNode->getOpCode().isVectorOrMaskResult())
         return TR_VRF;
     else
         return TR_GPR;

--- a/compiler/codegen/RegisterPressureSimulatorInner.hpp
+++ b/compiler/codegen/RegisterPressureSimulatorInner.hpp
@@ -330,7 +330,7 @@ uint8_t gprCount(TR::DataType type, int32_t size);
 
 uint8_t fprCount(TR::DataType type) { return type.isFloatingPoint() ? 1 : 0; }
 
-uint8_t vrfCount(TR::DataType type) { return type.isVector() ? 1 : 0; }
+uint8_t vrfCount(TR::DataType type) { return type.isVectorOrMask() ? 1 : 0; }
 
 void initializeRegisterPressureSimulator();
 

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -659,7 +659,7 @@ TR_BitVector *OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool i
 #endif
 
             // alias vector arrays shadows  with corresponding scalar array shadows
-            if (_symbol->isArrayShadowSymbol() && _symbol->getDataType().isVector()) {
+            if (_symbol->isArrayShadowSymbol() && _symbol->getDataType().isVectorOrMask()) {
                 if (!aliases)
                     aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
                 aliases->set(symRefTab->getArrayShadowIndex(_symbol->getDataType().getVectorElementType()));

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -822,7 +822,7 @@ static std::pair<TR_GlobalRegisterNumber, TR_GlobalRegisterNumber> findAvailable
     } else if (dt.isFloatingPoint()) {
         start = firstFPR;
         end = lastFPR;
-    } else if (dt.isVector()) {
+    } else if (dt.isVectorOrMask()) {
         start = firstVRF;
         end = lastVRF;
     } else {

--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -128,7 +128,7 @@ TR::DataType OMR::DataType::getFloatTypeFromSize(int32_t size)
 
 int32_t OMR::DataType::getVectorSize()
 {
-    TR_ASSERT_FATAL(isVector() || isMask(), "getVectorSize() can only be called on vector or mask type\n");
+    TR_ASSERT_FATAL(isVectorOrMask(), "getVectorSize() can only be called on vector or mask type\n");
 
     switch (getVectorLength()) {
         case TR::VectorLength64:
@@ -148,7 +148,7 @@ int32_t OMR::DataType::getVectorSize()
 
 int32_t OMR::DataType::getVectorNumLanes()
 {
-    TR_ASSERT_FATAL(isVector() || isMask(), "getVectorNumlanes() can only be called on vector or mask type\n");
+    TR_ASSERT_FATAL(isVectorOrMask(), "getVectorNumlanes() can only be called on vector or mask type\n");
 
     return getVectorSize() / getSize(getVectorElementType());
 }
@@ -207,7 +207,7 @@ int32_t OMR::DataType::getSize(TR::DataType dt)
 
 void OMR::DataType::setSize(TR::DataType dt, int32_t newSize)
 {
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "setDataTypeSizeInMap called on unrecognized data type");

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -556,6 +556,14 @@ public:
     inline bool isMask();
 
     /** \brief
+     *     Checks if the type is Vector or  Mask type
+     *
+     *  \return
+     *     true iff is Vector or  Mask type
+     */
+    bool isVectorOrMask() { return isVector() || isMask(); }
+
+    /** \brief
      *     Creates mask type based on element type and vector length
      *
      *  \param elementType

--- a/compiler/il/OMRDataTypes_inlines.hpp
+++ b/compiler/il/OMRDataTypes_inlines.hpp
@@ -112,7 +112,7 @@ TR::DataTypes OMR::DataType::createVectorType(TR::DataType elementType, TR::Vect
 
 TR::DataType OMR::DataType::getVectorElementType()
 {
-    TR_ASSERT_FATAL(isVector() || isMask(), "getVectorElementType() is called on non-vector and oon non-mask type\n");
+    TR_ASSERT_FATAL(isVectorOrMask(), "getVectorElementType() is called for non-vector or non-mask type\n");
 
     if (isVector())
         return static_cast<TR::DataTypes>((_type - TR::FirstVectorType) % TR::NumVectorElementTypes + 1);
@@ -122,7 +122,7 @@ TR::DataType OMR::DataType::getVectorElementType()
 
 TR::VectorLength OMR::DataType::getVectorLength()
 {
-    TR_ASSERT_FATAL(isVector() || isMask(), "getVectorLength() is called on non-vector and non-mask type\n");
+    TR_ASSERT_FATAL(isVectorOrMask(), "getVectorLength() is called for non-vector or non-mask type\n");
 
     if (isVector())
         return static_cast<TR::VectorLength>((_type - TR::FirstVectorType) / TR::NumVectorElementTypes + 1);

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -548,7 +548,7 @@ TR::ILOpCodes OMR::IL::opCodeForSelect(TR::DataType dt)
     static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForSelect) / sizeof(OMR::IL::opCodesForSelect[0])),
         "OMR::IL::opCodesForSelect is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
@@ -561,7 +561,7 @@ TR::ILOpCodes OMR::IL::opCodeForConst(TR::DataType dt)
     static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForConst) / sizeof(OMR::IL::opCodesForConst[0])),
         "OMR::IL::opCodesForConst is not the correct size");
 
-    TR_ASSERT_FATAL(!dt.isVector() && !dt.isMask(), "Vector and Mask constants are not supported\n");
+    TR_ASSERT_FATAL(!dt.isVectorOrMask(), "Vector and Mask constants are not supported\n");
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
 
@@ -589,7 +589,7 @@ TR::ILOpCodes OMR::IL::opCodeForDirectReadBarrier(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForDirectReadBarrier) / sizeof(OMR::IL::opCodesForDirectReadBarrier[0])),
         "OMR::IL::opCodesForDirectReadBarrier is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -619,7 +619,7 @@ TR::ILOpCodes OMR::IL::opCodeForDirectWriteBarrier(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForDirectWriteBarrier) / sizeof(OMR::IL::opCodesForDirectWriteBarrier[0])),
         "OMR::IL::opCodesForDirectWriteBarrier is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -649,7 +649,7 @@ TR::ILOpCodes OMR::IL::opCodeForIndirectReadBarrier(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIndirectReadBarrier) / sizeof(OMR::IL::opCodesForIndirectReadBarrier[0])),
         "OMR::IL::opCodesForIndirectReadBarrier is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -679,7 +679,7 @@ TR::ILOpCodes OMR::IL::opCodeForIndirectWriteBarrier(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIndirectWriteBarrier) / sizeof(OMR::IL::opCodesForIndirectWriteBarrier[0])),
         "OMR::IL::opCodesForIndirectWriteBarrier is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -773,7 +773,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareEquals(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIfCompareEquals) / sizeof(OMR::IL::opCodesForIfCompareEquals[0])),
         "OMR::IL::opCodesForIfCompareEquals is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -803,7 +803,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareNotEquals(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIfCompareNotEquals) / sizeof(OMR::IL::opCodesForIfCompareNotEquals[0])),
         "OMR::IL::opCodesForIfCompareNotEquals is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -849,7 +849,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareLessThan(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIfCompareLessThan) / sizeof(OMR::IL::opCodesForIfCompareLessThan[0])),
         "OMR::IL::opCodesForIfCompareLessThan is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -863,7 +863,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareLessOrEquals(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIfCompareLessOrEquals) / sizeof(OMR::IL::opCodesForIfCompareLessOrEquals[0])),
         "OMR::IL::opCodesForIfCompareLessOrEquals is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -910,7 +910,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareGreaterThan(TR::DataType dt)
             == (sizeof(OMR::IL::opCodesForIfCompareGreaterThan) / sizeof(OMR::IL::opCodesForIfCompareGreaterThan[0])),
         "OMR::IL::opCodesForIfCompareGreaterThan is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");
@@ -925,7 +925,7 @@ TR::ILOpCodes OMR::IL::opCodeForIfCompareGreaterOrEquals(TR::DataType dt)
                 / sizeof(OMR::IL::opCodesForIfCompareGreaterOrEquals[0])),
         "OMR::IL::opCodesForIfCompareGreaterOrEquals is not the correct size");
 
-    if (dt.isVector() || dt.isMask())
+    if (dt.isVectorOrMask())
         return TR::BadILOp;
 
     TR_ASSERT(dt < TR::NumOMRTypes, "unexpected opcode");

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -92,8 +92,7 @@ public:
      */
     static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, TR::DataType vectorType)
     {
-        TR_ASSERT_FATAL(vectorType.isVector() || vectorType.isMask(),
-            "createVectorOpCode should take vector or mask type\n");
+        TR_ASSERT_FATAL(vectorType.isVectorOrMask(), "createVectorOpCode should take vector or mask type\n");
 
         TR_ASSERT_FATAL(operation < TR::firstTwoTypeVectorOperation,
             "Vector operation should be one vector type operation\n");
@@ -123,10 +122,8 @@ public:
     static TR::ILOpCodes createVectorOpCode(TR::VectorOperation operation, TR::DataType srcVectorType,
         TR::DataType resVectorType)
     {
-        TR_ASSERT_FATAL(srcVectorType.isVector() || srcVectorType.isMask(),
-            "createVectorOpCode should take vector or mask source type\n");
-        TR_ASSERT_FATAL(resVectorType.isVector() || resVectorType.isMask(),
-            "createVectorOpCode should take vector or mask result type\n");
+        TR_ASSERT_FATAL(srcVectorType.isVectorOrMask(), "createVectorOpCode should take vector or mask source type\n");
+        TR_ASSERT_FATAL(resVectorType.isVectorOrMask(), "createVectorOpCode should take vector or mask result type\n");
 
         TR_ASSERT_FATAL(operation >= TR::firstTwoTypeVectorOperation,
             "Vector operation should be two vector type operation\n");

--- a/compiler/il/VectorOperations.enum
+++ b/compiler/il/VectorOperations.enum
@@ -340,7 +340,7 @@ VECTOR_OPERATION_MACRO(\
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    load from array and convert to vector mask. assumes that a value of 1 is true and 0 is false*/ \
+   /* .description             =    load from boolean array and convert to vector mask. Assumes that, within the array, a value of 1 is true and 0 is false*/ \
 )
 VECTOR_OPERATION_MACRO(\
    /* .operation               = */ mstoreiToArray, \
@@ -356,7 +356,7 @@ VECTOR_OPERATION_MACRO(\
    /* .reverseBranchOperation  = */ TR::vBadOperation, \
    /* .booleanCompareOpCode    = */ TR::BadILOp, \
    /* .ifCompareOpCode         = */ TR::BadILOp, \
-   /* .description             =    convert from vector mask and store to array. assumes that a value of 1 is true and 0 is false*/ \
+   /* .description             =    convert from vector mask and store to boolean array. assumes that, within the array, a value of 1 is true and 0 is false*/ \
 )
 
 // vector mask conversion opcodes (TO BE REMOVED)

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -560,7 +560,7 @@ void TR_FieldPrivatizer::detectFieldsThatCannotBePrivatized(TR::Node *node, vcou
             if (canPrivatize && !sym->isArrayShadowSymbol() && sym->isTransparent()
                 && comp()->cg()->considerTypeForGRA(symRef) && !_neverWritten->get(symRef->getReferenceNumber())
                 && (opCode.isIndirect() ? subtreeIsInvariantInLoop(node->getFirstChild()) : true)
-                && !isFieldAliasAccessed(symRef) && (symSize <= 8 || sym->getType().isVector())) {
+                && !isFieldAliasAccessed(symRef) && (symSize <= 8 || sym->getType().isVectorOrMask())) {
                 bool canPrivatizeBasedOnThisNode = canPrivatizeFieldSymRef(node);
 
                 if (!canPrivatizeBasedOnThisNode) {

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -4248,7 +4248,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
                 else
                     removeNodeFromList(node, &state->_currentlyCommonedFPCandidates, &state->_fpParents, false);
             }
-        } else if (node->getOpCode().isVectorResult()) {
+        } else if (node->getOpCode().isVectorOrMaskResult()) {
             state->_currentlyCommonedVector128Nodes.remove(node);
             if (isRematerializable(parent, node, true) && node->isRematerializeable()) {
                 if (isRematerializableLoad(node, parent))
@@ -4277,7 +4277,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
                 addParentToList(node, &state->_currentlyCommonedFPLoads, parent, &state->_parentsOfCommonedFPLoads);
             else
                 addParentToList(node, &state->_currentlyCommonedFPCandidates, parent, &state->_fpParents);
-        } else if (node->getOpCode().isVectorResult()) {
+        } else if (node->getOpCode().isVectorOrMaskResult()) {
             if (isRematerializableLoad(node, parent))
                 addParentToList(node, &state->_currentlyCommonedVector128Loads, parent,
                     &state->_parentsOfCommonedVector128Loads);
@@ -4324,7 +4324,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
             if (((child->getFutureUseCount() & 0x7fff) == 0) && !child->getOpCode().isLoadConst()) {
                 if (child->getOpCode().isFloatingPoint())
                     fpChildAdjustment++;
-                else if (child->getOpCode().isVectorResult()) {
+                else if (child->getOpCode().isVectorOrMaskResult()) {
                     vector128ChildAdjustment++;
                 } else {
                     childAdjustment++;
@@ -4369,7 +4369,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
             if (((maxChild->getFutureUseCount() & 0x7fff) == 0) && !maxChild->getOpCode().isLoadConst()) {
                 if (maxChild->getOpCode().isFloatingPoint())
                     fpChildAdjustment++;
-                else if (maxChild->getOpCode().isVectorResult()) {
+                else if (maxChild->getOpCode().isVectorOrMaskResult()) {
                     vector128ChildAdjustment++;
                 } else {
                     childAdjustment++;
@@ -4398,7 +4398,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
             if (node->getOpCode().isFloatingPoint())
                 removeNodeFromList(node->getFirstChild(), &state->_currentlyCommonedFPLoads,
                     &state->_parentsOfCommonedFPLoads, true);
-            else if (node->getOpCode().isVectorResult()) {
+            else if (node->getOpCode().isVectorOrMaskResult()) {
                 removeNodeFromList(node->getFirstChild(), &state->_currentlyCommonedVector128Loads,
                     &state->_parentsOfCommonedVector128Loads, true);
             } else
@@ -4442,7 +4442,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
         if (node->getOpCode().isFloatingPoint())
             removeNodeFromList(node, &state->_currentlyCommonedFPLoads, &state->_parentsOfCommonedFPLoads, true,
                 &state->_fpLoadsAlreadyVisited, &state->_fpLoadsAlreadyVisitedThatCannotBeRematerialized, aliases);
-        else if (node->getOpCode().isVectorResult()) {
+        else if (node->getOpCode().isVectorOrMaskResult()) {
             removeNodeFromList(node, &state->_currentlyCommonedVector128Loads, &state->_parentsOfCommonedVector128Loads,
                 true, &state->_vector128LoadsAlreadyVisited,
                 &state->_vector128LoadsAlreadyVisitedThatCannotBeRematerialized, aliases);
@@ -4526,7 +4526,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
             &state->_fpLoadsAlreadyVisitedThatCannotBeRematerialized, rematSpecialNode);
     }
 
-    if (trace() && node->getOpCode().isVectorResult()) {
+    if (trace() && node->getOpCode().isVectorOrMaskResult()) {
         log->printf("At node %p VSR pressure is %d (child adjust %d parent adjust %d) limit is %d\n", node,
             state->_currentlyCommonedVector128Nodes.getSize() + vector128ChildAdjustment
                 + adjustments.vector128AdjustmentFromParent,
@@ -4555,7 +4555,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
             if (parent) {
                 if (node->getOpCode().isFloatingPoint())
                     state->_currentlyCommonedFPNodes.add(node);
-                else if (node->getOpCode().isVectorResult()) {
+                else if (node->getOpCode().isVectorOrMaskResult()) {
                     state->_currentlyCommonedVector128Nodes.add(node);
                 } else
                     state->_currentlyCommonedNodes.add(node);
@@ -4572,7 +4572,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
                             parentList->add(parent);
                             state->_parentsOfCommonedFPLoads.add(parentList);
                         }
-                    } else if (node->getOpCode().isVectorResult()) {
+                    } else if (node->getOpCode().isVectorOrMaskResult()) {
                         if (!state->_vector128LoadsAlreadyVisitedThatCannotBeRematerialized.find(node)) {
                             state->_currentlyCommonedVector128Loads.add(node);
                             TR_ScratchList<TR::Node> *parentList
@@ -4596,7 +4596,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
                             = new (trStackMemory()) TR_ScratchList<TR::Node>(trMemory());
                         parentList->add(parent);
                         state->_fpParents.add(parentList);
-                    } else if (node->getOpCode().isVectorResult()) {
+                    } else if (node->getOpCode().isVectorOrMaskResult()) {
                         state->_currentlyCommonedVector128Candidates.add(node);
                         TR_ScratchList<TR::Node> *parentList
                             = new (trStackMemory()) TR_ScratchList<TR::Node>(trMemory());

--- a/compiler/optimizer/OMRRegisterCandidate.cpp
+++ b/compiler/optimizer/OMRRegisterCandidate.cpp
@@ -194,7 +194,7 @@ TR_RegisterKinds OMR::RegisterCandidate::getRegisterKinds()
     TR::DataType dt = getDataType();
     if (dt == TR::Float || dt == TR::Double)
         return TR_FPR;
-    else if (dt.isVector() || dt.isMask())
+    else if (dt.isVectorOrMask())
         return TR_VRF;
     else
         return TR_GPR;
@@ -2091,7 +2091,7 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
                 : "",
             rc->getWeight());
         bool isFloat = (rc->getDataType() == TR::Float || rc->getDataType() == TR::Double);
-        bool isVector = rc->getDataType().isVector() || rc->getDataType().isMask();
+        bool isVector = rc->getDataType().isVectorOrMask();
         bool needs2Regs = false;
 
         if (rc->rcNeeds2Regs(comp()))
@@ -2288,7 +2288,7 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
             continue;
         }
 
-        if ((dt.isVector() || dt.isMask()) && !comp()->cg()->hasGlobalVRF()) {
+        if (dt.isVectorOrMask() && !comp()->cg()->hasGlobalVRF()) {
             logprintf(trace, log, "Leaving candidate because it has %s type but no global vector registers provided\n",
                 TR::DataType::getName(dt));
             TR_ASSERT(!comp()->target().cpu.isZ(), "ed : debug : Should never get here for vector GRA on z");
@@ -2329,7 +2329,7 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
         }
 
         bool isFloat = (dt == TR::Float || dt == TR::Double);
-        bool isVector = dt.isVector() || dt.isMask();
+        bool isVector = dt.isVectorOrMask();
         int32_t firstRegister, lastRegister;
 
         if (isFloat) {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5137,8 +5137,9 @@ TR::Node *indirectLoadSimplifier(TR::Node *node, TR::Block *block, TR::Simplifie
         if ((node->getType().isIntegral() || node->getType().isDouble())
             && ((addressNode->getOpCode().isArrayRef() && addressNode->getSecondChild()->getOpCode().isLoadConst()
                     && addressNode->getFirstChild()->getOpCode().hasSymbolReference()
-                    && addressNode->getFirstChild()->getSymbol()->getType().isVector())
-                || (addressNode->getOpCode().hasSymbolReference() && addressNode->getSymbol()->getType().isVector()))
+                    && addressNode->getFirstChild()->getSymbol()->getType().isVectorOrMask())
+                || (addressNode->getOpCode().hasSymbolReference()
+                    && addressNode->getSymbol()->getType().isVectorOrMask()))
             && performTransformation(s->comp(), "%sReplace indirect load [" POINTER_PRINTF_FORMAT "] with vgetelem",
                 s->optDetailString(), node)) {
             int32_t offset = 0;
@@ -5297,8 +5298,9 @@ TR::Node *indirectStoreSimplifier(TR::Node *node, TR::Block *block, TR::Simplifi
             && (!valueNode->getOpCode().isLoadConst() || s->getLastRun())
             && ((addressNode->getOpCode().isArrayRef() && addressNode->getSecondChild()->getOpCode().isLoadConst()
                     && addressNode->getFirstChild()->getOpCode().hasSymbolReference()
-                    && addressNode->getFirstChild()->getSymbol()->getType().isVector())
-                || (addressNode->getOpCode().hasSymbolReference() && addressNode->getSymbol()->getType().isVector()))
+                    && addressNode->getFirstChild()->getSymbol()->getType().isVectorOrMask())
+                || (addressNode->getOpCode().hasSymbolReference()
+                    && addressNode->getSymbol()->getType().isVectorOrMask()))
             && performTransformation(s->comp(), "%sReplace indirect store [" POINTER_PRINTF_FORMAT "] with vsetelem",
                 s->optDetailString(), node)) {
             int32_t offset = 0;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1011,15 +1011,12 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             break;
 
         default:
-            if (sym->getDataType().isVector()) {
-                if (sym->getDataType().getVectorElementType() == TR::Int32
-                    || sym->getDataType().getVectorElementType() == TR::Double) {
-                    isVector = true;
-                    firstIndex = self()->getFirstGlobalVRF();
-                    lastIndex = self()->getLastGlobalVRF();
-                    lastVolIndex = lastIndex; // TODO: preserved VRF's !!
-                    break;
-                }
+            if (sym->getDataType().isVectorOrMask()) {
+                isVector = true;
+                firstIndex = self()->getFirstGlobalVRF();
+                lastIndex = self()->getLastGlobalVRF();
+                lastVolIndex = lastIndex; // TODO: preserved VRF's !!
+                break;
             }
 
             firstIndex = _firstGPR;
@@ -1029,7 +1026,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
     }
 
     bool gprCandidate = true;
-    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVector())
+    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVectorOrMask())
         gprCandidate = false;
 
     if (gprCandidate) {
@@ -1080,7 +1077,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             for (prev = candidates->getFirst(); prev; prev = prev->getNext()) {
                 bool gprCandidate = true;
                 if ((prev->getSymbol()->getDataType() == TR::Float) || (prev->getSymbol()->getDataType() == TR::Double)
-                    || sym->getDataType().isVector())
+                    || sym->getDataType().isVectorOrMask())
                     gprCandidate = false;
                 if (gprCandidate && prev->getBlocksLiveOnEntry().get(liveBlockNum)) {
                     numAssignedGlobalRegs++;
@@ -1238,7 +1235,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumbe
             result = -1;
         else
             result = _fprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
-    } else if (type.isVector())
+    } else if (type.isVectorOrMask())
         TR_ASSERT(false, "assertion failure"); // TODO
     else {
         if (linkageRegisterIndex >= self()->getProperties()._numIntegerArgumentRegisters)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3238,7 +3238,7 @@ bool OMR::X86::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddres
 
 bool OMR::X86::CodeGenerator::considerTypeForGRA(TR::Node *node) { return !node->getOpCode().isVectorOpCode(); }
 
-bool OMR::X86::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !(dt.isVector() || dt.isMask()); }
+bool OMR::X86::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !dt.isVectorOrMask(); }
 
 bool OMR::X86::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
 {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -6230,8 +6230,7 @@ TR::Register *OMR::X86::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::Co
 void OMR::X86::TreeEvaluator::vectorMaskToGPRHelper(TR::Node *node, TR::DataType type, TR::Register *gprReg,
     TR::Register *maskReg, TR::CodeGenerator *cg)
 {
-    TR_ASSERT_FATAL(type.isVector() || type.isMask(),
-        "vectorMaskToGPRHelper requires vector type, not raw element type");
+    TR_ASSERT_FATAL(type.isVectorOrMask(), "vectorMaskToGPRHelper requires vector type, not raw element type");
     TR::DataType et = type.getVectorElementType();
 
     if (maskReg->getKind() == TR_VMR) {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2211,7 +2211,7 @@ TR_GlobalRegisterNumber OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(in
 
     if (isFloat) {
         result = self()->machine()->getLastLinkageFPR() - linkageRegisterIndex;
-    } else if (type.isVector()) {
+    } else if (type.isVectorOrMask()) {
         result = self()->machine()->getLastGlobalVRFRegisterNumber() - linkageRegisterIndex;
     } else {
         result = self()->getGlobalRegisterNumber(


### PR DESCRIPTION
- Ideally, we need to create an OMRCodeGenerator method that checks if type is stored in a particular type of register
- This PR is a tactical solution to fix any potential bugs
- It works since, currently, all vectors and masks use the same register