### PR TITLE
Add an API for get network interfaces with statistics

### DIFF
--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -33,6 +33,7 @@ omr_add_executable(omrporttest
 	omrintrospectTest.cpp
 	omrmemTest.cpp
 	omrmmapTest.cpp
+	omrnetworkTest.cpp
 	omrsignalExtendedTest.cpp
 	omrsignalTest.cpp
 	omrslTest.cpp

--- a/fvtest/porttest/omrnetworkTest.cpp
+++ b/fvtest/porttest/omrnetworkTest.cpp
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+#if defined(LINUX) || defined(OSX) || defined(OMR_OS_WINDOWS)
+
+#include "omrcfg.h"
+#include "omrport.h"
+#include "testHelpers.hpp"
+
+/**
+ * Test data structure to collect network interface information.
+ */
+struct NetworkInterfaceTestData {
+	uint32_t interfaceCount;
+	bool foundLoopback;
+	bool foundNonLoopback;
+	uint64_t totalRxBytes;
+	uint64_t totalTxBytes;
+};
+
+/**
+ * Callback function for testing network_get_network_interfaces.
+ * Collects statistics about discovered network interfaces.
+ *
+ * @param[in] name The name of the network interface.
+ * @param[in] rxBytes Number of bytes received on this interface.
+ * @param[in] txBytes Number of bytes transmitted on this interface.
+ * @param[in] userData Pointer to NetworkInterfaceTestData structure.
+ *
+ * @return 0 to continue enumeration, non-zero to stop.
+ */
+static uintptr_t
+networkInterfaceCallback(const char *name, uint64_t rxBytes, uint64_t txBytes, void *userData)
+{
+	NetworkInterfaceTestData *testData = static_cast<NetworkInterfaceTestData *>(userData);
+
+	if (NULL == name) {
+		return 1; /* Stop enumeration on error. */
+	}
+
+	testData->interfaceCount++;
+	testData->totalRxBytes += rxBytes;
+	testData->totalTxBytes += txBytes;
+
+	/* Check for common loopback interface names. */
+	if ((0 == strcmp(name, "lo")) || (0 == strcmp(name, "lo0"))) {
+		testData->foundLoopback = true;
+	} else {
+		testData->foundNonLoopback = true;
+	}
+
+	return 0; /* Continue enumeration. */
+}
+
+/**
+ * Callback function that stops enumeration after first interface.
+ *
+ * @param[in] name The name of the network interface.
+ * @param[in] rxBytes Number of bytes received on this interface.
+ * @param[in] txBytes Number of bytes transmitted on this interface.
+ * @param[in] userData Pointer to NetworkInterfaceTestData structure.
+ *
+ * @return 1 to stop enumeration immediately.
+ */
+static uintptr_t
+networkInterfaceCallbackStopEarly(const char *name, uint64_t rxBytes, uint64_t txBytes, void *userData)
+{
+	NetworkInterfaceTestData *testData = static_cast<NetworkInterfaceTestData *>(userData);
+
+	if (NULL != name) {
+		testData->interfaceCount++;
+	}
+
+	return 1; /* Stop enumeration after first interface. */
+}
+
+/**
+ * Test if port library function pointer for network_get_network_interfaces is not NULL.
+ */
+TEST(PortNetworkTest, library_function_pointer_not_null)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	EXPECT_NE(OMRPORTLIB->network_get_network_interfaces, (void *)NULL);
+}
+
+/**
+ * Test basic functionality of network_get_network_interfaces.
+ *
+ * This test verifies that:
+ * - The function can be called successfully.
+ * - At least one network interface is discovered.
+ * - Interface names are provided.
+ * - The callback is invoked for each interface.
+ */
+TEST(PortNetworkTest, get_network_interfaces_basic)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	NetworkInterfaceTestData testData = {0};
+	uintptr_t result = OMRPORTLIB->network_get_network_interfaces(
+		OMRPORTLIB,
+		networkInterfaceCallback,
+		&testData
+	);
+
+	EXPECT_EQ(result, (uintptr_t)0);
+	EXPECT_GT(testData.interfaceCount, (uint32_t)0) << "Expected at least one network interface";
+}
+
+/**
+ * Test that network_get_network_interfaces handles NULL callback gracefully.
+ *
+ * This test verifies that passing a NULL callback returns an appropriate error.
+ */
+TEST(PortNetworkTest, get_network_interfaces_null_callback)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	uintptr_t result = OMRPORTLIB->network_get_network_interfaces(
+		OMRPORTLIB,
+		NULL,
+		NULL
+	);
+
+	EXPECT_NE(result, (uintptr_t)0) << "Expected error when callback is NULL";
+}
+
+/**
+ * Test that callback can stop enumeration early.
+ *
+ * This test verifies that:
+ * - The callback can return non-zero to stop enumeration.
+ * - The function returns the callback's return value.
+ * - Only one interface is counted when stopping early.
+ */
+TEST(PortNetworkTest, get_network_interfaces_early_stop)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	NetworkInterfaceTestData testData = {0};
+	uintptr_t result = OMRPORTLIB->network_get_network_interfaces(
+		OMRPORTLIB,
+		networkInterfaceCallbackStopEarly,
+		&testData
+	);
+
+	EXPECT_EQ(result, (uintptr_t)1) << "Expected callback return value to be propagated";
+	EXPECT_EQ(testData.interfaceCount, (uint32_t)1) << "Expected enumeration to stop after first interface";
+}
+
+/**
+ * Test that network interface statistics are reasonable.
+ *
+ * This test verifies that:
+ * - RX and TX byte counts are non-negative (they're uint64_t, so always true).
+ * - At least some interfaces report statistics (on supported platforms).
+ *
+ * Note: On some platforms or in some environments, statistics may not be available.
+ * This test is lenient and only checks that the function completes successfully.
+ */
+TEST(PortNetworkTest, get_network_interfaces_statistics)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	NetworkInterfaceTestData testData = {0};
+	uintptr_t result = OMRPORTLIB->network_get_network_interfaces(
+		OMRPORTLIB,
+		networkInterfaceCallback,
+		&testData
+	);
+
+	EXPECT_EQ(result, (uintptr_t)0);
+	EXPECT_GT(testData.interfaceCount, (uint32_t)0);
+
+	/* Statistics may be zero on some platforms or if no traffic has occurred. */
+	/* We just verify the function completed successfully. */
+}
+
+/**
+ * Test that common network interfaces are discovered.
+ *
+ * This test verifies that:
+ * - At least one interface is discovered.
+ * - The loopback interface is typically present (though not guaranteed on all systems).
+ *
+ * Note: This test is lenient as interface availability varies by platform and configuration.
+ */
+TEST(PortNetworkTest, get_network_interfaces_common_interfaces)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+
+	NetworkInterfaceTestData testData = {0};
+	uintptr_t result = OMRPORTLIB->network_get_network_interfaces(
+		OMRPORTLIB,
+		networkInterfaceCallback,
+		&testData
+	);
+
+	EXPECT_EQ(result, (uintptr_t)0);
+	EXPECT_GT(testData.interfaceCount, (uint32_t)0);
+
+	/* Most systems have a loopback interface, but we don't make it a hard requirement. */
+	if (!testData.foundLoopback) {
+		portTestEnv->log(LEVEL_WARN, "Warning: No loopback interface found. This may be expected on some systems.\n");
+	}
+}
+
+#endif /* defined(LINUX) || defined(OSX) || defined(OMR_OS_WINDOWS) */

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -2033,6 +2033,7 @@ typedef uintptr_t (*omrsig_protected_fn)(struct OMRPortLibrary *portLib, void *h
 typedef uintptr_t (*omrsig_handler_fn)(struct OMRPortLibrary *portLib, uint32_t gpType, void *gpInfo, void *handler_arg);
 typedef uintptr_t (*OMRLibraryInfoCallback)(const char *name, void *addressLow, void *addressHigh, void *userData);
 typedef uintptr_t (*OMRProcessInfoCallback)(uintptr_t pid, const char *commandLine, void *userData);
+typedef uintptr_t (*OMRNetworkInterfaceCallback)(const char *name, uint64_t rxBytes, uint64_t txBytes, void *userData);
 
 typedef struct OMRPortLibrary {
 	/** portGlobals*/
@@ -2919,6 +2920,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrcuda.cpp::omrcuda_streamWaitEvent "omrcuda_streamWaitEvent" */
 	int32_t (*cuda_streamWaitEvent)(struct OMRPortLibrary *portLibrary, uint32_t deviceId, J9CudaStream stream, J9CudaEvent event);
 #endif /* OMR_OPT_CUDA */
+	uintptr_t (*network_get_network_interfaces)(struct OMRPortLibrary *portLibrary, OMRNetworkInterfaceCallback callback, void *userData);
 } OMRPortLibrary;
 
 /**
@@ -3508,6 +3510,8 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrcuda_streamWaitEvent(deviceId, stream, event) \
 				privateOmrPortLibrary->cuda_streamWaitEvent(privateOmrPortLibrary, (deviceId), (stream), (event))
 #endif /* OMR_OPT_CUDA */
+#define omrnetwork_get_network_interfaces(callback, userData) \
+				privateOmrPortLibrary->network_get_network_interfaces(privateOmrPortLibrary, (callback), (userData))
 
 #endif /* !defined(OMRPORT_LIBRARY_DEFINE) */
 

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -198,6 +198,7 @@ list(APPEND OBJECTS
 	omrsl.c
 	omrstr.c
 	omrsysinfo.c
+	omrnetwork.c
 )
 
 list(APPEND OBJECTS omrsysinfo_helpers.c)
@@ -473,5 +474,5 @@ if(OMR_OS_OSX)
 endif()
 
 if(OMR_OS_WINDOWS)
-	target_link_libraries(omrport PRIVATE psapi pdh)
+	target_link_libraries(omrport PRIVATE psapi pdh Iphlpapi)
 endif()

--- a/port/common/omrnetwork.c
+++ b/port/common/omrnetwork.c
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Network information
+ */
+#include "omrport.h"
+
+/**
+ * Get the information for each network interface.
+ * @param[in] portLibrary The port library.
+ * @param[in] callback The function to be invoked for each network interface.
+ * @param[in] userData Data passed to the callback.
+ * @return 0 on success, or the first non-zero value returned by the callback.
+ */
+uintptr_t
+omrnetwork_get_network_interfaces(struct OMRPortLibrary *portLibrary, OMRNetworkInterfaceCallback callback, void *userData)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -484,6 +484,7 @@ static OMRPortLibrary MainPortLibraryTable = {
 	omrcuda_streamSynchronize, /* cuda_streamSynchronize */
 	omrcuda_streamWaitEvent, /* cuda_streamWaitEvent */
 #endif /* OMR_OPT_CUDA */
+	omrnetwork_get_network_interfaces,
 };
 
 /**

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -1124,5 +1124,7 @@ omrcuda_streamSynchronize(struct OMRPortLibrary *portLibrary, uint32_t deviceId,
 extern J9_CFUNC int32_t
 omrcuda_streamWaitEvent(struct OMRPortLibrary *portLibrary, uint32_t deviceId, J9CudaStream stream, J9CudaEvent event);
 #endif /* OMR_OPT_CUDA */
+extern J9_CFUNC uintptr_t
+omrnetwork_get_network_interfaces(struct OMRPortLibrary *portLibrary, OMRNetworkInterfaceCallback callback, void *userData);
 
 #endif /* omrportlibraryprivatedefines_h */

--- a/port/unix/omrnetwork.c
+++ b/port/unix/omrnetwork.c
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Network information
+ */
+#include "omrport.h"
+
+#if defined(LINUX) || defined(OSX)
+#include <ifaddrs.h>
+#endif /* defined(LINUX) || defined(OSX) */
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+uintptr_t
+omrnetwork_get_network_interfaces(struct OMRPortLibrary *portLibrary, OMRNetworkInterfaceCallback callback, void *userData)
+{
+	uintptr_t callbackResult = 0;
+	FILE *procNetDevFile = NULL;
+
+	if (NULL == callback) {
+		portLibrary->error_set_last_error_with_message(
+				portLibrary,
+				OMRPORT_ERROR_OPFAILED,
+				"Callback function is NULL.");
+		goto fail;
+	}
+
+	/* On Linux, read statistics from /proc/net/dev. */
+	procNetDevFile = fopen("/proc/net/dev", "r");
+	if (NULL != procNetDevFile) {
+		char lineBuffer[256];
+		/* Skip the first two header lines. */
+		if (NULL == fgets(lineBuffer, sizeof(lineBuffer), procNetDevFile)) {
+			goto fail;
+		}
+		if (NULL == fgets(lineBuffer, sizeof(lineBuffer), procNetDevFile)) {
+			goto fail;
+		}
+
+		/* Process each interface line. */
+		while (NULL != fgets(lineBuffer, sizeof(lineBuffer), procNetDevFile)) {
+			char interfaceName[64];
+			unsigned long long rxBytes = 0;
+			unsigned long long rxPackets = 0;
+			unsigned long long rxErrs = 0;
+			unsigned long long rxDrop = 0;
+			unsigned long long rxFifo = 0;
+			unsigned long long rxFrame = 0;
+			unsigned long long rxCompressed = 0;
+			unsigned long long rxMulticast = 0;
+			unsigned long long txBytes = 0;
+			unsigned long long txPackets = 0;
+			unsigned long long txErrs = 0;
+			unsigned long long txDrop = 0;
+			unsigned long long txFifo = 0;
+			unsigned long long txColls = 0;
+			unsigned long long txCarrier = 0;
+			unsigned long long txCompressed = 0;
+
+			/* Parse the line: interface: rxBytes rxPackets ... txBytes txPackets .... */
+			int numStatsRead = sscanf(
+					lineBuffer, "%63[^:]:%llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu",
+					interfaceName,
+					&rxBytes, &rxPackets, &rxErrs, &rxDrop, &rxFifo, &rxFrame, &rxCompressed, &rxMulticast,
+					&txBytes, &txPackets, &txErrs, &txDrop, &txFifo, &txColls, &txCarrier, &txCompressed);
+			if (numStatsRead >= 9) {
+				/* Remove leading/trailing whitespace from interface name. */
+				char *trimmedName = interfaceName;
+				char *nameEnd = NULL;
+				while ((*trimmedName == ' ') || (*trimmedName == '\t')) {
+					trimmedName++;
+				}
+				nameEnd = trimmedName + strlen(trimmedName) - 1;
+				while ((nameEnd > trimmedName) && ((*nameEnd == ' ') || (*nameEnd == '\t'))) {
+					*nameEnd = '\0';
+					nameEnd--;
+				}
+
+				/* Invoke callback for this interface. */
+				callbackResult = callback(trimmedName, (uint64_t)rxBytes, (uint64_t)txBytes, userData);
+				if (0 != callbackResult) {
+					break;
+				}
+			}
+		}
+		fclose(procNetDevFile);
+	} else {
+#if defined(LINUX) || defined(OSX)
+		struct ifaddrs *interfaceList = NULL;
+		struct ifaddrs *currentInterface = NULL;
+
+		/* Get list of network interfaces. */
+		if (-1 == getifaddrs(&interfaceList)) {
+			portLibrary->error_set_last_error_with_message(
+					portLibrary,
+					OMRPORT_ERROR_OPFAILED,
+					"getifaddrs() failed.");
+			goto fail;
+		}
+		/* If /proc/net/dev is not available, just enumerate interfaces without statistics. */
+		for (currentInterface = interfaceList; NULL != currentInterface; currentInterface = currentInterface->ifa_next) {
+			uint64_t rxBytes = 0;
+			uint64_t txBytes = 0;
+			if (NULL == currentInterface->ifa_name) {
+				continue;
+			}
+#if defined(OSX)
+			if (NULL != currentInterface->ifa_data) {
+				struct if_data *data = (struct if_data *)currentInterface->ifa_data;
+				rxBytes = data->ifi_ibytes;
+				txBytes = data->ifi_obytes;
+			}
+#endif /* defined(OSX) */
+			callbackResult = callback(currentInterface->ifa_name, rxBytes, txBytes, userData);
+			if (0 != callbackResult) {
+				break;
+			}
+		}
+
+		freeifaddrs(interfaceList);
+#else /* defined(LINUX) || defined(OSX) */
+		goto fail;
+#endif /* defined(LINUX) || defined(OSX) */
+	}
+
+	return callbackResult;
+fail:
+	if (NULL != procNetDevFile) {
+		fclose(procNetDevFile);
+	}
+	return (uintptr_t)OMRPORT_ERROR_OPFAILED;
+}

--- a/port/win32/omrnetwork.c
+++ b/port/win32/omrnetwork.c
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Network information
+ */
+
+/**
+ * windows.h defined UDATA. Ignore its definition to avoid redefinition errors.
+ */
+#define UDATA UDATA_win32_
+#include <windows.h>
+#undef UDATA
+/**
+ * To avoid WINSOCK redefinition errors.
+ */
+#if defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_)
+#undef _WINSOCKAPI_
+#endif /* defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_) */
+
+
+#include "omrport.h"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+
+uintptr_t
+omrnetwork_get_network_interfaces(struct OMRPortLibrary *portLibrary, OMRNetworkInterfaceCallback callback, void *userData)
+{
+	PMIB_IF_TABLE2 interfaceTable = NULL;
+	DWORD getTableResult = 0;
+	uintptr_t callbackResult = 0;
+	DWORD interfaceIndex = 0;
+
+	if (NULL == callback) {
+		portLibrary->error_set_last_error_with_message(
+				portLibrary,
+				OMRPORT_ERROR_OPFAILED,
+				"Callback function is NULL.");
+		return (uintptr_t)OMRPORT_ERROR_OPFAILED;
+	}
+
+	/* Get the interface table. */
+	getTableResult = GetIfTable2(&interfaceTable);
+	if (NO_ERROR != getTableResult) {
+		portLibrary->error_set_last_error_with_message(
+				portLibrary,
+				OMRPORT_ERROR_OPFAILED,
+				"GetIfTable2() failed.");
+		return (uintptr_t)OMRPORT_ERROR_OPFAILED;
+	}
+
+	/* Iterate through each interface. */
+	for (interfaceIndex = 0; interfaceIndex < interfaceTable->NumEntries; interfaceIndex++) {
+		MIB_IF_ROW2 *currentInterface = &interfaceTable->Table[interfaceIndex];
+		char interfaceName[256];
+		uint64_t rxBytes = 0;
+		uint64_t txBytes = 0;
+
+		/* Skip loopback and down interfaces. */
+		if ((currentInterface->Type == IF_TYPE_SOFTWARE_LOOPBACK) 
+			|| (currentInterface->OperStatus != IfOperStatusUp)
+		) {
+			continue;
+		}
+
+		/* Convert wide string alias to narrow string. */
+		if (0 == WideCharToMultiByte(CP_UTF8, 0, currentInterface->Alias, -1, interfaceName, sizeof(interfaceName), NULL, NULL)) {
+			continue;
+		}
+
+		/* Get statistics. */
+		rxBytes = currentInterface->InOctets;
+		txBytes = currentInterface->OutOctets;
+
+		/* Invoke callback for this interface. */
+		callbackResult = callback(interfaceName, rxBytes, txBytes, userData);
+		if (0 != callbackResult) {
+			break;
+		}
+	}
+
+	FreeMibTable(interfaceTable);
+	return callbackResult;
+}


### PR DESCRIPTION
Read /proc/net/dev on Linux and use getifaddrs() as a backup.

Use GetIfTable2() on Windows.

Co-written by IBM-Bob