### PR TITLE
AArch64: Implement mulDecompositionCostIsJustified()

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -961,3 +961,9 @@ bool OMR::ARM64::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
 {
     return !self()->comp()->getOption(TR_DisableArrayCopyOpts);
 }
+
+bool OMR::ARM64::CodeGenerator::mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[],
+    char operationType[], int64_t value)
+{
+    return numOfOperations <= 2 && numOfOperations != 0;
+}

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -636,6 +636,8 @@ public:
 
     bool internalPointerSupportImplemented() { return true; }
 
+    bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
+
     bool considerTypeForGRA(TR::Node *node);
     bool considerTypeForGRA(TR::DataType dt);
     bool considerTypeForGRA(TR::SymbolReference *symRef);


### PR DESCRIPTION
This PR implements CodeGenerator::mulDecompositionCostIsJustified() for AArch64.