### PR TITLE
AArch64: Fix MemoryReference with index register

### DIFF
--- a/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/compiler/aarch64/codegen/MemoryReference.hpp
@@ -98,7 +98,7 @@ private:
 public:
     static TR::MemoryReference *create(TR::CodeGenerator *cg);
     static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg,
-        uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);
+        uint8_t scale = 0);
     static TR::MemoryReference *createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg,
         int64_t displacement);
     static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore);

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -40,9 +40,9 @@ TR::MemoryReference *TR::MemoryReference::create(TR::CodeGenerator *cg)
 }
 
 TR::MemoryReference *TR::MemoryReference::createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg,
-    TR::Register *indexReg, uint8_t scale, TR::ARM64ExtendCode extendCode)
+    TR::Register *indexReg, uint8_t scale)
 {
-    return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, cg);
+    return new (cg->trHeapMemory()) TR::MemoryReference(baseReg, indexReg, scale, cg);
 }
 
 TR::MemoryReference *TR::MemoryReference::createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg,
@@ -137,6 +137,21 @@ OMR::ARM64::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir,
     , _unresolvedSnippet(NULL)
     , _flag(0)
     , _scale(0)
+    , _length(0)
+{
+    _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
+    _offset = _symbolReference->getOffset();
+}
+
+OMR::ARM64::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir, uint8_t scale, TR::CodeGenerator *cg)
+    : _baseRegister(br)
+    , _baseNode(NULL)
+    , _indexRegister(ir)
+    , _indexNode(NULL)
+    , _extraRegister(NULL)
+    , _unresolvedSnippet(NULL)
+    , _flag(0)
+    , _scale(scale)
     , _length(0)
 {
     _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());


### PR DESCRIPTION
This commit changes generation of MemoryReference with index register on AArch64:

- Remove unused extendCode parameter from the createWithIndexReg() function
- Pass scale to MemoryReference constructor in createWithIndexReg()
- Implement MemoryReference constructor with baseReg, indexReg, and scale (Only declared until now)