### PR TITLE
Remove compiler TR_PrettyPrinterString

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -948,7 +948,11 @@ public:
 
     void setNodeOpCodeLength(int32_t opCodeLen) { _nodeOpCodeLength = opCodeLen; }
 
-    void incrNodeOpCodeLength(int32_t incr) { _nodeOpCodeLength += incr; }
+    void incrNodeOpCodeLength(int32_t incr)
+    {
+        if (incr > 0)
+            _nodeOpCodeLength += incr;
+    }
 
     // ==========================================================================
     // CHTable

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -713,13 +713,6 @@ void TR_Debug::print(OMR::Logger *log, TR::SparseBitVector *sparse)
     log->printc('}');
 }
 
-void TR_Debug::print(OMR::Logger *log, TR::SymbolReference *symRef)
-{
-    TR_PrettyPrinterString output(this);
-    print(symRef, output);
-    log->prints(output.getStr());
-}
-
 const char *TR_Debug::signature(TR::ResolvedMethodSymbol *s)
 {
 #ifdef J9_PROJECT_SPECIFIC
@@ -742,32 +735,34 @@ TR_OpaqueClassBlock *TR_Debug::containingClass(TR::SymbolReference *symRef)
     return NULL;
 }
 
-void TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
+int32_t TR_Debug::nodePrintAllFlags(OMR::Logger *log, TR::Node *node)
 {
+    int32_t len = 0;
+
     // This guard info is not strictly speaking in the node flags anymore, but
     // with the node flags is a good place to show it.
     TR_VirtualGuard *guard = node->virtualGuardInfo();
     if (guard != NULL) {
         const char *kind = getVirtualGuardKindName(guard->getKind());
         const char *testType = getVirtualGuardTestTypeName(guard->getTestType());
-        output.appendf("%s/%s", kind, testType);
+        len += log->printf("%s/%s", kind, testType);
 
         if (guard->mergedWithHCRGuard())
-            output.appends("+HCRGuard");
+            len_logprints_literal(len, log, "+HCRGuard");
 
         if (guard->mergedWithOSRGuard())
-            output.appends("+OSRGuard");
+            len_logprints_literal(len, log, "+OSRGuard");
 
         if (!guard->getInnerAssumptions().isEmpty())
-            output.appends("+inner");
+            len_logprints_literal(len, log, "+inner");
 
-        output.appends(" ");
+        len_logprintc(len, log, ' ');
     }
 
-#define FLAG_IF(cond, text)           \
-    do {                              \
-        if (cond)                     \
-            output.appends(text " "); \
+#define FLAG_IF(cond, text)                            \
+    do {                                               \
+        if (cond)                                      \
+            len_logprints_literal(len, log, text " "); \
     } while (false)
 #define FLAG(query, text) FLAG_IF(node->query(), text)
 
@@ -893,205 +888,315 @@ void TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
 
 #undef FLAG
 #undef FLAG_IF
+
+    return len;
 }
 
-void TR_Debug::print(TR::SymbolReference *symRef, TR_PrettyPrinterString &output, bool hideHelperMethodInfo,
-    bool verbose)
+// Prints the SymRef offset if total displacement is non-zero
+int32_t TR_Debug::printSymRefOffset(OMR::Logger *log, TR::SymbolReference *symRef)
 {
+    int32_t len = 0;
     int32_t displacement = 0;
-    uint32_t numSpaces;
-    TR_PrettyPrinterString symRefNum(this), symRefOffset(this), symRefAddress(this), symRefName(this), symRefKind(this),
-        otherInfo(this), symRefObjIndex(this), labelSymbol(this);
-
     TR::Symbol *sym = symRef->getSymbol();
 
-    symRefAddress.appendf("%s", getName(sym));
-
-    if (sym) {
-        if (_comp->cg()->getMappingAutomatics() && sym->isRegisterMappedSymbol()
-            && sym->getRegisterMappedSymbol()->getOffset() != 0) {
-            displacement = sym->getRegisterMappedSymbol()->getOffset();
-        }
+    if (comp()->cg()->getMappingAutomatics() && sym && sym->isRegisterMappedSymbol()) {
+        displacement = sym->getRegisterMappedSymbol()->getOffset();
     }
 
     if (symRef->getOffset() + displacement) {
-        symRefOffset.appendf("%+d", displacement + symRef->getOffset());
+        len += log->printf("%+d", displacement + symRef->getOffset());
     }
 
-    if (symRef->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN)
-        symRefObjIndex.appendf(" (obj%d)", (int)symRef->getKnownObjectIndex());
-    else if (sym && sym->isFixedObjectRef() && comp()->getKnownObjectTable() && !symRef->isUnresolved()) {
-        symRefObjIndex.appends(" (fixed obj ref missing known object index)");
+    return len;
+}
+
+int32_t TR_Debug::printSymRefObjIndex(OMR::Logger *log, TR::SymbolReference *symRef)
+{
+    int32_t len = 0;
+    TR::Symbol *sym = symRef->getSymbol();
+
+    if (symRef->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN) {
+        len += log->printf("(obj%d)", (int32_t)symRef->getKnownObjectIndex());
+    } else if (sym && sym->isFixedObjectRef() && comp()->getKnownObjectTable() && !symRef->isUnresolved()) {
+        len_logprints_literal(len, log, "(fixed obj ref missing known object index)");
+
         TR::KnownObjectTable::Index i = comp()->getKnownObjectTable()->getExistingIndexAt(
             (uintptr_t *)sym->castToStaticSymbol()->getStaticAddress());
+
         if (i != TR::KnownObjectTable::UNKNOWN)
-            symRefObjIndex.appendf(" (==obj%d)", (int)i);
+            len += log->printf(" (==obj%d)", (int32_t)i);
     }
 
-    if (sym) {
-        if (symRef->isUnresolved())
-            symRefKind.appends(" unresolved");
-        switch (symRef->hasBeenAccessedAtRuntime()) {
-            case TR_yes:
-                symRefKind.appends(" accessed");
-                break;
-            case TR_no:
-                symRefKind.appends(" notAccessed");
-                break;
-            default:
-                break;
-        }
-        if (symRef->getSymbol()->isFinal())
-            symRefKind.appends(" final");
-        if (!symRef->getSymbol()->isTransparent())
-            symRefKind.appendf(" %s", TR::Symbol::getMemoryOrderingName(symRef->getSymbol()->getMemoryOrdering()));
-        switch (sym->getKind()) {
-            case TR::Symbol::IsAutomatic:
-                symRefName.appendf(" %s", getName(symRef));
-                if (sym->getAutoSymbol()->getName() == NULL)
-                    symRefKind.appends(" Auto");
-                else
-                    symRefKind.appendf(" %s", sym->getAutoSymbol()->getName());
-                break;
-            case TR::Symbol::IsParameter:
-                symRefKind.appends(" Parm");
-                symRefName.appendf(" %s", getName(symRef));
-                break;
-            case TR::Symbol::IsStatic:
-                if (symRef->isFromLiteralPool()) {
-                    symRefKind.appends(" DLP-Static");
-                    symRefName.appendf(" %s", getName(symRef));
-                } else {
-                    symRefKind.appends(" Static");
-                    if (sym->isNamed()) {
-                        symRefName.appendf(" \"%s\"", ((TR::StaticSymbol *)sym)->getName());
-                    }
-                    symRefName.appendf(" %s", getName(symRef));
-                }
-                break;
+    return len;
+}
 
-            case TR::Symbol::IsResolvedMethod:
-            case TR::Symbol::IsMethod: {
-                TR::MethodSymbol *methodSym = sym->castToMethodSymbol();
-                if (methodSym->isNative())
-                    symRefKind.appends(" native");
-                switch (methodSym->getMethodKind()) {
-                    case TR::MethodSymbol::Virtual:
-                        symRefKind.appends(" virtual");
-                        break;
-                    case TR::MethodSymbol::Interface:
-                        symRefKind.appends(" interface");
-                        break;
-                    case TR::MethodSymbol::Static:
-                        symRefKind.appends(" static");
-                        break;
-                    case TR::MethodSymbol::Special:
-                        symRefKind.appends(" special");
-                        break;
-                    case TR::MethodSymbol::Helper:
-                        symRefKind.appends(" helper");
-                        break;
-                    case TR::MethodSymbol::ComputedStatic:
-                        symRefKind.appends(" computed-static");
-                        break;
-                    case TR::MethodSymbol::ComputedVirtual:
-                        symRefKind.appends(" computed-virtual");
-                        break;
-                    default:
-                        symRefKind.appends(" UNKNOWN");
-                        break;
-                }
+int32_t TR_Debug::printSymRefKind(OMR::Logger *log, TR::SymbolReference *symRef)
+{
+    int32_t len = 0;
+    TR::Symbol *sym = symRef->getSymbol();
 
-                symRefKind.appends(" Method");
-                symRefName.appendf(" %s", getName(symRef));
-                TR_OpaqueClassBlock *clazz = containingClass(symRef);
-                if (clazz) {
-                    if (TR::Compiler->cls.isInterfaceClass(_comp, clazz))
-                        otherInfo.appends(" (Interface class)");
-                    else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
-                        otherInfo.appends(" (Abstract class)");
-                }
-            } break;
+    if (symRef->isUnresolved())
+        len_logprints_literal(len, log, " unresolved");
 
-            case TR::Symbol::IsShadow:
-                if (sym->isNamedShadowSymbol() && sym->getNamedShadowSymbol()->getName() != NULL) {
-                    symRefKind.appendf(" Named Shadow");
-                    symRefName.appendf(" %s", getName(symRef));
-                } else {
-                    symRefKind.appends(" Shadow");
-                    symRefName.appendf(" %s", getName(symRef));
-                }
-                break;
-            case TR::Symbol::IsMethodMetaData:
-                symRefKind.appends(" MethodMeta");
-                symRefName.appendf(" %s", symRef->getSymbol()->getMethodMetaDataSymbol()->getName());
-                break;
-            case TR::Symbol::IsLabel:
-                print(sym->castToLabelSymbol(), labelSymbol);
-                if (!labelSymbol.isEmpty())
-                    labelSymbol.appends(" ");
-                break;
-            default:
-                TR_ASSERT(0, "unexpected symbol kind");
-        }
-        otherInfo.appendf(" [flags 0x%x 0x%x ]", sym->getFlags(), sym->getFlags2());
+    switch (symRef->hasBeenAccessedAtRuntime()) {
+        case TR_yes:
+            len_logprints_literal(len, log, " accessed");
+            break;
+        case TR_no:
+            len_logprints_literal(len, log, " notAccessed");
+            break;
+        default:
+            break;
     }
 
-    numSpaces
-        = getNumSpacesAfterIndex(symRef->getReferenceNumber(), getIntLength(_comp->getSymRefTab()->baseArray.size()));
+    if (symRef->getSymbol()->isFinal())
+        len_logprints_literal(len, log, " final");
 
-    symRefNum.appendf("#%d", symRef->getReferenceNumber());
+    if (!symRef->getSymbol()->isTransparent())
+        len += log->printf(" %s", TR::Symbol::getMemoryOrderingName(symRef->getSymbol()->getMemoryOrdering()));
+
+    switch (sym->getKind()) {
+        case TR::Symbol::IsAutomatic:
+            if (sym->getAutoSymbol()->getName() == NULL)
+                len_logprints_literal(len, log, " Auto");
+            else
+                len += log->printf(" %s", sym->getAutoSymbol()->getName());
+            break;
+        case TR::Symbol::IsParameter:
+            len_logprints_literal(len, log, " Parm");
+            break;
+        case TR::Symbol::IsStatic:
+            if (symRef->isFromLiteralPool()) {
+                len_logprints_literal(len, log, " DLP-Static");
+            } else {
+                len_logprints_literal(len, log, " Static");
+            }
+            break;
+
+        case TR::Symbol::IsResolvedMethod:
+        case TR::Symbol::IsMethod: {
+            TR::MethodSymbol *methodSym = sym->castToMethodSymbol();
+            if (methodSym->isNative())
+                len_logprints_literal(len, log, " native");
+            switch (methodSym->getMethodKind()) {
+                case TR::MethodSymbol::Virtual:
+                    len_logprints_literal(len, log, " virtual");
+                    break;
+                case TR::MethodSymbol::Interface:
+                    len_logprints_literal(len, log, " interface");
+                    break;
+                case TR::MethodSymbol::Static:
+                    len_logprints_literal(len, log, " static");
+                    break;
+                case TR::MethodSymbol::Special:
+                    len_logprints_literal(len, log, " special");
+                    break;
+                case TR::MethodSymbol::Helper:
+                    len_logprints_literal(len, log, " helper");
+                    break;
+                case TR::MethodSymbol::ComputedStatic:
+                    len_logprints_literal(len, log, " computed-static");
+                    break;
+                case TR::MethodSymbol::ComputedVirtual:
+                    len_logprints_literal(len, log, " computed-virtual");
+                    break;
+                default:
+                    len_logprints_literal(len, log, " UNKNOWN");
+                    break;
+            }
+
+            len_logprints_literal(len, log, " Method");
+        } break;
+
+        case TR::Symbol::IsShadow:
+            if (sym->isNamedShadowSymbol() && sym->getNamedShadowSymbol()->getName() != NULL) {
+                len_logprints_literal(len, log, " Named Shadow");
+            } else {
+                len_logprints_literal(len, log, " Shadow");
+            }
+            break;
+        case TR::Symbol::IsMethodMetaData:
+            len_logprints_literal(len, log, " MethodMeta");
+            break;
+        case TR::Symbol::IsLabel:
+            break;
+        default:
+            TR_ASSERT_FATAL(false, "unexpected symbol kind");
+    }
+
+    return len;
+}
+
+int32_t TR_Debug::printSymRefName(OMR::Logger *log, TR::SymbolReference *symRef)
+{
+    int32_t len = 0;
+    TR::Symbol *sym = symRef->getSymbol();
+
+    switch (sym->getKind()) {
+        case TR::Symbol::IsStatic:
+            if (!symRef->isFromLiteralPool() && sym->isNamed()) {
+                len += log->printf("\"%s\" ", ((TR::StaticSymbol *)sym)->getName());
+            }
+            // deliberate fall through
+
+        case TR::Symbol::IsAutomatic:
+        case TR::Symbol::IsParameter:
+        case TR::Symbol::IsResolvedMethod:
+        case TR::Symbol::IsMethod:
+        case TR::Symbol::IsShadow:
+            len += log->printf("%s", getName(symRef));
+            break;
+
+        case TR::Symbol::IsMethodMetaData:
+            len += log->printf("%s", sym->getMethodMetaDataSymbol()->getName());
+            break;
+
+        case TR::Symbol::IsLabel:
+            break;
+
+        default:
+            TR_ASSERT_FATAL(0, "unexpected symbol kind");
+    }
+
+    return len;
+}
+
+int32_t TR_Debug::printSymRefOtherInfo(OMR::Logger *log, TR::SymbolReference *symRef)
+{
+    int32_t len = 0;
+    TR::Symbol *sym = symRef->getSymbol();
+
+    switch (sym->getKind()) {
+        case TR::Symbol::IsAutomatic:
+        case TR::Symbol::IsParameter:
+        case TR::Symbol::IsStatic:
+        case TR::Symbol::IsShadow:
+        case TR::Symbol::IsMethodMetaData:
+        case TR::Symbol::IsLabel:
+            break;
+
+        case TR::Symbol::IsResolvedMethod:
+        case TR::Symbol::IsMethod: {
+            TR_OpaqueClassBlock *clazz = containingClass(symRef);
+            if (clazz) {
+                if (TR::Compiler->cls.isInterfaceClass(_comp, clazz))
+                    len_logprints_literal(len, log, " (Interface class)");
+                else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
+                    len_logprints_literal(len, log, " (Abstract class)");
+            }
+        } break;
+
+        default:
+            TR_ASSERT_FATAL(false, "unexpected symbol kind");
+    }
+
+    len += log->printf(" [flags 0x%x 0x%x ]", sym->getFlags(), sym->getFlags2());
+
+    return len;
+}
+
+int32_t TR_Debug::print(OMR::Logger *log, TR::SymbolReference *symRef, bool hideHelperMethodInfo, bool verbose)
+{
+    int32_t len = 0;
+    TR::Symbol *sym = symRef->getSymbol();
 
     if (verbose) {
-        output.appendf("%s:%*s", symRefNum.getStr(), numSpaces, "");
+        uint32_t numSpaces = getNumSpacesAfterIndex(symRef->getReferenceNumber(),
+            getIntLength(comp()->getSymRefTab()->baseArray.size()));
+        len += log->printf("#%d:%*s ", symRef->getReferenceNumber(), numSpaces, "");
 
-        if (hideHelperMethodInfo)
-            output.appendf(" %s[%s]%s", labelSymbol.getStr(), symRefOffset.getStr(), symRefObjIndex.getStr());
-        else
-            output.appendf(" %s%s[%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefKind.getStr(),
-                symRefOffset.isEmpty() ? "" : " ", symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
+        // Short circuit for NULL symbols.  These can appear, for example, from
+        // some code generator memory references.
+        //
+        if (!sym) {
+            len_logprintc(len, log, '[');
+            len += printSymRefOffset(log, symRef);
+            len_logprints_literal(len, log, "] ");
+            len += printSymRefObjIndex(log, symRef);
+            len_logprints_literal(len, log, " [(null)]");
+            return len;
+        }
 
-        output.appendf(" [%s]", symRefAddress.getStr());
+        if (!hideHelperMethodInfo) {
+            len += printSymRefName(log, symRef);
+        }
 
-        if (sym) {
-            output.appendf(" (%s", TR::DataType::getName(sym->getDataType()));
+        if (sym->getKind() == TR::Symbol::IsLabel) {
+            len += log->prints_len(getName(sym->castToLabelSymbol()));
+            len_logprintc(len, log, ' ');
+        }
 
-            TR_OpaqueClassBlock *klass = sym->getDeclaredClass();
-            if (klass != NULL) {
-                int32_t len = 0;
-                const char *className = TR::Compiler->cls.classNameChars(_comp, klass, len);
+        len_logprintc(len, log, '[');
 
-                output.appendf(": %p %.*s", klass, len, className);
-            }
+        if (!hideHelperMethodInfo) {
+            len += printSymRefKind(log, symRef);
+            len_logprintc(len, log, ' ');
+        }
 
-            output.appendf(")");
+        len += printSymRefOffset(log, symRef);
+        len_logprints_literal(len, log, "] ");
+        len += printSymRefObjIndex(log, symRef);
 
-            if (!sym->isTransparent()) {
-                output.appendf(" [%s]", TR::Symbol::getMemoryOrderingName(sym->getMemoryOrdering()));
-            }
+        if (!hideHelperMethodInfo) {
+            len += printSymRefOtherInfo(log, symRef);
+        }
+
+        len += log->printf(" [%s] (%s", getName(sym), TR::DataType::getName(sym->getDataType()));
+
+        TR_OpaqueClassBlock *klass = sym->getDeclaredClass();
+        if (klass != NULL) {
+            int32_t klassLen = 0;
+            const char *className = TR::Compiler->cls.classNameChars(_comp, klass, klassLen);
+            len += log->printf(": %p %.*s", klass, klassLen, className);
+        }
+
+        len_logprintc(len, log, ')');
+
+        if (!sym->isTransparent()) {
+            len += log->printf(" [%s]", TR::Symbol::getMemoryOrderingName(sym->getMemoryOrdering()));
         }
     } else {
-        if (hideHelperMethodInfo)
-            output.appendf(" %s[%s%s%s]%s", labelSymbol.getStr(), symRefNum.getStr(), symRefOffset.isEmpty() ? "" : " ",
-                symRefOffset.getStr(), symRefObjIndex.getStr());
-        else
-            output.appendf(" %s%s[%s%s%s%s%s]%s%s", symRefName.getStr(), labelSymbol.getStr(), symRefNum.getStr(),
-                symRefKind.isEmpty() ? "" : " ", symRefKind.getStr(), symRefOffset.isEmpty() ? "" : " ",
-                symRefOffset.getStr(), symRefObjIndex.getStr(), otherInfo.getStr());
+        len_logprintc(len, log, ' ');
+
+        // Short circuit for NULL symbols.  These can appear, for example, from
+        // some code generator memory references.
+        //
+        if (!sym) {
+            len += log->printf("[#%d ", symRef->getReferenceNumber());
+            len += printSymRefOffset(log, symRef);
+            len_logprintc(len, log, ']');
+            len += printSymRefObjIndex(log, symRef);
+            return len;
+        }
+
+        if (!hideHelperMethodInfo) {
+            len += printSymRefName(log, symRef);
+        }
+
+        if (sym->getKind() == TR::Symbol::IsLabel) {
+            len += log->printf("%s ", getName(sym->castToLabelSymbol()));
+        }
+
+        len += log->printf("[#%d ", symRef->getReferenceNumber());
+
+        if (!hideHelperMethodInfo) {
+            len += printSymRefKind(log, symRef);
+            len_logprintc(len, log, ' ');
+        }
+
+        len += printSymRefOffset(log, symRef);
+        len_logprintc(len, log, ']');
+        len += printSymRefObjIndex(log, symRef);
+
+        if (!hideHelperMethodInfo) {
+            len += printSymRefOtherInfo(log, symRef);
+        }
     }
+
+    return len;
 }
 
-void TR_Debug::print(OMR::Logger *log, TR::LabelSymbol *labelSymbol)
-{
-    TR_PrettyPrinterString output(this);
-    print(labelSymbol, output);
-    log->prints(output.getStr());
-}
-
-void TR_Debug::print(TR::LabelSymbol *labelSymbol, TR_PrettyPrinterString &output)
-{
-    output.appendf("%s", getName(labelSymbol));
-}
+void TR_Debug::print(OMR::Logger *log, TR::LabelSymbol *labelSymbol) { log->prints(getName(labelSymbol)); }
 
 const char *TR_Debug::getName(TR_YesNoMaybe value)
 {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -66,7 +66,6 @@ class TR_FilterBST;
 class TR_FrontEnd;
 class TR_GCStackMap;
 class TR_InductionVariable;
-class TR_PrettyPrinterString;
 class TR_PseudoRandomNumbersListElement;
 class TR_RegionAnalysis;
 class TR_RegionStructure;
@@ -621,11 +620,9 @@ public:
     virtual void print(OMR::Logger *log, TR_RegionAnalysis *structure, uint32_t indentation);
     virtual int32_t print(OMR::Logger *log, TR::TreeTop *);
     virtual int32_t print(OMR::Logger *log, TR::Node *, uint32_t indentation = 0, bool printSubtree = true);
-    virtual void print(OMR::Logger *log, TR::SymbolReference *);
-    virtual void print(TR::SymbolReference *, TR_PrettyPrinterString &, bool hideHelperMethodInfo = false,
+    virtual int32_t print(OMR::Logger *log, TR::SymbolReference *, bool hideHelperMethodInfo = false,
         bool verbose = false);
     virtual void print(OMR::Logger *log, TR::LabelSymbol *);
-    virtual void print(TR::LabelSymbol *, TR_PrettyPrinterString &);
     virtual void print(OMR::Logger *log, TR_BitVector *);
     virtual void print(OMR::Logger *log, TR_SingleBitContainer *);
     virtual void print(OMR::Logger *log, TR::BitVector *bv);
@@ -764,13 +761,11 @@ public:
 
     TR_OpaqueClassBlock *containingClass(TR::SymbolReference *);
     const char *signature(TR::ResolvedMethodSymbol *s);
-    virtual void nodePrintAllFlags(TR::Node *, TR_PrettyPrinterString &);
+    virtual int32_t nodePrintAllFlags(OMR::Logger *log, TR::Node *node);
 
     // used by DebugExt and may be overridden
     virtual void printDestination(OMR::Logger *log, TR::TreeTop *);
-    virtual void printDestination(TR::TreeTop *, TR_PrettyPrinterString &);
     virtual void printNodeInfo(OMR::Logger *log, TR::Node *);
-    virtual void printNodeInfo(TR::Node *, TR_PrettyPrinterString &output, bool);
     virtual void print(OMR::Logger *log, TR::CFGNode *, uint32_t indentation);
     virtual void printNodesInEdgeListIterator(OMR::Logger *log, TR::CFGEdgeList &li, bool fromNode);
     virtual void print(OMR::Logger *log, TR::Block *block, uint32_t indentation);
@@ -783,6 +778,12 @@ public:
     virtual void *dxMallocAndReadString(void *remotePtr, bool dontAddToMap = false) { return remotePtr; }
 
     virtual void dxFree(void *localPtr) { return; }
+
+    int32_t printSymRefOffset(OMR::Logger *log, TR::SymbolReference *symRef);
+    int32_t printSymRefObjIndex(OMR::Logger *log, TR::SymbolReference *symRef);
+    int32_t printSymRefKind(OMR::Logger *log, TR::SymbolReference *symRef);
+    int32_t printSymRefName(OMR::Logger *log, TR::SymbolReference *symRef);
+    int32_t printSymRefOtherInfo(OMR::Logger *log, TR::SymbolReference *symRef);
 
     void printTopLegend(OMR::Logger *log);
     void printBottomLegend(OMR::Logger *log);
@@ -802,7 +803,6 @@ public:
     void printNodeFlags(OMR::Logger *log, TR::Node *);
 #ifdef J9_PROJECT_SPECIFIC
     void printBCDNodeInfo(OMR::Logger *log, TR::Node *node);
-    void printBCDNodeInfo(TR::Node *node, TR_PrettyPrinterString &output);
 #endif
 
     int32_t *printStackAtlas(OMR::Logger *log, uintptr_t startPC, uint8_t *mapBits, int32_t numberOfSlotsMapped,
@@ -838,7 +838,6 @@ public:
     void printFirstAndConstant(OMR::Logger *log, int32_t i, int32_t j);
 
     void printLoadConst(OMR::Logger *log, TR::Node *);
-    void printLoadConst(TR::Node *, TR_PrettyPrinterString &);
 
     TR::CompilationFilters *findOrCreateFilters(TR::CompilationFilters *);
     TR::CompilationFilters *findOrCreateFilters(bool loadLimit);
@@ -1374,49 +1373,6 @@ protected:
         = 82; // Tree information printed to the right of node OPCode will be aligned if node OPCode's length <=
               // DEFAULT_NODE_LENGTH, or will follow the node OPCode immediately (non-aligned) otherwise.
     const static uint32_t MAX_GLOBAL_INDEX_LENGTH = 5;
-};
-
-class TR_PrettyPrinterString {
-public:
-    TR_PrettyPrinterString(TR_Debug *debug);
-
-    /**
-     * @brief Append a null-terminated string with format specifiers to the buffer.
-     *        The buffer is guaranteed not to overflow and will be null-terminated.
-     *
-     * @param[in] format : null-terminated string to append with optional format specifiers
-     * @param[in] ... : optional arguments for format specifiers
-     */
-    void appendf(char const *format, ...);
-
-    /**
-     * @brief Append a null-terminated string to the buffer.  No format specifiers
-     *        are permitted.  The buffer is guaranteed not to overflow and will be
-     *        null-terminated.
-     *
-     * @param[in] str : null-terminated string to append
-     */
-    void appends(char const *str);
-
-    const char *getStr() { return buffer; }
-
-    int32_t getLength() { return len; }
-
-    void reset()
-    {
-        buffer[0] = '\0';
-        len = 0;
-    }
-
-    bool isEmpty() { return len <= 0; }
-
-    static const int32_t maxBufferLength = 2000;
-
-private:
-    char buffer[maxBufferLength];
-    int32_t len;
-    TR::Compilation *_comp;
-    TR_Debug *_debug;
 };
 
 typedef TR_Debug *(*TR_CreateDebug_t)(TR::Compilation *);

--- a/compiler/ras/Logger.cpp
+++ b/compiler/ras/Logger.cpp
@@ -44,6 +44,18 @@ OMR::Logger::Logger()
     setSkipFlush(envSkipLoggerFlushes ? true : false);
 }
 
+int32_t OMR::Logger::prints_len(const char *string)
+{
+    int32_t rc = prints(string);
+    return (rc >= 0) ? static_cast<int32_t>(strlen(string)) : rc;
+}
+
+int32_t OMR::Logger::printc_len(char c)
+{
+    int32_t rc = printc(c);
+    return (rc >= 0) ? 1 : rc;
+}
+
 /*
  * -----------------------------------------------------------------------------
  * NullLogger

--- a/compiler/ras/Logger.hpp
+++ b/compiler/ras/Logger.hpp
@@ -84,6 +84,44 @@
             log->println();   \
     } while (0)
 
+/**
+ * @brief Convenience macro to log a literal string and accumulate the length
+ *     of that string (excluding the trailing NUL-terminator) into a provided
+ *     variable. The length of the string literal is a compile-time constant.
+ *
+ * @details
+ *     No error checking is performed on the result from the \c Logger::prints
+ *     function.
+ *
+ * @param[in] len : int32_t variable to accumulate string length in
+ * @param[in] log : (OMR::Logger *) to the log to print to
+ * @param[in] str : the string literal. This must be a string literal whose
+ *     length can be determined at compile-time.
+ */
+#define len_logprints_literal(len, log, str) \
+    do {                                     \
+        log->prints(str);                    \
+        len += sizeof(str) - 1;              \
+    } while (0)
+
+/**
+ * @brief Convenience macro to log a single char and accumulate the length
+ *     into a provided variable.
+ *
+ * @details
+ *     No error checking is performed on the result from the \c Logger::printc
+ *     function.
+ *
+ * @param[in] len : int32_t variable to accumulate char length in
+ * @param[in] log : (OMR::Logger *) to the log to print to
+ * @param[in] c : the char to log
+ */
+#define len_logprintc(len, log, c) \
+    do {                           \
+        log->printc(c);            \
+        len++;                     \
+    } while (0)
+
 namespace OMR {
 
 /**

--- a/compiler/ras/Logger.hpp
+++ b/compiler/ras/Logger.hpp
@@ -140,11 +140,27 @@ public:
     virtual int32_t prints(const char *string) = 0;
 
     /**
+     * @brief Send a raw `\0`-terminated string to the Logger.
+     *
+     * @return the exact number of characters written on success, or a negative
+     *     value on any error
+     */
+    virtual int32_t prints_len(const char *string);
+
+    /**
      * @brief Send a single `char` to the Logger.
      *
      * @return a nonnegative number on success, or a negative value on any error
      */
     virtual int32_t printc(char c) = 0;
+
+    /**
+     * @brief Send a single `char` to the Logger.
+     *
+     * @return 1 on success (number of chars written), or a negative value on
+     *     any error
+     */
+    virtual int32_t printc_len(char c);
 
     /**
      * @brief

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -111,7 +111,6 @@ void TR_Debug::printBottomLegend(OMR::Logger *log)
 //
 void TR_Debug::printSymRefTable(OMR::Logger *log, bool printFullTable)
 {
-    TR_PrettyPrinterString output(this);
     TR::SymbolReferenceTable *symRefTab = _comp->getSymRefTab();
     TR::SymbolReference *symRefIterator;
     int32_t currSymRefTabSize = symRefTab->baseArray.size();
@@ -128,11 +127,10 @@ void TR_Debug::printSymRefTable(OMR::Logger *log, bool printFullTable)
         else
             log->prints("\nSymbol References (incremental):\n--------------------------------\n");
 
-        for (int i = _comp->getPrevSymRefTabSize(); i < currSymRefTabSize; i++) {
+        for (int32_t i = _comp->getPrevSymRefTabSize(); i < currSymRefTabSize; i++) {
             if ((symRefIterator = symRefTab->getSymRef(i))) {
-                output.reset();
-                print(symRefIterator, output, false /*hideHelperMethodInfo*/, true /*verbose*/);
-                log->printf("%s\n", output.getStr());
+                print(log, symRefIterator, false /*hideHelperMethodInfo*/, true /*verbose*/);
+                log->println();
             }
         }
         log->flush();
@@ -171,74 +169,72 @@ static bool valueIsProbablyHex(TR::Node *node)
 
 void TR_Debug::printLoadConst(OMR::Logger *log, TR::Node *node)
 {
-    TR_PrettyPrinterString output(this);
-    printLoadConst(node, output);
-    log->prints(output.getStr());
-    _comp->incrNodeOpCodeLength(output.getLength());
-}
-
-void TR_Debug::printLoadConst(TR::Node *node, TR_PrettyPrinterString &output)
-{
+    int32_t len = 0;
     char const *fmtStr;
     bool isUnsigned = node->getOpCode().isUnsigned();
+
     switch (node->getDataType()) {
         case TR::Int8:
             if (isUnsigned)
-                output.appendf(" %3u", node->getUnsignedByte());
+                len = log->printf(" %3u", node->getUnsignedByte());
             else
-                output.appendf(" %3d", node->getByte());
+                len = log->printf(" %3d", node->getByte());
             break;
         case TR::Int16:
             fmtStr = valueIsProbablyHex(node) ? " 0x%4x" : " '%5d' ";
-            output.appendf(fmtStr, node->getConst<uint16_t>());
+            len = log->printf(fmtStr, node->getConst<uint16_t>());
             break;
         case TR::Int32:
             if (isUnsigned) {
                 fmtStr = valueIsProbablyHex(node) ? " 0x%x" : " %u";
-                output.appendf(fmtStr, node->getUnsignedInt());
+                len = log->printf(fmtStr, node->getUnsignedInt());
             } else {
                 fmtStr = valueIsProbablyHex(node) ? " 0x%x" : " %d";
-                output.appendf(fmtStr, node->getInt());
+                len = log->printf(fmtStr, node->getInt());
             }
             break;
         case TR::Int64:
             if (isUnsigned) {
                 fmtStr = valueIsProbablyHex(node) ? " " UINT64_PRINTF_FORMAT_HEX : " " UINT64_PRINTF_FORMAT;
-                output.appendf(fmtStr, node->getUnsignedLongInt());
+                len = log->printf(fmtStr, node->getUnsignedLongInt());
             } else {
                 fmtStr = valueIsProbablyHex(node) ? " " INT64_PRINTF_FORMAT_HEX : " " INT64_PRINTF_FORMAT;
-                output.appendf(fmtStr, node->getLongInt());
+                len = log->printf(fmtStr, node->getLongInt());
             }
             break;
-        case TR::Float: {
-            output.appendf(" %g [0x%08x]", node->getFloat(), node->getFloatBits());
-        } break;
-        case TR::Double: {
-            output.appendf(" %g [" UINT64_PRINTF_FORMAT_HEX "]", node->getDouble(), node->getDoubleBits());
-        } break;
+        case TR::Float:
+            len = log->printf(" %g [0x%08x]", node->getFloat(), node->getFloatBits());
+            break;
+        case TR::Double:
+            len = log->printf(" %g [" UINT64_PRINTF_FORMAT_HEX "]", node->getDouble(), node->getDoubleBits());
+            break;
         case TR::Address:
-            if (node->getAddress() == 0)
-                output.appends(" NULL");
-            else
-                output.appendf(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
+            if (node->getAddress() == 0) {
+                len_logprints_literal(len, log, " NULL");
+            } else {
+                len = log->printf(" " UINT64_PRINTF_FORMAT_HEX, node->getAddress());
+            }
+
             if (node->isClassPointerConstant()) {
                 TR_OpaqueClassBlock *clazz = (TR_OpaqueClassBlock *)node->getAddress();
-                int32_t len;
-                const char *sig = TR::Compiler->cls.classNameChars(_comp, clazz, len);
+                int32_t sigLen;
+                const char *sig = TR::Compiler->cls.classNameChars(_comp, clazz, sigLen);
                 if (clazz) {
                     if (TR::Compiler->cls.isInterfaceClass(_comp, clazz))
-                        output.appends(" Interface");
+                        len_logprints_literal(len, log, " Interface");
                     else if (TR::Compiler->cls.isAbstractClass(_comp, clazz))
-                        output.appends(" Abstract");
+                        len_logprints_literal(len, log, " Abstract");
                 }
-                output.appendf(" (%.*s.class)", len, sig);
+                len += log->printf(" (%.*s.class)", sigLen, sig);
             }
             break;
 
         default:
-            output.appendf(" Bad Type %s", node->getDataType().toString());
+            len = log->printf(" Bad Type %s", node->getDataType().toString());
             break;
     }
+
+    _comp->incrNodeOpCodeLength(len);
 }
 
 void TR_Debug::print(OMR::Logger *log, TR::CFG *cfg)
@@ -759,14 +755,6 @@ void TR_Debug::printBlockOrders(OMR::Logger *log, const char *title, TR::Resolve
     }
 }
 
-TR_PrettyPrinterString::TR_PrettyPrinterString(TR_Debug *debug)
-{
-    len = 0;
-    buffer[0] = '\0';
-    _comp = debug->comp();
-    _debug = debug;
-}
-
 char *TR_Debug::formattedString(char *buf, uint32_t bufLen, const char *format, va_list args,
     TR_AllocationKind allocationKind)
 {
@@ -797,31 +785,6 @@ char *TR_Debug::formattedString(char *buf, uint32_t bufLen, const char *format, 
     vsnprintf(buf, bufLen, format, args);
 
     return buf;
-}
-
-void TR_PrettyPrinterString::appendf(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    len += vsnprintf(buffer + len, maxBufferLength - len, format, args);
-    va_end(args);
-}
-
-void TR_PrettyPrinterString::appends(char const *str)
-{
-    size_t const strLen0 = strlen(str) + 1; // include terminating '\0'
-    size_t const bufLenBytes = maxBufferLength - len;
-
-    char *buf = buffer + len;
-
-    if (strLen0 < bufLenBytes) {
-        memcpy(buf, str, strLen0);
-        len += static_cast<int32_t>(strLen0 - 1);
-    } else if (bufLenBytes != 0) {
-        memcpy(buf, str, bufLenBytes - 1);
-        buf[bufLenBytes - 1] = '\0';
-        len += static_cast<int32_t>(bufLenBytes - 1);
-    }
 }
 
 int32_t TR_Debug::print(OMR::Logger *log, TR::TreeTop *tt)
@@ -864,9 +827,8 @@ int32_t TR_Debug::print(OMR::Logger *log, TR::Node *node, uint32_t indentation, 
 
     log->println();
 
-    TR_PrettyPrinterString output(this);
-
     if (printChildren) {
+        int32_t len = 0;
         indentation += DEFAULT_INDENT_INCREMENT;
         if (node->getOpCode().isSwitch()) {
             nodeCount += print(log, node->getFirstChild(), indentation, true);
@@ -874,10 +836,8 @@ int32_t TR_Debug::print(OMR::Logger *log, TR::Node *node, uint32_t indentation, 
             printBasicPreNodeInfoAndIndent(log, node->getSecondChild(), indentation);
             nodeCount++;
 
-            output.appends("default ");
-            _comp->incrNodeOpCodeLength(output.getLength());
-            log->prints(output.getStr());
-            output.reset();
+            len_logprints_literal(len, log, "default ");
+            _comp->incrNodeOpCodeLength(len);
 
             printDestination(log, node->getSecondChild()->getBranchDestination());
             printBasicPostNodeInfo(log, node->getSecondChild(), indentation);
@@ -909,11 +869,9 @@ int32_t TR_Debug::print(OMR::Logger *log, TR::Node *node, uint32_t indentation, 
                     } else {
                         fmtStr = unsigned_case ? "%u:\t" : "%d:\t";
                     }
-                    output.appendf(fmtStr, node->getChild(i)->getCaseConstant());
 
-                    _comp->incrNodeOpCodeLength(output.getLength());
-                    log->prints(output.getStr());
-                    output.reset();
+                    len = log->printf(fmtStr, node->getChild(i)->getCaseConstant());
+                    _comp->incrNodeOpCodeLength(len);
 
                     printDestination(log, node->getChild(i)->getBranchDestination());
 
@@ -933,10 +891,9 @@ int32_t TR_Debug::print(OMR::Logger *log, TR::Node *node, uint32_t indentation, 
                 for (i = 2; i < upperBound; i++) {
                     printBasicPreNodeInfoAndIndent(log, node->getChild(i), indentation);
                     nodeCount++;
-                    output.appendf("%d", i - 2);
-                    _comp->incrNodeOpCodeLength(output.getLength());
-                    log->prints(output.getStr());
-                    output.reset();
+
+                    len = log->printf("%d", i - 2);
+                    _comp->incrNodeOpCodeLength(len);
 
                     printDestination(log, node->getChild(i)->getBranchDestination());
                     printBasicPostNodeInfo(log, node->getChild(i), indentation);
@@ -1025,14 +982,14 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
 {
     uint32_t numSpaces, globalIndex;
 
-    TR_PrettyPrinterString output(this);
-
     _comp->setNodeOpCodeLength(0);
 
     char const * const globalIndexPrefix = "n";
 
     globalIndex = node->getGlobalIndex();
     numSpaces = getNumSpacesAfterIndex(globalIndex, MAX_GLOBAL_INDEX_LENGTH);
+
+    int32_t len = 0;
 
     // If this node has already been printed, just print a reference to it.
     //
@@ -1053,10 +1010,8 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
 
         if (_comp->cg()->getAppendInstruction() != NULL && node->getDataType() != TR::NoType
             && node->getRegister() != NULL) {
-            output.appendf(" (in %s)", getName(node->getRegister()));
-            _comp->incrNodeOpCodeLength(output.getLength());
-            log->prints(output.getStr());
-            output.reset();
+            len = log->printf(" (in %s)", getName(node->getRegister()));
+            _comp->incrNodeOpCodeLength(len);
         }
         if (!debug("disableDumpNodeFlags"))
             printNodeFlags(log, node);
@@ -1079,10 +1034,8 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
     printNodeInfo(log, node);
     if (_comp->cg()->getAppendInstruction() != NULL && node->getDataType() != TR::NoType
         && node->getRegister() != NULL) {
-        output.appendf(" (in %s)", getName(node->getRegister()));
-        _comp->incrNodeOpCodeLength(output.getLength());
-        log->prints(output.getStr());
-        output.reset();
+        len = log->printf(" (in %s)", getName(node->getRegister()));
+        _comp->incrNodeOpCodeLength(len);
     }
     if (!debug("disableDumpNodeFlags"))
         printNodeFlags(log, node);
@@ -1099,10 +1052,9 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
 
             log->printf("\n%s%s%dn%*s  %*s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation, " ");
             nodeCount++;
-            output.appends("default ");
-            _comp->incrNodeOpCodeLength(output.getLength());
-            log->prints(output.getStr());
-            output.reset();
+
+            len_logprints_literal(len, log, "default ");
+            _comp->incrNodeOpCodeLength(len);
 
             printDestination(log, node->getSecondChild()->getBranchDestination());
             printBasicPostNodeInfo(log, node->getSecondChild(), indentation);
@@ -1128,10 +1080,9 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
                     } else {
                         fmtStr = (node->getFirstChild()->getOpCode().isUnsigned()) ? "%u:\t" : "%d:\t";
                     }
-                    output.appendf(fmtStr, node->getChild(i)->getCaseConstant());
-                    _comp->incrNodeOpCodeLength(output.getLength());
-                    log->prints(output.getStr());
-                    output.reset();
+
+                    len = log->printf(fmtStr, node->getChild(i)->getCaseConstant());
+                    _comp->incrNodeOpCodeLength(len);
 
                     printDestination(log, node->getChild(i)->getBranchDestination());
 
@@ -1149,10 +1100,9 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
                     log->printf("\n%s%s%dn%*s  %*s", prefix, globalIndexPrefix, globalIndex, numSpaces, "", indentation,
                         " ");
                     nodeCount++;
-                    output.appendf("%d", i - 2);
-                    _comp->incrNodeOpCodeLength(output.getLength());
-                    log->prints(output.getStr());
-                    output.reset();
+
+                    len = log->printf("%d", i - 2);
+                    _comp->incrNodeOpCodeLength(len);
 
                     printDestination(log, node->getChild(i)->getBranchDestination());
                     if (node->getChild(i)->getNumChildren() == 1) // a GlRegDep
@@ -1185,23 +1135,21 @@ int32_t TR_Debug::printWithFixedPrefix(OMR::Logger *log, TR::Node *node, uint32_
 
 void TR_Debug::printDestination(OMR::Logger *log, TR::TreeTop *treeTop)
 {
-    TR_PrettyPrinterString output(this);
-    printDestination(treeTop, output);
-    log->prints(output.getStr());
-    _comp->incrNodeOpCodeLength(output.getLength());
-}
-
-void TR_Debug::printDestination(TR::TreeTop *treeTop, TR_PrettyPrinterString &output)
-{
     if (treeTop == NULL)
         return;
 
     TR::Node *node = treeTop->getNode();
     TR::Block *block = node->getBlock();
-    output.appends(" --> ");
-    if (block->getNumber() >= 0)
-        output.appendf("block_%d", block->getNumber());
-    output.appendf(" BBStart at n%dn", node->getGlobalIndex());
+
+    int32_t len = 0;
+    len_logprints_literal(len, log, " --> ");
+    if (block->getNumber() >= 0) {
+        len += log->printf("block_%d", block->getNumber());
+    }
+
+    len += log->printf(" BBStart at n%dn", node->getGlobalIndex());
+
+    _comp->incrNodeOpCodeLength(len);
 }
 
 void TR_Debug::printBasicPreNodeInfoAndIndent(OMR::Logger *log, TR::Node *node, uint32_t indentation)
@@ -1225,70 +1173,54 @@ void TR_Debug::printBasicPreNodeInfoAndIndent(OMR::Logger *log, TR::Node *node, 
 
 void TR_Debug::printBasicPostNodeInfo(OMR::Logger *log, TR::Node *node, uint32_t indentation)
 {
-    TR_PrettyPrinterString output(this);
-
-    output.appends("  ");
+    log->prints("  ");
     if ((_comp->getNodeOpCodeLength() + indentation) < DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT)
-        output.appendf("%*s",
+        log->printf("%*s",
             DEFAULT_NODE_LENGTH + DEFAULT_INDENT_INCREMENT - (_comp->getNodeOpCodeLength() + indentation), "");
+
+    log->printf("[%s] ", getName(node));
 
     int32_t lineNumber = _comp->getLineNumber(node);
 
-    output.appendf("[%s] ", getName(node));
-
-    char const *bciOrLoc = "bci";
-
     if (lineNumber < 0) {
-        output.appendf("%s=[%d,%d,-] rc=", bciOrLoc, node->getByteCodeInfo().getCallerIndex(),
+        log->printf("bci=[%d,%d,-] rc=", node->getByteCodeInfo().getCallerIndex(),
             node->getByteCodeInfo().getByteCodeIndex());
     } else {
-        output.appendf("%s=[%d,%d,%d] rc=", bciOrLoc, node->getByteCodeInfo().getCallerIndex(),
+        log->printf("bci=[%d,%d,%d] rc=", node->getByteCodeInfo().getCallerIndex(),
             node->getByteCodeInfo().getByteCodeIndex(), lineNumber);
     }
 
-    output.appendf("%d vc=%d", node->getReferenceCount(), node->getVisitCount());
+    log->printf("%d vc=%d", node->getReferenceCount(), node->getVisitCount());
 
     if (_comp->getOptimizer() && _comp->getOptimizer()->getValueNumberInfo())
-        output.appendf(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
+        log->printf(" vn=%d", _comp->getOptimizer()->getValueNumberInfo()->getValueNumber(node));
     else
-        output.appends(" vn=-");
+        log->prints(" vn=-");
 
     if (node->getLocalIndex())
-        output.appendf(" li=%d", node->getLocalIndex());
+        log->printf(" li=%d", node->getLocalIndex());
     else
-        output.appends(" li=-");
+        log->prints(" li=-");
 
     if (node->getUseDefIndex())
-        output.appendf(" udi=%d", node->getUseDefIndex());
+        log->printf(" udi=%d", node->getUseDefIndex());
     else
-        output.appends(" udi=-");
+        log->prints(" udi=-");
 
-    output.appendf(" nc=%d", node->getNumChildren());
+    log->printf(" nc=%d", node->getNumChildren());
 
     if (node->getFlags().getValue())
-        output.appendf(" flg=0x%x", node->getFlags().getValue());
-
-    log->prints(output.getStr());
+        log->printf(" flg=0x%x", node->getFlags().getValue());
 
     _comp->setNodeOpCodeLength(0); // redundant - just to be safe
 }
 
-void TR_Debug::printNodeInfo(OMR::Logger *log, TR::Node *node)
-{
-    TR_PrettyPrinterString output(this);
-    printNodeInfo(node, output, false);
-    log->prints(output.getStr());
-    _comp->incrNodeOpCodeLength(output.getLength());
-}
-
 // Dump the node information for this node
-void TR_Debug::printNodeInfo(TR::Node *node, TR_PrettyPrinterString &output, bool prettyPrint)
+void TR_Debug::printNodeInfo(OMR::Logger *log, TR::Node *node)
 {
     char const * const globalIndexPrefix = "n";
 
-    if (!prettyPrint || (node->getOpCodeValue() != TR::BBStart && node->getOpCodeValue() != TR::BBEnd)) {
-        output.appendf("%s", getName(node->getOpCode()));
-    }
+    int32_t len = log->prints_len(getName(node->getOpCode()));
 
     // print vector type immediately after opcode name
     if (node->getOpCode().isVectorOpCode()) {
@@ -1296,88 +1228,89 @@ void TR_Debug::printNodeInfo(TR::Node *node, TR_PrettyPrinterString &output, boo
 
         if (opcode.isTwoTypeVectorOpCode()) {
             // example: vconvVector128Int32_Vector128Float
-            output.appendf("%s_%s", getName(opcode.getVectorSourceDataType()),
+            len += log->printf("%s_%s", getName(opcode.getVectorSourceDataType()),
                 getName(opcode.getVectorResultDataType()));
         } else {
             // example: vaddVector128Int32
-            output.appendf("%s", getName(opcode.getVectorResultDataType()));
+            len += log->prints_len(getName(opcode.getVectorResultDataType()));
         }
     }
 
 #ifdef TR_ALLOW_NON_CONST_KNOWN_OBJECTS
     if (node->hasKnownObjectIndex()) {
-        output.appendf(" (node obj%d)", node->getKnownObjectIndex());
+        len += log->printf(" (node obj%d)", node->getKnownObjectIndex());
     }
 #endif
 
     if (node->getOpCode().isNullCheck()) {
         if (node->getNullCheckReference())
-            output.appendf(" on %s%dn", globalIndexPrefix, node->getNullCheckReference()->getGlobalIndex());
+            len += log->printf(" on %s%dn", globalIndexPrefix, node->getNullCheckReference()->getGlobalIndex());
         else
-            output.appends(" on null NullCheckReference ----- INVALID tree!!");
+            len_logprints_literal(len, log, " on null NullCheckReference ----- INVALID tree!!");
     } else if (node->getOpCodeValue() == TR::allocationFence) {
         if (node->getAllocation())
-            output.appendf(" on %s%dn", globalIndexPrefix, node->getAllocation()->getGlobalIndex());
+            len += log->printf(" on %s%dn", globalIndexPrefix, node->getAllocation()->getGlobalIndex());
         else
-            output.appends(" on ALL");
+            len_logprints_literal(len, log, " on ALL");
     }
 
     if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()) {
-        bool hideHelperMethodInfo = false;
-        if (node->getOpCode().isCheck()) // Omit helper method info for OpCodes that are checked
-            hideHelperMethodInfo = true;
-
-        print(node->getSymbolReference(), output, hideHelperMethodInfo);
+        // Omit helper method info for OpCodes that are checked
+        len += print(log, node->getSymbolReference(), node->getOpCode().isCheck());
     } else if (node->getOpCode().isBranch()) {
-        printDestination(node->getBranchDestination(), output);
+        // printDestination adjusts incrNodeOpCodeLength() directly, so len is
+        // not adjusted by the characters written
+        //
+        printDestination(log, node->getBranchDestination());
     } else if (node->getOpCodeValue() == TR::exceptionRangeFence) {
         if (node->getNumRelocations() > 0) {
             if (node->getRelocationType() == TR_AbsoluteAddress)
-                output.appends(" Absolute [");
+                len_logprints_literal(len, log, " Absolute [");
             else if (node->getRelocationType() == TR_ExternalAbsoluteAddress)
-                output.appends(" External Absolute [");
+                len_logprints_literal(len, log, " External Absolute [");
             else
-                output.appends(" Relative [");
+                len_logprints_literal(len, log, " Relative [");
 
             for (auto i = 0U; i < node->getNumRelocations(); ++i)
-                output.appendf(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
+                len += log->printf(" " POINTER_PRINTF_FORMAT, node->getRelocationDestination(i));
 
-            output.appends(" ]");
+            len_logprints_literal(len, log, " ]");
         }
     } else if (node->getOpCodeValue() == TR::BBStart) {
         TR::Block *block = node->getBlock();
         if (block->getNumber() >= 0) {
-            output.appendf(" <block_%d>", block->getNumber());
+            len += log->printf(" <block_%d>", block->getNumber());
         }
 
         if (block->getFrequency() >= 0)
-            output.appendf(" (freq %d)", block->getFrequency());
+            len += log->printf(" (freq %d)", block->getFrequency());
         if (block->isExtensionOfPreviousBlock())
-            output.appends(" (extension of previous block)");
+            len_logprints_literal(len, log, " (extension of previous block)");
         if (block->isCatchBlock()) {
-            int32_t length;
+            int32_t classNameLen;
             const char *classNameChars = block->getExceptionClassNameChars();
             if (classNameChars) {
-                length = block->getExceptionClassNameLength();
-                output.appendf(" (catches %.*s)", length, getName(classNameChars, length));
+                classNameLen = block->getExceptionClassNameLength();
+                len += log->printf(" (catches %.*s)", classNameLen, getName(classNameChars, classNameLen));
             } else {
                 classNameChars = "...";
-                length = 3;
-                output.appendf(" (catches %.*s)", length,
+                classNameLen = 3;
+                len += log->printf(" (catches %.*s)", classNameLen,
                     classNameChars); // passing literal string shouldn't use getName()
             }
 
             if (block->isOSRCatchBlock()) {
-                output.appends(" (OSR handler)");
+                len_logprints_literal(len, log, " (OSR handler)");
             }
         }
         if (block->isSuperCold())
-            output.appends(" (super cold)");
+            len_logprints_literal(len, log, " (super cold)");
         else if (block->isCold())
-            output.appends(" (cold)");
+            len_logprints_literal(len, log, " (cold)");
 
         if (block->isLoopInvariantBlock())
-            output.appends(" (loop pre-header)");
+            len_logprints_literal(len, log, " (loop pre-header)");
+
         TR_BlockStructure *blockStructure = block->getStructureOf();
         if (blockStructure) {
             if (_comp->getFlowGraph()->getStructure()) {
@@ -1385,66 +1318,69 @@ void TR_Debug::printNodeInfo(TR::Node *node, TR_PrettyPrinterString &output, boo
                 while (parent) {
                     TR_RegionStructure *region = parent->asRegion();
                     if (region->isNaturalLoop() || region->containsInternalCycles()) {
-                        output.appendf(" (in loop %d)", region->getNumber());
+                        len += log->printf(" (in loop %d)", region->getNumber());
                         break;
                     }
                     parent = parent->getParent();
                 }
                 TR_BlockStructure *dupBlock = blockStructure->getDuplicatedBlock();
                 if (dupBlock)
-                    output.appendf(" (dup of block_%d)", dupBlock->getNumber());
+                    len += log->printf(" (dup of block_%d)", dupBlock->getNumber());
             }
         }
     } else if (node->getOpCodeValue() == TR::BBEnd) {
         TR::Block *block = node->getBlock(), *nextBlock;
         if (block->getNumber() >= 0) {
-            output.appendf(" </block_%d>", block->getNumber());
+            len += log->printf(" </block_%d>", block->getNumber());
             if (block->isSuperCold())
-                output.appends(" (super cold)");
+                len_logprints_literal(len, log, " (super cold)");
             else if (block->isCold())
-                output.appends(" (cold)");
+                len_logprints_literal(len, log, " (cold)");
         }
 
         if ((nextBlock = block->getNextBlock())
             && !nextBlock->isExtensionOfPreviousBlock()) // end of a block that is not the last block and the next block
                                                          // is not an extension of it
-            output.appends(" =====");
+            len_logprints_literal(len, log, " =====");
     } else if (node->getOpCode().isArrayLength()) {
         int32_t stride = node->getArrayStride();
 
         if (stride > 0)
-            output.appendf(" (stride %d)", stride);
+            len += log->printf(" (stride %d)", stride);
     } else if (node->getOpCode().isLoadReg() || node->getOpCode().isStoreReg()) {
         TR::DataType dt = node->getDataType();
         if ((node->getType().isInt64() && _comp->target().is32Bit() && !_comp->cg()->use64BitRegsOn32Bit()))
-            output.appendf(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber(), dt),
+            len += log->printf(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber(), dt),
                 getGlobalRegisterName(node->getLowGlobalRegisterNumber(), dt));
         else
-            output.appendf(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber(), dt));
+            len += log->printf(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber(), dt));
 
         if (node->getOpCode().isLoadReg())
-            print(node->getRegLoadStoreSymbolReference(), output);
+            len += print(log, node->getRegLoadStoreSymbolReference());
     } else if (node->getOpCodeValue() == TR::PassThrough) {
         // print only if under a GlRegDep
         bool isParentGlRegDep = getCurrentParent() ? (getCurrentParent()->getOpCodeValue() == TR::GlRegDeps) : false;
         if (isParentGlRegDep) {
             TR::DataType dt = node->getDataType();
             if ((node->getFirstChild()->getType().isInt64() && _comp->target().is32Bit()))
-                output.appendf(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber(), dt),
+                len += log->printf(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber(), dt),
                     getGlobalRegisterName(node->getLowGlobalRegisterNumber(), dt));
             else
-                output.appendf(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber(), dt));
+                len += log->printf(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber(), dt));
         }
     } else if (node->getOpCode().hasNoDataType()) {
-        output.appendf(" (%s)", getName(node->getDataType()));
+        len += log->printf(" (%s)", getName(node->getDataType()));
     }
 
     if (node->getOpCode().isLoadConst()) {
-        printLoadConst(node, output);
+        // printLoadConst adjusts incrNodeOpCodeLength() directly, so len is
+        // not adjusted by the characters written
+        //
+        printLoadConst(log, node);
 
         if (getCurrentParent() && getCurrentParent()->getOpCodeValue() == TR::newarray
             && getCurrentParent()->getSecondChild() == node) {
-            output.appends("   ; array type is ");
+            len_logprints_literal(len, log, "   ; array type is ");
 
             const char *typeStr;
             switch (node->getInt()) {
@@ -1477,101 +1413,98 @@ void TR_Debug::printNodeInfo(TR::Node *node, TR_PrettyPrinterString &output, boo
                     typeStr = "unknown";
             }
 
-            output.appends(typeStr);
+            len += log->prints_len(typeStr);
         }
     }
 
 #ifdef J9_PROJECT_SPECIFIC
-    printBCDNodeInfo(node, output);
+    // printBCDNodeInfo adjusts incrNodeOpCodeLength() directly, so len is
+    // not adjusted by the characters written
+    //
+    printBCDNodeInfo(log, node);
 #endif
+
+    _comp->incrNodeOpCodeLength(len);
 }
 
 // Dump the node flags for this node
 // All flag printers should be called from here
 void TR_Debug::printNodeFlags(OMR::Logger *log, TR::Node *node)
 {
-    TR_PrettyPrinterString output(this);
-
     if (node->getFlags().getValue()) {
-        output.appends(" (");
-        nodePrintAllFlags(node, output);
-        output.appends(")");
+        int32_t len = 0;
+        len_logprints_literal(len, log, " (");
+        len += nodePrintAllFlags(log, node);
+        len_logprintc(len, log, ')');
+        _comp->incrNodeOpCodeLength(len);
     }
-
-    log->prints(output.getStr());
-
-    _comp->incrNodeOpCodeLength(output.getLength());
 }
 
 #ifdef J9_PROJECT_SPECIFIC
 void TR_Debug::printBCDNodeInfo(OMR::Logger *log, TR::Node *node)
 {
-    TR_PrettyPrinterString output(this);
-    printBCDNodeInfo(node, output);
-    log->prints(output.getStr());
-    _comp->incrNodeOpCodeLength(output.getLength());
-}
+    int32_t len = 0;
 
-void TR_Debug::printBCDNodeInfo(TR::Node *node, TR_PrettyPrinterString &output)
-{
     if (node->getType().isBCD()) {
         if (node->getOpCode().isStore() || node->getOpCode().isCall() || node->getOpCode().isLoadConst()
             || (node->getOpCode().isConversion() && !node->getOpCode().isConversionWithFraction())) {
             if (node->hasSourcePrecision()) {
-                output.appendf(" <prec=%d (len=%d) srcprec=%d> ", node->getDecimalPrecision(), node->getSize(),
+                len += log->printf(" <prec=%d (len=%d) srcprec=%d> ", node->getDecimalPrecision(), node->getSize(),
                     node->getSourcePrecision());
             } else {
-                output.appendf(" <prec=%d (len=%d)> ", node->getDecimalPrecision(), node->getSize());
+                len += log->printf(" <prec=%d (len=%d)> ", node->getDecimalPrecision(), node->getSize());
             }
         } else if (node->getOpCode().isLoad()) {
-            output.appendf(" <prec=%d (len=%d) adj=%d> ", node->getDecimalPrecision(), node->getSize(),
+            len += log->printf(" <prec=%d (len=%d) adj=%d> ", node->getDecimalPrecision(), node->getSize(),
                 node->getDecimalAdjust());
         } else if (node->canHaveSourcePrecision()) {
-            output.appendf(" <prec=%d (len=%d) srcprec=%d %s=%d round=%d> ", node->getDecimalPrecision(),
+            len += log->printf(" <prec=%d (len=%d) srcprec=%d %s=%d round=%d> ", node->getDecimalPrecision(),
                 node->getSize(), node->getSourcePrecision(),
                 node->getOpCode().isConversionWithFraction() ? "frac" : "adj",
                 node->getOpCode().isConversionWithFraction() ? node->getDecimalFraction() : node->getDecimalAdjust(),
                 node->getDecimalRound());
         } else {
-            output.appendf(" <prec=%d (len=%d) %s=%d round=%d> ", node->getDecimalPrecision(), node->getSize(),
+            len += log->printf(" <prec=%d (len=%d) %s=%d round=%d> ", node->getDecimalPrecision(), node->getSize(),
                 node->getOpCode().isConversionWithFraction() ? "frac" : "adj",
                 node->getOpCode().isConversionWithFraction() ? node->getDecimalFraction() : node->getDecimalAdjust(),
                 node->getDecimalRound());
         }
         if (!node->getOpCode().isStore()) {
-            output.appends("sign=");
+            len_logprints_literal(len, log, "sign=");
             if (node->hasKnownOrAssumedCleanSign() || node->hasKnownOrAssumedPreferredSign()
                 || node->hasKnownOrAssumedSignCode()) {
                 if (node->signStateIsKnown())
-                    output.appends("known(");
+                    len_logprints_literal(len, log, "known(");
                 else
-                    output.appends("assumed(");
+                    len_logprints_literal(len, log, "assumed(");
                 if (node->hasKnownOrAssumedCleanSign())
-                    output.appends("clean");
+                    len_logprints_literal(len, log, "clean");
                 if (node->hasKnownOrAssumedPreferredSign())
-                    output.appendf("%spreferred", node->hasKnownOrAssumedCleanSign() ? "/" : "");
+                    len += log->printf("%spreferred", node->hasKnownOrAssumedCleanSign() ? "/" : "");
                 if (node->hasKnownOrAssumedSignCode())
-                    output.appendf("%s%s",
+                    len += log->printf("%s%s",
                         node->hasKnownOrAssumedCleanSign() || node->hasKnownOrAssumedPreferredSign() ? "/" : "",
                         getName(node->hasKnownSignCode() ? node->getKnownSignCode() : node->getAssumedSignCode()));
-                output.appends(") ");
+                len_logprints_literal(len, log, ") ");
             } else if (node->getOpCode().isLoad()) {
-                output.appendf("%s ", node->hasSignStateOnLoad() ? "hasState" : "noState");
+                len += log->printf("%s ", node->hasSignStateOnLoad() ? "hasState" : "noState");
             } else {
-                output.appends("? ");
+                len_logprints_literal(len, log, "? ");
             }
         }
         if (node->isSetSignValueOnNode()) {
-            output.appendf("setSign=%s ", getName(node->getSetSign()));
+            len += log->printf("setSign=%s ", getName(node->getSetSign()));
         }
     } else if (node->getOpCode().isConversionWithFraction()) {
-        output.appendf(" <frac=%d> ", node->getDecimalFraction());
+        len += log->printf(" <frac=%d> ", node->getDecimalFraction());
     } else if ((node->getType()).isAggregate()) {
-        output.appendf(" <size=%lld bytes>", (int64_t)0);
+        len += log->printf(" <size=%lld bytes>", (int64_t)0);
     }
     if (node->castedToBCD()) {
-        output.appends(" <castedToBCD=true> ");
+        len_logprints_literal(len, log, " <castedToBCD=true> ");
     }
+
+    _comp->incrNodeOpCodeLength(len);
 }
 #endif
 

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -615,15 +615,13 @@ void TR_Debug::print(OMR::Logger *log, TR::S390RISInstruction *instr)
 
 void TR_Debug::print(OMR::Logger *log, TR::S390LabelInstruction *instr)
 {
-    TR::LabelSymbol *label = instr->getLabelSymbol();
-    const char *symbolName = getName(label);
     printPrefix(log, instr);
 
     if (instr->getOpCodeValue() == TR::InstOpCode::label) {
-        {
-            log->prints(symbolName);
-            log->printc(':');
-        }
+        TR::LabelSymbol *label = instr->getLabelSymbol();
+        const char *symbolName = getName(label);
+        log->prints(symbolName);
+        log->printc(':');
 
         if (label->isStartInternalControlFlow()) {
             log->prints("\t# (Start of internal control flow)");
@@ -1692,67 +1690,57 @@ void TR_Debug::print(OMR::Logger *log, TR::MemoryReference *mr, TR::Instruction 
 
 void TR_Debug::printSymbolName(OMR::Logger *log, TR::Symbol *sym, TR::SymbolReference *symRef, TR::MemoryReference *mr)
 {
-    char *str;
-    bool sawWCodeName = false;
-#define LSTBUFSZ 1024
-#define MAXBUFSZ LSTBUFSZ - 1
-    char outString[LSTBUFSZ];
-    outString[0] = '\0';
-    outString[MAXBUFSZ] = '\0';
-    int32_t prefixLen = 0;
-
-#define ADD_WITH_PREFIX(s)                           \
-    {                                                \
-        strcpy(outString, internalNamePrefix());     \
-        strncat(outString, s, MAXBUFSZ - prefixLen); \
-    }
-
-    snprintf(outString, MAXBUFSZ, "#%d", symRef ? symRef->getReferenceNumber() : 0);
-
-    if (sym && !sawWCodeName) {
+    if (sym) {
         switch (sym->getKind()) {
             case TR::Symbol::IsAutomatic:
                 if (sym->getAutoSymbol()->getName() == NULL) {
-                    snprintf(outString, MAXBUFSZ, " Auto[%s]", getName(symRef));
+                    log->printf(" Auto[%s]", getName(symRef));
                 } else {
-                    snprintf(outString, MAXBUFSZ, " %s[%s]", sym->getAutoSymbol()->getName(), getName(symRef));
+                    log->printf(" %s[%s]", sym->getAutoSymbol()->getName(), getName(symRef));
                 }
-                break;
+                return;
             case TR::Symbol::IsParameter:
-                snprintf(outString, MAXBUFSZ, " Parm[%s]", getName(symRef));
-                break;
+                log->printf(" Parm[%s]", getName(symRef));
+                return;
             case TR::Symbol::IsStatic:
                 if (mr && mr->getConstantDataSnippet() == NULL) {
-                    snprintf(outString, MAXBUFSZ, " Static[%s]", getName(symRef));
+                    log->printf(" Static[%s]", getName(symRef));
+                    return;
                 }
                 break;
             case TR::Symbol::IsResolvedMethod:
             case TR::Symbol::IsMethod:
-                snprintf(outString, MAXBUFSZ, " Method[%s]", getName(symRef));
-                break;
+                log->printf(" Method[%s]", getName(symRef));
+                return;
             case TR::Symbol::IsShadow:
                 if (mr->getConstantDataSnippet() == NULL) {
                     const char *symRefName = getName(symRef);
-                    if (sym->isNamedShadowSymbol() && sym->getNamedShadowSymbol()->getName() != NULL) {
-                        snprintf(outString, MAXBUFSZ, "   %s[%s]", sym->getNamedShadowSymbol()->getName(), symRefName);
+                    if (sym->isNamedShadowSymbol()) {
+                        const char *namedShadowName = sym->getNamedShadowSymbol()->getName();
+                        if (namedShadowName) {
+                            log->printf("   %s[%s]", namedShadowName, symRefName);
+                        } else {
+                            log->printf(" Shadow[%s]", symRefName);
+                        }
                     } else {
-                        snprintf(outString, MAXBUFSZ, " Shadow[%s]", getName(symRef));
+                        log->printf(" Shadow[%s]", symRefName);
                     }
+                    return;
                 }
                 break;
             case TR::Symbol::IsMethodMetaData:
-                snprintf(outString, MAXBUFSZ, " MethodMeta[%s]", getName(symRef));
-                break;
+                log->printf(" MethodMeta[%s]", getName(symRef));
+                return;
             case TR::Symbol::IsLabel:
-                strncpy(outString, getName(sym->castToLabelSymbol()), MAXBUFSZ);
-                break;
-
+                log->prints(getName(sym->castToLabelSymbol()));
+                return;
             default:
-                TR_ASSERT(0, "unexpected symbol kind");
+                TR_ASSERT_FATAL(0, "unexpected symbol kind");
+                break;
         }
     }
 
-    log->prints(outString);
+    log->printf("#%d", symRef ? symRef->getReferenceNumber() : 0);
 }
 
 void TR_Debug::print(OMR::Logger *log, TR::S390NOPInstruction *instr)


### PR DESCRIPTION
`TR_PrettyPrinterString` is a utility class in the compiler component used for
rendering text strings into a fixed size array. This is used in a number of
places during compiler tracing and logging.

While simple and functional, there are some significant performance issues with
its use and implementation:

* A `TR_PrettyPrinterString` object can be used to render a string piecemeal
  across many functions. In nearly all cases, that string is then simply output
  to a Logger (or historically, a log file). However, other than simplifying the
  accounting for computing the length of the string rendered, it is more
  efficient to output the string directly to the Logger while it is being
  created. This saves the cost of copying the string to the Logger once it has
  been rendered.

* Each `TR_PrettyPrinterString` maintains an internal, fixed buffer of 2000
  characters to perform the rendering. To illustrate how wasteful this is, to
  print a `TR::SymbolReference`, eight temporary `TR_PrettyPrinterString`
  objects are allocated on the stack for various parts of the symbol reference,
  many of which will only be filled with a small number of characters. While
  thankfully these objects have a short lifetime, they do have an impact on the
  cache and performance, and a better design is possible.

This pull request eliminates the `TR_PrettyPrinterString` and modifies the
tracing behaviour to perform without it. It makes the following contributions:

* Introduces new functions in the Logger API to return the number of characters
  printed for strings that don't have format specifiers and for single
  characters. The reason new APIs were created for these operations rather than
  changing existing ones to return the number of characters written is because
  it is anticipated that the need to know the exact number of characters output
  is rare. The Loggers typically used for tracing and logging are often
  implemented by functions in the C++ standard library. In the case of strings
  without format specifiers and for single characters, the C++ functions do not
  report the number of characters successfully written, and this must be
  computed separately (e.g., using `strlen()` or simply returning 1 in the case of
  characters). Since the length in these cases must be computed separately and
  this requirement is considered rare, new API functions were created.

* Eliminate `TR_PrettyPrinterString` functionality and refactor the code to
  write directly to a Logger object instead. One challenge with this is that
  because these objects were used to print artifacts in the compiler trace log,
  adjustments to the indentation are necessary. This requires accounting for
  the length of all strings outputted. As Loggers are more like a stream, one
  option is to use the `ftell()` API function at the beginning and end of the
  string being outputted and subtract them. Another approach is to accumulate
  the length incrementally from each Logger API function called. Because the
  Logger `ftell()` function for many Loggers is implemented with a C++ runtime
  `ftell()` call, this can cost hundreds of cycles on some platform
  implementations. Rather than do that, the output of Logger APIs reporting the
  number of characters written is accumulated in functions where this was
  previously done with `TR_PrettyPrinterString`. While it adds verbosity to the
  code, the performance cost of this approach over the alternative is
  considered a win. Preprocessor macros are introduced to improve code density
  and readability for some of these accounting functions.

* Similar to `TR_PrettyPrinterString`, the Z debug function `printSymbolName()`
  rendered its output into a buffer before printing. This logic has been
  eliminated and now outputs directly to a Logger.