### PR TITLE
Fix mul decomposition on Power

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -501,25 +501,17 @@ bool OMR::Power::CodeGenerator::mulDecompositionCostIsJustified(int numOfOperati
     //         on processors we still care about.
     switch (self()->comp()->target().cpu.getProcessorDescription().processor) {
         case OMR_PROCESSOR_PPC_PWR630: // 2S+1M FXU out-of-order
-            return (numOfOperations <= 4);
+            return (numOfOperations <= 3);
 
         case OMR_PROCESSOR_PPC_NSTAR:
         case OMR_PROCESSOR_PPC_PULSAR: // 1S+1M FXU in-order
-            return (numOfOperations <= 8);
-
-        case OMR_PROCESSOR_PPC_GPUL:
-        case OMR_PROCESSOR_PPC_GP:
-        case OMR_PROCESSOR_PPC_GR: // 2 FXU out-of-order back-to-back 2 cycles. Mul is only 4 to 6 cycles
-            return (numOfOperations <= 2);
+            return (numOfOperations <= 4);
 
         case OMR_PROCESSOR_PPC_P6: // Mul is on FPU for 17cycles blocking other operations
-            return (numOfOperations <= 16);
+            return (numOfOperations <= 9);
 
-        case OMR_PROCESSOR_PPC_P7: // Mul blocks other operations for up to 4 cycles
-            return (numOfOperations <= 3);
-
-        default: // assume a generic design similar to 604
-            return (numOfOperations <= 3);
+        default: // assume a generic design similar to POWER7/8/9
+            return (numOfOperations <= 2);
     }
 }
 


### PR DESCRIPTION
According to specific processor implmentation (e.g. number of FXU unit, mul is pipelined, and mul is blocking or not), we can do decomposition of particular values for a performance benefit.