### PR TITLE
AArch64: Replace magic numbers for extendCode in MemoryReference

### DIFF
--- a/compiler/aarch64/codegen/ARM64ShiftCode.hpp
+++ b/compiler/aarch64/codegen/ARM64ShiftCode.hpp
@@ -35,17 +35,18 @@ typedef enum {
 } ARM64ShiftCode;
 
 /*
- * Extend codes used in "extended register" instructions
+ * Extend codes used in "extended register" instructions and memory references
  */
 typedef enum {
     EXT_UXTB = 0,
     EXT_UXTH,
     EXT_UXTW,
     EXT_UXTX,
+    EXT_LSL = EXT_UXTX, // alias
     EXT_SXTB,
     EXT_SXTH,
     EXT_SXTW,
-    EXT_SXTX,
+    EXT_SXTX
 } ARM64ExtendCode;
 
 /*

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -1091,11 +1091,9 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
                     index->setRegisterFieldRM(wcursor);
 
                     if (self()->isIndexSignExtendedWord()) {
-                        // SXTW
-                        *wcursor |= 0x6 << 13;
+                        *wcursor |= TR::EXT_SXTW << 13;
                     } else {
-                        // LSL
-                        *wcursor |= 0x3 << 13;
+                        *wcursor |= TR::EXT_LSL << 13;
                     }
                     uint8_t scale = self()->getScale();
                     if (scale != 0) {


### PR DESCRIPTION
This commit replaces some magic numbers in MemoryReference for AArch64 with EXT_SXTW and EXT_LSL.