### PR TITLE
Add cycle start and end time snapshots

### DIFF
--- a/gc/base/CycleState.hpp
+++ b/gc/base/CycleState.hpp
@@ -75,6 +75,8 @@ public:
 
 	uintptr_t _currentIncrement; /**< The index of the current increment within the cycle, starting at 0 (used for event reporting) */
 	uintptr_t _currentCycleID; /**< The index of the current cycle (used for event reporting) */
+	uintptr_t _startTime; /**< The start time of the collection cycle */
+	uintptr_t _endTime; /**< The end time of the collection cycle */
 
 	bool _shouldRunCopyForward; /**< True if this cycle is to run a copy-forward-based attempt at reclaiming memory, false if mark-compact is to be used */
 
@@ -115,6 +117,8 @@ public:
 		, _collectionReason(gc_reason_other)
 		, _currentIncrement(0)
 		, _currentCycleID(0)
+		, _startTime(0)
+		, _endTime(0)
 		, _shouldRunCopyForward(false)
 		, _reasonForMarkCompactPGC(reason_not_exceptional)
 		, _externalCycleState(NULL)

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1591,6 +1591,8 @@ MM_ConcurrentGC::acquireExclusiveVMAccessAndSignalThreadsToActivateWriteBarrier(
 			env->_cycleState->_collectionStatistics = &_collectionStatistics;
 			_extensions->globalGCStats.gcCount += 1;
 			env->_cycleState->_currentCycleID = _extensions->getUniqueGCCycleCount();
+			OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+			env->_cycleState->_startTime = omrtime_hires_clock();
 			reportGCCycleStart(env);
 			env->_cycleState = previousCycleState;
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -71,13 +71,9 @@ class MM_Scavenger : public MM_Collector
 	 * Data members
 	 */
 public:
-	struct {
-		/* The following start/end times record total cycle and cycle increment durations, done only by main thread. */
-		uint64_t cycleStart;
-		uint64_t cycleEnd;
-		uint64_t incrementStart;
-		uint64_t incrementEnd;
-	} _cycleTimes;
+
+	uint64_t _incrementStart; /**< start time of the ongoing/last STW/concurrent increment */
+	uint64_t _incrementEnd; /**< end time of the ongoing/last STW/concurrent increment */
 
 private:
 	MM_ScavengerDelegate _delegate;
@@ -974,7 +970,6 @@ public:
 
 	MM_Scavenger(MM_EnvironmentBase *env) :
 		MM_Collector()
-		, _cycleTimes()
 		, _delegate(env)
 		, _objectAlignmentInBytes(env->getObjectAlignmentInBytes())
 		, _isRememberedSetInOverflowAtTheBeginning(false)


### PR DESCRIPTION
This change snapshots start and end times for GC cycles. Also,
consolidated some other start and end time reporting.

Associated openj9 PR: https://github.com/eclipse-openj9/openj9/pull/23173