### PR TITLE
Disable short enums used by Open XL on z/OS

### DIFF
--- a/cmake/modules/platform/toolcfg/openxl.cmake
+++ b/cmake/modules/platform/toolcfg/openxl.cmake
@@ -39,6 +39,7 @@ if(OMR_OS_ZOS)
 	endif()
 
 	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+		"-fno-short-enums"
 		"-fstrict-aliasing"
 		"-mzos-target=${OMR_ZOS_COMPILE_TARGET}"
 		"-m64"


### PR DESCRIPTION
XLC is using `-Wc,enum(4)` with OMR_PLATFORM_COMPILE_OPTIONS. There is no equivalent available to specify the enumsize on Open XL. However, by default short enums are being used. This adds `-fno-short-enums` to disable this default, and have the enum size allocations similar to XLC.

---

When comparing j9ddr blob binary files between the compilers (XLC and Open XL), there are a considerable amount of differences between the size/offset of fields and classes. This cuts those differences down significantly from 826 -> 78 differences (verifying locally on stlaba0)