### PR TITLE
Fix logger errors under DEBUG

### DIFF
--- a/compiler/infra/InterferenceGraph.cpp
+++ b/compiler/infra/InterferenceGraph.cpp
@@ -235,10 +235,10 @@ void TR_InterferenceGraph::partitionNodesIntoDegreeSets(TR_BitVector *workingSet
         diagnostic("-----------------\n");
 
         diagnostic("\n[%4d] degree < %-10d : ", colourableDegreeSet->elementCount(), getNumColours());
-        colourableDegreeSet->print(comp());
+        colourableDegreeSet->print(comp()->log(), comp());
 
         diagnostic("\n[%4d] degree < MAX_DEGREE : ", notColourableDegreeSet->elementCount());
-        notColourableDegreeSet->print(comp());
+        notColourableDegreeSet->print(comp()->log(), comp());
         diagnostic("\n\n");
     }
 #endif

--- a/compiler/optimizer/ReachingDefinitions.cpp
+++ b/compiler/optimizer/ReachingDefinitions.cpp
@@ -126,22 +126,22 @@ void TR_ReachingDefinitions::initializeGenAndKillSetInfo()
             log->printf("  Block %d:\n", blockNum);
             log->prints("     Gen set ");
             if (_regularGenSetInfo[blockNum])
-                _regularGenSetInfo[blockNum]->print(comp());
+                _regularGenSetInfo[blockNum]->print(log, comp());
             else
                 log->prints("{}");
             log->prints("\n     Kill set ");
             if (_regularKillSetInfo[blockNum])
-                _regularKillSetInfo[blockNum]->print(comp());
+                _regularKillSetInfo[blockNum]->print(log, comp());
             else
                 log->prints("{}");
             log->prints("\n     Exception Gen set ");
             if (_exceptionGenSetInfo[blockNum])
-                _exceptionGenSetInfo[blockNum]->print(comp());
+                _exceptionGenSetInfo[blockNum]->print(log, comp());
             else
                 log->prints("{}");
             log->prints("\n     Exception Kill set ");
             if (_exceptionKillSetInfo[blockNum])
-                _exceptionKillSetInfo[blockNum]->print(comp());
+                _exceptionKillSetInfo[blockNum]->print(log, comp());
             else
                 log->prints("{}");
             continue;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1681,7 +1681,7 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(TR_RegisterKinds kin
 #ifdef DEBUG
         if (dumpPreGP) {
             origNextInstruction = instructionCursor->getNext();
-            self()->dumpPreGPRegisterAssignment(instructionCursor);
+            self()->dumpPreGPRegisterAssignment(comp->log(), instructionCursor);
         }
 #endif
         self()->tracePreRAInstruction(instructionCursor);
@@ -1705,7 +1705,7 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(TR_RegisterKinds kin
 
 #ifdef DEBUG
         if (dumpPostGP)
-            self()->dumpPostGPRegisterAssignment(instructionCursor, origNextInstruction);
+            self()->dumpPostGPRegisterAssignment(comp->log(), instructionCursor, origNextInstruction);
 #endif
         self()->tracePostRAInstruction(instructionCursor);
         TR::ClobberingInstruction *clobInst;

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -772,10 +772,10 @@ public:
     bool nopsAlsoProcessedByRelocations() { return false; }
 
 #if defined(DEBUG)
-    void dumpPreFPRegisterAssignment(TR::Instruction *);
-    void dumpPostFPRegisterAssignment(TR::Instruction *, TR::Instruction *);
-    void dumpPreGPRegisterAssignment(TR::Instruction *);
-    void dumpPostGPRegisterAssignment(TR::Instruction *, TR::Instruction *);
+    void dumpPreFPRegisterAssignment(OMR::Logger *log, TR::Instruction *);
+    void dumpPostFPRegisterAssignment(OMR::Logger *log, TR::Instruction *, TR::Instruction *);
+    void dumpPreGPRegisterAssignment(OMR::Logger *log, TR::Instruction *);
+    void dumpPostGPRegisterAssignment(OMR::Logger *log, TR::Instruction *, TR::Instruction *);
 #endif
 
     void dumpDataSnippets(OMR::Logger *log);


### PR DESCRIPTION
After the logger overhaul, there are a few places where compilation fails when DEBUG is defined.