### PR TITLE
Revert "Apply inliner policy to direct targets added after Not_Sane removal"

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4226,11 +4226,6 @@ TR_CallSite *TR_InlinerBase::findAndUpdateCallSiteInGraph(TR_CallStack *callStac
             if (findDirectCallSiteTarget(comp(), callsite, this)) {
                 // Can't do a partial inline anymore as the blocks are wrong.
                 callsite->getTarget(0)->_isPartialInliningCandidate = false;
-                // Apply policy (e.g. TR_DontInlineUnloadableMethods) to the
-                // newly added target, since it bypassed the normal path through
-                // getSymbolAndFindInlineTargets() where applyPolicyToTargets()
-                // is called.
-                applyPolicyToTargets(callStack, callsite);
             }
         }
     }


### PR DESCRIPTION
Reverts eclipse-omr/omr#8214 due to OMR acceptance test failures that require additional investigation.