### PR TITLE
Modify GC Assertion with message to take variable number of parameters

### DIFF
--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -68,7 +68,7 @@ private:
 	{
 		Assert_GC_true_with_message(env, objectPtr != J9_INVALID_OBJECT, "Invalid object pointer %p\n", objectPtr);
 		Assert_MM_objectAligned(env, objectPtr);
-		Assert_GC_true_with_message3(env, isHeapObject(objectPtr), "Object %p not in heap range [%p,%p)\n", objectPtr, _heapBase, _heapTop);
+		Assert_GC_true_with_message(env, isHeapObject(objectPtr), "Object %p not in heap range [%p,%p)\n", objectPtr, _heapBase, _heapTop);
 	}
 	
 	/**

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -408,7 +408,7 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase *env, MM_MemoryH
 				handle->setMemoryBase((void *)heapBase);
 
 				/* top of adjusted Nursery should fit reserved memory */
-				Assert_GC_true_with_message3(env, ((heapBase + size) <= (uintptr_t)handle->getMemoryTop()),
+				Assert_GC_true_with_message(env, ((heapBase + size) <= (uintptr_t)handle->getMemoryTop()),
 						"End of projected heap (base 0x%zx + size 0x%zx) is larger then Top allocated %p\n",
 						heapBase, size, handle->getMemoryTop());
 			}

--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -267,7 +267,7 @@ MM_MemoryPoolLargeObjects::resizeLOA(MM_EnvironmentBase* env)
 
 			if (newLOAsize < loaMinimumSize){
 
-				Assert_GC_true_with_message2(env, (_loaSize >= loaMinimumSize), "current LOA size(%zu) should not be smaller than minimum LOA size(%zu).\n", _loaSize, loaMinimumSize);
+				Assert_GC_true_with_message(env, (_loaSize >= loaMinimumSize), "current LOA size(%zu) should not be smaller than minimum LOA size(%zu).\n", _loaSize, loaMinimumSize);
 				contractRequired = _loaSize - loaMinimumSize;
 				newLOAsize = _loaSize - contractRequired;
 
@@ -311,7 +311,7 @@ MM_MemoryPoolLargeObjects::resizeLOA(MM_EnvironmentBase* env)
 				assume0(_memoryPoolSmallObjects->isValidListOrdering());
 				assume0(_memoryPoolLargeObjects->isValidListOrdering());
 
-				Assert_GC_true_with_message2(env, (_loaSize >= loaMinimumSize), "resize LOA size(%zu) should not be smaller than minimum LOA size(%zu).\n", _loaSize, loaMinimumSize);
+				Assert_GC_true_with_message(env, (_loaSize >= loaMinimumSize), "resize LOA size(%zu) should not be smaller than minimum LOA size(%zu).\n", _loaSize, loaMinimumSize);
 			}
 		}
 	}
@@ -340,7 +340,7 @@ MM_MemoryPoolLargeObjects::calculateTargetLOARatio(MM_EnvironmentBase* env, uint
 	double newLOARatio = _currentLOARatio;
 	float maxLOAFreeRatio = ((float)_extensions->heapFreeMaximumRatioMultiplier) / ((float)_extensions->heapFreeMinimumRatioDivisor);
 	uintptr_t loaFreeBytes = _memoryPoolLargeObjects->getActualFreeMemorySize();
-	Assert_GC_true_with_message2(env, (loaFreeBytes <= _loaSize), "loaFreeBytes(%zu) should be equal or smaller than _loaSize(%zu).", loaFreeBytes, _loaSize);
+	Assert_GC_true_with_message(env, (loaFreeBytes <= _loaSize), "loaFreeBytes(%zu) should be equal or smaller than _loaSize(%zu).", loaFreeBytes, _loaSize);
 
 	/*
 	 * shift elements to make room for current loa free Ratio

--- a/gc/base/MemoryPoolSplitAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedList.cpp
@@ -795,7 +795,7 @@ MM_MemoryPoolSplitAddressOrderedList::expandWithRange(MM_EnvironmentBase* env, u
 	}
 
 	assume0(isMemoryPoolValid(env, true));
-	Assert_GC_true_with_message2(env, reservedFreeEntryConsistencyCheck(), "expandWithRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
+	Assert_GC_true_with_message(env, reservedFreeEntryConsistencyCheck(), "expandWithRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
 }
 
 /**
@@ -920,7 +920,7 @@ MM_MemoryPoolSplitAddressOrderedList::contractWithRange(MM_EnvironmentBase* env,
 
 	assume0(isMemoryPoolValid(env, true));
 
-	Assert_GC_true_with_message2(env, reservedFreeEntryConsistencyCheck(), "contractWithRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
+	Assert_GC_true_with_message(env, reservedFreeEntryConsistencyCheck(), "contractWithRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
 	return lowAddress;
 }
 
@@ -1041,7 +1041,7 @@ MM_MemoryPoolSplitAddressOrderedList::addFreeEntries(MM_EnvironmentBase* env,
 		_heapFreeLists[previousFreeListIndex]._freeCount += localFreeListMemoryCount;
 	}
 
-	Assert_GC_true_with_message2(env, reservedFreeEntryConsistencyCheck(), "addFreeEntries _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
+	Assert_GC_true_with_message(env, reservedFreeEntryConsistencyCheck(), "addFreeEntries _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
 }
 
 /**
@@ -1292,7 +1292,7 @@ MM_MemoryPoolSplitAddressOrderedList::removeFreeEntriesWithinRange(MM_Environmen
 		_heapFreeLists[i].clearHints();
 	}
 
-	Assert_GC_true_with_message2(env, reservedFreeEntryConsistencyCheck(), "removeFreeEntriesWithinRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
+	Assert_GC_true_with_message(env, reservedFreeEntryConsistencyCheck(), "removeFreeEntriesWithinRange _previousReservedFreeEntry=%p, _reservedFreeEntrySize=%zu\n", _previousReservedFreeEntry, _reservedFreeEntrySize);
 	return true;
 }
 

--- a/gc/base/ModronAssertions.h
+++ b/gc/base/ModronAssertions.h
@@ -77,41 +77,27 @@ extern void omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread 
         assert(0);\
 	} while(0)
 
-/* One printed parameter macro */
-#define Assert_GC_true_with_message(__env__,__condition,__message,__parameter) \
+#define Assert_GC_true_with_message(__env__, __condition, __message, ...) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter);\
+		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __VA_ARGS__);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)
 
+/* Keep next three definitions for compatibility temporary */
 /* Two printed parameters macro */
 #define Assert_GC_true_with_message2(__env__,__condition,__message,__parameter1,__parameter2) \
-do {\
-	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2);\
-		Assert_MM_unreachable();\
-	}\
-} while (false)
+		Assert_GC_true_with_message(__env__,__condition,__message,__parameter1,__parameter2)
 
 /* THree printed parameters macro */
 #define Assert_GC_true_with_message3(__env__,__condition,__message,__parameter1,__parameter2,__parameter3) \
-do {\
-	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3);\
-		Assert_MM_unreachable();\
-	}\
-} while (false)
+		Assert_GC_true_with_message(__env__,__condition,__message,__parameter1,__parameter2,__parameter3)
+
 
 /* Four printed parameters macro */
 #define Assert_GC_true_with_message4(__env__,__condition,__message,__parameter1,__parameter2,__parameter3,__parameter4) \
-do {\
-	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __parameter1, __parameter2, __parameter3, __parameter4);\
-		Assert_MM_unreachable();\
-	}\
-} while (false)
+		Assert_GC_true_with_message(__env__,__condition,__message,__parameter1,__parameter2,__parameter3,__parameter4)
 
 #define Assert_MM_objectAligned(__env__,__pointer) \
 do {\
@@ -119,18 +105,22 @@ do {\
 		Assert_GC_true_with_message2(__env__,false, "Pointer: %p has is not object aligned (to %zu bytes) \n", __pointer, __env__->getObjectAlignmentInBytes());\
 	}\
 } while(false)
-#else /* defined(OMR_GC_DEBUG_ASSERTS) */
 
+#else /* defined(OMR_GC_DEBUG_ASSERTS) */
 
 #define Assert_MM_true(arg) Assert_MM_true_internal(arg)
 #define Assert_MM_false(arg) Assert_MM_false_internal(arg)
 #define Assert_MM_unreachable() Assert_MM_unreachable_internal()
 #define Assert_MM_unimplemented() Assert_MM_unimplemented_internal()
 #define Assert_MM_invalidJNICall() Assert_MM_invalidJNICall_internal()
+
 #define Assert_GC_true_with_message(__env__,__condition,__message,__parameter) Assert_MM_true(__condition)
+
+/* Keep next three definitions for compatibility temporary */
 #define Assert_GC_true_with_message2(__env__,__condition,__message,__parameter1,__parameter2) Assert_MM_true(__condition)
 #define Assert_GC_true_with_message3(__env__,__condition,__message,__parameter1,__parameter2,__parameter3) Assert_MM_true(__condition)
 #define Assert_GC_true_with_message4(__env__,__condition,__message,__parameter1,__parameter2,__parameter3,__parameter4) Assert_MM_true(__condition)
+
 #define Assert_MM_objectAligned(__env__,__pointer) Assert_MM_true_internal((uintptr_t)(__pointer) & (__env__->getObjectAlignmentInBytes() - 1))
 #endif /* defined(OMR_GC_DEBUG_ASSERTS) */
 

--- a/gc/base/ObjectMap.hpp
+++ b/gc/base/ObjectMap.hpp
@@ -70,7 +70,7 @@ private:
 	{
 		Assert_GC_true_with_message(env, objectPtr != J9_INVALID_OBJECT, "Invalid object pointer %p\n", objectPtr);
 		Assert_MM_objectAligned(env, objectPtr);
-		Assert_GC_true_with_message3(env, isHeapObject(objectPtr), "Object %p not in heap range [%p,%p)\n", objectPtr, _heapBase, _heapTop);
+		Assert_GC_true_with_message(env, isHeapObject(objectPtr), "Object %p not in heap range [%p,%p)\n", objectPtr, _heapBase, _heapTop);
 	}
 
 protected:

--- a/gc/base/ParallelTask.cpp
+++ b/gc/base/ParallelTask.cpp
@@ -83,9 +83,9 @@ MM_ParallelTask::synchronizeGCThreads(MM_EnvironmentBase *env, const char *id)
 			_syncPointUniqueId = id;
 			_syncPointWorkUnitIndex = env->getWorkUnitIndex();
 		} else {
-			Assert_GC_true_with_message4(env, _syncPointUniqueId == id,
+			Assert_GC_true_with_message(env, _syncPointUniqueId == id,
 				"%s at %p from synchronizeGCThreads: call from (%s), expected (%s)\n", getBaseVirtualTypeId(), this, id, _syncPointUniqueId);
-			Assert_GC_true_with_message4(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
+			Assert_GC_true_with_message(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
 				"%s at %p from synchronizeGCThreads: call with syncPointWorkUnitIndex %zu, expected %zu\n", getBaseVirtualTypeId(), this, env->getWorkUnitIndex(), _syncPointWorkUnitIndex);
 		}
 
@@ -127,9 +127,9 @@ MM_ParallelTask::synchronizeGCThreadsAndReleaseMain(MM_EnvironmentBase *env, con
 			_syncPointUniqueId = id;
 			_syncPointWorkUnitIndex = env->getWorkUnitIndex();
 		} else {
-			Assert_GC_true_with_message4(env, _syncPointUniqueId == id,
+			Assert_GC_true_with_message(env, _syncPointUniqueId == id,
 				"%s at %p from synchronizeGCThreadsAndReleaseMain: call from (%s), expected (%s)\n", getBaseVirtualTypeId(), this, id, _syncPointUniqueId);
-			Assert_GC_true_with_message4(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
+			Assert_GC_true_with_message(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
 				"%s at %p from synchronizeGCThreadsAndReleaseMain: call with syncPointWorkUnitIndex %zu, expected %zu\n", getBaseVirtualTypeId(), this, env->getWorkUnitIndex(), _syncPointWorkUnitIndex);
 		}
 
@@ -183,9 +183,9 @@ MM_ParallelTask::synchronizeGCThreadsAndReleaseSingleThread(MM_EnvironmentBase *
 			_syncPointUniqueId = id;
 			_syncPointWorkUnitIndex = workUnitIndex;
 		} else {
-			Assert_GC_true_with_message4(env, _syncPointUniqueId == id,
+			Assert_GC_true_with_message(env, _syncPointUniqueId == id,
 				"%s at %p from synchronizeGCThreadsAndReleaseSingleThread: call from (%s), expected (%s)\n", getBaseVirtualTypeId(), this, id, _syncPointUniqueId);
-			Assert_GC_true_with_message4(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
+			Assert_GC_true_with_message(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
 				"%s at %p from synchronizeGCThreadsAndReleaseSingleThread: call with syncPointWorkUnitIndex %zu, expected %zu\n", getBaseVirtualTypeId(), this, env->getWorkUnitIndex(), _syncPointWorkUnitIndex);
 		}
 
@@ -227,7 +227,7 @@ MM_ParallelTask::releaseSynchronizedGCThreads(MM_EnvironmentBase *env)
 		return;
 	}
 	
-	Assert_GC_true_with_message2(env, _synchronized, "%s at %p from releaseSynchronizedGCThreads: call for non-synchronized\n", getBaseVirtualTypeId(), this);
+	Assert_GC_true_with_message(env, _synchronized, "%s at %p from releaseSynchronizedGCThreads: call for non-synchronized\n", getBaseVirtualTypeId(), this);
 	/* Could not have gotten here unless all other threads are sync'd - don't check, just release */
 	_synchronized = false;
 	omrthread_monitor_enter(_synchronizeMutex);
@@ -262,7 +262,7 @@ MM_ParallelTask::complete(MM_EnvironmentBase *env)
 			_syncPointUniqueId = id;
 			_syncPointWorkUnitIndex = env->getWorkUnitIndex();
 		} else {
-			Assert_GC_true_with_message3(env, _syncPointUniqueId == id,
+			Assert_GC_true_with_message(env, _syncPointUniqueId == id,
 				"%s at %p from complete: reach end of the task however threads are waiting at (%s)\n", getBaseVirtualTypeId(), this, _syncPointUniqueId);
 			/*
 			 * MM_ParallelScrubCardTableTask is implemented to be aborted if it takes too much time
@@ -270,7 +270,7 @@ MM_ParallelTask::complete(MM_EnvironmentBase *env)
 			 * Temporary commenting out
 			 */
 			/*
-			Assert_GC_true_with_message4(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
+			Assert_GC_true_with_message(env, _syncPointWorkUnitIndex == env->getWorkUnitIndex(),
 				"%s at %p from complete: call with syncPointWorkUnitIndex %zu, expected %zu\n", getBaseVirtualTypeId(), this, env->getWorkUnitIndex(), _syncPointWorkUnitIndex);
 			*/
 		}

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1538,7 +1538,7 @@ MM_ConcurrentGC::concurrentMark(MM_EnvironmentBase *env, MM_MemorySubSpace *subs
 				Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < executionMode) && (CONCURRENT_TRACE_ONLY > executionMode), "MM_ConcurrentStats::_executionMode = %zu\n", executionMode);
 				nextExecutionMode = _concurrentDelegate.getNextTracingMode(executionMode);
 				if (_stats.switchExecutionMode(executionMode, nextExecutionMode)) {
-					Assert_GC_true_with_message2(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) && (CONCURRENT_TRACE_ONLY >= nextExecutionMode), "MM_ConcurrentStats::_executionMode = %zu; MM_ConcurrentMarkingDelegate::getNextTracingMode(MM_ConcurrentStats::_executionMode) = %zu\n", executionMode, nextExecutionMode);
+					Assert_GC_true_with_message(env, (CONCURRENT_ROOT_TRACING < nextExecutionMode) && (CONCURRENT_TRACE_ONLY >= nextExecutionMode), "MM_ConcurrentStats::_executionMode = %zu; MM_ConcurrentMarkingDelegate::getNextTracingMode(MM_ConcurrentStats::_executionMode) = %zu\n", executionMode, nextExecutionMode);
 					/* Collect some roots */
 					bool collectedRoots = false;
 					_concurrentDelegate.collectRoots(env, executionMode, &collectedRoots, &taxPaid);

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1675,7 +1675,7 @@ MM_Scavenger::copyForVariant(MM_EnvironmentStandard *env, MM_ForwardedHeader* fo
 			Trc_MM_Scavenger_semispaceAllocateFailed(env->getLanguageVMThread(), objectReserveSizeInBytes, "yes");
 
 			uintptr_t spaceAvailableForObject = _activeSubSpace->getMaxSpaceForObjectInEvacuateMemory(forwardedHeader->getObject());
-			Assert_GC_true_with_message4(env, objectCopySizeInBytes <= spaceAvailableForObject,
+			Assert_GC_true_with_message(env, objectCopySizeInBytes <= spaceAvailableForObject,
 					"Corruption in Evacuate at %p: calculated object size %zu larger than available %zu, Forwarded Header at %p\n",
 					forwardedHeader->getObject(), objectCopySizeInBytes, spaceAvailableForObject, forwardedHeader);
 
@@ -1710,7 +1710,7 @@ MM_Scavenger::copyForVariant(MM_EnvironmentStandard *env, MM_ForwardedHeader* fo
 			Trc_MM_Scavenger_tenureAllocateFailed(env->getLanguageVMThread(), objectReserveSizeInBytes, env->_scavengerStats._failedTenureLargest, "yes");
 
 			uintptr_t spaceAvailableForObject = _activeSubSpace->getMaxSpaceForObjectInEvacuateMemory(forwardedHeader->getObject());
-			Assert_GC_true_with_message4(env, objectCopySizeInBytes <= spaceAvailableForObject,
+			Assert_GC_true_with_message(env, objectCopySizeInBytes <= spaceAvailableForObject,
 					"Corruption in Evacuate at %p: calculated object size %zu larger than available %zu, Forwarded Header at %p\n",
 					forwardedHeader->getObject(), objectCopySizeInBytes, spaceAvailableForObject, forwardedHeader);
 

--- a/gc/stats/ScavengerCopyScanRatio.cpp
+++ b/gc/stats/ScavengerCopyScanRatio.cpp
@@ -123,6 +123,6 @@ MM_ScavengerCopyScanRatio::getSpannedMicros(MM_EnvironmentBase* env, UpdateHisto
 void
 MM_ScavengerCopyScanRatio::failedUpdate(MM_EnvironmentBase* env, uint64_t copied, uint64_t scanned)
 {
-	Assert_GC_true_with_message2(env, copied <= scanned, "MM_ScavengerCopyScanRatio::getScalingFactor(): copied (=%llu) exceeds scanned (=%llu) -- non-atomic 64-bit read\n", copied, scanned);
+	Assert_GC_true_with_message(env, copied <= scanned, "MM_ScavengerCopyScanRatio::getScalingFactor(): copied (=%llu) exceeds scanned (=%llu) -- non-atomic 64-bit read\n", copied, scanned);
 }
 


### PR DESCRIPTION
Mofify Assert_GC_true_with_message macro to take variable number of parameters. Start removing usage of versions with 2, 3 and 4 fixed parameters.
Keep obsolete definitions temporary for compatibility.