### PR TITLE
AArch64: Introduce new functions for generating RegisterDependency

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -526,7 +526,6 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
 }
 
 int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
-
 {
     const TR::ARM64LinkageProperties &properties = getProperties();
     TR::ARM64MemoryArgument *pushToMemory = NULL;
@@ -799,8 +798,8 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
 
     // Extra post dependency for killing vector registers (see KillVectorRegs)
     const int extraPostReg = killsVectorRegisters() ? 1 : 0;
-    TR::RegisterDependencyConditions *dependencies = new (trHeapMemory()) TR::RegisterDependencyConditions(
-        pp.getNumberOfDependencyGPRegisters(), pp.getNumberOfDependencyGPRegisters() + extraPostReg, trMemory());
+    TR::RegisterDependencyConditions *dependencies
+        = RegDeps(pp.getNumberOfDependencyGPRegisters(), pp.getNumberOfDependencyGPRegisters() + extraPostReg, cg());
 
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -716,8 +716,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
             (eType == TR::Int8) ? 8 : 16);
         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmw, node, counterReg, counterReg, 1);
 
-        TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory())
-            TR::RegisterDependencyConditions(0, 3 + srm->numAvailableRegisters(), cg->trMemory());
+        auto *cond = RegDeps(0, 3 + srm->numAvailableRegisters(), cg);
         cond->addPostCondition(lhsReg, TR::RealRegister::NoReg);
         cond->addPostCondition(rhsReg, TR::RealRegister::NoReg);
         cond->addPostCondition(resultReg, TR::RealRegister::NoReg);
@@ -1035,8 +1034,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
     TR::Register *tmpReg = NULL;
 
     TR::Register *zeroReg = cg->allocateRegister();
-    TR::RegisterDependencyConditions *cond
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+    auto *cond = RegDeps(1, 1, cg);
     TR::addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
 
     // imulh is generated for constant idiv and the second child is the magic number

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -41,8 +41,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *returnRegister = cg->evaluate(firstChild);
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
+    auto *deps = RegDeps(1, 0, cg);
     deps->addPreCondition(returnRegister, rnum);
     generateAdminInstruction(cg, TR::InstOpCode::retn, node, deps);
 
@@ -81,8 +80,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeG
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        generateLabelInstruction(cg, TR::InstOpCode::b, node, gotoLabel,
-            generateRegisterDependencyConditions(cg, child, 0));
+        generateLabelInstruction(cg, TR::InstOpCode::b, node, gotoLabel, RegDeps(cg, child, 0));
         cg->decReferenceCount(child);
     } else {
         generateLabelInstruction(cg, TR::InstOpCode::b, node, gotoLabel);
@@ -205,7 +203,7 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
                     "The third child of a compare must be a TR::GlRegDeps");
                 cg->evaluate(thirdChild);
 
-                deps = generateRegisterDependencyConditions(cg, thirdChild, 1);
+                deps = RegDeps(cg, thirdChild, 1);
                 uint32_t numPreConditions = deps->getAddCursorForPre();
                 if (!deps->getPreConditions()->containsVirtualRegister(src1Reg, numPreConditions)) {
                     TR::addDependency(deps, src1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
@@ -248,7 +246,7 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
 
         cg->evaluate(thirdChild);
 
-        deps = generateRegisterDependencyConditions(cg, thirdChild, 0);
+        deps = RegDeps(cg, thirdChild, 0);
         result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
     } else {
         result = generateConditionalBranchInstruction(cg, node, dstLabel, cc);
@@ -570,11 +568,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
 
     if (!constantIsUnsignedImm12(node->getChild(2)->getCaseConstant())
         || !constantIsUnsignedImm12(node->getChild(numChildren - 1)->getCaseConstant())) {
-        conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
+        conditions = RegDeps(2, 2, cg);
         tmpRegister = cg->allocateRegister();
         TR::addDependency(conditions, tmpRegister, TR::RealRegister::NoReg, TR_GPR, cg);
     } else {
-        conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+        conditions = RegDeps(1, 1, cg);
     }
     TR::addDependency(conditions, selectorReg, TR::RealRegister::NoReg, TR_GPR, cg);
 
@@ -593,7 +591,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
         if (child->getNumChildren() > 0) {
             // GRA
             cg->evaluate(child->getFirstChild());
-            cond = cond->clone(cg, generateRegisterDependencyConditions(cg, child->getFirstChild(), 0));
+            cond = cond->clone(cg, RegDeps(cg, child->getFirstChild(), 0));
         }
         generateConditionalBranchInstruction(cg, node, child->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ,
             cond);
@@ -603,7 +601,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
     if (defaultChild->getNumChildren() > 0) {
         // GRA
         cg->evaluate(defaultChild->getFirstChild());
-        conditions = conditions->clone(cg, generateRegisterDependencyConditions(cg, defaultChild->getFirstChild(), 0));
+        conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
     }
     generateLabelInstruction(cg, TR::InstOpCode::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
         conditions);
@@ -626,18 +624,18 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
     int32_t i;
 
     if (5 <= numBranchTableEntries) {
-        conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
+        conditions = RegDeps(2, 2, cg);
         tmpRegister = cg->allocateRegister();
         TR::addDependency(conditions, tmpRegister, TR::RealRegister::NoReg, TR_GPR, cg);
     } else {
-        conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+        conditions = RegDeps(1, 1, cg);
     }
 
     TR::addDependency(conditions, selectorReg, TR::RealRegister::NoReg, TR_GPR, cg);
 
     if (0 < defaultChild->getNumChildren()) {
         cg->evaluate(defaultChild->getFirstChild());
-        conditions = conditions->clone(cg, generateRegisterDependencyConditions(cg, defaultChild->getFirstChild(), 0));
+        conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
     }
 
     if (5 > numBranchTableEntries) {
@@ -911,9 +909,9 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
     if (node->getNumChildren() == 3) {
         TR::Node *third = node->getChild(2);
         cg->evaluate(third);
-        deps = generateRegisterDependencyConditions(cg, third, 0);
+        deps = RegDeps(cg, third, 0);
     } else
-        deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg->trMemory());
+        deps = RegDeps(0, 0, cg);
 
     if (virtualGuard->shouldGenerateChildrenCode())
         cg->evaluateChildrenWithMultipleRefCount(node);
@@ -939,7 +937,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::igotoEvaluator(TR::Node *node, TR::Code
             "igoto has maximum of two children and second one must be global register dependency");
         TR::Node *glregdep = node->getChild(1);
         cg->evaluate(glregdep);
-        deps = generateRegisterDependencyConditions(cg, glregdep, 0);
+        deps = RegDeps(cg, glregdep, 0);
         cg->decReferenceCount(glregdep);
     }
     if (deps)

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -538,7 +538,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
 
         cg->evaluate(thirdChild);
 
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(cg, thirdChild, 0);
+        auto *deps = RegDeps(cg, thirdChild, 0);
         if (!needsExplicitUnorderedCheck) {
             result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
         } else {

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1011,8 +1011,7 @@ void OMR::ARM64::Machine::createRegisterAssociationDirective(TR::Instruction *cu
 {
     int32_t first = TR::RealRegister::FirstGPR;
     int32_t last = TR::RealRegister::LastAssignableFPR;
-    TR::RegisterDependencyConditions *associations
-        = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, last, cg()->trMemory());
+    auto *associations = RegDeps(0, last, cg());
 
     // Go through the current associations held in the machine and put a copy of
     // that state out into the stream after the cursor
@@ -1133,7 +1132,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
     TR::RegisterDependencyConditions *deps = NULL;
 
     if (c) {
-        deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
+        deps = RegDeps(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableFPR; i++) {
             TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
             if (realReg->getState() == TR::RealRegister::Assigned) {

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -5691,8 +5691,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
             && valueChild->isConstZeroValue() && (valueChild->getRegister() == NULL))) {
         TR::Register *zeroReg = cg->allocateRegister();
         generateMemSrc1Instruction(cg, op, node, tempMR, zeroReg);
-        TR::RegisterDependencyConditions *deps
-            = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg->trMemory());
+        auto *deps = RegDeps(0, 1, cg);
         deps->addPostCondition(zeroReg, TR::RealRegister::xzr);
         generateLabelInstruction(cg, TR::InstOpCode::label, node, generateLabelSymbol(cg), deps);
         cg->stopUsingRegister(zeroReg);
@@ -5732,8 +5731,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
                 TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node);
                 TR::SymbolReference *patchGCRHelperRef
                     = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64PatchGCRHelper);
-                TR::RegisterDependencyConditions *deps
-                    = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg->trMemory());
+                auto *deps = RegDeps(0, 2, cg);
                 TR::Register *tempReg = cg->allocateRegister();
                 deps->addPostCondition(tempMR->getBaseRegister(), TR::RealRegister::x0);
                 deps->addPostCondition(tempReg, TR::RealRegister::x1);
@@ -5887,8 +5885,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraytranslateEvaluator(TR::Node *node,
     TR::Register *inputLenReg = cg->gprClobberEvaluate(node->getChild(4));
     TR::Register *outputLenReg = cg->allocateRegister();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, numDeps, cg->trMemory());
+    auto *deps = RegDeps(1, numDeps, cg);
 
     deps->addPreCondition(inputReg, TR::RealRegister::x0);
 
@@ -6111,8 +6108,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         }
         if ((valueReg != NULL) && isValueZero) {
             TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-            TR::RegisterDependencyConditions *conditions
-                = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg->trMemory());
+            auto *conditions = RegDeps(0, 1, cg);
             conditions->addPostCondition(valueReg, TR::RealRegister::xzr);
             generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
         }
@@ -6311,8 +6307,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         }
 
         /* dstReg, lengthReg, valueReg, and registers allocated through SRM */
-        TR::RegisterDependencyConditions *conditions = new (cg->trHeapMemory())
-            TR::RegisterDependencyConditions(0, 3 + srm->numAvailableRegisters(), cg->trMemory());
+        auto *conditions = RegDeps(0, 3 + srm->numAvailableRegisters(), cg);
         conditions->addPostCondition(dstReg, TR::RealRegister::NoReg);
         conditions->addPostCondition(lengthReg, TR::RealRegister::NoReg);
         conditions->addPostCondition(valueReg, isValueZero ? TR::RealRegister::xzr : TR::RealRegister::NoReg);
@@ -6648,8 +6643,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
 
     /* savedSrc1Reg, src2Reg, lengthReg, resultReg, and registers allocated through SRM */
-    TR::RegisterDependencyConditions *conditions = new (cg->trHeapMemory())
-        TR::RegisterDependencyConditions(0, 4 + srm->numAvailableRegisters(), cg->trMemory());
+    auto *conditions = RegDeps(0, 4 + srm->numAvailableRegisters(), cg);
     conditions->addPostCondition(savedSrc1Reg, TR::RealRegister::NoReg);
     conditions->addPostCondition(src2Reg, TR::RealRegister::NoReg);
     conditions->addPostCondition(lengthReg, TR::RealRegister::NoReg);
@@ -6953,8 +6947,7 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
     //
 
     // x0-x3 and v30-v31 are destroyed in the helper
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(6, 6, cg->trMemory());
+    auto *deps = RegDeps(6, 6, cg);
     TR::addDependency(deps, lengthReg, TR::RealRegister::x0, TR_GPR, cg);
     TR::addDependency(deps, srcAddrReg, TR::RealRegister::x1, TR_GPR, cg);
     TR::addDependency(deps, dstAddrReg, TR::RealRegister::x2, TR_GPR, cg);
@@ -7149,8 +7142,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
         inlinePrimitiveForwardArraycopy(node, srcAddrReg, dstAddrReg, lengthReg, cg);
     } else {
         // x0-x3 and v30-v31 are destroyed in the helper
-        TR::RegisterDependencyConditions *deps
-            = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(6, 6, cg->trMemory());
+        auto *deps = RegDeps(6, 6, cg);
         TR::addDependency(deps, lengthReg, TR::RealRegister::x0, TR_GPR, cg);
         TR::addDependency(deps, srcAddrReg, TR::RealRegister::x1, TR_GPR, cg);
         TR::addDependency(deps, dstAddrReg, TR::RealRegister::x2, TR_GPR, cg);
@@ -7366,7 +7358,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
 
             cg->evaluate(child);
 
-            deps = generateRegisterDependencyConditions(cg, child, 0);
+            deps = RegDeps(cg, child, 0);
             if (cg->getCurrentEvaluationTreeTop() == comp->getStartTree()) {
                 for (i = 0; i < child->getNumChildren(); i++) {
                     TR::ParameterSymbol *sym = child->getChild(i)->getSymbol()->getParmSymbol();
@@ -7425,7 +7417,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
         if (node->getNumChildren() > 0) {
             TR::Node *child = node->getFirstChild();
             cg->evaluate(child);
-            deps = generateRegisterDependencyConditions(cg, child, 0);
+            deps = RegDeps(cg, child, 0);
             cg->decReferenceCount(child);
         }
     }
@@ -7620,7 +7612,7 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
         generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
 
         // Set the conditions and dependencies
-        auto conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg->trMemory());
+        auto conditions = RegDeps(0, 4, cg);
 
         conditions->addPostCondition(newValueReg, TR::RealRegister::NoReg);
         conditions->addPostCondition(oldValueReg, TR::RealRegister::NoReg);
@@ -7772,7 +7764,7 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
 
         // Set the conditions and dependencies
         const int numDeps = (valueReg != NULL) ? 5 : 4;
-        auto conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, numDeps, cg->trMemory());
+        auto conditions = RegDeps(0, numDeps, cg);
 
         conditions->addPostCondition(newValueReg, TR::RealRegister::NoReg);
         conditions->addPostCondition(oldValueReg, TR::RealRegister::NoReg);
@@ -7886,7 +7878,7 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
         generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
 
         // Set the conditions and dependencies
-        auto conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg->trMemory());
+        auto conditions = RegDeps(0, 4, cg);
 
         conditions->addPostCondition(oldValueReg, TR::RealRegister::NoReg);
         conditions->addPostCondition(addressReg, TR::RealRegister::NoReg);

--- a/compiler/aarch64/codegen/RegisterDependency.hpp
+++ b/compiler/aarch64/codegen/RegisterDependency.hpp
@@ -60,6 +60,17 @@ public:
 };
 } // namespace TR
 
+inline TR::RegisterDependencyConditions *RegDeps(TR::CodeGenerator *cg, TR::Node *node, uint32_t additionalRegDeps,
+    TR::Instruction **cursorPtr = NULL)
+{
+    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(cg, node, additionalRegDeps, cursorPtr);
+}
+
+inline TR::RegisterDependencyConditions *RegDeps(uint32_t numPreConds, uint32_t numPostConds, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numPreConds, numPostConds, cg->trMemory());
+}
+
 /**
  * @brief Generates RegisterDependencyConditions
  * @param[in] cg : CodeGenerator object
@@ -67,11 +78,15 @@ public:
  * @param[in] extranum : additional # of conditions
  * @param[in] cursorPtr : instruction cursor
  * @return generated RegisterDependencyConditions
+ *
+ * THE USE OF THE generateRegisterDependencyConditions() FUNCTIONS IS
+ * DEPRECATED IN FAVOUR OF THE MORE CONCISE RegDeps() FORMS AND SHOULD NOT BE
+ * USED. THESE DEPRECATED FORMS WILL BE REMOVED IN A FUTURE OMR RELEASE.
  */
 inline TR::RegisterDependencyConditions *generateRegisterDependencyConditions(TR::CodeGenerator *cg, TR::Node *node,
     uint32_t extranum, TR::Instruction **cursorPtr = NULL)
 {
-    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(cg, node, extranum, cursorPtr);
+    return RegDeps(cg, node, extranum, cursorPtr);
 }
 
 #endif


### PR DESCRIPTION
This commit replaces the calls to RegisterDependencyConditions constructor and generateRegisterDependencyConditions() in AArch64 codegen by new functions.