### PR TITLE
Misc. OMR_FINAL cleanup

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -47,7 +47,7 @@ uint8_t *OMR::ARM64::Instruction::generateBinaryEncoding()
 int32_t OMR::ARM64::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
     setEstimatedBinaryLength(ARM64_INSTRUCTION_LENGTH);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 uint8_t *TR::ARM64ImmInstruction::generateBinaryEncoding()
@@ -108,7 +108,7 @@ uint8_t *TR::ARM64RelocatableImmInstruction::generateBinaryEncoding()
 int32_t TR::ARM64RelocatableImmInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
     setEstimatedBinaryLength(sizeof(uintptr_t));
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
@@ -525,7 +525,7 @@ uint8_t *TR::ARM64ZeroSrc1ImmInstruction::generateBinaryEncoding()
     // If this memory reference is about my count for recompile,
     // then it's the cmp instruction that I need to patch
     if (comp->getOption(TR_EnableGCRPatching)) {
-        TR::Node *node = self()->getNode();
+        TR::Node *node = getNode();
         if (node && (node->getOpCodeValue() == TR::ificmpeq || node->getOpCodeValue() == TR::ificmpne)) {
             if (node->getFirstChild()->getOpCodeValue() == TR::iload) {
                 TR::SymbolReference *symref = node->getFirstChild()->getSymbolReference();

--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -83,8 +83,8 @@ void TR::ARM64LabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
     TR::RegisterDependencyConditions *cond = OMR::ARM64::Instruction::getDependencyConditions();
 
     if (cond) {
-        cond->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());
-        cond->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned, self()->cg());
+        cond->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        cond->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 
     assignRegistersForOutOfLineCodeSection(kindToBeAssigned);
@@ -96,8 +96,8 @@ void TR::ARM64AdminInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
 {
     if (getOpCodeValue() != TR::InstOpCode::assocreg) {
         OMR::ARM64::Instruction::assignRegisters(kindToBeAssigned);
-    } else if (self()->cg()->enableRegisterAssociations()) {
-        TR::Machine *machine = self()->cg()->machine();
+    } else if (cg()->enableRegisterAssociations()) {
+        TR::Machine *machine = cg()->machine();
 
         int32_t first = TR::RealRegister::FirstGPR;
         int32_t last = TR::RealRegister::LastAssignableFPR;

--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -95,8 +95,8 @@ void OMR::ARM64::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
     TR::RegisterDependencyConditions *cond = OMR::ARM64::Instruction::getDependencyConditions();
     if (cond) {
-        cond->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());
-        cond->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned, self()->cg());
+        cond->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        cond->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 }
 

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -100,7 +100,7 @@ TR::RealRegister *OMR::ARM64::Machine::findBestFreeRegister(TR::Instruction *cur
     bool considerUnlatched, TR::Register *virtualReg)
 {
     uint32_t preference = (virtualReg != NULL) ? virtualReg->getAssociation() : 0;
-    bool liveRegOn = (self()->cg()->getLiveRegisters(rk) != NULL);
+    bool liveRegOn = (cg()->getLiveRegisters(rk) != NULL);
     uint32_t interference = 0;
     if (liveRegOn && virtualReg != NULL)
         interference = virtualReg->getInterference();
@@ -150,7 +150,7 @@ TR::RealRegister *OMR::ARM64::Machine::findBestFreeRegister(TR::Instruction *cur
             bestRegister->setState(TR::RealRegister::Free);
         }
 
-        self()->cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is %R", virtualReg, bestRegister);
+        cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is %R", virtualReg, bestRegister);
 
         return bestRegister;
     }
@@ -178,9 +178,9 @@ TR::RealRegister *OMR::ARM64::Machine::findBestFreeRegister(TR::Instruction *cur
     }
 
     if (freeRegister != NULL)
-        self()->cg()->traceRegisterAssignment("BEST FREE REG for %R is %R", virtualReg, freeRegister);
+        cg()->traceRegisterAssignment("BEST FREE REG for %R is %R", virtualReg, freeRegister);
     else
-        self()->cg()->traceRegisterAssignment("BEST FREE REG for %R is NULL (could not find one)", virtualReg);
+        cg()->traceRegisterAssignment("BEST FREE REG for %R is NULL (could not find one)", virtualReg);
 
     return freeRegister;
 }
@@ -189,13 +189,12 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
     TR::Register *virtualRegister, TR::RealRegister *forced)
 {
     TR::Register *candidates[NUM_ARM64_MAXR];
-    TR::CodeGenerator *cg = self()->cg();
     TR::RealRegister *best;
     TR::Instruction *cursor;
     TR_RegisterKinds rk = (virtualRegister == NULL) ? TR_GPR : virtualRegister->getKind();
     int numCandidates = 0;
 
-    cg->traceRegisterAssignment("FREE BEST REGISTER FOR %R", virtualRegister);
+    cg()->traceRegisterAssignment("FREE BEST REGISTER FOR %R", virtualRegister);
 
     if (forced != NULL) {
         best = forced;
@@ -221,7 +220,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
                 TR_ASSERT(false, "Unsupported RegisterKind.");
                 break;
         }
-        if ((cg->getLiveRegisters(rk) != NULL) && (virtualRegister != NULL)) {
+        if ((cg()->getLiveRegisters(rk) != NULL) && (virtualRegister != NULL)) {
             interference = virtualRegister->getInterference();
             preference = virtualRegister->getAssociation();
 
@@ -392,12 +391,12 @@ void OMR::ARM64::Machine::spillRegister(TR::Instruction *currentInstruction, TR:
 TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *currentInstruction,
     TR::Register *spilledRegister, TR::RealRegister *targetRegister)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::MemoryReference *tmemref;
     TR_BackingStore *location = spilledRegister->getBackingStorage();
     TR::Node *currentNode = currentInstruction->getNode();
     TR_RegisterKinds rk = spilledRegister->getKind();
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
     int32_t dataSize = 0;
     TR::InstOpCode::Mnemonic storeOp;
 
@@ -409,13 +408,13 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
         targetRegister->setState(TR::RealRegister::Assigned);
     }
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         // the future and total use count might not always reflect register spill state
         // for example a new register assignment in the hot path would cause FC != TC
         // in this case, assign a new register and return
         if (!location) {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
+                cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
                     debugObj->getName(spilledRegister));
             return targetRegister;
         }
@@ -426,7 +425,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             targetRegister->getRegisterName(comp));
     }
 
-    tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference());
+    tmemref = TR::MemoryReference::createWithSymRef(cg(), currentNode, location->getSymbolReference());
 
     switch (rk) {
         case TR_GPR:
@@ -442,7 +441,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         bool isOOLentryReverseSpill = false;
         if (currentInstruction->isLabel()) {
             if (((TR::ARM64LabelInstruction *)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream()) {
@@ -466,53 +465,53 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             if (location->getMaxSpillDepth() != 0)
                 location->setMaxSpillDepth(0);
             else if (debugObj)
-                self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
-                                                      "spill on both paths indicated, free spill slot (%p)\n",
+                cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
+                                              "spill on both paths indicated, free spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
 
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
-    } else if (self()->cg()->isOutOfLineHotPath()) {
+    } else if (cg()->isOutOfLineHotPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
         // Any registers reverse spilled before entering OOL should be removed from the spilled list
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
 
         // Reset maxSpillDepth here so that in the cold path we know to free the spill
         // and so that the spill is not included in future GC points in the hot path while it is protected
         location->setMaxSpillDepth(0);
         if (location->getMaxSpillDepth() == 2) {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            cg()->freeSpill(location, dataSize, 0);
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
     } else // main line
     {
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         location->setMaxSpillDepth(0);
-        self()->cg()->freeSpill(location, dataSize, 0);
+        cg()->freeSpill(location, dataSize, 0);
 
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     }
@@ -530,7 +529,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    generateMemSrc1Instruction(self()->cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
+    generateMemSrc1Instruction(cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
 
     return targetRegister;
 }
@@ -626,7 +625,7 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruction, TR::Register *virtualRegister,
     TR::RealRegister::RegNum registerNumber)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::RealRegister *targetRegister = _registerFile[registerNumber];
     TR::RealRegister *realReg = virtualRegister->getAssignedRealRegister();
     TR::RealRegister *currentAssignedRegister = realReg ? toRealRegister(realReg) : NULL;
@@ -652,15 +651,15 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
 #endif
         if (currentAssignedRegister == NULL) {
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             } else {
-                if (self()->cg()->isOutOfLineColdPath()) {
-                    self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                if (cg()->isOutOfLineColdPath()) {
+                    cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                 }
             }
         } else {
-            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, self()->cg());
+            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, cg());
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
@@ -674,34 +673,34 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
                 diagnostic(", which is blocked and assigned to %s", currentTargetVirtual->getRegisterName(comp));
 #endif
             if (currentAssignedRegister) {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, cg());
                 currentAssignedRegister->setState(TR::RealRegister::Blocked);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
                 // For Non-GPR, spareReg remains FREE.
             } else {
                 spareReg = self()->findBestFreeRegister(currentInstruction, rk, false, currentTargetVirtual);
-                self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+                cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                     virtualRegister->block();
                     spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual);
                     virtualRegister->unblock();
                 }
-                self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-                registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
                 spareReg->setState(TR::RealRegister::Blocked);
                 currentTargetVirtual->setAssignedRegister(spareReg);
                 spareReg->setAssignedRegister(currentTargetVirtual);
                 // spareReg is assigned.
 
                 if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                     self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
                 } else {
-                    if (self()->cg()->isOutOfLineColdPath()) {
-                        self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                    if (cg()->isOutOfLineColdPath()) {
+                        cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                     }
                 }
             }
@@ -711,21 +710,21 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
                 diagnostic(", which is assigned to %s", currentTargetVirtual->getRegisterName(comp));
 #endif
 
-            self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+            cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
             if (currentAssignedRegister) {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, cg());
                 currentAssignedRegister->setState(TR::RealRegister::Assigned);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
             } else {
                 spareReg = self()->findBestFreeRegister(currentInstruction, rk, false, currentTargetVirtual);
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                     self()->freeBestRegister(currentInstruction, currentTargetVirtual, targetRegister);
                 } else {
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-                    registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+                    cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                    registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
                     spareReg->setState(TR::RealRegister::Assigned);
                     spareReg->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(spareReg);
@@ -733,15 +732,15 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
                 }
 
                 if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                     self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
                 } else {
-                    if (self()->cg()->isOutOfLineColdPath()) {
-                        self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                    if (cg()->isOutOfLineColdPath()) {
+                        cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                     }
                 }
             }
-            self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+            cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
         } else {
 #ifdef DEBUG
             if (comp->getOption(TR_TraceCG))
@@ -753,7 +752,7 @@ void OMR::ARM64::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
     targetRegister->setState(TR::RealRegister::Assigned);
     targetRegister->setAssignedRegister(virtualRegister);
     virtualRegister->setAssignedRegister(targetRegister);
-    self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+    cg()->traceRegAssigned(virtualRegister, targetRegister);
 }
 
 void OMR::ARM64::Machine::spillAllVectorRegisters(TR::Instruction *currentInstruction)
@@ -777,209 +776,209 @@ void OMR::ARM64::Machine::initializeRegisterFile()
     _registerFile[TR::RealRegister::NoReg] = NULL;
     _registerFile[TR::RealRegister::SpilledReg] = NULL;
 
-    _registerFile[TR::RealRegister::x0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x0, TR::RealRegister::x0Mask, self()->cg());
+    _registerFile[TR::RealRegister::x0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x0, TR::RealRegister::x0Mask, cg());
 
-    _registerFile[TR::RealRegister::x1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x1, TR::RealRegister::x1Mask, self()->cg());
+    _registerFile[TR::RealRegister::x1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x1, TR::RealRegister::x1Mask, cg());
 
-    _registerFile[TR::RealRegister::x2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x2, TR::RealRegister::x2Mask, self()->cg());
+    _registerFile[TR::RealRegister::x2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x2, TR::RealRegister::x2Mask, cg());
 
-    _registerFile[TR::RealRegister::x3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x3, TR::RealRegister::x3Mask, self()->cg());
+    _registerFile[TR::RealRegister::x3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x3, TR::RealRegister::x3Mask, cg());
 
-    _registerFile[TR::RealRegister::x4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x4, TR::RealRegister::x4Mask, self()->cg());
+    _registerFile[TR::RealRegister::x4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x4, TR::RealRegister::x4Mask, cg());
 
-    _registerFile[TR::RealRegister::x5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x5, TR::RealRegister::x5Mask, self()->cg());
+    _registerFile[TR::RealRegister::x5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x5, TR::RealRegister::x5Mask, cg());
 
-    _registerFile[TR::RealRegister::x6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x6, TR::RealRegister::x6Mask, self()->cg());
+    _registerFile[TR::RealRegister::x6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x6, TR::RealRegister::x6Mask, cg());
 
-    _registerFile[TR::RealRegister::x7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x7, TR::RealRegister::x7Mask, self()->cg());
+    _registerFile[TR::RealRegister::x7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x7, TR::RealRegister::x7Mask, cg());
 
-    _registerFile[TR::RealRegister::x8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x8, TR::RealRegister::x8Mask, self()->cg());
+    _registerFile[TR::RealRegister::x8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x8, TR::RealRegister::x8Mask, cg());
 
-    _registerFile[TR::RealRegister::x9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x9, TR::RealRegister::x9Mask, self()->cg());
+    _registerFile[TR::RealRegister::x9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x9, TR::RealRegister::x9Mask, cg());
 
-    _registerFile[TR::RealRegister::x10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x10, TR::RealRegister::x10Mask, self()->cg());
+    _registerFile[TR::RealRegister::x10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x10, TR::RealRegister::x10Mask, cg());
 
-    _registerFile[TR::RealRegister::x11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x11, TR::RealRegister::x11Mask, self()->cg());
+    _registerFile[TR::RealRegister::x11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x11, TR::RealRegister::x11Mask, cg());
 
-    _registerFile[TR::RealRegister::x12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x12, TR::RealRegister::x12Mask, self()->cg());
+    _registerFile[TR::RealRegister::x12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x12, TR::RealRegister::x12Mask, cg());
 
-    _registerFile[TR::RealRegister::x13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x13, TR::RealRegister::x13Mask, self()->cg());
+    _registerFile[TR::RealRegister::x13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x13, TR::RealRegister::x13Mask, cg());
 
-    _registerFile[TR::RealRegister::x14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x14, TR::RealRegister::x14Mask, self()->cg());
+    _registerFile[TR::RealRegister::x14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x14, TR::RealRegister::x14Mask, cg());
 
-    _registerFile[TR::RealRegister::x15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x15, TR::RealRegister::x15Mask, self()->cg());
+    _registerFile[TR::RealRegister::x15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x15, TR::RealRegister::x15Mask, cg());
 
-    _registerFile[TR::RealRegister::x16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x16, TR::RealRegister::x16Mask, self()->cg());
+    _registerFile[TR::RealRegister::x16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x16, TR::RealRegister::x16Mask, cg());
 
-    _registerFile[TR::RealRegister::x17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x17, TR::RealRegister::x17Mask, self()->cg());
+    _registerFile[TR::RealRegister::x17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x17, TR::RealRegister::x17Mask, cg());
 
-    _registerFile[TR::RealRegister::x18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x18, TR::RealRegister::x18Mask, self()->cg());
+    _registerFile[TR::RealRegister::x18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x18, TR::RealRegister::x18Mask, cg());
 
-    _registerFile[TR::RealRegister::x19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x19, TR::RealRegister::x19Mask, self()->cg());
+    _registerFile[TR::RealRegister::x19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x19, TR::RealRegister::x19Mask, cg());
 
-    _registerFile[TR::RealRegister::x20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x20, TR::RealRegister::x20Mask, self()->cg());
+    _registerFile[TR::RealRegister::x20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x20, TR::RealRegister::x20Mask, cg());
 
-    _registerFile[TR::RealRegister::x21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x21, TR::RealRegister::x21Mask, self()->cg());
+    _registerFile[TR::RealRegister::x21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x21, TR::RealRegister::x21Mask, cg());
 
-    _registerFile[TR::RealRegister::x22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x22, TR::RealRegister::x22Mask, self()->cg());
+    _registerFile[TR::RealRegister::x22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x22, TR::RealRegister::x22Mask, cg());
 
-    _registerFile[TR::RealRegister::x23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x23, TR::RealRegister::x23Mask, self()->cg());
+    _registerFile[TR::RealRegister::x23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x23, TR::RealRegister::x23Mask, cg());
 
-    _registerFile[TR::RealRegister::x24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x24, TR::RealRegister::x24Mask, self()->cg());
+    _registerFile[TR::RealRegister::x24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x24, TR::RealRegister::x24Mask, cg());
 
-    _registerFile[TR::RealRegister::x25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x25, TR::RealRegister::x25Mask, self()->cg());
+    _registerFile[TR::RealRegister::x25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x25, TR::RealRegister::x25Mask, cg());
 
-    _registerFile[TR::RealRegister::x26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x26, TR::RealRegister::x26Mask, self()->cg());
+    _registerFile[TR::RealRegister::x26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x26, TR::RealRegister::x26Mask, cg());
 
-    _registerFile[TR::RealRegister::x27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x27, TR::RealRegister::x27Mask, self()->cg());
+    _registerFile[TR::RealRegister::x27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x27, TR::RealRegister::x27Mask, cg());
 
-    _registerFile[TR::RealRegister::x28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x28, TR::RealRegister::x28Mask, self()->cg());
+    _registerFile[TR::RealRegister::x28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x28, TR::RealRegister::x28Mask, cg());
 
-    _registerFile[TR::RealRegister::x29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::x29, TR::RealRegister::x29Mask, self()->cg());
+    _registerFile[TR::RealRegister::x29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::x29, TR::RealRegister::x29Mask, cg());
 
     /* x30 is used as LR on ARM64 */
-    _registerFile[TR::RealRegister::lr] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::lr, TR::RealRegister::x30Mask, self()->cg());
+    _registerFile[TR::RealRegister::lr] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::lr, TR::RealRegister::x30Mask, cg());
 
     /* SP */
-    _registerFile[TR::RealRegister::sp] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::sp, TR::RealRegister::x31Mask, self()->cg());
+    _registerFile[TR::RealRegister::sp] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::sp, TR::RealRegister::x31Mask, cg());
 
     /* XZR */
-    _registerFile[TR::RealRegister::xzr] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::xzr, TR::RealRegister::x31Mask, self()->cg());
+    _registerFile[TR::RealRegister::xzr] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::xzr, TR::RealRegister::x31Mask, cg());
 
-    _registerFile[TR::RealRegister::v0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v0, TR::RealRegister::v0Mask, self()->cg());
+    _registerFile[TR::RealRegister::v0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v0, TR::RealRegister::v0Mask, cg());
 
-    _registerFile[TR::RealRegister::v1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v1, TR::RealRegister::v1Mask, self()->cg());
+    _registerFile[TR::RealRegister::v1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v1, TR::RealRegister::v1Mask, cg());
 
-    _registerFile[TR::RealRegister::v2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v2, TR::RealRegister::v2Mask, self()->cg());
+    _registerFile[TR::RealRegister::v2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v2, TR::RealRegister::v2Mask, cg());
 
-    _registerFile[TR::RealRegister::v3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v3, TR::RealRegister::v3Mask, self()->cg());
+    _registerFile[TR::RealRegister::v3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v3, TR::RealRegister::v3Mask, cg());
 
-    _registerFile[TR::RealRegister::v4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v4, TR::RealRegister::v4Mask, self()->cg());
+    _registerFile[TR::RealRegister::v4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v4, TR::RealRegister::v4Mask, cg());
 
-    _registerFile[TR::RealRegister::v5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v5, TR::RealRegister::v5Mask, self()->cg());
+    _registerFile[TR::RealRegister::v5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v5, TR::RealRegister::v5Mask, cg());
 
-    _registerFile[TR::RealRegister::v6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v6, TR::RealRegister::v6Mask, self()->cg());
+    _registerFile[TR::RealRegister::v6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v6, TR::RealRegister::v6Mask, cg());
 
-    _registerFile[TR::RealRegister::v7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v7, TR::RealRegister::v7Mask, self()->cg());
+    _registerFile[TR::RealRegister::v7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v7, TR::RealRegister::v7Mask, cg());
 
-    _registerFile[TR::RealRegister::v8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v8, TR::RealRegister::v8Mask, self()->cg());
+    _registerFile[TR::RealRegister::v8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v8, TR::RealRegister::v8Mask, cg());
 
-    _registerFile[TR::RealRegister::v9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v9, TR::RealRegister::v9Mask, self()->cg());
+    _registerFile[TR::RealRegister::v9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v9, TR::RealRegister::v9Mask, cg());
 
-    _registerFile[TR::RealRegister::v10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v10, TR::RealRegister::v10Mask, self()->cg());
+    _registerFile[TR::RealRegister::v10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v10, TR::RealRegister::v10Mask, cg());
 
-    _registerFile[TR::RealRegister::v11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v11, TR::RealRegister::v11Mask, self()->cg());
+    _registerFile[TR::RealRegister::v11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v11, TR::RealRegister::v11Mask, cg());
 
-    _registerFile[TR::RealRegister::v12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v12, TR::RealRegister::v12Mask, self()->cg());
+    _registerFile[TR::RealRegister::v12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v12, TR::RealRegister::v12Mask, cg());
 
-    _registerFile[TR::RealRegister::v13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v13, TR::RealRegister::v13Mask, self()->cg());
+    _registerFile[TR::RealRegister::v13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v13, TR::RealRegister::v13Mask, cg());
 
-    _registerFile[TR::RealRegister::v14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v14, TR::RealRegister::v14Mask, self()->cg());
+    _registerFile[TR::RealRegister::v14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v14, TR::RealRegister::v14Mask, cg());
 
-    _registerFile[TR::RealRegister::v15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v15, TR::RealRegister::v15Mask, self()->cg());
+    _registerFile[TR::RealRegister::v15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v15, TR::RealRegister::v15Mask, cg());
 
-    _registerFile[TR::RealRegister::v16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v16, TR::RealRegister::v16Mask, self()->cg());
+    _registerFile[TR::RealRegister::v16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v16, TR::RealRegister::v16Mask, cg());
 
-    _registerFile[TR::RealRegister::v17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v17, TR::RealRegister::v17Mask, self()->cg());
+    _registerFile[TR::RealRegister::v17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v17, TR::RealRegister::v17Mask, cg());
 
-    _registerFile[TR::RealRegister::v18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v18, TR::RealRegister::v18Mask, self()->cg());
+    _registerFile[TR::RealRegister::v18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v18, TR::RealRegister::v18Mask, cg());
 
-    _registerFile[TR::RealRegister::v19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v19, TR::RealRegister::v19Mask, self()->cg());
+    _registerFile[TR::RealRegister::v19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v19, TR::RealRegister::v19Mask, cg());
 
-    _registerFile[TR::RealRegister::v20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v20, TR::RealRegister::v20Mask, self()->cg());
+    _registerFile[TR::RealRegister::v20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v20, TR::RealRegister::v20Mask, cg());
 
-    _registerFile[TR::RealRegister::v21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v21, TR::RealRegister::v21Mask, self()->cg());
+    _registerFile[TR::RealRegister::v21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v21, TR::RealRegister::v21Mask, cg());
 
-    _registerFile[TR::RealRegister::v22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v22, TR::RealRegister::v22Mask, self()->cg());
+    _registerFile[TR::RealRegister::v22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v22, TR::RealRegister::v22Mask, cg());
 
-    _registerFile[TR::RealRegister::v23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v23, TR::RealRegister::v23Mask, self()->cg());
+    _registerFile[TR::RealRegister::v23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v23, TR::RealRegister::v23Mask, cg());
 
-    _registerFile[TR::RealRegister::v24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v24, TR::RealRegister::v24Mask, self()->cg());
+    _registerFile[TR::RealRegister::v24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v24, TR::RealRegister::v24Mask, cg());
 
-    _registerFile[TR::RealRegister::v25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v25, TR::RealRegister::v25Mask, self()->cg());
+    _registerFile[TR::RealRegister::v25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v25, TR::RealRegister::v25Mask, cg());
 
-    _registerFile[TR::RealRegister::v26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v26, TR::RealRegister::v26Mask, self()->cg());
+    _registerFile[TR::RealRegister::v26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v26, TR::RealRegister::v26Mask, cg());
 
-    _registerFile[TR::RealRegister::v27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v27, TR::RealRegister::v27Mask, self()->cg());
+    _registerFile[TR::RealRegister::v27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v27, TR::RealRegister::v27Mask, cg());
 
-    _registerFile[TR::RealRegister::v28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v28, TR::RealRegister::v28Mask, self()->cg());
+    _registerFile[TR::RealRegister::v28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v28, TR::RealRegister::v28Mask, cg());
 
-    _registerFile[TR::RealRegister::v29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v29, TR::RealRegister::v29Mask, self()->cg());
+    _registerFile[TR::RealRegister::v29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v29, TR::RealRegister::v29Mask, cg());
 
-    _registerFile[TR::RealRegister::v30] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v30, TR::RealRegister::v30Mask, self()->cg());
+    _registerFile[TR::RealRegister::v30] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v30, TR::RealRegister::v30Mask, cg());
 
-    _registerFile[TR::RealRegister::v31] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::v31, TR::RealRegister::v31Mask, self()->cg());
+    _registerFile[TR::RealRegister::v31] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::v31, TR::RealRegister::v31Mask, cg());
 }
 
 // Register Association ////////////////////////////////////////////
 void OMR::ARM64::Machine::setRegisterWeightsFromAssociations()
 {
-    TR::ARM64LinkageProperties linkageProperties = self()->cg()->getProperties();
+    TR::ARM64LinkageProperties linkageProperties = cg()->getProperties();
     int32_t first = TR::RealRegister::FirstGPR;
     int32_t last = TR::RealRegister::LastAssignableFPR;
 
@@ -1013,7 +1012,7 @@ void OMR::ARM64::Machine::createRegisterAssociationDirective(TR::Instruction *cu
     int32_t first = TR::RealRegister::FirstGPR;
     int32_t last = TR::RealRegister::LastAssignableFPR;
     TR::RegisterDependencyConditions *associations
-        = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, last, self()->cg()->trMemory());
+        = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, last, cg()->trMemory());
 
     // Go through the current associations held in the machine and put a copy of
     // that state out into the stream after the cursor
@@ -1025,7 +1024,7 @@ void OMR::ARM64::Machine::createRegisterAssociationDirective(TR::Instruction *cu
         associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum);
     }
 
-    generateAdminInstruction(self()->cg(), TR::InstOpCode::assocreg, cursor->getNode(), associations, NULL, cursor);
+    generateAdminInstruction(cg(), TR::InstOpCode::assocreg, cursor->getNode(), associations, NULL, cursor);
 }
 
 TR::Register *OMR::ARM64::Machine::setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register *virtReg)
@@ -1134,7 +1133,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
+        deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableFPR; i++) {
             TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
             if (realReg->getState() == TR::RealRegister::Assigned) {
@@ -1221,11 +1220,11 @@ void OMR::ARM64::Machine::decFutureUseCountAndUnlatch(TR::Instruction *currentIn
     // will revive the register and proceed to allocate registers in the outlined code,
     // where presumably the future use count will finally hit 0.
     if (virtualRegister->getFutureUseCount() == 0
-        || (self()->cg()->isOutOfLineHotPath()
+        || (cg->isOutOfLineHotPath()
             && virtualRegister->getFutureUseCount() == virtualRegister->getOutOfLineUseCount())) {
         if (virtualRegister->getFutureUseCount() != 0) {
             if (debugObj) {
-                self()->cg()->traceRegisterAssignment("\nOOL: %s's remaining uses are out-of-line, unlatching\n",
+                cg->traceRegisterAssignment("\nOOL: %s's remaining uses are out-of-line, unlatching\n",
                     debugObj->getName(virtualRegister));
             }
         }

--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -41,20 +41,20 @@ void OMR::ARM::Instruction::generateConditionBinaryEncoding(uint8_t *instruction
 
 uint8_t *OMR::ARM::Instruction::generateBinaryEncoding()
 {
-    uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
+    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = instructionStart;
-    cursor = self()->getOpCode().copyBinaryToBuffer(instructionStart);
+    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
     self()->generateConditionBinaryEncoding(instructionStart);
     cursor += 4;
-    self()->setBinaryLength(cursor - instructionStart);
-    self()->setBinaryEncoding(instructionStart);
+    setBinaryLength(cursor - instructionStart);
+    setBinaryEncoding(instructionStart);
     return cursor;
 }
 
 int32_t OMR::ARM::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    self()->setEstimatedBinaryLength(ARM_INSTRUCTION_LENGTH);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    setEstimatedBinaryLength(ARM_INSTRUCTION_LENGTH);
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 uint32_t encodeBranchDistance(uint32_t from, uint32_t to)

--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -117,7 +117,7 @@ OMR::ARM::Instruction::Instruction(TR::Instruction *precedingInstruction, TR::In
 
 void OMR::ARM::Instruction::ARMNeedsGCMap(uint32_t mask)
 {
-    if (self()->cg()->comp()->useRegisterMaps())
+    if (cg()->comp()->useRegisterMaps())
         self()->setNeedsGCMap(mask);
 }
 
@@ -153,14 +153,13 @@ TR::ARMConditionalBranchInstruction *OMR::ARM::Instruction::getARMConditionalBra
 TR::ARMImmInstruction *OMR::ARM::Instruction::getARMImmInstruction() { return NULL; }
 #endif // defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 
-int32_t OMR::ARM::Instruction::getMachineOpCode() { return self()->getOpCodeValue(); }
+int32_t OMR::ARM::Instruction::getMachineOpCode() { return getOpCodeValue(); }
 
 void OMR::ARM::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
     if (self()->getDependencyConditions()) {
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());
-        self()->getDependencyConditions()->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned,
-            self()->cg());
+        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        self()->getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 }
 

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -88,7 +88,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
     TR::RealRegister *forced, bool excludeGPR0, bool isSinglePrecision)
 {
     TR::Register *candidates[NUM_ARM_MAXR];
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::MemoryReference *tmemref;
     TR_BackingStore *location;
     TR::RealRegister *best, *crtemp = NULL;
@@ -152,11 +152,11 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
                     // reuse.
                     location->setIsOccupied();
                 } else {
-                    location = self()->cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
+                    location = cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
                         candidates[0]->containsCollectedReference(), NULL);
                 }
             } else {
-                location = self()->cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
+                location = cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
                     candidates[0]->containsCollectedReference(), NULL);
             }
             break;
@@ -169,7 +169,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
             //!(cursor->refsRegister(candidates[0])))
             //  cursor = cursor->getPrev();
             // if (!cursor->getOpCode().doubleFPOp())
-            //  location = self()->cg()->getFreeLocalFloatSpill();
+            //  location = cg()->getFreeLocalFloatSpill();
             // else
             if (candidates[0]->getBackingStorage()) {
                 // If there is backing storage associated with a register, it means the
@@ -184,28 +184,28 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
                     // reuse.
                     location->setIsOccupied();
                 } else {
-                    location = self()->cg()->allocateSpill(8, false, NULL);
+                    location = cg()->allocateSpill(8, false, NULL);
                 }
             } else {
-                location = self()->cg()->allocateSpill(8, false, NULL); // TODO: use 4 when floatSpill is implemented
+                location = cg()->allocateSpill(8, false, NULL); // TODO: use 4 when floatSpill is implemented
             }
             break;
     }
     candidates[0]->setBackingStorage(location);
 
-    tmemref = new (self()->cg()->trHeapMemory())
-        TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), self()->cg());
+    tmemref = new (cg()->trHeapMemory())
+        TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), cg());
 
-    if (!self()->cg()->isOutOfLineColdPath()) {
-        TR_Debug *debugObj = self()->cg()->getDebug();
+    if (!cg()->isOutOfLineColdPath()) {
+        TR_Debug *debugObj = cg()->getDebug();
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL cold path, post dependencies will be generated using this list
-        self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
+        cg()->getSpilledRegisterList()->push_front(candidates[0]);
 
         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
         // if we reverse spill this register inside the OOL cold/hot path
-        if (!self()->cg()->isOutOfLineHotPath()) { // main line
+        if (!cg()->isOutOfLineHotPath()) { // main line
             location->setMaxSpillDepth(1);
         } else {
             // hot path
@@ -214,7 +214,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
                 location->setMaxSpillDepth(2);
         }
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
+            cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
                 debugObj->getName(candidates[0]), location->getMaxSpillDepth());
     } else {
         // do not overwrite mainline and hot path spill depth
@@ -222,26 +222,24 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
         // because the post condition at OOL entry does not expect this register to be spilled
         if (location->getMaxSpillDepth() != 1 && location->getMaxSpillDepth() != 2) {
             location->setMaxSpillDepth(3);
-            self()->cg()->traceRegisterAssignment(
-                "OOL: In OOL cold path, spilling %s not adding to spilledRegisterList",
-                (candidates[0])->getRegisterName(self()->cg()->comp()));
+            cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList",
+                (candidates[0])->getRegisterName(cg()->comp()));
         }
     }
 
-    if (self()->cg()->comp()->getOption(TR_TraceCG)) {
-        diagnostic("\n\tspilling %s (%s)", best->getAssignedRegister()->getRegisterName(self()->cg()->comp()),
-            best->getRegisterName(self()->cg()->comp()));
+    if (cg()->comp()->getOption(TR_TraceCG)) {
+        diagnostic("\n\tspilling %s (%s)", best->getAssignedRegister()->getRegisterName(cg()->comp()),
+            best->getRegisterName(cg()->comp()));
     }
 
     switch (rk) {
         case TR_GPR:
-            generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::ldr, currentNode, best, tmemref,
-                currentInstruction);
+            generateTrg1MemInstruction(cg(), TR::InstOpCode::ldr, currentNode, best, tmemref, currentInstruction);
             break;
 
         case TR_FPR:
             // if targetRegister is FS0-FS15, using TR::InstOpCode::flds.
-            generateTrg1MemInstruction(self()->cg(), (isSinglePrecision ? TR::InstOpCode::flds : TR::InstOpCode::fldd),
+            generateTrg1MemInstruction(cg(), (isSinglePrecision ? TR::InstOpCode::flds : TR::InstOpCode::fldd),
                 currentNode, best, tmemref, currentInstruction);
             break;
     }
@@ -261,7 +259,7 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction *currentI
     TR::Node *currentNode = currentInstruction->getNode();
     TR_RegisterKinds rk = spilledRegister->getKind();
     TR::InstOpCode::Mnemonic opCode;
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
 
     if (targetRegister == NULL) {
         targetRegister = self()->findBestFreeRegister(rk, excludeGPR0);
@@ -270,24 +268,24 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction *currentI
         }
         targetRegister->setState(TR::RealRegister::Assigned);
     }
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         // the future and total use count might not always reflect register spill state
         // for example a new register assignment in the hot path would cause FC != TC
         // in this case, assign a new register and return
         if (!location) {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
+                cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
                     debugObj->getName(spilledRegister));
             return targetRegister;
         }
     }
-    if (self()->cg()->comp()->getOption(TR_TraceCG)) {
-        diagnostic("\n\tre-assigning spilled %s to %s", spilledRegister->getRegisterName(self()->cg()->comp()),
-            targetRegister->getRegisterName(self()->cg()->comp()));
+    if (cg()->comp()->getOption(TR_TraceCG)) {
+        diagnostic("\n\tre-assigning spilled %s to %s", spilledRegister->getRegisterName(cg()->comp()),
+            targetRegister->getRegisterName(cg()->comp()));
     }
 
-    tmemref = new (self()->cg()->trHeapMemory())
-        TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), self()->cg());
+    tmemref = new (cg()->trHeapMemory())
+        TR::MemoryReference(currentNode, location->getSymbolReference(), ((rk == TR_FPR) ? 8 : 4), cg());
 
     int32_t dataSize = 0; // GARY OOL
     switch (rk) {
@@ -298,7 +296,7 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction *currentI
             dataSize = 8; // TODO: use 4 when floatSpill is implemented
             break;
     }
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         bool isOOLentryReverseSpill = false;
         if (currentInstruction->isLabel()) {
             if (((TR::ARMLabelInstruction *)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream()) {
@@ -322,61 +320,61 @@ TR::RealRegister *OMR::ARM::Machine::reverseSpillState(TR::Instruction *currentI
             if (location->getMaxSpillDepth() != 0)
                 location->setMaxSpillDepth(0);
             else if (debugObj)
-                self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
-                                                      "spill on both paths indicated, free spill slot (%p)\n",
+                cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
+                                              "spill on both paths indicated, free spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            cg()->freeSpill(location, dataSize, 0);
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
-    } else if (self()->cg()->isOutOfLineHotPath()) {
+    } else if (cg()->isOutOfLineHotPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
         // Any registers reverse spilled before entering OOL should be removed from the spilled list
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         // Reset maxSpillDepth here so that in the cold path we know to free the spill
         // and so that the spill is not included in future GC points in the hot path while it is protected
         location->setMaxSpillDepth(0);
         if (location->getMaxSpillDepth() == 2) {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            cg()->freeSpill(location, dataSize, 0);
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
     } else // main line
     {
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         location->setMaxSpillDepth(0);
-        self()->cg()->freeSpill(location, dataSize, 0);
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        cg()->freeSpill(location, dataSize, 0);
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     }
     switch (rk) {
         case TR_GPR:
-            generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::str, currentNode, tmemref, targetRegister,
+            generateMemSrc1Instruction(cg(), TR::InstOpCode::str, currentNode, tmemref, targetRegister,
                 currentInstruction);
             break;
         case TR_FPR:
             // if targetRegister is FS0-FS15, using TR::InstOpCode::fsts.
-            generateMemSrc1Instruction(self()->cg(), (isSinglePrecision ? TR::InstOpCode::fsts : TR::InstOpCode::fstd),
+            generateMemSrc1Instruction(cg(), (isSinglePrecision ? TR::InstOpCode::fsts : TR::InstOpCode::fstd),
                 currentNode, tmemref, targetRegister, currentInstruction);
             break;
     }
@@ -393,14 +391,13 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
     TR::Register *currentTargetVirtual;
     TR_RegisterKinds rk = virtualRegister->getKind();
 
-    if (self()->cg()->comp()->getOption(TR_TraceCG)) {
+    if (cg()->comp()->getOption(TR_TraceCG)) {
         if (currentAssignedRegister)
-            diagnostic("\n\tcoercing %s from %s to %s", virtualRegister->getRegisterName(self()->cg()->comp()),
-                currentAssignedRegister->getRegisterName(self()->cg()->comp()),
-                targetRegister->getRegisterName(self()->cg()->comp()));
+            diagnostic("\n\tcoercing %s from %s to %s", virtualRegister->getRegisterName(cg()->comp()),
+                currentAssignedRegister->getRegisterName(cg()->comp()), targetRegister->getRegisterName(cg()->comp()));
         else
-            diagnostic("\n\tcoercing %s to %s", virtualRegister->getRegisterName(self()->cg()->comp()),
-                targetRegister->getRegisterName(self()->cg()->comp()));
+            diagnostic("\n\tcoercing %s to %s", virtualRegister->getRegisterName(cg()->comp()),
+                targetRegister->getRegisterName(cg()->comp()));
     }
 
     if (currentAssignedRegister == targetRegister)
@@ -408,7 +405,7 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
     if (targetRegister->getState() == TR::RealRegister::Free
         || targetRegister->getState() == TR::RealRegister::Unlatched) {
 #ifdef DEBUG
-        if (self()->cg()->comp()->getOption(TR_TraceCG))
+        if (cg()->comp()->getOption(TR_TraceCG))
             diagnostic(", which is free");
 #endif
         if (currentAssignedRegister == NULL) {
@@ -417,16 +414,15 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
                     isSinglePrecision(registerNumber));
             }
         } else {
-            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, self()->cg());
+            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, cg());
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
     } else if (targetRegister->getState() == TR::RealRegister::Blocked) {
         currentTargetVirtual = targetRegister->getAssignedRegister();
 #ifdef DEBUG
-        if (self()->cg()->comp()->getOption(TR_TraceCG))
-            diagnostic(", which is blocked and assigned to %s",
-                currentTargetVirtual->getRegisterName(self()->cg()->comp()));
+        if (cg()->comp()->getOption(TR_TraceCG))
+            diagnostic(", which is blocked and assigned to %s", currentTargetVirtual->getRegisterName(cg()->comp()));
 #endif
         if (!currentAssignedRegister || rk != TR_GPR) {
             spareReg = self()->findBestFreeRegister(rk);
@@ -438,13 +434,13 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
         }
 
         if (currentAssignedRegister) {
-            registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, self()->cg());
+            registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, cg());
             currentAssignedRegister->setState(TR::RealRegister::Blocked);
             currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
             currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
             // For Non-GPR, spareReg remains FREE.
         } else {
-            registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+            registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
             spareReg->setState(TR::RealRegister::Blocked);
             currentTargetVirtual->setAssignedRegister(spareReg);
             spareReg->setAssignedRegister(currentTargetVirtual);
@@ -456,8 +452,8 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
     } else if (targetRegister->getState() == TR::RealRegister::Assigned) {
         currentTargetVirtual = targetRegister->getAssignedRegister();
 #ifdef DEBUG
-        if (self()->cg()->comp()->getOption(TR_TraceCG))
-            diagnostic(", which is assigned to %s", currentTargetVirtual->getRegisterName(self()->cg()->comp()));
+        if (cg()->comp()->getOption(TR_TraceCG))
+            diagnostic(", which is assigned to %s", currentTargetVirtual->getRegisterName(cg()->comp()));
 #endif
         spareReg = self()->findBestFreeRegister(rk, false, false, isSinglePrecision(registerNumber));
         if (currentAssignedRegister != NULL) {
@@ -466,8 +462,7 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
             if ((rk != TR_GPR) && (spareReg == NULL)) {
                 self()->freeBestRegister(currentInstruction, rk, targetRegister);
             } else {
-                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg,
-                    self()->cg());
+                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, cg());
                 currentAssignedRegister->setState(TR::RealRegister::Assigned);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -480,7 +475,7 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
             } else {
                 TR_ASSERT(!isSinglePrecision(registerNumber),
                     "We want to free all the registers between FS0 and FS15 before DirectToJNI call.");
-                registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+                registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
                 spareReg->setState(TR::RealRegister::Assigned);
                 spareReg->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(spareReg);
@@ -494,7 +489,7 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
         }
     } else {
 #ifdef DEBUG
-        if (self()->cg()->comp()->getOption(TR_TraceCG))
+        if (cg()->comp()->getOption(TR_TraceCG))
             diagnostic(", which is in an unknown state %d", targetRegister->getState());
 #endif
     }
@@ -506,158 +501,158 @@ void OMR::ARM::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruc
 
 void OMR::ARM::Machine::initializeRegisterFile()
 {
-    self()->cg()->_unlatchedRegisterList = (TR::RealRegister **)self()->cg()->trMemory()->allocateHeapMemory(
+    cg()->_unlatchedRegisterList = (TR::RealRegister **)cg()->trMemory()->allocateHeapMemory(
         sizeof(TR::RealRegister *) * (TR::RealRegister::NumRegisters + 1));
-    self()->cg()->_unlatchedRegisterList[0] = 0; // mark that list is empty
+    cg()->_unlatchedRegisterList[0] = 0; // mark that list is empty
 
     _registerFile[TR::RealRegister::NoReg] = NULL;
     _registerFile[TR::RealRegister::SpilledReg] = NULL;
-    _registerFile[TR::RealRegister::gr0] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr0, self()->cg());
+    _registerFile[TR::RealRegister::gr0]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr0, cg());
 
-    _registerFile[TR::RealRegister::gr1] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr1, self()->cg());
+    _registerFile[TR::RealRegister::gr1]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr1, cg());
 
-    _registerFile[TR::RealRegister::gr2] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr2, self()->cg());
+    _registerFile[TR::RealRegister::gr2]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr2, cg());
 
-    _registerFile[TR::RealRegister::gr3] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr3, self()->cg());
+    _registerFile[TR::RealRegister::gr3]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr3, cg());
 
-    _registerFile[TR::RealRegister::gr4] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr4, self()->cg());
+    _registerFile[TR::RealRegister::gr4]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr4, cg());
 
-    _registerFile[TR::RealRegister::gr5] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr5, self()->cg());
+    _registerFile[TR::RealRegister::gr5]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr5, cg());
 
-    _registerFile[TR::RealRegister::gr6] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr6, self()->cg());
+    _registerFile[TR::RealRegister::gr6]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr6, cg());
 
-    _registerFile[TR::RealRegister::gr7] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr7, self()->cg());
+    _registerFile[TR::RealRegister::gr7]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr7, cg());
 
-    _registerFile[TR::RealRegister::gr8] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr8, self()->cg());
+    _registerFile[TR::RealRegister::gr8]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr8, cg());
 
-    _registerFile[TR::RealRegister::gr9] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr9, self()->cg());
+    _registerFile[TR::RealRegister::gr9]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr9, cg());
 
-    _registerFile[TR::RealRegister::gr10] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr10, self()->cg());
+    _registerFile[TR::RealRegister::gr10]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr10, cg());
 
-    _registerFile[TR::RealRegister::gr11] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr11, self()->cg());
+    _registerFile[TR::RealRegister::gr11]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr11, cg());
 
-    _registerFile[TR::RealRegister::gr12] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr12, self()->cg());
+    _registerFile[TR::RealRegister::gr12]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr12, cg());
 
-    _registerFile[TR::RealRegister::gr13] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr13, self()->cg());
+    _registerFile[TR::RealRegister::gr13]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr13, cg());
 
-    _registerFile[TR::RealRegister::gr14] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr14, self()->cg());
+    _registerFile[TR::RealRegister::gr14]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr14, cg());
 
-    _registerFile[TR::RealRegister::gr15] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr15, self()->cg());
+    _registerFile[TR::RealRegister::gr15]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr15, cg());
 
     // need only f0 for floating point return from jni (on some platforms)
-    _registerFile[TR::RealRegister::fp0] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp0, self()->cg());
+    _registerFile[TR::RealRegister::fp0]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp0, cg());
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-    _registerFile[TR::RealRegister::fp1] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp1, self()->cg());
+    _registerFile[TR::RealRegister::fp1]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp1, cg());
 
-    _registerFile[TR::RealRegister::fp2] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp2, self()->cg());
+    _registerFile[TR::RealRegister::fp2]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp2, cg());
 
-    _registerFile[TR::RealRegister::fp3] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp3, self()->cg());
+    _registerFile[TR::RealRegister::fp3]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp3, cg());
 
-    _registerFile[TR::RealRegister::fp4] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp4, self()->cg());
+    _registerFile[TR::RealRegister::fp4]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp4, cg());
 
-    _registerFile[TR::RealRegister::fp5] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp5, self()->cg());
+    _registerFile[TR::RealRegister::fp5]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp5, cg());
 
-    _registerFile[TR::RealRegister::fp6] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp6, self()->cg());
+    _registerFile[TR::RealRegister::fp6]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp6, cg());
 
-    _registerFile[TR::RealRegister::fp7] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp7, self()->cg());
+    _registerFile[TR::RealRegister::fp7]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp7, cg());
 
-    _registerFile[TR::RealRegister::fp8] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp8, self()->cg());
+    _registerFile[TR::RealRegister::fp8]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp8, cg());
 
-    _registerFile[TR::RealRegister::fp9] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp9, self()->cg());
+    _registerFile[TR::RealRegister::fp9]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp9, cg());
 
-    _registerFile[TR::RealRegister::fp10] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp10, self()->cg());
+    _registerFile[TR::RealRegister::fp10]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp10, cg());
 
-    _registerFile[TR::RealRegister::fp11] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp11, self()->cg());
+    _registerFile[TR::RealRegister::fp11]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp11, cg());
 
-    _registerFile[TR::RealRegister::fp12] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp12, self()->cg());
+    _registerFile[TR::RealRegister::fp12]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp12, cg());
 
-    _registerFile[TR::RealRegister::fp13] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp13, self()->cg());
+    _registerFile[TR::RealRegister::fp13]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp13, cg());
 
-    _registerFile[TR::RealRegister::fp14] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp14, self()->cg());
+    _registerFile[TR::RealRegister::fp14]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp14, cg());
 
-    _registerFile[TR::RealRegister::fp15] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp15, self()->cg());
+    _registerFile[TR::RealRegister::fp15]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp15, cg());
 
     /* For fs0~fs15 (FSR) */
-    _registerFile[TR::RealRegister::fs0] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs0, self()->cg());
+    _registerFile[TR::RealRegister::fs0]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs0, cg());
 
-    _registerFile[TR::RealRegister::fs1] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs1, self()->cg());
+    _registerFile[TR::RealRegister::fs1]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs1, cg());
 
-    _registerFile[TR::RealRegister::fs2] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs2, self()->cg());
+    _registerFile[TR::RealRegister::fs2]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs2, cg());
 
-    _registerFile[TR::RealRegister::fs3] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs3, self()->cg());
+    _registerFile[TR::RealRegister::fs3]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs3, cg());
 
-    _registerFile[TR::RealRegister::fs4] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs4, self()->cg());
+    _registerFile[TR::RealRegister::fs4]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs4, cg());
 
-    _registerFile[TR::RealRegister::fs5] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs5, self()->cg());
+    _registerFile[TR::RealRegister::fs5]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs5, cg());
 
-    _registerFile[TR::RealRegister::fs6] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs6, self()->cg());
+    _registerFile[TR::RealRegister::fs6]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs6, cg());
 
-    _registerFile[TR::RealRegister::fs7] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs7, self()->cg());
+    _registerFile[TR::RealRegister::fs7]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs7, cg());
 
-    _registerFile[TR::RealRegister::fs8] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs8, self()->cg());
+    _registerFile[TR::RealRegister::fs8]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs8, cg());
 
-    _registerFile[TR::RealRegister::fs9] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs9, self()->cg());
+    _registerFile[TR::RealRegister::fs9]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs9, cg());
 
-    _registerFile[TR::RealRegister::fs10] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs10, self()->cg());
+    _registerFile[TR::RealRegister::fs10]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs10, cg());
 
-    _registerFile[TR::RealRegister::fs11] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs11, self()->cg());
+    _registerFile[TR::RealRegister::fs11]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs11, cg());
 
-    _registerFile[TR::RealRegister::fs12] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs12, self()->cg());
+    _registerFile[TR::RealRegister::fs12]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs12, cg());
 
-    _registerFile[TR::RealRegister::fs13] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs13, self()->cg());
+    _registerFile[TR::RealRegister::fs13]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs13, cg());
 
-    _registerFile[TR::RealRegister::fs14] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs14, self()->cg());
+    _registerFile[TR::RealRegister::fs14]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs14, cg());
 
-    _registerFile[TR::RealRegister::fs15] = new (self()->cg()->trHeapMemory())
-        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs15, self()->cg());
+    _registerFile[TR::RealRegister::fs15]
+        = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fs15, cg());
 
 #endif
 }
@@ -793,7 +788,7 @@ TR::RegisterDependencyConditions *OMR::ARM::Machine::createCondForLiveAndSpilled
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
+        deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
         for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++) {
             TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
             if (realReg->getState() == TR::RealRegister::Assigned) {
@@ -825,7 +820,7 @@ TR::RegisterDependencyConditions *OMR::ARM::Machine::createCondForLiveAndSpilled
 void OMR::ARM::Machine::takeRegisterStateSnapShot()
 {
     int32_t i;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     OMR::Logger *log = comp->log();
     bool trace = comp->getOption(TR_TraceRA);
 
@@ -856,7 +851,7 @@ void OMR::ARM::Machine::takeRegisterStateSnapShot()
 void OMR::ARM::Machine::restoreRegisterStateFromSnapShot()
 {
     int32_t i;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     OMR::Logger *log = comp->log();
     bool trace = comp->getOption(TR_TraceRA);
 

--- a/compiler/codegen/OMRInstruction.cpp
+++ b/compiler/codegen/OMRInstruction.cpp
@@ -51,13 +51,13 @@ Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR:
 
     TR::Compilation *comp = cg->comp();
 
-    if (self()->getPrev()) {
+    if (getPrev()) {
         _prev->setNext(self());
         cg->setAppendInstruction(self());
         _index = (_prev->getIndex() + INSTRUCTION_INDEX_INCREMENT) & ~FlagsMask;
     } else {
-        self()->setNext(cg->getFirstInstruction());
-        self()->setPrev(0);
+        setNext(cg->getFirstInstruction());
+        setPrev(0);
         TR::Instruction *first = cg->getFirstInstruction();
 
         if (first) {
@@ -100,8 +100,8 @@ Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstru
     TR::Compilation *comp = cg->comp();
 
     if (precedingInstruction != 0) {
-        self()->setNext(precedingInstruction->getNext());
-        self()->setPrev(precedingInstruction);
+        setNext(precedingInstruction->getNext());
+        setPrev(precedingInstruction);
 
         if (precedingInstruction->getNext()) {
             precedingInstruction->getNext()->setPrev(self());
@@ -121,8 +121,8 @@ Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstru
             _node = precedingInstruction->_node;
         }
     } else {
-        self()->setNext(cg->getFirstInstruction());
-        self()->setPrev(0);
+        setNext(cg->getFirstInstruction());
+        setPrev(0);
         TR::Instruction *first = cg->getFirstInstruction();
 
         if (first) {
@@ -162,8 +162,8 @@ TR::Instruction *Instruction::move(TR::Instruction *newLocation)
         newLocNext->setPrev(self());
     }
 
-    self()->setNext(newLocNext);
-    self()->setPrev(newLocation);
+    setNext(newLocNext);
+    setPrev(newLocation);
 
     newLocation->setNext(self());
 
@@ -181,47 +181,47 @@ TR::Instruction *Instruction::move(TR::Instruction *newLocation)
 
 void Instruction::remove()
 {
-    if (self()->getPrev())
-        self()->getPrev()->setNext(self()->getNext());
+    if (getPrev())
+        getPrev()->setNext(getNext());
     else
-        self()->cg()->setFirstInstruction(self()->getNext());
+        cg()->setFirstInstruction(getNext());
 
-    if (self()->getNext())
-        self()->getNext()->setPrev(self()->getPrev());
+    if (getNext())
+        getNext()->setPrev(getPrev());
     else
-        self()->cg()->setAppendInstruction(self()->getPrev());
+        cg()->setAppendInstruction(getPrev());
 
-    self()->setPrev(NULL);
-    self()->setNext(NULL);
+    setPrev(NULL);
+    setNext(NULL);
 }
 
 void Instruction::useRegister(TR::Register *reg)
 {
     if (reg->getStartOfRange() == 0
-        || ((reg->getStartOfRange()->getIndex() > self()->getIndex()) && !self()->cg()->getIsInOOLSection())) {
+        || ((reg->getStartOfRange()->getIndex() > self()->getIndex()) && !cg()->getIsInOOLSection())) {
         reg->setStartOfRange(self());
     }
 
     if (reg->getEndOfRange() == 0
-        || ((reg->getEndOfRange()->getIndex() < self()->getIndex()) && !self()->cg()->getIsInOOLSection())) {
+        || ((reg->getEndOfRange()->getIndex() < self()->getIndex()) && !cg()->getIsInOOLSection())) {
         reg->setEndOfRange(self());
     }
 
-    if (self()->cg()->getEnableRegisterUsageTracking()) {
-        self()->cg()->recordSingleRegisterUse(reg);
+    if (cg()->getEnableRegisterUsageTracking()) {
+        cg()->recordSingleRegisterUse(reg);
     }
 
     reg->incTotalUseCount();
 
-    if (self()->cg()->getIsInOOLSection())
+    if (cg()->getIsInOOLSection())
         reg->incOutOfLineUseCount();
 }
 
-bool Instruction::requiresAtomicPatching() { return !(self()->getNode() && self()->getNode()->isStopTheWorldGuard()); }
+bool Instruction::requiresAtomicPatching() { return !(getNode() && getNode()->isStopTheWorldGuard()); }
 
 bool Instruction::isMergeableGuard()
 {
     static char *mergeOnlyHCRGuards = feGetEnv("TR_MergeOnlyHCRGuards");
-    return mergeOnlyHCRGuards ? self()->getNode()->isStopTheWorldGuard() : self()->getNode()->isNopableInlineGuard();
+    return mergeOnlyHCRGuards ? getNode()->isStopTheWorldGuard() : getNode()->isNopableInlineGuard();
 }
 } // namespace OMR

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -92,22 +92,22 @@ public:
     /*
      * Instruction OpCodes
      */
-    TR::InstOpCode &getOpCode() { return _opcode; }
+    OMR_FINAL TR::InstOpCode &getOpCode() { return _opcode; }
 
-    TR::InstOpCode::Mnemonic getOpCodeValue() { return _opcode.getMnemonic(); }
+    OMR_FINAL TR::InstOpCode::Mnemonic getOpCodeValue() { return _opcode.getMnemonic(); }
 
-    void setOpCodeValue(TR::InstOpCode::Mnemonic op) { _opcode.setMnemonic(op); }
+    OMR_FINAL void setOpCodeValue(TR::InstOpCode::Mnemonic op) { _opcode.setMnemonic(op); }
 
     /*
      * Instruction stream links.
      */
-    TR::Instruction *getNext() { return _next; }
+    OMR_FINAL TR::Instruction *getNext() { return _next; }
 
-    void setNext(TR::Instruction *n) { _next = n; }
+    OMR_FINAL void setNext(TR::Instruction *n) { _next = n; }
 
-    TR::Instruction *getPrev() { return _prev; }
+    OMR_FINAL TR::Instruction *getPrev() { return _prev; }
 
-    void setPrev(TR::Instruction *p) { _prev = p; }
+    OMR_FINAL void setPrev(TR::Instruction *p) { _prev = p; }
 
     void remove();
     TR::Instruction *move(TR::Instruction *newLocation);
@@ -116,21 +116,21 @@ public:
      * Address of binary buffer where this instruction was encoded.  The binary buffer
      * is NULL if this instruction has not been encoded yet.
      */
-    uint8_t *getBinaryEncoding() { return _binaryEncodingBuffer; }
+    OMR_FINAL uint8_t *getBinaryEncoding() { return _binaryEncodingBuffer; }
 
-    void setBinaryEncoding(uint8_t *be) { _binaryEncodingBuffer = be; }
+    OMR_FINAL void setBinaryEncoding(uint8_t *be) { _binaryEncodingBuffer = be; }
 
-    uint8_t getBinaryLength() { return _binaryLength; }
+    OMR_FINAL uint8_t getBinaryLength() { return _binaryLength; }
 
-    void setBinaryLength(uint8_t length) { _binaryLength = length; }
+    OMR_FINAL void setBinaryLength(uint8_t length) { _binaryLength = length; }
 
     /*
      * Cached estimate of an instruction's worst case length in bytes.
      * Assumes that estimateBinaryLength() has been run before.
      */
-    uint8_t getEstimatedBinaryLength() { return _estimatedBinaryLength; }
+    OMR_FINAL uint8_t getEstimatedBinaryLength() { return _estimatedBinaryLength; }
 
-    void setEstimatedBinaryLength(uint8_t e) { _estimatedBinaryLength = e; }
+    OMR_FINAL void setEstimatedBinaryLength(uint8_t e) { _estimatedBinaryLength = e; }
 
     /*
      * Action to estimate the generated binary length of this instruction.
@@ -185,9 +185,9 @@ public:
     /*
      * The IR node whence this instruction was created.
      */
-    TR::Node *getNode() { return _node; }
+    OMR_FINAL TR::Node *getNode() { return _node; }
 
-    void setNode(TR::Node *n) { _node = n; }
+    OMR_FINAL void setNode(TR::Node *n) { _node = n; }
 
     /*
      * Answers whether the instruction can be included in a guard patch point

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -58,7 +58,7 @@ OMR::Power::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
 
 TR::Register *OMR::Power::Instruction::getTargetRegister(uint32_t i)
 {
-    return (_conditions == NULL) ? NULL : _conditions->getTargetRegister(i, self()->cg());
+    return (_conditions == NULL) ? NULL : _conditions->getTargetRegister(i, cg());
 }
 
 TR::Register *OMR::Power::Instruction::getSourceRegister(uint32_t i)
@@ -73,7 +73,7 @@ bool OMR::Power::Instruction::isCall()
 
 void OMR::Power::Instruction::PPCNeedsGCMap(uint32_t mask)
 {
-    if (self()->cg()->comp()->useRegisterMaps())
+    if (cg()->comp()->useRegisterMaps())
         self()->setNeedsGCMap(mask);
 }
 
@@ -126,13 +126,13 @@ void OMR::Power::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
     if (OMR::Power::Instruction::getDependencyConditions()) {
         OMR::Power::Instruction::getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned,
-            self()->cg());
-        OMR::Power::Instruction::getDependencyConditions()->assignPreConditionRegisters(self()->getPrev(),
-            kindToBeAssigned, self()->cg());
+            cg());
+        OMR::Power::Instruction::getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned,
+            cg());
     }
 }
 
-bool OMR::Power::Instruction::isBeginBlock() { return self()->getPrev()->getOpCodeValue() == TR::InstOpCode::label; }
+bool OMR::Power::Instruction::isBeginBlock() { return getPrev()->getOpCodeValue() == TR::InstOpCode::label; }
 
 bool OMR::Power::Instruction::setsCountRegister()
 {
@@ -141,11 +141,11 @@ bool OMR::Power::Instruction::setsCountRegister()
     return self()->isCall() | _opcode.setsCountRegister();
 }
 
-bool OMR::Power::Instruction::is4ByteLoad() { return (self()->getOpCodeValue() == TR::InstOpCode::lwz); }
+bool OMR::Power::Instruction::is4ByteLoad() { return (getOpCodeValue() == TR::InstOpCode::lwz); }
 
-int32_t OMR::Power::Instruction::getMachineOpCode() { return self()->getOpCodeValue(); }
+int32_t OMR::Power::Instruction::getMachineOpCode() { return getOpCodeValue(); }
 
-uint8_t OMR::Power::Instruction::getBinaryLengthLowerBound() { return self()->getEstimatedBinaryLength(); }
+uint8_t OMR::Power::Instruction::getBinaryLengthLowerBound() { return getEstimatedBinaryLength(); }
 
 int32_t TR::PPCDepImmSymInstruction::estimateBinaryLength(int32_t currentEstimate)
 {

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -147,7 +147,7 @@ void OMR::Power::Machine::initREGAssociations()
     int icount;
     int nextV = 0;
     int lastFPRv, lastVRFv;
-    const TR::PPCLinkageProperties &linkage = self()->cg()->getProperties();
+    const TR::PPCLinkageProperties &linkage = cg()->getProperties();
 
     // We assume the volatile/preserved registers to be consecutive
     // because the private linkage will either be a single volatile set or
@@ -186,7 +186,7 @@ void OMR::Power::Machine::initREGAssociations()
     // Power8/SAR:  confine to the smallest set of registers we can get away, because map cache
     // Others:      neutral --- take Power6 way for now
 
-    int rollingAllocator = !(self()->cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P8));
+    int rollingAllocator = !(cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P8));
 
     _inUseFPREnd = rollingAllocator ? lastFPRv : 0;
     _lastFPRAlloc = _inUseFPREnd;
@@ -201,7 +201,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
     uint64_t interference = 0;
     int first, maskI;
     int last;
-    bool liveRegOn = (self()->cg()->getLiveRegisters(rk) != NULL);
+    bool liveRegOn = (cg()->getLiveRegisters(rk) != NULL);
 
     if (liveRegOn && virtualReg != NULL)
         interference = virtualReg->getInterference();
@@ -238,7 +238,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
 
     if (liveRegOn && preference != 0 && (interference & (1 << (preference - maskI)))) {
         if (!boundNext(currentInstruction, preference, virtualReg,
-                (self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath())))
+                (cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath())))
             preference = 0;
     }
 
@@ -258,7 +258,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
 
     // For FPR/VSR/VRF
     if (rk == TR_FPR || rk == TR_VSX_SCALAR || rk == TR_VSX_VECTOR || rk == TR_VRF) {
-        int rollingAllocator = !(self()->cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P8));
+        int rollingAllocator = !(cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P8));
 
         // Find the best in the used FPR set so far
         int i, idx;
@@ -356,7 +356,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
 
             // Inject interference for last four assignments to prevent write-after-write dependancy in same p6 dispatch
             // group.
-            if (rk == TR_GPR && (self()->cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P6))) {
+            if (rk == TR_GPR && (cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P6))) {
                 if (_lastGPRAssigned != -1)
                     iNew |= currentReg & _lastGPRAssigned;
                 if (_2ndLastGPRAssigned != -1)
@@ -378,7 +378,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
             }
         }
         // Track the last four registers used for use in above interference injection.
-        if ((rk == TR_GPR) && (freeRegister != NULL) && (self()->cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P6))) {
+        if ((rk == TR_GPR) && (freeRegister != NULL) && (cg()->comp()->target().cpu.is(OMR_PROCESSOR_PPC_P6))) {
             _4thLastGPRAssigned = _3rdLastGPRAssigned;
             _3rdLastGPRAssigned = _2ndLastGPRAssigned;
             _2ndLastGPRAssigned = _lastGPRAssigned;
@@ -403,13 +403,13 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
     TR::RealRegister *best, *crtemp = NULL;
     TR::Instruction *cursor;
     TR::InstOpCode::Mnemonic opCode;
-    TR::Machine *machine = self()->cg()->machine();
+    TR::Machine *machine = cg()->machine();
     TR::Node *currentNode = currentInstruction->getNode();
     TR_RegisterKinds rk = (virtReg == NULL) ? TR_GPR : virtReg->getKind();
     int32_t numCandidates = 0, first, last, maskI;
     uint64_t interference = 0;
     TR::RealRegister::RegState crtemp_state;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     if (forced != NULL) {
         best = forced;
@@ -447,14 +447,14 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
         }
 
         int32_t preference = 0, pref_favored = 0;
-        if (self()->cg()->getLiveRegisters(rk) != NULL && virtReg != NULL) {
+        if (cg()->getLiveRegisters(rk) != NULL && virtReg != NULL) {
             interference = virtReg->getInterference();
             preference = virtReg->getAssociation();
 
             // Consider yielding
             if (preference != 0
                 && boundNext(currentInstruction, preference, virtReg,
-                    (self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath()))) {
+                    (cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()))) {
                 pref_favored = 1;
                 interference &= ~((uint64_t)(1 << (preference - maskI)));
             }
@@ -512,9 +512,9 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             if (false /*(cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage()*/) {
                 location = virtReg->getBackingStorage();
                 // reuse the spill slot
-                if (self()->cg()->getDebug())
-                    self()->cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n",
-                        location, self()->cg()->getDebug()->getName(virtReg));
+                if (cg()->getDebug())
+                    cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n", location,
+                        cg()->getDebug()->getName(virtReg));
             } else {
                 if (candidates[0]->getBackingStorage()) {
                     // If there is backing storage associated with a register, it means the
@@ -534,9 +534,9 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                 } else {
                     if (candidates[0]->containsInternalPointer()) {
                         TR::AutomaticSymbol *parray = candidates[0]->getPinningArrayPointer();
-                        location = self()->cg()->allocateInternalPointerSpill(parray);
+                        location = cg()->allocateInternalPointerSpill(parray);
                     } else {
-                        location = self()->cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
+                        location = cg()->allocateSpill(TR::Compiler->om.sizeofReferenceAddress(),
                             candidates[0]->containsCollectedReference(), NULL);
                     }
                 }
@@ -546,9 +546,9 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             if (false /*(cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage()*/) {
                 location = virtReg->getBackingStorage();
                 // reuse the spill slot
-                if (self()->cg()->getDebug())
-                    self()->cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n",
-                        location, self()->cg()->getDebug()->getName(virtReg));
+                if (cg()->getDebug())
+                    cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n", location,
+                        cg()->getDebug()->getName(virtReg));
             } else {
                 if (candidates[0]->getBackingStorage()) {
                     // If there is backing storage associated with a register, it means the
@@ -566,7 +566,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                     else
                         location->setIsOccupied();
                 } else {
-                    location = self()->cg()->allocateSpill(candidates[0]->isSinglePrecision() ? 4 : 8, false, NULL);
+                    location = cg()->allocateSpill(candidates[0]->isSinglePrecision() ? 4 : 8, false, NULL);
                 }
             }
             break;
@@ -586,16 +586,16 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                 else
                     location->setIsOccupied();
             } else {
-                location = self()->cg()->allocateSpill(candidates[0]->isSinglePrecision() ? 4 : 8, false, NULL);
+                location = cg()->allocateSpill(candidates[0]->isSinglePrecision() ? 4 : 8, false, NULL);
             }
             break;
         case TR_CCR:
             if (false /*(cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage()*/) {
                 location = virtReg->getBackingStorage();
                 // reuse the spill slot
-                if (self()->cg()->getDebug())
-                    self()->cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n",
-                        location, self()->cg()->getDebug()->getName(virtReg));
+                if (cg()->getDebug())
+                    cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n", location,
+                        cg()->getDebug()->getName(virtReg));
             } else {
                 if (candidates[0]->getBackingStorage()) {
                     // If there is backing storage associated with a register, it means the
@@ -612,8 +612,8 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                     else
                         location->setIsOccupied();
                 } else {
-                    location = new (self()->cg()->trHeapMemory()) TR_PPCCRBackingStore(comp,
-                        self()->cg()->allocateSpill(4, false, NULL)); // TODO: Could this be 1 byte?
+                    location = new (cg()->trHeapMemory())
+                        TR_PPCCRBackingStore(comp, cg()->allocateSpill(4, false, NULL)); // TODO: Could this be 1 byte?
                 }
             }
             break;
@@ -631,7 +631,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                 // occupied flag for this reuse.
                 location->setIsOccupied();
             } else {
-                location = self()->cg()->allocateSpill(16, false, NULL);
+                location = cg()->allocateSpill(16, false, NULL);
             }
             break;
         default:
@@ -642,7 +642,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
         toPPCCRBackingStore(location)->setCcrFieldIndex(best->getRegisterNumber() - TR::RealRegister::FirstCCR);
     candidates[0]->setBackingStorage(location);
 
-    tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference(),
+    tmemref = TR::MemoryReference::createWithSymRef(cg(), currentNode, location->getSymbolReference(),
         TR::Compiler->om.sizeofReferenceAddress());
 
     if (rk == TR_CCR) {
@@ -652,21 +652,21 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
         else
             crtemp->setHasBeenAssignedInMethod(true);
         crtemp_state = crtemp->getState();
-        TR::Instruction *ccrInstr = generateSrc1Instruction(self()->cg(), TR::InstOpCode::mtocrf, currentNode, crtemp,
+        TR::Instruction *ccrInstr = generateSrc1Instruction(cg(), TR::InstOpCode::mtocrf, currentNode, crtemp,
             1 << (7 - toPPCCRBackingStore(location)->getCcrFieldIndex()), currentInstruction);
-        self()->cg()->traceRAInstruction(ccrInstr);
+        cg()->traceRAInstruction(ccrInstr);
     }
 
-    if (!self()->cg()->isOutOfLineColdPath()) {
-        TR_Debug *debugObj = self()->cg()->getDebug();
+    if (!cg()->isOutOfLineColdPath()) {
+        TR_Debug *debugObj = cg()->getDebug();
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL cold path, post dependencies will be generated using this list
-        self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
+        cg()->getSpilledRegisterList()->push_front(candidates[0]);
 
         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
         // if we reverse spill this register inside the OOL cold/hot path
-        if (!self()->cg()->isOutOfLineHotPath()) { // main line
+        if (!cg()->isOutOfLineHotPath()) { // main line
             location->setMaxSpillDepth(1);
         } else {
             // hot path
@@ -675,7 +675,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                 location->setMaxSpillDepth(2);
         }
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
+            cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
                 debugObj->getName(candidates[0]), location->getMaxSpillDepth());
     } else {
         // do not overwrite mainline and hot path spill depth
@@ -689,7 +689,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
     TR::RealRegister *tempIndexRegister = NULL;
     switch (rk) {
         case TR_GPR:
-            reloadInstr = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::Op_load, currentNode, best, tmemref,
+            reloadInstr = generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, currentNode, best, tmemref,
                 currentInstruction);
             break;
         case TR_FPR:
@@ -700,8 +700,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
                 opCode = TR::InstOpCode::lfd;
                 tmemref->setLength(8);
             }
-            reloadInstr
-                = generateTrg1MemInstruction(self()->cg(), opCode, currentNode, best, tmemref, currentInstruction);
+            reloadInstr = generateTrg1MemInstruction(cg(), opCode, currentNode, best, tmemref, currentInstruction);
             break;
         case TR_VSX_SCALAR:
             tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
@@ -712,13 +711,12 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::lxsdx;
             tmemref->setLength(8);
-            reloadInstr
-                = generateTrg1MemInstruction(self()->cg(), opCode, currentNode, best, tmemref, currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            reloadInstr = generateTrg1MemInstruction(cg(), opCode, currentNode, best, tmemref, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         case TR_CCR:
-            reloadInstr = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::Op_load, currentNode, crtemp,
-                tmemref, currentInstruction);
+            reloadInstr = generateTrg1MemInstruction(cg(), TR::InstOpCode::Op_load, currentNode, crtemp, tmemref,
+                currentInstruction);
             break;
         case TR_VSX_VECTOR:
             tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
@@ -729,16 +727,14 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::lxvd2x;
             tmemref->setLength(16);
-            reloadInstr
-                = generateTrg1MemInstruction(self()->cg(), opCode, currentNode, best, tmemref, currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            reloadInstr = generateTrg1MemInstruction(cg(), opCode, currentNode, best, tmemref, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         case TR_VRF:
             // Until stack frame is 16-byte aligned, we cannot use VMX load/store here
             // So, we use VSX load/store instead as a work-around
 
-            TR_ASSERT(self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX),
-                "VSX support not enabled");
+            TR_ASSERT(comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX), "VSX support not enabled");
 
             tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
             if (tempIndexRegister == NULL)
@@ -748,16 +744,15 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction *current
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::lxvd2x;
             tmemref->setLength(16);
-            reloadInstr
-                = generateTrg1MemInstruction(self()->cg(), opCode, currentNode, best, tmemref, currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            reloadInstr = generateTrg1MemInstruction(cg(), opCode, currentNode, best, tmemref, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         default:
             break;
     }
 
-    self()->cg()->traceRegFreed(candidates[0], best);
-    self()->cg()->traceRAInstruction(reloadInstr);
+    cg()->traceRegFreed(candidates[0], best);
+    cg()->traceRAInstruction(reloadInstr);
 
     best->setAssignedRegister(NULL);
     best->setState(TR::RealRegister::Free);
@@ -788,16 +783,16 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
     TR::Register *spilledRegister, TR::RealRegister *targetRegister, bool excludeGPR0)
 {
     TR::MemoryReference *tmemref;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::RealRegister *sameReg, *crtemp = NULL;
     TR_BackingStore *location = spilledRegister->getBackingStorage();
     TR::Node *currentNode = currentInstruction->getNode();
     TR_RegisterKinds rk = spilledRegister->getKind();
     TR::InstOpCode::Mnemonic opCode;
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
     if (targetRegister == NULL) {
-        if ((rk == TR_CCR) && (!self()->cg()->isOutOfLineColdPath() && !self()->cg()->isOutOfLineHotPath())
-            && ((sameReg = self()->cg()->machine()->getRealRegister((TR::RealRegister::RegNum)(
+        if ((rk == TR_CCR) && (!cg()->isOutOfLineColdPath() && !cg()->isOutOfLineHotPath())
+            && ((sameReg = cg()->machine()->getRealRegister((TR::RealRegister::RegNum)(
                      TR::RealRegister::FirstCCR + toPPCCRBackingStore(location)->getCcrFieldIndex())))
                     ->getState()
                 == TR::RealRegister::Free)) {
@@ -811,13 +806,13 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
         targetRegister->setState(TR::RealRegister::Assigned);
     }
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         // the future and total use count might not always reflect register spill state
         // for example a new register assignment in the hot path would cause FC != TC
         // in this case, assign a new register and return
         if (!location) {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
+                cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
                     debugObj->getName(spilledRegister));
             return targetRegister;
         }
@@ -831,13 +826,13 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
             crtemp->setHasBeenAssignedInMethod(true);
     }
 
-    tmemref = TR::MemoryReference::createWithSymRef(self()->cg(), currentNode, location->getSymbolReference(),
+    tmemref = TR::MemoryReference::createWithSymRef(cg(), currentNode, location->getSymbolReference(),
         TR::Compiler->om.sizeofReferenceAddress());
     TR::Instruction *spillInstr = NULL;
 
     int32_t dataSize = spillSizeForRegister(spilledRegister);
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         bool isOOLentryReverseSpill = false;
         if (currentInstruction->isLabel()) {
             if (((TR::PPCLabelInstruction *)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream()) {
@@ -861,37 +856,37 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
             if (location->getMaxSpillDepth() != 0)
                 location->setMaxSpillDepth(0);
             else if (debugObj)
-                self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
-                                                      "spill on both paths indicated, free spill slot (%p)\n",
+                cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
+                                              "spill on both paths indicated, free spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
 
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
-    } else if (self()->cg()->isOutOfLineHotPath()) {
+    } else if (cg()->isOutOfLineHotPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
         // Any registers reverse spilled before entering OOL should be removed from the spilled list
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         if (location->getMaxSpillDepth() == 2) {
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
             location->setMaxSpillDepth(0);
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
             // Reset maxSpillDepth here so that in the cold path we know to free the spill
@@ -901,13 +896,13 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
     } else // main line
     {
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         location->setMaxSpillDepth(0);
-        self()->cg()->freeSpill(location, dataSize, 0);
+        cg()->freeSpill(location, dataSize, 0);
 
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     }
@@ -915,8 +910,8 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
     TR::Register *tempIndexRegister = NULL;
     switch (rk) {
         case TR_GPR:
-            spillInstr = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::Op_st, currentNode, tmemref,
-                targetRegister, currentInstruction);
+            spillInstr = generateMemSrc1Instruction(cg(), TR::InstOpCode::Op_st, currentNode, tmemref, targetRegister,
+                currentInstruction);
             break;
         case TR_FPR:
             if (spilledRegister->isSinglePrecision()) {
@@ -926,8 +921,8 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
                 opCode = TR::InstOpCode::stfd;
                 tmemref->setLength(8);
             }
-            spillInstr = generateMemSrc1Instruction(self()->cg(), opCode, currentNode, tmemref, targetRegister,
-                currentInstruction);
+            spillInstr
+                = generateMemSrc1Instruction(cg(), opCode, currentNode, tmemref, targetRegister, currentInstruction);
             break;
         case TR_VSX_SCALAR:
             tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
@@ -938,12 +933,12 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::stxsdx;
             tmemref->setLength(8);
-            spillInstr = generateMemSrc1Instruction(self()->cg(), opCode, currentNode, tmemref, targetRegister,
-                currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            spillInstr
+                = generateMemSrc1Instruction(cg(), opCode, currentNode, tmemref, targetRegister, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         case TR_CCR:
-            spillInstr = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::Op_st, currentNode, tmemref, crtemp,
+            spillInstr = generateMemSrc1Instruction(cg(), TR::InstOpCode::Op_st, currentNode, tmemref, crtemp,
                 currentInstruction);
             break;
         case TR_VSX_VECTOR:
@@ -955,16 +950,15 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::stxvd2x;
             tmemref->setLength(16);
-            spillInstr = generateMemSrc1Instruction(self()->cg(), opCode, currentNode, tmemref, targetRegister,
-                currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            spillInstr
+                = generateMemSrc1Instruction(cg(), opCode, currentNode, tmemref, targetRegister, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         case TR_VRF:
             // Until stack frame is 16-byte aligned, we cannot use VMX load/store here
             // So, we use VSX load/store instead as a work-around
 
-            TR_ASSERT(self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX),
-                "VSX support not enabled");
+            TR_ASSERT(comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX), "VSX support not enabled");
 
             tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
             if (tempIndexRegister == NULL)
@@ -974,14 +968,14 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
             tmemref->setIndexModifiable();
             opCode = TR::InstOpCode::stxvd2x;
             tmemref->setLength(16);
-            spillInstr = generateMemSrc1Instruction(self()->cg(), opCode, currentNode, tmemref, targetRegister,
-                currentInstruction);
-            self()->cg()->stopUsingRegister(tempIndexRegister);
+            spillInstr
+                = generateMemSrc1Instruction(cg(), opCode, currentNode, tmemref, targetRegister, currentInstruction);
+            cg()->stopUsingRegister(tempIndexRegister);
             break;
         default:
             break;
     }
-    self()->cg()->traceRAInstruction(spillInstr);
+    cg()->traceRAInstruction(spillInstr);
     if (rk == TR_CCR) {
         int32_t tindex = targetRegister->getRegisterNumber() - TR::RealRegister::FirstCCR;
         int32_t sindex = toPPCCRBackingStore(location)->getCcrFieldIndex();
@@ -990,11 +984,11 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction *curren
                 sindex = 32 - (sindex - tindex) * 4;
             else
                 sindex = (tindex - sindex) * 4;
-            self()->cg()->traceRAInstruction(generateTrg1Src1Imm2Instruction(self()->cg(), TR::InstOpCode::rlwinm,
-                currentNode, crtemp, crtemp, sindex, 0xFFFFFFFF, currentInstruction));
+            cg()->traceRAInstruction(generateTrg1Src1Imm2Instruction(cg(), TR::InstOpCode::rlwinm, currentNode, crtemp,
+                crtemp, sindex, 0xFFFFFFFF, currentInstruction));
         }
-        self()->cg()->traceRAInstruction(
-            generateTrg1Instruction(self()->cg(), TR::InstOpCode::mfcr, currentNode, crtemp, currentInstruction));
+        cg()->traceRAInstruction(
+            generateTrg1Instruction(cg(), TR::InstOpCode::mfcr, currentNode, crtemp, currentInstruction));
     }
 
     return targetRegister;
@@ -1006,16 +1000,16 @@ TR::RealRegister *OMR::Power::Machine::assignOneRegister(TR::Instruction *curren
     TR_RegisterKinds rk = virtReg->getKind();
     TR::RealRegister *assignedReg;
 
-    self()->cg()->clearRegisterAssignmentFlags();
-    self()->cg()->setRegisterAssignmentFlag(TR_NormalAssignment);
+    cg()->clearRegisterAssignmentFlags();
+    cg()->setRegisterAssignmentFlag(TR_NormalAssignment);
 
     if (virtReg->getTotalUseCount() != virtReg->getFutureUseCount()) {
-        self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+        cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
         assignedReg = self()->reverseSpillState(currentInstruction, virtReg, NULL, excludeGPR0);
     } else {
         assignedReg = self()->findBestFreeRegister(currentInstruction, rk, excludeGPR0, true, virtReg);
         if (assignedReg == NULL) {
-            self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+            cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
             assignedReg = self()->freeBestRegister(currentInstruction, virtReg, NULL, excludeGPR0);
         }
     }
@@ -1023,7 +1017,7 @@ TR::RealRegister *OMR::Power::Machine::assignOneRegister(TR::Instruction *curren
     virtReg->setAssignedRegister(assignedReg);
     assignedReg->setAssignedRegister(virtReg);
     assignedReg->setState(TR::RealRegister::Assigned);
-    self()->cg()->traceRegAssigned(virtReg, assignedReg);
+    cg()->traceRegAssigned(virtReg, assignedReg);
     return (assignedReg);
 }
 
@@ -1041,11 +1035,11 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
         || targetRegister->getState() == TR::RealRegister::Unlatched) {
         if (currentAssignedRegister == NULL) {
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         } else {
-            registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, self()->cg());
+            registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, cg());
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
@@ -1063,31 +1057,30 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
 
         // RegisterExchange: GPR/VRF have xor op always, and only CCR has no xor after P6
         bool needTemp = !((ctv_rk == TR_GPR) || (ctv_rk == TR_VRF)
-            || (self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) && ctv_rk != TR_CCR));
+            || (cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX) && ctv_rk != TR_CCR));
 
         if (targetRegister->getState() == TR::RealRegister::Blocked) {
             if ((currentAssignedRegister == NULL) || !currentAssignedUseful || needTemp) {
                 spareReg = self()->findBestFreeRegister(currentInstruction, ctv_rk, false, false, currentTargetVirtual);
 
-                self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+                cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                     virtualRegister->block();
                     spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual);
                     virtualRegister->unblock();
                 }
             }
             if (currentAssignedRegister != NULL && currentAssignedUseful) {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                registerExchange(currentInstruction, ctv_rk, targetRegister, currentAssignedRegister, spareReg,
-                    self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                registerExchange(currentInstruction, ctv_rk, targetRegister, currentAssignedRegister, spareReg, cg());
                 currentAssignedRegister->setState(TR::RealRegister::Blocked);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
                 // spareReg remains FREE, if it is none NULL.
             } else {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-                registerCopy(currentInstruction, ctv_rk, targetRegister, spareReg, self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                registerCopy(currentInstruction, ctv_rk, targetRegister, spareReg, cg());
                 spareReg->setState(TR::RealRegister::Blocked);
                 currentTargetVirtual->setAssignedRegister(spareReg);
                 spareReg->setAssignedRegister(currentTargetVirtual);
@@ -1095,11 +1088,11 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
 
                 if (currentAssignedRegister == NULL) {
                     if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                        self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                        cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                         self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
                     }
                 } else {
-                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, self()->cg());
+                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, cg());
                     currentAssignedRegister->setState(TR::RealRegister::Free);
                     currentAssignedRegister->setAssignedRegister(NULL);
                 }
@@ -1108,31 +1101,31 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
             if ((currentAssignedRegister == NULL) || !currentAssignedUseful || needTemp)
                 spareReg = self()->findBestFreeRegister(currentInstruction, ctv_rk, false, false, currentTargetVirtual);
 
-            self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+            cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
             if (currentAssignedRegister != NULL && currentAssignedUseful) {
                 if (!needTemp || (spareReg != NULL)) {
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                    cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
                     registerExchange(currentInstruction, ctv_rk, targetRegister, currentAssignedRegister, spareReg,
-                        self()->cg());
+                        cg());
                     currentAssignedRegister->setState(TR::RealRegister::Assigned);
                     currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
                     // spareReg is still FREE.
                 } else {
                     self()->freeBestRegister(currentInstruction, currentTargetVirtual, targetRegister);
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
-                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, self()->cg());
+                    cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, cg());
                     currentAssignedRegister->setState(TR::RealRegister::Free);
                     currentAssignedRegister->setAssignedRegister(NULL);
                 }
             } else {
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                     self()->freeBestRegister(currentInstruction, currentTargetVirtual, targetRegister);
                 } else {
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-                    registerCopy(currentInstruction, ctv_rk, targetRegister, spareReg, self()->cg());
+                    cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                    registerCopy(currentInstruction, ctv_rk, targetRegister, spareReg, cg());
                     spareReg->setState(TR::RealRegister::Assigned);
                     spareReg->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(spareReg);
@@ -1141,22 +1134,22 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction *currentInstr
 
                 if (currentAssignedRegister == NULL) {
                     if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                        self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                        cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                         self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
                     }
                 } else {
-                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, self()->cg());
+                    registerCopy(currentInstruction, vr_rk, currentAssignedRegister, targetRegister, cg());
                     currentAssignedRegister->setState(TR::RealRegister::Free);
                     currentAssignedRegister->setAssignedRegister(NULL);
                 }
             }
-            self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+            cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
         }
     }
     targetRegister->setState(TR::RealRegister::Assigned);
     targetRegister->setAssignedRegister(virtualRegister);
     virtualRegister->setAssignedRegister(targetRegister);
-    self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+    cg()->traceRegAssigned(virtualRegister, targetRegister);
 }
 
 void OMR::Power::Machine::initializeRegisterFile()
@@ -1164,320 +1157,320 @@ void OMR::Power::Machine::initializeRegisterFile()
     _registerFile[TR::RealRegister::NoReg] = NULL;
     _registerFile[TR::RealRegister::SpilledReg] = NULL;
 
-    _registerFile[TR::RealRegister::gr0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr0, TR::RealRegister::gr0Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr0, TR::RealRegister::gr0Mask, cg());
 
-    _registerFile[TR::RealRegister::gr1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr1, TR::RealRegister::gr1Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr1, TR::RealRegister::gr1Mask, cg());
 
-    _registerFile[TR::RealRegister::gr2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr2, TR::RealRegister::gr2Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr2, TR::RealRegister::gr2Mask, cg());
 
-    _registerFile[TR::RealRegister::gr3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr3, TR::RealRegister::gr3Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr3, TR::RealRegister::gr3Mask, cg());
 
-    _registerFile[TR::RealRegister::gr4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr4, TR::RealRegister::gr4Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr4, TR::RealRegister::gr4Mask, cg());
 
-    _registerFile[TR::RealRegister::gr5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr5, TR::RealRegister::gr5Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr5, TR::RealRegister::gr5Mask, cg());
 
-    _registerFile[TR::RealRegister::gr6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr6, TR::RealRegister::gr6Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr6, TR::RealRegister::gr6Mask, cg());
 
-    _registerFile[TR::RealRegister::gr7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr7, TR::RealRegister::gr7Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr7, TR::RealRegister::gr7Mask, cg());
 
-    _registerFile[TR::RealRegister::gr8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr8, TR::RealRegister::gr8Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr8, TR::RealRegister::gr8Mask, cg());
 
-    _registerFile[TR::RealRegister::gr9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr9, TR::RealRegister::gr9Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr9, TR::RealRegister::gr9Mask, cg());
 
-    _registerFile[TR::RealRegister::gr10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr10, TR::RealRegister::gr10Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr10, TR::RealRegister::gr10Mask, cg());
 
-    _registerFile[TR::RealRegister::gr11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr11, TR::RealRegister::gr11Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr11, TR::RealRegister::gr11Mask, cg());
 
-    _registerFile[TR::RealRegister::gr12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr12, TR::RealRegister::gr12Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr12, TR::RealRegister::gr12Mask, cg());
 
-    _registerFile[TR::RealRegister::gr13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr13, TR::RealRegister::gr13Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr13, TR::RealRegister::gr13Mask, cg());
 
-    _registerFile[TR::RealRegister::gr14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr14, TR::RealRegister::gr14Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr14, TR::RealRegister::gr14Mask, cg());
 
-    _registerFile[TR::RealRegister::gr15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr15, TR::RealRegister::gr15Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr15, TR::RealRegister::gr15Mask, cg());
 
-    _registerFile[TR::RealRegister::gr16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr16, TR::RealRegister::gr16Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr16, TR::RealRegister::gr16Mask, cg());
 
-    _registerFile[TR::RealRegister::gr17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr17, TR::RealRegister::gr17Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr17, TR::RealRegister::gr17Mask, cg());
 
-    _registerFile[TR::RealRegister::gr18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr18, TR::RealRegister::gr18Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr18, TR::RealRegister::gr18Mask, cg());
 
-    _registerFile[TR::RealRegister::gr19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr19, TR::RealRegister::gr19Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr19, TR::RealRegister::gr19Mask, cg());
 
-    _registerFile[TR::RealRegister::gr20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr20, TR::RealRegister::gr20Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr20, TR::RealRegister::gr20Mask, cg());
 
-    _registerFile[TR::RealRegister::gr21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr21, TR::RealRegister::gr21Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr21, TR::RealRegister::gr21Mask, cg());
 
-    _registerFile[TR::RealRegister::gr22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr22, TR::RealRegister::gr22Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr22, TR::RealRegister::gr22Mask, cg());
 
-    _registerFile[TR::RealRegister::gr23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr23, TR::RealRegister::gr23Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr23, TR::RealRegister::gr23Mask, cg());
 
-    _registerFile[TR::RealRegister::gr24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr24, TR::RealRegister::gr24Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr24, TR::RealRegister::gr24Mask, cg());
 
-    _registerFile[TR::RealRegister::gr25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr25, TR::RealRegister::gr25Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr25, TR::RealRegister::gr25Mask, cg());
 
-    _registerFile[TR::RealRegister::gr26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr26, TR::RealRegister::gr26Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr26, TR::RealRegister::gr26Mask, cg());
 
-    _registerFile[TR::RealRegister::gr27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr27, TR::RealRegister::gr27Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr27, TR::RealRegister::gr27Mask, cg());
 
-    _registerFile[TR::RealRegister::gr28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr28, TR::RealRegister::gr28Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr28, TR::RealRegister::gr28Mask, cg());
 
-    _registerFile[TR::RealRegister::gr29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr29, TR::RealRegister::gr29Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr29, TR::RealRegister::gr29Mask, cg());
 
-    _registerFile[TR::RealRegister::gr30] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr30, TR::RealRegister::gr30Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr30] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr30, TR::RealRegister::gr30Mask, cg());
 
-    _registerFile[TR::RealRegister::gr31] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::gr31, TR::RealRegister::gr31Mask, self()->cg());
+    _registerFile[TR::RealRegister::gr31] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::gr31, TR::RealRegister::gr31Mask, cg());
 
-    _registerFile[TR::RealRegister::fp0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp0, TR::RealRegister::fp0Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp0, TR::RealRegister::fp0Mask, cg());
 
-    _registerFile[TR::RealRegister::fp1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp1, TR::RealRegister::fp1Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp1, TR::RealRegister::fp1Mask, cg());
 
-    _registerFile[TR::RealRegister::fp2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp2, TR::RealRegister::fp2Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp2, TR::RealRegister::fp2Mask, cg());
 
-    _registerFile[TR::RealRegister::fp3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp3, TR::RealRegister::fp3Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp3, TR::RealRegister::fp3Mask, cg());
 
-    _registerFile[TR::RealRegister::fp4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp4, TR::RealRegister::fp4Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp4, TR::RealRegister::fp4Mask, cg());
 
-    _registerFile[TR::RealRegister::fp5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp5, TR::RealRegister::fp5Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp5, TR::RealRegister::fp5Mask, cg());
 
-    _registerFile[TR::RealRegister::fp6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp6, TR::RealRegister::fp6Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp6, TR::RealRegister::fp6Mask, cg());
 
-    _registerFile[TR::RealRegister::fp7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp7, TR::RealRegister::fp7Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp7, TR::RealRegister::fp7Mask, cg());
 
-    _registerFile[TR::RealRegister::fp8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp8, TR::RealRegister::fp8Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp8, TR::RealRegister::fp8Mask, cg());
 
-    _registerFile[TR::RealRegister::fp9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp9, TR::RealRegister::fp9Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp9, TR::RealRegister::fp9Mask, cg());
 
-    _registerFile[TR::RealRegister::fp10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp10, TR::RealRegister::fp10Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp10, TR::RealRegister::fp10Mask, cg());
 
-    _registerFile[TR::RealRegister::fp11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp11, TR::RealRegister::fp11Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp11, TR::RealRegister::fp11Mask, cg());
 
-    _registerFile[TR::RealRegister::fp12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp12, TR::RealRegister::fp12Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp12, TR::RealRegister::fp12Mask, cg());
 
-    _registerFile[TR::RealRegister::fp13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp13, TR::RealRegister::fp13Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp13, TR::RealRegister::fp13Mask, cg());
 
-    _registerFile[TR::RealRegister::fp14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp14, TR::RealRegister::fp14Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp14, TR::RealRegister::fp14Mask, cg());
 
-    _registerFile[TR::RealRegister::fp15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp15, TR::RealRegister::fp15Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp15, TR::RealRegister::fp15Mask, cg());
 
-    _registerFile[TR::RealRegister::fp16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp16, TR::RealRegister::fp16Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp16, TR::RealRegister::fp16Mask, cg());
 
-    _registerFile[TR::RealRegister::fp17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp17, TR::RealRegister::fp17Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp17, TR::RealRegister::fp17Mask, cg());
 
-    _registerFile[TR::RealRegister::fp18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp18, TR::RealRegister::fp18Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp18, TR::RealRegister::fp18Mask, cg());
 
-    _registerFile[TR::RealRegister::fp19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp19, TR::RealRegister::fp19Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp19, TR::RealRegister::fp19Mask, cg());
 
-    _registerFile[TR::RealRegister::fp20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp20, TR::RealRegister::fp20Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp20, TR::RealRegister::fp20Mask, cg());
 
-    _registerFile[TR::RealRegister::fp21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp21, TR::RealRegister::fp21Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp21, TR::RealRegister::fp21Mask, cg());
 
-    _registerFile[TR::RealRegister::fp22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp22, TR::RealRegister::fp22Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp22, TR::RealRegister::fp22Mask, cg());
 
-    _registerFile[TR::RealRegister::fp23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp23, TR::RealRegister::fp23Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp23, TR::RealRegister::fp23Mask, cg());
 
-    _registerFile[TR::RealRegister::fp24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp24, TR::RealRegister::fp24Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp24, TR::RealRegister::fp24Mask, cg());
 
-    _registerFile[TR::RealRegister::fp25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp25, TR::RealRegister::fp25Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp25, TR::RealRegister::fp25Mask, cg());
 
-    _registerFile[TR::RealRegister::fp26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp26, TR::RealRegister::fp26Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp26, TR::RealRegister::fp26Mask, cg());
 
-    _registerFile[TR::RealRegister::fp27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp27, TR::RealRegister::fp27Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp27, TR::RealRegister::fp27Mask, cg());
 
-    _registerFile[TR::RealRegister::fp28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp28, TR::RealRegister::fp28Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp28, TR::RealRegister::fp28Mask, cg());
 
-    _registerFile[TR::RealRegister::fp29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp29, TR::RealRegister::fp29Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp29, TR::RealRegister::fp29Mask, cg());
 
-    _registerFile[TR::RealRegister::fp30] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp30, TR::RealRegister::fp30Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp30] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp30, TR::RealRegister::fp30Mask, cg());
 
-    _registerFile[TR::RealRegister::fp31] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::fp31, TR::RealRegister::fp31Mask, self()->cg());
+    _registerFile[TR::RealRegister::fp31] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::fp31, TR::RealRegister::fp31Mask, cg());
 
-    _registerFile[TR::RealRegister::cr0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr0, TR::RealRegister::cr0Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr0, TR::RealRegister::cr0Mask, cg());
 
-    _registerFile[TR::RealRegister::cr1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr1, TR::RealRegister::cr1Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr1, TR::RealRegister::cr1Mask, cg());
 
-    _registerFile[TR::RealRegister::cr2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr2, TR::RealRegister::cr2Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr2, TR::RealRegister::cr2Mask, cg());
 
-    _registerFile[TR::RealRegister::cr3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr3, TR::RealRegister::cr3Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr3, TR::RealRegister::cr3Mask, cg());
 
-    _registerFile[TR::RealRegister::cr4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr4, TR::RealRegister::cr4Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr4, TR::RealRegister::cr4Mask, cg());
 
-    _registerFile[TR::RealRegister::cr5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr5, TR::RealRegister::cr5Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr5, TR::RealRegister::cr5Mask, cg());
 
-    _registerFile[TR::RealRegister::cr6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr6, TR::RealRegister::cr6Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr6, TR::RealRegister::cr6Mask, cg());
 
-    _registerFile[TR::RealRegister::cr7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_CCR, 0,
-        TR::RealRegister::Free, TR::RealRegister::cr7, TR::RealRegister::cr7Mask, self()->cg());
+    _registerFile[TR::RealRegister::cr7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_CCR, 0, TR::RealRegister::Free, TR::RealRegister::cr7, TR::RealRegister::cr7Mask, cg());
 
-    _registerFile[TR::RealRegister::lr] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::lr, TR::RealRegister::noRegMask, self()->cg());
+    _registerFile[TR::RealRegister::lr] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::lr, TR::RealRegister::noRegMask, cg());
 
-    _registerFile[TR::RealRegister::vr0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr0, TR::RealRegister::vr0Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr0, TR::RealRegister::vr0Mask, cg());
 
-    _registerFile[TR::RealRegister::vr1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr1, TR::RealRegister::vr1Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr1, TR::RealRegister::vr1Mask, cg());
 
-    _registerFile[TR::RealRegister::vr2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr2, TR::RealRegister::vr2Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr2, TR::RealRegister::vr2Mask, cg());
 
-    _registerFile[TR::RealRegister::vr3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr3, TR::RealRegister::vr3Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr3, TR::RealRegister::vr3Mask, cg());
 
-    _registerFile[TR::RealRegister::vr4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr4, TR::RealRegister::vr4Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr4, TR::RealRegister::vr4Mask, cg());
 
-    _registerFile[TR::RealRegister::vr5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr5, TR::RealRegister::vr5Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr5, TR::RealRegister::vr5Mask, cg());
 
-    _registerFile[TR::RealRegister::vr6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr6, TR::RealRegister::vr6Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr6, TR::RealRegister::vr6Mask, cg());
 
-    _registerFile[TR::RealRegister::vr7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr7, TR::RealRegister::vr7Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr7, TR::RealRegister::vr7Mask, cg());
 
-    _registerFile[TR::RealRegister::vr8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr8, TR::RealRegister::vr8Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr8, TR::RealRegister::vr8Mask, cg());
 
-    _registerFile[TR::RealRegister::vr9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr9, TR::RealRegister::vr9Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr9, TR::RealRegister::vr9Mask, cg());
 
-    _registerFile[TR::RealRegister::vr10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr10, TR::RealRegister::vr10Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr10, TR::RealRegister::vr10Mask, cg());
 
-    _registerFile[TR::RealRegister::vr11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr11, TR::RealRegister::vr11Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr11, TR::RealRegister::vr11Mask, cg());
 
-    _registerFile[TR::RealRegister::vr12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr12, TR::RealRegister::vr12Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr12, TR::RealRegister::vr12Mask, cg());
 
-    _registerFile[TR::RealRegister::vr13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr13, TR::RealRegister::vr13Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr13, TR::RealRegister::vr13Mask, cg());
 
-    _registerFile[TR::RealRegister::vr14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr14, TR::RealRegister::vr14Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr14, TR::RealRegister::vr14Mask, cg());
 
-    _registerFile[TR::RealRegister::vr15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr15, TR::RealRegister::vr15Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr15, TR::RealRegister::vr15Mask, cg());
 
-    _registerFile[TR::RealRegister::vr16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr16, TR::RealRegister::vr16Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr16, TR::RealRegister::vr16Mask, cg());
 
-    _registerFile[TR::RealRegister::vr17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr17, TR::RealRegister::vr17Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr17, TR::RealRegister::vr17Mask, cg());
 
-    _registerFile[TR::RealRegister::vr18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr18, TR::RealRegister::vr18Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr18, TR::RealRegister::vr18Mask, cg());
 
-    _registerFile[TR::RealRegister::vr19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr19, TR::RealRegister::vr19Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr19, TR::RealRegister::vr19Mask, cg());
 
-    _registerFile[TR::RealRegister::vr20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr20, TR::RealRegister::vr20Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr20, TR::RealRegister::vr20Mask, cg());
 
-    _registerFile[TR::RealRegister::vr21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr21, TR::RealRegister::vr21Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr21, TR::RealRegister::vr21Mask, cg());
 
-    _registerFile[TR::RealRegister::vr22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr22, TR::RealRegister::vr22Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr22, TR::RealRegister::vr22Mask, cg());
 
-    _registerFile[TR::RealRegister::vr23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr23, TR::RealRegister::vr23Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr23, TR::RealRegister::vr23Mask, cg());
 
-    _registerFile[TR::RealRegister::vr24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr24, TR::RealRegister::vr24Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr24, TR::RealRegister::vr24Mask, cg());
 
-    _registerFile[TR::RealRegister::vr25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr25, TR::RealRegister::vr25Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr25, TR::RealRegister::vr25Mask, cg());
 
-    _registerFile[TR::RealRegister::vr26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr26, TR::RealRegister::vr26Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr26, TR::RealRegister::vr26Mask, cg());
 
-    _registerFile[TR::RealRegister::vr27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr27, TR::RealRegister::vr27Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr27, TR::RealRegister::vr27Mask, cg());
 
-    _registerFile[TR::RealRegister::vr28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr28, TR::RealRegister::vr28Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr28, TR::RealRegister::vr28Mask, cg());
 
-    _registerFile[TR::RealRegister::vr29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr29, TR::RealRegister::vr29Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr29, TR::RealRegister::vr29Mask, cg());
 
-    _registerFile[TR::RealRegister::vr30] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr30, TR::RealRegister::vr30Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr30] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr30, TR::RealRegister::vr30Mask, cg());
 
-    _registerFile[TR::RealRegister::vr31] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::vr31, TR::RealRegister::vr31Mask, self()->cg());
+    _registerFile[TR::RealRegister::vr31] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::vr31, TR::RealRegister::vr31Mask, cg());
 }
 
 static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds rk, TR::RealRegister *targetReg,
@@ -1562,7 +1555,7 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 
 bool OMR::Power::Machine::setLinkRegisterKilled(bool b)
 {
-    TR_ASSERT(self()->cg()->getCurrentEvaluationBlock(), "No current block info\n");
+    TR_ASSERT(cg()->getCurrentEvaluationBlock(), "No current block info\n");
     return _registerFile[TR::RealRegister::lr]->setHasBeenAssignedInMethod(b);
 }
 
@@ -1590,7 +1583,7 @@ TR::RegisterDependencyConditions *OMR::Power::Machine::createCondForLiveAndSpill
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
+        deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
         for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++) {
             TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
             if (realReg->getState() == TR::RealRegister::Assigned) {
@@ -1603,7 +1596,7 @@ TR::RegisterDependencyConditions *OMR::Power::Machine::createCondForLiveAndSpill
 
                 virtReg->incTotalUseCount();
                 virtReg->incFutureUseCount();
-                if (self()->cg()->isOutOfLineColdPath())
+                if (cg()->isOutOfLineColdPath())
                     virtReg->incOutOfLineUseCount();
                 virtReg->setAssignedRegister(NULL);
                 realReg->setAssignedRegister(NULL);
@@ -1703,7 +1696,7 @@ void OMR::Power::Machine::decFutureUseCountAndUnlatch(TR::Register *virtualRegis
     bool trace = comp->getOption(TR_TraceRA);
 
     virtualRegister->decFutureUseCount();
-    if (self()->cg()->isOutOfLineColdPath())
+    if (cg->isOutOfLineColdPath())
         virtualRegister->decOutOfLineUseCount();
 
     TR_ASSERT(virtualRegister->getFutureUseCount() >= virtualRegister->getOutOfLineUseCount(),
@@ -1718,11 +1711,11 @@ void OMR::Power::Machine::decFutureUseCountAndUnlatch(TR::Register *virtualRegis
     // will revive the register and proceed to allocate registers in the outlined code,
     // where presumably the future use count will finally hit 0.
     if (virtualRegister->getFutureUseCount() == 0
-        || (self()->cg()->isOutOfLineHotPath()
+        || (cg->isOutOfLineHotPath()
             && virtualRegister->getFutureUseCount() == virtualRegister->getOutOfLineUseCount())) {
         if (virtualRegister->getFutureUseCount() != 0) {
             logprintf(trace, log, "\nOOL: %s's remaining uses are out-of-line, unlatching\n",
-                self()->cg()->getDebug()->getName(virtualRegister));
+                cg->getDebug()->getName(virtualRegister));
         }
         virtualRegister->getAssignedRealRegister()->setState(TR::RealRegister::Unlatched);
         virtualRegister->setAssignedRegister(NULL);
@@ -1732,7 +1725,7 @@ void OMR::Power::Machine::decFutureUseCountAndUnlatch(TR::Register *virtualRegis
     // we need to free its backing store, if any, otherwise we will not have
     // any future opportunity to do so and the backing store will never be re-used.
     TR_BackingStore *location = virtualRegister->getBackingStorage();
-    if (virtualRegister->getFutureUseCount() == 0 && location != NULL && self()->cg()->isOutOfLineColdPath()) {
+    if (virtualRegister->getFutureUseCount() == 0 && location != NULL && cg->isOutOfLineColdPath()) {
         TR_ASSERT(cg->isFreeSpillListLocked(), "Expecting the free spill list to be locked on this path");
         int32_t size = spillSizeForRegister(virtualRegister);
         logprintf(trace, log, "\nFreeing backing storage " POINTER_PRINTF_FORMAT " of size %u from dead virtual %s\n",

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1092,36 +1092,36 @@ static void fillFieldIMM8(TR::Instruction *instr, uint32_t *cursor, uint32_t val
 
 uint8_t *OMR::Power::Instruction::generateBinaryEncoding()
 {
-    uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
+    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = instructionStart;
-    TR::InstOpCode &opCode = self()->getOpCode();
+    TR::InstOpCode &opCode = getOpCode();
 
     cursor = opCode.copyBinaryToBuffer(cursor);
     self()->fillBinaryEncodingFields(reinterpret_cast<uint32_t *>(cursor));
 
     cursor += opCode.getBinaryLength();
 
-    TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), (cursor - instructionStart) <= self()->getEstimatedBinaryLength(),
-        "Estimated binary length was %u bytes, but actual length was %u bytes", self()->getEstimatedBinaryLength(),
+    TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), (cursor - instructionStart) <= getEstimatedBinaryLength(),
+        "Estimated binary length was %u bytes, but actual length was %u bytes", getEstimatedBinaryLength(),
         static_cast<uint32_t>(cursor - instructionStart));
 
-    self()->setBinaryLength(cursor - instructionStart);
-    self()->setBinaryEncoding(instructionStart);
+    setBinaryLength(cursor - instructionStart);
+    setBinaryEncoding(instructionStart);
 
     return cursor;
 }
 
 void OMR::Power::Instruction::fillBinaryEncodingFields(uint32_t *cursor)
 {
-    switch (self()->getOpCode().getFormat()) {
+    switch (getOpCode().getFormat()) {
         case FORMAT_NONE:
             break;
 
         case FORMAT_DIRECT:
         case FORMAT_DIRECT_PREFIXED:
             // TODO: Split genop into two instructions depending on version of Power in use
-            if (self()->getOpCodeValue() == TR::InstOpCode::genop) {
-                TR::RealRegister *r = self()->cg()->machine()->getRealRegister(
+            if (getOpCodeValue() == TR::InstOpCode::genop) {
+                TR::RealRegister *r = cg()->machine()->getRealRegister(
                     TR::Compiler->target.cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) ? TR::RealRegister::gr2
                                                                              : TR::RealRegister::gr1);
                 fillFieldRA(self(), cursor, r);
@@ -1131,15 +1131,15 @@ void OMR::Power::Instruction::fillBinaryEncodingFields(uint32_t *cursor)
 
         default:
             TR_ASSERT_FATAL_WITH_INSTRUCTION(self(), false, "Format %d cannot be binary encoded by Instruction",
-                self()->getOpCode().getFormat());
+                getOpCode().getFormat());
     }
 }
 
 int32_t OMR::Power::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    int8_t maxLength = self()->getOpCode().getMaxBinaryLength();
+    int8_t maxLength = getOpCode().getMaxBinaryLength();
 
-    self()->setEstimatedBinaryLength(maxLength);
+    setEstimatedBinaryLength(maxLength);
     return currentEstimate + maxLength;
 }
 
@@ -1180,8 +1180,8 @@ uint8_t *TR::PPCAlignmentNopInstruction::generateBinaryEncoding()
 
 int32_t TR::PPCAlignmentNopInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    self()->setEstimatedBinaryLength(_alignment - PPC_INSTRUCTION_LENGTH);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    setEstimatedBinaryLength(_alignment - PPC_INSTRUCTION_LENGTH);
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 uint8_t TR::PPCAlignmentNopInstruction::getBinaryLengthLowerBound() { return 0; }
@@ -1370,7 +1370,7 @@ int32_t TR::PPCAdminInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
     if (getOpCodeValue() == TR::InstOpCode::proc && cg()->supportsJitMethodEntryAlignment()) {
         cg()->setPreJitMethodEntrySize(currentEstimate);
-        self()->setEstimatedBinaryLength(cg()->getJitMethodEntryAlignmentBoundary() - 1);
+        setEstimatedBinaryLength(cg()->getJitMethodEntryAlignmentBoundary() - 1);
         return currentEstimate + cg()->getJitMethodEntryAlignmentBoundary() - 1;
     } else {
         return self()->TR::Instruction::estimateBinaryLength(currentEstimate);

--- a/compiler/riscv/codegen/OMRInstruction.cpp
+++ b/compiler/riscv/codegen/OMRInstruction.cpp
@@ -64,8 +64,8 @@ OMR::RV::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *preced
 
 void OMR::RV::Instruction::remove()
 {
-    self()->getPrev()->setNext(self()->getNext());
-    self()->getNext()->setPrev(self()->getPrev());
+    getPrev()->setNext(getNext());
+    getNext()->setPrev(getPrev());
 }
 
 void OMR::RV::Instruction::RVNeedsGCMap(TR::CodeGenerator *cg, uint32_t mask)
@@ -102,8 +102,8 @@ void OMR::RV::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
     TR::RegisterDependencyConditions *cond = OMR::RV::Instruction::getDependencyConditions();
     if (cond) {
-        cond->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());
-        cond->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned, self()->cg());
+        cond->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        cond->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 }
 
@@ -116,7 +116,7 @@ uint8_t *OMR::RV::Instruction::generateBinaryEncoding()
 int32_t OMR::RV::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
     setEstimatedBinaryLength(RISCV_INSTRUCTION_LENGTH);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 TR::BtypeInstruction *OMR::RV::Instruction::getBtypeInstruction() { return NULL; }

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -77,7 +77,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
     TR::RealRegister *forced)
 {
     TR::Register *candidates[NUM_RV_MAXR];
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::MemoryReference *tmemref;
     TR_BackingStore *location;
     TR::RealRegister *best;
@@ -153,27 +153,26 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
             // the list. Therefore we need to set the occupied flag for this reuse.
             location->setIsOccupied();
         } else {
-            location = self()->cg()->allocateSpill(dataSize, containsCollectedReference, NULL);
+            location = cg()->allocateSpill(dataSize, containsCollectedReference, NULL);
         }
     } else {
-        location = self()->cg()->allocateSpill(dataSize, containsCollectedReference, NULL);
+        location = cg()->allocateSpill(dataSize, containsCollectedReference, NULL);
     }
 
     candidates[0]->setBackingStorage(location);
 
-    tmemref = new (self()->cg()->trHeapMemory())
-        TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
+    tmemref = new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, cg());
 
-    if (!self()->cg()->isOutOfLineColdPath()) {
-        TR_Debug *debugObj = self()->cg()->getDebug();
+    if (!cg()->isOutOfLineColdPath()) {
+        TR_Debug *debugObj = cg()->getDebug();
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL cold path, post dependencies will be generated using this list
-        self()->cg()->getSpilledRegisterList()->push_front(candidates[0]);
+        cg()->getSpilledRegisterList()->push_front(candidates[0]);
 
         // OOL cold path: depth = 3, hot path: depth = 2,  main line: depth = 1
         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
         // if we reverse spill this register inside the OOL cold/hot path
-        if (!self()->cg()->isOutOfLineHotPath()) { // main line
+        if (!cg()->isOutOfLineHotPath()) { // main line
             location->setMaxSpillDepth(1);
         } else {
             // hot path
@@ -183,7 +182,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
             }
         }
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
+            cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d ",
                 debugObj->getName(candidates[0]), location->getMaxSpillDepth());
     } else {
         // do not overwrite mainline and hot path spill depth
@@ -191,15 +190,14 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
         // because the post condition at OOL entry does not expect this register to be spilled
         if (location->getMaxSpillDepth() != 1 && location->getMaxSpillDepth() != 2) {
             location->setMaxSpillDepth(3);
-            self()->cg()->traceRegisterAssignment(
-                "OOL: In OOL cold path, spilling %s not adding to spilledRegisterList",
-                (candidates[0])->getRegisterName(self()->cg()->comp()));
+            cg()->traceRegisterAssignment("OOL: In OOL cold path, spilling %s not adding to spilledRegisterList",
+                (candidates[0])->getRegisterName(cg()->comp()));
         }
     }
 
-    if (self()->cg()->comp()->getOption(TR_TraceCG)) {
-        diagnostic("\n\tspilling %s (%s)", best->getAssignedRegister()->getRegisterName(self()->cg()->comp()),
-            best->getRegisterName(self()->cg()->comp()));
+    if (cg()->comp()->getOption(TR_TraceCG)) {
+        diagnostic("\n\tspilling %s (%s)", best->getAssignedRegister()->getRegisterName(cg()->comp()),
+            best->getRegisterName(cg()->comp()));
     }
 
     switch (rk) {
@@ -213,9 +211,9 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    generateLOAD(loadOp, currentNode, best, tmemref, self()->cg(), currentInstruction);
+    generateLOAD(loadOp, currentNode, best, tmemref, cg(), currentInstruction);
 
-    self()->cg()->traceRegFreed(candidates[0], best);
+    cg()->traceRegFreed(candidates[0], best);
 
     best->setAssignedRegister(NULL);
     best->setState(TR::RealRegister::Free);
@@ -226,13 +224,13 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
 TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentInstruction,
     TR::Register *spilledRegister, TR::RealRegister *targetRegister)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::MemoryReference *tmemref;
     TR::RealRegister *sameReg;
     TR_BackingStore *location = spilledRegister->getBackingStorage();
     TR::Node *currentNode = currentInstruction->getNode();
     TR_RegisterKinds rk = spilledRegister->getKind();
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
     int32_t dataSize = 0;
     TR::InstOpCode::Mnemonic storeOp;
 
@@ -244,13 +242,13 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
         targetRegister->setState(TR::RealRegister::Assigned);
     }
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         // the future and total use count might not always reflect register spill state
         // for example a new register assignment in the hot path would cause FC != TC
         // in this case, assign a new register and return
         if (!location) {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
+                cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
                     debugObj->getName(spilledRegister));
             return targetRegister;
         }
@@ -261,8 +259,7 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             targetRegister->getRegisterName(comp));
     }
 
-    tmemref = new (self()->cg()->trHeapMemory())
-        TR::MemoryReference(currentNode, location->getSymbolReference(), 8, self()->cg());
+    tmemref = new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, cg());
 
     switch (rk) {
         case TR_GPR:
@@ -275,7 +272,7 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         bool isOOLentryReverseSpill = false;
         if (currentInstruction->isLabel()) {
             if (((TR::LabelInstruction *)currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream()) {
@@ -299,53 +296,53 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             if (location->getMaxSpillDepth() != 0)
                 location->setMaxSpillDepth(0);
             else if (debugObj)
-                self()->cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
-                                                      "spill on both paths indicated, free spill slot (%p)\n",
+                cg()->traceRegisterAssignment("\nOOL: reverse spill %s in less dominant path (%d / 3), reverse "
+                                              "spill on both paths indicated, free spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
 
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
-    } else if (self()->cg()->isOutOfLineHotPath()) {
+    } else if (cg()->isOutOfLineHotPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
         // Any registers reverse spilled before entering OOL should be removed from the spilled list
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
 
         // Reset maxSpillDepth here so that in the cold path we know to free the spill
         // and so that the spill is not included in future GC points in the hot path while it is protected
         location->setMaxSpillDepth(0);
         if (location->getMaxSpillDepth() == 2) {
-            self()->cg()->freeSpill(location, dataSize, 0);
-            if (!self()->cg()->isFreeSpillListLocked()) {
+            cg()->freeSpill(location, dataSize, 0);
+            if (!cg()->isFreeSpillListLocked()) {
                 spilledRegister->setBackingStorage(NULL);
             }
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
     } else // main line
     {
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         location->setMaxSpillDepth(0);
-        self()->cg()->freeSpill(location, dataSize, 0);
+        cg()->freeSpill(location, dataSize, 0);
 
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     }
@@ -361,7 +358,7 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             break;
     }
 
-    generateSTORE(storeOp, currentNode, tmemref, targetRegister, self()->cg(), currentInstruction);
+    generateSTORE(storeOp, currentNode, tmemref, targetRegister, cg(), currentInstruction);
 
     return targetRegister;
 }
@@ -373,16 +370,16 @@ TR::RealRegister *OMR::RV::Machine::assignOneRegister(TR::Instruction *currentIn
     TR::RealRegister *assignedRegister = virtualRegister->getAssignedRealRegister();
 
     if (assignedRegister == NULL) {
-        self()->cg()->clearRegisterAssignmentFlags();
-        self()->cg()->setRegisterAssignmentFlag(TR_NormalAssignment);
+        cg()->clearRegisterAssignmentFlags();
+        cg()->setRegisterAssignmentFlag(TR_NormalAssignment);
 
         if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-            self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+            cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
             assignedRegister = self()->reverseSpillState(currentInstruction, virtualRegister, NULL);
         } else {
             assignedRegister = self()->findBestFreeRegister(rk, true);
             if (assignedRegister == NULL) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 assignedRegister = self()->freeBestRegister(currentInstruction, virtualRegister, NULL);
             }
         }
@@ -390,7 +387,7 @@ TR::RealRegister *OMR::RV::Machine::assignOneRegister(TR::Instruction *currentIn
         virtualRegister->setAssignedRegister(assignedRegister);
         assignedRegister->setAssignedRegister(virtualRegister);
         assignedRegister->setState(TR::RealRegister::Assigned);
-        self()->cg()->traceRegAssigned(virtualRegister, assignedRegister);
+        cg()->traceRegAssigned(virtualRegister, assignedRegister);
     }
 
     if (virtualRegister->decFutureUseCount() == 0) {
@@ -446,7 +443,7 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruction, TR::Register *virtualRegister,
     TR::RealRegister::RegNum registerNumber)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::RealRegister *targetRegister = _registerFile[registerNumber];
     TR::RealRegister *realReg = virtualRegister->getAssignedRealRegister();
     TR::RealRegister *currentAssignedRegister = realReg ? toRealRegister(realReg) : NULL;
@@ -473,11 +470,11 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
 #endif
         if (currentAssignedRegister == NULL) {
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         } else {
-            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, self()->cg());
+            registerCopy(currentInstruction, rk, currentAssignedRegister, targetRegister, cg());
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
@@ -490,7 +487,7 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
         if (!currentAssignedRegister || rk != TR_GPR) {
             spareReg = self()->findBestFreeRegister(rk);
             if (spareReg == NULL) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 virtualRegister->block();
                 spareReg = self()->freeBestRegister(currentInstruction, currentTargetVirtual);
                 virtualRegister->unblock();
@@ -498,20 +495,20 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
         }
 
         if (currentAssignedRegister) {
-            self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-            registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, self()->cg());
+            cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+            registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, cg());
             currentAssignedRegister->setState(TR::RealRegister::Blocked);
             currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
             currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
             // For Non-GPR, spareReg remains FREE.
         } else {
-            self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-            registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+            cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+            registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
             spareReg->setState(TR::RealRegister::Blocked);
             currentTargetVirtual->setAssignedRegister(spareReg);
             spareReg->setAssignedRegister(currentTargetVirtual);
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             }
             // spareReg is assigned.
@@ -524,14 +521,13 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
 #endif
         spareReg = self()->findBestFreeRegister(rk);
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
         if (currentAssignedRegister != NULL) {
             if ((rk != TR_GPR) && (spareReg == NULL)) {
                 self()->freeBestRegister(currentInstruction, currentTargetVirtual, targetRegister);
             } else {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg,
-                    self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                registerExchange(currentInstruction, rk, targetRegister, currentAssignedRegister, spareReg, cg());
                 currentAssignedRegister->setState(TR::RealRegister::Assigned);
                 currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -539,22 +535,22 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
             }
         } else {
             if (spareReg == NULL) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 self()->freeBestRegister(currentInstruction, currentTargetVirtual, targetRegister);
             } else {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
-                registerCopy(currentInstruction, rk, targetRegister, spareReg, self()->cg());
+                cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                registerCopy(currentInstruction, rk, targetRegister, spareReg, cg());
                 spareReg->setState(TR::RealRegister::Assigned);
                 spareReg->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(spareReg);
                 // spareReg is assigned.
             }
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         }
-        self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
     } else {
 #ifdef DEBUG
         if (comp->getOption(TR_TraceCG))
@@ -565,7 +561,7 @@ void OMR::RV::Machine::coerceRegisterAssignment(TR::Instruction *currentInstruct
     targetRegister->setState(TR::RealRegister::Assigned);
     targetRegister->setAssignedRegister(virtualRegister);
     virtualRegister->setAssignedRegister(targetRegister);
-    self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+    cg()->traceRegAssigned(virtualRegister, targetRegister);
 }
 
 void OMR::RV::Machine::initializeRegisterFile()
@@ -573,9 +569,9 @@ void OMR::RV::Machine::initializeRegisterFile()
     _registerFile[TR::RealRegister::NoReg] = NULL;
     _registerFile[TR::RealRegister::SpilledReg] = NULL;
 
-#define DECLARE_REG(regname, type)                                                \
-    _registerFile[TR::RealRegister::regname] = new (self()->cg()->trHeapMemory()) \
-        TR::RealRegister(type, 0, TR::RealRegister::Free, TR::RealRegister::regname, self()->cg());
+#define DECLARE_REG(regname, type)                                        \
+    _registerFile[TR::RealRegister::regname] = new (cg()->trHeapMemory()) \
+        TR::RealRegister(type, 0, TR::RealRegister::Free, TR::RealRegister::regname, cg());
 #define DECLARE_GPR(regname, abiname, encoding) DECLARE_REG(regname, TR_GPR)
 #define DECLARE_FPR(regname, abiname, encoding) DECLARE_REG(regname, TR_FPR)
 #include <codegen/riscv-regs.h>

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -370,7 +370,7 @@ int32_t TR::BtypeInstruction::estimateBinaryLength(int32_t currentEstimate)
     // expanded to ensure that the binary length estimates are correct.
     setEstimatedBinaryLength(RISCV_INSTRUCTION_LENGTH * 2);
     setEstimatedBinaryLocation(currentEstimate);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 TR::BtypeInstruction *TR::BtypeInstruction::getBtypeInstruction() { return this; }

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -83,13 +83,12 @@ void OMR::X86::Instruction::initialize(TR::CodeGenerator *cg, TR::RegisterDepend
 
 void OMR::X86::Instruction::assumeValidInstruction()
 {
-    TR_ASSERT(!(self()->cg()->comp()->target().is64Bit() && self()->getOpCode().isIA32Only()),
-        "Cannot use invalid AMD64 instructions");
+    TR_ASSERT(!(cg()->comp()->target().is64Bit() && getOpCode().isIA32Only()), "Cannot use invalid AMD64 instructions");
 }
 
 bool OMR::X86::Instruction::isRegRegMove()
 {
-    switch (self()->getOpCodeValue()) {
+    switch (getOpCodeValue()) {
         case TR::InstOpCode::MOVAPSRegReg:
         case TR::InstOpCode::MOVAPDRegReg:
         case TR::InstOpCode::MOVUPSRegReg:
@@ -109,7 +108,7 @@ bool OMR::X86::Instruction::isRegRegMove()
 
 bool OMR::X86::Instruction::isPatchBarrier(TR::CodeGenerator *cg)
 {
-    Kind kind = self()->getKind();
+    Kind kind = getKind();
     return kind == TR::Instruction::IsPatchableCodeAlignment || kind == TR::Instruction::IsBoundaryAvoidance
         || kind == TR::Instruction::IsAlignment;
 }
@@ -122,12 +121,12 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
         return;
     }
 
-    if (self()->getOpCodeValue() != TR::InstOpCode::assocreg) {
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindsToBeAssigned, self()->cg());
-        self()->getDependencyConditions()->assignPreConditionRegisters(self(), kindsToBeAssigned, self()->cg());
-    } else if ((self()->getOpCodeValue() == TR::InstOpCode::assocreg) && self()->cg()->enableRegisterAssociations()) {
+    if (getOpCodeValue() != TR::InstOpCode::assocreg) {
+        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindsToBeAssigned, cg());
+        self()->getDependencyConditions()->assignPreConditionRegisters(self(), kindsToBeAssigned, cg());
+    } else if ((getOpCodeValue() == TR::InstOpCode::assocreg) && cg()->enableRegisterAssociations()) {
         if (kindsToBeAssigned & TR_GPR_Mask) {
-            TR::Machine *machine = self()->cg()->machine();
+            TR::Machine *machine = cg()->machine();
 
             // First traverse the existing associations and remove them
             // so that they don't interfere with the new ones
@@ -158,7 +157,7 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
 
         // Process FPR/XMM associations
         if (kindsToBeAssigned & TR_FPR_Mask) {
-            TR::Machine *machine = self()->cg()->machine();
+            TR::Machine *machine = cg()->machine();
 
             // Clear existing XMM associations
             for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; ++i) {
@@ -221,12 +220,12 @@ void OMR::X86::Instruction::adjustVFPState(TR_VFPState *state, TR::CodeGenerator
 {
     TR::Compilation *comp = cg->comp();
     if (state->_register == TR::RealRegister::esp) {
-        if (self()->getOpCode().isPushOp())
+        if (getOpCode().isPushOp())
             state->_displacement += static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress());
-        else if (self()->getOpCode().isPopOp())
+        else if (getOpCode().isPopOp())
             state->_displacement -= static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress());
-        else if (self()->getOpCodeValue() == TR::InstOpCode::RET || self()->getOpCodeValue() == TR::InstOpCode::RETImm2
-            || self()->getOpCodeValue() == TR::InstOpCode::retn)
+        else if (getOpCodeValue() == TR::InstOpCode::RET || getOpCodeValue() == TR::InstOpCode::RETImm2
+            || getOpCodeValue() == TR::InstOpCode::retn)
             *state = cg->vfpResetInstruction()->getSavedState();
     }
 }
@@ -234,7 +233,7 @@ void OMR::X86::Instruction::adjustVFPState(TR_VFPState *state, TR::CodeGenerator
 void OMR::X86::Instruction::adjustVFPStateForCall(TR_VFPState *state, int32_t vfpAdjustmentForCall,
     TR::CodeGenerator *cg)
 {
-    if (state->_register == TR::RealRegister::esp && self()->getOpCode().isCallOp()) {
+    if (state->_register == TR::RealRegister::esp && getOpCode().isCallOp()) {
         state->_displacement += vfpAdjustmentForCall;
     } else {
         OMR::X86::Instruction::adjustVFPState(state, cg);
@@ -246,14 +245,13 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
     // We assume most instructions modify all registers that appear in their
     // postconditions, with a few exceptions.
     //
-    if (self()->cg()->enableRematerialisation() && self()->getDependencyConditions()
-        && (self()->getOpCodeValue()
+    if (cg()->enableRematerialisation() && self()->getDependencyConditions()
+        && (getOpCodeValue()
             != TR::InstOpCode::assocreg) // reg associations aren't really instructions, so they don't modify anything
-        && (self()->getOpCodeValue()
+        && (getOpCodeValue()
             != TR::InstOpCode::label) // labels must already be handled properly for a variety of reasons
-        && (!self()->getOpCode().isShiftOp())
-        && (!self()->getOpCode().isRotateOp()) // shifts and rotates often have a postcondition on ecx but don't clobber
-                                               // it
+        && (!getOpCode().isShiftOp()) && (!getOpCode().isRotateOp()) // shifts and rotates often have a postcondition on
+                                                                     // ecx but don't clobber it
     ) {
         // Check the live discardable register list to see if this is the first
         // instruction that kills the rematerialisable range of a register.
@@ -264,18 +262,17 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
             TR::Register *reg = post->getRegisterDependency(i)->getRegister();
             if (reg->isDiscardable()) {
                 if (!clob) {
-                    clob = new (self()->cg()->trHeapMemory())
-                        TR::ClobberingInstruction(self(), self()->cg()->trMemory());
-                    self()->cg()->addClobberingInstruction(clob);
+                    clob = new (cg()->trHeapMemory()) TR::ClobberingInstruction(self(), cg()->trMemory());
+                    cg()->addClobberingInstruction(clob);
                 }
                 clob->addClobberedRegister(reg);
-                self()->cg()->removeLiveDiscardableRegister(reg);
-                self()->cg()->clobberLiveDependentDiscardableRegisters(clob, reg);
+                cg()->removeLiveDiscardableRegister(reg);
+                cg()->clobberLiveDependentDiscardableRegisters(clob, reg);
 
                 if (debug("dumpRemat"))
                     diagnostic("---> Clobbering %s discardable postcondition register %s at instruction %s\n",
-                        self()->cg()->getDebug()->toString(reg->getRematerializationInfo()),
-                        self()->cg()->getDebug()->getName(reg), self()->cg()->getDebug()->getName(self()));
+                        cg()->getDebug()->toString(reg->getRematerializationInfo()), cg()->getDebug()->getName(reg),
+                        cg()->getDebug()->getName(self()));
             }
         }
     }
@@ -284,7 +281,7 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
 #if defined(TR_TARGET_64BIT)
 uint8_t OMR::X86::Instruction::operandSizeRexBits() // Rex bits indicating 32/64-bit operand sizes
 {
-    if (self()->getOpCode().info().rex_w)
+    if (getOpCode().info().rex_w)
         return TR::RealRegister::REX | TR::RealRegister::REX_W;
     else
         return 0;
@@ -293,7 +290,7 @@ uint8_t OMR::X86::Instruction::operandSizeRexBits() // Rex bits indicating 32/64
 uint8_t OMR::X86::Instruction::rexBits() { return self()->operandSizeRexBits(); }
 #endif
 
-bool OMR::X86::Instruction::isLabel() { return self()->getOpCodeValue() == TR::InstOpCode::label; }
+bool OMR::X86::Instruction::isLabel() { return getOpCodeValue() == TR::InstOpCode::label; }
 
 uint8_t *OMR::X86::Instruction::generateRepeatedRexPrefix(uint8_t *cursor)
 {

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -108,7 +108,7 @@ public:
 
     virtual Kind getKind() { return IsNotExtended; }
 
-    OMR::X86::Encoding getEncodingMethod() { return _encodingMethod; }
+    OMR_FINAL OMR::X86::Encoding getEncodingMethod() { return _encodingMethod; }
 
     void setEncodingMethod(OMR::X86::Encoding method) { _encodingMethod = method; }
 
@@ -167,14 +167,14 @@ public:
     // Number of unnecessary REX bytes for instruction expansion and/or padding
     uint8_t rexRepeatCount();
     // Only repeated REX bytes for expansion/padding are generated
-    uint8_t *generateRepeatedRexPrefix(uint8_t *cursor);
+    OMR_FINAL uint8_t *generateRepeatedRexPrefix(uint8_t *cursor);
 
 #if defined(TR_TARGET_64BIT)
     uint8_t operandSizeRexBits();
     // Each subclass should override this as necessary
     virtual uint8_t rexBits();
 #else
-    uint8_t rexBits() { return 0; }
+    OMR_FINAL uint8_t rexBits() { return 0; }
 #endif
 
     // Adjust the VFP state to reflect the execution of this instruction.

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -189,7 +189,7 @@ void OMR::X86::Machine::resetXMMGlobalRegisters()
         self()->setXMMGlobalRegister(i, NULL);
 }
 
-TR_Debug *OMR::X86::Machine::getDebug() { return self()->cg()->getDebug(); }
+TR_Debug *OMR::X86::Machine::getDebug() { return cg()->getDebug(); }
 
 int32_t OMR::X86::Machine::getGlobalReg(TR::RealRegister::RegNum reg)
 {
@@ -217,9 +217,9 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
                             || virtReg->getKind() == TR_VMR)),
         "OMR::X86::Machine::findBestFreeGPRegister() ==> Unexpected register kind!");
 
-    bool useRegisterAssociations = self()->cg()->enableRegisterAssociations() ? true : false;
-    bool useRegisterInterferences = self()->cg()->enableRegisterInterferences() ? true : false;
-    bool useRegisterWeights = self()->cg()->enableRegisterWeights() ? true : false;
+    bool useRegisterAssociations = cg()->enableRegisterAssociations() ? true : false;
+    bool useRegisterInterferences = cg()->enableRegisterInterferences() ? true : false;
+    bool useRegisterWeights = cg()->enableRegisterWeights() ? true : false;
 
     if (useRegisterAssociations && virtReg->getAssociation() != TR::RealRegister::NoReg
         && self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)virtReg->getAssociation()) == virtReg
@@ -228,7 +228,7 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
                 && _registerFile[virtReg->getAssociation()]->getState() == TR::RealRegister::Unlatched))) {
         if (_registerFile[virtReg->getAssociation()]->getState() != TR::RealRegister::Locked) {
             if (requestedRegSize != TR_ByteReg || virtReg->getAssociation() <= TR::RealRegister::Last8BitGPR) {
-                self()->cg()->setRegisterAssignmentFlag(TR_ByAssociation);
+                cg()->setRegisterAssignmentFlag(TR_ByAssociation);
                 return _registerFile[virtReg->getAssociation()];
             }
         }
@@ -273,13 +273,13 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
     TR_RegisterMask interference = virtReg->getInterference();
     TR_RegisterMask byteRegisterInterference = interference & 0x80000000;
     TR::RealRegister *freeRegister = NULL;
-    const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
+    const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
     for (i = first; i <= last; i++) {
         // Don't consider registers that can't be assigned.
         //
         if (_registerFile[i]->getState() == TR::RealRegister::Locked) {
-            self()->cg()->traceRegWeight(_registerFile[i], 0xdead1);
+            cg()->traceRegWeight(_registerFile[i], 0xdead1);
             interference >>= 1;
             continue;
         }
@@ -327,7 +327,7 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
         if (((_registerFile[i]->getAssignedRegister() == NULL
                  && _registerFile[i]->getState() != TR::RealRegister::Blocked)
                 || (considerUnlatched && _registerFile[i]->getState() == TR::RealRegister::Unlatched))) {
-            self()->cg()->traceRegWeight(_registerFile[i], weight);
+            cg()->traceRegWeight(_registerFile[i], weight);
 
             if (weight < bestWeightSoFar) {
                 freeRegister = _registerFile[i];
@@ -343,9 +343,9 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
                 }
             }
         } else if (_registerFile[i]->getAssignedRegister() == NULL)
-            self()->cg()->traceRegWeight(_registerFile[i], 0xdead2);
+            cg()->traceRegWeight(_registerFile[i], 0xdead2);
         else
-            self()->cg()->traceRegWeight(_registerFile[i], 0xdead3);
+            cg()->traceRegWeight(_registerFile[i], 0xdead3);
 
         interference >>= 1;
     }
@@ -365,7 +365,7 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
 
             for (i = 0; i < numCandidates; i++) {
                 if (cursor->refsRegister(candidates[i]._virtual)) {
-                    self()->cg()->traceRegInterference(virtReg, candidates[i]._virtual, distance);
+                    cg()->traceRegInterference(virtReg, candidates[i]._virtual, distance);
                     candidates[i] = candidates[--numCandidates];
                 }
             }
@@ -396,10 +396,10 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
     int32_t i, j;
     TR::RealRegister *realReg;
 
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
-    bool useRegisterInterferences = self()->cg()->enableRegisterInterferences() ? true : false;
-    bool enableRematerialisation = self()->cg()->enableRematerialisation() && virtReg->getKind() != TR_VMR;
+    bool useRegisterInterferences = cg()->enableRegisterInterferences() ? true : false;
+    bool enableRematerialisation = cg()->enableRematerialisation() && virtReg->getKind() != TR_VMR;
     // rematerialisation not supported for vector masks
 
     TR_ASSERT_FATAL(virtReg
@@ -449,10 +449,9 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
         "interfering register" };
 
     if (targetRegister)
-        self()->cg()->traceRegisterAssignment("Spill candidates for %R (target %R):", virtReg,
-            _registerFile[targetRegister]);
+        cg()->traceRegisterAssignment("Spill candidates for %R (target %R):", virtReg, _registerFile[targetRegister]);
     else
-        self()->cg()->traceRegisterAssignment("Spill candidates for %R:", virtReg);
+        cg()->traceRegisterAssignment("Spill candidates for %R:", virtReg);
 
     for (i = 0; i < NumBestRegisters; i++) {
         bestRegisters[i] = NULL;
@@ -490,8 +489,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
         // virtual itself as a spill candidate.
         //
         TR_ASSERT_FATAL(considerVirtAsSpillCandidate,
-            "freeBestGPRegister(): could not find any GPR spill candidates for %s\n",
-            self()->getDebug()->getName(virtReg));
+            "freeBestGPRegister(): could not find any GPR spill candidates for %s\n", getDebug()->getName(virtReg));
 
         bestRegister = virtReg;
     }
@@ -535,7 +533,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                     realReg = toRealRegister(candidates[j]->getAssignedRegister());
                     if (realReg->getRegisterNumber() == virtReg->getAssociation()) {
                         bestRegister = candidates[j];
-                        self()->cg()->setRegisterAssignmentFlag(TR_ByAssociation);
+                        cg()->setRegisterAssignmentFlag(TR_ByAssociation);
                         goto done; // Rude exit
                     }
                 }
@@ -570,8 +568,8 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                         if (debug("dumpRemat")) {
                             diagnostic("---> Identified %s rematerialisation spill "
                                        "candidate %s at instruction %s in %s\n",
-                                self()->getDebug()->toString(info), self()->getDebug()->getName(candidates[i]),
-                                self()->getDebug()->getName(currentInstruction), comp->signature());
+                                getDebug()->toString(info), getDebug()->getName(candidates[i]),
+                                getDebug()->getName(currentInstruction), comp->signature());
                         }
                     } else {
                         if (useRegisterInterferences) {
@@ -654,8 +652,8 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
     if (bestType >= 0) {
         for (i = 0; i < NumBestRegisters; i++) {
             if (bestRegisters[i])
-                self()->cg()->traceRegisterAssignment("   (best %s %R at distance %d)", bestRegisters[i],
-                    bestRegisterTypes[i], bestDistances[i]);
+                cg()->traceRegisterAssignment("   (best %s %R at distance %d)", bestRegisters[i], bestRegisterTypes[i],
+                    bestDistances[i]);
         }
 
         // See if there is a candidate with higher priority close enough to the
@@ -689,7 +687,7 @@ done:
         vmrSpillOpcode = TR::InstOpCode::KMOVWMaskMem;
         vmrStoreSize = 2;
 
-        if (cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512BW)) {
+        if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512BW)) {
             vmrSpillOpcode = TR::InstOpCode::KMOVQMaskMem;
             vmrStoreSize = 8;
         }
@@ -699,43 +697,39 @@ done:
         TR_RematerializationInfo *info = bestDiscardableRegister->getRematerializationInfo();
 
         if (info->isRematerializableFromMemory()) {
-            TR::MemoryReference *tempMR = generateX86MemoryReference(info->getSymbolReference(), self()->cg());
+            TR::MemoryReference *tempMR = generateX86MemoryReference(info->getSymbolReference(), cg());
 
             if (info->isIndirect()) {
                 TR_ASSERT(info->getBaseRegister()->getAssignedRegister(),
                     "base register %s of dependent rematerialisable register %s must be assigned\n",
-                    self()->getDebug()->getName(info->getBaseRegister()),
-                    self()->getDebug()->getName(bestDiscardableRegister));
+                    getDebug()->getName(info->getBaseRegister()), getDebug()->getName(bestDiscardableRegister));
 
                 tempMR->setBaseRegister(info->getBaseRegister()->getAssignedRegister());
             }
 
             if (info->getDataType() == TR_RematerializableFloat) {
-                instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::MOVSSRegMem, best, tempMR,
-                    self()->cg());
+                instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::MOVSSRegMem, best, tempMR, cg());
             } else {
-                instr = TR::TreeEvaluator::insertLoadMemory(0, best, tempMR, info->getDataType(), self()->cg(),
+                instr = TR::TreeEvaluator::insertLoadMemory(0, best, tempMR, info->getDataType(), cg(),
                     currentInstruction);
             }
         } else if (info->isRematerializableFromAddress()) {
-            TR::MemoryReference *tempMR = generateX86MemoryReference(info->getSymbolReference(), self()->cg());
-            instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::LEARegMem(), best, tempMR,
-                self()->cg());
+            TR::MemoryReference *tempMR = generateX86MemoryReference(info->getSymbolReference(), cg());
+            instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::LEARegMem(), best, tempMR, cg());
         } else {
             if (info->getDataType() == TR_RematerializableFloat) {
                 TR::MemoryReference *tempMR
-                    = generateX86MemoryReference(self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(),
+                    = generateX86MemoryReference(cg()->findOrCreate4ByteConstant(currentInstruction->getNode(),
                                                      static_cast<int32_t>(info->getConstant())),
-                        self()->cg());
-                instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::MOVSSRegMem, best, tempMR,
-                    self()->cg());
+                        cg());
+                instr = generateRegMemInstruction(currentInstruction, TR::InstOpCode::MOVSSRegMem, best, tempMR, cg());
             } else {
-                instr = TR::TreeEvaluator::insertLoadConstant(0, best, info->getConstant(), info->getDataType(),
-                    self()->cg(), currentInstruction);
+                instr = TR::TreeEvaluator::insertLoadConstant(0, best, info->getConstant(), info->getDataType(), cg(),
+                    currentInstruction);
             }
         }
 
-        self()->cg()->traceRAInstruction(instr);
+        cg()->traceRAInstruction(instr);
         if (comp->getDebug())
             comp->getDebug()->addInstructionComment(instr, "$REMAT");
 
@@ -745,12 +739,11 @@ done:
         if (debug("dumpRemat")) {
             if (info->isIndirect())
                 diagnostic("---> Spilling %s rematerialisable register %s (type %d, base %s)\n",
-                    self()->getDebug()->toString(info), self()->getDebug()->getName(bestDiscardableRegister),
-                    info->getDataType(), self()->getDebug()->getName(info->getBaseRegister()));
+                    getDebug()->toString(info), getDebug()->getName(bestDiscardableRegister), info->getDataType(),
+                    getDebug()->getName(info->getBaseRegister()));
             else
-                diagnostic("---> Spilling %s rematerialisable register %s (type %d)\n",
-                    self()->getDebug()->toString(info), self()->getDebug()->getName(bestDiscardableRegister),
-                    info->getDataType());
+                diagnostic("---> Spilling %s rematerialisable register %s (type %d)\n", getDebug()->toString(info),
+                    getDebug()->getName(bestDiscardableRegister), info->getDataType());
         }
     } else {
         bool containsInternalPointer = false;
@@ -766,7 +759,7 @@ done:
                 //
                 location = bestRegister->getBackingStorage();
             } else {
-                location = self()->cg()->allocateSpill(bestRegister->isSinglePrecision() ? 4 : 8, false, &offset);
+                location = cg()->allocateSpill(bestRegister->isSinglePrecision() ? 4 : 8, false, &offset);
             }
         } else if ((bestRegister->getKind() == TR_VRF)) {
             if (bestRegister->getBackingStorage()) {
@@ -775,9 +768,9 @@ done:
                 //
                 location = bestRegister->getBackingStorage();
             } else {
-                int32_t size = self()->cg()->comp()->target().cpu.supportsAVX() ? 32 : 16;
-                size = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 64 : size;
-                location = self()->cg()->allocateSpill(size, false, &offset);
+                int32_t size = comp->target().cpu.supportsAVX() ? 32 : 16;
+                size = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 64 : size;
+                location = cg()->allocateSpill(size, false, &offset);
             }
         } else if ((bestRegister->getKind() == TR_VMR)) {
             if (bestRegister->getBackingStorage()) {
@@ -786,7 +779,7 @@ done:
                 //
                 location = bestRegister->getBackingStorage();
             } else {
-                location = self()->cg()->allocateSpill(vmrStoreSize, false, &offset);
+                location = cg()->allocateSpill(vmrStoreSize, false, &offset);
             }
         } else {
             if (containsInternalPointer) {
@@ -796,7 +789,7 @@ done:
                     //
                     location = bestRegister->getBackingStorage();
                 } else {
-                    location = self()->cg()->allocateInternalPointerSpill(bestRegister->getPinningArrayPointer());
+                    location = cg()->allocateInternalPointerSpill(bestRegister->getPinningArrayPointer());
                 }
             } else {
                 if (bestRegister->getBackingStorage()) {
@@ -804,69 +797,61 @@ done:
                     // backing store wasn't returned to the free list and it can be used.
                     //
                     location = bestRegister->getBackingStorage();
-                    location->setMaxSpillDepth(self()->cg()->getCurrentPathDepth());
-                    if (self()->cg()->getDebug())
-                        self()->cg()->traceRegisterAssignment("find or create free backing store (%p) for %s with "
-                                                              "initial max spill depth of %d and adding to list\n",
-                            location, self()->cg()->getDebug()->getName(bestRegister),
-                            self()->cg()->getCurrentPathDepth());
+                    location->setMaxSpillDepth(cg()->getCurrentPathDepth());
+                    if (cg()->getDebug())
+                        cg()->traceRegisterAssignment("find or create free backing store (%p) for %s with "
+                                                      "initial max spill depth of %d and adding to list\n",
+                            location, cg()->getDebug()->getName(bestRegister), cg()->getCurrentPathDepth());
                 } else {
-                    location
-                        = self()->cg()->allocateSpill(static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress()),
-                            bestRegister->containsCollectedReference(), &offset);
-                    location->setMaxSpillDepth(self()->cg()->getCurrentPathDepth());
-                    if (self()->cg()->getDebug())
-                        self()->cg()->traceRegisterAssignment("find or create free backing store (%p) for %s with "
-                                                              "initial max spill depth of %d and adding to list\n",
-                            location, self()->cg()->getDebug()->getName(bestRegister),
-                            self()->cg()->getCurrentPathDepth());
+                    location = cg()->allocateSpill(static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress()),
+                        bestRegister->containsCollectedReference(), &offset);
+                    location->setMaxSpillDepth(cg()->getCurrentPathDepth());
+                    if (cg()->getDebug())
+                        cg()->traceRegisterAssignment("find or create free backing store (%p) for %s with "
+                                                      "initial max spill depth of %d and adding to list\n",
+                            location, cg()->getDebug()->getName(bestRegister), cg()->getCurrentPathDepth());
                 }
             }
         }
 
-        if (self()->cg()->getUseNonLinearRegisterAssigner()) {
+        if (cg()->getUseNonLinearRegisterAssigner()) {
             TR_ASSERT(bestRegister, "did not find bestRegister");
-            TR_ASSERT(self()->cg()->getSpilledRegisterList(), "no spilled reg list allocated");
+            TR_ASSERT(cg()->getSpilledRegisterList(), "no spilled reg list allocated");
 
-            if (self()->getDebug())
-                self()->cg()->traceRegisterAssignment("adding %s to the spilledRegisterList)\n",
-                    self()->getDebug()->getName(bestRegister));
+            if (getDebug())
+                cg()->traceRegisterAssignment("adding %s to the spilledRegisterList)\n",
+                    getDebug()->getName(bestRegister));
 
-            self()->cg()->getSpilledRegisterList()->push_front(bestRegister);
+            cg()->getSpilledRegisterList()->push_front(bestRegister);
         }
 
-        TR::MemoryReference *tempMR = generateX86MemoryReference(location->getSymbolReference(), offset, self()->cg());
+        TR::MemoryReference *tempMR = generateX86MemoryReference(location->getSymbolReference(), offset, cg());
         bestRegister->setBackingStorage(location);
         TR_ASSERT(offset == 0 || offset == 4, "assertion failure");
         bestRegister->setIsSpilledToSecondHalf(offset > 0);
 
         bestRegister->setAssignedRegister(NULL);
-        self()->cg()->getSpilledIntRegisters().push_front(bestRegister);
+        cg()->getSpilledIntRegisters().push_front(bestRegister);
 
         TR::InstOpCode::Mnemonic op;
         if (bestRegister->getKind() == TR_FPR) {
-            op = (bestRegister->isSinglePrecision()) ? TR::InstOpCode::MOVSSRegMem
-                                                     : (self()->cg()->getXMMDoubleLoadOpCode());
+            op = (bestRegister->isSinglePrecision()) ? TR::InstOpCode::MOVSSRegMem : (cg()->getXMMDoubleLoadOpCode());
         } else if (bestRegister->getKind() == TR_VRF) {
-            op = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmMem
-                                                                  : TR::InstOpCode::MOVDQURegMem;
-            op = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
-                ? TR::InstOpCode::VMOVDQUZmmMem
-                : op;
+            op = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmMem : TR::InstOpCode::MOVDQURegMem;
+            op = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? TR::InstOpCode::VMOVDQUZmmMem : op;
         } else if (bestRegister->getKind() == TR_VMR) {
             op = vmrSpillOpcode;
         } else {
             op = TR::InstOpCode::LRegMem();
         }
-        instr = new (self()->cg()->trHeapMemory())
-            TR::X86RegMemInstruction(currentInstruction, op, best, tempMR, self()->cg());
+        instr = new (cg()->trHeapMemory()) TR::X86RegMemInstruction(currentInstruction, op, best, tempMR, cg());
 
-        self()->cg()->traceRegFreed(bestRegister, best);
-        self()->cg()->traceRAInstruction(instr);
+        cg()->traceRegFreed(bestRegister, best);
+        cg()->traceRAInstruction(instr);
     }
 
     if (enableRematerialisation)
-        self()->cg()->deactivateDependentDiscardableRegisters(bestRegister);
+        cg()->deactivateDependentDiscardableRegisters(bestRegister);
 
     best->setAssignedRegister(NULL);
     best->setState(TR::RealRegister::Free);
@@ -881,7 +866,7 @@ done:
 TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction *currentInstruction,
     TR::Register *spilledRegister, TR::RealRegister *targetRegister, TR_RegisterSizes requestedRegSize)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     if (targetRegister == NULL) {
         targetRegister = self()->findBestFreeGPRegister(currentInstruction, spilledRegister, requestedRegSize);
@@ -895,27 +880,27 @@ TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction *curre
     // If the virtual register has better spill placement info, see if the spill
     // can be moved to later in the instruction stream
     //
-    if (self()->cg()->enableBetterSpillPlacements()) {
+    if (cg()->enableBetterSpillPlacements()) {
         if (spilledRegister->hasBetterSpillPlacement()) {
             TR::Instruction *betterInstruction
-                = self()->cg()->findBetterSpillPlacement(spilledRegister, targetRegister->getRegisterNumber());
+                = cg()->findBetterSpillPlacement(spilledRegister, targetRegister->getRegisterNumber());
             if (betterInstruction) {
-                self()->cg()->setRegisterAssignmentFlag(TR_HasBetterSpillPlacement);
+                cg()->setRegisterAssignmentFlag(TR_HasBetterSpillPlacement);
                 currentInstruction = betterInstruction;
             }
         }
 
-        self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+        cg()->removeBetterSpillPlacementCandidate(targetRegister);
     }
 
-    if (self()->cg()->getUseNonLinearRegisterAssigner()) {
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+    if (cg()->getUseNonLinearRegisterAssigner()) {
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
     }
 
-    self()->cg()->getSpilledIntRegisters().remove(spilledRegister);
+    cg()->getSpilledIntRegisters().remove(spilledRegister);
 
-    if (self()->cg()->enableRematerialisation() && spilledRegister->getKind() != TR_VMR) {
-        self()->cg()->reactivateDependentDiscardableRegisters(spilledRegister);
+    if (cg()->enableRematerialisation() && spilledRegister->getKind() != TR_VMR) {
+        cg()->reactivateDependentDiscardableRegisters(spilledRegister);
 
         // A store is not necessary if the register can be rematerialised.
         //
@@ -923,8 +908,8 @@ TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction *curre
             && spilledRegister->getRematerializationInfo()->isRematerialized()) {
             if (debug("dumpRemat")) {
                 diagnostic("---> Avoiding storing %s rematerializable register %s to memory in %s\n",
-                    self()->getDebug()->toString(spilledRegister->getRematerializationInfo()),
-                    self()->getDebug()->getName(spilledRegister), comp->signature());
+                    getDebug()->toString(spilledRegister->getRematerializationInfo()),
+                    getDebug()->getName(spilledRegister), comp->signature());
             }
 
             return targetRegister;
@@ -932,75 +917,73 @@ TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction *curre
     }
 
     TR::MemoryReference *tempMR = generateX86MemoryReference(location->getSymbolReference(),
-        spilledRegister->isSpilledToSecondHalf() ? 4 : 0, self()->cg());
+        spilledRegister->isSpilledToSecondHalf() ? 4 : 0, cg());
     TR::Instruction *instr = NULL;
 
     if (spilledRegister->getKind() == TR_FPR) {
-        instr = new (self()->cg()->trHeapMemory()) TR::X86MemRegInstruction(currentInstruction,
+        instr = new (cg()->trHeapMemory()) TR::X86MemRegInstruction(currentInstruction,
             spilledRegister->isSinglePrecision() ? TR::InstOpCode::MOVSSMemReg : TR::InstOpCode::MOVSDMemReg, tempMR,
-            targetRegister, self()->cg());
+            targetRegister, cg());
 
         // Do not add a freed spill slot back onto the free list if the list is locked.
         // This is to enforce re-use of the same spill slot for a virtual register
         // while assigning non-linear control flow regions.
         //
-        self()->cg()->freeSpill(location, spilledRegister->isSinglePrecision() ? 4 : 8,
+        cg()->freeSpill(location, spilledRegister->isSinglePrecision() ? 4 : 8,
             spilledRegister->isSpilledToSecondHalf() ? 4 : 0);
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     } else if (spilledRegister->getKind() == TR_VRF) {
         TR::InstOpCode::Mnemonic movOpcode;
-        movOpcode = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUMemYmm
-                                                                     : TR::InstOpCode::MOVDQUMemReg;
-        movOpcode = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
-            ? TR::InstOpCode::VMOVDQUMemZmm
-            : movOpcode;
-        instr = new (self()->cg()->trHeapMemory())
-            TR::X86MemRegInstruction(currentInstruction, movOpcode, tempMR, targetRegister, self()->cg());
+        movOpcode = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUMemYmm : TR::InstOpCode::MOVDQUMemReg;
+        movOpcode
+            = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? TR::InstOpCode::VMOVDQUMemZmm : movOpcode;
+        instr = new (cg()->trHeapMemory())
+            TR::X86MemRegInstruction(currentInstruction, movOpcode, tempMR, targetRegister, cg());
 
         // Do not add a freed spill slot back onto the free list if the list is locked.
         // This is to enforce re-use of the same spill slot for a virtual register
         // while assigning non-linear control flow regions.
         //
-        int32_t size = self()->cg()->comp()->target().cpu.supportsAVX() ? 32 : 16;
-        size = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 64 : size;
-        self()->cg()->freeSpill(location, size, 0);
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        int32_t size = comp->target().cpu.supportsAVX() ? 32 : 16;
+        size = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? 64 : size;
+        cg()->freeSpill(location, size, 0);
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     } else if (spilledRegister->getKind() == TR_VMR) {
         TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::KMOVWMemMask;
         int32_t spillSize = 2;
 
-        if (cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512BW)) {
+        if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512BW)) {
             opcode = TR::InstOpCode::KMOVQMemMask;
             spillSize = 8;
         }
 
-        instr = new (self()->cg()->trHeapMemory())
-            TR::X86MemRegInstruction(currentInstruction, opcode, tempMR, targetRegister, self()->cg());
+        instr = new (cg()->trHeapMemory())
+            TR::X86MemRegInstruction(currentInstruction, opcode, tempMR, targetRegister, cg());
 
         // Do not add a freed spill slot back onto the free list if the list is locked.
         // This is to enforce re-use of the same spill slot for a virtual register
         // while assigning non-linear control flow regions.
         //
-        self()->cg()->freeSpill(location, spillSize, 0);
+        cg()->freeSpill(location, spillSize, 0);
     } else {
-        instr = new (self()->cg()->trHeapMemory()) TR::X86MemRegInstruction(currentInstruction,
-            TR::InstOpCode::SMemReg(), tempMR, targetRegister, self()->cg());
+        instr = new (cg()->trHeapMemory())
+            TR::X86MemRegInstruction(currentInstruction, TR::InstOpCode::SMemReg(), tempMR, targetRegister, cg());
         // Do not add a freed spill slot back onto the free list if the list is locked.
         // This is to enforce re-use of the same spill slot for a virtual register
         // while assigning non-linear control flow regions.
         //
-        self()->cg()->freeSpill(location, static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress()),
+        cg()->freeSpill(location, static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress()),
             spilledRegister->isSpilledToSecondHalf() ? 4 : 0);
-        if (!self()->cg()->isFreeSpillListLocked()) {
+        if (!cg()->isFreeSpillListLocked()) {
             spilledRegister->setBackingStorage(NULL);
         }
     }
 
-    self()->cg()->traceRAInstruction(instr);
+    cg()->traceRAInstruction(instr);
 
     return targetRegister;
 }
@@ -1023,78 +1006,78 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction *currentInstr
     if (targetRegister->getState() == TR::RealRegister::Free) {
         if (currentAssignedRegister == NULL) {
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseGPRSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         } else {
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, movOpcode,
-                currentAssignedRegister, targetRegister, self()->cg());
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, movOpcode, currentAssignedRegister, targetRegister, cg());
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
 
-        if (self()->cg()->enableBetterSpillPlacements())
-            self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+        if (cg()->enableBetterSpillPlacements())
+            cg()->removeBetterSpillPlacementCandidate(targetRegister);
 
-        self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+        cg()->traceRegAssigned(virtualRegister, targetRegister);
         if (instr)
-            self()->cg()->traceRAInstruction(instr);
+            cg()->traceRAInstruction(instr);
     } else if (targetRegister->getState() == TR::RealRegister::Blocked
         || targetRegister->getState() == TR::RealRegister::Assigned) {
         TR::Register *currentTargetVirtual = targetRegister->getAssignedRegister();
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
 
         // Cannot XCHG vector mask registers
         if (currentAssignedRegister != NULL && currentTargetVirtual->getKind() != TR_VMR) {
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                TR::InstOpCode::XCHGRegReg(), currentAssignedRegister, targetRegister, self()->cg());
+            instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                TR::InstOpCode::XCHGRegReg(), currentAssignedRegister, targetRegister, cg());
 
             if (targetRegister->getState() == TR::RealRegister::Assigned)
                 currentAssignedRegister->setState(TR::RealRegister::Assigned, currentTargetVirtual->isPlaceholderReg());
             currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
             currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
-            self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-            self()->cg()->traceRAInstruction(instr);
+            cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+            cg()->traceRAInstruction(instr);
         } else {
             TR::RealRegister *candidate = self()->findBestFreeGPRegister(currentInstruction, currentTargetVirtual);
 
             if (candidate) {
-                if (self()->cg()->enableBetterSpillPlacements())
-                    self()->cg()->removeBetterSpillPlacementCandidate(candidate);
+                if (cg()->enableBetterSpillPlacements())
+                    cg()->removeBetterSpillPlacementCandidate(candidate);
             } else {
                 // A spill is needed, either to satisfy the coercion, or to free up a second
                 // register whence the virtual currently occupying the target may be moved,
                 // i.e. an indirect coercion.
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 candidate = self()->freeBestGPRegister(currentInstruction, currentTargetVirtual, TR_WordReg,
                     registerNumber, coerceToSatisfyRegDeps);
             }
 
             if ((targetRegister != candidate) && (candidate != currentTargetVirtual)) {
-                instr = new (self()->cg()->trHeapMemory())
-                    TR::X86RegRegInstruction(currentInstruction, movOpcode, targetRegister, candidate, self()->cg());
+                instr = new (cg()->trHeapMemory())
+                    TR::X86RegRegInstruction(currentInstruction, movOpcode, targetRegister, candidate, cg());
                 currentTargetVirtual->setAssignedRegister(candidate);
                 candidate->setAssignedRegister(currentTargetVirtual);
                 candidate->setState(targetRegister->getState());
-                self()->cg()->traceRegAssigned(currentTargetVirtual, candidate);
-                self()->cg()->traceRAInstruction(instr);
-                self()->cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
+                cg()->traceRegAssigned(currentTargetVirtual, candidate);
+                cg()->traceRAInstruction(instr);
+                cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
             }
 
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseGPRSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         }
 
         if (targetRegister->getState() == TR::RealRegister::Blocked) {
-            if (self()->cg()->enableBetterSpillPlacements())
-                self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+            if (cg()->enableBetterSpillPlacements())
+                cg()->removeBetterSpillPlacementCandidate(targetRegister);
         }
 
-        self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
-        self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+        cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->traceRegAssigned(virtualRegister, targetRegister);
     }
 
     targetRegister->setState(TR::RealRegister::Assigned, virtualRegister->isPlaceholderReg());
@@ -1106,6 +1089,8 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction *currentInstr
 void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInstruction, TR::Register *virtualRegister,
     TR::RealRegister::RegNum regNum, bool coerceToSatisfyRegDeps)
 {
+    TR::Compilation *comp = cg()->comp();
+
     TR::RealRegister *targetRegister = _registerFile[regNum];
     TR::RealRegister *currentAssignedRegister = virtualRegister->getAssignedRealRegister();
     TR::Instruction *instr = NULL;
@@ -1113,39 +1098,38 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
     if (targetRegister->getState() == TR::RealRegister::Free) {
         if (currentAssignedRegister == NULL) {
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseGPRSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         } else {
             if (virtualRegister->getKind() == TR_VRF) {
                 TR::InstOpCode::Mnemonic movOpcode;
-                movOpcode = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm
-                                                                             : TR::InstOpCode::MOVDQURegReg;
-                movOpcode = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
-                    ? TR::InstOpCode::VMOVDQUZmmZmm
-                    : movOpcode;
+                movOpcode
+                    = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm : TR::InstOpCode::MOVDQURegReg;
+                movOpcode = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? TR::InstOpCode::VMOVDQUZmmZmm
+                                                                                        : movOpcode;
 
-                instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, movOpcode,
-                    currentAssignedRegister, targetRegister, self()->cg());
+                instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, movOpcode,
+                    currentAssignedRegister, targetRegister, cg());
             } else if (virtualRegister->isSinglePrecision()) {
-                instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                    TR::InstOpCode::MOVAPSRegReg, currentAssignedRegister, targetRegister, self()->cg());
+                instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                    TR::InstOpCode::MOVAPSRegReg, currentAssignedRegister, targetRegister, cg());
             } else {
-                instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                    TR::InstOpCode::MOVAPDRegReg, currentAssignedRegister, targetRegister, self()->cg());
+                instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                    TR::InstOpCode::MOVAPDRegReg, currentAssignedRegister, targetRegister, cg());
             }
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
         }
-        self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+        cg()->removeBetterSpillPlacementCandidate(targetRegister);
 
-        self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+        cg()->traceRegAssigned(virtualRegister, targetRegister);
         if (instr)
-            self()->cg()->traceRAInstruction(instr);
+            cg()->traceRAInstruction(instr);
     } else if (targetRegister->getState() == TR::RealRegister::Blocked) {
         TR::Register *currentTargetVirtual = targetRegister->getAssignedRegister();
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
         if (currentAssignedRegister != NULL) {
             // Exchange the contents of two XMM registers without an XCHG instruction.
             //
@@ -1153,25 +1137,23 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
             if (virtualRegister->getKind() == TR_FPR && virtualRegister->isSinglePrecision()) {
                 xchgOp = TR::InstOpCode::XORPSRegReg;
             } else if (virtualRegister->getKind() == TR_VRF) {
-                xchgOp = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VXORPDYmmYmm
-                                                                          : TR::InstOpCode::XORPDRegReg;
-                xchgOp = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
-                    ? TR::InstOpCode::VPXORDZmmZmm
-                    : xchgOp;
+                xchgOp = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VXORPDYmmYmm : TR::InstOpCode::XORPDRegReg;
+                xchgOp = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? TR::InstOpCode::VPXORDZmmZmm
+                                                                                     : xchgOp;
             } else {
                 xchgOp = TR::InstOpCode::XORPDRegReg;
             }
 
-            self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                currentAssignedRegister, targetRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                targetRegister, currentAssignedRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                currentAssignedRegister, targetRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
+            cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, currentAssignedRegister, targetRegister, cg());
+            cg()->traceRAInstruction(instr);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, targetRegister, currentAssignedRegister, cg());
+            cg()->traceRAInstruction(instr);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, currentAssignedRegister, targetRegister, cg());
+            cg()->traceRAInstruction(instr);
             currentAssignedRegister->setState(TR::RealRegister::Blocked);
             currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
             currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -1180,12 +1162,12 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
                 = self()->findBestFreeGPRegister(currentInstruction, currentTargetVirtual, TR_QuadWordReg);
 
             if (candidate) {
-                self()->cg()->removeBetterSpillPlacementCandidate(candidate);
+                cg()->removeBetterSpillPlacementCandidate(candidate);
             } else {
                 // A spill is needed, either to satisfy the coercion, or to free up a second
                 // register whence the virtual currently occupying the target may be moved,
                 // i.e. an indirect coercion.
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 candidate = self()->freeBestGPRegister(currentInstruction, currentTargetVirtual, TR_QuadWordReg, regNum,
                     coerceToSatisfyRegDeps);
             }
@@ -1193,65 +1175,63 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
             if (targetRegister != candidate) {
                 if (virtualRegister->getKind() == TR_VRF) {
                     TR::InstOpCode::Mnemonic movOpcode;
-                    movOpcode = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm
-                                                                                 : TR::InstOpCode::MOVDQURegReg;
-                    movOpcode = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
+                    movOpcode = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm
+                                                                 : TR::InstOpCode::MOVDQURegReg;
+                    movOpcode = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
                         ? TR::InstOpCode::VMOVDQUZmmZmm
                         : movOpcode;
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, movOpcode,
-                        targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory())
+                        TR::X86RegRegInstruction(currentInstruction, movOpcode, targetRegister, candidate, cg());
                 } else if (currentTargetVirtual->isSinglePrecision()) {
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                        TR::InstOpCode::MOVAPSRegReg, targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                        TR::InstOpCode::MOVAPSRegReg, targetRegister, candidate, cg());
                 } else {
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                        TR::InstOpCode::MOVAPDRegReg, targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                        TR::InstOpCode::MOVAPDRegReg, targetRegister, candidate, cg());
                 }
                 candidate->setState(TR::RealRegister::Blocked);
                 candidate->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(candidate);
-                self()->cg()->traceRegAssigned(currentTargetVirtual, candidate);
-                self()->cg()->traceRAInstruction(instr);
-                self()->cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
+                cg()->traceRegAssigned(currentTargetVirtual, candidate);
+                cg()->traceRAInstruction(instr);
+                cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
             }
 
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseGPRSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         }
 
-        self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
-        self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
-        self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+        cg()->removeBetterSpillPlacementCandidate(targetRegister);
+        cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->traceRegAssigned(virtualRegister, targetRegister);
     } else if (targetRegister->getState() == TR::RealRegister::Assigned) {
         TR::Register *currentTargetVirtual = targetRegister->getAssignedRegister();
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
         if (currentAssignedRegister != NULL) {
             TR::InstOpCode::Mnemonic xchgOp = TR::InstOpCode::bad;
             if (virtualRegister->getKind() == TR_FPR && virtualRegister->isSinglePrecision()) {
                 xchgOp = TR::InstOpCode::XORPSRegReg;
             } else if (virtualRegister->getKind() == TR_VRF) {
-                xchgOp = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VXORPDYmmYmm
-                                                                          : TR::InstOpCode::XORPDRegReg;
-                xchgOp = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
-                    ? TR::InstOpCode::VPXORDZmmZmm
-                    : xchgOp;
+                xchgOp = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VXORPDYmmYmm : TR::InstOpCode::XORPDRegReg;
+                xchgOp = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F) ? TR::InstOpCode::VPXORDZmmZmm
+                                                                                     : xchgOp;
             } else {
                 xchgOp = TR::InstOpCode::XORPDRegReg;
             }
 
-            self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                currentAssignedRegister, targetRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                targetRegister, currentAssignedRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
-            instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, xchgOp,
-                currentAssignedRegister, targetRegister, self()->cg());
-            self()->cg()->traceRAInstruction(instr);
+            cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, currentAssignedRegister, targetRegister, cg());
+            cg()->traceRAInstruction(instr);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, targetRegister, currentAssignedRegister, cg());
+            cg()->traceRAInstruction(instr);
+            instr = new (cg()->trHeapMemory())
+                TR::X86RegRegInstruction(currentInstruction, xchgOp, currentAssignedRegister, targetRegister, cg());
+            cg()->traceRAInstruction(instr);
             currentAssignedRegister->setState(TR::RealRegister::Assigned, currentTargetVirtual->isPlaceholderReg());
             currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
             currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -1259,12 +1239,12 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
             TR::RealRegister *candidate
                 = self()->findBestFreeGPRegister(currentInstruction, currentTargetVirtual, TR_QuadWordReg);
             if (candidate) {
-                self()->cg()->removeBetterSpillPlacementCandidate(candidate);
+                cg()->removeBetterSpillPlacementCandidate(candidate);
             } else {
                 // A spill is needed, either to satisfy the coercion, or to free up a second
                 // register whence the virtual currently occupying the target may be moved,
                 // i.e. an indirect coercion.
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
                 candidate = self()->freeBestGPRegister(currentInstruction, currentTargetVirtual, TR_QuadWordReg, regNum,
                     coerceToSatisfyRegDeps);
             }
@@ -1272,36 +1252,36 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
             if (targetRegister != candidate) {
                 if (virtualRegister->getKind() == TR_VRF) {
                     TR::InstOpCode::Mnemonic movOpcode;
-                    movOpcode = self()->cg()->comp()->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm
-                                                                                 : TR::InstOpCode::MOVDQURegReg;
-                    movOpcode = self()->cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
+                    movOpcode = comp->target().cpu.supportsAVX() ? TR::InstOpCode::VMOVDQUYmmYmm
+                                                                 : TR::InstOpCode::MOVDQURegReg;
+                    movOpcode = comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)
                         ? TR::InstOpCode::VMOVDQUZmmZmm
                         : movOpcode;
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, movOpcode,
-                        targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory())
+                        TR::X86RegRegInstruction(currentInstruction, movOpcode, targetRegister, candidate, cg());
                 } else if (currentTargetVirtual->isSinglePrecision()) {
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                        TR::InstOpCode::MOVAPSRegReg, targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                        TR::InstOpCode::MOVAPSRegReg, targetRegister, candidate, cg());
                 } else {
-                    instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
-                        TR::InstOpCode::MOVAPDRegReg, targetRegister, candidate, self()->cg());
+                    instr = new (cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction,
+                        TR::InstOpCode::MOVAPDRegReg, targetRegister, candidate, cg());
                 }
                 candidate->setState(TR::RealRegister::Assigned, currentTargetVirtual->isPlaceholderReg());
                 candidate->setAssignedRegister(currentTargetVirtual);
                 currentTargetVirtual->setAssignedRegister(candidate);
-                self()->cg()->traceRegAssigned(currentTargetVirtual, candidate);
-                self()->cg()->traceRAInstruction(instr);
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
+                cg()->traceRegAssigned(currentTargetVirtual, candidate);
+                cg()->traceRAInstruction(instr);
+                cg()->setRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
             }
 
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseGPRSpillState(currentInstruction, virtualRegister, targetRegister);
             }
         }
 
-        self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
-        self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+        cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->traceRegAssigned(virtualRegister, targetRegister);
     }
 
     targetRegister->setState(TR::RealRegister::Assigned, virtualRegister->isPlaceholderReg());
@@ -1315,8 +1295,8 @@ void OMR::X86::Machine::swapGPRegisters(TR::Instruction *currentInstruction, TR:
 {
     TR::RealRegister *realReg1 = self()->getRealRegister(regNum1);
     TR::RealRegister *realReg2 = self()->getRealRegister(regNum2);
-    TR::Instruction *instr = new (self()->cg()->trHeapMemory())
-        TR::X86RegRegInstruction(currentInstruction, TR::InstOpCode::XCHGRegReg(), realReg1, realReg2, self()->cg());
+    TR::Instruction *instr = new (cg()->trHeapMemory())
+        TR::X86RegRegInstruction(currentInstruction, TR::InstOpCode::XCHGRegReg(), realReg1, realReg2, cg());
 
     TR::Register *virtReg1 = realReg1->getAssignedRegister();
     TR::Register *virtReg2 = realReg2->getAssignedRegister();
@@ -1326,9 +1306,9 @@ void OMR::X86::Machine::swapGPRegisters(TR::Instruction *currentInstruction, TR:
     realReg1->setAssignedRegister(virtReg2);
     realReg2->setAssignedRegister(virtReg1);
 
-    self()->cg()->traceRegAssigned(virtReg1, realReg2);
-    self()->cg()->traceRegAssigned(virtReg2, realReg1);
-    self()->cg()->traceRAInstruction(instr);
+    cg()->traceRegAssigned(virtReg1, realReg2);
+    cg()->traceRegAssigned(virtReg2, realReg1);
+    cg()->traceRAInstruction(instr);
 }
 
 void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction *currentInstruction, TR::Register *virtualRegister,
@@ -1336,29 +1316,29 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction *currentInstr
 {
     TR::RealRegister *candidate;
     if ((candidate = self()->findBestFreeGPRegister(currentInstruction, virtualRegister, requestedRegSize)) == NULL) {
-        self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+        cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
         candidate = self()->freeBestGPRegister(currentInstruction, virtualRegister, requestedRegSize);
     }
 
     if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-        self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+        cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
         self()->reverseGPRSpillState(currentInstruction, virtualRegister, candidate);
     }
 
-    if (self()->cg()->enableBetterSpillPlacements())
-        self()->cg()->removeBetterSpillPlacementCandidate(candidate);
+    if (cg()->enableBetterSpillPlacements())
+        cg()->removeBetterSpillPlacementCandidate(candidate);
 
     candidate->setState(TR::RealRegister::Assigned, virtualRegister->isPlaceholderReg());
     candidate->setAssignedRegister(virtualRegister);
     virtualRegister->setAssignedRegister(candidate);
     virtualRegister->setAssignedAsByteRegister(false);
 
-    self()->cg()->traceRegAssigned(virtualRegister, candidate);
+    cg()->traceRegAssigned(virtualRegister, candidate);
 }
 
 void OMR::X86::Machine::setGPRWeightsFromAssociations()
 {
-    const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
+    const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
     for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
         // Skip non-assignable registers
@@ -1392,7 +1372,7 @@ void OMR::X86::Machine::setGPRWeightsFromAssociations()
 
 void OMR::X86::Machine::setXMMWeightsFromAssociations()
 {
-    const TR::X86LinkageProperties &linkageProperties = self()->cg()->getProperties();
+    const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
     for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; ++i) {
         if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
@@ -1421,14 +1401,14 @@ void OMR::X86::Machine::setXMMWeightsFromAssociations()
 
 void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     // Calculate total number of registers (GPRs + XMMRs)
     int numGPRs = TR::RealRegister::LastAssignableGPR;
     int numXMMRs = TR::RealRegister::LastXMMR - TR::RealRegister::FirstXMMR + 1;
 
     TR::RegisterDependencyConditions *associations
-        = generateRegisterDependencyConditions((uint8_t)0, numGPRs + numXMMRs, self()->cg());
+        = generateRegisterDependencyConditions((uint8_t)0, numGPRs + numXMMRs, cg());
 
     // Go through the current associations held in the machine and put a copy of
     // that state out into the stream after the cursor
@@ -1443,7 +1423,7 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
         if (self()->getRealRegister(regNum)->getState() == TR::RealRegister::Locked)
             continue;
 
-        associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum, self()->cg(), 0, true);
+        associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum, cg(), 0, true);
     }
 
     // Add XMM associations
@@ -1451,14 +1431,14 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
         if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
         associations->addPostCondition(self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i),
-            (TR::RealRegister::RegNum)i, self()->cg(), 0, true);
+            (TR::RealRegister::RegNum)i, cg(), 0, true);
     }
 
     associations->stopAddingPostConditions();
 
-    new (self()->cg()->trHeapMemory()) TR::Instruction(associations, TR::InstOpCode::assocreg, cursor, self()->cg());
-    if (cursor == self()->cg()->getAppendInstruction())
-        self()->cg()->setAppendInstruction(cursor->getNext());
+    new (cg()->trHeapMemory()) TR::Instruction(associations, TR::InstOpCode::assocreg, cursor, cg());
+    if (cursor == cg()->getAppendInstruction())
+        cg()->setAppendInstruction(cursor->getNext());
 
     // There's no need to have a virtual appear in more than one TR::InstOpCode::assocreg after
     // its live range has ended.  One is enough.  So we clear out all the dead
@@ -1495,76 +1475,76 @@ void OMR::X86::Machine::initializeRegisterFile(const struct TR::X86LinkageProper
 
     // GPRs
     //
-    _registerFile[TR::RealRegister::eax] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+    _registerFile[TR::RealRegister::eax] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
         properties.isPreservedRegister(TR::RealRegister::eax) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-        TR::RealRegister::Free, TR::RealRegister::eax, TR::RealRegister::eaxMask, self()->cg());
+        TR::RealRegister::Free, TR::RealRegister::eax, TR::RealRegister::eaxMask, cg());
 
     static char *dontUseEBXasGPR = feGetEnv("dontUseEBXasGPR");
 
     if (!dontUseEBXasGPR) {
-        _registerFile[TR::RealRegister::ebx] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+        _registerFile[TR::RealRegister::ebx] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
             properties.isPreservedRegister(TR::RealRegister::ebx) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-            TR::RealRegister::Free, TR::RealRegister::ebx, TR::RealRegister::ebxMask, self()->cg());
+            TR::RealRegister::Free, TR::RealRegister::ebx, TR::RealRegister::ebxMask, cg());
     } else {
-        _registerFile[TR::RealRegister::ebx] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
-            UNUSED_WEIGHT, TR::RealRegister::Locked, TR::RealRegister::ebx, TR::RealRegister::ebxMask, self()->cg());
+        _registerFile[TR::RealRegister::ebx] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
+            TR::RealRegister::Locked, TR::RealRegister::ebx, TR::RealRegister::ebxMask, cg());
         _registerFile[TR::RealRegister::ebx]->setAssignedRegister(_registerFile[TR::RealRegister::ebx]);
     }
 
-    _registerFile[TR::RealRegister::ecx] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+    _registerFile[TR::RealRegister::ecx] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
         properties.isPreservedRegister(TR::RealRegister::ecx) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-        TR::RealRegister::Free, TR::RealRegister::ecx, TR::RealRegister::ecxMask, self()->cg());
+        TR::RealRegister::Free, TR::RealRegister::ecx, TR::RealRegister::ecxMask, cg());
 
-    _registerFile[TR::RealRegister::edx] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+    _registerFile[TR::RealRegister::edx] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
         properties.isPreservedRegister(TR::RealRegister::edx) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-        TR::RealRegister::Free, TR::RealRegister::edx, TR::RealRegister::edxMask, self()->cg());
+        TR::RealRegister::Free, TR::RealRegister::edx, TR::RealRegister::edxMask, cg());
 
-    _registerFile[TR::RealRegister::edi] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+    _registerFile[TR::RealRegister::edi] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
         properties.isPreservedRegister(TR::RealRegister::edi) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-        TR::RealRegister::Free, TR::RealRegister::edi, TR::RealRegister::ediMask, self()->cg());
+        TR::RealRegister::Free, TR::RealRegister::edi, TR::RealRegister::ediMask, cg());
 
-    _registerFile[TR::RealRegister::esi] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+    _registerFile[TR::RealRegister::esi] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
         properties.isPreservedRegister(TR::RealRegister::esi) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
-        TR::RealRegister::Free, TR::RealRegister::esi, TR::RealRegister::esiMask, self()->cg());
+        TR::RealRegister::Free, TR::RealRegister::esi, TR::RealRegister::esiMask, cg());
 
     // Platforms that are able to use ebp as a GPR can set the state to Free and
     // clear the assigned register in the CodeGen constructor.
-    _registerFile[TR::RealRegister::ebp] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
-        TR::RealRegister::Locked, TR::RealRegister::ebp, TR::RealRegister::ebpMask, self()->cg());
+    _registerFile[TR::RealRegister::ebp] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
+        TR::RealRegister::Locked, TR::RealRegister::ebp, TR::RealRegister::ebpMask, cg());
     _registerFile[TR::RealRegister::ebp]->setAssignedRegister(_registerFile[TR::RealRegister::ebp]);
 
-    _registerFile[TR::RealRegister::esp] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
-        TR::RealRegister::Locked, TR::RealRegister::esp, TR::RealRegister::espMask, self()->cg());
+    _registerFile[TR::RealRegister::esp] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
+        TR::RealRegister::Locked, TR::RealRegister::esp, TR::RealRegister::espMask, cg());
     _registerFile[TR::RealRegister::esp]->setAssignedRegister(_registerFile[TR::RealRegister::esp]);
 
-    _registerFile[TR::RealRegister::vfp] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
-        TR::RealRegister::Locked, TR::RealRegister::vfp, TR::RealRegister::noRegMask, self()->cg());
+    _registerFile[TR::RealRegister::vfp] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR, UNUSED_WEIGHT,
+        TR::RealRegister::Locked, TR::RealRegister::vfp, TR::RealRegister::noRegMask, cg());
     _registerFile[TR::RealRegister::vfp]->setAssignedRegister(_registerFile[TR::RealRegister::NoReg]);
 
 #ifdef TR_TARGET_64BIT
     for (reg = TR::RealRegister::r8; reg <= TR::RealRegister::LastAssignableGPR; reg++) {
-        _registerFile[reg] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
+        _registerFile[reg] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
             properties.isPreservedRegister((TR::RealRegister::RegNum)reg) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
             TR::RealRegister::Free, (TR::RealRegister::RegNum)reg,
-            TR::RealRegister::gprMask((TR::RealRegister::RegNum)reg), self()->cg());
+            TR::RealRegister::gprMask((TR::RealRegister::RegNum)reg), cg());
     }
 #endif
 
     // Other register kinds
     //
     for (reg = TR::RealRegister::FirstXMMR; reg <= TR::RealRegister::LastXMMR; reg++) {
-        _registerFile[reg] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR,
+        _registerFile[reg] = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR,
             properties.isPreservedRegister((TR::RealRegister::RegNum)reg) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
             TR::RealRegister::Free, (TR::RealRegister::RegNum)reg,
-            TR::RealRegister::xmmrMask((TR::RealRegister::RegNum)reg), self()->cg());
+            TR::RealRegister::xmmrMask((TR::RealRegister::RegNum)reg), cg());
     }
 
     if (cg()->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) {
         for (reg = TR::RealRegister::k0; reg <= TR::RealRegister::k7; reg++) {
-            _registerFile[reg] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VMR,
+            _registerFile[reg] = new (cg()->trHeapMemory()) TR::RealRegister(TR_VMR,
                 properties.isPreservedRegister((TR::RealRegister::RegNum)reg) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
                 TR::RealRegister::Free, (TR::RealRegister::RegNum)reg,
-                TR::RealRegister::vectorMaskMask((TR::RealRegister::RegNum)reg), self()->cg());
+                TR::RealRegister::vectorMaskMask((TR::RealRegister::RegNum)reg), cg());
         }
     }
 }
@@ -1596,7 +1576,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = generateRegisterDependencyConditions(0, c, self()->cg());
+        deps = generateRegisterDependencyConditions(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
             TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
@@ -1604,15 +1584,14 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
                 || realReg->getState() == TR::RealRegister::Blocked) {
                 TR::Register *virtReg;
                 if (realReg->getState() == TR::RealRegister::Free) {
-                    virtReg
-                        = self()->cg()->allocateRegister(i <= TR::RealRegister::LastAssignableGPR ? TR_GPR : TR_FPR);
+                    virtReg = cg()->allocateRegister(i <= TR::RealRegister::LastAssignableGPR ? TR_GPR : TR_FPR);
                     virtReg->setPlaceholderReg();
                 } else {
                     virtReg = realReg->getAssignedRegister();
                 }
-                deps->addPostCondition(virtReg, realReg->getRegisterNumber(), self()->cg());
+                deps->addPostCondition(virtReg, realReg->getRegisterNumber(), cg());
                 if (virtReg->isPlaceholderReg())
-                    self()->cg()->stopUsingRegister(virtReg);
+                    cg()->stopUsingRegister(virtReg);
                 virtReg->incTotalUseCount();
                 virtReg->incFutureUseCount();
             }
@@ -1632,8 +1611,8 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
     // it is space conscious.
     //
     int32_t endReg = TR::RealRegister::LastAssignableGPR;
-    TR_LiveRegisters *liveFPRs = self()->cg()->getLiveRegisters(TR_FPR);
-    TR_LiveRegisters *liveVRFs = self()->cg()->getLiveRegisters(TR_VRF);
+    TR_LiveRegisters *liveFPRs = cg()->getLiveRegisters(TR_FPR);
+    TR_LiveRegisters *liveVRFs = cg()->getLiveRegisters(TR_VRF);
     if ((liveFPRs && liveFPRs->getNumberOfLiveRegisters() > 0)
         || (liveVRFs && liveVRFs->getNumberOfLiveRegisters() > 0))
         endReg = TR::RealRegister::LastXMMR;
@@ -1652,7 +1631,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = generateRegisterDependencyConditions(0, c, self()->cg());
+        deps = generateRegisterDependencyConditions(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= endReg;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
             TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
@@ -1662,7 +1641,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
                         || !(std::find(spilledRegisterList->begin(), spilledRegisterList->end(), virtReg)
                             != spilledRegisterList->end()),
                     "a register should not be in both an assigned state and in the spilled list\n");
-                deps->addPostCondition(virtReg, realReg->getRegisterNumber(), self()->cg());
+                deps->addPostCondition(virtReg, realReg->getRegisterNumber(), cg());
 
                 virtReg->incTotalUseCount();
                 virtReg->incFutureUseCount();
@@ -1674,7 +1653,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
 
         if (spilledRegisterList) {
             for (auto i = spilledRegisterList->begin(); i != spilledRegisterList->end(); ++i) {
-                deps->addPostCondition(*i, TR::RealRegister::SpilledReg, self()->cg());
+                deps->addPostCondition(*i, TR::RealRegister::SpilledReg, cg());
             }
         }
     }
@@ -1686,19 +1665,18 @@ TR::RealRegister **OMR::X86::Machine::captureRegisterFile()
 {
     int32_t arraySize = sizeof(TR::RealRegister *) * TR::RealRegister::NumRegisters;
 
-    TR::RealRegister **registerFileClone
-        = (TR::RealRegister **)self()->cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
+    TR::RealRegister **registerFileClone = (TR::RealRegister **)cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
 
     int32_t endReg = TR::RealRegister::LastXMMR;
     for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
         registerFileClone[i]
-            = (TR::RealRegister *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
+            = (TR::RealRegister *)cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
         *registerFileClone[i] = *_registerFile[i];
     }
 
     registerFileClone[TR::RealRegister::vfp]
-        = (TR::RealRegister *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
+        = (TR::RealRegister *)cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
     *registerFileClone[TR::RealRegister::vfp] = *_registerFile[TR::RealRegister::vfp];
 
     return registerFileClone;
@@ -1757,15 +1735,14 @@ TR::Register **OMR::X86::Machine::captureRegisterAssociations()
 {
     int32_t arraySize = sizeof(TR::Register *) * TR::RealRegister::NumRegisters;
 
-    TR::Register **registerAssociationsClone
-        = (TR::Register **)self()->cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
+    TR::Register **registerAssociationsClone = (TR::Register **)cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
 
     int32_t endReg = TR::RealRegister::LastXMMR;
     for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
         if (_registerAssociations[i] != NULL) {
             registerAssociationsClone[i]
-                = (TR::Register *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
+                = (TR::Register *)cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
             *registerAssociationsClone[i] = *_registerAssociations[i];
         } else {
             registerAssociationsClone[i] = NULL;
@@ -1774,7 +1751,7 @@ TR::Register **OMR::X86::Machine::captureRegisterAssociations()
 
     if (_registerAssociations[TR::RealRegister::vfp] != NULL) {
         registerAssociationsClone[TR::RealRegister::vfp]
-            = (TR::Register *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
+            = (TR::Register *)cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
         *registerAssociationsClone[TR::RealRegister::vfp] = *_registerAssociations[TR::RealRegister::vfp];
     } else {
         registerAssociationsClone[TR::RealRegister::vfp] = NULL;
@@ -1787,12 +1764,11 @@ TR::list<TR::Register *> *OMR::X86::Machine::captureSpilledRegistersList()
 {
     // TODO: hang a spilled registers list from the machine
 
-    TR_ASSERT(self()->cg()->getSpilledRegisterList(), "expecting an existing spilledRegistersList before capture");
+    TR_ASSERT(cg()->getSpilledRegisterList(), "expecting an existing spilledRegistersList before capture");
 
-    TR::list<TR::Register *> *srl = new (self()->cg()->trHeapMemory())
-        TR::list<TR::Register *>(getTypedAllocator<TR::Register *>(self()->cg()->comp()->allocator()));
-    for (auto iter = self()->cg()->getSpilledRegisterList()->begin();
-         iter != self()->cg()->getSpilledRegisterList()->end(); ++iter) {
+    TR::list<TR::Register *> *srl = new (cg()->trHeapMemory())
+        TR::list<TR::Register *>(getTypedAllocator<TR::Register *>(cg()->comp()->allocator()));
+    for (auto iter = cg()->getSpilledRegisterList()->begin(); iter != cg()->getSpilledRegisterList()->end(); ++iter) {
         srl->push_front(*iter);
     }
 
@@ -1988,7 +1964,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsUp(TR::list<OMR::RegisterUsage *>
     if (!rul)
         return;
 
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     OMR::Logger *log = comp->log();
 
     for (auto iter = rul->begin(); iter != rul->end(); ++iter) {
@@ -2013,7 +1989,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsDown(TR::list<OMR::RegisterUsage 
     if (!rul)
         return;
 
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     OMR::Logger *log = comp->log();
     bool trace = comp->getOption(TR_TraceNonLinearRegisterAssigner);
 
@@ -2037,7 +2013,7 @@ void OMR::X86::Machine::disassociateUnspilledBackingStorage()
     int32_t i;
     int32_t endReg = TR::RealRegister::LastXMMR;
     TR_BackingStore *location = NULL;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     for (i = TR::RealRegister::FirstGPR; i <= endReg;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
@@ -2059,7 +2035,7 @@ void OMR::X86::Machine::disassociateUnspilledBackingStorage()
                 } else {
                     size = static_cast<int32_t>(TR::Compiler->om.sizeofReferenceAddress());
                 }
-                self()->cg()->freeSpill(location, size, virtReg->isSpilledToSecondHalf() ? 4 : 0);
+                cg()->freeSpill(location, size, virtReg->isSpilledToSecondHalf() ? 4 : 0);
                 virtReg->setBackingStorage(NULL);
 
                 logprintf(comp->getOption(TR_TraceNonLinearRegisterAssigner), comp->log(),
@@ -2106,10 +2082,10 @@ void OMR::X86::Machine::purgeDeadRegistersFromRegisterFile()
 TR::MemoryReference *OMR::X86::Machine::getDummyLocalMR(TR::DataType dt)
 {
     if (_dummyLocal[dt] == NULL) {
-        _dummyLocal[dt] = self()->cg()->allocateLocalTemp(dt);
+        _dummyLocal[dt] = cg()->allocateLocalTemp(dt);
     }
 
-    return generateX86MemoryReference(_dummyLocal[dt], self()->cg());
+    return generateX86MemoryReference(_dummyLocal[dt], cg());
 }
 
 uint32_t OMR::X86::Machine::maxAssignableRegisters()
@@ -2130,10 +2106,10 @@ void OMR::X86::Machine::printGPRegisterStatus(OMR::Logger *log, TR_FrontEnd *fe,
     log->prints("\n  GP Reg Status:          Register         State        Assigned\n");
     int i;
     for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++) {
-        printOneRegisterStatus(log, fe, self()->getDebug(), registerFile[i]);
+        printOneRegisterStatus(log, fe, getDebug(), registerFile[i]);
     }
     for (i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; i++) {
-        printOneRegisterStatus(log, fe, self()->getDebug(), registerFile[i]);
+        printOneRegisterStatus(log, fe, getDebug(), registerFile[i]);
     }
 
     log->flush();

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -205,7 +205,7 @@ public:
 
     void resetXMMGlobalRegisters();
 
-    TR_Debug *getDebug();
+    OMR_FINAL TR_Debug *getDebug();
 
     uint8_t _numGlobalGPRs, _numGlobal8BitGPRs, _numGlobalFPRs;
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -146,7 +146,7 @@ void TR::X86LabelInstruction::initialize(TR::LabelSymbol *sym)
     _outlinedInstructionBranch = NULL;
     _reloType = TR_NoRelocation;
     _permitShortening = true;
-    if (sym && self()->getOpCodeValue() == TR::InstOpCode::label)
+    if (sym && getOpCodeValue() == TR::InstOpCode::label)
         sym->setInstruction(this);
     else if (sym)
         sym->setDirectlyTargeted();

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -176,9 +176,9 @@ uint8_t getMemoryBarrierBinaryLengthLowerBound(int32_t barrier, TR::CodeGenerato
 
 // -----------------------------------------------------------------------------
 // OMR::X86::Instruction:: member functions
-bool OMR::X86::Instruction::needsRepPrefix() { return self()->getOpCode().needsRepPrefix() != 0; }
+bool OMR::X86::Instruction::needsRepPrefix() { return getOpCode().needsRepPrefix() != 0; }
 
-bool OMR::X86::Instruction::needsLockPrefix() { return self()->getOpCode().needsLockPrefix() != 0; }
+bool OMR::X86::Instruction::needsLockPrefix() { return getOpCode().needsLockPrefix() != 0; }
 
 uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
 {
@@ -186,9 +186,9 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
     // it is needed to avoid recursive calls when generateOperand() requests to regenerate the binary code by returning
     // NULL;
     for (;;) {
-        uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
+        uint8_t *instructionStart = cg()->getBinaryBufferCursor();
         uint8_t *cursor = instructionStart;
-        self()->setBinaryEncoding(instructionStart);
+        setBinaryEncoding(instructionStart);
         if (self()->needsRepPrefix()) {
             *cursor++ = 0xf3;
         }
@@ -196,18 +196,17 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
             *cursor++ = 0xf0;
         }
         cursor = self()->generateRepeatedRexPrefix(cursor);
-        cursor = self()->getOpCode().binary(cursor, self()->getEncodingMethod(), self()->rexBits());
+        cursor = getOpCode().binary(cursor, self()->getEncodingMethod(), self()->rexBits());
         cursor = self()->generateOperand(cursor);
         // cursor is normal not NULL, and hence we can finish binary encoding and exit the loop
         // cursor is NULL when generateOperand() requests to regenerate the binary code, which may happen during
         // encoding of memref with unresolved symbols on 64-bit
         if (cursor) {
             if (!self()->getSource2ndRegister()) {
-                self()->getOpCode().finalize(instructionStart);
+                getOpCode().finalize(instructionStart);
             }
-            self()->setBinaryLength(static_cast<int8_t>(cursor - instructionStart));
-            self()->cg()->addAccumulatedInstructionLengthError(
-                self()->getEstimatedBinaryLength() - self()->getBinaryLength());
+            setBinaryLength(static_cast<int8_t>(cursor - instructionStart));
+            cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
             return cursor;
         }
     }
@@ -215,9 +214,9 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
 
 int32_t OMR::X86::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    self()->setEstimatedBinaryLength(self()->getOpCode().length(self()->getEncodingMethod(), self()->rexBits())
-        + (self()->needsRepPrefix() ? 1 : 0));
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    setEstimatedBinaryLength(
+        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + (self()->needsRepPrefix() ? 1 : 0));
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 // -----------------------------------------------------------------------------
@@ -611,9 +610,8 @@ uint8_t *TR::X86FenceInstruction::generateBinaryEncoding()
 
 int32_t TR::X86VirtualGuardNOPInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    setEstimatedBinaryLength(self()->cg()->comp()->target().is64Bit()
-            ? 5
-            : 6); // TODO:AMD64: What if patched instruction needs a Rex?  Is 6 enough?
+    setEstimatedBinaryLength(
+        cg()->comp()->target().is64Bit() ? 5 : 6); // TODO:AMD64: What if patched instruction needs a Rex?  Is 6 enough?
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -931,7 +929,7 @@ void TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                         int rType = methodSym->getMethodKind() - 1; // method kinds are 1-based
                         TR_ASSERT(reloTypes[rType], "There shouldn't be direct JNI interface calls!");
 
-                        uint8_t *startOfInstruction = self()->getBinaryEncoding();
+                        uint8_t *startOfInstruction = getBinaryEncoding();
                         uint8_t *startOfImmediate = cursor;
                         intptr_t diff = reinterpret_cast<intptr_t>(startOfImmediate)
                             - reinterpret_cast<intptr_t>(startOfInstruction);
@@ -1118,7 +1116,7 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
                     //
                     TR::MethodSymbol *methodSym = sym->getMethodSymbol();
 
-                    if (self()->cg()->comp()->target().is64Bit()) {
+                    if (cg()->comp()->target().is64Bit()) {
                         // Obtain the actual target of this call instruction.
                         //
                         // Symbols created for JNI methods have their method address pointing to the RAM method.
@@ -2594,7 +2592,7 @@ void TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
                 case TR_JNIStaticTargetAddress:
                 case TR_JNISpecialTargetAddress:
                 case TR_JNIVirtualTargetAddress: {
-                    uint8_t *startOfInstruction = self()->getBinaryEncoding();
+                    uint8_t *startOfInstruction = getBinaryEncoding();
                     uint8_t *startOfImmediate = cursor;
                     intptr_t diff
                         = reinterpret_cast<intptr_t>(startOfImmediate) - reinterpret_cast<intptr_t>(startOfInstruction);

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -97,9 +97,8 @@ int32_t memoryBarrierRequired(TR::InstOpCode &op, TR::MemoryReference *mr, TR::C
 
     static char *mbou = feGetEnv("TR_MemoryBarriersOnUnresolved");
 
-    TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation()
-            || cg->comp()->compilePortableCode()
-            || cg->comp()->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(),
+    TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation() || comp->compilePortableCode()
+            || comp->target().cpu.requiresLFence() == cg->getX86ProcessorInfo().requiresLFENCE(),
         "requiresLFence() failed\n");
 
     // Unresolved references are assumed to be volatile until they can be proven otherwise.
@@ -114,7 +113,7 @@ int32_t memoryBarrierRequired(TR::InstOpCode &op, TR::MemoryReference *mr, TR::C
                     barrier |= LockOR;
                 else
                     barrier |= kMemoryFence;
-            } else if (cg->comp()->target().cpu.requiresLFence())
+            } else if (comp->target().cpu.requiresLFence())
                 barrier |= kLoadFence;
         } else {
             if (op.modifiesTarget()) {
@@ -123,23 +122,22 @@ int32_t memoryBarrierRequired(TR::InstOpCode &op, TR::MemoryReference *mr, TR::C
                     barrier |= LockOR;
                 else
                     barrier |= kMemoryFence;
-            } else if (op.usesTarget() && cg->comp()->target().cpu.requiresLFence())
+            } else if (op.usesTarget() && comp->target().cpu.requiresLFence())
                 barrier |= kLoadFence;
         }
     }
 
     static char *disableExplicitFences = feGetEnv("TR_DisableExplicitFences");
     if (barrier) {
-        TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation()
-                || cg->comp()->compilePortableCode()
-                || cg->comp()->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(),
+        TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation()
+                || comp->compilePortableCode()
+                || comp->target().cpu.supportsLFence() == cg->getX86ProcessorInfo().supportsLFence(),
             "supportsLFence() failed\n");
-        TR_ASSERT_FATAL(cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation()
-                || cg->comp()->compilePortableCode()
-                || cg->comp()->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(),
+        TR_ASSERT_FATAL(comp->compileRelocatableCode() || comp->isOutOfProcessCompilation()
+                || comp->compilePortableCode()
+                || comp->target().cpu.supportsMFence() == cg->getX86ProcessorInfo().supportsMFence(),
             "supportsMFence() failed\n");
-        if ((!cg->comp()->target().cpu.supportsLFence() || !cg->comp()->target().cpu.supportsMFence())
-            || disableExplicitFences) {
+        if ((!comp->target().cpu.supportsLFence() || !comp->target().cpu.supportsMFence()) || disableExplicitFences) {
             if (op.supportsLockPrefix())
                 barrier |= LockPrefix;
             else
@@ -182,27 +180,32 @@ bool OMR::X86::Instruction::needsLockPrefix() { return getOpCode().needsLockPref
 
 uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
 {
-    // Normally the loop only executes once,
-    // it is needed to avoid recursive calls when generateOperand() requests to regenerate the binary code by returning
-    // NULL;
+    // Normally the loop only executes once. It is needed to avoid recursive
+    // calls when generateOperand() requests to regenerate the binary code by
+    // returning NULL.
+    //
     for (;;) {
         uint8_t *instructionStart = cg()->getBinaryBufferCursor();
         uint8_t *cursor = instructionStart;
         setBinaryEncoding(instructionStart);
-        if (self()->needsRepPrefix()) {
+        if (needsRepPrefix()) {
             *cursor++ = 0xf3;
         }
-        if (self()->needsLockPrefix()) {
+
+        if (needsLockPrefix()) {
             *cursor++ = 0xf0;
         }
-        cursor = self()->generateRepeatedRexPrefix(cursor);
-        cursor = getOpCode().binary(cursor, self()->getEncodingMethod(), self()->rexBits());
-        cursor = self()->generateOperand(cursor);
-        // cursor is normal not NULL, and hence we can finish binary encoding and exit the loop
+
+        cursor = generateRepeatedRexPrefix(cursor);
+        cursor = getOpCode().binary(cursor, getEncodingMethod(), rexBits());
+        cursor = generateOperand(cursor);
+
+        // cursor is normally not NULL, and hence we can finish binary encoding and exit the loop
         // cursor is NULL when generateOperand() requests to regenerate the binary code, which may happen during
         // encoding of memref with unresolved symbols on 64-bit
+        //
         if (cursor) {
-            if (!self()->getSource2ndRegister()) {
+            if (!getSource2ndRegister()) {
                 getOpCode().finalize(instructionStart);
             }
             setBinaryLength(static_cast<int8_t>(cursor - instructionStart));
@@ -214,8 +217,7 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
 
 int32_t OMR::X86::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + (self()->needsRepPrefix() ? 1 : 0));
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + (needsRepPrefix() ? 1 : 0));
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -400,7 +402,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
         if (label == NULL) {
             // Dummy instruction - stays a long branch and gets a zero distance
             //
-            cursor = getOpCode().binary(instructionStart, self()->getEncodingMethod(), self()->rexBits());
+            cursor = getOpCode().binary(instructionStart, getEncodingMethod(), rexBits());
             immediateCursor = cursor;
             *(uint32_t *)cursor = 0;
             cursor += 4;
@@ -433,7 +435,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                     getOpCode().convertLongBranchToShort();
                 }
 
-                cursor = getOpCode().binary(instructionStart, self()->getEncodingMethod(), self()->rexBits());
+                cursor = getOpCode().binary(instructionStart, getEncodingMethod(), rexBits());
                 immediateCursor = cursor;
 
                 if (label->getCodeLocation() != NULL) {
@@ -456,12 +458,12 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
                     comp->failCompilation<TR::CompilationException>("short form branch displacement too large");
                 }
 
-                cursor = getOpCode().binary(instructionStart, self()->getEncodingMethod(), self()->rexBits());
+                cursor = getOpCode().binary(instructionStart, getEncodingMethod(), rexBits());
                 immediateCursor = cursor;
 
                 if (label->getCodeLocation() != NULL) {
-                    *(int32_t *)cursor = distance + IA32LengthOfShortBranch
-                        - getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) - 4;
+                    *(int32_t *)cursor
+                        = distance + IA32LengthOfShortBranch - getOpCode().length(getEncodingMethod(), rexBits()) - 4;
                 } else {
                     cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, label));
                     *(uint32_t *)cursor = (uint32_t)(-(intptr_t)(cursor + 4));
@@ -475,7 +477,7 @@ uint8_t *TR::X86LabelInstruction::generateBinaryEncoding()
         immediateCursor = cursor;
     } else // assume absolute code address referencing instruction like push label
     {
-        cursor = getOpCode().binary(instructionStart, self()->getEncodingMethod(), self()->rexBits());
+        cursor = getOpCode().binary(instructionStart, getEncodingMethod(), rexBits());
         immediateCursor = cursor;
         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation(cursor, label));
         *(uint32_t *)cursor = 0;
@@ -500,8 +502,8 @@ uint8_t TR::X86LabelInstruction::getBinaryLengthLowerBound()
     }
 
     if (getOpCode().isBranchOp())
-        return getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + (_permitShortening ? 0 : 4);
-    return getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + 4; // assume absolute code reference
+        return getOpCode().length(getEncodingMethod(), rexBits()) + (_permitShortening ? 0 : 4);
+    return getOpCode().length(getEncodingMethod(), rexBits()) + 4; // assume absolute code reference
 }
 
 OMR::X86::EnlargementResult TR::X86LabelInstruction::enlarge(int32_t requestedEnlargementSize,
@@ -556,13 +558,13 @@ int32_t TR::X86LabelInstruction::estimateBinaryLength(int32_t currentEstimate)
                 }
             }
         }
-        setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + immediateLength);
+        setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + immediateLength);
     } else if (getOpCodeValue() == TR::InstOpCode::label) {
         getLabelSymbol()->setEstimatedCodeLocation(currentEstimate);
     } else // assume absolute code reference
     {
-        setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits())
-            + 4); // full offset for absolute address reference
+        setEstimatedBinaryLength(
+            getOpCode().length(getEncodingMethod(), rexBits()) + 4); // full offset for absolute address reference
     }
     return currentEstimate + getEstimatedBinaryLength();
 }
@@ -680,7 +682,7 @@ uint8_t *TR::X86VirtualGuardNOPInstruction::generateBinaryEncoding()
     TR::Instruction *instToBePatched = cg()->getInstructionToBePatched(this);
 
     int32_t shortJumpWidth = 2;
-    int32_t longJumpWidth = cg()->comp()->target().is64Bit() ? 5 : 6;
+    int32_t longJumpWidth = comp->target().is64Bit() ? 5 : 6;
 
     _nopSize = 0;
 
@@ -821,7 +823,7 @@ uint8_t *TR::X86ImmInstruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::X86ImmInstruction::getBinaryLengthLowerBound()
 {
-    uint8_t len = getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    uint8_t len = getOpCode().length(getEncodingMethod(), rexBits());
     if (getOpCode().hasIntImmediate())
         len += 4;
     else if (getOpCode().hasByteImmediate() || getOpCode().hasSignExtendImmediate())
@@ -839,7 +841,7 @@ int32_t TR::X86ImmInstruction::estimateBinaryLength(int32_t currentEstimate)
     } else if (getOpCode().hasShortImmediate()) {
         immediateLength = 2;
     }
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + immediateLength);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + immediateLength);
 
     return currentEstimate + getEstimatedBinaryLength();
 }
@@ -974,7 +976,7 @@ void TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                     __FILE__, __LINE__, getNode());
             } else if (symbol->isClassObject()) {
                 if (cg()->needClassAndMethodPointerRelocations()) {
-                    if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+                    if (comp->getOption(TR_UseSymbolValidationManager)) {
                         cg()->addExternalRelocation(
                             TR::ExternalRelocation::create(cursor, (uint8_t *)(uintptr_t)getSourceImmediate(),
                                 (uint8_t *)TR::SymbolType::typeClass, TR_SymbolFromManager, cg()),
@@ -1028,14 +1030,14 @@ void TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                                     NULL, TR_MethodEnterExitHookAddress, cg()),
                         __FILE__, __LINE__, getNode());
                 } else if (sym->isCallSiteTableEntry()) {
-                    if (cg()->comp()->compileRelocatableCode()) {
+                    if (comp->compileRelocatableCode()) {
                         cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                         (uint8_t *)getSymbolReference(), NULL,
                                                         TR_CallsiteTableEntryAddress, cg()),
                             __FILE__, __LINE__, getNode());
                     }
                 } else if (sym->isMethodTypeTableEntry()) {
-                    if (cg()->comp()->compileRelocatableCode()) {
+                    if (comp->compileRelocatableCode()) {
                         cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                         (uint8_t *)getSymbolReference(), NULL,
                                                         TR_MethodTypeTableEntryAddress, cg()),
@@ -1075,8 +1077,8 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
             /**
              * Branches to labels do not require trampolines on x86
              */
-            if (cg()->comp()->target().is64Bit() && cg()->hasCodeCacheSwitched()
-                && getOpCodeValue() == TR::InstOpCode::CALLImm4 && !labelSym) {
+            if (comp->target().is64Bit() && cg()->hasCodeCacheSwitched() && getOpCodeValue() == TR::InstOpCode::CALLImm4
+                && !labelSym) {
                 cg()->redoTrampolineReservationIfNecessary(this, getSymbolReference());
             }
 
@@ -1116,7 +1118,7 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
                     //
                     TR::MethodSymbol *methodSym = sym->getMethodSymbol();
 
-                    if (cg()->comp()->target().is64Bit()) {
+                    if (comp->target().is64Bit()) {
                         // Obtain the actual target of this call instruction.
                         //
                         // Symbols created for JNI methods have their method address pointing to the RAM method.
@@ -1148,7 +1150,7 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
                     } else {
                         // we need to reserve trampoline in all cases, since methods can get recompiled
                         // and we might need one in the future.
-                        if (cg()->comp()->target().is64Bit())
+                        if (comp->target().is64Bit())
                             cg()->fe()->reserveTrampolineIfNecessary(comp, getSymbolReference(), true);
 
                         if (isTrampolineRequired) {
@@ -1157,8 +1159,7 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
                         }
                     }
 
-                    TR_ASSERT_FATAL(
-                        cg()->comp()->target().cpu.isTargetWithinRIPRange(targetAddress, nextInstructionAddress),
+                    TR_ASSERT_FATAL(comp->target().cpu.isTargetWithinRIPRange(targetAddress, nextInstructionAddress),
                         "Direct call target must be reachable directly");
                 }
             }
@@ -1171,11 +1172,11 @@ uint8_t *TR::X86ImmSymInstruction::generateOperand(uint8_t *cursor)
             if (!symbol->isConst() && symbol->isClassObject()) {
                 if (cg()->needClassAndMethodPointerRelocations()) {
                     if (sym->isStatic()) {
-                        *(intptr_t *)cursor = (intptr_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(
-                            cg()->comp(), (TR_OpaqueClassBlock *)sym->getStaticSymbol()->getStaticAddress());
+                        *(intptr_t *)cursor = (intptr_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(comp,
+                            (TR_OpaqueClassBlock *)sym->getStaticSymbol()->getStaticAddress());
                     } else {
-                        *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(
-                            cg()->comp(), (TR_OpaqueClassBlock *)(uintptr_t)getSourceImmediate());
+                        *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(comp,
+                            (TR_OpaqueClassBlock *)(uintptr_t)getSourceImmediate());
                     }
                 }
             }
@@ -1208,24 +1209,26 @@ uint8_t *TR::X86RegInstruction::generateOperand(uint8_t *cursor)
 uint8_t TR::X86RegInstruction::getBinaryLengthLowerBound()
 {
     TR::InstOpCode &opCode = getOpCode();
-    return opCode.length(self()->getEncodingMethod(), self()->rexBits());
+    return opCode.length(getEncodingMethod(), rexBits());
 }
 
 int32_t TR::X86RegInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
     TR::InstOpCode &opCode = getOpCode();
-    setEstimatedBinaryLength(opCode.length(self()->getEncodingMethod(), self()->rexBits()) + rexRepeatCount());
+    setEstimatedBinaryLength(opCode.length(getEncodingMethod(), rexBits()) + rexRepeatCount());
     return currentEstimate + getEstimatedBinaryLength();
 }
 
 OMR::X86::EnlargementResult TR::X86RegInstruction::enlarge(int32_t requestedEnlargementSize, int32_t maxEnlargementSize,
     bool allowPartialEnlargement)
 {
+    TR::Compilation *comp = cg()->comp();
+
     static char *disableRexExpansion = feGetEnv("TR_DisableREXInstructionExpansion");
-    if (disableRexExpansion || cg()->comp()->getOption(TR_DisableZealousCodegenOpts))
+    if (disableRexExpansion || comp->getOption(TR_DisableZealousCodegenOpts))
         return OMR::X86::EnlargementResult(0, 0);
 
-    if (getOpCode().info().supportsAVX() && cg()->comp()->target().cpu.supportsAVX())
+    if (getOpCode().info().supportsAVX() && comp->target().cpu.supportsAVX())
         return OMR::X86::EnlargementResult(0, 0); // REX expansion isn't allowed for AVX instructions
 
     if ((maxEnlargementSize < requestedEnlargementSize && !allowPartialEnlargement) || requestedEnlargementSize < 1)
@@ -1233,7 +1236,6 @@ OMR::X86::EnlargementResult TR::X86RegInstruction::enlarge(int32_t requestedEnla
 
     int32_t enlargementSize = std::min(requestedEnlargementSize, maxEnlargementSize);
 
-    TR::Compilation *comp = cg()->comp();
     if (comp->target().is64Bit() && !getOpCode().info().hasMandatoryPrefix()
         && performTransformation(comp, "O^O Enlarging instruction %p by %d bytes by repeating the REX prefix\n", this,
             enlargementSize)) {
@@ -1376,7 +1378,7 @@ uint8_t *TR::X86RegMaskRegRegImmInstruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::X86RegMaskRegRegImmInstruction::getBinaryLengthLowerBound()
 {
-    uint8_t len = getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    uint8_t len = getOpCode().length(getEncodingMethod(), rexBits());
 
     if (getOpCode().hasIntImmediate())
         len += 4;
@@ -1395,7 +1397,7 @@ int32_t TR::X86RegMaskRegRegImmInstruction::estimateBinaryLength(int32_t current
     } else if (getOpCode().hasShortImmediate()) {
         immediateLength = 2;
     }
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + immediateLength);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + immediateLength);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -1516,15 +1518,14 @@ void TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
             case TR_MethodPointer:
                 if (getNode() && getNode()->getInlinedSiteIndex() == -1
-                    && (void *)(uintptr_t)getSourceImmediate()
-                        == cg()->comp()->getCurrentMethod()->resolvedMethodAddress())
+                    && (void *)(uintptr_t)getSourceImmediate() == comp->getCurrentMethod()->resolvedMethodAddress())
                     setReloKind(TR_RamMethod);
                 // intentional fall-through
             case TR_RamMethod:
                 symbolKind = TR::SymbolType::typeMethod;
                 // intentional fall-through
             case TR_ClassPointer:
-                if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+                if (comp->getOption(TR_UseSymbolValidationManager)) {
                     cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                     (uint8_t *)(uintptr_t)getSourceImmediate(), (uint8_t *)symbolKind,
                                                     TR_SymbolFromManager, cg()),
@@ -1570,7 +1571,7 @@ uint8_t *TR::X86RegImmInstruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::X86RegImmInstruction::getBinaryLengthLowerBound()
 {
-    uint8_t len = getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    uint8_t len = getOpCode().length(getEncodingMethod(), rexBits());
 
     if (getOpCode().hasIntImmediate())
         len += 4;
@@ -1590,8 +1591,7 @@ int32_t TR::X86RegImmInstruction::estimateBinaryLength(int32_t currentEstimate)
         immediateLength = 2;
     }
 
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + rexRepeatCount() + immediateLength);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + rexRepeatCount() + immediateLength);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -1628,9 +1628,9 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                 TR_ASSERT(!(getSymbolReference()->isUnresolved() && !symbol->isClassObject()),
                     "expecting a resolved symbol for this instruction class!\n");
 
-                *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(),
+                *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(comp,
                     (TR_OpaqueClassBlock *)(uintptr_t)getSourceImmediate());
-                if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+                if (comp->getOption(TR_UseSymbolValidationManager)) {
                     cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                     (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                     (uint8_t *)TR::SymbolType::typeClass, TR_SymbolFromManager, cg()),
@@ -1657,12 +1657,12 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             break;
         case TR_MethodPointer:
             if (getNode() && getNode()->getInlinedSiteIndex() == -1
-                && (void *)(uintptr_t)getSourceImmediate() == cg()->comp()->getCurrentMethod()->resolvedMethodAddress())
+                && (void *)(uintptr_t)getSourceImmediate() == comp->getCurrentMethod()->resolvedMethodAddress())
                 setReloKind(TR_RamMethod);
             symbolKind = TR::SymbolType::typeMethod;
             // intentional fall-through
         case TR_ClassPointer:
-            if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+            if (comp->getOption(TR_UseSymbolValidationManager)) {
                 cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                 (uint8_t *)(uintptr_t)getSourceImmediate(), (uint8_t *)symbolKind,
                                                 TR_SymbolFromManager, cg()),
@@ -1674,13 +1674,13 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             }
             break;
         case TR_DebugCounter: {
-            TR::DebugCounterBase *counter = cg()->comp()->getCounterFromStaticAddress(getSymbolReference());
+            TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(getSymbolReference());
             if (counter == NULL) {
-                cg()->comp()->failCompilation<TR::CompilationException>(
+                comp->failCompilation<TR::CompilationException>(
                     "Could not generate relocation for debug counter in "
                     "TR::X86RegImmSymInstruction::addMetaDataForCodeAddress\n");
             }
-            TR::DebugCounter::generateRelocation(cg()->comp(), cursor, getNode(), counter);
+            TR::DebugCounter::generateRelocation(comp, cursor, getNode(), counter);
         } break;
 
         case TR_BlockFrequency: {
@@ -1706,7 +1706,7 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
         } break;
 
         case TR_CallsiteTableEntryAddress: {
-            if (cg()->comp()->compileRelocatableCode()) {
+            if (comp->compileRelocatableCode()) {
                 cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
                                                 NULL, TR_CallsiteTableEntryAddress, cg()),
                     __FILE__, __LINE__, getNode());
@@ -1714,7 +1714,7 @@ void TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
         } break;
 
         case TR_MethodTypeTableEntryAddress: {
-            if (cg()->comp()->compileRelocatableCode()) {
+            if (comp->compileRelocatableCode()) {
                 cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
                                                 NULL, TR_MethodTypeTableEntryAddress, cg()),
                     __FILE__, __LINE__, getNode());
@@ -1751,9 +1751,11 @@ uint8_t *TR::X86RegImmSymInstruction::generateOperand(uint8_t *cursor)
 
 void TR::X86RegRegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 {
+    TR::Compilation *comp = cg()->comp();
+
     if (getOpCode().hasIntImmediate()) {
-        if (std::find(cg()->comp()->getStaticHCRPICSites()->begin(), cg()->comp()->getStaticHCRPICSites()->end(), this)
-            != cg()->comp()->getStaticHCRPICSites()->end()) {
+        if (std::find(comp->getStaticHCRPICSites()->begin(), comp->getStaticHCRPICSites()->end(), this)
+            != comp->getStaticHCRPICSites()->end()) {
             cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *)(uintptr_t)getSourceImmediateAsAddress()),
                 (void *)cursor);
         }
@@ -1788,7 +1790,7 @@ uint8_t *TR::X86RegRegImmInstruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::X86RegRegImmInstruction::getBinaryLengthLowerBound()
 {
-    uint8_t len = getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    uint8_t len = getOpCode().length(getEncodingMethod(), rexBits());
 
     if (getOpCode().hasIntImmediate())
         len += 4;
@@ -1807,7 +1809,7 @@ int32_t TR::X86RegRegImmInstruction::estimateBinaryLength(int32_t currentEstimat
     } else if (getOpCode().hasShortImmediate()) {
         immediateLength = 2;
     }
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + immediateLength);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + immediateLength);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -1838,7 +1840,7 @@ uint8_t TR::X86MemInstruction::getBinaryLengthLowerBound()
     if (barrier & NeedsExplicitBarrier)
         length += getMemoryBarrierBinaryLengthLowerBound(barrier, cg());
 
-    return getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length;
+    return getOpCode().length(getEncodingMethod(), rexBits()) + length;
 }
 
 int32_t TR::X86MemInstruction::estimateBinaryLength(int32_t currentEstimate)
@@ -1856,8 +1858,7 @@ int32_t TR::X86MemInstruction::estimateBinaryLength(int32_t currentEstimate)
     int32_t patchBoundaryPadding
         = (cg()->comp()->target().isSMP() && getMemoryReference()->getSymbolReference().isUnresolved()) ? 1 : 0;
 
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length + patchBoundaryPadding);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + length + patchBoundaryPadding);
 
     return currentEstimate + getEstimatedBinaryLength();
 }
@@ -1928,7 +1929,7 @@ void TR::X86MemImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
         if (_reloKind == TR_ClassAddress && cg()->needClassAndMethodPointerRelocations()) {
             TR_ASSERT(getNode(), "node expected to be non-NULL here");
-            if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+            if (comp->getOption(TR_UseSymbolValidationManager)) {
                 cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                 (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                 (uint8_t *)TR::SymbolType::typeClass, TR_SymbolFromManager, cg()),
@@ -2000,7 +2001,7 @@ uint8_t TR::X86MemImmInstruction::getBinaryLengthLowerBound()
     if (barrier & NeedsExplicitBarrier)
         length += getMemoryBarrierBinaryLengthLowerBound(barrier, cg());
 
-    length += getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    length += getOpCode().length(getEncodingMethod(), rexBits());
 
     if (getOpCode().hasIntImmediate())
         length += 4;
@@ -2034,8 +2035,7 @@ int32_t TR::X86MemImmInstruction::estimateBinaryLength(int32_t currentEstimate)
     uint32_t patchBoundaryPadding
         = (cg()->comp()->target().isSMP() && getMemoryReference()->getSymbolReference().isUnresolved()) ? 1 : 0;
 
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length + patchBoundaryPadding);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + length + patchBoundaryPadding);
 
     return currentEstimate + getEstimatedBinaryLength();
 }
@@ -2068,9 +2068,9 @@ void TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
     } else if (symbol->isClassObject()) {
         TR_ASSERT(getNode(), "No node where expected!");
         if (cg()->needClassAndMethodPointerRelocations()) {
-            *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(cg()->comp(),
+            *(int32_t *)cursor = (int32_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(comp,
                 (TR_OpaqueClassBlock *)(uintptr_t)getSourceImmediate());
-            if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+            if (comp->getOption(TR_UseSymbolValidationManager)) {
                 cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                 (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                 (uint8_t *)TR::SymbolType::typeClass, TR_SymbolFromManager, cg()),
@@ -2112,13 +2112,13 @@ void TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                         TR_MethodEnterExitHookAddress, cg()),
             __FILE__, __LINE__, getNode());
     } else if (symbol->isCallSiteTableEntry()) {
-        if (cg()->comp()->compileRelocatableCode()) {
+        if (comp->compileRelocatableCode()) {
             cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
                                             TR_CallsiteTableEntryAddress, cg()),
                 __FILE__, __LINE__, getNode());
         }
     } else if (symbol->isMethodTypeTableEntry()) {
-        if (cg()->comp()->compileRelocatableCode()) {
+        if (comp->compileRelocatableCode()) {
             cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(), NULL,
                                             TR_MethodTypeTableEntryAddress, cg()),
                 __FILE__, __LINE__, getNode());
@@ -2231,7 +2231,7 @@ uint8_t TR::X86MemRegImmInstruction::getBinaryLengthLowerBound()
     if (barrier & NeedsExplicitBarrier)
         length += getMemoryBarrierBinaryLengthLowerBound(barrier, cg());
 
-    length += getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    length += getOpCode().length(getEncodingMethod(), rexBits());
     if (getOpCode().hasIntImmediate())
         length += 4;
     else if (getOpCode().hasShortImmediate())
@@ -2264,8 +2264,7 @@ int32_t TR::X86MemRegImmInstruction::estimateBinaryLength(int32_t currentEstimat
     int32_t patchBoundaryPadding
         = (cg()->comp()->target().isSMP() && getMemoryReference()->getSymbolReference().isUnresolved()) ? 1 : 0;
 
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length + patchBoundaryPadding);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + length + patchBoundaryPadding);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -2307,7 +2306,7 @@ uint8_t TR::X86RegMemInstruction::getBinaryLengthLowerBound()
     if (barrier & NeedsExplicitBarrier)
         length += getMemoryBarrierBinaryLengthLowerBound(barrier, cg());
 
-    return getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length;
+    return getOpCode().length(getEncodingMethod(), rexBits()) + length;
 }
 
 int32_t TR::X86RegMemInstruction::estimateBinaryLength(int32_t currentEstimate)
@@ -2325,8 +2324,8 @@ int32_t TR::X86RegMemInstruction::estimateBinaryLength(int32_t currentEstimate)
     int32_t patchBoundaryPadding
         = (cg()->comp()->target().isSMP() && getMemoryReference()->getSymbolReference().isUnresolved()) ? 1 : 0;
 
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + rexRepeatCount()
-        + length + patchBoundaryPadding);
+    setEstimatedBinaryLength(
+        getOpCode().length(getEncodingMethod(), rexBits()) + rexRepeatCount() + length + patchBoundaryPadding);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -2440,7 +2439,7 @@ uint8_t TR::X86RegMemImmInstruction::getBinaryLengthLowerBound()
     if (barrier & NeedsExplicitBarrier)
         length += getMemoryBarrierBinaryLengthLowerBound(barrier, cg());
 
-    length += getOpCode().length(self()->getEncodingMethod(), self()->rexBits());
+    length += getOpCode().length(getEncodingMethod(), rexBits());
 
     if (getOpCode().hasIntImmediate())
         length += 4;
@@ -2474,8 +2473,7 @@ int32_t TR::X86RegMemImmInstruction::estimateBinaryLength(int32_t currentEstimat
     int32_t patchBoundaryPadding
         = (cg()->comp()->target().isSMP() && getMemoryReference()->getSymbolReference().isUnresolved()) ? 1 : 0;
 
-    setEstimatedBinaryLength(
-        getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + length + patchBoundaryPadding);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + length + patchBoundaryPadding);
 
     return currentEstimate + getEstimatedBinaryLength();
 }
@@ -2547,7 +2545,7 @@ void TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
             switch (_reloKind) {
                 case TR_ClassAddress: {
                     TR_ASSERT(getNode(), "node assumed to be non-NULL here");
-                    if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+                    if (comp->getOption(TR_UseSymbolValidationManager)) {
                         cg()->addExternalRelocation(
                             TR::ExternalRelocation::create(cursor, (uint8_t *)getSourceImmediate(),
                                 (uint8_t *)TR::SymbolType::typeClass, TR_SymbolFromManager, cg()),
@@ -2562,14 +2560,14 @@ void TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
                 case TR_MethodPointer:
                     if (getNode() && getNode()->getInlinedSiteIndex() == -1
-                        && (void *)getSourceImmediate() == cg()->comp()->getCurrentMethod()->resolvedMethodAddress())
+                        && (void *)getSourceImmediate() == comp->getCurrentMethod()->resolvedMethodAddress())
                         setReloKind(TR_RamMethod);
                     // intentional fall-through
                 case TR_RamMethod:
                     symbolKind = TR::SymbolType::typeMethod;
                     // intentional fall-through
                 case TR_ClassPointer:
-                    if (cg()->comp()->getOption(TR_UseSymbolValidationManager)) {
+                    if (comp->getOption(TR_UseSymbolValidationManager)) {
                         cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor,
                                                         (uint8_t *)getSourceImmediate(), (uint8_t *)symbolKind,
                                                         TR_SymbolFromManager, cg()),
@@ -2655,12 +2653,12 @@ uint8_t *TR::AMD64RegImm64Instruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::AMD64RegImm64Instruction::getBinaryLengthLowerBound()
 {
-    return getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + rexRepeatCount() + 8;
+    return getOpCode().length(getEncodingMethod(), rexBits()) + rexRepeatCount() + 8;
 }
 
 int32_t TR::AMD64RegImm64Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + 8);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + 8);
     return currentEstimate + getEstimatedBinaryLength();
 }
 
@@ -2712,7 +2710,7 @@ void TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             }
 
             case TR_NativeMethodAbsolute: {
-                if (cg()->comp()->getOption(TR_EmitRelocatableELFFile)) {
+                if (comp->getOption(TR_EmitRelocatableELFFile)) {
                     TR_ResolvedMethod *target
                         = getSymbolReference()->getSymbol()->castToResolvedMethodSymbol()->getResolvedMethod();
                     cg()->addStaticRelocation(TR::StaticRelocation(cursor, target->externalName(cg()->trMemory()),
@@ -2723,13 +2721,13 @@ void TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
             case TR_DebugCounter: {
                 if (cg()->needRelocationsForStatics()) {
-                    TR::DebugCounterBase *counter = cg()->comp()->getCounterFromStaticAddress(getSymbolReference());
+                    TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(getSymbolReference());
                     if (counter == NULL) {
-                        cg()->comp()->failCompilation<TR::CompilationException>(
+                        comp->failCompilation<TR::CompilationException>(
                             "Could not generate relocation for debug counter in "
                             "TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress\n");
                     }
-                    TR::DebugCounter::generateRelocation(cg()->comp(), cursor, getNode(), counter);
+                    TR::DebugCounter::generateRelocation(comp, cursor, getNode(), counter);
                 }
             } break;
             case TR_BlockFrequency: {
@@ -2754,7 +2752,7 @@ void TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             } break;
 
             case TR_CallsiteTableEntryAddress: {
-                if (cg()->comp()->compileRelocatableCode()) {
+                if (comp->compileRelocatableCode()) {
                     cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
                                                     NULL, TR_CallsiteTableEntryAddress, cg()),
                         __FILE__, __LINE__, getNode());
@@ -2762,7 +2760,7 @@ void TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             } break;
 
             case TR_MethodTypeTableEntryAddress: {
-                if (cg()->comp()->compileRelocatableCode()) {
+                if (comp->compileRelocatableCode()) {
                     cg()->addExternalRelocation(TR::ExternalRelocation::create(cursor, (uint8_t *)getSymbolReference(),
                                                     NULL, TR_MethodTypeTableEntryAddress, cg()),
                         __FILE__, __LINE__, getNode());
@@ -2818,13 +2816,13 @@ uint8_t *TR::AMD64Imm64Instruction::generateOperand(uint8_t *cursor)
 
 uint8_t TR::AMD64Imm64Instruction::getBinaryLengthLowerBound()
 {
-    uint8_t len = getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + 8;
+    uint8_t len = getOpCode().length(getEncodingMethod(), rexBits()) + 8;
     return len;
 }
 
 int32_t TR::AMD64Imm64Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    setEstimatedBinaryLength(getOpCode().length(self()->getEncodingMethod(), self()->rexBits()) + 8);
+    setEstimatedBinaryLength(getOpCode().length(getEncodingMethod(), rexBits()) + 8);
     return currentEstimate + getEstimatedBinaryLength();
 }
 

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -111,7 +111,7 @@ TR::RegisterDependencyConditions *OMR::Z::Instruction::setDependencyConditionsNo
     // If register dependency conditions exist, merge with the argument conditions
     if (_conditions) {
         TR::RegisterDependencyConditions *n
-            = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(_conditions, cond, self()->cg());
+            = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(_conditions, cond, cg());
         _conditions = 0;
         cond = n;
     }
@@ -130,13 +130,13 @@ TR::RegisterDependencyConditions *OMR::Z::Instruction::setDependencyConditions(T
         oldPostAddCursor = _conditions->getAddCursorForPost();
 
         TR::RegisterDependencyConditions *n
-            = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(_conditions, cond, self()->cg());
+            = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(_conditions, cond, cg());
         _conditions = 0;
         cond = n;
     }
 
     // Perform book keeping only on argument conditions
-    cond->bookKeepingRegisterUses(self(), self()->cg(), oldPreAddCursor, oldPostAddCursor);
+    cond->bookKeepingRegisterUses(self(), cg(), oldPreAddCursor, oldPostAddCursor);
     cond->setIsUsed();
     if (cond->getPreConditions())
         cond->getPreConditions()->incNumUses();
@@ -156,7 +156,7 @@ TR::RegisterDependencyConditions *OMR::Z::Instruction::updateDependencyCondition
         currentPostCursor = _conditions->getAddCursorForPost();
     }
 
-    cond->bookKeepingRegisterUses(self(), self()->cg(), currentPreCursor, currentPostCursor);
+    cond->bookKeepingRegisterUses(self(), cg(), currentPreCursor, currentPostCursor);
     cond->setIsUsed();
     return _conditions = cond;
 }
@@ -173,7 +173,7 @@ void OMR::Z::Instruction::initialize(TR::Instruction *precedingInstruction, bool
         // Don't want to increment total use counts for assocreg instructions
         // because their register references will confuse the code that tries
         // to determine when the first use of a register takes place
-        if (condFlag || self()->getOpCodeValue() != TR::InstOpCode::assocreg) {
+        if (condFlag || getOpCodeValue() != TR::InstOpCode::assocreg) {
             cond->bookKeepingRegisterUses(self(), cg);
             if (cond->getPreConditions())
                 cond->getPreConditions()->incNumUses();
@@ -211,7 +211,7 @@ uint32_t OMR::Z::Instruction::getEstimatedBinaryOffset()
         uint32_t i;
     } _u;
 
-    _u.p = self()->getBinaryEncoding();
+    _u.p = getBinaryEncoding();
     return _u.i;
 }
 
@@ -223,40 +223,40 @@ void OMR::Z::Instruction::setEstimatedBinaryOffset(uint32_t l)
     } _u;
 
     _u.i = l;
-    self()->setBinaryEncoding(_u.p);
+    setBinaryEncoding(_u.p);
 }
 
 void OMR::Z::Instruction::setCCInfo()
 {
-    if (self()->getNode() == NULL) {
+    if (getNode() == NULL) {
         // play it safe... perhaps this should be changed to an assert that the node should never be NULL?
         self()->clearCCInfo();
         return;
     }
 
     if (_opcode.setsCC()) {
-        if (self()->cg()->ccInstruction() != NULL) {
+        if (cg()->ccInstruction() != NULL) {
             // Check previous CC setting instruction... we can mark its usage as
             // known, since the current instruction will override its CC value.
-            self()->cg()->ccInstruction()->setCCuseKnown();
+            cg()->ccInstruction()->setCCuseKnown();
         }
-        if (!self()->cg()->comp()->getOption(TR_EnableEBBCCInfo)) {
+        if (!cg()->comp()->getOption(TR_EnableEBBCCInfo)) {
             if (_opcode.setsOverflowFlag() || _opcode.setsZeroFlag() || _opcode.setsSignFlag()
                 || _opcode.setsCarryFlag()) {
                 // we have detailed information on the CC setting
-                self()->cg()->setHasCCInfo(true);
-                self()->cg()->setHasCCOverflow(_opcode.setsOverflowFlag() && !self()->getNode()->cannotOverflow());
-                self()->cg()->setHasCCZero(_opcode.setsZeroFlag());
-                self()->cg()->setHasCCSigned(_opcode.setsSignFlag() || _opcode.setsCompareFlag());
-                self()->cg()->setCCInstruction(self());
-                self()->cg()->setHasCCCarry(_opcode.setsCarryFlag());
+                cg()->setHasCCInfo(true);
+                cg()->setHasCCOverflow(_opcode.setsOverflowFlag() && !getNode()->cannotOverflow());
+                cg()->setHasCCZero(_opcode.setsZeroFlag());
+                cg()->setHasCCSigned(_opcode.setsSignFlag() || _opcode.setsCompareFlag());
+                cg()->setCCInstruction(self());
+                cg()->setHasCCCarry(_opcode.setsCarryFlag());
             } else {
                 // the CC setting is generic or
                 // there is no node associated with this instruction,
                 // play it safe and record no information
-                self()->cg()->setHasCCInfo(false);
+                cg()->setHasCCInfo(false);
             }
-            self()->cg()->setCCInstruction(self());
+            cg()->setCCInstruction(self());
         } else {
             if (_opcode.setsOverflowFlag() || _opcode.setsZeroFlag() || _opcode.setsSignFlag()
                 || _opcode.setsCompareFlag() || _opcode.setsCarryFlag())
@@ -266,20 +266,20 @@ void OMR::Z::Instruction::setCCInfo()
             // flags
             {
                 // we have detailed information on the CC setting
-                self()->cg()->setHasCCInfo(true);
-                self()->cg()->setHasCCOverflow(_opcode.setsOverflowFlag() && !self()->getNode()->cannotOverflow());
-                self()->cg()->setHasCCZero(_opcode.setsZeroFlag());
-                self()->cg()->setHasCCSigned(_opcode.setsSignFlag());
-                self()->cg()->setHasCCCompare(_opcode.setsCompareFlag());
-                self()->cg()->setHasCCCarry(_opcode.setsCarryFlag());
-                self()->cg()->setCCInstruction(self());
+                cg()->setHasCCInfo(true);
+                cg()->setHasCCOverflow(_opcode.setsOverflowFlag() && !getNode()->cannotOverflow());
+                cg()->setHasCCZero(_opcode.setsZeroFlag());
+                cg()->setHasCCSigned(_opcode.setsSignFlag());
+                cg()->setHasCCCompare(_opcode.setsCompareFlag());
+                cg()->setHasCCCarry(_opcode.setsCarryFlag());
+                cg()->setCCInstruction(self());
             } else {
                 // the CC setting is generic, such as Load & Test Reg, Test Under Mask etc are not handled; or,
                 // there is no node associated with this instruction,
                 // play it safe and record no information
-                self()->cg()->setHasCCInfo(false);
+                cg()->setHasCCInfo(false);
             }
-            self()->cg()->setCCInstruction(self());
+            cg()->setCCInstruction(self());
         } // if enableEBBCCInfo
     }
 }
@@ -287,19 +287,19 @@ void OMR::Z::Instruction::setCCInfo()
 void OMR::Z::Instruction::readCCInfo()
 {
     if (_opcode.readsCC()) {
-        if (self()->cg()->ccInstruction() != NULL) {
+        if (cg()->ccInstruction() != NULL) {
             // Current instruction reads CC.  Mark the last instruction that
             // set the CC value as having its CC being used.
-            self()->cg()->ccInstruction()->setCCuseKnown();
-            self()->cg()->ccInstruction()->setCCused();
+            cg()->ccInstruction()->setCCuseKnown();
+            cg()->ccInstruction()->setCCused();
         }
     }
 }
 
 void OMR::Z::Instruction::clearCCInfo()
 {
-    self()->cg()->setHasCCInfo(false);
-    self()->cg()->setCCInstruction(NULL);
+    cg()->setHasCCInfo(false);
+    cg()->setCCInstruction(NULL);
 }
 
 bool OMR::Z::Instruction::matchesTargetRegister(TR::Register *reg)
@@ -497,7 +497,7 @@ TR::Instruction *OMR::Z::Instruction::getOutOfLineEXInstr()
 {
     if (!self()->isOutOfLineEX())
         return NULL;
-    switch (self()->getOpCodeValue()) {
+    switch (getOpCodeValue()) {
         case TR::InstOpCode::EX: {
             TR::MemoryReference *tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
             TR::S390ConstantInstructionSnippet *cis
@@ -520,8 +520,8 @@ TR::Instruction *OMR::Z::Instruction::getOutOfLineEXInstr()
 // and set appropriate flags
 void OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, TR::MemoryReference *mr)
 {
-    TR::Compilation *comp = self()->cg()->comp();
-    if (self()->cg()->getSupportsImplicitNullChecks()) {
+    TR::Compilation *comp = cg()->comp();
+    if (cg()->getSupportsImplicitNullChecks()) {
         // this instruction throws an implicit null check if:
         // 1. The treetop node is a NULLCHK node
         // 2. The memory reference of this instruction can cause a null pointer exception
@@ -531,11 +531,11 @@ void OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, T
 
         // Test conditions 1, 2, and 5
         if (n != NULL & mr != NULL && mr->getCausesImplicitNullPointerException()
-            && self()->cg()->getCurrentEvaluationTreeTop()->getNode()->getOpCode().isNullCheck()
-            && self()->cg()->getImplicitExceptionPoint() == NULL) {
+            && cg()->getCurrentEvaluationTreeTop()->getNode()->getOpCode().isNullCheck()
+            && cg()->getImplicitExceptionPoint() == NULL) {
             // determine what the NULLcheck reference node is
             TR::Node *nullCheckReference;
-            TR::Node *firstChild = self()->cg()->getCurrentEvaluationTreeTop()->getNode()->getFirstChild();
+            TR::Node *firstChild = cg()->getCurrentEvaluationTreeTop()->getNode()->getFirstChild();
             if (comp->useCompressedPointers() && firstChild->getOpCodeValue() == TR::l2a) {
                 TR::ILOpCodes loadOp = comp->il.opCodeForIndirectLoad(TR::Int32);
                 TR::ILOpCodes rdbarOp = comp->il.opCodeForIndirectReadBarrier(TR::Int32);
@@ -543,15 +543,15 @@ void OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, T
                     firstChild = firstChild->getFirstChild();
                 nullCheckReference = firstChild->getFirstChild();
             } else
-                nullCheckReference = self()->cg()->getCurrentEvaluationTreeTop()->getNode()->getNullCheckReference();
+                nullCheckReference = cg()->getCurrentEvaluationTreeTop()->getNode()->getNullCheckReference();
 
             // Test conditions 3 and 4
-            if ((self()->getNode()->getOpCode().hasSymbolReference()
-                    && self()->getNode()->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())
+            if ((getNode()->getOpCode().hasSymbolReference()
+                    && getNode()->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef())
                 || (n->hasChild(nullCheckReference) && mr->usesRegister(nullCheckReference->getRegister()))) {
                 logprintf(comp->getOption(TR_TraceCG), comp->log(),
                     "Instruction %p throws an implicit NPE, node: %p NPE node: %p\n", self(), n, nullCheckReference);
-                self()->cg()->setImplicitExceptionPoint(self());
+                cg()->setImplicitExceptionPoint(self());
             }
         }
     }
@@ -565,21 +565,21 @@ TR::S390ImmInstruction *OMR::Z::Instruction::getS390ImmInstruction() { return NU
 
 uint8_t *OMR::Z::Instruction::generateBinaryEncoding()
 {
-    uint8_t *instructionStart = self()->cg()->getBinaryBufferCursor();
+    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = instructionStart;
-    memset((void *)cursor, 0, self()->getEstimatedBinaryLength());
+    memset((void *)cursor, 0, getEstimatedBinaryLength());
 
-    self()->getOpCode().copyBinaryToBuffer(instructionStart);
-    self()->setBinaryLength(self()->getOpCode().getInstructionLength());
-    self()->setBinaryEncoding(instructionStart);
-    self()->cg()->addAccumulatedInstructionLengthError(self()->getEstimatedBinaryLength() - self()->getBinaryLength());
+    getOpCode().copyBinaryToBuffer(instructionStart);
+    setBinaryLength(getOpCode().getInstructionLength());
+    setBinaryEncoding(instructionStart);
+    cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
     return cursor;
 }
 
 int32_t OMR::Z::Instruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    self()->setEstimatedBinaryLength(self()->getOpCode().getInstructionLength());
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    setEstimatedBinaryLength(getOpCode().getInstructionLength());
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 bool OMR::Z::Instruction::dependencyRefsRegister(TR::Register *reg) { return false; }
@@ -725,14 +725,14 @@ static void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg
 
 void OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
-    if (self()->getOpCodeValue() != TR::InstOpCode::assocreg) {
+    if (getOpCodeValue() != TR::InstOpCode::assocreg) {
         self()->assignRegistersAndDependencies(kindToBeAssigned);
-    } else if (self()->cg()->enableRegisterAssociations()) {
+    } else if (cg()->enableRegisterAssociations()) {
         // if (kindToBeAssigned == TR_GPR)
         {
-            TR::Machine *machine = self()->cg()->machine();
+            TR::Machine *machine = cg()->machine();
 
             int32_t first = TR::RealRegister::FirstGPR;
             int32_t last = TR::RealRegister::LastAssignableVRF;
@@ -763,9 +763,9 @@ void OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
     if (outOfLineEXInstr) {
         TR::Instruction *savePrev = outOfLineEXInstr->getPrev();
 
-        outOfLineEXInstr->setPrev(self()->getPrev()); // Temporarily set Prev() instruction of snippet to Prev() of EX
-                                                      // just in case we insert LR_move on assignRegisters()
-        self()->cg()->tracePreRAInstruction(outOfLineEXInstr);
+        outOfLineEXInstr->setPrev(getPrev()); // Temporarily set Prev() instruction of snippet to Prev() of EX
+                                              // just in case we insert LR_move on assignRegisters()
+        cg()->tracePreRAInstruction(outOfLineEXInstr);
         outOfLineEXInstr->assignRegisters(kindToBeAssigned);
         TR::RegisterDependencyConditions *deps = outOfLineEXInstr->getDependencyConditions();
         if (deps) // merge the dependency into the EX deps
@@ -773,24 +773,24 @@ void OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
             outOfLineEXInstr->resetDependencyConditions();
             TR::RegisterDependencyConditions *exDeps = (self())->getDependencyConditions();
             TR::RegisterDependencyConditions *newDeps
-                = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(deps, exDeps, self()->cg());
+                = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(deps, exDeps, cg());
             (self())->setDependencyConditionsNoBookKeeping(newDeps);
         }
 
         outOfLineEXInstr->setPrev(savePrev); // Restore Prev() of snippet
-        self()->cg()->tracePostRAInstruction(outOfLineEXInstr);
+        cg()->tracePostRAInstruction(outOfLineEXInstr);
 
         // Java and other languages probably need the value field to be set to the binary encoding of the instruction
         // This can be done any time after register assignment
         // If the value is set here, the snippet can be handled in an identical fashion to a normal constantdataSnippet
     }
 
-    handleLoadWithRegRanges(self(), self()->cg());
+    handleLoadWithRegRanges(self(), cg());
 }
 
 uint32_t OMR::Z::Instruction::useSourceRegister(TR::Register *reg)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     if (_sourceStart < 0) {
         if (_targetStart < 0)
@@ -825,7 +825,7 @@ const char *OMR::Z::Instruction::getName(TR_Debug *debug)
 
 void OMR::Z::Instruction::recordOperand(void *operand, int8_t &operandCount)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     uint32_t n = self()->numOperands();
 
     void **p = (void **)comp->allocator().allocate(sizeof(void *) * (n + 1));
@@ -873,14 +873,14 @@ bool OMR::Z::Instruction::containsRegister(TR::Register *reg)
             return true;
 
     if (self()->isOutOfLineEX()) {
-        if (self()->getOpCodeValue() == TR::InstOpCode::EX) {
+        if (getOpCodeValue() == TR::InstOpCode::EX) {
             TR::MemoryReference *tempMR = ((TR::S390RXInstruction *)self())->getMemoryReference();
             TR::S390ConstantInstructionSnippet *cis
                 = (TR::S390ConstantInstructionSnippet *)tempMR->getConstantDataSnippet();
             TR_ASSERT(cis != NULL, "Out of line EX instruction doesn't have a constantInstructionSnippet\n");
             if (cis->getInstruction()->containsRegister(reg))
                 return true;
-        } else if (self()->getOpCodeValue() == TR::InstOpCode::EXRL) {
+        } else if (getOpCodeValue() == TR::InstOpCode::EXRL) {
             TR::S390ConstantInstructionSnippet *cis
                 = (TR::S390ConstantInstructionSnippet *)((TR::S390RILInstruction *)self())->getTargetSnippet();
             TR_ASSERT(cis != NULL, "Out of line EXRL instruction doesn't have a constantInstructionSnippet\n");
@@ -893,7 +893,7 @@ bool OMR::Z::Instruction::containsRegister(TR::Register *reg)
 
 uint32_t OMR::Z::Instruction::useTargetRegister(TR::Register *reg)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     if (_targetStart < 0) {
         if (_sourceStart < 0)
             _targetStart = 0;
@@ -904,8 +904,8 @@ uint32_t OMR::Z::Instruction::useTargetRegister(TR::Register *reg)
     self()->recordOperand((void *)reg, _targetRegSize);
 
     // Invalidate CC if target kills any of the usesOnlyRegisters of ccInst
-    TR::Instruction *ccInst = self()->cg()->ccInstruction();
-    if (self()->cg()->hasCCInfo() && (self() != ccInst) && ccInst->containsRegister(reg)) {
+    TR::Instruction *ccInst = cg()->ccInstruction();
+    if (cg()->hasCCInfo() && (self() != ccInst) && ccInst->containsRegister(reg)) {
         ccInst->setCCuseKnown();
         self()->clearCCInfo();
     }
@@ -915,10 +915,9 @@ uint32_t OMR::Z::Instruction::useTargetRegister(TR::Register *reg)
     if (reg->getKind() == TR_GPR
         && (_opcode.is64bit() || _opcode.is32to64bit()
             || (comp->target().is64Bit()
-                && (self()->getOpCodeValue() == TR::InstOpCode::LA || self()->getOpCodeValue() == TR::InstOpCode::LAY
-                    || self()->getOpCodeValue() == TR::InstOpCode::LARL
-                    || self()->getOpCodeValue() == TR::InstOpCode::BASR
-                    || self()->getOpCodeValue() == TR::InstOpCode::BRASL)))) {
+                && (getOpCodeValue() == TR::InstOpCode::LA || getOpCodeValue() == TR::InstOpCode::LAY
+                    || getOpCodeValue() == TR::InstOpCode::LARL || getOpCodeValue() == TR::InstOpCode::BASR
+                    || getOpCodeValue() == TR::InstOpCode::BRASL)))) {
         reg->setIs64BitReg(true);
 
         if (reg->getRegisterPair()) {
@@ -934,31 +933,31 @@ uint32_t OMR::Z::Instruction::useTargetRegister(TR::Register *reg)
 bool OMR::Z::Instruction::hasLongDisplacementSupport()
 {
     // Includes all instructions with long displacement support - RXE, RX, RXY, RS, RSY, SI, SIY
-    return self()->getOpCode().hasLongDispSupport();
+    return getOpCode().hasLongDispSupport();
 }
 
 uint32_t OMR::Z::Instruction::useSourceMemoryReference(TR::MemoryReference *memRef)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR_ASSERT(!memRef->getMemRefUsedBefore(), "Memory Reference Used Before");
     memRef->setMemRefUsedBefore();
 
     self()->recordOperand(memRef, _sourceMemSize);
 
-    memRef->bookKeepingRegisterUses(self(), self()->cg());
+    memRef->bookKeepingRegisterUses(self(), cg());
 
     return _sourceMemSize - 1; // index into source memref array
 }
 
 uint32_t OMR::Z::Instruction::useTargetMemoryReference(TR::MemoryReference *memRef, TR::MemoryReference *sourceMemRef)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR_ASSERT(!memRef->getMemRefUsedBefore(), "Memory Reference Used Before");
     memRef->setMemRefUsedBefore();
 
     self()->recordOperand(memRef, _targetMemSize);
 
-    memRef->bookKeepingRegisterUses(self(), self()->cg());
+    memRef->bookKeepingRegisterUses(self(), cg());
 
     return _targetMemSize - 1; // index into the target memref array
 }
@@ -982,7 +981,7 @@ int OMR::Z::Instruction::gatherRegPairsAtFrontOfArray(TR::Register **regArr, int
 
 TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *reg)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     // preventing assigning Real regs to Real regs
     if (reg->getRealRegister() != NULL) {
@@ -992,7 +991,7 @@ TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *re
         // BCR R15/R14, GPR0 have hardcoded GPR0 that we should ignore.
         // The register is treated as a NOP branch, and is neither used nor defined.
         bool skipBookkeeping = false;
-        if (self()->getOpCodeValue() == TR::InstOpCode::BCR
+        if (getOpCodeValue() == TR::InstOpCode::BCR
             && toRealRegister(reg)->getRegisterNumber() == TR::RealRegister::GPR0
             && (((TR::S390RegInstruction *)self())->getBranchCondition() == TR::InstOpCode::COND_MASK14
                 || ((TR::S390RegInstruction *)self())->getBranchCondition() == TR::InstOpCode::COND_MASK15))
@@ -1004,7 +1003,7 @@ TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *re
             realReg->setAssignedRegister(NULL);
             realReg->setState(TR::RealRegister::Free);
 
-            self()->cg()->traceRegFreed(virtReg, realReg);
+            cg()->traceRegFreed(virtReg, realReg);
         }
 
         return reg;
@@ -1024,7 +1023,7 @@ TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *re
             realRegHigh->setAssignedRegister(NULL);
             realRegHigh->setState(TR::RealRegister::Free);
 
-            self()->cg()->traceRegFreed(virtRegHigh, realRegHigh);
+            cg()->traceRegFreed(virtRegHigh, realRegHigh);
         }
 
         if (realRegLow->getState() != TR::RealRegister::Locked && BOOKKEEPING && virtRegLow
@@ -1033,7 +1032,7 @@ TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *re
             realRegLow->setAssignedRegister(NULL);
             realRegLow->setState(TR::RealRegister::Free);
 
-            self()->cg()->traceRegFreed(virtRegLow, realRegLow);
+            cg()->traceRegFreed(virtRegLow, realRegLow);
         }
 
         return reg;
@@ -1042,7 +1041,7 @@ TR::Register *OMR::Z::Instruction::assignRegisterNoDependencies(TR::Register *re
     uint64_t regMask = 0xffffffff;
     if (reg->isUsedInMemRef())
         regMask = ~TR::RealRegister::GPR0Mask;
-    return self()->cg()->machine()->assignBestRegister(reg, self(), BOOKKEEPING, regMask);
+    return cg()->machine()->assignBestRegister(reg, self(), BOOKKEEPING, regMask);
 }
 
 // Make sure reg life is really ended.
@@ -1124,7 +1123,7 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
     int32_t i;
     int32_t numTrgtPairs = 0;
     bool blockTarget = true;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     TR::Register **_sourceReg = self()->sourceRegBase();
     TR::Register **_targetReg = self()->targetRegBase();
@@ -1133,7 +1132,7 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
 
     TR::Register *srcRegister = NULL;
     TR::Register *trgtRegister = NULL;
-    TR::Machine *machine = self()->cg()->machine();
+    TR::Machine *machine = cg()->machine();
     TR::RealRegister *postInstrFreeRealReg = NULL;
     TR::Register *postInstrFreeReg = NULL;
 
@@ -1166,15 +1165,15 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
         }
     }
 
-    if ((self()->getOpCodeValue() == TR::InstOpCode::XGR || self()->getOpCodeValue() == TR::InstOpCode::XR)
+    if ((getOpCodeValue() == TR::InstOpCode::XGR || getOpCodeValue() == TR::InstOpCode::XR)
         && _sourceReg[0] == _targetReg[0]) {
         postInstrFreeReg = _targetReg[0];
     }
 
     //  If there is only 1 target register we don't need to block
     //
-    if (numTrgtPairs == 0 && _targetReg && _targetRegSize == 1 && _targetMem == NULL
-        && !self()->getOpCode().usesTarget() && // ii: !getOpCode().isRegCopy() &&
+    if (numTrgtPairs == 0 && _targetReg && _targetRegSize == 1 && _targetMem == NULL && !getOpCode().usesTarget()
+        && // ii: !getOpCode().isRegCopy() &&
         !self()->anySpilledRegisters(_sourceReg, _sourceRegSize)
         && !self()->anySpilledRegisters(_sourceMem, _sourceMemSize)) {
         blockTarget = false;
@@ -1248,8 +1247,7 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
     }
 
     if (self()->getDependencyConditions()) {
-        self()->getDependencyConditions()->assignPreConditionRegisters(self()->getPrev(), kindToBeAssigned,
-            self()->cg());
+        self()->getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 
     // unblock blocked targetRegs
@@ -1282,13 +1280,13 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
 
     if (_sourceMem) {
         for (i = 0; i < _sourceMemSize; ++i) {
-            _sourceMem[i]->assignRegisters(self(), self()->cg());
+            _sourceMem[i]->assignRegisters(self(), cg());
             _sourceMem[i]->blockRegisters();
         }
     }
     if (_targetMem) {
         for (i = 0; i < _targetMemSize; ++i) {
-            _targetMem[i]->assignRegisters(self(), self()->cg());
+            _targetMem[i]->assignRegisters(self(), cg());
             _targetMem[i]->blockRegisters();
         }
     }
@@ -1307,12 +1305,12 @@ void OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
     TR::MemoryReference **_targetMem = self()->targetMemBase();
 
     // RIE for CompareAndBranch
-    if (self()->getOpCode().isBranchOp() && self()->getKind() == IsRIE
+    if (getOpCode().isBranchOp() && getKind() == IsRIE
         && ((TR::S390RIEInstruction *)self())->getLabelSymbol()->isStartOfColdInstructionStream()) {
         // Switch to the outlined instruction stream and assign registers.
         //
         TR_S390OutOfLineCodeSection *oi
-            = self()->cg()->findS390OutOfLineCodeSectionFromLabel(((TR::S390RIEInstruction *)self())->getLabelSymbol());
+            = cg()->findS390OutOfLineCodeSectionFromLabel(((TR::S390RIEInstruction *)self())->getLabelSymbol());
         TR_ASSERT(oi, "Could not find S390OutOfLineCodeSection stream from label.  instr=%p, label=%p\n", self(),
             ((TR::S390RIEInstruction *)self())->getLabelSymbol());
         if (!oi->hasBeenRegisterAssigned())
@@ -1324,15 +1322,15 @@ void OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
     //
     if (self()->getDependencyConditions()) {
         self()->block(_sourceReg, _sourceRegSize, _targetReg, _targetRegSize, _sourceMem, _targetMem);
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, self()->cg());
+        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
 
         // FPR and VRF register files overlap. Some of the FPRs are non-volatile but if they hold vector data
         // that part of the data would not be preserved. This code looks at the data stored in non-volatile FPRs
         // and if it is assigned a vector virtual then it needs to be killed.
-        if (self()->cg()->getSupportsVectorRegisters() && self()->isCall()) {
-            TR::Machine *machine = self()->cg()->machine();
-            TR::Register *dummy = self()->cg()->allocateRegister(TR_FPR);
-            TR::Linkage *linkage = self()->cg()->getLinkage();
+        if (cg()->getSupportsVectorRegisters() && self()->isCall()) {
+            TR::Machine *machine = cg()->machine();
+            TR::Register *dummy = cg()->allocateRegister(TR_FPR);
+            TR::Linkage *linkage = cg()->getLinkage();
             dummy->setPlaceholderReg();
             for (int32_t i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; i++) {
                 if (linkage->getPreserved(REGNUM(i))) {
@@ -1346,7 +1344,7 @@ void OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
                     }
                 }
             }
-            self()->cg()->stopUsingRegister(dummy);
+            cg()->stopUsingRegister(dummy);
         }
 
         self()->unblock(_sourceReg, _sourceRegSize, _targetReg, _targetRegSize, _sourceMem, _targetMem);
@@ -1378,7 +1376,7 @@ int32_t OMR::Z::Instruction::renameRegister(TR::Register *from, TR::Register *to
     TR::MemoryReference *memRef2 = self()->getMemoryReference2();
     if (memRef1) {
         if (memRef1->getBaseRegister() == from) {
-            memRef1->setBaseRegister(to, self()->cg());
+            memRef1->setBaseRegister(to, cg());
             numReplaced++;
         }
         if (memRef1->getIndexRegister() == from) {
@@ -1388,7 +1386,7 @@ int32_t OMR::Z::Instruction::renameRegister(TR::Register *from, TR::Register *to
     }
     if (memRef2) {
         if (memRef2->getBaseRegister() == from) {
-            memRef2->setBaseRegister(to, self()->cg());
+            memRef2->setBaseRegister(to, cg());
             numReplaced++;
         }
         if (memRef2->getIndexRegister() == from) {
@@ -1480,8 +1478,8 @@ bool OMR::Z::Instruction::checkRegForGPR0Disable(TR::InstOpCode::Mnemonic op, TR
     TR_ASSERT(reg != NULL, "Reg cannot be null!");
 
     if (reg->getRealRegister() == NULL
-        && ((self()->getOpCode().isBranchOp() && self()->getOpCode().getInstructionFormat() == RR_FORMAT)
-            || self()->getOpCodeValue() == TR::InstOpCode::EX || self()->getOpCodeValue() == TR::InstOpCode::EXRL)) {
+        && ((getOpCode().isBranchOp() && getOpCode().getInstructionFormat() == RR_FORMAT)
+            || getOpCodeValue() == TR::InstOpCode::EX || getOpCodeValue() == TR::InstOpCode::EXRL)) {
         reg->setIsUsedInMemRef();
         return true;
     }
@@ -1511,7 +1509,7 @@ void OMR::Z::Instruction::resetUseDefRegisters()
 
 void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::Register **_sourceReg = self()->sourceRegBase();
     TR::Register **_targetReg = self()->targetRegBase();
     TR::MemoryReference **_sourceMem = self()->sourceMemBase();
@@ -1520,19 +1518,18 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
     uint32_t indexSource = 0, indexTarget = 0, i;
     TR::RegisterPair *regPair;
     TR::RegisterDependencyConditions *dependencies = self()->getDependencyConditions();
-    if (self()->cg()->getCodeGeneratorPhase() == TR::CodeGenPhase::PeepholePhase) {
+    if (cg()->getCodeGeneratorPhase() == TR::CodeGenPhase::PeepholePhase) {
         // In Peephole Phase, UseDefRegisters need to reset. The check on non Peephole Phase needs to be avoided here.
         if ((_useRegs != NULL && _useRegs->size() != 0) || (_defRegs != NULL && _defRegs->size() != 0)) {
         } else
-            _sourceUsedInMemoryReference
-                = new (self()->cg()->comp()->allocator()) RegisterBitVector(self()->cg()->comp());
+            _sourceUsedInMemoryReference = new (cg()->comp()->allocator()) RegisterBitVector(cg()->comp());
         // allocate arrays
     } else {
         TR_ASSERT(((_useRegs == NULL || _useRegs->size() == 0) || (_defRegs == NULL || _defRegs->size() == 0)),
             "source&target registers have already been set\n");
         if ((_useRegs != NULL && _useRegs->size() != 0) || (_defRegs != NULL && _defRegs->size() != 0))
             return;
-        _sourceUsedInMemoryReference = new (self()->cg()->comp()->allocator()) RegisterBitVector(self()->cg()->comp());
+        _sourceUsedInMemoryReference = new (cg()->comp()->allocator()) RegisterBitVector(cg()->comp());
         // allocate arrays
     }
 
@@ -1541,19 +1538,19 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
     if ((_sourceReg != NULL) || (_sourceMem != NULL) || (_targetMem != NULL)
         || (self()->implicitlyUsesGPR0() || self()->implicitlyUsesGPR1() || self()->implicitlyUsesGPR2())
         || ((_targetReg != NULL)
-            && (self()->isStore() || self()->isCompare() || self()->isTrap() || self()->getOpCode().usesTarget()))) {
+            && (self()->isStore() || self()->isCompare() || self()->isTrap() || getOpCode().usesTarget()))) {
         if (_useRegs == NULL) {
-            _useRegs = new (self()->cg()->comp()->allocator()) RegisterArray<TR::Register *>(self()->cg()->comp());
+            _useRegs = new (cg()->comp()->allocator()) RegisterArray<TR::Register *>(cg()->comp());
         }
     }
     if ((self()->implicitlySetsGPR0() || self()->implicitlySetsGPR1() || self()->implicitlySetsGPR2())
         || ((_targetReg != NULL)
                 && ((!self()->isStore() && (!self()->isCompare()) && (!self()->isTrap())
-                        && (self()->getOpCodeValue() != TR::InstOpCode::PPA))
+                        && (getOpCodeValue() != TR::InstOpCode::PPA))
                     || self()->isLoad())
             || (dependencies != NULL))) {
         if (_defRegs == NULL) {
-            _defRegs = new (self()->cg()->comp()->allocator()) RegisterArray<TR::Register *>(self()->cg()->comp());
+            _defRegs = new (cg()->comp()->allocator()) RegisterArray<TR::Register *>(cg()->comp());
         }
     }
 
@@ -1572,14 +1569,12 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
                 // TO-DO:  generalize the TR::InstOpCode::EDMK  support to something
                 // more generic like "usesImpliedSource and setsImpliedTarget"
                 // (rather than handing a specific op-code)
-                if ((self()->getOpCodeValue() == TR::InstOpCode::CPSDR) && (i == 1)) {
+                if ((getOpCodeValue() == TR::InstOpCode::CPSDR) && (i == 1)) {
                     (*_defRegs)[indexTarget++] = _sourceReg[i];
-                } else if (self()->getOpCodeValue() == TR::InstOpCode::EDMK) {
+                } else if (getOpCodeValue() == TR::InstOpCode::EDMK) {
                     (*_useRegs)[indexSource++] = _sourceReg[i];
-                } else if (self()->getOpCodeValue() != TR::InstOpCode::LM
-                    && self()->getOpCodeValue() != TR::InstOpCode::LMG
-                    && self()->getOpCodeValue() != TR::InstOpCode::LMH
-                    && self()->getOpCodeValue() != TR::InstOpCode::LMY) {
+                } else if (getOpCodeValue() != TR::InstOpCode::LM && getOpCodeValue() != TR::InstOpCode::LMG
+                    && getOpCodeValue() != TR::InstOpCode::LMH && getOpCodeValue() != TR::InstOpCode::LMY) {
                     (*_useRegs)[indexSource++] = _sourceReg[i];
                 } else {
                     (*_defRegs)[indexTarget++] = _sourceReg[i];
@@ -1592,38 +1587,36 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
             regPair = _targetReg[i]->getRegisterPair();
             if (regPair != NULL) {
                 // if it's a store or compare instruction, put all regs in _useRegs
-                if (self()->isStore() || self()->isCompare() || self()->isTrap() || self()->getOpCode().usesTarget()) {
+                if (self()->isStore() || self()->isCompare() || self()->isTrap() || getOpCode().usesTarget()) {
                     (*_useRegs)[indexSource++] = regPair->getHighOrder();
                     (*_useRegs)[indexSource++] = regPair->getLowOrder();
                 }
-                if ((!self()->isStore() && !self()->getOpCode().setsCompareFlag()) || self()->isLoad()) {
+                if ((!self()->isStore() && !getOpCode().setsCompareFlag()) || self()->isLoad()) {
                     (*_defRegs)[indexTarget++] = regPair->getHighOrder();
                     (*_defRegs)[indexTarget++] = regPair->getLowOrder();
                 }
             } else {
                 // if it's a store or compare instruction, put all regs in _useRegs
-                if ((self()->isStore() || self()->isCompare() || self()->isTrap() || self()->getOpCode().usesTarget()
-                        || (self()->getOpCodeValue() == TR::InstOpCode::CPSDR))
-                    && (self()->getOpCodeValue() != TR::InstOpCode::EDMK)
-                    && (self()->getOpCodeValue() != TR::InstOpCode::TRTR)) {
+                if ((self()->isStore() || self()->isCompare() || self()->isTrap() || getOpCode().usesTarget()
+                        || (getOpCodeValue() == TR::InstOpCode::CPSDR))
+                    && (getOpCodeValue() != TR::InstOpCode::EDMK) && (getOpCodeValue() != TR::InstOpCode::TRTR)) {
                     (*_useRegs)[indexSource++] = _targetReg[i];
                 }
                 if ((!self()->isStore() && !self()->isCompare() && !self()->isTrap()
-                        && (self()->getOpCodeValue() != TR::InstOpCode::CPSDR)
-                        && (self()->getOpCodeValue() != TR::InstOpCode::PPA))
-                    || self()->isLoad() || (self()->getOpCodeValue() == TR::InstOpCode::EDMK)
-                    || (self()->getOpCodeValue() == TR::InstOpCode::TRTR)) {
+                        && (getOpCodeValue() != TR::InstOpCode::CPSDR) && (getOpCodeValue() != TR::InstOpCode::PPA))
+                    || self()->isLoad() || (getOpCodeValue() == TR::InstOpCode::EDMK)
+                    || (getOpCodeValue() == TR::InstOpCode::TRTR)) {
                     (*_defRegs)[indexTarget++] = _targetReg[i];
                 }
             }
         }
     }
 
-    if (self()->getOpCodeValue() == TR::InstOpCode::LM || self()->getOpCodeValue() == TR::InstOpCode::LMG
-        || self()->getOpCodeValue() == TR::InstOpCode::LMH || self()->getOpCodeValue() == TR::InstOpCode::LMY)
+    if (getOpCodeValue() == TR::InstOpCode::LM || getOpCodeValue() == TR::InstOpCode::LMG
+        || getOpCodeValue() == TR::InstOpCode::LMH || getOpCodeValue() == TR::InstOpCode::LMY)
         loadOrStoreMultiple = 0; // load
-    else if (self()->getOpCodeValue() == TR::InstOpCode::STM || self()->getOpCodeValue() == TR::InstOpCode::STMG
-        || self()->getOpCodeValue() == TR::InstOpCode::STMH || self()->getOpCodeValue() == TR::InstOpCode::STMY)
+    else if (getOpCodeValue() == TR::InstOpCode::STM || getOpCodeValue() == TR::InstOpCode::STMG
+        || getOpCodeValue() == TR::InstOpCode::STMH || getOpCodeValue() == TR::InstOpCode::STMY)
         loadOrStoreMultiple = 1; // store
 
     if (loadOrStoreMultiple >= 0) {
@@ -1659,7 +1652,7 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
                 lowRegNum = (lowRegNum == 15) ? 0 : lowRegNum + 1;
                 for (uint32_t i = lowRegNum; i != highRegNum; i = ((i == 15) ? 0 : i + 1)) // wrap around to 0 at 15
                 {
-                    TR::RealRegister *reg = self()->cg()->machine()->getRealRegister(i + TR::RealRegister::GPR0);
+                    TR::RealRegister *reg = cg()->machine()->getRealRegister(i + TR::RealRegister::GPR0);
                     if (loadOrStoreMultiple == 0) // load
                         (*_defRegs)[indexTarget++] = reg;
                     else if (loadOrStoreMultiple == 1) // store
@@ -1700,7 +1693,7 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
         // dont look at the dependencies for anything other than TR::InstOpCode::DEPEND
         // to avoid double entries due to register pair dependencies
         TR::Register *tempRegister;
-        if ((dependencies != NULL) && ((self()->getOpCode().getOpCodeValue() == TR::InstOpCode::DEPEND))) {
+        if ((dependencies != NULL) && ((getOpCode().getOpCodeValue() == TR::InstOpCode::DEPEND))) {
             TR::RegisterDependencyGroup *preConditions = dependencies->getPreConditions();
             TR::RegisterDependencyGroup *postConditions = dependencies->getPostConditions();
             if (preConditions != NULL) {
@@ -1770,7 +1763,7 @@ bool OMR::Z::Instruction::getOneLocalLocalAllocFreeReg(TR::RealRegister **reg)
 
     for (i = first; i <= last; i++) {
         if ((_binFreeRegs >> cnt) & 0x1) {
-            *reg = self()->cg()->machine()->getRealRegister(cnt + 1);
+            *reg = cg()->machine()->getRealRegister(cnt + 1);
             return true;
         }
         cnt++;
@@ -1792,9 +1785,9 @@ bool OMR::Z::Instruction::getTwoLocalLocalAllocFreeReg(TR::RealRegister **reg1, 
     for (i = first; i <= last; i++) {
         if ((_binFreeRegs >> cnt) & 0x1) {
             if (*reg1 == NULL) {
-                *reg1 = self()->cg()->machine()->getRealRegister(cnt + 1);
+                *reg1 = cg()->machine()->getRealRegister(cnt + 1);
             } else {
-                *reg2 = self()->cg()->machine()->getRealRegister(cnt + 1);
+                *reg2 = cg()->machine()->getRealRegister(cnt + 1);
                 return true;
             }
         }
@@ -1813,14 +1806,14 @@ bool OMR::Z::Instruction::getTwoLocalLocalAllocFreeReg(TR::RealRegister **reg1, 
 TR::RealRegister *OMR::Z::Instruction::assignBestSpillRegister()
 {
     // Possible improvement here would be to pick a register using the SPILL policy
-    return _longDispSpillReg1 = self()->cg()->machine()->findRegNotUsedInInstruction(self());
+    return _longDispSpillReg1 = cg()->machine()->findRegNotUsedInInstruction(self());
 }
 
 // Populate the local-local reg alloc fields
 //  Select the best spill register
 TR::RealRegister *OMR::Z::Instruction::assignBestSpillRegister2()
 {
-    return _longDispSpillReg2 = self()->cg()->machine()->findRegNotUsedInInstruction(self());
+    return _longDispSpillReg2 = cg()->machine()->findRegNotUsedInInstruction(self());
 }
 
 // Setup the bit vect of free regs
@@ -1828,7 +1821,7 @@ TR::RealRegister *OMR::Z::Instruction::assignBestSpillRegister2()
 //  and volatiles (excluding GPR0) are included.
 uint32_t OMR::Z::Instruction::assignFreeRegBitVector()
 {
-    return _binFreeRegs = self()->cg()->machine()->constructFreeRegBitVector(self());
+    return _binFreeRegs = cg()->machine()->constructFreeRegBitVector(self());
 }
 
 bool OMR::Z::Instruction::isCall()
@@ -1867,10 +1860,10 @@ void OMR::Z::Instruction::setThrowsImplicitNullPointerException()
     self()->setThrowsImplicitException();
 }
 
-int32_t OMR::Z::Instruction::getMachineOpCode() { return self()->getOpCodeValue(); }
+int32_t OMR::Z::Instruction::getMachineOpCode() { return getOpCodeValue(); }
 
-bool OMR::Z::Instruction::is4ByteLoad() { return self()->getOpCodeValue() == TR::InstOpCode::L; }
+bool OMR::Z::Instruction::is4ByteLoad() { return getOpCodeValue() == TR::InstOpCode::L; }
 
-bool OMR::Z::Instruction::isRet() { return self()->getOpCodeValue() == TR::InstOpCode::retn; }
+bool OMR::Z::Instruction::isRet() { return getOpCodeValue() == TR::InstOpCode::retn; }
 
 int8_t OMR::Z::Instruction::lastOperandIndex(void) { return self()->numOperands() - 1; }

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -89,7 +89,7 @@
 // OMR::Z::Machine memeber functions
 ////////////////////////////////////////////////////////////////////////////////
 
-TR_Debug *OMR::Z::Machine::getDebug() { return self()->cg()->getDebug(); }
+TR_Debug *OMR::Z::Machine::getDebug() { return cg()->getDebug(); }
 
 static const char *getRegisterName(TR::Register *reg, TR::CodeGenerator *cg)
 {
@@ -366,7 +366,7 @@ static bool boundNext(TR::Instruction *currentInstruction, int32_t realNum, TR::
     return true;
 }
 
-uint8_t OMR::Z::Machine::getGPRSize() { return self()->cg()->comp()->target().is64Bit() ? 8 : 4; }
+uint8_t OMR::Z::Machine::getGPRSize() { return cg()->comp()->target().is64Bit() ? 8 : 4; }
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Constructor
@@ -627,10 +627,10 @@ TR::RealRegister *OMR::Z::Machine::findBestLegalOddRegister(uint64_t availRegMas
 
     if (freeRegister == NULL) {
         if (lastOddReg)
-            self()->cg()->traceRegisterAssignment("BEST LEGAL ODD: %R", lastOddReg);
+            cg()->traceRegisterAssignment("BEST LEGAL ODD: %R", lastOddReg);
         return lastOddReg;
     } else {
-        self()->cg()->traceRegisterAssignment("BEST LEGAL ODD: %R", freeRegister);
+        cg()->traceRegisterAssignment("BEST LEGAL ODD: %R", freeRegister);
         return freeRegister;
     }
 }
@@ -682,7 +682,7 @@ TR::RealRegister *OMR::Z::Machine::findBestLegalEvenRegister(uint64_t availRegMa
         }
 
         lastEvenReg = _registerFile[i];
-        // self()->cg()->traceRegWeight(lastEvenReg, lastEvenReg->getWeight());
+        // cg()->traceRegWeight(lastEvenReg, lastEvenReg->getWeight());
 
         if ((_registerFile[i + 0]->getState() == TR::RealRegister::Free
                 || _registerFile[i + 0]->getState() == TR::RealRegister::Unlatched)
@@ -704,10 +704,10 @@ TR::RealRegister *OMR::Z::Machine::findBestLegalEvenRegister(uint64_t availRegMa
 
     if (freeRegister == NULL) {
         if (lastEvenReg)
-            self()->cg()->traceRegisterAssignment("BEST LAST LEGAL EVEN: %R", lastEvenReg);
+            cg()->traceRegisterAssignment("BEST LAST LEGAL EVEN: %R", lastEvenReg);
         return lastEvenReg;
     } else {
-        self()->cg()->traceRegisterAssignment("BEST LEGAL EVEN: %R", freeRegister);
+        cg()->traceRegisterAssignment("BEST LEGAL EVEN: %R", freeRegister);
         return freeRegister;
     }
 }
@@ -743,7 +743,7 @@ TR::RealRegister *OMR::Z::Machine::findBestLegalSiblingFPRegister(bool isFirst, 
 
         lastSiblingFPReg = isFirst ? lastFirstOfPair : lastSecondOfPair;
 
-        // self()->cg()->traceRegWeight(lastSiblingFPReg, lastSiblingFPReg->getWeight());
+        // cg()->traceRegWeight(lastSiblingFPReg, lastSiblingFPReg->getWeight());
 
         if ((lastFirstOfPair->getState() == TR::RealRegister::Free
                 || lastFirstOfPair->getState() == TR::RealRegister::Unlatched)
@@ -763,10 +763,10 @@ TR::RealRegister *OMR::Z::Machine::findBestLegalSiblingFPRegister(bool isFirst, 
     }
 
     if (freeRegister == NULL) {
-        self()->cg()->traceRegisterAssignment("BEST LEGAL sibling FP Reg: %R", lastSiblingFPReg);
+        cg()->traceRegisterAssignment("BEST LEGAL sibling FP Reg: %R", lastSiblingFPReg);
         return lastSiblingFPReg;
     } else {
-        self()->cg()->traceRegisterAssignment("BEST LEGAL sibling FP Reg: %R", freeRegister);
+        cg()->traceRegisterAssignment("BEST LEGAL sibling FP Reg: %R", freeRegister);
         return freeRegister;
     }
 }
@@ -824,9 +824,8 @@ TR::RealRegister *OMR::Z::Machine::findBestRegisterForShuffle(TR::Instruction *c
     if (blockingRegister)
         targetRegister->getRealRegister()->unblock();
 
-    self()->cg()->traceRegisterAssignment(
-        "%R is assigned to invalid register in this instruction. Shuffling %R => %R...", currentAssignedRegister,
-        currentAssignedRegister->getAssignedRegister(), newRegister);
+    cg()->traceRegisterAssignment("%R is assigned to invalid register in this instruction. Shuffling %R => %R...",
+        currentAssignedRegister, currentAssignedRegister->getAssignedRegister(), newRegister);
     return newRegister;
 }
 
@@ -848,7 +847,7 @@ TR::RealRegister *OMR::Z::Machine::shuffleOrSpillRegister(TR::Instruction *currI
         self()->spillRegister(currInst, toFreeReg);
     else {
         TR::Instruction *cursor
-            = self()->registerCopy(self()->cg(), toFreeReg->getKind(), assignedRegister, bestRegister, currInst);
+            = self()->registerCopy(cg(), toFreeReg->getKind(), assignedRegister, bestRegister, currInst);
         toFreeReg->setAssignedRegister(bestRegister);
         bestRegister->setAssignedRegister(toFreeReg);
         bestRegister->setState(TR::RealRegister::Assigned);
@@ -868,15 +867,15 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
 {
     TR_RegisterKinds kindOfRegister = targetRegister->getKind();
     TR::RealRegister *assignedRegister = targetRegister->getAssignedRealRegister();
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     bool reverseSpilled = false;
 
     bool defsRegister = currInst->defsRegister(targetRegister);
     if (assignedRegister == NULL) {
-        if (self()->cg()->insideInternalControlFlow()) {
+        if (cg()->insideInternalControlFlow()) {
             TR_ASSERT_FATAL(false, "Attempting to assign a register (%s) inside ICF",
-                getRegisterName(targetRegister, self()->cg()));
+                getRegisterName(targetRegister, cg()));
         }
     }
     if (kindOfRegister != TR_FPR && kindOfRegister != TR_VRF && assignedRegister != NULL) {
@@ -885,8 +884,8 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
             // find a new register to shuffle to
             TR::RealRegister *newAssignedRegister
                 = self()->findBestRegisterForShuffle(currInst, targetRegister, availRegMask);
-            TR::Instruction *cursor = self()->registerCopy(self()->cg(), kindOfRegister,
-                toRealRegister(assignedRegister), newAssignedRegister, currInst);
+            TR::Instruction *cursor = self()->registerCopy(cg(), kindOfRegister, toRealRegister(assignedRegister),
+                newAssignedRegister, currInst);
             targetRegister->setAssignedRegister(newAssignedRegister);
             newAssignedRegister->setAssignedRegister(targetRegister);
             newAssignedRegister->setState(TR::RealRegister::Assigned);
@@ -903,9 +902,9 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
             = self()->findBestRegisterForShuffle(currInst, targetRegister, availRegMask);
         assignedRegister->unblock();
         TR::Instruction *cursor
-            = self()->registerCopy(self()->cg(), kindOfRegister, assignedRegister, newAssignedRegister, currInst);
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
-        self()->cg()->traceRegAssigned(targetRegister, assignedRegister);
+            = self()->registerCopy(cg(), kindOfRegister, assignedRegister, newAssignedRegister, currInst);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->traceRegAssigned(targetRegister, assignedRegister);
         targetRegister->setAssignedRegister(newAssignedRegister);
         newAssignedRegister->setAssignedRegister(targetRegister);
         newAssignedRegister->setState(TR::RealRegister::Assigned);
@@ -939,8 +938,8 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
         assignedRegister->setAssignedRegister(targetRegister);
         assignedRegister->setState(TR::RealRegister::Assigned);
 
-        self()->cg()->traceRegAssigned(targetRegister, assignedRegister);
-        self()->cg()->clearRegisterAssignmentFlags();
+        cg()->traceRegAssigned(targetRegister, assignedRegister);
+        cg()->clearRegisterAssignmentFlags();
     }
 
     // Bookkeeping to update the future use count
@@ -951,7 +950,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
         TR_ASSERT(targetRegister->getFutureUseCount() >= 0,
             "\nRegister assignment: register [%s] futureUseCount should not be negative (for node [%s], ref count=%d) "
             "!\n",
-            self()->cg()->getDebug()->getName(targetRegister), self()->cg()->getDebug()->getName(currInst->getNode()),
+            cg()->getDebug()->getName(targetRegister), cg()->getDebug()->getName(currInst->getNode()),
             currInst->getNode()->getReferenceCount());
 
         // If we aren't re-using this reg anymore, kill assignment
@@ -960,7 +959,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
         // live registers
 
         bool killOOLReg = false;
-        if (self()->cg()->isOutOfLineHotPath() && targetRegister->getStartOfRange() == currInst) {
+        if (cg()->isOutOfLineHotPath() && targetRegister->getStartOfRange() == currInst) {
             killOOLReg = true;
             TR::Instruction *currS390Inst = currInst;
             // this is to prevent problems with instructions such as XR virtRegx,virtRegx
@@ -973,7 +972,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterSingle(TR::Register *targetRegi
         }
 
         if ((targetRegister->getFutureUseCount() == 0) || killOOLReg) {
-            self()->cg()->traceRegFreed(targetRegister, assignedRegister);
+            cg()->traceRegFreed(targetRegister, assignedRegister);
             targetRegister->resetIsLive();
 
             if (assignedRegister->getState() == TR::RealRegister::Locked) {
@@ -1027,7 +1026,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
     TR_ASSERT(regPair->getRegisterPair() != NULL,
         "OMR::Z::Machine::assignBestRegisterPair: Attempting to assign a real pair to a non-pair virtual\n");
 
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     TR::Register *firstReg = regPair->getHighOrder();
     TR::Register *lastReg = regPair->getLowOrder();
@@ -1036,15 +1035,15 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
     TR::RealRegister *freeRegisterLow = lastReg->getAssignedRealRegister();
     TR_RegisterKinds regPairKind = regPair->getKind();
 
-    self()->cg()->traceRegisterAssignment("attempt to assign components of register pair ( %R %R )", firstReg, lastReg);
+    cg()->traceRegisterAssignment("attempt to assign components of register pair ( %R %R )", firstReg, lastReg);
 
     if (firstReg->is64BitReg())
-        self()->cg()->traceRegisterAssignment("%R is64BitReg", firstReg);
+        cg()->traceRegisterAssignment("%R is64BitReg", firstReg);
     if (lastReg->is64BitReg())
-        self()->cg()->traceRegisterAssignment("%R is64BitReg", lastReg);
+        cg()->traceRegisterAssignment("%R is64BitReg", lastReg);
 
     if (freeRegisterHigh == NULL || freeRegisterLow == NULL) {
-        if (self()->cg()->insideInternalControlFlow()) {
+        if (cg()->insideInternalControlFlow()) {
             TR_ASSERT(0,
                 "ASSERTION assignBestRegisterPair inside Internal Control Flow for inst %p.\n"
                 "Ensure all registers within ICF have a dependency anchored at the end-ICF label\n",
@@ -1061,7 +1060,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
     // We need a new placeholder for the pair that will stay with the instruction, leaving the
     // input pair free to change under further allocation.
     TR::RegisterPair *assignedRegPair
-        = new (self()->cg()->trHeapMemory(), TR_MemoryBase::RegisterPair) TR::RegisterPair(lastReg, firstReg);
+        = new (cg()->trHeapMemory(), TR_MemoryBase::RegisterPair) TR::RegisterPair(lastReg, firstReg);
     if (regPair->getKind() == TR_FPR)
         assignedRegPair->setKind(TR_FPR);
 
@@ -1281,7 +1280,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
     if (doBookKeeping) {
         firstReg->setIsLive();
         if (((firstReg->decFutureUseCount() == 0)
-                || (self()->cg()->isOutOfLineHotPath() && firstReg->getStartOfRange() == currInst))
+                || (cg()->isOutOfLineHotPath() && firstReg->getStartOfRange() == currInst))
             && (freeRegisterHigh->getState() != TR::RealRegister::Locked)) {
             firstReg->resetIsLive();
             firstReg->setAssignedRegister(NULL);
@@ -1292,7 +1291,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
         }
         lastReg->setIsLive();
         if (((lastReg->decFutureUseCount() == 0)
-                || (self()->cg()->isOutOfLineHotPath() && lastReg->getStartOfRange() == currInst))
+                || (cg()->isOutOfLineHotPath() && lastReg->getStartOfRange() == currInst))
             && (freeRegisterLow->getState() != TR::RealRegister::Locked)) {
             lastReg->resetIsLive();
             lastReg->setAssignedRegister(NULL);
@@ -1303,8 +1302,8 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
         }
     }
 
-    assignedRegPair->setHighOrder(freeRegisterHigh, self()->cg());
-    assignedRegPair->setLowOrder(freeRegisterLow, self()->cg());
+    assignedRegPair->setHighOrder(freeRegisterHigh, cg());
+    assignedRegPair->setLowOrder(freeRegisterLow, cg());
 
     return assignedRegPair;
 }
@@ -1390,7 +1389,7 @@ bool OMR::Z::Machine::findBestFreeRegisterPair(TR::RealRegister **firstRegister,
         *firstRegister = freeRegisterHigh;
         *lastRegister = freeRegisterLow;
 
-        self()->cg()->traceRegisterAssignment("BEST FREE PAIR: (%R, %R)", freeRegisterHigh, freeRegisterLow);
+        cg()->traceRegisterAssignment("BEST FREE PAIR: (%R, %R)", freeRegisterHigh, freeRegisterLow);
         return true;
     } else {
         return false;
@@ -1401,7 +1400,7 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
     TR::Instruction *currInst, uint64_t availRegMask)
 {
     TR::Node *currentNode = currInst->getNode();
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     TR::Instruction *cursor = NULL;
 
@@ -1412,7 +1411,7 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
     TR::RealRegister *bestCandidateHigh = NULL;
     TR::RealRegister *bestCandidateLow = NULL;
 
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
 
     // search through all FP reg pairs
     for (int32_t i = 0; i < NUM_S390_FPR_PAIRS; i++) {
@@ -1455,29 +1454,28 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
     if (bestVirtCandidateLow != NULL) {
         locationLow = bestVirtCandidateLow->getBackingStorage();
         if (locationLow == NULL)
-            locationLow = self()->cg()->allocateSpill(8, false, NULL, true);
+            locationLow = cg()->allocateSpill(8, false, NULL, true);
 
         TR::MemoryReference *tempMRLow
-            = generateS390MemoryReference(currentNode, locationLow->getSymbolReference(), self()->cg());
+            = generateS390MemoryReference(currentNode, locationLow->getSymbolReference(), cg());
         locationLow->getSymbolReference()->getSymbol()->setSpillTempLoaded();
         bestVirtCandidateLow->setBackingStorage(locationLow);
-        cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, currentNode, bestCandidateLow, tempMRLow,
-            currInst);
+        cursor = generateRXInstruction(cg(), TR::InstOpCode::LD, currentNode, bestCandidateLow, tempMRLow, currInst);
         if (!cursor->assignFreeRegBitVector()) {
             cursor->assignBestSpillRegister();
         }
 
         bestVirtCandidateLow->setAssignedRegister(NULL);
 
-        if (!self()->cg()->isOutOfLineColdPath()) {
+        if (!cg()->isOutOfLineColdPath()) {
             // the spilledRegisterList contains all registers that are spilled before entering
             // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
+            cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
 
             // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
             // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
             // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath()) { // main line
+            if (!cg()->isOutOfLineHotPath()) { // main line
                 locationLow->setMaxSpillDepth(1);
             } else {
                 // hot path
@@ -1486,7 +1484,7 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
                     locationLow->setMaxSpillDepth(2);
             }
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
                     debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
         } else {
@@ -1501,29 +1499,28 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
     if (bestVirtCandidateHigh != NULL) {
         locationHigh = bestVirtCandidateHigh->getBackingStorage();
         if (locationHigh == NULL)
-            locationHigh = self()->cg()->allocateSpill(8, false, NULL, true);
+            locationHigh = cg()->allocateSpill(8, false, NULL, true);
 
         TR::MemoryReference *tempMRHigh
-            = generateS390MemoryReference(currentNode, locationHigh->getSymbolReference(), self()->cg());
+            = generateS390MemoryReference(currentNode, locationHigh->getSymbolReference(), cg());
         locationHigh->getSymbolReference()->getSymbol()->setSpillTempLoaded();
         bestVirtCandidateHigh->setBackingStorage(locationHigh);
-        cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, currentNode, bestCandidateHigh, tempMRHigh,
-            currInst);
+        cursor = generateRXInstruction(cg(), TR::InstOpCode::LD, currentNode, bestCandidateHigh, tempMRHigh, currInst);
         if (!cursor->assignFreeRegBitVector()) {
             cursor->assignBestSpillRegister();
         }
 
         bestVirtCandidateHigh->setAssignedRegister(NULL);
 
-        if (!self()->cg()->isOutOfLineColdPath()) {
+        if (!cg()->isOutOfLineColdPath()) {
             // the spilledRegisterList contains all registers that are spilled before entering
             // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
+            cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
 
             // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
             // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
             // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath()) { // main line
+            if (!cg()->isOutOfLineHotPath()) { // main line
                 locationHigh->setMaxSpillDepth(1);
             } else {
                 // hot path
@@ -1532,7 +1529,7 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
                     locationHigh->setMaxSpillDepth(2);
             }
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
                     debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
         } else {
@@ -1558,7 +1555,7 @@ void OMR::Z::Machine::freeBestFPRegisterPair(TR::RealRegister **firstReg, TR::Re
 void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::RealRegister **lastReg, TR_RegisterKinds rk,
     TR::Instruction *currInst, uint64_t availRegMask)
 {
-    self()->cg()->traceRegisterAssignment("FREE BEST REGISTER PAIR");
+    cg()->traceRegisterAssignment("FREE BEST REGISTER PAIR");
     if (rk == TR_FPR) {
         self()->freeBestFPRegisterPair(firstReg, lastReg, currInst, availRegMask);
         return;
@@ -1566,8 +1563,8 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
     TR::Node *currentNode = currInst->getNode();
 
     TR::Instruction *cursor = NULL;
-    TR::Compilation *comp = self()->cg()->comp();
-    TR::Machine *machine = self()->cg()->machine();
+    TR::Compilation *comp = cg()->comp();
+    TR::Machine *machine = cg()->machine();
 
     TR_BackingStore *locationLow;
     TR_BackingStore *locationHigh;
@@ -1576,7 +1573,7 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
     TR::RealRegister *bestCandidateHigh = NULL;
     TR::RealRegister *bestCandidateLow = NULL;
 
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
 
     // Look at all reg pairs (starting with an even reg)
     for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i += 2) {
@@ -1611,8 +1608,8 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
 
     // Assert if no register pair was found
     if (bestCandidateHigh == NULL && bestCandidateLow == NULL) {
-        if (self()->cg()->getDebug() != NULL) {
-            self()->cg()->getDebug()->printGPRegisterStatus(comp->log(), machine);
+        if (cg()->getDebug() != NULL) {
+            cg()->getDebug()->printGPRegisterStatus(comp->log(), machine);
         }
 
         TR_ASSERT_FATAL(0, "Ran out of register pairs to use as a pair on instruction [%p]", currInst);
@@ -1629,30 +1626,28 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
 
         if (locationLow == NULL) {
             if (bestVirtCandidateLow->containsInternalPointer()) {
-                locationLow
-                    = self()->cg()->allocateInternalPointerSpill(bestVirtCandidateLow->getPinningArrayPointer());
+                locationLow = cg()->allocateInternalPointerSpill(bestVirtCandidateLow->getPinningArrayPointer());
             } else {
                 locationLow = bestVirtCandidateLow->is64BitReg()
-                    ? self()->cg()->allocateSpill(8, bestVirtCandidateLow->containsCollectedReference(), NULL, true)
-                    : self()->cg()->allocateSpill(4, bestVirtCandidateLow->containsCollectedReference(), NULL, true);
+                    ? cg()->allocateSpill(8, bestVirtCandidateLow->containsCollectedReference(), NULL, true)
+                    : cg()->allocateSpill(4, bestVirtCandidateLow->containsCollectedReference(), NULL, true);
             }
 
             bestVirtCandidateLow->setBackingStorage(locationLow);
         }
 
         TR::MemoryReference *tempMRLow
-            = generateS390MemoryReference(currentNode, locationLow->getSymbolReference(), self()->cg());
+            = generateS390MemoryReference(currentNode, locationLow->getSymbolReference(), cg());
         locationLow->getSymbolReference()->getSymbol()->setSpillTempLoaded();
 
         if (bestVirtCandidateLow->is64BitReg()) {
-            cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LG, currentNode, bestCandidateLow, tempMRLow,
-                currInst);
+            cursor
+                = generateRXInstruction(cg(), TR::InstOpCode::LG, currentNode, bestCandidateLow, tempMRLow, currInst);
         } else {
-            cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, currentNode, bestCandidateLow, tempMRLow,
-                currInst);
+            cursor = generateRXInstruction(cg(), TR::InstOpCode::L, currentNode, bestCandidateLow, tempMRLow, currInst);
         }
 
-        self()->cg()->traceRAInstruction(cursor);
+        cg()->traceRAInstruction(cursor);
         if (debugObj) {
             debugObj->addInstructionComment(cursor, "Load Spill : reg pair even");
         }
@@ -1663,15 +1658,15 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
 
         bestVirtCandidateLow->setAssignedRegister(NULL);
 
-        if (!self()->cg()->isOutOfLineColdPath()) {
+        if (!cg()->isOutOfLineColdPath()) {
             // the spilledRegisterList contains all registers that are spilled before entering
             // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
+            cg()->getSpilledRegisterList()->push_front(bestVirtCandidateLow);
 
             // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
             // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
             // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath()) { // main line
+            if (!cg()->isOutOfLineHotPath()) { // main line
                 locationLow->setMaxSpillDepth(1);
             } else {
                 // hot path
@@ -1680,7 +1675,7 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
                     locationLow->setMaxSpillDepth(2);
             }
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "OOL: adding reg pair low %s to the spilledRegisterList, maxSpillDepth = %d\n",
                     debugObj->getName(bestVirtCandidateLow), locationLow->getMaxSpillDepth());
         } else {
@@ -1698,30 +1693,29 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
 
         if (locationHigh == NULL) {
             if (bestVirtCandidateHigh->containsInternalPointer()) {
-                locationHigh
-                    = self()->cg()->allocateInternalPointerSpill(bestVirtCandidateHigh->getPinningArrayPointer());
+                locationHigh = cg()->allocateInternalPointerSpill(bestVirtCandidateHigh->getPinningArrayPointer());
             } else {
                 locationHigh = bestVirtCandidateHigh->is64BitReg()
-                    ? self()->cg()->allocateSpill(8, bestVirtCandidateHigh->containsCollectedReference(), NULL, true)
-                    : self()->cg()->allocateSpill(4, bestVirtCandidateHigh->containsCollectedReference(), NULL, true);
+                    ? cg()->allocateSpill(8, bestVirtCandidateHigh->containsCollectedReference(), NULL, true)
+                    : cg()->allocateSpill(4, bestVirtCandidateHigh->containsCollectedReference(), NULL, true);
             }
 
             bestVirtCandidateHigh->setBackingStorage(locationHigh);
         }
 
         TR::MemoryReference *tempMRHigh
-            = generateS390MemoryReference(currentNode, locationHigh->getSymbolReference(), self()->cg());
+            = generateS390MemoryReference(currentNode, locationHigh->getSymbolReference(), cg());
         locationHigh->getSymbolReference()->getSymbol()->setSpillTempLoaded();
 
         if (bestVirtCandidateHigh->is64BitReg()) {
-            cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LG, currentNode, bestCandidateHigh, tempMRHigh,
-                currInst);
+            cursor
+                = generateRXInstruction(cg(), TR::InstOpCode::LG, currentNode, bestCandidateHigh, tempMRHigh, currInst);
         } else {
-            cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, currentNode, bestCandidateHigh, tempMRHigh,
-                currInst);
+            cursor
+                = generateRXInstruction(cg(), TR::InstOpCode::L, currentNode, bestCandidateHigh, tempMRHigh, currInst);
         }
 
-        self()->cg()->traceRAInstruction(cursor);
+        cg()->traceRAInstruction(cursor);
         if (debugObj) {
             debugObj->addInstructionComment(cursor, "Load Spill : reg pair odd");
         }
@@ -1732,15 +1726,15 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
 
         bestVirtCandidateHigh->setAssignedRegister(NULL);
 
-        if (!self()->cg()->isOutOfLineColdPath()) {
+        if (!cg()->isOutOfLineColdPath()) {
             // the spilledRegisterList contains all registers that are spilled before entering
             // the OOL cold path, post dependencies will be generated using this list
-            self()->cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
+            cg()->getSpilledRegisterList()->push_front(bestVirtCandidateHigh);
 
             // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
             // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
             // if we reverse spill this register inside the OOL cold/hot path
-            if (!self()->cg()->isOutOfLineHotPath()) { // main line
+            if (!cg()->isOutOfLineHotPath()) { // main line
                 locationHigh->setMaxSpillDepth(1);
             } else {
                 // hot path
@@ -1749,7 +1743,7 @@ void OMR::Z::Machine::freeBestRegisterPair(TR::RealRegister **firstReg, TR::Real
                     locationHigh->setMaxSpillDepth(2);
             }
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "OOL: adding reg pair high %s to the spilledRegisterList, maxSpillDepth = %d\n",
                     debugObj->getName(bestVirtCandidateHigh), locationHigh->getMaxSpillDepth());
         } else {
@@ -1787,29 +1781,25 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
     uint32_t randomInterference;
     int32_t randomWeight;
     uint32_t randomPreference;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     uint32_t preference = (virtualReg != NULL) ? virtualReg->getAssociation() : 0;
 
     bool useGPR0 = (virtualReg == NULL) ? false : (availRegMask & TR::RealRegister::GPR0Mask);
-    bool liveRegOn = (self()->cg()->getLiveRegisters(rk) != NULL);
+    bool liveRegOn = (cg()->getLiveRegisters(rk) != NULL);
 
     if (comp->getOption(TR_Randomize)) {
         randomPreference = preference;
 
         if (TR::RealRegister::isFPR((TR::RealRegister::RegNum)preference)) {
-            randomPreference
-                = self()->cg()->randomizer.randomInt(TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR);
+            randomPreference = cg()->randomizer.randomInt(TR::RealRegister::FirstFPR, TR::RealRegister::LastFPR);
         } else if (TR::RealRegister::isVRF((TR::RealRegister::RegNum)preference)) {
-            randomPreference
-                = self()->cg()->randomizer.randomInt(TR::RealRegister::FirstVRF, TR::RealRegister::LastVRF);
+            randomPreference = cg()->randomizer.randomInt(TR::RealRegister::FirstVRF, TR::RealRegister::LastVRF);
         } else if (TR::RealRegister::isGPR((TR::RealRegister::RegNum)preference)) {
             if (useGPR0) {
-                randomPreference
-                    = self()->cg()->randomizer.randomInt(TR::RealRegister::GPR0, TR::RealRegister::LastGPR);
+                randomPreference = cg()->randomizer.randomInt(TR::RealRegister::GPR0, TR::RealRegister::LastGPR);
             } else {
-                randomPreference
-                    = self()->cg()->randomizer.randomInt(TR::RealRegister::GPR1, TR::RealRegister::LastGPR);
+                randomPreference = cg()->randomizer.randomInt(TR::RealRegister::GPR1, TR::RealRegister::LastGPR);
             }
         }
         if (preference != randomPreference
@@ -1826,10 +1816,10 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
     if (liveRegOn && virtualReg != NULL) {
         interference = virtualReg->getInterference();
         if (comp->getOption(TR_Randomize)) {
-            randomInterference = self()->cg()->randomizer.randomInt(0, 65535);
+            randomInterference = cg()->randomizer.randomInt(0, 65535);
             if (performTransformation(comp,
                     "O^O Random Codegen - Randomizing Interference for %s: Original=%x Random=%x\n",
-                    self()->cg()->getDebug()->getName(virtualReg), interference, randomInterference)) {
+                    cg()->getDebug()->getName(virtualReg), interference, randomInterference)) {
                 interference = randomInterference;
             }
         }
@@ -1840,7 +1830,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
     }
 
     // We can't use FPRs for vector registers when current instruction is a call
-    if (virtualReg->getKind() == TR_VRF && self()->cg()->getSupportsVectorRegisters() && currentInstruction->isCall()) {
+    if (virtualReg->getKind() == TR_VRF && cg()->getSupportsVectorRegisters() && currentInstruction->isCall()) {
         for (int32_t i = TR::RealRegister::FPR0Mask; i <= TR::RealRegister::FPR15Mask; ++i) {
             availRegMask &= ~i;
         }
@@ -1870,7 +1860,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
     // Register Associations are best effort. If you really need to map a virtual to a real, use register pre/post
     // dependency conditions.
 
-    if (self()->cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalEvenOfPair) {
+    if (cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalEvenOfPair) {
         // Check to see if there is a sibling already assigned
         if ((virtualReg->getSiblingRegister())
             && (realSibling = virtualReg->getSiblingRegister()->getAssignedRegister())
@@ -1911,7 +1901,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
             }
             return bestRegister;
         }
-    } else if (self()->cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalOddOfPair) {
+    } else if (cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalOddOfPair) {
         // Check to see if there is a sibling already assigned
         if ((virtualReg->getSiblingRegister())
             && (realSibling = virtualReg->getSiblingRegister()->getAssignedRegister())
@@ -1944,7 +1934,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
             }
             return bestRegister;
         }
-    } else if (self()->cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalFirstOfFPPair) {
+    } else if (cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalFirstOfFPPair) {
         // Check to see if there is a sibling already assigned
         if ((virtualReg->getSiblingRegister())
             && (realSibling = virtualReg->getSiblingRegister()->getAssignedRegister())
@@ -1976,7 +1966,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
             }
             return bestRegister;
         }
-    } else if (self()->cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalSecondOfFPPair) {
+    } else if (cg()->enableRegisterPairAssociation() && preference == TR::RealRegister::LegalSecondOfFPPair) {
         // Check to see if there is a sibling already assigned
         if ((virtualReg->getSiblingRegister())
             && (realSibling = virtualReg->getSiblingRegister()->getAssignedRegister())
@@ -2032,12 +2022,12 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
                 bestRegister->setState(TR::RealRegister::Free);
             }
 
-            self()->cg()->setRegisterAssignmentFlag(TR_ByAssociation);
+            cg()->setRegisterAssignmentFlag(TR_ByAssociation);
 
             if (bestRegister != NULL)
-                self()->cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is %R", virtualReg, bestRegister);
+                cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is %R", virtualReg, bestRegister);
             else
-                self()->cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is NULL", virtualReg);
+                cg()->traceRegisterAssignment("BEST FREE REG by pref for %R is NULL", virtualReg);
 
             return bestRegister;
         }
@@ -2054,7 +2044,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
         if ((_registerFile[i]->getState() == TR::RealRegister::Locked) || ((tRegMask & availRegMask) == 0)) {
             continue;
         }
-        // self()->cg()->traceRegWeight(_registerFile[i], _registerFile[i]->getWeight());
+        // cg()->traceRegWeight(_registerFile[i], _registerFile[i]->getWeight());
 
         iNew = interference & (1 << (i - maskI));
         if ((_registerFile[i]->getState() == TR::RealRegister::Free
@@ -2066,11 +2056,11 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
             freeRegister = _registerFile[i];
             bestWeightSoFar = freeRegister->getWeight();
             if (comp->getOption(TR_Randomize)) {
-                randomWeight = self()->cg()->randomizer.randomInt(0, 0xFFF);
+                randomWeight = cg()->randomizer.randomInt(0, 0xFFF);
                 if (performTransformation(comp,
                         "O^O Random Codegen - Randomizing Weight for %s, Original bestWeightSoFar: %x randomized to: "
                         "%x\n",
-                        self()->cg()->getDebug()->getName(_registerFile[i]), bestWeightSoFar, randomWeight)) {
+                        cg()->getDebug()->getName(_registerFile[i]), bestWeightSoFar, randomWeight)) {
                     bestWeightSoFar = randomWeight;
                 }
             }
@@ -2083,9 +2073,9 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
     }
 
     if (freeRegister != NULL)
-        self()->cg()->traceRegisterAssignment("BEST FREE REG for %R is %R", virtualReg, freeRegister);
+        cg()->traceRegisterAssignment("BEST FREE REG for %R is %R", virtualReg, freeRegister);
     else
-        self()->cg()->traceRegisterAssignment("BEST FREE REG for %R is NULL (could not find one)", virtualReg);
+        cg()->traceRegisterAssignment("BEST FREE REG for %R is NULL (could not find one)", virtualReg);
 
     return freeRegister;
 }
@@ -2100,7 +2090,7 @@ TR::RealRegister *OMR::Z::Machine::findBestFreeRegister(TR::Instruction *current
  */
 uint64_t OMR::Z::Machine::constructFreeRegBitVector(TR::Instruction *currentInstruction)
 {
-    TR::Linkage *linkage = self()->cg()->getS390Linkage();
+    TR::Linkage *linkage = cg()->getS390Linkage();
     int32_t first = TR::RealRegister::FirstGPR + 1; // skip GPR0
     int32_t last = TR::RealRegister::LastAssignableGPR;
     uint64_t vector = 0;
@@ -2147,8 +2137,8 @@ void OMR::Z::Machine::spillAllVolatileHighRegisters(TR::Instruction *currentInst
 {
     int32_t first = TR::RealRegister::FirstGPR;
     int32_t last = TR::RealRegister::LastGPR;
-    TR::Machine *machine = self()->cg()->machine();
-    TR::Linkage *linkage = self()->cg()->getS390Linkage();
+    TR::Machine *machine = cg()->machine();
+    TR::Linkage *linkage = cg()->getS390Linkage();
     TR::Node *node = currentInstruction->getNode();
 
     for (int32_t i = first; i <= last; i++) {
@@ -2169,14 +2159,14 @@ void OMR::Z::Machine::spillAllVolatileHighRegisters(TR::Instruction *currentInst
 TR::RealRegister *OMR::Z::Machine::freeBestRegister(TR::Instruction *currentInstruction, TR::Register *virtReg,
     TR_RegisterKinds rk, bool allowNullReturn)
 {
-    self()->cg()->traceRegisterAssignment("FREE BEST REGISTER FOR %R", virtReg);
-    TR::Compilation *comp = self()->cg()->comp();
+    cg()->traceRegisterAssignment("FREE BEST REGISTER FOR %R", virtReg);
+    TR::Compilation *comp = cg()->comp();
 
     if (virtReg->containsCollectedReference())
-        self()->cg()->traceRegisterAssignment("%R contains collected", virtReg);
+        cg()->traceRegisterAssignment("%R contains collected", virtReg);
     int32_t numCandidates = 0, interference = 0, first, last, maskI;
     TR::Register *candidates[TR::RealRegister::LastVRF];
-    TR::Machine *machine = self()->cg()->machine();
+    TR::Machine *machine = cg()->machine();
     bool useGPR0 = (virtReg == NULL) ? false : (virtReg->isUsedInMemRef() == false);
 
     switch (rk) {
@@ -2201,7 +2191,7 @@ TR::RealRegister *OMR::Z::Machine::freeBestRegister(TR::Instruction *currentInst
     }
 
     int32_t preference = 0, pref_favored = 0;
-    if (self()->cg()->getLiveRegisters(rk) != NULL && virtReg != NULL) {
+    if (cg()->getLiveRegisters(rk) != NULL && virtReg != NULL) {
         interference = virtReg->getInterference();
         // interference might not be acurate beacuse not all vRegs clobber high words
         // todo: merge with boundnext
@@ -2226,7 +2216,7 @@ TR::RealRegister *OMR::Z::Machine::freeBestRegister(TR::Instruction *currentInst
         // leave this assert here for a little while and we can remove it once it has had time to bake.
         TR_ASSERT_FATAL(realReg->getState() != TR::RealRegister::Free,
             "Attempting to free best register for virtual register (%s) when a free register (%s) already exists",
-            getRegisterName(virtReg, self()->cg()), getRegisterName(realReg, self()->cg()));
+            getRegisterName(virtReg, cg()), getRegisterName(realReg, cg()));
 
         if (realReg->getState() == TR::RealRegister::Assigned) {
             TR::Register *associatedVirtual = realReg->getAssignedRegister();
@@ -2249,8 +2239,8 @@ TR::RealRegister *OMR::Z::Machine::freeBestRegister(TR::Instruction *currentInst
 
     if (numCandidates == 0) {
         if (!allowNullReturn) {
-            if (self()->cg()->getDebug() != NULL) {
-                self()->cg()->getDebug()->printGPRegisterStatus(comp->log(), machine);
+            if (cg()->getDebug() != NULL) {
+                cg()->getDebug()->printGPRegisterStatus(comp->log(), machine);
             }
 
             TR_ASSERT_FATAL(false, "Ran out of register candidates to free on instruction [%p]", currentInstruction);
@@ -2288,7 +2278,7 @@ TR::RealRegister *OMR::Z::Machine::freeBestRegister(TR::Instruction *currentInst
  */
 void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Register *virtReg)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     TR::InstOpCode::Mnemonic opCode;
     bool containsInternalPointer = false;
     bool containsCollectedReg = false;
@@ -2297,7 +2287,7 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
     TR::Node *currentNode = currentInstruction->getNode();
     TR::Instruction *cursor = NULL;
     TR::RealRegister *best = NULL;
-    TR_Debug *debugObj = self()->cg()->getDebug();
+    TR_Debug *debugObj = cg()->getDebug();
 
     best = toRealRegister(virtReg->getAssignedRegister());
 
@@ -2309,36 +2299,34 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
         containsCollectedReg = true;
     }
     if (debugObj) {
-        self()->cg()->traceRegisterAssignment("SPILLING REGISTER %R", virtReg);
+        cg()->traceRegisterAssignment("SPILLING REGISTER %R", virtReg);
         if (virtReg->is64BitReg())
-            self()->cg()->traceRegisterAssignment("%R is 64 bit", virtReg);
+            cg()->traceRegisterAssignment("%R is 64 bit", virtReg);
         else
-            self()->cg()->traceRegisterAssignment("%R is 32 bit", virtReg);
+            cg()->traceRegisterAssignment("%R is 32 bit", virtReg);
         if (containsCollectedReg)
-            self()->cg()->traceRegisterAssignment("%R contains collected", virtReg);
+            cg()->traceRegisterAssignment("%R contains collected", virtReg);
     }
 
     location = virtReg->getBackingStorage();
     switch (rk) {
         case TR_GPR:
-            if ((self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath())
-                && virtReg->getBackingStorage()) {
+            if ((cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage()) {
                 // reuse the spill slot
                 if (debugObj)
-                    self()->cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n",
-                        location, debugObj->getName(virtReg));
+                    cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n", location,
+                        debugObj->getName(virtReg));
             } else if (!containsInternalPointer) {
                 location = virtReg->is64BitReg()
-                    ? self()->cg()->allocateSpill(8, virtReg->containsCollectedReference(), NULL, true)
-                    : self()->cg()->allocateSpill(4, virtReg->containsCollectedReference(), NULL, true);
+                    ? cg()->allocateSpill(8, virtReg->containsCollectedReference(), NULL, true)
+                    : cg()->allocateSpill(4, virtReg->containsCollectedReference(), NULL, true);
 
                 if (debugObj)
-                    self()->cg()->traceRegisterAssignment("\nSpilling %s to (%p)\n", debugObj->getName(virtReg),
-                        location);
+                    cg()->traceRegisterAssignment("\nSpilling %s to (%p)\n", debugObj->getName(virtReg), location);
             } else {
-                location = self()->cg()->allocateInternalPointerSpill(virtReg->getPinningArrayPointer());
+                location = cg()->allocateInternalPointerSpill(virtReg->getPinningArrayPointer());
                 if (debugObj)
-                    self()->cg()->traceRegisterAssignment("\nSpilling internal pointer %s to (%p)\n",
+                    cg()->traceRegisterAssignment("\nSpilling internal pointer %s to (%p)\n",
                         debugObj->getName(virtReg), location);
             }
 
@@ -2346,27 +2334,24 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
 
             break;
         case TR_FPR:
-            if ((self()->cg()->isOutOfLineColdPath() || self()->cg()->isOutOfLineHotPath())
-                && virtReg->getBackingStorage()) {
+            if ((cg()->isOutOfLineColdPath() || cg()->isOutOfLineHotPath()) && virtReg->getBackingStorage()) {
                 // reuse the spill slot
                 if (debugObj)
-                    self()->cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n",
-                        location, debugObj->getName(virtReg));
+                    cg()->traceRegisterAssignment("\nOOL: Reuse backing store (%p) for %s inside OOL\n", location,
+                        debugObj->getName(virtReg));
             } else {
-                location = self()->cg()->allocateSpill(8, false, NULL, true); // TODO: Use 4 for single-precision values
+                location = cg()->allocateSpill(8, false, NULL, true); // TODO: Use 4 for single-precision values
                 if (debugObj)
-                    self()->cg()->traceRegisterAssignment("\nSpilling FPR %s to (%p)\n", debugObj->getName(virtReg),
-                        location);
+                    cg()->traceRegisterAssignment("\nSpilling FPR %s to (%p)\n", debugObj->getName(virtReg), location);
             }
             opCode = TR::InstOpCode::LD;
             break;
         case TR_VRF:
             // Spill of size 16 has never been done before. The call hierarchy seems to support it but this should be
             // watched closely.
-            location = self()->cg()->allocateSpill(16, false, NULL, true);
+            location = cg()->allocateSpill(16, false, NULL, true);
             if (debugObj)
-                self()->cg()->traceRegisterAssignment("\nSpilling VRF %s to (%p)\n", debugObj->getName(virtReg),
-                    location);
+                cg()->traceRegisterAssignment("\nSpilling VRF %s to (%p)\n", debugObj->getName(virtReg), location);
 
             opCode = TR::InstOpCode::VL;
             break;
@@ -2374,17 +2359,16 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
             break;
     }
 
-    TR::MemoryReference *tempMR
-        = generateS390MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
+    TR::MemoryReference *tempMR = generateS390MemoryReference(currentNode, location->getSymbolReference(), cg());
     location->getSymbolReference()->getSymbol()->setSpillTempLoaded();
     virtReg->setBackingStorage(location);
 
     if (opCode == TR::InstOpCode::VL)
-        cursor = generateVRXInstruction(self()->cg(), opCode, currentNode, best, tempMR, 0, currentInstruction);
+        cursor = generateVRXInstruction(cg(), opCode, currentNode, best, tempMR, 0, currentInstruction);
     else
-        cursor = generateRXInstruction(self()->cg(), opCode, currentNode, best, tempMR, currentInstruction);
+        cursor = generateRXInstruction(cg(), opCode, currentNode, best, tempMR, currentInstruction);
 
-    self()->cg()->traceRAInstruction(cursor);
+    cg()->traceRAInstruction(cursor);
     if (debugObj) {
         debugObj->addInstructionComment(cursor, "Load Spill");
     }
@@ -2394,15 +2378,15 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
         cursor->assignBestSpillRegister();
     }
 
-    if (!self()->cg()->isOutOfLineColdPath()) {
+    if (!cg()->isOutOfLineColdPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL cold path, post dependencies will be generated using this list
-        self()->cg()->getSpilledRegisterList()->push_front(virtReg);
+        cg()->getSpilledRegisterList()->push_front(virtReg);
 
         // OOL cold path: depth = 3, hot path: depth =2,  main line: depth = 1
         // if the spill is outside of the OOL cold/hot path, we need to protect the spill slot
         // if we reverse spill this register inside the OOL cold/hot path
-        if (!self()->cg()->isOutOfLineHotPath()) { // main line
+        if (!cg()->isOutOfLineHotPath()) { // main line
             location->setMaxSpillDepth(1);
         } else {
             // hot path
@@ -2411,7 +2395,7 @@ void OMR::Z::Machine::spillRegister(TR::Instruction *currentInstruction, TR::Reg
                 location->setMaxSpillDepth(2);
         }
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
+            cg()->traceRegisterAssignment("OOL: adding %s to the spilledRegisterList, maxSpillDepth = %d\n",
                 debugObj->getName(virtReg), location->getMaxSpillDepth());
     } else {
         // do not overwrite mainline and hot path spill depth
@@ -2434,7 +2418,7 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
     TR::RealRegister *targetRegister)
 {
     TR_ASSERT_FATAL(spilledRegister->getAssignedRegister() == NULL,
-        "Attempting to fill an already assigned virtual register (%s)", getRegisterName(spilledRegister, self()->cg()));
+        "Attempting to fill an already assigned virtual register (%s)", getRegisterName(spilledRegister, cg()));
 
     TR_BackingStore *location = spilledRegister->getBackingStorage();
     TR::Node *currentNode = currentInstruction->getNode();
@@ -2443,12 +2427,12 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
     TR::InstOpCode::Mnemonic opCode;
     int32_t dataSize;
     TR::Instruction *cursor = NULL;
-    TR_Debug *debugObj = self()->cg()->getDebug();
-    TR::Compilation *comp = self()->cg()->comp();
+    TR_Debug *debugObj = cg()->getDebug();
+    TR::Compilation *comp = cg()->comp();
     // This may not actually need to be reversed if
     // this is a dummy register used for OOL dependencies
 
-    self()->cg()->traceRegisterAssignment("REVERSE SPILL STATE FOR %R", spilledRegister);
+    cg()->traceRegisterAssignment("REVERSE SPILL STATE FOR %R", spilledRegister);
 
     if (spilledRegister->isPlaceholderReg()) {
         return NULL;
@@ -2468,13 +2452,13 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
         }
     }
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         // the future and total use count might not always reflect register spill state
         // for example a new register assignment in the hot path would cause FC != TC
         // in this case, assign a new register and return
         if (location == NULL) {
             if (debugObj) {
-                self()->cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
+                cg()->traceRegisterAssignment("OOL: Not generating reverse spill for (%s)\n",
                     debugObj->getName(spilledRegister));
             }
 
@@ -2489,12 +2473,12 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
     if (location == NULL) {
         if (rk == TR_GPR) {
             location = spilledRegister->is64BitReg()
-                ? self()->cg()->allocateSpill(8, spilledRegister->containsCollectedReference(), NULL, true)
-                : self()->cg()->allocateSpill(4, spilledRegister->containsCollectedReference(), NULL, true);
+                ? cg()->allocateSpill(8, spilledRegister->containsCollectedReference(), NULL, true)
+                : cg()->allocateSpill(4, spilledRegister->containsCollectedReference(), NULL, true);
         } else if (rk == TR_VRF) {
-            location = self()->cg()->allocateSpill(16, false, NULL, true);
+            location = cg()->allocateSpill(16, false, NULL, true);
         } else {
-            location = self()->cg()->allocateSpill(8, false, NULL, true); // TODO: Use 4 for single-precision values
+            location = cg()->allocateSpill(8, false, NULL, true); // TODO: Use 4 for single-precision values
         }
         spilledRegister->setBackingStorage(location);
     }
@@ -2503,8 +2487,7 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
     targetRegister->setAssignedRegister(spilledRegister);
     spilledRegister->setAssignedRegister(targetRegister);
 
-    TR::MemoryReference *tempMR
-        = generateS390MemoryReference(currentNode, location->getSymbolReference(), self()->cg());
+    TR::MemoryReference *tempMR = generateS390MemoryReference(currentNode, location->getSymbolReference(), cg());
 
     switch (rk) {
         case TR_GPR:
@@ -2528,7 +2511,7 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
             break;
     }
 
-    if (self()->cg()->isOutOfLineColdPath()) {
+    if (cg()->isOutOfLineColdPath()) {
         bool isOOLentryReverseSpill = false;
         if (currentInstruction->isLabel()) {
             if (toS390LabelInstruction(currentInstruction)->getLabelSymbol()->isStartOfColdInstructionStream()) {
@@ -2549,29 +2532,29 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
         // maxSpillDepth: 3:cold path, 2:hot path, 1:main line
         if (location->getMaxSpillDepth() == 0 || location->getMaxSpillDepth() == 3 || isOOLentryReverseSpill) {
             location->setMaxSpillDepth(0);
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
             spilledRegister->setBackingStorage(NULL);
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spill %s in less dominant path (%d / 3), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
         }
-    } else if (self()->cg()->isOutOfLineHotPath()) {
+    } else if (cg()->isOutOfLineHotPath()) {
         // the spilledRegisterList contains all registers that are spilled before entering
         // the OOL path (in backwards RA). Post dependencies will be generated using this list.
         // Any registers reverse spilled before entering OOL should be removed from the spilled list
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         if (location->getMaxSpillDepth() == 2) {
             location->setMaxSpillDepth(0);
-            self()->cg()->freeSpill(location, dataSize, 0);
+            cg()->freeSpill(location, dataSize, 0);
             spilledRegister->setBackingStorage(NULL);
         } else {
             if (debugObj)
-                self()->cg()->traceRegisterAssignment(
+                cg()->traceRegisterAssignment(
                     "\nOOL: reverse spilling %s in less dominant path (%d / 2), protect spill slot (%p)\n",
                     debugObj->getName(spilledRegister), location->getMaxSpillDepth(), location);
             location->setMaxSpillDepth(0);
@@ -2579,21 +2562,20 @@ TR::RealRegister *OMR::Z::Machine::reverseSpillState(TR::Instruction *currentIns
     } else // main line
     {
         if (debugObj)
-            self()->cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
+            cg()->traceRegisterAssignment("\nOOL: removing %s from the spilledRegisterList)\n",
                 debugObj->getName(spilledRegister));
-        self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+        cg()->getSpilledRegisterList()->remove(spilledRegister);
         location->setMaxSpillDepth(0);
-        self()->cg()->freeSpill(location, dataSize, 0);
+        cg()->freeSpill(location, dataSize, 0);
         spilledRegister->setBackingStorage(NULL);
     }
 
     if (opCode == TR::InstOpCode::VST)
-        cursor
-            = generateVRXInstruction(self()->cg(), opCode, currentNode, targetRegister, tempMR, 0, currentInstruction);
+        cursor = generateVRXInstruction(cg(), opCode, currentNode, targetRegister, tempMR, 0, currentInstruction);
     else
-        cursor = generateRXInstruction(self()->cg(), opCode, currentNode, targetRegister, tempMR, currentInstruction);
+        cursor = generateRXInstruction(cg(), opCode, currentNode, targetRegister, tempMR, currentInstruction);
 
-    self()->cg()->traceRAInstruction(cursor);
+    cg()->traceRAInstruction(cursor);
 
     if (debugObj) {
         debugObj->addInstructionComment(cursor, "Spill");
@@ -2635,17 +2617,17 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
     TR::Instruction *cursor = NULL;
     TR::Node *currentNode = currentInstruction->getNode();
     bool doNotRegCopy = false;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     virtualRegister->setIsLive();
 
-    self()->cg()->traceRegisterAssignment("COERCE %R into %R", virtualRegister, targetRegister);
+    cg()->traceRegisterAssignment("COERCE %R into %R", virtualRegister, targetRegister);
 
     if (rk != TR_FPR && rk != TR_VRF) {
         if (virtualRegister->is64BitReg()) {
-            self()->cg()->traceRegisterAssignment(" coerceRA: %R needs 64 bit reg ", virtualRegister);
+            cg()->traceRegisterAssignment(" coerceRA: %R needs 64 bit reg ", virtualRegister);
         } else {
-            self()->cg()->traceRegisterAssignment(" coerceRA: %R needs 32 bit reg ", virtualRegister);
+            cg()->traceRegisterAssignment(" coerceRA: %R needs 32 bit reg ", virtualRegister);
         }
     }
 
@@ -2660,7 +2642,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         if (virtualRegister->isPlaceholderReg())
             targetRegister
                 ->setIsAssignedMoreThanOnce(); // Register is killed invalidate it for moving spill out of loop
-        self()->cg()->traceRegisterAssignment("target %R is free", targetRegister);
+        cg()->traceRegisterAssignment("target %R is free", targetRegister);
 
         // the virtual register haven't be assigned to any real register yet
         if (currentAssignedRegister == NULL) {
@@ -2668,18 +2650,17 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
 
             // get the value of virtual register back from spill state if not first use
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             } else {
-                if (self()->cg()->isOutOfLineColdPath()) {
-                    self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                if (cg()->isOutOfLineColdPath()) {
+                    cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                 }
             }
         } else {
             // virtual register is currently assigned to a different register,
             // override it with the target reg
-            cursor
-                = self()->registerCopy(self()->cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+            cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
 
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
@@ -2688,18 +2669,17 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
     // the target reg is blocked so we need to guarantee it stays in a reg
     else if (targetRegister->getState() == TR::RealRegister::Blocked) {
         currentTargetVirtual = targetRegister->getAssignedRegister();
-        self()->cg()->traceRegisterAssignment("target %R is blocked, assigned to %R", targetRegister,
-            currentTargetVirtual);
+        cg()->traceRegisterAssignment("target %R is blocked, assigned to %R", targetRegister, currentTargetVirtual);
         uint64_t regMask = 0xffffffff;
         if (currentTargetVirtual->isUsedInMemRef())
             regMask = ~TR::RealRegister::GPR0Mask;
         spareReg = self()->findBestFreeRegister(currentInstruction, rk, currentTargetVirtual, regMask);
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
 
         // We may need spare reg no matter what
         if (spareReg == NULL) {
-            self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+            cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
             virtualRegister->block();
             currentTargetVirtual->block();
 
@@ -2729,11 +2709,11 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                         comp->failCompilation<TR::CompilationException>(
                             "Abort compilation as we can not find a spareReg for blocked target real register");
                     }
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                    cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
-                    cursor = self()->registerCopy(self()->cg(), rk, targetRegister, spareReg, currentInstruction);
-                    cursor = self()->registerCopy(self()->cg(), rk, currentAssignedRegister, targetRegister,
-                        currentInstruction);
+                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
+                    cursor
+                        = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
 
                     spareReg->setState(TR::RealRegister::Assigned);
                     currentTargetVirtual->setAssignedRegister(spareReg);
@@ -2746,9 +2726,9 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     currentAssignedRegister->setAssignedRegister(NULL);
                 }
             } else {
-                self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
 
-                cursor = self()->registerExchange(self()->cg(), rk, targetRegister, currentAssignedRegister, spareReg,
+                cursor = self()->registerExchange(cg(), rk, targetRegister, currentAssignedRegister, spareReg,
                     currentInstruction);
 
                 currentAssignedRegister->setState(TR::RealRegister::Blocked);
@@ -2756,10 +2736,10 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
             }
         } else {
-            self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+            cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
             // virtual register is not assigned yet, copy register
-            cursor = self()->registerCopy(self()->cg(), rk, targetRegister, spareReg, currentInstruction);
+            cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
 
             spareReg->setState(TR::RealRegister::Assigned);
             spareReg->setAssignedRegister(currentTargetVirtual);
@@ -2769,11 +2749,11 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             targetRegister->setAssignedRegister(NULL);
 
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             } else {
-                if (self()->cg()->isOutOfLineColdPath()) {
-                    self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                if (cg()->isOutOfLineColdPath()) {
+                    cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                 }
             }
             // spareReg is assigned.
@@ -2783,15 +2763,14 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
     else if (targetRegister->getState() == TR::RealRegister::Assigned) {
         //  Since target is assigned, it must have a virtReg associated to it
         currentTargetVirtual = targetRegister->getAssignedRegister();
-        self()->cg()->traceRegisterAssignment("target %R is assigned, assigned to %R", targetRegister,
-            currentTargetVirtual);
+        cg()->traceRegisterAssignment("target %R is assigned, assigned to %R", targetRegister, currentTargetVirtual);
 
         if (rk != TR_FPR && rk != TR_VRF && currentTargetVirtual) {
             // this happens for OOL spill, simply return
             if (currentTargetVirtual == virtualRegister) {
                 virtualRegister->setAssignedRegister(targetRegister);
-                self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
-                self()->cg()->clearRegisterAssignmentFlags();
+                cg()->traceRegAssigned(virtualRegister, targetRegister);
+                cg()->clearRegisterAssignmentFlags();
                 return cursor;
             }
         }
@@ -2800,7 +2779,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
             regMask = ~TR::RealRegister::GPR0Mask;
         spareReg = self()->findBestFreeRegister(currentInstruction, rk, currentTargetVirtual, regMask);
 
-        self()->cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->setRegisterAssignmentFlag(TR_IndirectCoercion);
 
         // If the source register is already assigned a realReg, we will try and
         // keep both source and target in real regs by:
@@ -2817,7 +2796,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 //   1. there was a FREE reg
                 //   2. freeBestReg found a better choice to be spilled
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
 
                     //  The current source reg's assignment is automatically blocked out
                     virtualRegister->block();
@@ -2845,9 +2824,9 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 // Spill policy decided the best reg to spill was not the targetReg, so move target
                 // to the spareReg, and move the source reg to the target.
                 if (targetRegister->getRegisterNumber() != spareReg->getRegisterNumber() && !doNotRegCopy) {
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                    cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
-                    cursor = self()->registerCopy(self()->cg(), rk, targetRegister, spareReg, currentInstruction);
+                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
 
                     targetRegister->setState(TR::RealRegister::Unlatched);
                     targetRegister->setAssignedRegister(NULL);
@@ -2857,8 +2836,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     currentTargetVirtual->setAssignedRegister(spareReg);
                 }
 
-                cursor = self()->registerCopy(self()->cg(), rk, currentAssignedRegister, targetRegister,
-                    currentInstruction);
+                cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
                 currentAssignedRegister->setState(TR::RealRegister::Unlatched);
                 currentAssignedRegister->setAssignedRegister(NULL);
             } else {
@@ -2879,16 +2857,16 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 if (spareReg == NULL) {
                     self()->spillRegister(currentInstruction, currentTargetVirtual);
 
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
 
-                    cursor = self()->registerCopy(self()->cg(), rk, currentAssignedRegister, targetRegister,
-                        currentInstruction);
+                    cursor
+                        = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
                     currentAssignedRegister->setState(TR::RealRegister::Unlatched);
                     currentAssignedRegister->setAssignedRegister(NULL);
                 } else {
-                    cursor = self()->registerExchange(self()->cg(), rk, targetRegister, currentAssignedRegister,
-                        spareReg, currentInstruction);
+                    cursor = self()->registerExchange(cg(), rk, targetRegister, currentAssignedRegister, spareReg,
+                        currentInstruction);
                     currentAssignedRegister->setState(TR::RealRegister::Assigned);
                     currentAssignedRegister->setAssignedRegister(currentTargetVirtual);
                     currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
@@ -2909,7 +2887,7 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 // If we didn't find a FREE reg, choose the best one to spill.
                 // The worst case situation is that only the target is left to spill.
                 if (spareReg == NULL) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
 
                     virtualRegister->block();
                     if (virtualRegister->is64BitReg()) {
@@ -2937,10 +2915,10 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                 //  If we chose to spill a reg that wasn't the target, we use the new space
                 //  to free up the target.
                 if (targetRegister->getRegisterNumber() != spareReg->getRegisterNumber() && !doNotRegCopy) {
-                    self()->cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled);
-                    self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+                    cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled);
+                    cg()->traceRegAssigned(currentTargetVirtual, spareReg);
 
-                    cursor = self()->registerCopy(self()->cg(), rk, targetRegister, spareReg, currentInstruction);
+                    cursor = self()->registerCopy(cg(), rk, targetRegister, spareReg, currentInstruction);
 
                     spareReg->setState(TR::RealRegister::Assigned);
                     spareReg->setAssignedRegister(currentTargetVirtual);
@@ -2949,22 +2927,22 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
                     targetRegister->setAssignedRegister(NULL);
 
                     currentTargetVirtual->setAssignedRegister(spareReg);
-                    self()->cg()->recordRegisterAssignment(spareReg, currentTargetVirtual);
+                    cg()->recordRegisterAssignment(spareReg, currentTargetVirtual);
                 }
 
                 //  Draw the source reg back out of SPILL state
                 if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                    self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                    cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                     self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
                 } else {
-                    if (self()->cg()->isOutOfLineColdPath()) {
-                        self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                    if (cg()->isOutOfLineColdPath()) {
+                        cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                     }
                 }
             }
         }
 
-        self()->cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
+        cg()->resetRegisterAssignmentFlag(TR_IndirectCoercion);
     }
 
     //  We will allow Locked regs to be pointed to, but do not allow
@@ -2979,8 +2957,8 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
     } else {
         if (comp->getOption(TR_TraceCG)) {
             OMR::Logger *log = comp->log();
-            log->printf("    WARNING: Assigning a Locked register %s to %s\n",
-                getRegisterName(targetRegister, self()->cg()), getRegisterName(virtualRegister, self()->cg()));
+            log->printf("    WARNING: Assigning a Locked register %s to %s\n", getRegisterName(targetRegister, cg()),
+                getRegisterName(virtualRegister, cg()));
             log->prints("             This assignment is equivalent to using a hard coded real register.\n");
         }
 
@@ -2988,18 +2966,17 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
         if (currentAssignedRegister == NULL) {
             // get the value of virtual register back from spill state if not first use
             if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
-                self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+                cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
                 self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
             } else {
-                if (self()->cg()->isOutOfLineColdPath()) {
-                    self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                if (cg()->isOutOfLineColdPath()) {
+                    cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
                 }
             }
         } else {
             // virtual register is currently assigned to a different register,
             // override it with the target reg
-            cursor
-                = self()->registerCopy(self()->cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
+            cursor = self()->registerCopy(cg(), rk, currentAssignedRegister, targetRegister, currentInstruction);
 
             currentAssignedRegister->setState(TR::RealRegister::Free);
             currentAssignedRegister->setAssignedRegister(NULL);
@@ -3008,9 +2985,9 @@ TR::Instruction *OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction *curr
 
     virtualRegister->setAssignedRegister(targetRegister);
 
-    self()->cg()->traceRegAssigned(virtualRegister, targetRegister);
+    cg()->traceRegAssigned(virtualRegister, targetRegister);
 
-    self()->cg()->clearRegisterAssignmentFlags();
+    cg()->clearRegisterAssignmentFlags();
     return cursor;
 }
 
@@ -3022,53 +2999,53 @@ void OMR::Z::Machine::initializeRegisterFile()
     // Initialize GPRs
     _registerFile[TR::RealRegister::NoReg] = NULL;
 
-    _registerFile[TR::RealRegister::GPR0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR0, TR::RealRegister::GPR0Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR0, TR::RealRegister::GPR0Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR1, TR::RealRegister::GPR1Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR1, TR::RealRegister::GPR1Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR2, TR::RealRegister::GPR2Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR2, TR::RealRegister::GPR2Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR3, TR::RealRegister::GPR3Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR3, TR::RealRegister::GPR3Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR4, TR::RealRegister::GPR4Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR4, TR::RealRegister::GPR4Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR5, TR::RealRegister::GPR5Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR5, TR::RealRegister::GPR5Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR6, TR::RealRegister::GPR6Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR6, TR::RealRegister::GPR6Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR7, TR::RealRegister::GPR7Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR7, TR::RealRegister::GPR7Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR8, TR::RealRegister::GPR8Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR8, TR::RealRegister::GPR8Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR9, TR::RealRegister::GPR9Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR9, TR::RealRegister::GPR9Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR10, TR::RealRegister::GPR10Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR10, TR::RealRegister::GPR10Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR11, TR::RealRegister::GPR11Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR11, TR::RealRegister::GPR11Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR12, TR::RealRegister::GPR12Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR12, TR::RealRegister::GPR12Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR13, TR::RealRegister::GPR13Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR13, TR::RealRegister::GPR13Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR14, TR::RealRegister::GPR14Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR14, TR::RealRegister::GPR14Mask, cg());
 
-    _registerFile[TR::RealRegister::GPR15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::GPR15, TR::RealRegister::GPR15Mask, self()->cg());
+    _registerFile[TR::RealRegister::GPR15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free, TR::RealRegister::GPR15, TR::RealRegister::GPR15Mask, cg());
 
     _registerFile[TR::RealRegister::GPR0]->setSiblingRegister(_registerFile[TR::RealRegister::GPR1]);
     _registerFile[TR::RealRegister::GPR1]->setSiblingRegister(_registerFile[TR::RealRegister::GPR0]);
@@ -3089,53 +3066,53 @@ void OMR::Z::Machine::initializeRegisterFile()
 
     // Initialize FPRs
 
-    _registerFile[TR::RealRegister::FPR0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR0, TR::RealRegister::FPR0Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR0] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR0, TR::RealRegister::FPR0Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR1] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR1, TR::RealRegister::FPR1Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR1] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR1, TR::RealRegister::FPR1Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR2] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR2, TR::RealRegister::FPR2Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR2] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR2, TR::RealRegister::FPR2Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR3] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR3, TR::RealRegister::FPR3Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR3] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR3, TR::RealRegister::FPR3Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR4] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR4, TR::RealRegister::FPR4Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR4] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR4, TR::RealRegister::FPR4Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR5] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR5, TR::RealRegister::FPR5Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR5] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR5, TR::RealRegister::FPR5Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR6] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR6, TR::RealRegister::FPR6Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR6] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR6, TR::RealRegister::FPR6Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR7] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR7, TR::RealRegister::FPR7Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR7] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR7, TR::RealRegister::FPR7Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR8] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR8, TR::RealRegister::FPR8Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR8] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR8, TR::RealRegister::FPR8Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR9] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR9, TR::RealRegister::FPR9Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR9] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR9, TR::RealRegister::FPR9Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR10, TR::RealRegister::FPR10Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR10] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR10, TR::RealRegister::FPR10Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR11] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR11, TR::RealRegister::FPR11Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR11] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR11, TR::RealRegister::FPR11Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR12] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR12, TR::RealRegister::FPR12Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR12] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR12, TR::RealRegister::FPR12Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR13] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR13, TR::RealRegister::FPR13Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR13] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR13, TR::RealRegister::FPR13Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR14] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR14, TR::RealRegister::FPR14Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR14] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR14, TR::RealRegister::FPR14Mask, cg());
 
-    _registerFile[TR::RealRegister::FPR15] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR, 0,
-        TR::RealRegister::Free, TR::RealRegister::FPR15, TR::RealRegister::FPR15Mask, self()->cg());
+    _registerFile[TR::RealRegister::FPR15] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_FPR, 0, TR::RealRegister::Free, TR::RealRegister::FPR15, TR::RealRegister::FPR15Mask, cg());
 
     // Initialize Vector Regs
     // first 16 overlaps with FPRs
@@ -3156,53 +3133,53 @@ void OMR::Z::Machine::initializeRegisterFile()
     _registerFile[TR::RealRegister::VRF14] = _registerFile[TR::RealRegister::FPR14];
     _registerFile[TR::RealRegister::VRF15] = _registerFile[TR::RealRegister::FPR15];
 
-    _registerFile[TR::RealRegister::VRF16] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF16, TR::RealRegister::VRF16Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF16] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF16, TR::RealRegister::VRF16Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF17] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF17, TR::RealRegister::VRF17Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF17] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF17, TR::RealRegister::VRF17Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF18] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF18, TR::RealRegister::VRF18Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF18] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF18, TR::RealRegister::VRF18Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF19] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF19, TR::RealRegister::VRF19Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF19] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF19, TR::RealRegister::VRF19Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF20] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF20, TR::RealRegister::VRF20Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF20] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF20, TR::RealRegister::VRF20Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF21] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF21, TR::RealRegister::VRF21Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF21] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF21, TR::RealRegister::VRF21Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF22] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF22, TR::RealRegister::VRF22Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF22] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF22, TR::RealRegister::VRF22Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF23] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF23, TR::RealRegister::VRF23Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF23] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF23, TR::RealRegister::VRF23Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF24] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF24, TR::RealRegister::VRF24Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF24] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF24, TR::RealRegister::VRF24Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF25] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF25, TR::RealRegister::VRF25Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF25] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF25, TR::RealRegister::VRF25Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF26] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF26, TR::RealRegister::VRF26Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF26] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF26, TR::RealRegister::VRF26Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF27] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF27, TR::RealRegister::VRF27Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF27] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF27, TR::RealRegister::VRF27Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF28] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF28, TR::RealRegister::VRF28Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF28] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF28, TR::RealRegister::VRF28Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF29] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF29, TR::RealRegister::VRF29Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF29] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF29, TR::RealRegister::VRF29Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF30] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF30, TR::RealRegister::VRF30Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF30] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF30, TR::RealRegister::VRF30Mask, cg());
 
-    _registerFile[TR::RealRegister::VRF31] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_VRF, 0,
-        TR::RealRegister::Free, TR::RealRegister::VRF31, TR::RealRegister::VRF31Mask, self()->cg());
+    _registerFile[TR::RealRegister::VRF31] = new (cg()->trHeapMemory())
+        TR::RealRegister(TR_VRF, 0, TR::RealRegister::Free, TR::RealRegister::VRF31, TR::RealRegister::VRF31Mask, cg());
 
     // set siblings for Floating Point register pairs used by long doubles
     _registerFile[TR::RealRegister::FPR0]->setSiblingRegister(_registerFile[TR::RealRegister::FPR2]);
@@ -3288,11 +3265,11 @@ void OMR::Z::Machine::initializeFPRegPairTable()
 
 uint32_t *OMR::Z::Machine::initializeGlobalRegisterTable()
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
 
     int32_t p = 0;
 
-    TR::Linkage *linkage = self()->cg()->getS390Linkage();
+    TR::Linkage *linkage = cg()->getS390Linkage();
     self()->setFirstGlobalGPRRegisterNumber(0);
 
     if (linkage->isZLinuxLinkageType())
@@ -3324,12 +3301,12 @@ uint32_t *OMR::Z::Machine::initializeGlobalRegisterTable()
 
     self()->setLastLinkageGPR(p - 1);
 
-    if ((self()->cg()->isLiteralPoolOnDemandOn() && !linkage->isZLinuxLinkageType())
-        || (self()->cg()->isLiteralPoolOnDemandOn() && !linkage->getPreserved(linkage->getLitPoolRegister())))
+    if ((cg()->isLiteralPoolOnDemandOn() && !linkage->isZLinuxLinkageType())
+        || (cg()->isLiteralPoolOnDemandOn() && !linkage->getPreserved(linkage->getLitPoolRegister())))
         p = self()->addGlobalReg(linkage->getLitPoolRegister(), p);
-    if (!self()->cg()->isGlobalStaticBaseRegisterOn())
+    if (!cg()->isGlobalStaticBaseRegisterOn())
         p = self()->addGlobalReg(linkage->getStaticBaseRegister(), p);
-    if (!self()->cg()->isGlobalPrivateStaticBaseRegisterOn())
+    if (!cg()->isGlobalPrivateStaticBaseRegisterOn())
         p = self()->addGlobalReg(linkage->getPrivateStaticBaseRegister(), p);
     p = self()->addGlobalReg(linkage->getIntegerReturnRegister(), p);
     p = self()->addGlobalReg(linkage->getLongReturnRegister(), p);
@@ -3368,8 +3345,8 @@ uint32_t *OMR::Z::Machine::initializeGlobalRegisterTable()
     }
 
     p = self()->addGlobalRegLater(linkage->getMethodMetaDataRegister(), p);
-    if (self()->cg()->comp()->target().isZOS()) {
-        p = self()->addGlobalRegLater(self()->cg()->getS390Linkage()->getStackPointerRegister(), p);
+    if (comp->target().isZOS()) {
+        p = self()->addGlobalRegLater(cg()->getS390Linkage()->getStackPointerRegister(), p);
     }
 
     // Special regs that add to prologue cost
@@ -3415,7 +3392,7 @@ uint32_t *OMR::Z::Machine::initializeGlobalRegisterTable()
     self()->setLastGlobalFPRRegisterNumber(p - 1);
 
     // initGlobalVectorRegisterMap sets first/last global grns and overlapped grns
-    if (self()->cg()->getSupportsVectorRegisters())
+    if (cg()->getSupportsVectorRegisters())
         p = self()->initGlobalVectorRegisterMap(p);
 
     self()->setLastGlobalVRFRegisterNumber(p - 1);
@@ -3447,7 +3424,7 @@ uint32_t *OMR::Z::Machine::initializeGlobalRegisterTable()
  */
 uint32_t OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 {
-    if (!self()->cg()->getSupportsVectorRegisters() && !self()->cg()->comp()->getOption(TR_DisableVectorRegGRA)) {
+    if (!cg()->getSupportsVectorRegisters() && !cg()->comp()->getOption(TR_DisableVectorRegGRA)) {
         self()->setFirstGlobalVRFRegisterNumber(-1);
         self()->setLastGlobalVRFRegisterNumber(-1);
         self()->setFirstOverlappedGlobalVRFRegisterNumber(-1);
@@ -3461,7 +3438,7 @@ uint32_t OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
     // This flag prevents the low reg file (VRF0-15 from being part of GRA). This ensures no overlap.
 
     static const char *hideLowerHalf = feGetEnv("TR_hideOverlappingVecRegsFromGRA");
-    const bool useEntireRegFile = ((hideLowerHalf == NULL) && self()->cg()->getSupportsVectorRegisters());
+    const bool useEntireRegFile = ((hideLowerHalf == NULL) && cg()->getSupportsVectorRegisters());
 
     TR_GlobalRegisterNumber firstOverlappingVecOffset = -1;
     TR_GlobalRegisterNumber lastOverlappingVecOffset = -1;
@@ -3531,7 +3508,7 @@ uint32_t OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
     self()->setLastGlobalFPRRegisterNumber(self()->getLastOverlappedGlobalVRFRegisterNumber());
 
     if (traceVectorGRN) {
-        printf("Java func: %s func: %s\n", self()->cg()->comp()->getCurrentMethod()->nameChars(), __FUNCTION__);
+        printf("Java func: %s func: %s\n", cg()->comp()->getCurrentMethod()->nameChars(), __FUNCTION__);
         printf("ff %d\t", self()->getFirstGlobalFPRRegisterNumber());
         printf("lf %d\t", self()->getLastGlobalFPRRegisterNumber());
         printf("fof %d\t", self()->getFirstOverlappedGlobalFPRRegisterNumber());
@@ -3550,7 +3527,7 @@ uint32_t OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 // call this if optimizer run TR_DynamicLiteralPool pass
 void OMR::Z::Machine::releaseLiteralPoolRegister()
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     if (comp->getOption(TR_DisableRegisterPressureSimulation)) {
         _globalRegisterNumberToRealRegisterMap[GLOBAL_REG_FOR_LITPOOL] = TR::RealRegister::GPR6;
     }
@@ -3596,9 +3573,9 @@ TR_GlobalRegisterNumber OMR::Z::Machine::setLastGlobalCCRRegisterNumber(TR_Globa
 // Register Association ////////////////////////////////////////////
 void OMR::Z::Machine::setRegisterWeightsFromAssociations()
 {
-    TR::Linkage *linkage = self()->cg()->getS390Linkage();
+    TR::Linkage *linkage = cg()->getS390Linkage();
     int32_t first = TR::RealRegister::FirstGPR;
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     int32_t last = TR::RealRegister::LastAssignableVRF;
 
     for (int32_t i = first; i <= last; ++i) {
@@ -3631,10 +3608,10 @@ void OMR::Z::Machine::setRegisterWeightsFromAssociations()
 
 void OMR::Z::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
 {
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     int32_t last = TR::RealRegister::LastAssignableVRF;
-    TR::RegisterDependencyConditions *associations = new (self()->cg()->trHeapMemory(),
-        TR_MemoryBase::RegisterDependencyConditions) TR::RegisterDependencyConditions(0, last, self()->cg());
+    TR::RegisterDependencyConditions *associations = new (cg()->trHeapMemory(),
+        TR_MemoryBase::RegisterDependencyConditions) TR::RegisterDependencyConditions(0, last, cg());
 
     // Go through the current associations held in the machine and put a copy of
     // that state out into the stream after the cursor
@@ -3646,11 +3623,11 @@ void OMR::Z::Machine::createRegisterAssociationDirective(TR::Instruction *cursor
         associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum);
     }
 
-    TR::Instruction *cursor1 = new (self()->cg()->trHeapMemory(), TR_MemoryBase::S390Instruction)
-        TR::Instruction(cursor, TR::InstOpCode::assocreg, associations, self()->cg());
+    TR::Instruction *cursor1 = new (cg()->trHeapMemory(), TR_MemoryBase::S390Instruction)
+        TR::Instruction(cursor, TR::InstOpCode::assocreg, associations, cg());
 
-    if (cursor == self()->cg()->getAppendInstruction()) {
-        self()->cg()->setAppendInstruction(cursor->getNext());
+    if (cursor == cg()->getAppendInstruction()) {
+        cg()->setAppendInstruction(cursor->getNext());
     }
 }
 
@@ -3721,7 +3698,7 @@ void OMR::Z::Machine::restoreRegisterStateFromSnapShot()
         //_registerFile[i]->setHasBeenAssignedInMethod(_registerAssignedSnapShot[i]);
         // make sure to double link virt - real reg if assigned
         if (_registerFile[i]->getState() == TR::RealRegister::Assigned) {
-            // self()->cg()->traceRegisterAssignment("\nOOL: restoring %R : %R", _registerFile[i],
+            // cg()->traceRegisterAssignment("\nOOL: restoring %R : %R", _registerFile[i],
             // _registerFile[i]->getAssignedRegister());
             _registerFile[i]->getAssignedRegister()->setAssignedRegister(_registerFile[i]);
         }
@@ -3747,7 +3724,7 @@ TR::RegisterDependencyConditions *OMR::Z::Machine::createCondForLiveAndSpilledGP
     // Calculate number of register dependencies required. This step is not really necessary, but
     // it is space conscious
     //
-    TR::Compilation *comp = self()->cg()->comp();
+    TR::Compilation *comp = cg()->comp();
     for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i + 1)) {
         TR::RealRegister *realReg = self()->getRealRegister(i);
@@ -3765,8 +3742,8 @@ TR::RegisterDependencyConditions *OMR::Z::Machine::createCondForLiveAndSpilledGP
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = new (self()->cg()->trHeapMemory(), TR_MemoryBase::RegisterDependencyConditions)
-            TR::RegisterDependencyConditions(0, c, self()->cg());
+        deps = new (cg()->trHeapMemory(), TR_MemoryBase::RegisterDependencyConditions)
+            TR::RegisterDependencyConditions(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i + 1)) {
             TR::RealRegister *realReg = self()->getRealRegister(i);

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -4744,8 +4744,8 @@ uint8_t *TR::S390NOPInstruction::generateBinaryEncoding()
 
 int32_t TR::S390AlignmentNopInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    self()->setEstimatedBinaryLength(_alignment - 2);
-    return currentEstimate + self()->getEstimatedBinaryLength();
+    setEstimatedBinaryLength(_alignment - 2);
+    return currentEstimate + getEstimatedBinaryLength();
 }
 
 uint8_t *TR::S390AlignmentNopInstruction::generateBinaryEncoding()


### PR DESCRIPTION
* Remove unnecessary `self()` calls from `OMR::Machine` classes
* Miscellaneous cleanup in X86BinaryEncoding.cpp
* Add `OMR_FINAL` to some `OMR::Instruction` functions and remove `self()` calls