### PR TITLE
Support objcopy compression via OMR_OBJCOPY_COMPRESS_FLAGS

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -176,7 +176,7 @@ function(_omr_toolchain_separate_debug_symbols tgt)
 			add_custom_command(
 				TARGET "${tgt}"
 				POST_BUILD
-				COMMAND "${CMAKE_OBJCOPY}" --only-keep-debug "${exe_file}" "${dbg_file}"
+				COMMAND "${CMAKE_OBJCOPY}" ${OMR_OBJCOPY_COMPRESS_FLAGS} --only-keep-debug "${exe_file}" "${dbg_file}"
 			)
 			if (NOT ${skip_strip})
 				add_custom_command(


### PR DESCRIPTION
OpenJDK added the configuration option `--enable-objcopy-debuginfo-compression`
* [8383243: Make objcopy configurable to compress debug info](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/e77f7ecdbbcdf4fe8d5ed584cf423e97b1289ee8)

In a local build on x86-64 Linux, using that option (via this change) shrinks `.debuginfo` files from a total of around 1.1GB to 457MB.