### PR TITLE
RISC-V: remove length parameter from MemoryReference

### DIFF
--- a/compiler/riscv/codegen/FPTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/FPTreeEvaluator.cpp
@@ -123,25 +123,25 @@ TR::Register *OMR::RV::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGe
 // also handles floadi
 TR::Register *OMR::RV::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_flw, 4, cg);
+    return commonLoadEvaluator(node, OP::_flw, cg);
 }
 
 // also handles dloadi
 TR::Register *OMR::RV::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_fld, 8, cg);
+    return commonLoadEvaluator(node, OP::_fld, cg);
 }
 
 // also handles fstorei
 TR::Register *OMR::RV::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_fsw, 4, cg);
+    return commonStoreEvaluator(node, OP::_fsw, cg);
 }
 
 // also handles dstorei
 TR::Register *OMR::RV::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_fsd, 8, cg);
+    return commonStoreEvaluator(node, OP::_fsd, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/riscv/codegen/MemoryReference.hpp
+++ b/compiler/riscv/codegen/MemoryReference.hpp
@@ -67,23 +67,21 @@ public:
 
     /**
      * @brief Constructor
-     * @param[in] node : load or store node
-     * @param[in] len : length
+     * @param[in] rootLoadOrStore : load or store node
      * @param[in] cg : CodeGenerator object
      */
-    MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg)
-        : OMR::MemoryReferenceConnector(node, len, cg)
+    MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGenerator *cg)
+        : OMR::MemoryReferenceConnector(rootLoadOrStore, cg)
     {}
 
     /**
      * @brief Constructor
      * @param[in] node : node
      * @param[in] symRef : symbol reference
-     * @param[in] len : length
      * @param[in] cg : CodeGenerator object
      */
-    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg)
-        : OMR::MemoryReferenceConnector(node, symRef, len, cg)
+    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg)
+        : OMR::MemoryReferenceConnector(node, symRef, cg)
     {}
 };
 
@@ -119,7 +117,7 @@ inline TR::MemoryReference *MRef_Base(TR::Register *br, TR::CodeGenerator *cg) {
  */
 inline TR::MemoryReference *MRef_Node(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSize(), cg);
+    return new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
 }
 
 /**
@@ -132,7 +130,7 @@ inline TR::MemoryReference *MRef_Node(TR::Node *node, TR::CodeGenerator *cg)
  */
 inline TR::MemoryReference *MRef_Sym(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg)
 {
-    return new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSize(), cg);
+    return new (cg->trHeapMemory()) TR::MemoryReference(node, cg);
 }
 
 } // namespace TR

--- a/compiler/riscv/codegen/OMRMemoryReference.cpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.cpp
@@ -35,7 +35,6 @@ OMR::RV::MemoryReference::MemoryReference(TR::CodeGenerator *cg)
     , _baseNode(NULL)
     , _unresolvedSnippet(NULL)
     , _flag(0)
-    , _length(0)
     , _scale(0)
 {
     _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
@@ -47,7 +46,6 @@ OMR::RV::MemoryReference::MemoryReference(TR::Register *br, TR::CodeGenerator *c
     , _baseNode(NULL)
     , _unresolvedSnippet(NULL)
     , _flag(0)
-    , _length(0)
     , _scale(0)
 {
     _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
@@ -59,19 +57,17 @@ OMR::RV::MemoryReference::MemoryReference(TR::Register *br, int32_t disp, TR::Co
     , _baseNode(NULL)
     , _unresolvedSnippet(NULL)
     , _flag(0)
-    , _length(0)
     , _scale(0)
     , _offset(disp)
 {
     _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
 }
 
-OMR::RV::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, uint32_t len, TR::CodeGenerator *cg)
+OMR::RV::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGenerator *cg)
     : _baseRegister(NULL)
     , _baseNode(NULL)
     , _unresolvedSnippet(NULL)
     , _flag(0)
-    , _length(len)
     , _scale(0)
     , _offset(0)
     , _symbolReference(rootLoadOrStore->getSymbolReference())
@@ -104,13 +100,11 @@ OMR::RV::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, uint32_t le
     }
 }
 
-OMR::RV::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len,
-    TR::CodeGenerator *cg)
+OMR::RV::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg)
     : _baseRegister(NULL)
     , _baseNode(NULL)
     , _unresolvedSnippet(NULL)
     , _flag(0)
-    , _length(len)
     , _scale(0)
     , _offset(0)
     , _symbolReference(symRef)

--- a/compiler/riscv/codegen/OMRMemoryReference.hpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.hpp
@@ -66,7 +66,6 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference {
     TR::SymbolReference *_symbolReference;
 
     uint8_t _flag;
-    uint8_t _length;
     uint8_t _scale;
 
 public:
@@ -100,20 +99,18 @@ public:
 
     /**
      * @brief Constructor
-     * @param[in] node : load or store node
-     * @param[in] len : length
+     * @param[in] rootLoadOrStore : load or store node
      * @param[in] cg : CodeGenerator object
      */
-    MemoryReference(TR::Node *node, uint32_t len, TR::CodeGenerator *cg);
+    MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGenerator *cg);
 
     /**
      * @brief Constructor
      * @param[in] node : node
      * @param[in] symRef : symbol reference
-     * @param[in] len : length
      * @param[in] cg : CodeGenerator object
      */
-    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, uint32_t len, TR::CodeGenerator *cg);
+    MemoryReference(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg);
 
     /**
      * @brief Gets base register
@@ -140,19 +137,6 @@ public:
      * @return base node
      */
     TR::Node *setBaseNode(TR::Node *bn) { return (_baseNode = bn); }
-
-    /**
-     * @brief Gets length
-     * @return length
-     */
-    uint32_t getLength() { return _length; }
-
-    /**
-     * @brief Sets length
-     * @param[in] len : length
-     * @return length
-     */
-    uint32_t setLength(uint32_t len) { return (_length = len); }
 
     /**
      * @brief Gets scale

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -2423,7 +2423,7 @@ TR::Register *OMR::RV::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeG
     return OMR::RV::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
 {
     TR::Register *tempReg;
     if (op == OP::_flw) {
@@ -2453,7 +2453,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
 // also handles iloadi
 TR::Register *OMR::RV::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_lw, 4, cg);
+    return commonLoadEvaluator(node, OP::_lw, cg);
 }
 
 // also handles aloadi
@@ -2507,19 +2507,19 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
 // also handles lloadi
 TR::Register *OMR::RV::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_ld, 8, cg);
+    return commonLoadEvaluator(node, OP::_ld, cg);
 }
 
 // also handles bloadi
 TR::Register *OMR::RV::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_lb, 1, cg);
+    return commonLoadEvaluator(node, OP::_lb, cg);
 }
 
 // also handles sloadi
 TR::Register *OMR::RV::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, OP::_lh, 2, cg);
+    return commonLoadEvaluator(node, OP::_lh, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2527,7 +2527,7 @@ TR::Register *OMR::RV::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeG
     return OMR::RV::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
+TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
 {
     TR::MemoryReference *tempMR = MRef_Node(node, cg);
     TR::Node *valueChild;
@@ -2564,25 +2564,25 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
 // also handles lstorei, astore, astorei
 TR::Register *OMR::RV::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_sd, 8, cg);
+    return commonStoreEvaluator(node, OP::_sd, cg);
 }
 
 // also handles bstorei
 TR::Register *OMR::RV::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_sb, 1, cg);
+    return commonStoreEvaluator(node, OP::_sb, cg);
 }
 
 // also handles sstorei
 TR::Register *OMR::RV::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_sh, 2, cg);
+    return commonStoreEvaluator(node, OP::_sh, cg);
 }
 
 // also handles istorei
 TR::Register *OMR::RV::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, OP::_sw, 4, cg);
+    return commonStoreEvaluator(node, OP::_sw, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::monentEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -65,7 +65,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
  * @param[in] memSize : data size on memory
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg);
+TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
 /**
  * @brief Helper function for xstoreEvaluators
@@ -74,7 +74,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
  * @param[in] memSize : data size on memory
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg);
+TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg);
 
 namespace OMR { namespace RV {
 


### PR DESCRIPTION
This PR removes length parameter from MemoryReference ctors. This is a prerequisite for a follow-up PR to #8215 that will introduce short(er) names in RISC-V backend. 