### PR TITLE
Remove unused fields from OMR_VMThread

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1326,23 +1326,11 @@ public:
 	 * @param base low address of Old subspace range
 	 * @param size size of Old subspace in bytes
 	 */
-	virtual void setTenureAddressRange(void* base, uintptr_t size)
+	virtual void
+	setTenureAddressRange(void* base, uintptr_t size)
 	{
 		_tenureBase = base;
 		_tenureSize = size;
-
-		/* todo: dagar move back to MemorySubSpaceGeneric addTenureRange() and removeTenureRange() once
-		 * heapBaseForBarrierRange0 heapSizeForBarrierRange0 can be removed from J9VMThread
-		 *
-		 * setTenureAddressRange() can be removed from GCExtensions.hpp and made inline again
-		 */
-		GC_OMRVMThreadListIterator vmThreadListIterator(_omrVM);
-		while (OMR_VMThread* walkThread = vmThreadListIterator.nextOMRVMThread()) {
-			walkThread->lowTenureAddress = heapBaseForBarrierRange0;
-			walkThread->highTenureAddress = (void*)((uintptr_t)heapBaseForBarrierRange0 + heapSizeForBarrierRange0);
-			walkThread->heapBaseForBarrierRange0 = heapBaseForBarrierRange0;
-			walkThread->heapSizeForBarrierRange0 = heapSizeForBarrierRange0;
-		}
 	}
 
 	virtual void identityHashDataAddRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, uintptr_t size, void* lowAddress, void* highAddress);

--- a/gc/startup/mminitcore.cpp
+++ b/gc/startup/mminitcore.cpp
@@ -52,31 +52,6 @@ initializeMutatorModel(OMR_VMThread *omrVMThread)
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(omrVMThread->_vm);
 	omrVMThread->_gcOmrVMThreadExtensions = extensions->configuration->createEnvironment(extensions, omrVMThread);
 	if (NULL != omrVMThread->_gcOmrVMThreadExtensions) {
-		if (extensions->isStandardGC()) {
-			void *lowAddress = extensions->heapBaseForBarrierRange0;
-			void *highAddress = (void *)((uintptr_t)extensions->heapBaseForBarrierRange0 + extensions->heapSizeForBarrierRange0);
-			omrVMThread->lowTenureAddress = lowAddress;
-			omrVMThread->highTenureAddress = highAddress;
-
-			/* replacement values for lowTenureAddress and highTenureAddress */
-			omrVMThread->heapBaseForBarrierRange0 = extensions->heapBaseForBarrierRange0;
-			omrVMThread->heapSizeForBarrierRange0 = extensions->heapSizeForBarrierRange0;
-		} else if (extensions->isVLHGC()) {
-			MM_Heap *heap = extensions->getHeap();
-			void *heapBase = heap->getHeapBase();
-			void *heapTop = heap->getHeapTop();
-
-			/* replacement values for lowTenureAddress and highTenureAddress */
-			omrVMThread->heapBaseForBarrierRange0 = heapBase;
-			omrVMThread->heapSizeForBarrierRange0 = (uintptr_t)heapTop - (uintptr_t)heapBase;
-
-			/* lowTenureAddress and highTenureAddress are actually supposed to be the low and high addresses of the heap for which card
-			 * dirtying is required (the JIT uses this as a range check to determine if it needs to dirty a card when writing into an
-			 * object).  Setting these for Tarok is just a work-around until a more generic solution is implemented
-			 */
-			omrVMThread->lowTenureAddress = heapBase;
-			omrVMThread->highTenureAddress = heapTop;
-		}
 		omrVMThread->memorySpace = extensions->heap->getDefaultMemorySpace();
 	} else {
 		return -1;

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -179,13 +179,6 @@ typedef struct OMR_VMThread {
 	} _trace;
 #endif /* OMR_RAS_TDF_TRACE */
 
-	/* todo: dagar these are temporarily duplicated and should be removed from J9VMThread */
-	void *lowTenureAddress;
-	void *highTenureAddress;
-
-	void *heapBaseForBarrierRange0;
-	uintptr_t heapSizeForBarrierRange0;
-
 	void *memorySpace;
 
 	int32_t _attachCount;


### PR DESCRIPTION
Remove unused fields from OMR_VMThread

Removes the following fields from OMR_VMThread:
- lowTenureAddress
- highTenureAddress;
- heapBaseForBarrierRange0;
- heapSizeForBarrierRange0

This reverts changes from a previous (unfinished) work to transfer these fields from J9VMThread to OMR_VMThread.

Signed-off-by: Shadman Siddiqui shadman2606@gmail.com