### PR TITLE
Apply inliner policy to direct targets added after Not_Sane removal

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4226,6 +4226,11 @@ TR_CallSite *TR_InlinerBase::findAndUpdateCallSiteInGraph(TR_CallStack *callStac
             if (findDirectCallSiteTarget(comp(), callsite, this)) {
                 // Can't do a partial inline anymore as the blocks are wrong.
                 callsite->getTarget(0)->_isPartialInliningCandidate = false;
+                // Apply policy (e.g. TR_DontInlineUnloadableMethods) to the
+                // newly added target, since it bypassed the normal path through
+                // getSymbolAndFindInlineTargets() where applyPolicyToTargets()
+                // is called.
+                applyPolicyToTargets(callStack, callsite);
             }
         }
     }


### PR DESCRIPTION
When shouldRemoveDifferingTargets() refines an indirect call site to direct, all existing targets may be removed with reason Not_Sane and a fresh target added via findDirectCallSiteTarget(). This path bypassed applyPolicyToTargets(), causing the TR_DontInlineUnloadableMethods check to be skipped. The resulting target had _needsBond set, triggering a fatal assertion in inlineCallTarget2().

Fix by calling applyPolicyToTargets() on the newly added target so it is subject to the same policy checks (including unloadable method filtering) as targets added through the normal getSymbolAndFindInlineTargets() path.

Issue: https://github.com/eclipse-openj9/openj9/issues/23683