### PR TITLE
Fix reference counts on memrefs on Power

### DIFF
--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -617,13 +617,16 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
                 //    iconst(lconst)
                 {
                     self()->addToOffset(subTree, subTree->getFirstChild()->getFirstChild()->getInt() << amount, cg);
-                    cg->decReferenceCount(subTree->getFirstChild()->getFirstChild());
+                    if (subTree->getFirstChild()->getReferenceCount() == 1
+                        && subTree->getFirstChild()->getRegister() == NULL)
+                        cg->decReferenceCount(subTree->getFirstChild()->getFirstChild());
                 }
             } else
                 self()->addToOffset(subTree, subTree->getFirstChild()->getInt() << subTree->getSecondChild()->getInt(),
                     cg);
             cg->decReferenceCount(subTree->getFirstChild());
             cg->decReferenceCount(subTree->getSecondChild());
+            cg->decReferenceCount(subTree);
         } else if ((subTree->getOpCodeValue() == TR::loadaddr) && !cg->comp()->compileRelocatableCode()) {
             TR::SymbolReference *ref = subTree->getSymbolReference();
             TR::Symbol *symbol = ref->getSymbol();
@@ -663,6 +666,7 @@ void OMR::Power::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
             subTree->getOpCodeValue() == TR::lconst) {
             int64_t amount = (subTree->getOpCodeValue() == TR::iconst) ? subTree->getInt() : subTree->getLongInt();
             self()->addToOffset(subTree, amount, cg);
+            cg->decReferenceCount(subTree);
         } else {
             if (_baseRegister != NULL) {
                 self()->consolidateRegisters(cg->evaluate(subTree), subTree, cg->canClobberNodesRegister(subTree), cg);


### PR DESCRIPTION
`isLoadConstAndShift` missed checking the reference count on a node. This causes reference counts on the children of the node to be decremented without evaluating the parent node. The parent node is evaluated later on causing the children to be decremented again when they should not. A check is added to ensure the parent node has a reference count of 1 and that the parent has not already been evaluated before proceeding with the optimization that skips evaluating the parent node.

While fixing the above, it was also discovered that reference counts were not properly decremented in two other cases. There is an expectation that the `subTree` node passed into the call to `populateMemoryReference` gets decremented or gets recorded as `_baseNode` or `_indexNode` to be decremented later. This was not happening in two places and has now been fixed.