### PR TITLE
Correct line number format

### DIFF
--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -251,7 +251,7 @@ outputErrorMessage(struct OMRPortLibrary *portLibrary, const char *fileName, int
 	}
 	va_end(args);
 
-	portTestEnv->log(LEVEL_ERROR, "%s line %4zi: %s ", fileName, lineNumber, testName);
+	portTestEnv->log(LEVEL_ERROR, "%s line %i: %s ", fileName, lineNumber, testName);
 	portTestEnv->log(LEVEL_ERROR, "%s\n", buf);
 	portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorNumber: %i\n", lastErrorNumber);
 	portTestEnv->log(LEVEL_ERROR, "\t\tLastErrorMessage: %s\n\n", portErrorBuf);


### PR DESCRIPTION
The 'z' modifier is inappropriate for an `int32_t` value.

Notice the failure in https://github.com/eclipse-omr/omr/pull/8191 which mentions line 1026497185163 (0xef0000058b). Only the low-order 32 bits should be used (0x58b) so the appropriate line number (1419) is reported.