### PR TITLE
Fix binary encoding of Power fres instruction

### DIFF
--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -2302,7 +2302,7 @@
         /* .name        = */ "fres",
         /* .description =    "Floating reciprocal estimate single", */
         /* .prefix      = */ 0x00000000,
-        /* .opcode      = */ 0xFC000030,
+        /* .opcode      = */ 0xEC000030,
         /* .format      = */ FORMAT_UNKNOWN,
         /* .minimumALS  = */ OMR_PROCESSOR_PPC_PWR630,
         /* .properties  = */ PPCOpProp_DoubleFP | PPCOpProp_SyncSideEffectFree,


### PR DESCRIPTION
- Change fres .opcode from 0xFC000030 to 0xEC000030 since,
  according to Power ISA, opcode for fres instruction is 59.