### PR TITLE
Move setupProfiledGuardRelocation implementation to OpenJ9

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -521,25 +521,11 @@ void OMR::X86::TreeEvaluator::setupProfiledGuardRelocation(TR::X86RegImmInstruct
     TR_ExternalRelocationTargetKind reloKind)
 {
 #ifdef J9_PROJECT_SPECIFIC
-    // The following makes sure that the TR_ProfiledInlinedMethod relocation for this inlined site will be created
-    // later in TR::CodeGenerator::processRelocations()
-    TR::Compilation *comp = TR::comp();
-    TR_VirtualGuard *virtualGuard = comp->findVirtualGuardInfo(node);
-    TR_AOTGuardSite *site = comp->addAOTNOPSite();
-    site->setLocation(NULL);
-    site->setType(TR_ProfiledGuard);
-    site->setGuard(virtualGuard);
-    site->setNode(node);
-    site->setAconstNode(node->getSecondChild());
-
-    // If we've generated an instruction, then make sure it is marked to get the right kind of relocation
-    if (cmpInstruction) {
-        cmpInstruction->setReloKind(reloKind);
-        cmpInstruction->setNode(node->getSecondChild());
-    }
-
-    logprintf(comp->getOption(TR_TraceCG), comp->log(), "setupProfiledGuardRelocation: site %p type %d node %p\n", site,
-        site->getType(), node);
+    J9::X86::TreeEvaluator::setupProfiledGuardRelocation(cmpInstruction, node, reloKind);
+#else
+    (void)cmpInstruction;
+    (void)node;
+    (void)reloKind;
 #endif
 }
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -522,10 +522,6 @@ void OMR::X86::TreeEvaluator::setupProfiledGuardRelocation(TR::X86RegImmInstruct
 {
 #ifdef J9_PROJECT_SPECIFIC
     J9::X86::TreeEvaluator::setupProfiledGuardRelocation(cmpInstruction, node, reloKind);
-#else
-    (void)cmpInstruction;
-    (void)node;
-    (void)reloKind;
 #endif
 }
 


### PR DESCRIPTION
Part of eclipse-openj9/omr
This PR moves the JVM-specific `setupProfiledGuardRelocation` logic from OMR to OpenJ9,
leaving only a stub.

Note: This change must be merged together with the corresponding OpenJ9 PR:
- https://github.com/eclipse-openj9/openj9/pull/23369

Resolves #6342 