### PR TITLE
Use #define to avoid variable length array folded to constant warning

### DIFF
--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -930,9 +930,9 @@ omrsock_get_pollfd_info(struct OMRPortLibrary *portLibrary, omrsock_pollfd_t han
 int32_t
 omrsock_poll(struct OMRPortLibrary *portLibrary, omrsock_pollfd_t fds, uint32_t nfds, int32_t timeoutMs)
 {
+#define MAX_NUM_POLL_FD 8
 	int32_t numPollFdSet = 0;
-	const uint32_t maxNumPollFd = 8;
-	struct pollfd pfdsArray[maxNumPollFd];
+	struct pollfd pfdsArray[MAX_NUM_POLL_FD];
 	struct pollfd *pfds = NULL;
 	int32_t i = 0;
 
@@ -946,7 +946,7 @@ omrsock_poll(struct OMRPortLibrary *portLibrary, omrsock_pollfd_t fds, uint32_t 
 		return OMRPORT_ERROR_INVALID_ARGUMENTS;
 	}
 
-	if (maxNumPollFd >= nfds) {
+	if (MAX_NUM_POLL_FD >= nfds) {
 		/* Use statically allocated array if nfds less than or equal to 8. */
 		pfds = pfdsArray;
 	} else {
@@ -966,7 +966,7 @@ omrsock_poll(struct OMRPortLibrary *portLibrary, omrsock_pollfd_t fds, uint32_t 
 	numPollFdSet = poll(pfds, nfds, timeoutMs);
 
 	if (0 > numPollFdSet) {
-		if (nfds > maxNumPollFd) {
+		if (nfds > MAX_NUM_POLL_FD) {
 			portLibrary->mem_free_memory(portLibrary, pfds);
 		}
 		return portLibrary->error_set_last_error(portLibrary, errno, get_omr_error(errno));
@@ -984,9 +984,10 @@ omrsock_poll(struct OMRPortLibrary *portLibrary, omrsock_pollfd_t fds, uint32_t 
 #endif /* defined (LINUX) */
 	}
 
-	if (maxNumPollFd < nfds) {
+	if (MAX_NUM_POLL_FD < nfds) {
 		portLibrary->mem_free_memory(portLibrary, pfds);
 	}
+#undef MAX_NUM_POLL_FD
 
 #if defined (AIXPPC) || defined (J9ZOS390)
 	return numPollFdSet & 0x0000FFFF;


### PR DESCRIPTION
Use `#define` to avoid variable length array folded to constant warning

Avoid the warning "variable length array folded to constant array as an extension" treated as an error with the compiler option `-Werror,-Wgnu-folding-constant`.

This addresses the compilation failure occurred at JDK head (JDK27 w/ Valhalla):
```
openj9-openjdk-jdk.valuetypes/omr/port/unix/omrsock.c:935:26: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  935 |         struct pollfd pfdsArray[maxNumPollFd];
      |                                 ^~~~~~~~~~~~
1 error generated.
make[6]: *** [runtime/omr/port/CMakeFiles/omrport_obj.dir/unix/omrsock.c.o] Error 1
```
The compiler in question is:
```
Apple clang version 17.0.0 (clang-1700.6.3.2)
Target: arm64-apple-darwin25.2.0
Thread model: posix
```


Signed-off-by: Jason Feng <fengj@ca.ibm.com>