### PR TITLE
RISC-V: use shorter names

### DIFF
--- a/compiler/riscv/codegen/BinaryEvaluator.cpp
+++ b/compiler/riscv/codegen/BinaryEvaluator.cpp
@@ -48,8 +48,8 @@ static void truncate(TR::Node *node, TR::Register *reg, TR::CodeGenerator *cg)
         return;
     }
 
-    Inst_ITYPE(TR::InstOpCode::_slli, node, reg, reg, 64 - bitwidth, cg);
-    Inst_ITYPE(TR::InstOpCode::_srai, node, reg, reg, 64 - bitwidth, cg);
+    Inst_ITYPE(OP::_slli, node, reg, reg, 64 - bitwidth, cg);
+    Inst_ITYPE(OP::_srai, node, reg, reg, 64 - bitwidth, cg);
 }
 
 /*
@@ -66,14 +66,14 @@ static TR::Register *RorIhelper(TR::Node *node, TR::InstOpCode::Mnemonic opr, TR
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *trgReg = cg->allocateRegister();
 
-    if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL && opi != TR::InstOpCode::bad) {
+    if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL && opi != OP::bad) {
         int64_t value = secondChild->getLongInt();
         if (VALID_ITYPE_IMM(value)) {
             /*
              * We have to convert _sub (_subw) to _addi (_addiw) since there's no
              * _subi (_subiw)
              */
-            if (opr == TR::InstOpCode::_sub || opr == TR::InstOpCode::_subw) {
+            if (opr == OP::_sub || opr == OP::_subw) {
                 value = -value;
             }
             Inst_ITYPE(opi, node, trgReg, src1Reg, value, cg);
@@ -118,7 +118,7 @@ static TR::Register *Rhelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Co
 // also handles badd and sadd
 TR::Register *OMR::RV::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_addw, TR::InstOpCode::_addiw, cg);
+    return RorIhelper(node, OP::_addw, OP::_addiw, cg);
 }
 
 // also handles aiadd and aladd
@@ -132,14 +132,14 @@ TR::Register *OMR::RV::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGene
     if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL) {
         int64_t value = secondChild->getLongInt();
         if (VALID_ITYPE_IMM(value)) {
-            Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, value, cg);
+            Inst_ITYPE(OP::_addi, node, trgReg, src1Reg, value, cg);
         } else {
             TR::Register *src2Reg = cg->evaluate(secondChild);
-            Inst_RTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
+            Inst_RTYPE(OP::_add, node, trgReg, src1Reg, src2Reg, cg);
         }
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        Inst_RTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(OP::_add, node, trgReg, src1Reg, src2Reg, cg);
     }
 
     if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aladd) && node->isInternalPointer()) {
@@ -175,12 +175,12 @@ TR::Register *OMR::RV::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGene
 // also handles bsub and ssub
 TR::Register *OMR::RV::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_subw, TR::InstOpCode::_addiw, cg);
+    return RorIhelper(node, OP::_subw, OP::_addiw, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_sub, TR::InstOpCode::_addi, cg);
+    return RorIhelper(node, OP::_sub, OP::_addi, cg);
 }
 
 // also handles bmul, smul and lmul
@@ -202,22 +202,22 @@ TR::Register *OMR::RV::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGene
             trgReg = cg->allocateRegister();
             if (value == 0) {
                 TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-                Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 0, cg);
+                Inst_ITYPE(OP::_addi, node, trgReg, zero, 0, cg);
             } else if (value == 1) {
-                Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, 0, cg);
+                Inst_ITYPE(OP::_addi, node, trgReg, src1Reg, 0, cg);
             } else if (value == -1) {
                 TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-                Inst_RTYPE(is32bit ? TR::InstOpCode::_subw : TR::InstOpCode::_sub, node, trgReg, zero, src1Reg, cg);
+                Inst_RTYPE(is32bit ? OP::_subw : OP::_sub, node, trgReg, zero, src1Reg, cg);
             } else {
                 TR::Register *src2Reg = cg->evaluate(secondChild);
                 trgReg = cg->allocateRegister();
-                Inst_RTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
+                Inst_RTYPE(is32bit ? OP::_mulw : OP::_mul, node, trgReg, src1Reg, src2Reg, cg);
             }
         }
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
         trgReg = cg->allocateRegister();
-        Inst_RTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(is32bit ? OP::_mulw : OP::_mul, node, trgReg, src1Reg, src2Reg, cg);
     }
 
     truncate(node, trgReg, cg);
@@ -236,8 +236,8 @@ TR::Register *OMR::RV::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::CodeGen
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
 
-    Inst_RTYPE(TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
-    Inst_ITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 32, cg);
+    Inst_RTYPE(OP::_mul, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_ITYPE(OP::_srai, node, trgReg, trgReg, 32, cg);
 
     firstChild->decReferenceCount();
     secondChild->decReferenceCount();
@@ -248,38 +248,38 @@ TR::Register *OMR::RV::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::CodeGen
 // also handles bdiv and sdiv
 TR::Register *OMR::RV::TreeEvaluator::idivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_divw, cg);
+    return Rhelper(node, OP::_divw, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iudivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_divuw, cg);
+    return Rhelper(node, OP::_divuw, cg);
 }
 
 // also handles brem and srem
 TR::Register *OMR::RV::TreeEvaluator::iremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_remw, cg);
+    return Rhelper(node, OP::_remw, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iuremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_remuw, cg);
+    return Rhelper(node, OP::_remuw, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ldivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_div, cg);
+    return Rhelper(node, OP::_div, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ludivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_divu, cg);
+    return Rhelper(node, OP::_divu, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return Rhelper(node, TR::InstOpCode::_rem, cg);
+    return Rhelper(node, OP::_rem, cg);
 }
 
 // also handles bshl, sshl and lshl
@@ -326,11 +326,10 @@ TR::Register *OMR::RV::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGene
             src1Reg = cg->evaluate(firstChild);
             trgReg = cg->allocateRegister(TR_GPR);
             if (width < 32) {
-                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width + shamt, cg);
-                Inst_ITYPE(TR::InstOpCode::_sraiw, node, trgReg, trgReg, 32 - width, cg);
+                Inst_ITYPE(OP::_slliw, node, trgReg, src1Reg, 32 - width + shamt, cg);
+                Inst_ITYPE(OP::_sraiw, node, trgReg, trgReg, 32 - width, cg);
             } else {
-                Inst_ITYPE(width == 64 ? TR::InstOpCode::_slli : TR::InstOpCode::_slliw, node, trgReg, src1Reg, shamt,
-                    cg);
+                Inst_ITYPE(width == 64 ? OP::_slli : OP::_slliw, node, trgReg, src1Reg, shamt, cg);
             }
         } else {
             trgReg = cg->evaluate(firstChild);
@@ -358,12 +357,12 @@ TR::Register *OMR::RV::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGene
              * Here we temporarily use trgReg to hold shift amount with high
              * bits cleared (using andi).
              */
-            Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, (width - 1), cg);
-            Inst_RTYPE(TR::InstOpCode::_sllw, node, trgReg, src1Reg, trgReg, cg);
-            Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, 64 - width, cg);
-            Inst_ITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 64 - width, cg);
+            Inst_ITYPE(OP::_andi, node, trgReg, src2Reg, (width - 1), cg);
+            Inst_RTYPE(OP::_sllw, node, trgReg, src1Reg, trgReg, cg);
+            Inst_ITYPE(OP::_slli, node, trgReg, trgReg, 64 - width, cg);
+            Inst_ITYPE(OP::_srai, node, trgReg, trgReg, 64 - width, cg);
         } else {
-            Inst_RTYPE(width == 64 ? TR::InstOpCode::_sll : TR::InstOpCode::_sllw, node, trgReg, src1Reg, src2Reg, cg);
+            Inst_RTYPE(width == 64 ? OP::_sll : OP::_sllw, node, trgReg, src1Reg, src2Reg, cg);
         }
     }
 
@@ -403,7 +402,7 @@ TR::Register *OMR::RV::TreeEvaluator::ishrEvaluator(TR::Node *node, TR::CodeGene
             src1Reg = cg->evaluate(firstChild);
             trgReg = cg->allocateRegister(TR_GPR);
 
-            Inst_ITYPE(width == 64 ? TR::InstOpCode::_srai : TR::InstOpCode::_sraiw, node, trgReg, src1Reg, shamt, cg);
+            Inst_ITYPE(width == 64 ? OP::_srai : OP::_sraiw, node, trgReg, src1Reg, shamt, cg);
         } else {
             trgReg = cg->evaluate(firstChild);
         }
@@ -431,10 +430,10 @@ TR::Register *OMR::RV::TreeEvaluator::ishrEvaluator(TR::Node *node, TR::CodeGene
              * Here we temporarily use trgReg to hold shift amount with high
              * bits cleared (using andi).
              */
-            Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, width - 1, cg);
-            Inst_RTYPE(TR::InstOpCode::_sraw, node, trgReg, src1Reg, trgReg, cg);
+            Inst_ITYPE(OP::_andi, node, trgReg, src2Reg, width - 1, cg);
+            Inst_RTYPE(OP::_sraw, node, trgReg, src1Reg, trgReg, cg);
         } else {
-            Inst_RTYPE(width == 64 ? TR::InstOpCode::_sra : TR::InstOpCode::_sraw, node, trgReg, src1Reg, src2Reg, cg);
+            Inst_RTYPE(width == 64 ? OP::_sra : OP::_sraw, node, trgReg, src1Reg, src2Reg, cg);
         }
     }
 
@@ -486,11 +485,10 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
             trgReg = cg->allocateRegister(TR_GPR);
 
             if (width < 32) {
-                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width, cg);
-                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - width + shamt, cg);
+                Inst_ITYPE(OP::_slliw, node, trgReg, src1Reg, 32 - width, cg);
+                Inst_ITYPE(OP::_srliw, node, trgReg, trgReg, 32 - width + shamt, cg);
             } else {
-                Inst_ITYPE(width == 64 ? TR::InstOpCode::_srli : TR::InstOpCode::_srliw, node, trgReg, src1Reg, shamt,
-                    cg);
+                Inst_ITYPE(width == 64 ? OP::_srli : OP::_srliw, node, trgReg, src1Reg, shamt, cg);
             }
         } else {
             trgReg = cg->evaluate(firstChild);
@@ -527,10 +525,10 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
              * value.
              */
             if (width == 8) {
-                Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src1Reg, 0xFF, cg);
+                Inst_ITYPE(OP::_andi, node, trgReg, src1Reg, 0xFF, cg);
             } else {
-                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 16, cg);
-                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 16, cg);
+                Inst_ITYPE(OP::_slliw, node, trgReg, src1Reg, 16, cg);
+                Inst_ITYPE(OP::_srliw, node, trgReg, trgReg, 16, cg);
             }
             src1Reg = trgReg;
 
@@ -539,12 +537,12 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
              * into src2Reg.
              */
             src2Reg = cg->allocateRegister(TR_GPR);
-            Inst_ITYPE(TR::InstOpCode::_andi, node, src2Reg, cg->evaluate(secondChild), width - 1, cg);
+            Inst_ITYPE(OP::_andi, node, src2Reg, cg->evaluate(secondChild), width - 1, cg);
         } else {
             src2Reg = cg->evaluate(secondChild);
         }
 
-        Inst_RTYPE(width == 64 ? TR::InstOpCode::_srl : TR::InstOpCode::_srlw, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(width == 64 ? OP::_srl : OP::_srlw, node, trgReg, src1Reg, src2Reg, cg);
         truncate(node, trgReg, cg);
     }
 
@@ -585,14 +583,14 @@ TR::Register *OMR::RV::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGene
 
         if (shift != 0) {
             if (is64bit) {
-                Inst_ITYPE(TR::InstOpCode::_slli, node, tmpReg, trgReg, shift, cg);
-                Inst_ITYPE(TR::InstOpCode::_srli, node, trgReg, trgReg, 64 - shift, cg);
-                Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+                Inst_ITYPE(OP::_slli, node, tmpReg, trgReg, shift, cg);
+                Inst_ITYPE(OP::_srli, node, trgReg, trgReg, 64 - shift, cg);
+                Inst_RTYPE(OP::_or, node, trgReg, trgReg, tmpReg, cg);
             } else {
-                Inst_ITYPE(TR::InstOpCode::_slliw, node, tmpReg, trgReg, shift, cg);
-                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - shift, cg);
-                Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-                Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
+                Inst_ITYPE(OP::_slliw, node, tmpReg, trgReg, shift, cg);
+                Inst_ITYPE(OP::_srliw, node, trgReg, trgReg, 32 - shift, cg);
+                Inst_RTYPE(OP::_or, node, trgReg, trgReg, tmpReg, cg);
+                Inst_ITYPE(OP::_addiw, node, trgReg, trgReg, 0, cg);
             }
         }
     } else {
@@ -600,16 +598,16 @@ TR::Register *OMR::RV::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGene
         TR::Register *shift2Reg = cg->allocateRegister();
         TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-        Inst_RTYPE(TR::InstOpCode::_subw, node, shift2Reg, zero, shift1Reg, cg);
+        Inst_RTYPE(OP::_subw, node, shift2Reg, zero, shift1Reg, cg);
         if (is64bit) {
-            Inst_RTYPE(TR::InstOpCode::_sll, node, tmpReg, trgReg, shift1Reg, cg);
-            Inst_RTYPE(TR::InstOpCode::_srl, node, trgReg, trgReg, shift2Reg, cg);
-            Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+            Inst_RTYPE(OP::_sll, node, tmpReg, trgReg, shift1Reg, cg);
+            Inst_RTYPE(OP::_srl, node, trgReg, trgReg, shift2Reg, cg);
+            Inst_RTYPE(OP::_or, node, trgReg, trgReg, tmpReg, cg);
         } else {
-            Inst_RTYPE(TR::InstOpCode::_sllw, node, tmpReg, trgReg, shift1Reg, cg);
-            Inst_RTYPE(TR::InstOpCode::_srlw, node, trgReg, trgReg, shift2Reg, cg);
-            Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-            Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
+            Inst_RTYPE(OP::_sllw, node, tmpReg, trgReg, shift1Reg, cg);
+            Inst_RTYPE(OP::_srlw, node, trgReg, trgReg, shift2Reg, cg);
+            Inst_RTYPE(OP::_or, node, trgReg, trgReg, tmpReg, cg);
+            Inst_ITYPE(OP::_addiw, node, trgReg, trgReg, 0, cg);
         }
         cg->stopUsingRegister(shift2Reg);
     }
@@ -624,17 +622,17 @@ TR::Register *OMR::RV::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGene
 // also handles band, sand and land
 TR::Register *OMR::RV::TreeEvaluator::iandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_and, TR::InstOpCode::_andi, cg);
+    return RorIhelper(node, OP::_and, OP::_andi, cg);
 }
 
 // also handles bor, sor and lor
 TR::Register *OMR::RV::TreeEvaluator::iorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_or, TR::InstOpCode::_ori, cg);
+    return RorIhelper(node, OP::_or, OP::_ori, cg);
 }
 
 // also handles bxor, sxor and lxor
 TR::Register *OMR::RV::TreeEvaluator::ixorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return RorIhelper(node, TR::InstOpCode::_xor, TR::InstOpCode::_xori, cg);
+    return RorIhelper(node, OP::_xor, OP::_xori, cg);
 }

--- a/compiler/riscv/codegen/BinaryEvaluator.cpp
+++ b/compiler/riscv/codegen/BinaryEvaluator.cpp
@@ -48,8 +48,8 @@ static void truncate(TR::Node *node, TR::Register *reg, TR::CodeGenerator *cg)
         return;
     }
 
-    generateITYPE(TR::InstOpCode::_slli, node, reg, reg, 64 - bitwidth, cg);
-    generateITYPE(TR::InstOpCode::_srai, node, reg, reg, 64 - bitwidth, cg);
+    Inst_ITYPE(TR::InstOpCode::_slli, node, reg, reg, 64 - bitwidth, cg);
+    Inst_ITYPE(TR::InstOpCode::_srai, node, reg, reg, 64 - bitwidth, cg);
 }
 
 /*
@@ -76,14 +76,14 @@ static TR::Register *RorIhelper(TR::Node *node, TR::InstOpCode::Mnemonic opr, TR
             if (opr == TR::InstOpCode::_sub || opr == TR::InstOpCode::_subw) {
                 value = -value;
             }
-            generateITYPE(opi, node, trgReg, src1Reg, value, cg);
+            Inst_ITYPE(opi, node, trgReg, src1Reg, value, cg);
         } else {
             TR::Register *src2Reg = cg->evaluate(secondChild);
-            generateRTYPE(opr, node, trgReg, src1Reg, src2Reg, cg);
+            Inst_RTYPE(opr, node, trgReg, src1Reg, src2Reg, cg);
         }
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateRTYPE(opr, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(opr, node, trgReg, src1Reg, src2Reg, cg);
     }
 
     truncate(node, trgReg, cg);
@@ -105,7 +105,7 @@ static TR::Register *Rhelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Co
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
 
-    generateRTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
 
     truncate(node, trgReg, cg);
 
@@ -132,14 +132,14 @@ TR::Register *OMR::RV::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGene
     if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL) {
         int64_t value = secondChild->getLongInt();
         if (VALID_ITYPE_IMM(value)) {
-            generateITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, value, cg);
+            Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, value, cg);
         } else {
             TR::Register *src2Reg = cg->evaluate(secondChild);
-            generateRTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
         }
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateRTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(TR::InstOpCode::_add, node, trgReg, src1Reg, src2Reg, cg);
     }
 
     if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aladd) && node->isInternalPointer()) {
@@ -202,23 +202,22 @@ TR::Register *OMR::RV::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGene
             trgReg = cg->allocateRegister();
             if (value == 0) {
                 TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-                generateITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 0, cg);
+                Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 0, cg);
             } else if (value == 1) {
-                generateITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, 0, cg);
+                Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, src1Reg, 0, cg);
             } else if (value == -1) {
                 TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-                generateRTYPE(is32bit ? TR::InstOpCode::_subw : TR::InstOpCode::_sub, node, trgReg, zero, src1Reg, cg);
+                Inst_RTYPE(is32bit ? TR::InstOpCode::_subw : TR::InstOpCode::_sub, node, trgReg, zero, src1Reg, cg);
             } else {
                 TR::Register *src2Reg = cg->evaluate(secondChild);
                 trgReg = cg->allocateRegister();
-                generateRTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg,
-                    cg);
+                Inst_RTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
             }
         }
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
         trgReg = cg->allocateRegister();
-        generateRTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(is32bit ? TR::InstOpCode::_mulw : TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
     }
 
     truncate(node, trgReg, cg);
@@ -237,8 +236,8 @@ TR::Register *OMR::RV::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::CodeGen
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
 
-    generateRTYPE(TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
-    generateITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 32, cg);
+    Inst_RTYPE(TR::InstOpCode::_mul, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_ITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 32, cg);
 
     firstChild->decReferenceCount();
     secondChild->decReferenceCount();
@@ -327,11 +326,11 @@ TR::Register *OMR::RV::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGene
             src1Reg = cg->evaluate(firstChild);
             trgReg = cg->allocateRegister(TR_GPR);
             if (width < 32) {
-                generateITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width + shamt, cg);
-                generateITYPE(TR::InstOpCode::_sraiw, node, trgReg, trgReg, 32 - width, cg);
+                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width + shamt, cg);
+                Inst_ITYPE(TR::InstOpCode::_sraiw, node, trgReg, trgReg, 32 - width, cg);
             } else {
-                generateITYPE(width == 64 ? TR::InstOpCode::_slli : TR::InstOpCode::_slliw, node, trgReg, src1Reg,
-                    shamt, cg);
+                Inst_ITYPE(width == 64 ? TR::InstOpCode::_slli : TR::InstOpCode::_slliw, node, trgReg, src1Reg, shamt,
+                    cg);
             }
         } else {
             trgReg = cg->evaluate(firstChild);
@@ -359,13 +358,12 @@ TR::Register *OMR::RV::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGene
              * Here we temporarily use trgReg to hold shift amount with high
              * bits cleared (using andi).
              */
-            generateITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, (width - 1), cg);
-            generateRTYPE(TR::InstOpCode::_sllw, node, trgReg, src1Reg, trgReg, cg);
-            generateITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, 64 - width, cg);
-            generateITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 64 - width, cg);
+            Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, (width - 1), cg);
+            Inst_RTYPE(TR::InstOpCode::_sllw, node, trgReg, src1Reg, trgReg, cg);
+            Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, 64 - width, cg);
+            Inst_ITYPE(TR::InstOpCode::_srai, node, trgReg, trgReg, 64 - width, cg);
         } else {
-            generateRTYPE(width == 64 ? TR::InstOpCode::_sll : TR::InstOpCode::_sllw, node, trgReg, src1Reg, src2Reg,
-                cg);
+            Inst_RTYPE(width == 64 ? TR::InstOpCode::_sll : TR::InstOpCode::_sllw, node, trgReg, src1Reg, src2Reg, cg);
         }
     }
 
@@ -405,8 +403,7 @@ TR::Register *OMR::RV::TreeEvaluator::ishrEvaluator(TR::Node *node, TR::CodeGene
             src1Reg = cg->evaluate(firstChild);
             trgReg = cg->allocateRegister(TR_GPR);
 
-            generateITYPE(width == 64 ? TR::InstOpCode::_srai : TR::InstOpCode::_sraiw, node, trgReg, src1Reg, shamt,
-                cg);
+            Inst_ITYPE(width == 64 ? TR::InstOpCode::_srai : TR::InstOpCode::_sraiw, node, trgReg, src1Reg, shamt, cg);
         } else {
             trgReg = cg->evaluate(firstChild);
         }
@@ -434,11 +431,10 @@ TR::Register *OMR::RV::TreeEvaluator::ishrEvaluator(TR::Node *node, TR::CodeGene
              * Here we temporarily use trgReg to hold shift amount with high
              * bits cleared (using andi).
              */
-            generateITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, width - 1, cg);
-            generateRTYPE(TR::InstOpCode::_sraw, node, trgReg, src1Reg, trgReg, cg);
+            Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src2Reg, width - 1, cg);
+            Inst_RTYPE(TR::InstOpCode::_sraw, node, trgReg, src1Reg, trgReg, cg);
         } else {
-            generateRTYPE(width == 64 ? TR::InstOpCode::_sra : TR::InstOpCode::_sraw, node, trgReg, src1Reg, src2Reg,
-                cg);
+            Inst_RTYPE(width == 64 ? TR::InstOpCode::_sra : TR::InstOpCode::_sraw, node, trgReg, src1Reg, src2Reg, cg);
         }
     }
 
@@ -490,11 +486,11 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
             trgReg = cg->allocateRegister(TR_GPR);
 
             if (width < 32) {
-                generateITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width, cg);
-                generateITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - width + shamt, cg);
+                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 32 - width, cg);
+                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - width + shamt, cg);
             } else {
-                generateITYPE(width == 64 ? TR::InstOpCode::_srli : TR::InstOpCode::_srliw, node, trgReg, src1Reg,
-                    shamt, cg);
+                Inst_ITYPE(width == 64 ? TR::InstOpCode::_srli : TR::InstOpCode::_srliw, node, trgReg, src1Reg, shamt,
+                    cg);
             }
         } else {
             trgReg = cg->evaluate(firstChild);
@@ -531,10 +527,10 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
              * value.
              */
             if (width == 8) {
-                generateITYPE(TR::InstOpCode::_andi, node, trgReg, src1Reg, 0xFF, cg);
+                Inst_ITYPE(TR::InstOpCode::_andi, node, trgReg, src1Reg, 0xFF, cg);
             } else {
-                generateITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 16, cg);
-                generateITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 16, cg);
+                Inst_ITYPE(TR::InstOpCode::_slliw, node, trgReg, src1Reg, 16, cg);
+                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 16, cg);
             }
             src1Reg = trgReg;
 
@@ -543,12 +539,12 @@ TR::Register *OMR::RV::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::CodeGen
              * into src2Reg.
              */
             src2Reg = cg->allocateRegister(TR_GPR);
-            generateITYPE(TR::InstOpCode::_andi, node, src2Reg, cg->evaluate(secondChild), width - 1, cg);
+            Inst_ITYPE(TR::InstOpCode::_andi, node, src2Reg, cg->evaluate(secondChild), width - 1, cg);
         } else {
             src2Reg = cg->evaluate(secondChild);
         }
 
-        generateRTYPE(width == 64 ? TR::InstOpCode::_srl : TR::InstOpCode::_srlw, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(width == 64 ? TR::InstOpCode::_srl : TR::InstOpCode::_srlw, node, trgReg, src1Reg, src2Reg, cg);
         truncate(node, trgReg, cg);
     }
 
@@ -589,14 +585,14 @@ TR::Register *OMR::RV::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGene
 
         if (shift != 0) {
             if (is64bit) {
-                generateITYPE(TR::InstOpCode::_slli, node, tmpReg, trgReg, shift, cg);
-                generateITYPE(TR::InstOpCode::_srli, node, trgReg, trgReg, 64 - shift, cg);
-                generateRTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+                Inst_ITYPE(TR::InstOpCode::_slli, node, tmpReg, trgReg, shift, cg);
+                Inst_ITYPE(TR::InstOpCode::_srli, node, trgReg, trgReg, 64 - shift, cg);
+                Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
             } else {
-                generateITYPE(TR::InstOpCode::_slliw, node, tmpReg, trgReg, shift, cg);
-                generateITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - shift, cg);
-                generateRTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-                generateITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
+                Inst_ITYPE(TR::InstOpCode::_slliw, node, tmpReg, trgReg, shift, cg);
+                Inst_ITYPE(TR::InstOpCode::_srliw, node, trgReg, trgReg, 32 - shift, cg);
+                Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+                Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
             }
         }
     } else {
@@ -604,16 +600,16 @@ TR::Register *OMR::RV::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGene
         TR::Register *shift2Reg = cg->allocateRegister();
         TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-        generateRTYPE(TR::InstOpCode::_subw, node, shift2Reg, zero, shift1Reg, cg);
+        Inst_RTYPE(TR::InstOpCode::_subw, node, shift2Reg, zero, shift1Reg, cg);
         if (is64bit) {
-            generateRTYPE(TR::InstOpCode::_sll, node, tmpReg, trgReg, shift1Reg, cg);
-            generateRTYPE(TR::InstOpCode::_srl, node, trgReg, trgReg, shift2Reg, cg);
-            generateRTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+            Inst_RTYPE(TR::InstOpCode::_sll, node, tmpReg, trgReg, shift1Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_srl, node, trgReg, trgReg, shift2Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
         } else {
-            generateRTYPE(TR::InstOpCode::_sllw, node, tmpReg, trgReg, shift1Reg, cg);
-            generateRTYPE(TR::InstOpCode::_srlw, node, trgReg, trgReg, shift2Reg, cg);
-            generateRTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-            generateITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
+            Inst_RTYPE(TR::InstOpCode::_sllw, node, tmpReg, trgReg, shift1Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_srlw, node, trgReg, trgReg, shift2Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+            Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, 0, cg);
         }
         cg->stopUsingRegister(shift2Reg);
     }

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -39,7 +39,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
     TR::RegisterDependencyConditions *deps
         = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
     deps->addPreCondition(returnRegister, rnum);
-    Inst_ADMIN(TR::InstOpCode::retn, node, deps, cg);
+    Inst_ADMIN(OP::retn, node, deps, cg);
 
     cg->comp()->setReturnInfo(i);
     cg->decReferenceCount(firstChild);
@@ -65,7 +65,7 @@ TR::Register *OMR::RV::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::CodeG
 // void return
 TR::Register *OMR::RV::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    Inst_ADMIN(TR::InstOpCode::retn, node, cg);
+    Inst_ADMIN(OP::retn, node, cg);
     cg->comp()->setReturnInfo(TR_VoidReturn);
     return NULL;
 }
@@ -77,10 +77,10 @@ TR::Register *OMR::RV::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeGene
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        Inst_JTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, generateRegisterDependencyConditions(cg, child, 0), cg);
+        Inst_JTYPE(OP::_jal, node, zero, gotoLabel, generateRegisterDependencyConditions(cg, child, 0), cg);
         cg->decReferenceCount(child);
     } else {
-        Inst_JTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, cg);
+        Inst_JTYPE(OP::_jal, node, zero, gotoLabel, cg);
     }
     return NULL;
 }
@@ -168,127 +168,127 @@ static TR::Instruction *ificmpHelper(TR::InstOpCode::Mnemonic op, TR::Node *node
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_beq, node, false, cg);
+    ificmpHelper(OP::_beq, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bne, node, false, cg);
+    ificmpHelper(OP::_bne, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_blt, node, false, cg);
+    ificmpHelper(OP::_blt, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bge, node, false, cg);
+    ificmpHelper(OP::_bge, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_blt, node, true, cg);
+    ificmpHelper(OP::_blt, node, true, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ificmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bge, node, true, cg);
+    ificmpHelper(OP::_bge, node, true, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ifiucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bltu, node, false, cg);
+    ificmpHelper(OP::_bltu, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ifiucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bgeu, node, false, cg);
+    ificmpHelper(OP::_bgeu, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ifiucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bltu, node, true, cg);
+    ificmpHelper(OP::_bltu, node, true, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ifiucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bgeu, node, true, cg);
+    ificmpHelper(OP::_bgeu, node, true, cg);
     return NULL;
 }
 
 // also handles ifacmpeq
 TR::Register *OMR::RV::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_beq, node, false, cg);
+    ificmpHelper(OP::_beq, node, false, cg);
     return NULL;
 }
 
 // also handles ifacmpne
 TR::Register *OMR::RV::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bne, node, false, cg);
+    ificmpHelper(OP::_bne, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iflcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_blt, node, false, cg);
+    ificmpHelper(OP::_blt, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iflcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bge, node, false, cg);
+    ificmpHelper(OP::_bge, node, false, cg);
     return NULL;
 }
 
 // also handles ifacmplt
 TR::Register *OMR::RV::TreeEvaluator::iflucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bltu, node, false, cg);
+    ificmpHelper(OP::_bltu, node, false, cg);
     return NULL;
 }
 
 // also handles ifacmpge
 TR::Register *OMR::RV::TreeEvaluator::iflucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bgeu, node, false, cg);
+    ificmpHelper(OP::_bgeu, node, false, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iflcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_blt, node, true, cg);
+    ificmpHelper(OP::_blt, node, true, cg);
     return NULL;
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iflcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bge, node, true, cg);
+    ificmpHelper(OP::_bge, node, true, cg);
     return NULL;
 }
 
 // also handles ifacmpgt
 TR::Register *OMR::RV::TreeEvaluator::iflucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bltu, node, true, cg);
+    ificmpHelper(OP::_bltu, node, true, cg);
     return NULL;
 }
 
 // also handles ifacmple
 TR::Register *OMR::RV::TreeEvaluator::iflucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    ificmpHelper(TR::InstOpCode::_bgeu, node, true, cg);
+    ificmpHelper(OP::_bgeu, node, true, cg);
     return NULL;
 }
 
@@ -307,7 +307,7 @@ static TR::Register *icmpHelper(TR::InstOpCode::Mnemonic op1, TR::InstOpCode::Mn
     else
         result = Inst_RTYPE(op1, node, trgReg, src1Reg, src2Reg, cg);
 
-    if (op2 != TR::InstOpCode::bad) {
+    if (op2 != OP::bad) {
         result = Inst_ITYPE(op2, node, trgReg, trgReg, imm2, cg, result);
     }
 
@@ -319,7 +319,7 @@ static TR::Register *icmpHelper(TR::InstOpCode::Mnemonic op1, TR::InstOpCode::Mn
 
 TR::Register *OMR::RV::TreeEvaluator::icmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_sub, TR::InstOpCode::_sltiu, 1, node, false, cg);
+    return icmpHelper(OP::_sub, OP::_sltiu, 1, node, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -342,8 +342,8 @@ TR::Register *OMR::RV::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
     TR::Instruction *result = nullptr;
 
-    result = Inst_RTYPE(TR::InstOpCode::_sub, node, trgReg, src1Reg, src2Reg, cg);
-    result = Inst_RTYPE(TR::InstOpCode::_sltu, node, trgReg, zero, trgReg, cg);
+    result = Inst_RTYPE(OP::_sub, node, trgReg, src1Reg, src2Reg, cg);
+    result = Inst_RTYPE(OP::_sltu, node, trgReg, zero, trgReg, cg);
 
     node->setRegister(trgReg);
     firstChild->decReferenceCount();
@@ -353,42 +353,42 @@ TR::Register *OMR::RV::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::RV::TreeEvaluator::icmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_slt, TR::InstOpCode::bad, 0, node, false, cg);
+    return icmpHelper(OP::_slt, OP::bad, 0, node, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::icmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_slt, TR::InstOpCode::_sltiu, 1, node, true, cg);
+    return icmpHelper(OP::_slt, OP::_sltiu, 1, node, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::icmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_slt, TR::InstOpCode::_xori, 1, node, false, cg);
+    return icmpHelper(OP::_slt, OP::_xori, 1, node, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::icmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_slt, TR::InstOpCode::bad, 0, node, true, cg);
+    return icmpHelper(OP::_slt, OP::bad, 0, node, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_sltu, TR::InstOpCode::bad, 0, node, false, cg);
+    return icmpHelper(OP::_sltu, OP::bad, 0, node, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_sltu, TR::InstOpCode::_xori, 1, node, true, cg);
+    return icmpHelper(OP::_sltu, OP::_xori, 1, node, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_sltu, TR::InstOpCode::_xori, 1, node, false, cg);
+    return icmpHelper(OP::_sltu, OP::_xori, 1, node, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return icmpHelper(TR::InstOpCode::_sltu, TR::InstOpCode::bad, 0, node, true, cg);
+    return icmpHelper(OP::_sltu, OP::bad, 0, node, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -466,8 +466,8 @@ TR::Register *OMR::RV::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGene
      *  - tmpReg = 1  iff  src1Reg > src2Reg
      *
      */
-    Inst_RTYPE(TR::InstOpCode::_slt, node, trgReg, src1Reg, src2Reg, cg);
-    Inst_RTYPE(TR::InstOpCode::_slt, node, tmpReg, src2Reg, src1Reg, cg);
+    Inst_RTYPE(OP::_slt, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_RTYPE(OP::_slt, node, tmpReg, src2Reg, src1Reg, cg);
 
     /*
      * There are three outcomes possible:
@@ -476,7 +476,7 @@ TR::Register *OMR::RV::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGene
      *  (ii) trgReg = 1, tmpReg = 0  => lcmp => -1
      * (iii) trgReg = 0, tmpReg = 0  => lcmp =>  0
      */
-    Inst_RTYPE(TR::InstOpCode::_sub, node, trgReg, tmpReg, trgReg, cg);
+    Inst_RTYPE(OP::_sub, node, trgReg, tmpReg, trgReg, cg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -527,10 +527,10 @@ TR::Register *OMR::RV::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeG
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
-    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
-    Inst_ITYPE(TR::InstOpCode::_addi, node, trueReg, falseReg, 0, cg);
-    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+    Inst_LABEL(OP::label, node, startLabel, cg);
+    Inst_BTYPE(OP::_bne, node, joinLabel, condReg, zero, cg);
+    Inst_ITYPE(OP::_addi, node, trueReg, falseReg, 0, cg);
+    Inst_LABEL(OP::label, node, joinLabel, deps, cg);
 
     node->setRegister(trueReg);
     cg->decReferenceCount(condNode);
@@ -610,10 +610,10 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mnemo
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_LABEL(OP::label, node, startLabel, cg);
     Inst_BTYPE(op, node, joinLabel, src1Reg, src2Reg, cg);
-    Inst_ITYPE(TR::InstOpCode::_addi, node, src1Reg, src2Reg, 0, cg);
-    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+    Inst_ITYPE(OP::_addi, node, src1Reg, src2Reg, 0, cg);
+    Inst_LABEL(OP::label, node, joinLabel, deps, cg);
 
     node->setRegister(src1Reg);
     cg->decReferenceCount(firstChild);
@@ -625,24 +625,24 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mnemo
 // Also handles lmax
 TR::Register *OMR::RV::TreeEvaluator::imaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonMinMaxEvaluator(node, TR::InstOpCode::_bge, cg);
+    return commonMinMaxEvaluator(node, OP::_bge, cg);
 }
 
 // Also handles lumax
 TR::Register *OMR::RV::TreeEvaluator::iumaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonMinMaxEvaluator(node, TR::InstOpCode::_bgeu, cg);
+    return commonMinMaxEvaluator(node, OP::_bgeu, cg);
 }
 
 // Also handles lmin
 TR::Register *OMR::RV::TreeEvaluator::iminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonMinMaxEvaluator(node, TR::InstOpCode::_blt, cg);
+    return commonMinMaxEvaluator(node, OP::_blt, cg);
 }
 
 // Also handles lumin
 TR::Register *OMR::RV::TreeEvaluator::iuminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonMinMaxEvaluator(node, TR::InstOpCode::_bltu, cg);
+    return commonMinMaxEvaluator(node, OP::_bltu, cg);
 }
 

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -39,7 +39,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
     TR::RegisterDependencyConditions *deps
         = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
     deps->addPreCondition(returnRegister, rnum);
-    generateADMIN(cg, TR::InstOpCode::retn, node, deps);
+    Inst_ADMIN(TR::InstOpCode::retn, node, deps, cg);
 
     cg->comp()->setReturnInfo(i);
     cg->decReferenceCount(firstChild);
@@ -65,7 +65,7 @@ TR::Register *OMR::RV::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::CodeG
 // void return
 TR::Register *OMR::RV::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateADMIN(cg, TR::InstOpCode::retn, node);
+    Inst_ADMIN(TR::InstOpCode::retn, node, cg);
     cg->comp()->setReturnInfo(TR_VoidReturn);
     return NULL;
 }
@@ -77,11 +77,10 @@ TR::Register *OMR::RV::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeGene
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        generateJTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, generateRegisterDependencyConditions(cg, child, 0),
-            cg);
+        Inst_JTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, generateRegisterDependencyConditions(cg, child, 0), cg);
         cg->decReferenceCount(child);
     } else {
-        generateJTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, cg);
+        Inst_JTYPE(TR::InstOpCode::_jal, node, zero, gotoLabel, cg);
     }
     return NULL;
 }
@@ -117,7 +116,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
         cg->evaluateChildrenWithMultipleRefCount(node);
 
     TR::LabelSymbol *label = node->getBranchDestination()->getNode()->getLabel();
-    generateVGNOP(node, site, deps, label, cg);
+    Inst_VGNOP(node, site, deps, label, cg);
     cg->recursivelyDecReferenceCount(node->getFirstChild());
     cg->recursivelyDecReferenceCount(node->getSecondChild());
 
@@ -154,9 +153,9 @@ static TR::Instruction *ificmpHelper(TR::InstOpCode::Mnemonic op, TR::Node *node
 #endif
     } else {
         if (reverse)
-            result = generateBTYPE(op, node, dstLabel, src2Reg, src1Reg, cg);
+            result = Inst_BTYPE(op, node, dstLabel, src2Reg, src1Reg, cg);
         else
-            result = generateBTYPE(op, node, dstLabel, src1Reg, src2Reg, cg);
+            result = Inst_BTYPE(op, node, dstLabel, src1Reg, src2Reg, cg);
     }
 
     firstChild->decReferenceCount();
@@ -304,12 +303,12 @@ static TR::Register *icmpHelper(TR::InstOpCode::Mnemonic op1, TR::InstOpCode::Mn
     TR::Instruction *result = nullptr;
 
     if (reverse)
-        result = generateRTYPE(op1, node, trgReg, src2Reg, src1Reg, cg);
+        result = Inst_RTYPE(op1, node, trgReg, src2Reg, src1Reg, cg);
     else
-        result = generateRTYPE(op1, node, trgReg, src1Reg, src2Reg, cg);
+        result = Inst_RTYPE(op1, node, trgReg, src1Reg, src2Reg, cg);
 
     if (op2 != TR::InstOpCode::bad) {
-        result = generateITYPE(op2, node, trgReg, trgReg, imm2, cg, result);
+        result = Inst_ITYPE(op2, node, trgReg, trgReg, imm2, cg, result);
     }
 
     node->setRegister(trgReg);
@@ -343,8 +342,8 @@ TR::Register *OMR::RV::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
     TR::Instruction *result = nullptr;
 
-    result = generateRTYPE(TR::InstOpCode::_sub, node, trgReg, src1Reg, src2Reg, cg);
-    result = generateRTYPE(TR::InstOpCode::_sltu, node, trgReg, zero, trgReg, cg);
+    result = Inst_RTYPE(TR::InstOpCode::_sub, node, trgReg, src1Reg, src2Reg, cg);
+    result = Inst_RTYPE(TR::InstOpCode::_sltu, node, trgReg, zero, trgReg, cg);
 
     node->setRegister(trgReg);
     firstChild->decReferenceCount();
@@ -467,8 +466,8 @@ TR::Register *OMR::RV::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGene
      *  - tmpReg = 1  iff  src1Reg > src2Reg
      *
      */
-    generateRTYPE(TR::InstOpCode::_slt, node, trgReg, src1Reg, src2Reg, cg);
-    generateRTYPE(TR::InstOpCode::_slt, node, tmpReg, src2Reg, src1Reg, cg);
+    Inst_RTYPE(TR::InstOpCode::_slt, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_RTYPE(TR::InstOpCode::_slt, node, tmpReg, src2Reg, src1Reg, cg);
 
     /*
      * There are three outcomes possible:
@@ -477,7 +476,7 @@ TR::Register *OMR::RV::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeGene
      *  (ii) trgReg = 1, tmpReg = 0  => lcmp => -1
      * (iii) trgReg = 0, tmpReg = 0  => lcmp =>  0
      */
-    generateRTYPE(TR::InstOpCode::_sub, node, trgReg, tmpReg, trgReg, cg);
+    Inst_RTYPE(TR::InstOpCode::_sub, node, trgReg, tmpReg, trgReg, cg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -528,10 +527,10 @@ TR::Register *OMR::RV::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeG
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
-    generateBTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
-    generateITYPE(TR::InstOpCode::_addi, node, trueReg, falseReg, 0, cg);
-    generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
+    Inst_ITYPE(TR::InstOpCode::_addi, node, trueReg, falseReg, 0, cg);
+    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
 
     node->setRegister(trueReg);
     cg->decReferenceCount(condNode);
@@ -611,10 +610,10 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mnemo
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
-    generateBTYPE(op, node, joinLabel, src1Reg, src2Reg, cg);
-    generateITYPE(TR::InstOpCode::_addi, node, src1Reg, src2Reg, 0, cg);
-    generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_BTYPE(op, node, joinLabel, src1Reg, src2Reg, cg);
+    Inst_ITYPE(TR::InstOpCode::_addi, node, src1Reg, src2Reg, 0, cg);
+    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
 
     node->setRegister(src1Reg);
     cg->decReferenceCount(firstChild);

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -36,8 +36,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *returnRegister = cg->evaluate(firstChild);
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(1, 0, cg);
     deps->addPreCondition(returnRegister, rnum);
     Inst_ADMIN(OP::retn, node, deps, cg);
 
@@ -77,7 +76,7 @@ TR::Register *OMR::RV::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeGene
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        Inst_JTYPE(OP::_jal, node, zero, gotoLabel, generateRegisterDependencyConditions(cg, child, 0), cg);
+        Inst_JTYPE(OP::_jal, node, zero, gotoLabel, RegDeps(cg, child, 0), cg);
         cg->decReferenceCount(child);
     } else {
         Inst_JTYPE(OP::_jal, node, zero, gotoLabel, cg);
@@ -108,9 +107,9 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
     if (node->getNumChildren() == 3) {
         TR::Node *third = node->getChild(2);
         cg->evaluate(third);
-        deps = generateRegisterDependencyConditions(cg, third, 0);
+        deps = RegDeps(cg, third, 0);
     } else
-        deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 0, cg->trMemory());
+        deps = RegDeps(0, 0, cg);
 
     if (virtualGuard->shouldGenerateChildrenCode())
         cg->evaluateChildrenWithMultipleRefCount(node);
@@ -148,7 +147,7 @@ static TR::Instruction *ificmpHelper(TR::InstOpCode::Mnemonic op, TR::Node *node
 
       cg->evaluate(thirdChild);
 
-      TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(cg, thirdChild, 0);
+      TR::RegisterDependencyConditions *deps = RegDeps(cg, thirdChild, 0);
       result = generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, dstLabel, cc, deps);
 #endif
     } else {
@@ -521,8 +520,7 @@ TR::Register *OMR::RV::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeG
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 3, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 3, cg);
     deps->addPostCondition(condReg, TR::RealRegister::NoReg);
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);
@@ -605,8 +603,7 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mnemo
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 2, cg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 

--- a/compiler/riscv/codegen/FPTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/FPTreeEvaluator.cpp
@@ -300,8 +300,7 @@ static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOp
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 2, cg);
 
     deps->addPostCondition(trgReg, TR::RealRegister::NoReg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
@@ -691,8 +690,7 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 4, cg);
     deps->addPostCondition(cmpReg, TR::RealRegister::NoReg);
     deps->addPostCondition(trgReg, TR::RealRegister::NoReg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
@@ -958,8 +956,7 @@ static TR::Register *compareThreeWayHelper(TR::Node *node, bool unorderedIsLess,
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 4, cg);
     deps->addPostCondition(tmpReg, TR::RealRegister::NoReg);
     deps->addPostCondition(trgReg, TR::RealRegister::NoReg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
@@ -1028,8 +1025,7 @@ static TR::Register *commonFpSelectEvaluator(TR::Node *node, bool isDouble, TR::
     startLabel->setStartInternalControlFlow();
     joinLabel->setEndInternalControlFlow();
 
-    TR::RegisterDependencyConditions *deps
-        = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 3, cg->trMemory());
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 3, cg);
     deps->addPostCondition(condReg, TR::RealRegister::NoReg);
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);

--- a/compiler/riscv/codegen/FPTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/FPTreeEvaluator.cpp
@@ -44,7 +44,7 @@ TR::Register *OMR::RV::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::CodeG
 {
     TR::Register *trgReg = cg->allocateSinglePrecisionRegister();
 
-    fpBitsMovHelper(node, TR::InstOpCode::_fmv_s_x, trgReg, cg);
+    fpBitsMovHelper(node, OP::_fmv_s_x, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -54,7 +54,7 @@ TR::Register *OMR::RV::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::CodeG
 {
     TR::Register *trgReg = cg->allocateRegister();
 
-    fpBitsMovHelper(node, TR::InstOpCode::_fmv_x_s, trgReg, cg);
+    fpBitsMovHelper(node, OP::_fmv_x_s, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -64,7 +64,7 @@ TR::Register *OMR::RV::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::CodeG
 {
     TR::Register *trgReg = cg->allocateRegister(TR_FPR);
 
-    fpBitsMovHelper(node, TR::InstOpCode::_fmv_d_x, trgReg, cg);
+    fpBitsMovHelper(node, OP::_fmv_d_x, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -74,7 +74,7 @@ TR::Register *OMR::RV::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::CodeG
 {
     TR::Register *trgReg = cg->allocateRegister();
 
-    fpBitsMovHelper(node, TR::InstOpCode::_fmv_x_d, trgReg, cg);
+    fpBitsMovHelper(node, OP::_fmv_x_d, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -93,7 +93,7 @@ TR::Register *OMR::RV::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeGe
 
     fvalue.f = node->getFloat();
     loadConstant32(cg, node, fvalue.i, tmpReg);
-    Inst_RTYPE(TR::InstOpCode::_fmv_s_x, node, trgReg, tmpReg, zero, cg);
+    Inst_RTYPE(OP::_fmv_s_x, node, trgReg, tmpReg, zero, cg);
     cg->stopUsingRegister(tmpReg);
 
     node->setRegister(trgReg);
@@ -113,7 +113,7 @@ TR::Register *OMR::RV::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGe
 
     dvalue.d = node->getDouble();
     loadConstant64(cg, node, dvalue.l, tmpReg);
-    Inst_RTYPE(TR::InstOpCode::_fmv_d_x, node, trgReg, tmpReg, zero, cg);
+    Inst_RTYPE(OP::_fmv_d_x, node, trgReg, tmpReg, zero, cg);
     cg->stopUsingRegister(tmpReg);
 
     node->setRegister(trgReg);
@@ -123,25 +123,25 @@ TR::Register *OMR::RV::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGe
 // also handles floadi
 TR::Register *OMR::RV::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_flw, 4, cg);
+    return commonLoadEvaluator(node, OP::_flw, 4, cg);
 }
 
 // also handles dloadi
 TR::Register *OMR::RV::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_fld, 8, cg);
+    return commonLoadEvaluator(node, OP::_fld, 8, cg);
 }
 
 // also handles fstorei
 TR::Register *OMR::RV::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_fsw, 4, cg);
+    return commonStoreEvaluator(node, OP::_fsw, 4, cg);
 }
 
 // also handles dstorei
 TR::Register *OMR::RV::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_fsd, 8, cg);
+    return commonStoreEvaluator(node, OP::_fsd, 8, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -183,42 +183,42 @@ static TR::Register *doublePrecisionEvaluator(TR::Node *node, TR::InstOpCode::Mn
 
 TR::Register *OMR::RV::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::_fadd_s, cg);
+    return singlePrecisionEvaluator(node, OP::_fadd_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::_fadd_d, cg);
+    return doublePrecisionEvaluator(node, OP::_fadd_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::_fsub_s, cg);
+    return singlePrecisionEvaluator(node, OP::_fsub_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::_fsub_d, cg);
+    return doublePrecisionEvaluator(node, OP::_fsub_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::_fmul_s, cg);
+    return singlePrecisionEvaluator(node, OP::_fmul_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::_fmul_d, cg);
+    return doublePrecisionEvaluator(node, OP::_fmul_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::_fdiv_s, cg);
+    return singlePrecisionEvaluator(node, OP::_fdiv_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ddivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::_fdiv_d, cg);
+    return doublePrecisionEvaluator(node, OP::_fdiv_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -261,22 +261,22 @@ static TR::Register *doublePrecisionUnaryEvaluator(TR::Node *node, TR::InstOpCod
 
 TR::Register *OMR::RV::TreeEvaluator::fabsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::_fsgnjx_s, cg);
+    return singlePrecisionUnaryEvaluator(node, OP::_fsgnjx_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dabsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::_fsgnjx_d, cg);
+    return doublePrecisionUnaryEvaluator(node, OP::_fsgnjx_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::_fsgnjn_s, cg);
+    return singlePrecisionUnaryEvaluator(node, OP::_fsgnjn_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::_fsgnjn_d, cg);
+    return doublePrecisionUnaryEvaluator(node, OP::_fsgnjn_d, cg);
 }
 
 static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op,
@@ -306,7 +306,7 @@ static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOp
     deps->addPostCondition(trgReg, TR::RealRegister::NoReg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_LABEL(OP::label, node, startLabel, cg);
 
     /*
      * Check if srcReg is NaN, if so then result 0.
@@ -317,16 +317,15 @@ static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOp
      * register to hold the result of comparison, we can just
      * jump over the actual conversion via fcvt_?_?.
      */
-    TR::InstOpCode::Mnemonic feqOp
-        = firstChild->getDataType().isDouble() ? TR::InstOpCode::_feq_d : TR::InstOpCode::_feq_s;
+    TR::InstOpCode::Mnemonic feqOp = firstChild->getDataType().isDouble() ? OP::_feq_d : OP::_feq_s;
     Inst_RTYPE(feqOp, node, trgReg, src1Reg, src1Reg, cg);
-    Inst_BTYPE(TR::InstOpCode::_beq, node, joinLabel, trgReg, zero, cg);
+    Inst_BTYPE(OP::_beq, node, joinLabel, trgReg, zero, cg);
     /*
      * Now do the actual conversion
      */
     Inst_RTYPE(op, node, trgReg, src1Reg, zero, cg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+    Inst_LABEL(OP::label, node, joinLabel, deps, cg);
 
     cg->decReferenceCount(firstChild);
     node->setRegister(trgReg);
@@ -365,37 +364,37 @@ static TR::Register *commonFPPtoFPconversionEvaluator(TR::Node *node, TR::InstOp
 
 TR::Register *OMR::RV::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonINTtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_s_w, cg);
+    return commonINTtoFPconversionEvaluator(node, OP::_fcvt_s_w, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonINTtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_d_w, cg);
+    return commonINTtoFPconversionEvaluator(node, OP::_fcvt_d_w, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonINTtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_s_l, cg);
+    return commonINTtoFPconversionEvaluator(node, OP::_fcvt_s_l, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonINTtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_d_l, cg);
+    return commonINTtoFPconversionEvaluator(node, OP::_fcvt_d_l, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPPtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_d_s, cg);
+    return commonFPPtoFPconversionEvaluator(node, OP::_fcvt_d_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPtoINTconversionEvaluator(node, TR::InstOpCode::_fcvt_w_s, cg);
+    return commonFPtoINTconversionEvaluator(node, OP::_fcvt_w_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPtoINTconversionEvaluator(node, TR::InstOpCode::_fcvt_w_d, cg);
+    return commonFPtoINTconversionEvaluator(node, OP::_fcvt_w_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::d2cEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -415,17 +414,17 @@ TR::Register *OMR::RV::TreeEvaluator::d2bEvaluator(TR::Node *node, TR::CodeGener
 
 TR::Register *OMR::RV::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPtoINTconversionEvaluator(node, TR::InstOpCode::_fcvt_l_s, cg);
+    return commonFPtoINTconversionEvaluator(node, OP::_fcvt_l_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPtoINTconversionEvaluator(node, TR::InstOpCode::_fcvt_l_d, cg);
+    return commonFPtoINTconversionEvaluator(node, OP::_fcvt_l_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFPPtoFPconversionEvaluator(node, TR::InstOpCode::_fcvt_s_d, cg);
+    return commonFPPtoFPconversionEvaluator(node, OP::_fcvt_s_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::ifdcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -503,11 +502,11 @@ static TR::Register *compareNotEqualHelper(TR::Node *node, TR::InstOpCode::Mnemo
 
     Inst_RTYPE(op, node, trgReg, src1Reg, src1Reg, cg);
     Inst_RTYPE(op, node, tmpReg, src2Reg, src2Reg, cg);
-    Inst_RTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
+    Inst_RTYPE(OP::_and, node, trgReg, trgReg, tmpReg, cg);
 
     Inst_RTYPE(op, node, tmpReg, src1Reg, src2Reg, cg);
-    Inst_ITYPE(TR::InstOpCode::_xori, node, tmpReg, tmpReg, 1, cg);
-    Inst_RTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
+    Inst_ITYPE(OP::_xori, node, tmpReg, tmpReg, 1, cg);
+    Inst_RTYPE(OP::_and, node, trgReg, trgReg, tmpReg, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -539,7 +538,7 @@ static TR::Register *compareUnorderedHelper(TR::Node *node, TR::InstOpCode::Mnem
     else
         Inst_RTYPE(cmpOp, node, trgReg, src1Reg, src2Reg, cg);
 
-    Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
+    Inst_ITYPE(OP::_xori, node, trgReg, trgReg, 1, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -569,14 +568,13 @@ static TR::Register *compareEqualOrUnorderedHelper(TR::Node *node, TR::CodeGener
      *   neither 1 nor 2 are true, i.e., compute !(x < y || x > y). This takes only two
      *   comparisons.
      */
-    TR::InstOpCode::Mnemonic ltOp
-        = firstChild->getDataType().isDouble() ? TR::InstOpCode::_flt_d : TR::InstOpCode::_flt_s;
+    TR::InstOpCode::Mnemonic ltOp = firstChild->getDataType().isDouble() ? OP::_flt_d : OP::_flt_s;
     TR::Register *tmpReg = cg->allocateRegister();
 
     Inst_RTYPE(ltOp, node, trgReg, src1Reg, src2Reg, cg);
     Inst_RTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
-    Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-    Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
+    Inst_RTYPE(OP::_or, node, trgReg, trgReg, tmpReg, cg);
+    Inst_ITYPE(OP::_xori, node, trgReg, trgReg, 1, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -587,62 +585,62 @@ static TR::Register *compareEqualOrUnorderedHelper(TR::Node *node, TR::CodeGener
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_feq_s, false, cg);
+    return compareHelper(node, OP::_feq_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareNotEqualHelper(node, TR::InstOpCode::_feq_s, cg);
+    return compareNotEqualHelper(node, OP::_feq_s, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_flt_s, false, cg);
+    return compareHelper(node, OP::_flt_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_fle_s, false, cg);
+    return compareHelper(node, OP::_fle_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_flt_s, true, cg);
+    return compareHelper(node, OP::_flt_s, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_fle_s, true, cg);
+    return compareHelper(node, OP::_fle_s, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_feq_d, false, cg);
+    return compareHelper(node, OP::_feq_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareNotEqualHelper(node, TR::InstOpCode::_feq_d, cg);
+    return compareNotEqualHelper(node, OP::_feq_d, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_flt_d, false, cg);
+    return compareHelper(node, OP::_flt_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_fle_d, false, cg);
+    return compareHelper(node, OP::_fle_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_flt_d, true, cg);
+    return compareHelper(node, OP::_flt_d, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareHelper(node, TR::InstOpCode::_fle_d, true, cg);
+    return compareHelper(node, OP::_fle_d, true, cg);
 }
 
 // also handles dRegLoad
@@ -674,16 +672,16 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     TR::RealRegister *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
     TR::Register *trgReg;
 
-    TR::InstOpCode::Mnemonic feqOp = isDouble ? TR::InstOpCode::_feq_d : TR::InstOpCode::_feq_s;
+    TR::InstOpCode::Mnemonic feqOp = isDouble ? OP::_feq_d : OP::_feq_s;
 
     if (cg->canClobberNodesRegister(firstChild)) {
         trgReg = src1Reg; // use the first child as the target
     } else {
         trgReg = cg->allocateRegister(TR_FPR);
         if (isDouble)
-            Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src1Reg, src1Reg, cg);
+            Inst_RTYPE(OP::_fsgnj_d, node, trgReg, src1Reg, src1Reg, cg);
         else
-            Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src1Reg, src1Reg, cg);
+            Inst_RTYPE(OP::_fsgnj_s, node, trgReg, src1Reg, src1Reg, cg);
     }
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
@@ -700,7 +698,7 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_LABEL(OP::label, node, startLabel, cg);
 
     /*
      * Check if src1Reg is NaN, if so then result is NaN.
@@ -710,7 +708,7 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
      * to the end (joinLabel)
      */
     Inst_RTYPE(feqOp, node, cmpReg, src1Reg, src1Reg, cg);
-    Inst_BTYPE(TR::InstOpCode::_beq, node, joinLabel, cmpReg, zero, cg);
+    Inst_BTYPE(OP::_beq, node, joinLabel, cmpReg, zero, cg);
 
     /*
      * Check if src2Reg is NaN, if so then result is NaN.
@@ -720,7 +718,7 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
      * So if src2Reg is NaN, just jump over comparison to that move.
      */
     Inst_RTYPE(feqOp, node, cmpReg, src2Reg, src2Reg, cg);
-    Inst_BTYPE(TR::InstOpCode::_beq, node, moveSrc2RegToTrgReg, cmpReg, zero, cg);
+    Inst_BTYPE(OP::_beq, node, moveSrc2RegToTrgReg, cmpReg, zero, cg);
 
     /*
      * Finally, compare the two values.
@@ -730,14 +728,14 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     else
         Inst_RTYPE(cmpOp, node, cmpReg, src1Reg, src2Reg, cg);
 
-    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, cmpReg, zero, cg);
-    Inst_LABEL(TR::InstOpCode::label, node, moveSrc2RegToTrgReg, cg);
+    Inst_BTYPE(OP::_bne, node, joinLabel, cmpReg, zero, cg);
+    Inst_LABEL(OP::label, node, moveSrc2RegToTrgReg, cg);
     if (isDouble)
-        Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src2Reg, src2Reg, cg);
+        Inst_RTYPE(OP::_fsgnj_d, node, trgReg, src2Reg, src2Reg, cg);
     else
-        Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src2Reg, src2Reg, cg);
+        Inst_RTYPE(OP::_fsgnj_s, node, trgReg, src2Reg, src2Reg, cg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+    Inst_LABEL(OP::label, node, joinLabel, deps, cg);
 
     cg->stopUsingRegister(cmpReg);
     node->setRegister(trgReg);
@@ -749,22 +747,22 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
 
 TR::Register *OMR::RV::TreeEvaluator::fmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFpMinMaxEvaluator(node, TR::InstOpCode::_flt_s, true, false, cg);
+    return commonFpMinMaxEvaluator(node, OP::_flt_s, true, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFpMinMaxEvaluator(node, TR::InstOpCode::_flt_s, false, false, cg);
+    return commonFpMinMaxEvaluator(node, OP::_flt_s, false, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFpMinMaxEvaluator(node, TR::InstOpCode::_flt_d, true, true, cg);
+    return commonFpMinMaxEvaluator(node, OP::_flt_d, true, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dminEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonFpMinMaxEvaluator(node, TR::InstOpCode::_flt_d, false, true, cg);
+    return commonFpMinMaxEvaluator(node, OP::_flt_d, false, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::b2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -828,27 +826,27 @@ TR::Register *OMR::RV::TreeEvaluator::fcmpneuEvaluator(TR::Node *node, TR::CodeG
      * the result.
      */
 
-    return compareUnorderedHelper(node, TR::InstOpCode::_feq_s, false, cg);
+    return compareUnorderedHelper(node, OP::_feq_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpltuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_fle_s, true, cg);
+    return compareUnorderedHelper(node, OP::_fle_s, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpgeuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_flt_s, false, cg);
+    return compareUnorderedHelper(node, OP::_flt_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpgtuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_fle_s, false, cg);
+    return compareUnorderedHelper(node, OP::_fle_s, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::fcmpleuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_flt_s, true, cg);
+    return compareUnorderedHelper(node, OP::_flt_s, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpequEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -872,27 +870,27 @@ TR::Register *OMR::RV::TreeEvaluator::dcmpneuEvaluator(TR::Node *node, TR::CodeG
      * the result.
      */
 
-    return compareUnorderedHelper(node, TR::InstOpCode::_feq_d, false, cg);
+    return compareUnorderedHelper(node, OP::_feq_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpltuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_fle_d, true, cg);
+    return compareUnorderedHelper(node, OP::_fle_d, true, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpgeuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_flt_d, false, cg);
+    return compareUnorderedHelper(node, OP::_flt_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpgtuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_fle_d, false, cg);
+    return compareUnorderedHelper(node, OP::_fle_d, false, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::dcmpleuEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return compareUnorderedHelper(node, TR::InstOpCode::_flt_d, true, cg);
+    return compareUnorderedHelper(node, OP::_flt_d, true, cg);
 }
 
 static TR::Register *compareThreeWayHelper(TR::Node *node, bool unorderedIsLess, TR::CodeGenerator *cg)
@@ -906,10 +904,8 @@ static TR::Register *compareThreeWayHelper(TR::Node *node, bool unorderedIsLess,
     TR::Register *trgReg = cg->allocateRegister();
     TR::RealRegister *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-    TR::InstOpCode::Mnemonic ltOp
-        = firstChild->getDataType().isDouble() ? TR::InstOpCode::_flt_d : TR::InstOpCode::_flt_s;
-    TR::InstOpCode::Mnemonic eqOp
-        = firstChild->getDataType().isDouble() ? TR::InstOpCode::_feq_d : TR::InstOpCode::_feq_s;
+    TR::InstOpCode::Mnemonic ltOp = firstChild->getDataType().isDouble() ? OP::_flt_d : OP::_flt_s;
+    TR::InstOpCode::Mnemonic eqOp = firstChild->getDataType().isDouble() ? OP::_feq_d : OP::_feq_s;
 
     /*
      * fcmpl / dcmpl does basically following:
@@ -971,20 +967,20 @@ static TR::Register *compareThreeWayHelper(TR::Node *node, bool unorderedIsLess,
 
     if (unorderedIsLess) {
         Inst_RTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
-        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 1, cg);
-        Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
-        Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
+        Inst_ITYPE(OP::_addi, node, trgReg, zero, 1, cg);
+        Inst_LABEL(OP::label, node, startLabel, cg);
+        Inst_BTYPE(OP::_bne, node, joinLabel, tmpReg, zero, cg);
         Inst_RTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
-        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, -1, cg);
-        Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+        Inst_ITYPE(OP::_addi, node, trgReg, trgReg, -1, cg);
+        Inst_LABEL(OP::label, node, joinLabel, deps, cg);
     } else {
         Inst_RTYPE(ltOp, node, tmpReg, src1Reg, src2Reg, cg);
-        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, -1, cg);
-        Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
-        Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
+        Inst_ITYPE(OP::_addi, node, trgReg, zero, -1, cg);
+        Inst_LABEL(OP::label, node, startLabel, cg);
+        Inst_BTYPE(OP::_bne, node, joinLabel, tmpReg, zero, cg);
         Inst_RTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
-        Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
-        Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+        Inst_ITYPE(OP::_xori, node, trgReg, trgReg, 1, cg);
+        Inst_LABEL(OP::label, node, joinLabel, deps, cg);
     }
 
     cg->stopUsingRegister(tmpReg);
@@ -1020,9 +1016,9 @@ static TR::Register *commonFpSelectEvaluator(TR::Node *node, bool isDouble, TR::
     if (!cg->canClobberNodesRegister(trueNode)) {
         TR::Register *resultReg = cg->allocateRegister(TR_FPR);
         if (isDouble)
-            Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, resultReg, trueReg, trueReg, cg);
+            Inst_RTYPE(OP::_fsgnj_d, node, resultReg, trueReg, trueReg, cg);
         else
-            Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, resultReg, trueReg, trueReg, cg);
+            Inst_RTYPE(OP::_fsgnj_s, node, resultReg, trueReg, trueReg, cg);
         trueReg = resultReg;
     }
 
@@ -1038,13 +1034,13 @@ static TR::Register *commonFpSelectEvaluator(TR::Node *node, bool isDouble, TR::
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);
 
-    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
-    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
+    Inst_LABEL(OP::label, node, startLabel, cg);
+    Inst_BTYPE(OP::_bne, node, joinLabel, condReg, zero, cg);
     if (isDouble)
-        Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trueReg, falseReg, falseReg, cg);
+        Inst_RTYPE(OP::_fsgnj_d, node, trueReg, falseReg, falseReg, cg);
     else
-        Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trueReg, falseReg, falseReg, cg);
-    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
+        Inst_RTYPE(OP::_fsgnj_s, node, trueReg, falseReg, falseReg, cg);
+    Inst_LABEL(OP::label, node, joinLabel, deps, cg);
 
     node->setRegister(trueReg);
     cg->decReferenceCount(condNode);

--- a/compiler/riscv/codegen/FPTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/FPTreeEvaluator.cpp
@@ -35,7 +35,7 @@ static void fpBitsMovHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Reg
     TR::Register *srcReg = cg->evaluate(child);
     TR::RealRegister *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-    generateRTYPE(op, node, trgReg, srcReg, zero, cg);
+    Inst_RTYPE(op, node, trgReg, srcReg, zero, cg);
 
     cg->decReferenceCount(child);
 }
@@ -93,7 +93,7 @@ TR::Register *OMR::RV::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeGe
 
     fvalue.f = node->getFloat();
     loadConstant32(cg, node, fvalue.i, tmpReg);
-    generateRTYPE(TR::InstOpCode::_fmv_s_x, node, trgReg, tmpReg, zero, cg);
+    Inst_RTYPE(TR::InstOpCode::_fmv_s_x, node, trgReg, tmpReg, zero, cg);
     cg->stopUsingRegister(tmpReg);
 
     node->setRegister(trgReg);
@@ -113,7 +113,7 @@ TR::Register *OMR::RV::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGe
 
     dvalue.d = node->getDouble();
     loadConstant64(cg, node, dvalue.l, tmpReg);
-    generateRTYPE(TR::InstOpCode::_fmv_d_x, node, trgReg, tmpReg, zero, cg);
+    Inst_RTYPE(TR::InstOpCode::_fmv_d_x, node, trgReg, tmpReg, zero, cg);
     cg->stopUsingRegister(tmpReg);
 
     node->setRegister(trgReg);
@@ -164,7 +164,7 @@ static TR::Register *commonFpEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic 
     TR::Register *trgReg;
 
     trgReg = isDouble ? cg->allocateRegister(TR_FPR) : cg->allocateSinglePrecisionRegister();
-    generateRTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
     node->setRegister(trgReg);
@@ -243,7 +243,7 @@ static TR::Register *commonFpUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnem
     } else {
         trgReg = srcReg;
     }
-    generateRTYPE(op, node, trgReg, srcReg, srcReg, cg);
+    Inst_RTYPE(op, node, trgReg, srcReg, srcReg, cg);
     cg->decReferenceCount(firstChild);
     node->setRegister(trgReg);
     return trgReg;
@@ -306,7 +306,7 @@ static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOp
     deps->addPostCondition(trgReg, TR::RealRegister::NoReg);
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
+    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
 
     /*
      * Check if srcReg is NaN, if so then result 0.
@@ -319,14 +319,14 @@ static TR::Register *commonFPtoINTconversionEvaluator(TR::Node *node, TR::InstOp
      */
     TR::InstOpCode::Mnemonic feqOp
         = firstChild->getDataType().isDouble() ? TR::InstOpCode::_feq_d : TR::InstOpCode::_feq_s;
-    generateRTYPE(feqOp, node, trgReg, src1Reg, src1Reg, cg);
-    generateBTYPE(TR::InstOpCode::_beq, node, joinLabel, trgReg, zero, cg);
+    Inst_RTYPE(feqOp, node, trgReg, src1Reg, src1Reg, cg);
+    Inst_BTYPE(TR::InstOpCode::_beq, node, joinLabel, trgReg, zero, cg);
     /*
      * Now do the actual conversion
      */
-    generateRTYPE(op, node, trgReg, src1Reg, zero, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, zero, cg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
 
     cg->decReferenceCount(firstChild);
     node->setRegister(trgReg);
@@ -341,7 +341,7 @@ static TR::Register *commonINTtoFPconversionEvaluator(TR::Node *node, TR::InstOp
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
     TR::Register *trgReg = cg->allocateRegister(TR_FPR);
 
-    generateRTYPE(op, node, trgReg, src1Reg, zero, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, zero, cg);
 
     cg->decReferenceCount(firstChild);
     node->setRegister(trgReg);
@@ -356,7 +356,7 @@ static TR::Register *commonFPPtoFPconversionEvaluator(TR::Node *node, TR::InstOp
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
     TR::Register *trgReg = cg->allocateRegister(TR_FPR);
 
-    generateRTYPE(op, node, trgReg, src1Reg, zero, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, zero, cg);
 
     cg->decReferenceCount(firstChild);
     node->setRegister(trgReg);
@@ -468,9 +468,9 @@ static TR::Register *compareHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, 
     TR::Register *trgReg = cg->allocateRegister();
 
     if (reverse)
-        generateRTYPE(op, node, trgReg, src2Reg, src1Reg, cg);
+        Inst_RTYPE(op, node, trgReg, src2Reg, src1Reg, cg);
     else
-        generateRTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(op, node, trgReg, src1Reg, src2Reg, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -501,13 +501,13 @@ static TR::Register *compareNotEqualHelper(TR::Node *node, TR::InstOpCode::Mnemo
      * logical and of all three comparisons. This way, we avoid branching.
      */
 
-    generateRTYPE(op, node, trgReg, src1Reg, src1Reg, cg);
-    generateRTYPE(op, node, tmpReg, src2Reg, src2Reg, cg);
-    generateRTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
+    Inst_RTYPE(op, node, trgReg, src1Reg, src1Reg, cg);
+    Inst_RTYPE(op, node, tmpReg, src2Reg, src2Reg, cg);
+    Inst_RTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
 
-    generateRTYPE(op, node, tmpReg, src1Reg, src2Reg, cg);
-    generateITYPE(TR::InstOpCode::_xori, node, tmpReg, tmpReg, 1, cg);
-    generateRTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
+    Inst_RTYPE(op, node, tmpReg, src1Reg, src2Reg, cg);
+    Inst_ITYPE(TR::InstOpCode::_xori, node, tmpReg, tmpReg, 1, cg);
+    Inst_RTYPE(TR::InstOpCode::_and, node, trgReg, trgReg, tmpReg, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -535,11 +535,11 @@ static TR::Register *compareUnorderedHelper(TR::Node *node, TR::InstOpCode::Mnem
      */
 
     if (reverse)
-        generateRTYPE(cmpOp, node, trgReg, src2Reg, src1Reg, cg);
+        Inst_RTYPE(cmpOp, node, trgReg, src2Reg, src1Reg, cg);
     else
-        generateRTYPE(cmpOp, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(cmpOp, node, trgReg, src1Reg, src2Reg, cg);
 
-    generateITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
+    Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -573,10 +573,10 @@ static TR::Register *compareEqualOrUnorderedHelper(TR::Node *node, TR::CodeGener
         = firstChild->getDataType().isDouble() ? TR::InstOpCode::_flt_d : TR::InstOpCode::_flt_s;
     TR::Register *tmpReg = cg->allocateRegister();
 
-    generateRTYPE(ltOp, node, trgReg, src1Reg, src2Reg, cg);
-    generateRTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
-    generateRTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
-    generateITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
+    Inst_RTYPE(ltOp, node, trgReg, src1Reg, src2Reg, cg);
+    Inst_RTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
+    Inst_RTYPE(TR::InstOpCode::_or, node, trgReg, trgReg, tmpReg, cg);
+    Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -681,9 +681,9 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     } else {
         trgReg = cg->allocateRegister(TR_FPR);
         if (isDouble)
-            generateRTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src1Reg, src1Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src1Reg, src1Reg, cg);
         else
-            generateRTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src1Reg, src1Reg, cg);
+            Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src1Reg, src1Reg, cg);
     }
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
@@ -700,7 +700,7 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
     deps->addPostCondition(src1Reg, TR::RealRegister::NoReg);
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
+    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
 
     /*
      * Check if src1Reg is NaN, if so then result is NaN.
@@ -709,8 +709,8 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
      * src1Reg (using feq.s / feq.d) and if it's NaN, we just jump
      * to the end (joinLabel)
      */
-    generateRTYPE(feqOp, node, cmpReg, src1Reg, src1Reg, cg);
-    generateBTYPE(TR::InstOpCode::_beq, node, joinLabel, cmpReg, zero, cg);
+    Inst_RTYPE(feqOp, node, cmpReg, src1Reg, src1Reg, cg);
+    Inst_BTYPE(TR::InstOpCode::_beq, node, joinLabel, cmpReg, zero, cg);
 
     /*
      * Check if src2Reg is NaN, if so then result is NaN.
@@ -719,25 +719,25 @@ static TR::Register *commonFpMinMaxEvaluator(TR::Node *node, TR::InstOpCode::Mne
      * later on when we compare and (eventually) move src2Reg into trgReg.
      * So if src2Reg is NaN, just jump over comparison to that move.
      */
-    generateRTYPE(feqOp, node, cmpReg, src2Reg, src2Reg, cg);
-    generateBTYPE(TR::InstOpCode::_beq, node, moveSrc2RegToTrgReg, cmpReg, zero, cg);
+    Inst_RTYPE(feqOp, node, cmpReg, src2Reg, src2Reg, cg);
+    Inst_BTYPE(TR::InstOpCode::_beq, node, moveSrc2RegToTrgReg, cmpReg, zero, cg);
 
     /*
      * Finally, compare the two values.
      */
     if (reverse)
-        generateRTYPE(cmpOp, node, cmpReg, src2Reg, src1Reg, cg);
+        Inst_RTYPE(cmpOp, node, cmpReg, src2Reg, src1Reg, cg);
     else
-        generateRTYPE(cmpOp, node, cmpReg, src1Reg, src2Reg, cg);
+        Inst_RTYPE(cmpOp, node, cmpReg, src1Reg, src2Reg, cg);
 
-    generateBTYPE(TR::InstOpCode::_bne, node, joinLabel, cmpReg, zero, cg);
-    generateLABEL(cg, TR::InstOpCode::label, node, moveSrc2RegToTrgReg);
+    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, cmpReg, zero, cg);
+    Inst_LABEL(TR::InstOpCode::label, node, moveSrc2RegToTrgReg, cg);
     if (isDouble)
-        generateRTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src2Reg, src2Reg, cg);
+        Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trgReg, src2Reg, src2Reg, cg);
     else
-        generateRTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src2Reg, src2Reg, cg);
+        Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trgReg, src2Reg, src2Reg, cg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
 
     cg->stopUsingRegister(cmpReg);
     node->setRegister(trgReg);
@@ -970,21 +970,21 @@ static TR::Register *compareThreeWayHelper(TR::Node *node, bool unorderedIsLess,
     deps->addPostCondition(src2Reg, TR::RealRegister::NoReg);
 
     if (unorderedIsLess) {
-        generateRTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
-        generateITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 1, cg);
-        generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
-        generateBTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
-        generateRTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
-        generateITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, -1, cg);
-        generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+        Inst_RTYPE(ltOp, node, tmpReg, src2Reg, src1Reg, cg);
+        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, 1, cg);
+        Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
+        Inst_RTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, -1, cg);
+        Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
     } else {
-        generateRTYPE(ltOp, node, tmpReg, src1Reg, src2Reg, cg);
-        generateITYPE(TR::InstOpCode::_addi, node, trgReg, zero, -1, cg);
-        generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
-        generateBTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
-        generateRTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
-        generateITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
-        generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+        Inst_RTYPE(ltOp, node, tmpReg, src1Reg, src2Reg, cg);
+        Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, zero, -1, cg);
+        Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, tmpReg, zero, cg);
+        Inst_RTYPE(eqOp, node, trgReg, src1Reg, src2Reg, cg);
+        Inst_ITYPE(TR::InstOpCode::_xori, node, trgReg, trgReg, 1, cg);
+        Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
     }
 
     cg->stopUsingRegister(tmpReg);
@@ -1020,9 +1020,9 @@ static TR::Register *commonFpSelectEvaluator(TR::Node *node, bool isDouble, TR::
     if (!cg->canClobberNodesRegister(trueNode)) {
         TR::Register *resultReg = cg->allocateRegister(TR_FPR);
         if (isDouble)
-            generateRTYPE(TR::InstOpCode::_fsgnj_d, node, resultReg, trueReg, trueReg, cg);
+            Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, resultReg, trueReg, trueReg, cg);
         else
-            generateRTYPE(TR::InstOpCode::_fsgnj_s, node, resultReg, trueReg, trueReg, cg);
+            Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, resultReg, trueReg, trueReg, cg);
         trueReg = resultReg;
     }
 
@@ -1038,13 +1038,13 @@ static TR::Register *commonFpSelectEvaluator(TR::Node *node, bool isDouble, TR::
     deps->addPostCondition(trueReg, TR::RealRegister::NoReg);
     deps->addPostCondition(falseReg, TR::RealRegister::NoReg);
 
-    generateLABEL(cg, TR::InstOpCode::label, node, startLabel);
-    generateBTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
+    Inst_LABEL(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_BTYPE(TR::InstOpCode::_bne, node, joinLabel, condReg, zero, cg);
     if (isDouble)
-        generateRTYPE(TR::InstOpCode::_fsgnj_d, node, trueReg, falseReg, falseReg, cg);
+        Inst_RTYPE(TR::InstOpCode::_fsgnj_d, node, trueReg, falseReg, falseReg, cg);
     else
-        generateRTYPE(TR::InstOpCode::_fsgnj_s, node, trueReg, falseReg, falseReg, cg);
-    generateLABEL(cg, TR::InstOpCode::label, node, joinLabel, deps);
+        Inst_RTYPE(TR::InstOpCode::_fsgnj_s, node, trueReg, falseReg, falseReg, cg);
+    Inst_LABEL(TR::InstOpCode::label, node, joinLabel, deps, cg);
 
     node->setRegister(trueReg);
     cg->decReferenceCount(condNode);

--- a/compiler/riscv/codegen/GenerateInstructions.cpp
+++ b/compiler/riscv/codegen/GenerateInstructions.cpp
@@ -37,15 +37,14 @@ class RegisterDependencyConditions;
 class SymbolReference;
 } // namespace TR
 
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Instruction *preced)
+TR::Instruction *Inst(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::Instruction(op, node, preced, cg);
     return new (cg->trHeapMemory()) TR::Instruction(op, node, cg);
 }
 
-TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_LABEL(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg,
     TR::Instruction *preced)
 {
     if (preced)
@@ -53,15 +52,15 @@ TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic o
     return new (cg->trHeapMemory()) TR::LabelInstruction(op, node, sym, cg);
 }
 
-TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+TR::Instruction *Inst_LABEL(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::LabelInstruction(op, node, sym, cond, preced, cg);
     return new (cg->trHeapMemory()) TR::LabelInstruction(op, node, sym, cond, cg);
 }
 
-TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
+TR::Instruction *Inst_ADMIN(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg, TR::Node *fenceNode,
     TR::Instruction *preced)
 {
     if (preced)
@@ -69,15 +68,23 @@ TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic o
     return new (cg->trHeapMemory()) TR::AdminInstruction(op, node, fenceNode, cg);
 }
 
-TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::RegisterDependencyConditions *cond, TR::Node *fenceNode, TR::Instruction *preced)
+TR::Instruction *Inst_ADMIN(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+    TR::CodeGenerator *cg, TR::Node *fenceNode, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::AdminInstruction(op, cond, node, fenceNode, preced, cg);
     return new (cg->trHeapMemory()) TR::AdminInstruction(op, cond, node, fenceNode, cg);
 }
 
-TR::Instruction *generateRTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_DATA(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg,
+    TR::Instruction *preced)
+{
+    if (preced)
+        return new (cg->trHeapMemory()) TR::DataInstruction(op, node, imm, preced, cg);
+    return new (cg->trHeapMemory()) TR::DataInstruction(op, node, imm, cg);
+}
+
+TR::Instruction *Inst_RTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -85,7 +92,7 @@ TR::Instruction *generateRTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::RtypeInstruction(op, n, treg, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_ITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
     uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -93,7 +100,7 @@ TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::ItypeInstruction(op, n, treg, sreg, imm, cg);
 }
 
-TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_ITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
     uint32_t imm, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -101,15 +108,15 @@ TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::ItypeInstruction(op, n, treg, sreg, imm, cond, cg);
 }
 
-TR::Instruction *generateLOAD(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
-    TR::MemoryReference *memRef, TR::CodeGenerator *cg, TR::Instruction *previous)
+TR::Instruction *Inst_LOAD(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::MemoryReference *memRef,
+    TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
         return new (cg->trHeapMemory()) TR::LoadInstruction(op, n, trgReg, memRef, previous, cg);
     return new (cg->trHeapMemory()) TR::LoadInstruction(op, n, trgReg, memRef, cg);
 }
 
-TR::Instruction *generateSTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg, TR::Register *s2reg,
+TR::Instruction *Inst_STYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg, TR::Register *s2reg,
     uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -117,15 +124,15 @@ TR::Instruction *generateSTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::StypeInstruction(op, n, s1reg, s2reg, imm, cg);
 }
 
-TR::Instruction *generateSTORE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::MemoryReference *memRef,
-    TR::Register *srcReg, TR::CodeGenerator *cg, TR::Instruction *previous)
+TR::Instruction *Inst_STORE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::MemoryReference *memRef, TR::Register *srcReg,
+    TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
         return new (cg->trHeapMemory()) TR::StoreInstruction(op, n, memRef, srcReg, previous, cg);
     return new (cg->trHeapMemory()) TR::StoreInstruction(op, n, memRef, srcReg, cg);
 }
 
-TR::Instruction *generateBTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::LabelSymbol *sym, TR::Register *src1,
+TR::Instruction *Inst_BTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::LabelSymbol *sym, TR::Register *src1,
     TR::Register *src2, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -133,7 +140,7 @@ TR::Instruction *generateBTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Lab
     return new (cg->trHeapMemory()) TR::BtypeInstruction(op, n, sym, src1, src2, cg);
 }
 
-TR::Instruction *generateUTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_t imm, TR::Register *reg,
+TR::Instruction *Inst_UTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_t imm, TR::Register *reg,
     TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -141,7 +148,7 @@ TR::Instruction *generateUTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_
     return new (cg->trHeapMemory()) TR::UtypeInstruction(op, n, imm, reg, cg);
 }
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, uintptr_t imm,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, uintptr_t imm,
     TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::CodeGenerator *cg,
     TR::Instruction *previous)
 {
@@ -150,7 +157,7 @@ TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::JtypeInstruction(op, n, trgReg, imm, cond, sr, s, cg);
 }
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -158,7 +165,7 @@ TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::JtypeInstruction(op, n, trgReg, label, cg);
 }
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -166,7 +173,7 @@ TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
     return new (cg->trHeapMemory()) TR::JtypeInstruction(op, n, trgReg, label, cond, cg);
 }
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::Snippet *snippet, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)
@@ -175,7 +182,7 @@ TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Reg
 }
 
 #ifdef J9_PROJECT_SPECIFIC
-TR::Instruction *generateVGNOP(TR::Node *n, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
+TR::Instruction *Inst_VGNOP(TR::Node *n, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
     TR::LabelSymbol *sym, TR::CodeGenerator *cg, TR::Instruction *previous)
 {
     if (previous)

--- a/compiler/riscv/codegen/GenerateInstructions.hpp
+++ b/compiler/riscv/codegen/GenerateInstructions.hpp
@@ -49,7 +49,7 @@ class TR_VirtualGuardSite;
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg,
     TR::Instruction *preced = NULL);
 
 /*
@@ -61,7 +61,7 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_LABEL(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg,
     TR::Instruction *preced = NULL);
 
 /*
@@ -74,74 +74,198 @@ TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic o
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_LABEL(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates admin instruction
- * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode
  * @param[in] node : node
+ * @param[in] cg : CodeGenerator
  * @param[in] fenceNode : fence node
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_ADMIN(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg,
     TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates admin instruction with register dependency
- * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode
  * @param[in] node : node
  * @param[in] cond : register dependency condition
+ * @param[in] cg : CodeGenerator*
  * @param[in] fenceNode : fence node
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_ADMIN(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+    TR::CodeGenerator *cg, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
-TR::Instruction *generateRTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_DATA(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg,
+    TR::Instruction *precedingInstruction = NULL);
+
+TR::Instruction *Inst_RTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_ITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
     uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_ITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg, TR::Register *sreg,
     uint32_t imm, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateLOAD(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
-    TR::MemoryReference *memRef, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
-
-TR::Instruction *generateSTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg, TR::Register *s2reg,
-    uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
-
-TR::Instruction *generateSTORE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::MemoryReference *memRef,
-    TR::Register *srcReg, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
-
-TR::Instruction *generateBTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::LabelSymbol *sym, TR::Register *src1,
-    TR::Register *src2, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
-
-TR::Instruction *generateUTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_t imm, TR::Register *reg,
+TR::Instruction *Inst_LOAD(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::MemoryReference *memRef,
     TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, uintptr_t imm,
+TR::Instruction *Inst_STYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg, TR::Register *s2reg,
+    uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
+
+TR::Instruction *Inst_STORE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::MemoryReference *memRef, TR::Register *srcReg,
+    TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
+
+TR::Instruction *Inst_BTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::LabelSymbol *sym, TR::Register *src1,
+    TR::Register *src2, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
+
+TR::Instruction *Inst_UTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_t imm, TR::Register *reg,
+    TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
+
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, uintptr_t imm,
     TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::CodeGenerator *cg,
     TR::Instruction *previous = NULL);
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 
-TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
+TR::Instruction *Inst_JTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg, TR::LabelSymbol *label,
     TR::Snippet *snippet, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg,
     TR::Instruction *previous = NULL);
 
 #ifdef J9_PROJECT_SPECIFIC
-TR::Instruction *generateVGNOP(TR::Node *n, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
+TR::Instruction *Inst_VGNOP(TR::Node *n, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
     TR::LabelSymbol *sym, TR::CodeGenerator *cg, TR::Instruction *previous = NULL);
 #endif // J9_PROJECT_SPECIFIC
+
+/*
+ * Following functions are DEPRECATED and should not be used in new code.
+ * The definitions here are only for backward compatibility!
+ * */
+
+static inline TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+    TR::Instruction *preced = NULL)
+{
+    return Inst(op, node, cg, preced);
+}
+
+static inline TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+    TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
+{
+    return Inst_LABEL(op, node, sym, cg, preced);
+}
+
+static inline TR::Instruction *generateLABEL(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
+{
+    return Inst_LABEL(op, node, sym, cond, cg, preced);
+}
+
+static inline TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+    TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
+{
+    return Inst_ADMIN(op, node, cg, fenceNode, preced);
+}
+
+static inline TR::Instruction *generateADMIN(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+    TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
+{
+    return Inst_ADMIN(op, node, cond, cg, fenceNode, preced);
+}
+
+static inline TR::Instruction *generateRTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_RTYPE(op, n, treg, s1reg, s2reg, cg, previous);
+}
+
+static inline TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg,
+    TR::Register *sreg, uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_ITYPE(op, n, treg, sreg, imm, cg, previous);
+}
+
+static inline TR::Instruction *generateITYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg,
+    TR::Register *sreg, uint32_t imm, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg,
+    TR::Instruction *previous = NULL)
+{
+    return Inst_ITYPE(op, n, treg, sreg, imm, cond, cg, previous);
+}
+
+static inline TR::Instruction *generateLOAD(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *treg,
+    TR::MemoryReference *memRef, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_LOAD(op, n, treg, memRef, cg, previous);
+}
+
+static inline TR::Instruction *generateSTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *s1reg,
+    TR::Register *s2reg, uint32_t imm, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_STYPE(op, n, s1reg, s2reg, imm, cg, previous);
+}
+
+static inline TR::Instruction *generateSTORE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::MemoryReference *memRef,
+    TR::Register *srcReg, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_STORE(op, n, memRef, srcReg, cg, previous);
+}
+
+static inline TR::Instruction *generateBTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::LabelSymbol *sym,
+    TR::Register *src1, TR::Register *src2, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_BTYPE(op, n, sym, src1, src2, cg, previous);
+}
+
+static inline TR::Instruction *generateUTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, uint32_t imm, TR::Register *reg,
+    TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_UTYPE(op, n, imm, reg, cg, previous);
+}
+
+static inline TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
+    uintptr_t imm, TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s,
+    TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_JTYPE(op, n, trgReg, imm, cond, sr, s, cg, previous);
+}
+
+static inline TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
+    TR::LabelSymbol *label, TR::CodeGenerator *cg, TR::Instruction *previous = NULL)
+{
+    return Inst_JTYPE(op, n, trgReg, label, cg, previous);
+}
+
+static inline TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
+    TR::LabelSymbol *label, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg,
+    TR::Instruction *previous = NULL)
+{
+    return Inst_JTYPE(op, n, trgReg, label, cond, cg, previous);
+}
+
+static inline TR::Instruction *generateJTYPE(TR::InstOpCode::Mnemonic op, TR::Node *n, TR::Register *trgReg,
+    TR::LabelSymbol *label, TR::Snippet *snippet, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg,
+    TR::Instruction *previous = NULL)
+{
+    return Inst_JTYPE(op, n, trgReg, label, snippet, cond, cg, previous);
+}
+
+#ifdef J9_PROJECT_SPECIFIC
+static inline TR::Instruction *generateVGNOP(TR::Node *n, TR_VirtualGuardSite *site,
+    TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::CodeGenerator *cg,
+    TR::Instruction *previous = NULL)
+{
+    return Inst_VGNOP(n, site, cond, sym, cg, previous);
+}
+#endif // J9_PROJECT_SPECIFIC
+
 #endif

--- a/compiler/riscv/codegen/InstOpCode.hpp
+++ b/compiler/riscv/codegen/InstOpCode.hpp
@@ -78,5 +78,9 @@ public:
     }
 };
 
+using OP = TR::InstOpCode;
+
 } // namespace TR
+
+using TR::OP;
 #endif

--- a/compiler/riscv/codegen/MemoryReference.hpp
+++ b/compiler/riscv/codegen/MemoryReference.hpp
@@ -23,6 +23,7 @@
 #define TR_MEMORYREFERENCE_INCL
 
 #include "codegen/OMRMemoryReference.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 #include <stdint.h>
 
@@ -85,6 +86,55 @@ public:
         : OMR::MemoryReferenceConnector(node, symRef, len, cg)
     {}
 };
+
+/**
+ * @brief Create a memory reference using base register and displacement.
+ *
+ * @param[in] br : base register
+ * @param[in] disp : displacement
+ * @param[in] cg : CodeGenerator object
+ * @return New memory reference.
+ */
+inline TR::MemoryReference *MRef_BaseDisp(TR::Register *br, int32_t disp, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::MemoryReference(br, disp, cg);
+}
+
+/**
+ * @brief Create a memory reference using base register only - the displacement is zero.
+ * Equivalent to `MRef_Base(br, 0, cg)`.
+ *
+ * @param[in] br : base register
+ * @param[in] cg : CodeGenerator object
+ * @return New memory reference.
+ */
+inline TR::MemoryReference *MRef_Base(TR::Register *br, TR::CodeGenerator *cg) { return MRef_BaseDisp(br, 0, cg); }
+
+/**
+ * @brief Creates a memory reference from given load or store IL node.
+ *
+ * @param[in] node : load or store node
+ * @param[in] cg : CodeGenerator object
+ * @return New memory reference.
+ */
+inline TR::MemoryReference *MRef_Node(TR::Node *node, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSize(), cg);
+}
+
+/**
+ * @brief Creates a memory reference from given node and symbol reference.
+ *
+ * @param[in] node : node
+ * @param[in] symRef : symbol reference.
+ * @param[in] cg : CodeGenerator object
+ * @return New memory reference.
+ */
+inline TR::MemoryReference *MRef_Sym(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::MemoryReference(node, node->getSize(), cg);
+}
+
 } // namespace TR
 
 #endif

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -34,6 +34,7 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "ras/Logger.hpp"
+#include "GenerateInstructions.hpp"
 
 OMR::RV::CodeGenerator::CodeGenerator(TR::Compilation *comp)
     : OMR::CodeGenerator(comp)
@@ -132,13 +133,13 @@ void OMR::RV::CodeGenerator::beginInstructionSelection()
     TR::Compilation *comp = self()->comp();
     TR::Node *startNode = comp->getStartTree()->getNode();
     if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private) {
-        _returnTypeInfoInstruction = new (trHeapMemory()) TR::DataInstruction(TR::InstOpCode::dd, startNode, 0, self());
+        _returnTypeInfoInstruction
+            = static_cast<TR::DataInstruction *>(Inst_DATA(TR::InstOpCode::dd, startNode, 0, self()));
     } else {
         _returnTypeInfoInstruction = NULL;
     }
 
-    new (trHeapMemory())
-        TR::AdminInstruction(TR::InstOpCode::proc, startNode, NULL, _returnTypeInfoInstruction, self());
+    Inst_ADMIN(TR::InstOpCode::proc, startNode, self(), NULL, _returnTypeInfoInstruction);
 }
 
 void OMR::RV::CodeGenerator::endInstructionSelection()
@@ -275,7 +276,7 @@ TR::Register *OMR::RV::CodeGenerator::gprClobberEvaluate(TR::Node *node)
     if (node->getReferenceCount() > 1) {
         TR::Register *sourceReg = self()->evaluate(node);
         TR::Register *targetReg = self()->allocateRegister();
-        generateITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, self());
+        Inst_ITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, self());
 
         if (sourceReg->containsCollectedReference()) {
             logprintf(trace, log, "Setting containsCollectedReference on register %s\n",

--- a/compiler/riscv/codegen/OMRCodeGenerator.cpp
+++ b/compiler/riscv/codegen/OMRCodeGenerator.cpp
@@ -133,13 +133,12 @@ void OMR::RV::CodeGenerator::beginInstructionSelection()
     TR::Compilation *comp = self()->comp();
     TR::Node *startNode = comp->getStartTree()->getNode();
     if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private) {
-        _returnTypeInfoInstruction
-            = static_cast<TR::DataInstruction *>(Inst_DATA(TR::InstOpCode::dd, startNode, 0, self()));
+        _returnTypeInfoInstruction = static_cast<TR::DataInstruction *>(Inst_DATA(OP::dd, startNode, 0, self()));
     } else {
         _returnTypeInfoInstruction = NULL;
     }
 
-    Inst_ADMIN(TR::InstOpCode::proc, startNode, self(), NULL, _returnTypeInfoInstruction);
+    Inst_ADMIN(OP::proc, startNode, self(), NULL, _returnTypeInfoInstruction);
 }
 
 void OMR::RV::CodeGenerator::endInstructionSelection()
@@ -174,7 +173,7 @@ void OMR::RV::CodeGenerator::doBinaryEncoding()
 
     bool skipOneReturn = false;
     while (cursorInstruction) {
-        if (cursorInstruction->getOpCodeValue() == TR::InstOpCode::retn) {
+        if (cursorInstruction->getOpCodeValue() == OP::retn) {
             if (skipOneReturn == false) {
                 TR::Instruction *temp = cursorInstruction->getPrev();
                 getLinkage()->createEpilogue(temp);
@@ -276,7 +275,7 @@ TR::Register *OMR::RV::CodeGenerator::gprClobberEvaluate(TR::Node *node)
     if (node->getReferenceCount() > 1) {
         TR::Register *sourceReg = self()->evaluate(node);
         TR::Register *targetReg = self()->allocateRegister();
-        Inst_ITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, self());
+        Inst_ITYPE(OP::_addi, node, targetReg, sourceReg, 0, self());
 
         if (sourceReg->containsCollectedReference()) {
             logprintf(trace, log, "Setting containsCollectedReference on register %s\n",

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -93,8 +93,7 @@ TR::MemoryReference *OMR::RV::Linkage::getOutgoingArgumentMemRef(TR::Register *a
     TR::Machine *machine = cg()->machine();
     const TR::RVLinkageProperties &properties = self()->getProperties();
 
-    TR::MemoryReference *result
-        = new (self()->trHeapMemory()) TR::MemoryReference(argMemReg, offset, cg()); // post-increment
+    TR::MemoryReference *result = MRef_BaseDisp(argMemReg, offset, cg()); // post-increment
     memArg.argRegister = argReg;
     memArg.argMemory = result;
     memArg.opCode = opCode; // opCode must be post-index form
@@ -305,7 +304,7 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
                     diagnostic("copyParametersToHomeLocation: Loading %d\n", ai);
 
                 // ai := stack
-                TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
+                TR::MemoryReference *stackMR = MRef_BaseDisp(stackPtr, offset, cg());
                 loadCursor = Inst_LOAD(getOpCodeForParmLoads(paramType), NULL, machine->getRealRegister(ai), stackMR,
                     cg(), loadCursor);
             }
@@ -327,8 +326,7 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
                         diagnostic("copyParametersToHomeLocation: Storing %d\n", sourceIndex);
 
                     TR::RealRegister *linkageReg = machine->getRealRegister(sourceIndex);
-                    TR::MemoryReference *stackMR
-                        = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
+                    TR::MemoryReference *stackMR = MRef_BaseDisp(stackPtr, offset, cg());
                     cursor = Inst_STORE(getOpCodeForParmStores(paramType), NULL, stackMR, linkageReg, cg(), cursor);
                 }
             }

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -306,7 +306,7 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
 
                 // ai := stack
                 TR::MemoryReference *stackMR = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
-                loadCursor = generateLOAD(getOpCodeForParmLoads(paramType), NULL, machine->getRealRegister(ai), stackMR,
+                loadCursor = Inst_LOAD(getOpCodeForParmLoads(paramType), NULL, machine->getRealRegister(ai), stackMR,
                     cg(), loadCursor);
             }
         } else // It's in a linkage register
@@ -329,7 +329,7 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
                     TR::RealRegister *linkageReg = machine->getRealRegister(sourceIndex);
                     TR::MemoryReference *stackMR
                         = new (cg()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, cg());
-                    cursor = generateSTORE(getOpCodeForParmStores(paramType), NULL, stackMR, linkageReg, cg(), cursor);
+                    cursor = Inst_STORE(getOpCodeForParmStores(paramType), NULL, stackMR, linkageReg, cg(), cursor);
                 }
             }
 
@@ -412,14 +412,12 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
                 TR::Register *trgReg = machine->getRealRegister(regCursor);
                 TR::Register *srcReg = machine->getRealRegister(source);
                 if ((paramType == TR::Double) || (paramType == TR::Float)) {
-                    cursor
-                        = generateRTYPE((paramType == TR::Double) ? TR::InstOpCode::_fsgnj_d : TR::InstOpCode::_fsgnj_s,
-                            NULL, trgReg, srcReg, srcReg, cg(), cursor);
+                    cursor = Inst_RTYPE((paramType == TR::Double) ? TR::InstOpCode::_fsgnj_d : TR::InstOpCode::_fsgnj_s,
+                        NULL, trgReg, srcReg, srcReg, cg(), cursor);
                 } else {
-                    cursor
-                        = generateITYPE((paramType == TR::Int64) || (paramType == TR::Address) ? TR::InstOpCode::_addi
+                    cursor = Inst_ITYPE((paramType == TR::Int64) || (paramType == TR::Address) ? TR::InstOpCode::_addi
                                                                                                : TR::InstOpCode::_addiw,
-                            NULL, trgReg, srcReg, 0, cg(), cursor);
+                        NULL, trgReg, srcReg, 0, cg(), cursor);
                 }
 
                 // Update movStatus as we go so we don't generate redundant moves

--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -201,14 +201,14 @@ static inline TR::InstOpCode::Mnemonic getOpCodeForParmLoads(TR::DataTypes type)
 {
     switch (type) {
         case TR::Double:
-            return TR::InstOpCode::_fld;
+            return OP::_fld;
         case TR::Float:
-            return TR::InstOpCode::_flw;
+            return OP::_flw;
         case TR::Int64:
         case TR::Address:
-            return TR::InstOpCode::_ld;
+            return OP::_ld;
         default:
-            return TR::InstOpCode::_lw;
+            return OP::_lw;
     }
 }
 
@@ -223,14 +223,14 @@ static inline TR::InstOpCode::Mnemonic getOpCodeForParmStores(TR::DataTypes type
 {
     switch (type) {
         case TR::Double:
-            return TR::InstOpCode::_fsd;
+            return OP::_fsd;
         case TR::Float:
-            return TR::InstOpCode::_fsw;
+            return OP::_fsw;
         case TR::Int64:
         case TR::Address:
-            return TR::InstOpCode::_sd;
+            return OP::_sd;
         default:
-            return TR::InstOpCode::_sw;
+            return OP::_sw;
     }
 }
 
@@ -412,11 +412,10 @@ TR::Instruction *OMR::RV::Linkage::copyParametersToHomeLocation(TR::Instruction 
                 TR::Register *trgReg = machine->getRealRegister(regCursor);
                 TR::Register *srcReg = machine->getRealRegister(source);
                 if ((paramType == TR::Double) || (paramType == TR::Float)) {
-                    cursor = Inst_RTYPE((paramType == TR::Double) ? TR::InstOpCode::_fsgnj_d : TR::InstOpCode::_fsgnj_s,
-                        NULL, trgReg, srcReg, srcReg, cg(), cursor);
+                    cursor = Inst_RTYPE((paramType == TR::Double) ? OP::_fsgnj_d : OP::_fsgnj_s, NULL, trgReg, srcReg,
+                        srcReg, cg(), cursor);
                 } else {
-                    cursor = Inst_ITYPE((paramType == TR::Int64) || (paramType == TR::Address) ? TR::InstOpCode::_addi
-                                                                                               : TR::InstOpCode::_addiw,
+                    cursor = Inst_ITYPE((paramType == TR::Int64) || (paramType == TR::Address) ? OP::_addi : OP::_addiw,
                         NULL, trgReg, srcReg, 0, cg(), cursor);
                 }
 

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -211,7 +211,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    generateLOAD(loadOp, currentNode, best, tmemref, cg(), currentInstruction);
+    Inst_LOAD(loadOp, currentNode, best, tmemref, cg(), currentInstruction);
 
     cg()->traceRegFreed(candidates[0], best);
 
@@ -358,7 +358,7 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             break;
     }
 
-    generateSTORE(storeOp, currentNode, tmemref, targetRegister, cg(), currentInstruction);
+    Inst_STORE(storeOp, currentNode, tmemref, targetRegister, cg(), currentInstruction);
 
     return targetRegister;
 }
@@ -408,12 +408,12 @@ static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds
     TR::Node *node = precedingInstruction->getNode();
     switch (rk) {
         case TR_GPR:
-            generateITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
+            Inst_ITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
             break;
         case TR_FPR:
             TR_ASSERT_FATAL(sourceReg->isSinglePrecision() == targetReg->isSinglePrecision(),
                 "Source and target register size mismatch");
-            generateRTYPE(sourceReg->isSinglePrecision() ? TR::InstOpCode::_fsgnj_s : TR::InstOpCode::_fsgnj_d, node,
+            Inst_RTYPE(sourceReg->isSinglePrecision() ? TR::InstOpCode::_fsgnj_s : TR::InstOpCode::_fsgnj_d, node,
                 targetReg, sourceReg, sourceReg, cg, precedingInstruction);
             break;
         default:
@@ -430,9 +430,9 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 
     TR::Node *node = precedingInstruction->getNode();
     if (rk == TR_GPR) {
-        generateRTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
-        generateRTYPE(TR::InstOpCode::_xor, node, sourceReg, targetReg, sourceReg, cg, precedingInstruction);
-        generateRTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(TR::InstOpCode::_xor, node, sourceReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
     } else {
         registerCopy(precedingInstruction, rk, middleReg, targetReg, cg);
         registerCopy(precedingInstruction, rk, targetReg, sourceReg, cg);

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -116,8 +116,8 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
         }
 
         cursor = currentInstruction;
-        while (numCandidates > 1 && cursor != NULL && cursor->getOpCodeValue() != TR::InstOpCode::label
-            && cursor->getOpCodeValue() != TR::InstOpCode::proc) {
+        while (numCandidates > 1 && cursor != NULL && cursor->getOpCodeValue() != OP::label
+            && cursor->getOpCodeValue() != OP::proc) {
             for (int32_t i = 0; i < numCandidates; i++) {
                 if (cursor->refsRegister(candidates[i])) {
                     candidates[i] = candidates[--numCandidates];
@@ -202,10 +202,10 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
 
     switch (rk) {
         case TR_GPR:
-            loadOp = TR::InstOpCode::_ld;
+            loadOp = OP::_ld;
             break;
         case TR_FPR:
-            loadOp = TR::InstOpCode::_fld;
+            loadOp = OP::_fld;
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -348,10 +348,10 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
     }
     switch (rk) {
         case TR_GPR:
-            storeOp = TR::InstOpCode::_sd;
+            storeOp = OP::_sd;
             break;
         case TR_FPR:
-            storeOp = TR::InstOpCode::_fsd;
+            storeOp = OP::_fsd;
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -408,13 +408,13 @@ static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds
     TR::Node *node = precedingInstruction->getNode();
     switch (rk) {
         case TR_GPR:
-            Inst_ITYPE(TR::InstOpCode::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
+            Inst_ITYPE(OP::_addi, node, targetReg, sourceReg, 0, cg, precedingInstruction);
             break;
         case TR_FPR:
             TR_ASSERT_FATAL(sourceReg->isSinglePrecision() == targetReg->isSinglePrecision(),
                 "Source and target register size mismatch");
-            Inst_RTYPE(sourceReg->isSinglePrecision() ? TR::InstOpCode::_fsgnj_s : TR::InstOpCode::_fsgnj_d, node,
-                targetReg, sourceReg, sourceReg, cg, precedingInstruction);
+            Inst_RTYPE(sourceReg->isSinglePrecision() ? OP::_fsgnj_s : OP::_fsgnj_d, node, targetReg, sourceReg,
+                sourceReg, cg, precedingInstruction);
             break;
         default:
             TR_ASSERT_FATAL(false, "Unsupported RegisterKind.");
@@ -430,9 +430,9 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 
     TR::Node *node = precedingInstruction->getNode();
     if (rk == TR_GPR) {
-        Inst_RTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
-        Inst_RTYPE(TR::InstOpCode::_xor, node, sourceReg, targetReg, sourceReg, cg, precedingInstruction);
-        Inst_RTYPE(TR::InstOpCode::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(OP::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(OP::_xor, node, sourceReg, targetReg, sourceReg, cg, precedingInstruction);
+        Inst_RTYPE(OP::_xor, node, targetReg, targetReg, sourceReg, cg, precedingInstruction);
     } else {
         registerCopy(precedingInstruction, rk, middleReg, targetReg, cg);
         registerCopy(precedingInstruction, rk, targetReg, sourceReg, cg);

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -161,7 +161,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
 
     candidates[0]->setBackingStorage(location);
 
-    tmemref = new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, cg());
+    tmemref = MRef_Sym(currentNode, location->getSymbolReference(), cg());
 
     if (!cg()->isOutOfLineColdPath()) {
         TR_Debug *debugObj = cg()->getDebug();
@@ -259,7 +259,7 @@ TR::RealRegister *OMR::RV::Machine::reverseSpillState(TR::Instruction *currentIn
             targetRegister->getRegisterName(comp));
     }
 
-    tmemref = new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, location->getSymbolReference(), 8, cg());
+    tmemref = MRef_Sym(currentNode, location->getSymbolReference(), cg());
 
     switch (rk) {
         case TR_GPR:

--- a/compiler/riscv/codegen/OMRMemoryReference.cpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.cpp
@@ -178,14 +178,14 @@ void OMR::RV::MemoryReference::addToOffset(TR::Node *node, intptr_t amount, TR::
 
         if (_baseRegister != NULL) {
             if (node->getOpCode().isLoadConst() && node->getRegister()) {
-                Inst_RTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, node->getRegister(), cg);
+                Inst_RTYPE(OP::_add, node, newBase, _baseRegister, node->getRegister(), cg);
             } else {
                 if (VALID_ITYPE_IMM(displacement)) {
-                    Inst_ITYPE(TR::InstOpCode::_addi, node, newBase, _baseRegister, displacement, cg);
+                    Inst_ITYPE(OP::_addi, node, newBase, _baseRegister, displacement, cg);
                 } else {
                     TR::Register *tempReg = cg->allocateRegister();
                     loadConstant64(cg, node, displacement, tempReg);
-                    Inst_RTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, tempReg, cg);
+                    Inst_RTYPE(OP::_add, node, newBase, _baseRegister, tempReg, cg);
                     cg->stopUsingRegister(tempReg);
                 }
             }
@@ -311,7 +311,7 @@ void OMR::RV::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::No
             else
                 tempTargetRegister = cg->allocateRegister();
 
-            Inst_RTYPE(TR::InstOpCode::_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
+            Inst_RTYPE(OP::_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
 
             if (_baseRegister != tempTargetRegister) {
                 self()->decNodeReferenceCounts(cg);

--- a/compiler/riscv/codegen/OMRMemoryReference.cpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.cpp
@@ -178,14 +178,14 @@ void OMR::RV::MemoryReference::addToOffset(TR::Node *node, intptr_t amount, TR::
 
         if (_baseRegister != NULL) {
             if (node->getOpCode().isLoadConst() && node->getRegister()) {
-                generateRTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, node->getRegister(), cg);
+                Inst_RTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, node->getRegister(), cg);
             } else {
                 if (VALID_ITYPE_IMM(displacement)) {
-                    generateITYPE(TR::InstOpCode::_addi, node, newBase, _baseRegister, displacement, cg);
+                    Inst_ITYPE(TR::InstOpCode::_addi, node, newBase, _baseRegister, displacement, cg);
                 } else {
                     TR::Register *tempReg = cg->allocateRegister();
                     loadConstant64(cg, node, displacement, tempReg);
-                    generateRTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, tempReg, cg);
+                    Inst_RTYPE(TR::InstOpCode::_add, node, newBase, _baseRegister, tempReg, cg);
                     cg->stopUsingRegister(tempReg);
                 }
             }
@@ -311,7 +311,7 @@ void OMR::RV::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::No
             else
                 tempTargetRegister = cg->allocateRegister();
 
-            generateRTYPE(TR::InstOpCode::_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
+            Inst_RTYPE(TR::InstOpCode::_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
 
             if (_baseRegister != tempTargetRegister) {
                 self()->decNodeReferenceCounts(cg);

--- a/compiler/riscv/codegen/OMRRegisterDependency.cpp
+++ b/compiler/riscv/codegen/OMRRegisterDependency.cpp
@@ -227,8 +227,8 @@ void OMR::RV::RegisterDependencyGroup::assignRegisters(TR::Instruction *currentI
                 logprints(trace, log, "\nOOL: Found register spilled in main line and re-assigned inside OOL");
                 TR::Node *currentNode = currentInstruction->getNode();
                 TR::RealRegister *assignedReg = toRealRegister(virtReg->getAssignedRegister());
-                TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(currentNode,
-                    (TR::SymbolReference *)virtReg->getBackingStorage()->getSymbolReference(), sizeof(uintptr_t), cg);
+                TR::MemoryReference *tempMR = MRef_Sym(currentNode,
+                    (TR::SymbolReference *)virtReg->getBackingStorage()->getSymbolReference(), cg);
                 TR_RegisterKinds rk = virtReg->getKind();
                 TR::InstOpCode::Mnemonic opCode;
                 switch (rk) {

--- a/compiler/riscv/codegen/OMRRegisterDependency.cpp
+++ b/compiler/riscv/codegen/OMRRegisterDependency.cpp
@@ -233,10 +233,10 @@ void OMR::RV::RegisterDependencyGroup::assignRegisters(TR::Instruction *currentI
                 TR::InstOpCode::Mnemonic opCode;
                 switch (rk) {
                     case TR_GPR:
-                        opCode = TR::InstOpCode::_ld;
+                        opCode = OP::_ld;
                         break;
                     case TR_FPR:
-                        opCode = TR::InstOpCode::_fld;
+                        opCode = OP::_fld;
                         break;
                     default:
                         TR_ASSERT(0, "\nRegister kind not supported in OOL spill\n");

--- a/compiler/riscv/codegen/OMRRegisterDependency.cpp
+++ b/compiler/riscv/codegen/OMRRegisterDependency.cpp
@@ -243,7 +243,7 @@ void OMR::RV::RegisterDependencyGroup::assignRegisters(TR::Instruction *currentI
                         break;
                 }
 
-                TR::Instruction *inst = generateLOAD(opCode, currentNode, assignedReg, tempMR, cg, currentInstruction);
+                TR::Instruction *inst = Inst_LOAD(opCode, currentNode, assignedReg, tempMR, cg, currentInstruction);
 
                 assignedReg->setAssignedRegister(NULL);
                 virtReg->setAssignedRegister(NULL);

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -2313,7 +2313,7 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
 
     if (VALID_ITYPE_IMM(value)) {
         TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-        cursor = generateITYPE(TR::InstOpCode::_addiw, node, trgReg, zero, value, cg);
+        cursor = Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, zero, value, cg);
     } else {
         /* Since value is too big to fit in 12bit immediate, we have to generate
            a sequence
@@ -2332,8 +2332,8 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
             hi += 1 << RISCV_IMM_BITS;
         }
 
-        cursor = generateUTYPE(TR::InstOpCode::_lui, node, hi, trgReg, cg);
-        cursor = generateITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, lo, cg);
+        cursor = Inst_UTYPE(TR::InstOpCode::_lui, node, hi, trgReg, cg);
+        cursor = Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, lo, cg);
     }
 
     if (!insertingInstructions)
@@ -2377,8 +2377,8 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         toShift += hi32 == 0 ? 0 : nbits;
         if (bits) {
             if (toShift)
-                cursor = generateITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
-            cursor = generateITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+                cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
             toShift = 0;
         }
 
@@ -2389,8 +2389,8 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         toShift += nbits;
         if (bits) {
             if (toShift)
-                cursor = generateITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
-            cursor = generateITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+                cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
             toShift = 0;
         }
 
@@ -2400,9 +2400,9 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         bits = extractBits(value, 31 - 2 * nbits, 0);
         toShift += 31 - 2 * nbits + 1;
         if (toShift)
-            cursor = generateITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
         if (bits) {
-            cursor = generateITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
         }
     }
 
@@ -2435,14 +2435,14 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
     }
     node->setRegister(tempReg);
     TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-    generateLOAD(op, node, tempReg, tempMR, cg);
+    Inst_LOAD(op, node, tempReg, tempMR, cg);
 
     /*
      * Enable this part when dmb instruction becomes available
     bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
     cg->comp()->target().isSMP()); if (needSync)
        {
-       generateInstruction(cg, TR::InstOpCode::dmb, node);
+       Inst(cg, TR::InstOpCode::dmb, node);
        }
      */
     tempMR->decNodeReferenceCounts(cg);
@@ -2477,7 +2477,7 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
     node->setRegister(tempReg);
 
     TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
-    generateLOAD(TR::InstOpCode::_ld, node, tempReg, tempMR, cg);
+    Inst_LOAD(TR::InstOpCode::_ld, node, tempReg, tempMR, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
     /*
@@ -2496,7 +2496,7 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
     bool needSync = (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
     cg->comp()->target().isSMP()); if (needSync)
        {
-       generateInstruction(cg, TR::InstOpCode::dmb, node);
+       Inst(cg, TR::InstOpCode::dmb, node);
        }
      */
     tempMR->decNodeReferenceCounts(cg);
@@ -2543,15 +2543,15 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
     if (node->getSymbolReference()->getSymbol()->isAtLeastOrStrongerThanAcquireRelease() &&
     cg->comp()->target().isSMP())
        {
-       generateInstruction(cg, TR::InstOpCode::dmb, node);
+       Inst(cg, TR::InstOpCode::dmb, node);
        }
      */
-    generateSTORE(op, node, tempMR, cg->evaluate(valueChild), cg);
+    Inst_STORE(op, node, tempMR, cg->evaluate(valueChild), cg);
     /*
      * Enable this part when dmb instruction becomes available
     if (node->getSymbolReference()->getSymbol()->isVolatile() && cg->comp()->target().isSMP())
        {
-       generateInstruction(cg, TR::InstOpCode::dmb, node);
+       Inst(cg, TR::InstOpCode::dmb, node);
        }
      */
 
@@ -2775,11 +2775,11 @@ TR::Register *OMR::RV::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeG
     }
 
     if (node->getLabel() != NULL) {
-        node->getLabel()->setInstruction(generateLABEL(cg, TR::InstOpCode::label, node, node->getLabel(), deps));
+        node->getLabel()->setInstruction(Inst_LABEL(TR::InstOpCode::label, node, node->getLabel(), deps, cg));
     }
 
     TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
-    TR::Instruction *fence = generateADMIN(cg, TR::InstOpCode::fence, node, fenceNode);
+    TR::Instruction *fence = Inst_ADMIN(TR::InstOpCode::fence, node, cg, fenceNode);
 
     if (block->isCatchBlock()) {
         cg->generateCatchBlockBBStartPrologue(node, fence);
@@ -2801,7 +2801,7 @@ TR::Register *OMR::RV::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGen
         if ((lastInstructionOp == TR::InstOpCode::_jal || lastInstructionOp == TR::InstOpCode::_jalr)
             && 0 /* TODO: check that jump stores return address into some register (not x0 / zero) */
             && lastInstruction->getNode()->getSymbolReference()->getReferenceNumber() == TR_aThrow) {
-            lastInstruction = generateInstruction(cg, TR::InstOpCode::bad, node, lastInstruction);
+            lastInstruction = Inst(TR::InstOpCode::bad, node, cg, lastInstruction);
         }
     }
 
@@ -2816,7 +2816,7 @@ TR::Register *OMR::RV::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGen
     }
 
     // put the dependencies (if any) on the fence
-    generateADMIN(cg, TR::InstOpCode::fence, node, deps, fenceNode);
+    Inst_ADMIN(TR::InstOpCode::fence, node, deps, cg, fenceNode);
 
     return NULL;
 }

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -2434,7 +2434,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
         tempReg = cg->allocateRegister();
     }
     node->setRegister(tempReg);
-    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
+    TR::MemoryReference *tempMR = MRef_Node(node, cg);
     Inst_LOAD(op, node, tempReg, tempMR, cg);
 
     /*
@@ -2476,7 +2476,7 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
 
     node->setRegister(tempReg);
 
-    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
+    TR::MemoryReference *tempMR = MRef_Node(node, cg);
     Inst_LOAD(OP::_ld, node, tempReg, tempMR, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -2529,7 +2529,7 @@ TR::Register *OMR::RV::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
 {
-    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
+    TR::MemoryReference *tempMR = MRef_Node(node, cg);
     TR::Node *valueChild;
 
     if (node->getOpCode().isIndirect()) {

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -2313,7 +2313,7 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
 
     if (VALID_ITYPE_IMM(value)) {
         TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
-        cursor = Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, zero, value, cg);
+        cursor = Inst_ITYPE(OP::_addiw, node, trgReg, zero, value, cg);
     } else {
         /* Since value is too big to fit in 12bit immediate, we have to generate
            a sequence
@@ -2332,8 +2332,8 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
             hi += 1 << RISCV_IMM_BITS;
         }
 
-        cursor = Inst_UTYPE(TR::InstOpCode::_lui, node, hi, trgReg, cg);
-        cursor = Inst_ITYPE(TR::InstOpCode::_addiw, node, trgReg, trgReg, lo, cg);
+        cursor = Inst_UTYPE(OP::_lui, node, hi, trgReg, cg);
+        cursor = Inst_ITYPE(OP::_addiw, node, trgReg, trgReg, lo, cg);
     }
 
     if (!insertingInstructions)
@@ -2377,8 +2377,8 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         toShift += hi32 == 0 ? 0 : nbits;
         if (bits) {
             if (toShift)
-                cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
-            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+                cursor = Inst_ITYPE(OP::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(OP::_addi, node, trgReg, trgReg, bits, cg, cursor);
             toShift = 0;
         }
 
@@ -2389,8 +2389,8 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         toShift += nbits;
         if (bits) {
             if (toShift)
-                cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
-            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+                cursor = Inst_ITYPE(OP::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(OP::_addi, node, trgReg, trgReg, bits, cg, cursor);
             toShift = 0;
         }
 
@@ -2400,9 +2400,9 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         bits = extractBits(value, 31 - 2 * nbits, 0);
         toShift += 31 - 2 * nbits + 1;
         if (toShift)
-            cursor = Inst_ITYPE(TR::InstOpCode::_slli, node, trgReg, trgReg, toShift, cg, cursor);
+            cursor = Inst_ITYPE(OP::_slli, node, trgReg, trgReg, toShift, cg, cursor);
         if (bits) {
-            cursor = Inst_ITYPE(TR::InstOpCode::_addi, node, trgReg, trgReg, bits, cg, cursor);
+            cursor = Inst_ITYPE(OP::_addi, node, trgReg, trgReg, bits, cg, cursor);
         }
     }
 
@@ -2426,9 +2426,9 @@ TR::Register *OMR::RV::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeG
 TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
 {
     TR::Register *tempReg;
-    if (op == TR::InstOpCode::_flw) {
+    if (op == OP::_flw) {
         tempReg = cg->allocateSinglePrecisionRegister();
-    } else if (op == TR::InstOpCode::_fld) {
+    } else if (op == OP::_fld) {
         tempReg = cg->allocateRegister(TR_FPR);
     } else {
         tempReg = cg->allocateRegister();
@@ -2453,7 +2453,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
 // also handles iloadi
 TR::Register *OMR::RV::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_lw, 4, cg);
+    return commonLoadEvaluator(node, OP::_lw, 4, cg);
 }
 
 // also handles aloadi
@@ -2477,7 +2477,7 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
     node->setRegister(tempReg);
 
     TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
-    Inst_LOAD(TR::InstOpCode::_ld, node, tempReg, tempMR, cg);
+    Inst_LOAD(OP::_ld, node, tempReg, tempMR, cg);
 
 #ifdef J9_PROJECT_SPECIFIC
     /*
@@ -2507,19 +2507,19 @@ TR::Register *OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGen
 // also handles lloadi
 TR::Register *OMR::RV::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_ld, 8, cg);
+    return commonLoadEvaluator(node, OP::_ld, 8, cg);
 }
 
 // also handles bloadi
 TR::Register *OMR::RV::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_lb, 1, cg);
+    return commonLoadEvaluator(node, OP::_lb, 1, cg);
 }
 
 // also handles sloadi
 TR::Register *OMR::RV::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::_lh, 2, cg);
+    return commonLoadEvaluator(node, OP::_lh, 2, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2564,25 +2564,25 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
 // also handles lstorei, astore, astorei
 TR::Register *OMR::RV::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_sd, 8, cg);
+    return commonStoreEvaluator(node, OP::_sd, 8, cg);
 }
 
 // also handles bstorei
 TR::Register *OMR::RV::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_sb, 1, cg);
+    return commonStoreEvaluator(node, OP::_sb, 1, cg);
 }
 
 // also handles sstorei
 TR::Register *OMR::RV::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_sh, 2, cg);
+    return commonStoreEvaluator(node, OP::_sh, 2, cg);
 }
 
 // also handles istorei
 TR::Register *OMR::RV::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::_sw, 4, cg);
+    return commonStoreEvaluator(node, OP::_sw, 4, cg);
 }
 
 TR::Register *OMR::RV::TreeEvaluator::monentEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2775,11 +2775,11 @@ TR::Register *OMR::RV::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeG
     }
 
     if (node->getLabel() != NULL) {
-        node->getLabel()->setInstruction(Inst_LABEL(TR::InstOpCode::label, node, node->getLabel(), deps, cg));
+        node->getLabel()->setInstruction(Inst_LABEL(OP::label, node, node->getLabel(), deps, cg));
     }
 
     TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
-    TR::Instruction *fence = Inst_ADMIN(TR::InstOpCode::fence, node, cg, fenceNode);
+    TR::Instruction *fence = Inst_ADMIN(OP::fence, node, cg, fenceNode);
 
     if (block->isCatchBlock()) {
         cg->generateCatchBlockBBStartPrologue(node, fence);
@@ -2798,10 +2798,10 @@ TR::Register *OMR::RV::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGen
     if (NULL == block->getNextBlock()) {
         TR::Instruction *lastInstruction = cg->getAppendInstruction();
         TR::InstOpCode::Mnemonic lastInstructionOp = lastInstruction->getOpCodeValue();
-        if ((lastInstructionOp == TR::InstOpCode::_jal || lastInstructionOp == TR::InstOpCode::_jalr)
+        if ((lastInstructionOp == OP::_jal || lastInstructionOp == OP::_jalr)
             && 0 /* TODO: check that jump stores return address into some register (not x0 / zero) */
             && lastInstruction->getNode()->getSymbolReference()->getReferenceNumber() == TR_aThrow) {
-            lastInstruction = Inst(TR::InstOpCode::bad, node, cg, lastInstruction);
+            lastInstruction = Inst(OP::bad, node, cg, lastInstruction);
         }
     }
 
@@ -2816,7 +2816,7 @@ TR::Register *OMR::RV::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGen
     }
 
     // put the dependencies (if any) on the fence
-    Inst_ADMIN(TR::InstOpCode::fence, node, deps, cg, fenceNode);
+    Inst_ADMIN(OP::fence, node, deps, cg, fenceNode);
 
     return NULL;
 }

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -2761,7 +2761,7 @@ TR::Register *OMR::RV::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeG
         int32_t i;
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        deps = generateRegisterDependencyConditions(cg, child, 0);
+        deps = RegDeps(cg, child, 0);
         if (cg->getCurrentEvaluationTreeTop() == comp->getStartTree()) {
             for (i = 0; i < child->getNumChildren(); i++) {
                 TR::ParameterSymbol *sym = child->getChild(i)->getSymbol()->getParmSymbol();
@@ -2811,7 +2811,7 @@ TR::Register *OMR::RV::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGen
     if (node->getNumChildren() > 0 && (!nextTT || !nextTT->getNode()->getBlock()->isExtensionOfPreviousBlock())) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        deps = generateRegisterDependencyConditions(cg, child, 0);
+        deps = RegDeps(cg, child, 0);
         child->decReferenceCount();
     }
 

--- a/compiler/riscv/codegen/RVDebug.cpp
+++ b/compiler/riscv/codegen/RVDebug.cpp
@@ -237,7 +237,7 @@ void TR_Debug::print(OMR::Logger *log, TR::LabelInstruction *instr)
 
     TR::LabelSymbol *label = instr->getLabelSymbol();
     TR::Snippet *snippet = label ? label->getSnippet() : NULL;
-    if (instr->getOpCodeValue() == TR::InstOpCode::label) {
+    if (instr->getOpCodeValue() == OP::label) {
         print(log, label);
         log->printc(':');
         if (label->isStartInternalControlFlow())

--- a/compiler/riscv/codegen/RVHelperCallSnippet.cpp
+++ b/compiler/riscv/codegen/RVHelperCallSnippet.cpp
@@ -42,8 +42,7 @@ uint8_t *TR::RVHelperCallSnippet::emitSnippetBody()
         TR_ASSERT_FATAL(VALID_UJTYPE_IMM(distance), "Trampoline too far away.");
     }
 
-    *(int32_t *)cursor
-        = TR_RISCV_UJTYPE(TR::InstOpCode::_jal, cg()->machine()->getRealRegister(OMR::RealRegister::ra), distance);
+    *(int32_t *)cursor = TR_RISCV_UJTYPE(OP::_jal, cg()->machine()->getRealRegister(OMR::RealRegister::ra), distance);
 
     cg()->addExternalRelocation(
         TR::ExternalRelocation::create(cursor, (uint8_t *)getDestination(), TR_HelperAddress, cg()), __FILE__, __LINE__,
@@ -56,8 +55,8 @@ uint8_t *TR::RVHelperCallSnippet::emitSnippetBody()
         distance = (intptr_t)(_restartLabel->getCodeLocation()) - (intptr_t)cursor;
         if (VALID_UJTYPE_IMM(distance)) {
             // b distance
-            *(int32_t *)cursor = TR_RISCV_UJTYPE(TR::InstOpCode::_jal,
-                cg()->machine()->getRealRegister(OMR::RealRegister::zero), distance >> 2);
+            *(int32_t *)cursor
+                = TR_RISCV_UJTYPE(OP::_jal, cg()->machine()->getRealRegister(OMR::RealRegister::zero), distance >> 2);
             cursor += RISCV_INSTRUCTION_LENGTH;
         } else {
             TR_ASSERT_FATAL(false, "Target too far away. Not supported yet");

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -391,10 +391,10 @@ void TR::BtypeInstruction::expandIntoFarBranch()
     TR::LabelSymbol *skipBranchLabel = generateLabelSymbol(cg());
     skipBranchLabel->setEstimatedCodeLocation(getEstimatedBinaryLocation() + RISCV_INSTRUCTION_LENGTH);
 
-    TR::Instruction *branchInstr = generateJTYPE(TR::InstOpCode::_jal, getNode(), zero, getLabelSymbol(), cg(), self());
+    TR::Instruction *branchInstr = Inst_JTYPE(TR::InstOpCode::_jal, getNode(), zero, getLabelSymbol(), cg(), self());
     branchInstr->setEstimatedBinaryLength(RISCV_INSTRUCTION_LENGTH);
 
-    TR::Instruction *labelInstr = generateLABEL(cg(), TR::InstOpCode::label, getNode(), skipBranchLabel, branchInstr);
+    TR::Instruction *labelInstr = Inst_LABEL(TR::InstOpCode::label, getNode(), skipBranchLabel, cg(), branchInstr);
     labelInstr->setEstimatedBinaryLength(0);
 
     setLabelSymbol(skipBranchLabel);

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -391,10 +391,10 @@ void TR::BtypeInstruction::expandIntoFarBranch()
     TR::LabelSymbol *skipBranchLabel = generateLabelSymbol(cg());
     skipBranchLabel->setEstimatedCodeLocation(getEstimatedBinaryLocation() + RISCV_INSTRUCTION_LENGTH);
 
-    TR::Instruction *branchInstr = Inst_JTYPE(TR::InstOpCode::_jal, getNode(), zero, getLabelSymbol(), cg(), self());
+    TR::Instruction *branchInstr = Inst_JTYPE(OP::_jal, getNode(), zero, getLabelSymbol(), cg(), self());
     branchInstr->setEstimatedBinaryLength(RISCV_INSTRUCTION_LENGTH);
 
-    TR::Instruction *labelInstr = Inst_LABEL(TR::InstOpCode::label, getNode(), skipBranchLabel, cg(), branchInstr);
+    TR::Instruction *labelInstr = Inst_LABEL(OP::label, getNode(), skipBranchLabel, cg(), branchInstr);
     labelInstr->setEstimatedBinaryLength(0);
 
     setLabelSymbol(skipBranchLabel);
@@ -583,7 +583,7 @@ uint8_t *TR::VGNOPInstruction::generateBinaryEncoding()
 
     setBinaryEncoding(cursor);
     uint32_t *iPtr = (uint32_t *)cursor;
-    *iPtr = TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::_addi), 0, 0, 0);
+    *iPtr = TR_RISCV_ITYPE(TR::InstOpCode::getOpCodeBinaryEncoding(OP::_addi), 0, 0, 0);
     length = RISCV_INSTRUCTION_LENGTH;
     setBinaryLength(length);
     return cursor + length;

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -683,8 +683,8 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
         target = cg()->evaluate(callNode->getFirstChild());
     }
 
-    TR::RegisterDependencyConditions *dependencies = new (trHeapMemory()) TR::RegisterDependencyConditions(
-        pp.getNumberOfDependencyRegisters(), pp.getNumberOfDependencyRegisters(), trMemory());
+    TR::RegisterDependencyConditions *dependencies
+        = RegDeps(pp.getNumberOfDependencyRegisters(), pp.getNumberOfDependencyRegisters(), cg());
 
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -346,7 +346,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
 
     // save link register (ra)
     if (machine->getLinkRegisterKilled()) {
-        TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
+        TR::MemoryReference *stackSlot = MRef_BaseDisp(sp, 0, cg);
         cursor = Inst_STORE(OP::_sd, firstNode, stackSlot, ra, cg, cursor);
     }
 
@@ -358,8 +358,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
          && (nextIntArgReg < getProperties().getNumIntArgRegs()
              || nextFltArgReg < getProperties().getNumFloatArgRegs());
          parameter = parameterIterator.getNext()) {
-        TR::MemoryReference *stackSlot
-            = new (trHeapMemory()) TR::MemoryReference(sp, parameter->getParameterOffset(), cg);
+        TR::MemoryReference *stackSlot = MRef_BaseDisp(sp, parameter->getParameterOffset(), cg);
         TR::InstOpCode::Mnemonic op;
 
         switch (parameter->getDataType()) {
@@ -406,7 +405,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     // save callee-saved registers
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
-        machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
+        machine, _properties, TR::MemoryReference *stackSlot = MRef_BaseDisp(sp, offset, cg);
         cursor = Inst_STORE(OP::_sd, firstNode, stackSlot, reg, this->cg(), cursor); offset += 8;)
 }
 
@@ -423,13 +422,13 @@ void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
     // restore callee-saved registers
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
-        machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
+        machine, _properties, TR::MemoryReference *stackSlot = MRef_BaseDisp(sp, offset, cg);
         cursor = Inst_LOAD(OP::_ld, lastNode, reg, stackSlot, this->cg(), cursor); offset += 8;)
 
     // restore link register (x30)
     TR::RealRegister *ra = machine->getRealRegister(TR::RealRegister::ra);
     if (machine->getLinkRegisterKilled()) {
-        TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
+        TR::MemoryReference *stackSlot = MRef_BaseDisp(sp, 0, cg);
         cursor = Inst_LOAD(OP::_ld, lastNode, ra, stackSlot, this->cg(), cursor);
     }
 

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -339,7 +339,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     // allocate stack space
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (VALID_ITYPE_IMM(frameSize)) {
-        cursor = Inst_ITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, cg, cursor);
+        cursor = Inst_ITYPE(OP::_addi, firstNode, sp, sp, -frameSize, cg, cursor);
     } else {
         TR_UNIMPLEMENTED();
     }
@@ -347,7 +347,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     // save link register (ra)
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
-        cursor = Inst_STORE(TR::InstOpCode::_sd, firstNode, stackSlot, ra, cg, cursor);
+        cursor = Inst_STORE(OP::_sd, firstNode, stackSlot, ra, cg, cursor);
     }
 
     // spill argument registers
@@ -369,7 +369,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
             case TR::Int64:
             case TR::Address:
                 if (nextIntArgReg < getProperties().getNumIntArgRegs()) {
-                    op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
+                    op = (parameter->getSize() == 8) ? OP::_sd : OP::_sw;
                     cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), cg,
                         cursor);
@@ -381,12 +381,12 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
             case TR::Float:
             case TR::Double:
                 if (nextFltArgReg < getProperties().getNumFloatArgRegs()) {
-                    op = (parameter->getSize() == 8) ? TR::InstOpCode::_fsd : TR::InstOpCode::_fsw;
+                    op = (parameter->getSize() == 8) ? OP::_fsd : OP::_fsw;
                     cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getFloatArgumentRegister(nextFltArgReg)), cg, cursor);
                     nextFltArgReg++;
                 } else if (nextIntArgReg < getProperties().getNumIntArgRegs()) {
-                    op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
+                    op = (parameter->getSize() == 8) ? OP::_sd : OP::_sw;
                     cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), cg,
                         cursor);
@@ -407,7 +407,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
         machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
-        cursor = Inst_STORE(TR::InstOpCode::_sd, firstNode, stackSlot, reg, this->cg(), cursor); offset += 8;)
+        cursor = Inst_STORE(OP::_sd, firstNode, stackSlot, reg, this->cg(), cursor); offset += 8;)
 }
 
 void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
@@ -424,25 +424,25 @@ void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
         machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
-        cursor = Inst_LOAD(TR::InstOpCode::_ld, lastNode, reg, stackSlot, this->cg(), cursor); offset += 8;)
+        cursor = Inst_LOAD(OP::_ld, lastNode, reg, stackSlot, this->cg(), cursor); offset += 8;)
 
     // restore link register (x30)
     TR::RealRegister *ra = machine->getRealRegister(TR::RealRegister::ra);
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
-        cursor = Inst_LOAD(TR::InstOpCode::_ld, lastNode, ra, stackSlot, this->cg(), cursor);
+        cursor = Inst_LOAD(OP::_ld, lastNode, ra, stackSlot, this->cg(), cursor);
     }
 
     // remove space for preserved registers
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (VALID_ITYPE_IMM(frameSize)) {
-        cursor = Inst_ITYPE(TR::InstOpCode::_addi, lastNode, sp, sp, frameSize, cg, cursor);
+        cursor = Inst_ITYPE(OP::_addi, lastNode, sp, sp, frameSize, cg, cursor);
     } else {
         TR_UNIMPLEMENTED();
     }
 
     // return
-    cursor = Inst_ITYPE(TR::InstOpCode::_jalr, lastNode, zero, ra, 0, cg, cursor);
+    cursor = Inst_ITYPE(OP::_jalr, lastNode, zero, ra, 0, cg, cursor);
 }
 
 int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
@@ -543,7 +543,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                             tempReg = cg()->allocateCollectedReferenceRegister();
                         else
                             tempReg = cg()->allocateRegister();
-                        Inst_ITYPE(TR::InstOpCode::_addi, callNode, tempReg, argRegister, 0, cg());
+                        Inst_ITYPE(OP::_addi, callNode, tempReg, argRegister, 0, cg());
                         argRegister = tempReg;
                     }
                     if (numIntegerArgs == 0 && (resType.isAddress() || resType.isInt32() || resType.isInt64())) {
@@ -563,9 +563,9 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                 } else {
                     // numIntegerArgs >= properties.getNumIntArgRegs()
                     if (childType == TR::Address || childType == TR::Int64) {
-                        op = TR::InstOpCode::_sd;
+                        op = OP::_sd;
                     } else {
-                        op = TR::InstOpCode::_sw;
+                        op = OP::_sw;
                     }
                     mref = getOutgoingArgumentMemRef(argMemReg, argSize, argRegister, op, pushToMemory[argIndex++]);
                     argSize += 8; // always 8-byte aligned
@@ -585,7 +585,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                         tempReg = cg()->allocateRegister(TR_FPR);
                         // TODO: check if this is the best way to move floating point values
                         // between regs
-                        op = (childType == TR::Float) ? TR::InstOpCode::_fsgnj_d : TR::InstOpCode::_fsgnj_s;
+                        op = (childType == TR::Float) ? OP::_fsgnj_d : OP::_fsgnj_s;
                         Inst_RTYPE(op, callNode, tempReg, argRegister, argRegister, cg());
                         argRegister = tempReg;
                     }
@@ -605,7 +605,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                 } else if ((numIntegerArgs + numFloatArgsPassedInGPRs) < properties.getNumIntArgRegs()) {
                     TR::Register *gprRegister = cg()->allocateRegister(TR_GPR);
                     TR::Register *zero = cg()->machine()->getRealRegister(TR::RealRegister::zero);
-                    op = (childType == TR::Float) ? TR::InstOpCode::_fmv_x_s : TR::InstOpCode::_fmv_x_d;
+                    op = (childType == TR::Float) ? OP::_fmv_x_s : OP::_fmv_x_d;
                     Inst_RTYPE(op, callNode, gprRegister, argRegister, zero, cg());
 
                     TR::addDependency(dependencies, gprRegister,
@@ -614,9 +614,9 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                 } else {
                     // numFloatArgs >= properties.getNumFloatArgRegs()
                     if (childType == TR::Double) {
-                        op = TR::InstOpCode::_fsd;
+                        op = OP::_fsd;
                     } else {
-                        op = TR::InstOpCode::_fsw;
+                        op = OP::_fsw;
                     }
                     mref = getOutgoingArgumentMemRef(argMemReg, argSize, argRegister, op, pushToMemory[argIndex++]);
                     argSize += 8; // always 8-byte aligned
@@ -658,7 +658,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
 
     if (numMemArgs > 0) {
         TR::RealRegister *sp = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
-        Inst_ITYPE(TR::InstOpCode::_addi, callNode, argMemReg, sp, -totalSize, cg());
+        Inst_ITYPE(OP::_addi, callNode, argMemReg, sp, -totalSize, cg());
 
         for (argIndex = 0; argIndex < numMemArgs; argIndex++) {
             TR::Register *aReg = pushToMemory[argIndex].argRegister;
@@ -689,14 +689,14 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(-totalSize)) {
-            Inst_ITYPE(TR::InstOpCode::_addi, callNode, sp, sp, -totalSize, cg());
+            Inst_ITYPE(OP::_addi, callNode, sp, sp, -totalSize, cg());
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }
     }
 
     if (callNode->getOpCode().isCallIndirect()) {
-        Inst_ITYPE(TR::InstOpCode::_jalr, callNode, ra, target, 0, dependencies, cg());
+        Inst_ITYPE(OP::_jalr, callNode, ra, target, 0, dependencies, cg());
     } else {
         auto targetAddr = callNode->getSymbolReference()->getMethodAddress();
 
@@ -707,7 +707,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
              *
              * This is the case of recursive calls.
              */
-            Inst_JTYPE(TR::InstOpCode::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
+            Inst_JTYPE(OP::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
         } else {
             /*
              * If the target address is known, we load it into a register and generate `jalr`. This may be
@@ -722,7 +722,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
              * anyways and this way we do not need to allocate another one.
              */
             loadConstant64(cg(), callNode, reinterpret_cast<int64_t>(targetAddr), ra);
-            Inst_ITYPE(TR::InstOpCode::_jalr, callNode, ra, ra, 0, dependencies, cg());
+            Inst_ITYPE(OP::_jalr, callNode, ra, ra, 0, dependencies, cg());
         }
     }
 
@@ -730,7 +730,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
 
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(totalSize)) {
-            Inst_ITYPE(TR::InstOpCode::_addi, callNode, sp, sp, totalSize, cg());
+            Inst_ITYPE(OP::_addi, callNode, sp, sp, totalSize, cg());
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }

--- a/compiler/riscv/codegen/RVSystemLinkage.cpp
+++ b/compiler/riscv/codegen/RVSystemLinkage.cpp
@@ -339,7 +339,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     // allocate stack space
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (VALID_ITYPE_IMM(frameSize)) {
-        cursor = generateITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, cg, cursor);
+        cursor = Inst_ITYPE(TR::InstOpCode::_addi, firstNode, sp, sp, -frameSize, cg, cursor);
     } else {
         TR_UNIMPLEMENTED();
     }
@@ -347,7 +347,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     // save link register (ra)
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
-        cursor = generateSTORE(TR::InstOpCode::_sd, firstNode, stackSlot, ra, cg, cursor);
+        cursor = Inst_STORE(TR::InstOpCode::_sd, firstNode, stackSlot, ra, cg, cursor);
     }
 
     // spill argument registers
@@ -370,7 +370,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
             case TR::Address:
                 if (nextIntArgReg < getProperties().getNumIntArgRegs()) {
                     op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
-                    cursor = generateSTORE(op, firstNode, stackSlot,
+                    cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), cg,
                         cursor);
                     nextIntArgReg++;
@@ -382,12 +382,12 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
             case TR::Double:
                 if (nextFltArgReg < getProperties().getNumFloatArgRegs()) {
                     op = (parameter->getSize() == 8) ? TR::InstOpCode::_fsd : TR::InstOpCode::_fsw;
-                    cursor = generateSTORE(op, firstNode, stackSlot,
+                    cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getFloatArgumentRegister(nextFltArgReg)), cg, cursor);
                     nextFltArgReg++;
                 } else if (nextIntArgReg < getProperties().getNumIntArgRegs()) {
                     op = (parameter->getSize() == 8) ? TR::InstOpCode::_sd : TR::InstOpCode::_sw;
-                    cursor = generateSTORE(op, firstNode, stackSlot,
+                    cursor = Inst_STORE(op, firstNode, stackSlot,
                         machine->getRealRegister(getProperties().getIntegerArgumentRegister(nextIntArgReg)), cg,
                         cursor);
                     nextIntArgReg++;
@@ -407,7 +407,7 @@ void TR::RVSystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Param
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
         machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
-        cursor = generateSTORE(TR::InstOpCode::_sd, firstNode, stackSlot, reg, this->cg(), cursor); offset += 8;)
+        cursor = Inst_STORE(TR::InstOpCode::_sd, firstNode, stackSlot, reg, this->cg(), cursor); offset += 8;)
 }
 
 void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
@@ -424,25 +424,25 @@ void TR::RVSystemLinkage::createEpilogue(TR::Instruction *cursor)
     uint32_t offset = bodySymbol->getLocalMappingCursor();
     FOR_EACH_ASSIGNED_CALLEE_SAVED_REGISTER(
         machine, _properties, TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, cg);
-        cursor = generateLOAD(TR::InstOpCode::_ld, lastNode, reg, stackSlot, this->cg(), cursor); offset += 8;)
+        cursor = Inst_LOAD(TR::InstOpCode::_ld, lastNode, reg, stackSlot, this->cg(), cursor); offset += 8;)
 
     // restore link register (x30)
     TR::RealRegister *ra = machine->getRealRegister(TR::RealRegister::ra);
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, 0, cg);
-        cursor = generateLOAD(TR::InstOpCode::_ld, lastNode, ra, stackSlot, this->cg(), cursor);
+        cursor = Inst_LOAD(TR::InstOpCode::_ld, lastNode, ra, stackSlot, this->cg(), cursor);
     }
 
     // remove space for preserved registers
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (VALID_ITYPE_IMM(frameSize)) {
-        cursor = generateITYPE(TR::InstOpCode::_addi, lastNode, sp, sp, frameSize, cg, cursor);
+        cursor = Inst_ITYPE(TR::InstOpCode::_addi, lastNode, sp, sp, frameSize, cg, cursor);
     } else {
         TR_UNIMPLEMENTED();
     }
 
     // return
-    cursor = generateITYPE(TR::InstOpCode::_jalr, lastNode, zero, ra, 0, cg, cursor);
+    cursor = Inst_ITYPE(TR::InstOpCode::_jalr, lastNode, zero, ra, 0, cg, cursor);
 }
 
 int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
@@ -543,7 +543,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                             tempReg = cg()->allocateCollectedReferenceRegister();
                         else
                             tempReg = cg()->allocateRegister();
-                        generateITYPE(TR::InstOpCode::_addi, callNode, tempReg, argRegister, 0, cg());
+                        Inst_ITYPE(TR::InstOpCode::_addi, callNode, tempReg, argRegister, 0, cg());
                         argRegister = tempReg;
                     }
                     if (numIntegerArgs == 0 && (resType.isAddress() || resType.isInt32() || resType.isInt64())) {
@@ -586,7 +586,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                         // TODO: check if this is the best way to move floating point values
                         // between regs
                         op = (childType == TR::Float) ? TR::InstOpCode::_fsgnj_d : TR::InstOpCode::_fsgnj_s;
-                        generateRTYPE(op, callNode, tempReg, argRegister, argRegister, cg());
+                        Inst_RTYPE(op, callNode, tempReg, argRegister, argRegister, cg());
                         argRegister = tempReg;
                     }
                     if ((numFloatArgs == 0 && resType.isFloatingPoint())) {
@@ -606,7 +606,7 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
                     TR::Register *gprRegister = cg()->allocateRegister(TR_GPR);
                     TR::Register *zero = cg()->machine()->getRealRegister(TR::RealRegister::zero);
                     op = (childType == TR::Float) ? TR::InstOpCode::_fmv_x_s : TR::InstOpCode::_fmv_x_d;
-                    generateRTYPE(op, callNode, gprRegister, argRegister, zero, cg());
+                    Inst_RTYPE(op, callNode, gprRegister, argRegister, zero, cg());
 
                     TR::addDependency(dependencies, gprRegister,
                         properties.getIntegerArgumentRegister(numIntegerArgs + numFloatArgsPassedInGPRs), TR_GPR, cg());
@@ -658,11 +658,11 @@ int32_t TR::RVSystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependenc
 
     if (numMemArgs > 0) {
         TR::RealRegister *sp = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
-        generateITYPE(TR::InstOpCode::_addi, callNode, argMemReg, sp, -totalSize, cg());
+        Inst_ITYPE(TR::InstOpCode::_addi, callNode, argMemReg, sp, -totalSize, cg());
 
         for (argIndex = 0; argIndex < numMemArgs; argIndex++) {
             TR::Register *aReg = pushToMemory[argIndex].argRegister;
-            generateSTORE(pushToMemory[argIndex].opCode, callNode, pushToMemory[argIndex].argMemory, aReg, cg());
+            Inst_STORE(pushToMemory[argIndex].opCode, callNode, pushToMemory[argIndex].argMemory, aReg, cg());
             cg()->stopUsingRegister(aReg);
         }
 
@@ -689,14 +689,14 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(-totalSize)) {
-            generateITYPE(TR::InstOpCode::_addi, callNode, sp, sp, -totalSize, cg());
+            Inst_ITYPE(TR::InstOpCode::_addi, callNode, sp, sp, -totalSize, cg());
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }
     }
 
     if (callNode->getOpCode().isCallIndirect()) {
-        generateITYPE(TR::InstOpCode::_jalr, callNode, ra, target, 0, dependencies, cg());
+        Inst_ITYPE(TR::InstOpCode::_jalr, callNode, ra, target, 0, dependencies, cg());
     } else {
         auto targetAddr = callNode->getSymbolReference()->getMethodAddress();
 
@@ -707,8 +707,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
              *
              * This is the case of recursive calls.
              */
-            generateJTYPE(TR::InstOpCode::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL,
-                cg());
+            Inst_JTYPE(TR::InstOpCode::_jal, callNode, ra, 0, dependencies, callNode->getSymbolReference(), NULL, cg());
         } else {
             /*
              * If the target address is known, we load it into a register and generate `jalr`. This may be
@@ -723,7 +722,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
              * anyways and this way we do not need to allocate another one.
              */
             loadConstant64(cg(), callNode, reinterpret_cast<int64_t>(targetAddr), ra);
-            generateITYPE(TR::InstOpCode::_jalr, callNode, ra, ra, 0, dependencies, cg());
+            Inst_ITYPE(TR::InstOpCode::_jalr, callNode, ra, ra, 0, dependencies, cg());
         }
     }
 
@@ -731,7 +730,7 @@ TR::Register *TR::RVSystemLinkage::buildDispatch(TR::Node *callNode)
 
     if (totalSize > 0) {
         if (VALID_ITYPE_IMM(totalSize)) {
-            generateITYPE(TR::InstOpCode::_addi, callNode, sp, sp, totalSize, cg());
+            Inst_ITYPE(TR::InstOpCode::_addi, callNode, sp, sp, totalSize, cg());
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }

--- a/compiler/riscv/codegen/RegisterDependency.hpp
+++ b/compiler/riscv/codegen/RegisterDependency.hpp
@@ -58,7 +58,6 @@ public:
         : OMR::RegisterDependencyConditionsConnector(cg, node, extranum, cursorPtr)
     {}
 };
-} // namespace TR
 
 /**
  * @brief Generates RegisterDependencyConditions
@@ -68,10 +67,46 @@ public:
  * @param[in] cursorPtr : instruction cursor
  * @return generated RegisterDependencyConditions
  */
-inline TR::RegisterDependencyConditions *generateRegisterDependencyConditions(TR::CodeGenerator *cg, TR::Node *node,
-    uint32_t extranum, TR::Instruction **cursorPtr = NULL)
+inline TR::RegisterDependencyConditions *RegDeps(TR::CodeGenerator *cg, TR::Node *node, uint32_t extranum,
+    TR::Instruction **cursorPtr = NULL)
 {
     return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(cg, node, extranum, cursorPtr);
 }
+
+/**
+ * @brief Generates RegisterDependencyConditions
+ *
+ * @param[in] numPreConds : # of preconditions
+ * @param[in] numPostConds : # of postconditions
+ * @param[in] cg : CodeGenerator object
+ * @return generated RegisterDependencyConditions
+ */
+inline TR::RegisterDependencyConditions *RegDeps(uint32_t numPreConds, uint32_t numPostConds, TR::CodeGenerator *cg)
+{
+    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numPreConds, numPostConds, cg->trMemory());
+}
+
+// THE USE OF THE generateRegisterDependencyConditions() FUNCTIONS IS
+// DEPRECATED IN FAVOUR OF THE MORE CONCISE RegDeps() FORMS AND SHOULD NOT BE
+// USED. THESE DEPRECATED FORMS WILL BE REMOVED IN A FUTURE OMR RELEASE.
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Generates RegisterDependencyConditions.
+ * @deprecated
+ *
+ * @param[in] cg : CodeGenerator object
+ * @param[in] node : node
+ * @param[in] extranum : additional # of conditions
+ * @param[in] cursorPtr : instruction cursor
+ * @return generated RegisterDependencyConditions
+ */
+inline TR::RegisterDependencyConditions *generateRegisterDependencyConditions(TR::CodeGenerator *cg, TR::Node *node,
+    uint32_t extranum, TR::Instruction **cursorPtr = NULL)
+{
+    return RegDeps(cg, node, extranum, cursorPtr);
+}
+
+} // namespace TR
 
 #endif

--- a/compiler/riscv/codegen/UnaryEvaluator.cpp
+++ b/compiler/riscv/codegen/UnaryEvaluator.cpp
@@ -71,7 +71,7 @@ TR::Register *OMR::RV::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGene
     TR::Register *reg = cg->gprClobberEvaluate(firstChild);
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-    Inst_RTYPE(TR::InstOpCode::_sub, node, reg, zero, reg, cg);
+    Inst_RTYPE(OP::_sub, node, reg, zero, reg, cg);
 
     firstChild->decReferenceCount();
     return node->setRegister(reg);
@@ -84,9 +84,9 @@ static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator
     TR::Register *tempReg = cg->allocateRegister();
     bool is64bit = node->getDataType().isInt64();
 
-    Inst_ITYPE(TR::InstOpCode::_srai, node, tempReg, reg, is64bit ? 63 : 31, cg);
-    Inst_RTYPE(TR::InstOpCode::_xor, node, reg, reg, tempReg, cg);
-    Inst_RTYPE(TR::InstOpCode::_sub, node, reg, reg, tempReg, cg);
+    Inst_ITYPE(OP::_srai, node, tempReg, reg, is64bit ? 63 : 31, cg);
+    Inst_RTYPE(OP::_xor, node, reg, reg, tempReg, cg);
+    Inst_RTYPE(OP::_sub, node, reg, reg, tempReg, cg);
 
     cg->stopUsingRegister(tempReg);
     node->setRegister(reg);

--- a/compiler/riscv/codegen/UnaryEvaluator.cpp
+++ b/compiler/riscv/codegen/UnaryEvaluator.cpp
@@ -71,7 +71,7 @@ TR::Register *OMR::RV::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGene
     TR::Register *reg = cg->gprClobberEvaluate(firstChild);
     TR::Register *zero = cg->machine()->getRealRegister(TR::RealRegister::zero);
 
-    generateRTYPE(TR::InstOpCode::_sub, node, reg, zero, reg, cg);
+    Inst_RTYPE(TR::InstOpCode::_sub, node, reg, zero, reg, cg);
 
     firstChild->decReferenceCount();
     return node->setRegister(reg);
@@ -84,9 +84,9 @@ static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator
     TR::Register *tempReg = cg->allocateRegister();
     bool is64bit = node->getDataType().isInt64();
 
-    generateITYPE(TR::InstOpCode::_srai, node, tempReg, reg, is64bit ? 63 : 31, cg);
-    generateRTYPE(TR::InstOpCode::_xor, node, reg, reg, tempReg, cg);
-    generateRTYPE(TR::InstOpCode::_sub, node, reg, reg, tempReg, cg);
+    Inst_ITYPE(TR::InstOpCode::_srai, node, tempReg, reg, is64bit ? 63 : 31, cg);
+    Inst_RTYPE(TR::InstOpCode::_xor, node, reg, reg, tempReg, cg);
+    Inst_RTYPE(TR::InstOpCode::_sub, node, reg, reg, tempReg, cg);
 
     cg->stopUsingRegister(tempReg);
     node->setRegister(reg);


### PR DESCRIPTION
This PR introduces shorter names to improve RISC-V backend readability, following the lead of #8215 that did it for X86.