### PR TITLE
Fix SegFault caused by invalid log file

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3294,8 +3294,14 @@ bool OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void *jitConfig)
             if (_debug) {
                 _logFile = _debug->findLogFile(TR::Options::getAOTCmdLineOptions(), TR::Options::getJITCmdLineOptions(),
                     optionSet, _logFileName, _logger);
-                if (_logFile == NULL)
+                if (_logFile == NULL) {
                     self()->openLogFileCreateLogger();
+                    if (!_logger) { // openLogFileCreateLogger failed
+                        fprintf(stderr, "Unable to open log file %s\n", _logFileName);
+                        _logger = TR::Options::getDefaultLogger();
+                    }
+                }
+
                 else
                     OMR::Options::_dualLogging = true; // a log file is used in two different option sets, or in
                                                        // in the main TR::Options object and in an option set


### PR DESCRIPTION
Fixes the segfault caused by running OpenJ9 with
and invalid log file, and traceFull both specified in an option set. See the following issue.

https://github.com/eclipse-openj9/openj9/issues/23152