### PR TITLE
Nursery only sliding compact

### DIFF
--- a/gc/base/standard/CompactScheme.cpp
+++ b/gc/base/standard/CompactScheme.cpp
@@ -352,12 +352,12 @@ MM_CompactScheme::postObjectMove(MM_EnvironmentBase *env, omrobjectptr_t objectP
 }
 
 void
-MM_CompactScheme::workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded)
+MM_CompactScheme::workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded, bool nurseryOnly)
 {
-	createSubAreaTable(env, singleThreaded);
+	createSubAreaTable(env, singleThreaded, nurseryOnly);
 	setRealLimitsSubAreas(env);
 	removeNullSubAreas(env);
-	completeSubAreaTable(env);
+	completeSubAreaTable(env, nurseryOnly);
 }
 
 void
@@ -385,7 +385,7 @@ MM_CompactScheme::freeChunkEnd(omrobjectptr_t chunk)
  *  Create sub areas table for regions.
  */
 void
-MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded)
+MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded, bool nurseryOnly)
 {
 	/* finding whether there are memory limitations */
 	uintptr_t max_subarea_num = _subAreaTableSize / sizeof(_subAreaTable[0]);
@@ -395,7 +395,7 @@ MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThr
 	GC_HeapRegionIteratorStandard regionCounter(_rootManager);
 	MM_HeapRegionDescriptorStandard *region = NULL;
 	uintptr_t number_of_regions = 0;
-	while(NULL != (region = regionCounter.nextRegion())) {
+	while (NULL != (region = regionCounter.nextRegion())) {
 		if (region->isCommitted()) {
 			number_of_regions += 1;
 		}
@@ -405,7 +405,7 @@ MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThr
 
 	Assert_MM_true(max_subarea_num > 0);
 
-	if(max_subarea_num > necessary_subareas) {
+	if (max_subarea_num > necessary_subareas) {
 		min_subarea_size = _heap->getMaximumPhysicalRange() / (max_subarea_num - necessary_subareas);
 	} else {
 		min_subarea_size = _heap->getMaximumPhysicalRange();
@@ -419,7 +419,7 @@ MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThr
 	if (env->_currentTask->synchronizeGCThreadsAndReleaseMain(env, UNIQUE_ID)) {
 		GC_HeapRegionIteratorStandard regionIterator(_rootManager);
 		uintptr_t i = 0;
-		while(NULL != (region = regionIterator.nextRegion())) {
+		while (NULL != (region = regionIterator.nextRegion())) {
 			if (!region->isCommitted() || (0 == region->getSize())) {
 				continue;
 			}
@@ -428,6 +428,9 @@ MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThr
 			uintptr_t areaSize = region->getSize();
 			MM_MemorySubSpace *memorySubSpace = region->getSubSpace();
 			intptr_t state = SubAreaEntry::init;
+			if (nurseryOnly && OMR_ARE_ALL_BITS_SET(memorySubSpace->getTypeFlags(), MEMORY_TYPE_OLD)) {
+				state = SubAreaEntry::fixup_only;
+			}
 
 			if (singleThreaded) {
 				size = areaSize;
@@ -437,7 +440,7 @@ MM_CompactScheme::createSubAreaTable(MM_EnvironmentStandard *env, bool singleThr
 			/* Calculate number of sub areas..take care to avoid overflow if size is large */
 			uintptr_t numSubAreas = ((areaSize - 1) / size) + 1;
 
-			for( uintptr_t subAreaNum=0; subAreaNum < numSubAreas; subAreaNum++){
+			for (uintptr_t subAreaNum=0; subAreaNum < numSubAreas; subAreaNum++){
 				uint8_t *p = (uint8_t*)(((uintptr_t)lowAddress) + (subAreaNum * size));
 
 				_subAreaTable[i].freeChunk = (omrobjectptr_t)p;
@@ -517,7 +520,7 @@ MM_CompactScheme::removeNullSubAreas(MM_EnvironmentStandard *env)
  *  Complete setup for each sub area.
  */
 void
-MM_CompactScheme::completeSubAreaTable(MM_EnvironmentStandard *env)
+MM_CompactScheme::completeSubAreaTable(MM_EnvironmentStandard *env, bool nurseryOnly)
 {
 	if (env->_currentTask->synchronizeGCThreadsAndReleaseMain(env, UNIQUE_ID)) {
 		MM_HeapRegionDescriptorStandard *region = NULL;
@@ -526,11 +529,15 @@ MM_CompactScheme::completeSubAreaTable(MM_EnvironmentStandard *env)
 		 * rebuild of free list at end of compaction
 		 */
 		GC_HeapRegionIteratorStandard regionIterator2(_rootManager);
-		while(NULL != (region = regionIterator2.nextRegion())) {
+		while (NULL != (region = regionIterator2.nextRegion())) {
 			if (!region->isCommitted() || (0 == region->getSize())) {
 				continue;
 			}
 			MM_MemorySubSpace *subspace = region->getSubSpace();
+			if (nurseryOnly && OMR_ARE_ALL_BITS_SET(subspace->getTypeFlags(), MEMORY_TYPE_OLD)) {
+				continue;
+			}
+
 			MM_MemoryPool *memoryPool = subspace->getMemoryPool();
 			memoryPool->reset(MM_MemoryPool::forCompact);
 		}
@@ -540,7 +547,7 @@ MM_CompactScheme::completeSubAreaTable(MM_EnvironmentStandard *env)
 }
 
 void
-MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, bool aggressive)
+MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, bool aggressive, bool nurseryOnly)
 {
 	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
@@ -577,7 +584,7 @@ MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, boo
 	}
 
 	env->_compactStats._setupStartTime = omrtime_hires_clock();
-	workerSetupForGC(env, singleThreaded);
+	workerSetupForGC(env, singleThreaded, nurseryOnly);
 	env->_compactStats._setupEndTime = omrtime_hires_clock();
 
 	/* If a single threaded compaction force compact to run on main thread. Required
@@ -595,7 +602,7 @@ MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, boo
 
 		env->_compactStats._fixupStartTime = omrtime_hires_clock();
 
-		fixupObjects(env, fixupObjectsCount);
+		fixupObjects(env, fixupObjectsCount, nurseryOnly);
 
 
 		env->_compactStats._fixupEndTime = omrtime_hires_clock();
@@ -607,19 +614,21 @@ MM_CompactScheme::compact(MM_EnvironmentBase *envBase, bool rebuildMarkBits, boo
 
 	/* FixupRoots can always be done in parallel */
 	env->_compactStats._rootFixupStartTime = omrtime_hires_clock();
-	_delegate.fixupRoots(env, this);
+	_delegate.fixupRoots(env, this, nurseryOnly);
 	env->_compactStats._rootFixupEndTime = omrtime_hires_clock();
 
 	MM_AtomicOperations::sync();
 
 	if (env->_currentTask->synchronizeGCThreadsAndReleaseMain(env, UNIQUE_ID)) {
-		rebuildFreelist(env);
+		rebuildFreelist(env, nurseryOnly);
 
 		MM_MemoryPool *memoryPool;
 		MM_HeapMemoryPoolIterator poolIterator(env, _extensions->heap);
 
-		while(NULL != (memoryPool = poolIterator.nextPool())) {
-			memoryPool->postProcess(env, MM_MemoryPool::forCompact);
+		while (NULL != (memoryPool = poolIterator.nextPool())) {
+			if (!nurseryOnly || OMR_ARE_NO_BITS_SET(memoryPool->getSubSpace()->getTypeFlags(), MEMORY_TYPE_OLD)) {
+				memoryPool->postProcess(env, MM_MemoryPool::forCompact);
+			}
 		}
 
 		MM_AtomicOperations::sync();
@@ -654,7 +663,7 @@ MM_CompactScheme::flushPool(MM_EnvironmentStandard *env, MM_CompactMemoryPoolSta
 	memoryPool->setLastFreeEntry(poolState->_previousFreeEntry);
 }
 
-void MM_CompactScheme::rebuildFreelist(MM_EnvironmentStandard *env)
+void MM_CompactScheme::rebuildFreelist(MM_EnvironmentStandard *env, bool nurseryOnly)
 {
 	uintptr_t i = 0;
 	MM_HeapRegionManager *regionManager = _heap->getHeapRegionManager();
@@ -662,7 +671,7 @@ void MM_CompactScheme::rebuildFreelist(MM_EnvironmentStandard *env)
 	MM_HeapRegionDescriptorStandard *region = NULL;
 	SubAreaEntry *subAreaTable = _subAreaTable;
 
-	while(NULL != (region = regionIterator.nextRegion())) {
+	while (NULL != (region = regionIterator.nextRegion())) {
 		if (!region->isCommitted() || (0 == region->getSize())) {
 			continue;
 		}
@@ -715,6 +724,10 @@ void MM_CompactScheme::rebuildFreelist(MM_EnvironmentStandard *env)
 				currentFreeSize = 0;
 			}
         } while (subAreaTable[i++].state != SubAreaEntry::end_segment);
+
+		if (nurseryOnly && OMR_ARE_ALL_BITS_SET(memorySubSpace->getTypeFlags(), MEMORY_TYPE_OLD)) {
+			continue;
+		}
 
 		Assert_MM_true(currentFreeBase == NULL);
 
@@ -1343,7 +1356,7 @@ MM_CompactScheme::getForwardingPtr(omrobjectptr_t objectPtr) const
 }
 
 void
-MM_CompactScheme::fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCount)
+MM_CompactScheme::fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCount, bool nurseryOnly)
 {
 	MM_HeapRegionManager *regionManager = _heap->getHeapRegionManager();
 	GC_HeapRegionIteratorStandard regionIterator(regionManager);
@@ -1356,6 +1369,10 @@ MM_CompactScheme::fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCou
 		}
 		intptr_t i;
         for (i = 0; subAreaTable[i].state != SubAreaEntry::end_segment; i++) {
+			if (nurseryOnly && OMR_ARE_ALL_BITS_SET(region->getSubSpace()->getTypeFlags(), MEMORY_TYPE_OLD)) {
+				continue;
+			}
+
         	if (changeSubAreaAction(env, &subAreaTable[i], SubAreaEntry::fixing_up)) {
         		fixupSubArea(env, subAreaTable[i].firstObject, subAreaTable[i+1].firstObject, subAreaTable[i].state == SubAreaEntry::fixup_only, objectCount);
 			}
@@ -1492,7 +1509,7 @@ MM_CompactScheme::parallelFixHeapForWalk(MM_EnvironmentBase *env)
         	if (subAreaTable[i].state == SubAreaEntry::fixup_only) {
 	        	if (changeSubAreaAction(env, &subAreaTable[i], SubAreaEntry::fixing_heap_for_walk)) {
 	        		omrobjectptr_t start = subAreaTable[i].firstObject;
-					omrobjectptr_t end   = subAreaTable[i].firstObject;
+					omrobjectptr_t end   = subAreaTable[i + 1].firstObject;
 					omrobjectptr_t alignedEnd = pageStart(pageIndex(end));
 
 					GC_ObjectHeapIteratorAddressOrderedList objectIterator(_extensions, start, end, false);

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -160,7 +160,7 @@ protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
 
-	void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded);
+	void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded, bool nurseryOnly);
 	/**
 	 * Set the real limits for a specific subArea
 	 *
@@ -168,7 +168,7 @@ protected:
 	 */
 	void setRealLimitsSubAreas(MM_EnvironmentStandard *env);
 	void removeNullSubAreas(MM_EnvironmentStandard *env);
-	void completeSubAreaTable(MM_EnvironmentStandard *env);
+	void completeSubAreaTable(MM_EnvironmentStandard *env, bool nurseryOnly);
 
 	void saveForwardingPtr(class CompactTableEntry&,
 					omrobjectptr_t objectPtr,
@@ -216,9 +216,9 @@ protected:
 	 * @param[in/out] objectCount the number of objects fixed up (accumulated)
 	 */
 	void fixupSubArea(MM_EnvironmentStandard *env, omrobjectptr_t firstObject, omrobjectptr_t finish,  bool markedOnly, uintptr_t& objectCount);
-	void fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCount);
+	void fixupObjects(MM_EnvironmentStandard *env, uintptr_t& objectCount, bool nurseryOnly);
 
-	void rebuildFreelist(MM_EnvironmentStandard *env);
+	void rebuildFreelist(MM_EnvironmentStandard *env, bool nurseryOnly);
 
 	void addFreeEntry(MM_EnvironmentStandard *env,
 					MM_MemorySubSpace *memorySubSpace,
@@ -307,9 +307,9 @@ public:
 	
 	void kill(MM_EnvironmentBase *env);
 
-	void workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded);
+	void workerSetupForGC(MM_EnvironmentStandard *env, bool singleThreaded, bool nurseryOnly);
 	void mainSetupForGC(MM_EnvironmentStandard *env);
-	virtual void compact(MM_EnvironmentBase *env, bool rebuildMarkBits, bool aggressive);
+	virtual void compact(MM_EnvironmentBase *env, bool rebuildMarkBits, bool aggressive, bool nurseryOnly);
 	omrobjectptr_t getForwardingPtr(omrobjectptr_t objectPtr) const;
 	void flushPool(MM_EnvironmentStandard *env, MM_CompactMemoryPoolState *freeListState);
 	void fixHeapForWalk(MM_EnvironmentBase *env, uintptr_t walkFlags, uintptr_t walkReason);

--- a/gc/base/standard/ParallelCompactTask.cpp
+++ b/gc/base/standard/ParallelCompactTask.cpp
@@ -42,7 +42,7 @@ MM_ParallelCompactTask::getVMStateID()
 void
 MM_ParallelCompactTask::run(MM_EnvironmentBase *env)
 {
-	_compactScheme->compact(env, _rebuildMarkBits, _aggressive);
+	_compactScheme->compact(env, _rebuildMarkBits, _aggressive, _nurseryOnly);
 }
 
 void

--- a/gc/base/standard/ParallelCompactTask.hpp
+++ b/gc/base/standard/ParallelCompactTask.hpp
@@ -48,6 +48,7 @@ private:
 	MM_CompactScheme *_compactScheme;
 	bool _rebuildMarkBits;
 	bool _aggressive;
+	bool _nurseryOnly; /**< if true, Nursery is only compacted and Tenure fixed-up via RS, otherwise whole heap is compacted/fixed-up */
 
 public:
 	virtual uintptr_t getVMStateID();
@@ -59,11 +60,12 @@ public:
 	/**
 	 * Create an ParallelCompactTask object.
 	 */
-	MM_ParallelCompactTask(MM_EnvironmentBase *env, MM_ParallelDispatcher *dispatcher, MM_CompactScheme *compactScheme, bool rebuildMarkBits, bool aggressive) :
+	MM_ParallelCompactTask(MM_EnvironmentBase *env, MM_ParallelDispatcher *dispatcher, MM_CompactScheme *compactScheme, bool rebuildMarkBits, bool aggressive, bool nurseryOnly) :
 		MM_ParallelTask(env, dispatcher),
 		_compactScheme(compactScheme),
 		_rebuildMarkBits(rebuildMarkBits),
-		_aggressive(aggressive)
+		_aggressive(aggressive),
+		_nurseryOnly(nurseryOnly)
 	{
 		_typeId = __FUNCTION__;
 	};

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -484,7 +484,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 	_extensions->globalGCStats.clear();
 
 #if defined(OMR_GC_MODRON_COMPACTION)
-	_compactThisCycle = false;
+	_compactThisCycle = COMPACT_NONE;
 #endif /* OMR_GC_MODRON_COMPACTION */
 
 	_fixHeapForWalkCompleted = false;
@@ -505,7 +505,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 
 #if defined(OMR_GC_MODRON_COMPACTION)
 	/* If a compaction was required, then do one */
-	if (_compactThisCycle) {
+	if (COMPACT_NONE != _compactThisCycle) {
 		_collectionStatistics._tenureFragmentation = MICRO_FRAGMENTATION;
 		if (GLOBALGC_ESTIMATE_FRAGMENTATION == (_extensions->estimateFragmentation & GLOBALGC_ESTIMATE_FRAGMENTATION)) {
 			_collectionStatistics._tenureFragmentation |= MACRO_FRAGMENTATION;
@@ -537,7 +537,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 	}
 #endif /* defined(OMR_GC_MODRON_COMPACTION) */	
 
-	bool compactedThisCycle = false;
+	CompactReason compactedThisCycle = COMPACT_NONE;
 #if defined(OMR_GC_MODRON_COMPACTION)
 	compactedThisCycle = _compactThisCycle;
 #endif /* OMR_GC_MODRON_COMPACTION */
@@ -548,7 +548,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 	if (_delegate.isAllowUserHeapWalk() || gcCode.isRASDumpGC() || gcCode.shouldClearHeap()) {
 		if (!_fixHeapForWalkCompleted) {
 #if defined(OMR_GC_MODRON_COMPACTION)
-			if (compactedThisCycle) {
+			if (COMPACT_NONE != compactedThisCycle) {
 				getCompactScheme(env)->fixHeapForWalk(env, MEMORY_TYPE_RAM, FIXUP_DEBUG_TOOLING);
 			} else
 #endif /* OMR_GC_MODRON_COMPACTION */
@@ -565,7 +565,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 	_delegate.mainThreadGarbageCollectFinished(env, compactedThisCycle);
 
 #if defined(OMR_GC_MODRON_COMPACTION)
-	if (compactedThisCycle) {
+	if (COMPACT_NONE != compactedThisCycle) {
 		/* Free space will have changed as a result of compaction so recalculate
 		 * any expand or contract target.
 		 * Concurrent Scavenger requires this be done after fixup heap for walk pass.
@@ -598,7 +598,7 @@ MM_ParallelGlobalGC::mainThreadGarbageCollect(MM_EnvironmentBase *env, MM_Alloca
 }
 
 #if defined(OMR_GC_MODRON_COMPACTION)
-bool
+CompactReason
 MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t activeSubspaceMaxExpansionInSpace, MM_GCCode gcCode) 
 {
 	MM_Heap *heap = _extensions->heap;
@@ -644,12 +644,6 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 		compactReason = COMPACT_ALWAYS;
 		goto compactionReqd;
 	}
-
-	/* Aborted CS needs global GC with Nursery compaction */
-	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
-		compactReason = COMPACT_ABORTED_SCAVENGE;
-		goto compactionReqd;
-	}	
 
 	/* Is this a system GC ? */ 
 	if (gcCode.isExplicitGC()) {
@@ -801,7 +795,15 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 		}
 	}
 
-	
+	/* Since for aborted CS only Nursery is compacted, it's at the bottom so that any other full-heap
+	 * compact can trigger before it. Still, it should not be prevented by compactToSatisfyAllocate,
+	 * whose main goal is to avoid expensive not-very-necessary compacts.
+	 */
+	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
+		compactReason = COMPACT_ABORTED_SCAVENGE;
+		goto compactionReqd;
+	}
+
 nocompact:	
 	/* Compaction not required or prevented from running */
 	_extensions->globalGCStats.compactStats._compactReason = compactReason;
@@ -809,7 +811,7 @@ nocompact:
 
 	Trc_ParallelGlobalGC_shouldCompactThisCycle_exit(env->getLanguageVMThread(), "nocompact", compactReason, compactPreventedReason);
 
-	return false;
+	return COMPACT_NONE;
 	
 compactionReqd:
 	compactPreventedReason = _delegate.checkIfCompactionShouldBePrevented(env);
@@ -822,7 +824,7 @@ compactionReqd:
 
 	Trc_ParallelGlobalGC_shouldCompactThisCycle_exit(env->getLanguageVMThread(), "compactionReqd", compactReason, compactPreventedReason);
 
-	return true;
+	return compactReason;
 }
 
 /**
@@ -831,7 +833,7 @@ compactionReqd:
  * beneficial before we attempt to contract the heap.
  * @return true if a compaction is required, false otherwise.
  */
-bool
+CompactReason
 MM_ParallelGlobalGC::compactRequiredBeforeHeapContraction(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t contractionSize)
 {
 	uintptr_t lengthLastFree;
@@ -840,12 +842,12 @@ MM_ParallelGlobalGC::compactRequiredBeforeHeapContraction(MM_EnvironmentBase *en
 	
 	/* if the user specified -XnoCompact then we're done */
 	if (_extensions->noCompactOnGlobalGC) {
-		return false;
+		return COMPACT_NONE;
 	}	
 	
 	if (env->_cycleState->_gcCode.isExplicitGC() && _extensions->nocompactOnSystemGC){
 		/* if the user specified -XnocompactexplicitGC then we don't compact*/
-		return false;
+		return COMPACT_NONE;
 	}
 
 	uintptr_t actualSoftMx = _extensions->heap->getActualSoftMxSize(env);
@@ -868,7 +870,7 @@ MM_ParallelGlobalGC::compactRequiredBeforeHeapContraction(MM_EnvironmentBase *en
 	 */
 	if((_extensions->globalGCStats.compactStats._lastHeapCompaction + 1 ==  _extensions->globalGCStats.gcCount) &&
 	(_extensions->heap->getResizeStats()->getLastHeapContractionGCCount() + 1 ==  _extensions->globalGCStats.gcCount)) {
-		return false;
+		return COMPACT_NONE;
 	}
 
 	/* Determine length of free chunk at top of heap */
@@ -883,14 +885,14 @@ MM_ParallelGlobalGC::compactRequiredBeforeHeapContraction(MM_EnvironmentBase *en
 								 * _extensions->minimumContractionRatio;
 
 		if (lengthLastFree > minContractSize) {
-			return false;
+			return COMPACT_NONE;
 		}
 	}
 
 compactionReqd:
 	_extensions->globalGCStats.compactStats._compactPreventedReason = _delegate.checkIfCompactionShouldBePrevented(env);
 	if (COMPACT_PREVENTED_NONE != _extensions->globalGCStats.compactStats._compactPreventedReason) {
-		return false;
+		return COMPACT_NONE;
 	}
 
 	/* If we get here we need to compact to assist the contraction. 
@@ -898,7 +900,7 @@ compactionReqd:
 	 */
 	_extensions->globalGCStats.compactStats._compactReason = COMPACT_CONTRACT;
 	
-	return true;
+	return COMPACT_CONTRACT;
 }
 #endif /* defined(OMR_GC_MODRON_COMPACTION) */
 
@@ -922,7 +924,7 @@ MM_ParallelGlobalGC::sweep(MM_EnvironmentBase *env, MM_AllocateDescription *allo
 	/* Decide is a compaction is required - this decision must be made after we sweep since we use the largestFreeEntrySize, as changed by sweep, to determine if a compaction should be done */
 	_compactThisCycle = shouldCompactThisCycle(env, allocDescription, activeSubSpace->maxExpansionInSpace(env), env->_cycleState->_gcCode);
 
-	if (!_compactThisCycle)  
+	if (COMPACT_NONE == _compactThisCycle)
 #endif /* OMR_GC_MODRON_COMPACTION */		
 	{
 		/* Decide whether we need to expand or shrink the heap. If the decision is to 
@@ -937,7 +939,7 @@ MM_ParallelGlobalGC::sweep(MM_EnvironmentBase *env, MM_AllocateDescription *allo
 		mainThreadSweepComplete(env, reason);
 			
 #if defined(OMR_GC_MODRON_COMPACTION)
-		if (!_compactThisCycle)  
+		if (COMPACT_NONE == _compactThisCycle)
 #endif /* OMR_GC_MODRON_COMPACTION */		
 		{
 			/* We now have accurate free space statistics so recalculate any expand/contract amount
@@ -1038,7 +1040,9 @@ MM_ParallelGlobalGC::mainThreadCompact(MM_EnvironmentBase *env, MM_AllocateDescr
 
 	reportCompactStart(env);
 	compactStats->_startTime = omrtime_hires_clock();
-	MM_ParallelCompactTask compactTask(env, _dispatcher, _compactScheme, rebuildMarkBits, env->_cycleState->_gcCode.shouldAggressivelyCompact());
+	bool nurseryOnly = (CompactReason::COMPACT_ABORTED_SCAVENGE == compactStats->_compactReason);
+
+	MM_ParallelCompactTask compactTask(env, _dispatcher, _compactScheme, rebuildMarkBits, env->_cycleState->_gcCode.shouldAggressivelyCompact(), nurseryOnly);
 	_dispatcher->run(env, &compactTask);
 	compactStats->_endTime = omrtime_hires_clock();
 	reportCompactEnd(env);

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -69,7 +69,7 @@ private:
 
 #if defined(OMR_GC_MODRON_COMPACTION)
 	MM_CompactScheme *_compactScheme;
-	bool _compactThisCycle;		/**< keep a decision should compact run this cycle */
+	CompactReason _compactThisCycle;		/**< keep a decision should compact run this cycle */
 #endif /* OMR_GC_MODRON_COMPACTION */
 
 protected:
@@ -135,14 +135,14 @@ private:
 	 *
 	 * @return true if a compaction is required, false otherwise
 	 */
-	bool shouldCompactThisCycle(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t activeSubspaceMaxExpansionInSpace, MM_GCCode gcCode);
+	CompactReason shouldCompactThisCycle(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t activeSubspaceMaxExpansionInSpace, MM_GCCode gcCode);
 	/**
 	 * Determine if a compact is required to aid contraction.
 	 * A heap contraction is due so decide whether a compaction would be
 	 * beneficial before we attempt to contract the heap.
 	 * @return true if a compaction is required, false otherwise.
 	 */
-	bool compactRequiredBeforeHeapContraction(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t contractionSize);
+	CompactReason compactRequiredBeforeHeapContraction(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t contractionSize);
 #endif /* OMR_GC_MODRON_COMPACTION */
 
 	/**
@@ -345,7 +345,7 @@ public:
 		, _portLibrary(env->getPortLibrary())
 #if defined(OMR_GC_MODRON_COMPACTION)
 		, _compactScheme(NULL)
-		, _compactThisCycle(false)
+		, _compactThisCycle(COMPACT_NONE)
 #endif /* OMR_GC_MODRON_COMPACTION */
 		, _markingScheme(NULL)
 		, _sweepScheme(NULL)


### PR DESCRIPTION
Nursery only sliding compact

- modified Sliding Compactor to be able to perform movement of objects
   only in Nursery. Tenure objects are not moved, but references from
   Tenure objects to moved Nursery objects are updated/fixed via
   Remembered Set
- modified Aborted Concurrent Scavenge compact reason to use Nursery
   only compaction (as before to help with efficient Tilting)
- reduced the priority of Aborted CS compact reason, so that any other
   full compact triggers before it

Issue: https://github.com/eclipse-openj9/openj9/issues/20515

Signed-off-by: Shadman Siddiqui shadman2606@gmail.com