### PR TITLE
Fix createStoresForVar OffHeap case and dont use internal pointers for arraycopy temps

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3268,7 +3268,8 @@ TR::Node *OMR::Node::createLongIfNeeded()
 /**
  * @return the top (first) inserted tree or null
  */
-TR::TreeTop *OMR::Node::createStoresForVar(TR::SymbolReference *&nodeRef, TR::TreeTop *insertBefore, bool simpleRef)
+TR::TreeTop *OMR::Node::createStoresForVar(TR::SymbolReference *&nodeRef, TR::TreeTop *insertBefore, bool simpleRef,
+    bool dontUseInternalPointers)
 {
     TR::Compilation *comp = TR::comp();
     TR::TreeTop *storeTree = NULL;
@@ -3324,7 +3325,8 @@ TR::TreeTop *OMR::Node::createStoresForVar(TR::SymbolReference *&nodeRef, TR::Tr
     }
 
     if (isInternalPointer && self()->getOpCode().isArrayRef()
-        && (comp->getSymRefTab()->getNumInternalPointers() >= (comp->maxInternalPointers() / 2)
+        && (dontUseInternalPointers
+            || comp->getSymRefTab()->getNumInternalPointers() >= (comp->maxInternalPointers() / 2)
             || comp->cg()->supportsComplexAddressing())
         && (self()->getReferenceCount() == 1)) {
         storesNeedToBeCreated = false;

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -721,7 +721,8 @@ public:
 
     TR::Node *createLongIfNeeded();
 
-    TR::TreeTop *createStoresForVar(TR::SymbolReference *&nodeRef, TR::TreeTop *insertBefore, bool simpleRef = false);
+    TR::TreeTop *createStoresForVar(TR::SymbolReference *&nodeRef, TR::TreeTop *insertBefore, bool simpleRef = false,
+        bool dontUseInternalPointers = false);
 
     void printFullSubtree();
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2158,10 +2158,10 @@ TR::TreeTop *createStoresForArraycopyChildren(TR::Compilation *comp, TR::TreeTop
     storeTree = len->createStoresForVar(lenRef, insertBefore);
     if (storeTree)
         insertBefore = storeTree;
-    storeTree = dst->createStoresForVar(dstRef, insertBefore);
+    storeTree = dst->createStoresForVar(dstRef, insertBefore, false, true);
     if (storeTree)
         insertBefore = storeTree;
-    storeTree = src->createStoresForVar(srcRef, insertBefore);
+    storeTree = src->createStoresForVar(srcRef, insertBefore, false, true);
     if (storeTree)
         insertBefore = storeTree;
 


### PR DESCRIPTION
OffHeap can result in compilation failures when using `createStoresForVar` for behaviour mismatch with OffHeap, forcing it to use internal-pointers when internal-pointers can be disabled. The behaviour got fixed by adding a special case for when the firstChild is a `dataAddr` load and storing its child the base array-ref instead.

This PR also stops the using of internal-pointer temps for arraycopy transformations as they don't yield performance advantage and adds complexity besides consuming more internal-pointers. This is achieved by adding a `dontUseInternalPointers` argument to `createStoresForVar` and used by `createStoresForArraycopyChildren` for src/dst nodes.