### PR TITLE
Disable v2m and m2v on PPC

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1781,12 +1781,8 @@ bool OMR::Power::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
                 return false;
         case TR::vbitselect:
         case TR::vcast:
-        case TR::v2m:
         case TR::vblend:
             return true;
-        case TR::m2v:
-            // only P9 has splat byte immediate, otherwise it's too expensive
-            return cpu->isAtLeast(OMR_PROCESSOR_PPC_P9);
         case TR::mloadiFromArray:
         case TR::mstoreiToArray:
             if ((et == TR::Int8 && cpu->isAtLeast(OMR_PROCESSOR_PPC_P9)) || et == TR::Int16 || et == TR::Int32


### PR DESCRIPTION
`mloadiFromArray` and `mstoreiToArray` have both been implemented on PPC for ByteVectors, so we can remove `m2v` and `v2m` from `getSupportsOpCodeForAutoSIMD()` entirely.