### PR TITLE
Introduce Machine fields to describe register ranges

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -112,7 +112,7 @@ void TR::ARM64AdminInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
 
         // Step 2 : loop through and set up the new associations (both on the machine and by associating the virtual
         // registers with their real dependencies)
-        auto depCond = self()->getDependencyConditions();
+        auto depCond = getDependencyConditions();
         auto depGroup = depCond->getPostConditions();
         auto numPostCond = depCond->getNumPostConditions();
         for (int32_t j = 0; j < numPostCond; ++j) {

--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -146,14 +146,14 @@ public:
      * @brief Gets the register dependency conditions
      * @return register dependency conditions
      */
-    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     /**
      * @brief Sets the register dependency conditions
      * @param[in] cond : register dependency conditions
      * @return register dependency conditions
      */
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {
         return (_conditions = cond);
     }

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -233,7 +233,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
 
         for (int i = first; i <= last; i++) {
             uint32_t iInterfere = interference & (1 << (i - maskI));
-            TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
+            TR::RealRegister *realReg = getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
             TR::Register *tempReg;
 
             if (realReg->getState() == TR::RealRegister::Assigned) {
@@ -762,7 +762,7 @@ void OMR::ARM64::Machine::spillAllVectorRegisters(TR::Instruction *currentInstru
 
     for (int32_t i = first; i <= last; i++) {
         TR::Register *virtReg = NULL;
-        TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
+        TR::RealRegister *realReg = getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
 
         if ((realReg->getState() == TR::RealRegister::Assigned) && (virtReg = realReg->getAssignedRegister())
             && (virtReg->getKind() == TR_VRF)) {
@@ -1117,7 +1117,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
     // it is space conscious
     //
     for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableFPR; i++) {
-        TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
+        TR::RealRegister *realReg = getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
 
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
@@ -1134,7 +1134,7 @@ TR::RegisterDependencyConditions *OMR::ARM64::Machine::createCondForLiveAndSpill
     if (c) {
         deps = RegDeps(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableFPR; i++) {
-            TR::RealRegister *realReg = self()->getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
+            TR::RealRegister *realReg = getRealRegister(static_cast<TR::RealRegister::RegNum>(i));
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
                 TR_ASSERT(!spilledRegisterList

--- a/compiler/arm/codegen/OMRInstruction.cpp
+++ b/compiler/arm/codegen/OMRInstruction.cpp
@@ -77,14 +77,14 @@ OMR::ARM::Instruction::Instruction(TR::Node *node, TR::CodeGenerator *cg)
     : OMR::InstructionConnector(cg, TR::InstOpCode::bad, node)
 {
     self()->setConditionCode(ARMConditionCodeAL);
-    self()->setDependencyConditions(NULL);
+    setDependencyConditions(NULL);
 }
 
 OMR::ARM::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
     : OMR::InstructionConnector(cg, op, node)
 {
     self()->setConditionCode(ARMConditionCodeAL);
-    self()->setDependencyConditions(NULL);
+    setDependencyConditions(NULL);
 }
 
 OMR::ARM::Instruction::Instruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::Node *node,
@@ -92,7 +92,7 @@ OMR::ARM::Instruction::Instruction(TR::Instruction *precedingInstruction, TR::In
     : OMR::InstructionConnector(cg, precedingInstruction, op, node)
 {
     self()->setConditionCode(ARMConditionCodeAL);
-    self()->setDependencyConditions(NULL);
+    setDependencyConditions(NULL);
 }
 
 OMR::ARM::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
@@ -100,7 +100,7 @@ OMR::ARM::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, 
     : OMR::InstructionConnector(cg, op, node)
 {
     self()->setConditionCode(ARMConditionCodeAL);
-    self()->setDependencyConditions(cond);
+    setDependencyConditions(cond);
     if (cond)
         cond->incRegisterTotalUseCounts(cg);
 }
@@ -110,7 +110,7 @@ OMR::ARM::Instruction::Instruction(TR::Instruction *precedingInstruction, TR::In
     : OMR::InstructionConnector(cg, precedingInstruction, op, node)
 {
     self()->setConditionCode(ARMConditionCodeAL);
-    self()->setDependencyConditions(cond);
+    setDependencyConditions(cond);
     if (cond)
         cond->incRegisterTotalUseCounts(cg);
 }
@@ -125,22 +125,22 @@ TR::Register *OMR::ARM::Instruction::getMemoryDataRegister() { return NULL; }
 
 bool OMR::ARM::Instruction::refsRegister(TR::Register *reg)
 {
-    return (self()->getDependencyConditions() && self()->getDependencyConditions()->refsRegister(reg));
+    return (getDependencyConditions() && getDependencyConditions()->refsRegister(reg));
 }
 
 bool OMR::ARM::Instruction::defsRegister(TR::Register *reg)
 {
-    return (self()->getDependencyConditions() && self()->getDependencyConditions()->defsRegister(reg));
+    return (getDependencyConditions() && getDependencyConditions()->defsRegister(reg));
 }
 
 bool OMR::ARM::Instruction::defsRealRegister(TR::Register *reg)
 {
-    return (self()->getDependencyConditions() && self()->getDependencyConditions()->defsRealRegister(reg));
+    return (getDependencyConditions() && getDependencyConditions()->defsRealRegister(reg));
 }
 
 bool OMR::ARM::Instruction::usesRegister(TR::Register *reg)
 {
-    return (self()->getDependencyConditions() && self()->getDependencyConditions()->usesRegister(reg));
+    return (getDependencyConditions() && getDependencyConditions()->usesRegister(reg));
 }
 
 bool OMR::ARM::Instruction::dependencyRefsRegister(TR::Register *reg) { return false; }
@@ -157,9 +157,9 @@ int32_t OMR::ARM::Instruction::getMachineOpCode() { return getOpCodeValue(); }
 
 void OMR::ARM::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
-    if (self()->getDependencyConditions()) {
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
-        self()->getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
+    if (getDependencyConditions()) {
+        getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 }
 

--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -105,9 +105,9 @@ public:
 
     virtual bool isLabel() { return _opcode.getOpCodeValue() == TR::InstOpCode::label; }
 
-    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {
         return (_conditions = cond);
     }

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -119,7 +119,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction *currentIn
         }
 
         for (int i = first; i <= last; i++) {
-            TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+            TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 candidates[numCandidates++] = realReg->getAssignedRegister();
             }
@@ -775,7 +775,7 @@ TR::RegisterDependencyConditions *OMR::ARM::Machine::createCondForLiveAndSpilled
     int32_t endReg = TR::RealRegister::LastFPR;
 
     for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg; i++) {
-        TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
             "cannot handle realReg state %d, (block state is %d)\n", realReg->getState(), TR::RealRegister::Blocked);
@@ -790,7 +790,7 @@ TR::RegisterDependencyConditions *OMR::ARM::Machine::createCondForLiveAndSpilled
     if (c) {
         deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
         for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++) {
-            TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
+            TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)j);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
                 TR_ASSERT(!spilledRegisterList

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -268,7 +268,7 @@ void OMR::CodeGenerator::initialize()
     TR::CodeGenerator *cg = self();
     TR::Compilation *comp = self()->comp();
 
-    _machine = new (cg->trHeapMemory()) TR::Machine(cg);
+    _machine = TR::Machine::create(cg);
 
     _disableInternalPointers = comp->getOption(TR_MimicInterpreterFrameShape) || comp->getOptions()->realTimeGC()
         || comp->getOption(TR_DisableInternalPointers);

--- a/compiler/codegen/OMRMachine.cpp
+++ b/compiler/codegen/OMRMachine.cpp
@@ -30,7 +30,13 @@
 #pragma csect(TEST, "OMRMachine#T")
 #endif
 
-#include "codegen/Machine.hpp"
-
+#include "codegen/CodeGenerator.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/Machine_inlines.hpp"
+
+TR::Machine *OMR::Machine::create(TR::CodeGenerator *cg)
+{
+    TR::Machine *m = new (cg->trHeapMemory()) TR::Machine(cg);
+    m->initialize();
+    return m;
+}

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -56,6 +56,20 @@ class OMR_EXTENSIBLE Machine {
 public:
     TR_ALLOC(TR_Memory::Machine)
 
+    /**
+     * @brief Factory function to create and initialize a new \c TR::Machine object.
+     *
+     * @param[in] cg \c TR::CodeGenerator object
+     *
+     * @return An allocated and initialized \c TR::Machine object
+     */
+    static TR::Machine *create(TR::CodeGenerator *cg);
+
+    /**
+     * @brief Initialize a \c TR::Machine object
+     */
+    void initialize() {}
+
     Machine(TR::CodeGenerator *cg)
         : _cg(cg)
         , numLockedGPRs(-1)

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -95,9 +95,9 @@ public:
 
     virtual bool setsCountRegister();
 
-    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {
         return (_conditions = cond);
     }

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -1574,7 +1574,7 @@ TR::RegisterDependencyConditions *OMR::Power::Machine::createCondForLiveAndSpill
                                                 // will cover all VRFs
 
     for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg; i++) {
-        TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
             "cannot handle realReg state %d, (block state is %d)\n", realReg->getState(), TR::RealRegister::Blocked);
@@ -1589,7 +1589,7 @@ TR::RegisterDependencyConditions *OMR::Power::Machine::createCondForLiveAndSpill
     if (c) {
         deps = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, cg()->trMemory());
         for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++) {
-            TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
+            TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)j);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
                 TR_ASSERT(!spilledRegisterList

--- a/compiler/riscv/codegen/OMRInstruction.hpp
+++ b/compiler/riscv/codegen/OMRInstruction.hpp
@@ -134,14 +134,14 @@ public:
      * @brief Gets the register dependency conditions
      * @return register dependency conditions
      */
-    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     /**
      * @brief Sets the register dependency conditions
      * @param[in] cond : register dependency conditions
      * @return register dependency conditions
      */
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {
         return (_conditions = cond);
     }

--- a/compiler/riscv/codegen/OMRMachine.cpp
+++ b/compiler/riscv/codegen/OMRMachine.cpp
@@ -109,7 +109,7 @@ TR::RealRegister *OMR::RV::Machine::freeBestRegister(TR::Instruction *currentIns
         }
 
         for (auto i = first; i <= last; i++) {
-            TR::RealRegister *realReg = self()->getRealRegister(i);
+            TR::RealRegister *realReg = getRealRegister(i);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 candidates[numCandidates++] = realReg->getAssignedRegister();
             }

--- a/compiler/x/amd64/codegen/OMRMachine.cpp
+++ b/compiler/x/amd64/codegen/OMRMachine.cpp
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-#include "x/amd64/codegen/OMRMachine.hpp"
-
 #include <stdint.h>
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/Machine.hpp"
+#include "codegen/Machine_inlines.hpp"
 #include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
@@ -30,13 +30,31 @@
 bool OMR::X86::AMD64::Machine::_disableNewPickRegister, OMR::X86::AMD64::Machine::_dnprIsInitialized = false;
 
 OMR::X86::AMD64::Machine::Machine(TR::CodeGenerator *cg)
-    : OMR::X86::Machine(AMD64_NUM_GPR, // TODO:AMD64: What do these actually do? Possibly
-          AMD64_NUM_FPR, // clean up TR_Machine to remove them.
-          cg, _registerAssociationsStorage,
-          TR::Machine::enableNewPickRegister() ? (AMD64_MAX_GLOBAL_GPRS - TR::Machine::numGPRRegsWithheld(cg)) : 8,
-          TR::Machine::enableNewPickRegister() ? (AMD64_MAX_8BIT_GLOBAL_GPRS - TR::Machine::numRegsWithheld(cg)) : 8,
-          TR::Machine::enableNewPickRegister() ? (AMD64_MAX_GLOBAL_FPRS - TR::Machine::numRegsWithheld(cg)) : 8,
-          _xmmGlobalRegisterStorage, _globalRegisterNumberToRealRegisterMapStorage) {};
+    : OMR::X86::Machine(cg)
+{
+    // Initialize fields in Machine superclass
+    //
+    _registerAssociations = _registerAssociationsStorage;
+    _xmmGlobalRegisters = _xmmGlobalRegisterStorage;
+    _globalRegisterNumberToRealRegisterMap = _globalRegisterNumberToRealRegisterMapStorage;
+}
+
+void OMR::X86::AMD64::Machine::initialize()
+{
+    self()->OMR::X86::Machine::initialize();
+
+    _numGPRs = AMD64_NUM_GPR;
+
+    if (TR::Machine::enableNewPickRegister()) {
+        _numGlobalGPRs = AMD64_MAX_GLOBAL_GPRS - TR::Machine::numGPRRegsWithheld(cg());
+        _numGlobal8BitGPRs = AMD64_MAX_8BIT_GLOBAL_GPRS - TR::Machine::numRegsWithheld(cg());
+        _numGlobalFPRs = AMD64_MAX_GLOBAL_FPRS - TR::Machine::numRegsWithheld(cg());
+    } else {
+        _numGlobalGPRs = 8;
+        _numGlobal8BitGPRs = 8;
+        _numGlobalFPRs = 8;
+    }
+}
 
 uint8_t OMR::X86::AMD64::Machine::numGPRRegsWithheld(TR::CodeGenerator *cg)
 {

--- a/compiler/x/amd64/codegen/OMRMachine.cpp
+++ b/compiler/x/amd64/codegen/OMRMachine.cpp
@@ -37,24 +37,46 @@ OMR::X86::AMD64::Machine::Machine(TR::CodeGenerator *cg)
     _registerAssociations = _registerAssociationsStorage;
     _xmmGlobalRegisters = _xmmGlobalRegisterStorage;
     _globalRegisterNumberToRealRegisterMap = _globalRegisterNumberToRealRegisterMapStorage;
-}
 
-void OMR::X86::AMD64::Machine::initialize()
-{
-    self()->OMR::X86::Machine::initialize();
+    // Initialize register limits
+    //
+    _firstGPR = TR::RealRegister::eax;
+    _lastGPR = TR::RealRegister::r15;
+    _lastAssignableGPR = TR::RealRegister::r15;
+    _last8BitGPR = TR::RealRegister::r15;
+    _numAssignableGPRs = AMD64_NUM_GPR;
 
-    _numGPRs = AMD64_NUM_GPR;
+    _firstXMMR = TR::RealRegister::xmm0;
+
+    static const char *enableAVX512ExtendedRegisters = feGetEnv("TR_EnableAVX512ExtendedRegisters");
+    if (enableAVX512ExtendedRegisters && cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F)) {
+        // AVX-512 extended registers have not been created yet.  Use xmm15 until then.
+        //
+        _lastXMMR = TR::RealRegister::xmm15;
+        _lastAssignableXMMR = TR::RealRegister::xmm15;
+    } else {
+        _lastXMMR = TR::RealRegister::xmm15;
+        _lastAssignableXMMR = TR::RealRegister::xmm15;
+    }
+    _numAssignableXMMRs = static_cast<uint8_t>(_lastAssignableXMMR - _firstXMMR);
+
+    _firstVMR = TR::RealRegister::k0;
+    _lastVMR = TR::RealRegister::k7;
+    _lastAssignableVMR = TR::RealRegister::k7;
+    _numAssignableVMRs = static_cast<uint8_t>(_lastAssignableVMR - _firstVMR);
 
     if (TR::Machine::enableNewPickRegister()) {
-        _numGlobalGPRs = AMD64_MAX_GLOBAL_GPRS - TR::Machine::numGPRRegsWithheld(cg());
-        _numGlobal8BitGPRs = AMD64_MAX_8BIT_GLOBAL_GPRS - TR::Machine::numRegsWithheld(cg());
-        _numGlobalFPRs = AMD64_MAX_GLOBAL_FPRS - TR::Machine::numRegsWithheld(cg());
+        _numGlobalGPRs = AMD64_MAX_GLOBAL_GPRS - TR::Machine::numGPRRegsWithheld(cg);
+        _numGlobal8BitGPRs = AMD64_MAX_8BIT_GLOBAL_GPRS - TR::Machine::numRegsWithheld(cg);
+        _numGlobalFPRs = AMD64_MAX_GLOBAL_FPRS - TR::Machine::numRegsWithheld(cg);
     } else {
         _numGlobalGPRs = 8;
         _numGlobal8BitGPRs = 8;
         _numGlobalFPRs = 8;
     }
 }
+
+void OMR::X86::AMD64::Machine::initialize() { self()->OMR::X86::Machine::initialize(); }
 
 uint8_t OMR::X86::AMD64::Machine::numGPRRegsWithheld(TR::CodeGenerator *cg)
 {

--- a/compiler/x/amd64/codegen/OMRMachine.hpp
+++ b/compiler/x/amd64/codegen/OMRMachine.hpp
@@ -69,6 +69,8 @@ class OMR_EXTENSIBLE Machine : public OMR::X86::Machine {
 public:
     Machine(TR::CodeGenerator *cg);
 
+    void initialize();
+
     static uint8_t numGPRRegsWithheld(TR::CodeGenerator *cg);
     static uint8_t numRegsWithheld(TR::CodeGenerator *cg);
 

--- a/compiler/x/amd64/codegen/RealRegisterEnum.hpp
+++ b/compiler/x/amd64/codegen/RealRegisterEnum.hpp
@@ -24,13 +24,20 @@
  * definitions are permitted.
  */
 
+// Pseudo register indicating any register
+//
 NoReg = 0,
 
-    // The order of the GPRS registers is defined by the linkage
-    // convention, and the VM may rely on it (eg. for GC).
+    // Some consumers of OMR may rely on this register ordering (e.g., for
+    // register masks for live references for garbage collection), so be
+    // mindful of altering it.
+    //
     eax = 1, FirstGPR = eax, ebx = 2, ecx = 3, edx = 4, edi = 5, esi = 6, ebp = 7, esp = 8, r8 = 9, r9 = 10, r10 = 11,
     r11 = 12, r12 = 13, r13 = 14, r14 = 15, r15 = 16, LastGPR = r15, Last8BitGPR = r15, LastAssignableGPR = r15,
 
+    // Virtual frame pointer used as a placeholder for frame references before
+    // their offsets are known for rsp mapping
+    //
     vfp = 17,
 
     // st0Return is used for 32-bit linkages where floating point values are
@@ -40,22 +47,28 @@ NoReg = 0,
     st0Return = 18,
 
     xmm0 = 19, FirstXMMR = xmm0, xmm1 = 20, xmm2 = 21, xmm3 = 22, xmm4 = 23, xmm5 = 24, xmm6 = 25, xmm7 = 26, xmm8 = 27,
-    xmm9 = 28, xmm10 = 29, FirstSpillReg = xmm10, xmm11 = 30, xmm12 = 31, xmm13 = 32, xmm14 = 33, xmm15 = 34,
-    LastSpillReg = xmm15, LastXMMR = xmm15,
+    xmm9 = 28, xmm10 = 29, xmm11 = 30, xmm12 = 31, xmm13 = 32, xmm14 = 33, xmm15 = 34, LastXMMR = xmm15,
 
-    ymm0 = xmm0, FirstYMMR = ymm0, ymm1 = xmm1, ymm2 = xmm2, ymm3 = xmm3, ymm4 = xmm4, ymm5 = xmm5, ymm6 = xmm6,
-    ymm7 = xmm7, ymm8 = xmm8, ymm9 = xmm9, ymm10 = xmm10, ymm11 = xmm11, ymm12 = xmm12, ymm13 = xmm13, ymm14 = xmm14,
-    ymm15 = xmm15, LastYMMR = ymm15,
+    // Alias ymm registers with xmm registers as they architecturally overlap
+    //
+    ymm0 = xmm0, ymm1 = xmm1, ymm2 = xmm2, ymm3 = xmm3, ymm4 = xmm4, ymm5 = xmm5, ymm6 = xmm6, ymm7 = xmm7, ymm8 = xmm8,
+    ymm9 = xmm9, ymm10 = xmm10, ymm11 = xmm11, ymm12 = xmm12, ymm13 = xmm13, ymm14 = xmm14, ymm15 = xmm15,
 
-    zmm0 = xmm0, FirstZMMR = zmm0, zmm1 = xmm1, zmm2 = xmm2, zmm3 = xmm3, zmm4 = xmm4, zmm5 = xmm5, zmm6 = xmm6,
-    zmm7 = xmm7, zmm8 = xmm8, zmm9 = xmm9, zmm10 = xmm10, zmm11 = xmm11, zmm12 = xmm12, zmm13 = xmm13, zmm14 = xmm14,
-    zmm15 = xmm15, LastZMMR = zmm15,
+    // Alias zmm registers with xmm registers as they architecturally overlap
+    //
+    zmm0 = xmm0, zmm1 = xmm1, zmm2 = xmm2, zmm3 = xmm3, zmm4 = xmm4, zmm5 = xmm5, zmm6 = xmm6, zmm7 = xmm7, zmm8 = xmm8,
+    zmm9 = xmm9, zmm10 = xmm10, zmm11 = xmm11, zmm12 = xmm12, zmm13 = xmm13, zmm14 = xmm14, zmm15 = xmm15,
 
-    // avx512 write mask registers
-    // k0 -> reserved for unmasked operations
+    // AVX-512 write mask registers
+    //
     k0 = 35, k1 = 36, k2 = 37, k3 = 38, k4 = 39, k5 = 40, k6 = 41, k7 = 42,
 
-    ByteReg = 43, BestFreeReg = 44, SpilledReg = 45, NumRegisters = 46,
+    // Pseudo register indicating any byte register
+    //
+    ByteReg = 43,
 
-    NumXMMRegisters = LastXMMR - FirstXMMR + 1,
-    MaxAssignableRegisters = NumXMMRegisters + (LastAssignableGPR - FirstGPR + 1) - 1 // -1 for stack pointer
+    // Pseudo register indicating a register in spill state
+    //
+    SpilledReg = 44,
+
+    NumRegisters = 45,

--- a/compiler/x/codegen/Instruction.hpp
+++ b/compiler/x/codegen/Instruction.hpp
@@ -73,7 +73,7 @@ TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *n
     TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
     : OMR::InstructionConnector(cg, op, node)
 {
-    self()->setDependencyConditions(cond);
+    setDependencyConditions(cond);
     self()->setEncodingMethod(encoding);
     self()->initialize(cg, cond, op, true);
 }
@@ -82,7 +82,7 @@ TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, OP::Mnemoni
     TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
     : OMR::InstructionConnector(cg, precedingInstruction, op)
 {
-    self()->setDependencyConditions(cond);
+    setDependencyConditions(cond);
     self()->setEncodingMethod(encoding);
     self()->initialize(cg, cond, op);
 }

--- a/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
+++ b/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
@@ -165,7 +165,7 @@ int32_t TR_X86IntegerMultiplyDecomposer::findDecomposition(int64_t multiplier)
             correctionIfTakeAdvantageOfClobberableSource = 1;
         }
         int32_t numLiveRegs = _cg->getLiveRegisters(TR_GPR)->getNumberOfLiveRegisters();
-        int32_t numGPRRegs = _cg->machine()->getNumberOfGPRs();
+        int32_t numGPRRegs = _cg->machine()->getNumAssignableGPRs();
         int32_t registerCostOfDecomposition
             = composition._numAdditionalRegistersNeeded - correctionIfTakeAdvantageOfClobberableSource;
         if (registerCostOfDecomposition <= 1 || // mul would have a default register cost, too

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -542,12 +542,13 @@ void OMR::X86::CodeGenerator::initializeX86(TR::Compilation *comp)
         self()->setGenerateMasmListingSyntax();
 
     if (comp->getOption(TR_TraceRA)) {
+        TR::Machine *machine = self()->machine();
         self()->setGPRegisterIterator(new (self()->trHeapMemory())
-                TR::RegisterIterator(machine(), TR::RealRegister::FirstGPR, TR::RealRegister::LastAssignableGPR));
+                TR::RegisterIterator(machine, machine->getFirstGPR(), machine->getLastAssignableGPR()));
         self()->setFPRegisterIterator(new (self()->trHeapMemory())
-                TR::RegisterIterator(machine(), TR::RealRegister::FirstXMMR, TR::RealRegister::LastXMMR));
+                TR::RegisterIterator(machine, machine->getFirstXMMR(), machine->getLastXMMR()));
         self()->setVMRegisterIterator(
-            new (self()->trHeapMemory()) TR::RegisterIterator(machine(), TR::RealRegister::k1, TR::RealRegister::k7));
+            new (self()->trHeapMemory()) TR::RegisterIterator(machine, TR::RealRegister::k1, TR::RealRegister::k7));
     }
 
     self()->setSupportsProfiledInlining();
@@ -691,12 +692,14 @@ TR_X86ProcessorInfo &OMR::X86::CodeGenerator::getX86ProcessorInfo()
 
 int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableGPRs()
 {
-    return TR::RealRegister::LastAssignableGPR - TR::RealRegister::FirstGPR + 1; // TODO:AMD64: This is including rsp
+    TR::Machine *machine = self()->machine();
+    return machine->getLastAssignableGPR() - machine->getFirstGPR() + 1; // TODO:AMD64: This is including rsp
 }
 
 int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
 {
-    return TR::RealRegister::LastXMMR - TR::RealRegister::FirstXMMR + 1;
+    TR::Machine *machine = self()->machine();
+    return machine->getLastXMMR() - machine->getFirstXMMR() + 1;
 }
 
 // X has a different concept of VR's compared to p/z but since LocalOpts needs this to be hoisted within CG,
@@ -1307,7 +1310,7 @@ void OMR::X86::CodeGenerator::saveBetterSpillPlacements(TR::Instruction *branchI
     int32_t i;
     TR::RealRegister *realReg;
 
-    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++) {
+    for (i = machine()->getFirstGPR(); i <= machine()->getLastAssignableGPR(); i++) {
         realReg = machine()->getRealRegister((TR::RealRegister::RegNum)i);
 
         // Skip non-assignable registers
@@ -2420,7 +2423,7 @@ void OMR::X86::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
     //
     // Build the register map
     //
-    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
+    for (int32_t i = machine()->getFirstGPR(); i <= machine()->getLastAssignableGPR(); ++i) {
         TR::RealRegister *reg = machine()->getRealRegister((TR::RealRegister::RegNum)i);
         if (reg->getHasBeenAssignedInMethod()) {
             TR::Register *virtReg = reg->getAssignedRegister();

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -114,15 +114,15 @@ bool OMR::X86::Instruction::isPatchBarrier(TR::CodeGenerator *cg)
 
 void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
 {
-    if (!self()->getDependencyConditions()) {
+    if (!getDependencyConditions()) {
         // Fast path when there are no dependency conditions.
         //
         return;
     }
 
     if (getOpCodeValue() != OP::assocreg) {
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindsToBeAssigned, cg());
-        self()->getDependencyConditions()->assignPreConditionRegisters(self(), kindsToBeAssigned, cg());
+        getDependencyConditions()->assignPostConditionRegisters(self(), kindsToBeAssigned, cg());
+        getDependencyConditions()->assignPreConditionRegisters(self(), kindsToBeAssigned, cg());
     } else if ((getOpCodeValue() == OP::assocreg) && cg()->enableRegisterAssociations()) {
         if (kindsToBeAssigned & TR_GPR_Mask) {
             TR::Machine *machine = cg()->machine();
@@ -145,8 +145,8 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
             // Next loop through and set up the new associations (both on the machine
             // and by associating the virtual registers with their real dependencies)
             //
-            TR::RegisterDependencyGroup *depGroup = self()->getDependencyConditions()->getPostConditions();
-            for (auto j = 0U; j < self()->getDependencyConditions()->getNumPostConditions(); ++j) {
+            TR::RegisterDependencyGroup *depGroup = getDependencyConditions()->getPostConditions();
+            for (auto j = 0U; j < getDependencyConditions()->getNumPostConditions(); ++j) {
                 TR::RegisterDependency *dep = depGroup->getRegisterDependency(j);
                 machine->setVirtualAssociatedWithReal(dep->getRealRegister(), dep->getRegister());
             }
@@ -169,8 +169,8 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
             }
 
             // Set new XMM associations from dependencies
-            TR::RegisterDependencyGroup *depGroup = self()->getDependencyConditions()->getPostConditions();
-            for (auto j = 0U; j < self()->getDependencyConditions()->getNumPostConditions(); ++j) {
+            TR::RegisterDependencyGroup *depGroup = getDependencyConditions()->getPostConditions();
+            for (auto j = 0U; j < getDependencyConditions()->getNumPostConditions(); ++j) {
                 TR::RegisterDependency *dep = depGroup->getRegisterDependency(j);
                 TR::Register *vr = dep->getRegister();
                 if (vr && (vr->getKind() == TR_FPR || vr->getKind() == TR_VRF)) {
@@ -185,30 +185,29 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
 
 bool OMR::X86::Instruction::refsRegister(TR::Register *reg)
 {
-    return self()->getDependencyConditions() ? _conditions->refsRegister(reg) : false;
+    return getDependencyConditions() ? _conditions->refsRegister(reg) : false;
 }
 
 bool OMR::X86::Instruction::defsRegister(TR::Register *reg)
 {
-    return self()->getDependencyConditions() ? _conditions->defsRegister(reg) : false;
+    return getDependencyConditions() ? _conditions->defsRegister(reg) : false;
 }
 
 bool OMR::X86::Instruction::usesRegister(TR::Register *reg)
 {
-    return self()->getDependencyConditions() ? _conditions->usesRegister(reg) : false;
+    return getDependencyConditions() ? _conditions->usesRegister(reg) : false;
 }
 
 bool OMR::X86::Instruction::dependencyRefsRegister(TR::Register *reg)
 {
-    return self()->getDependencyConditions() ? _conditions->refsRegister(reg) : false;
+    return getDependencyConditions() ? _conditions->refsRegister(reg) : false;
 }
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 uint32_t OMR::X86::Instruction::totalReferencedGPRegisters(TR::CodeGenerator *cg)
 {
-    if (self()->getDependencyConditions()) {
-        return self()->getNumOperandReferencedGPRegisters()
-            + self()->getDependencyConditions()->numReferencedGPRegisters(cg);
+    if (getDependencyConditions()) {
+        return self()->getNumOperandReferencedGPRegisters() + getDependencyConditions()->numReferencedGPRegisters(cg);
     }
 
     return self()->getNumOperandReferencedGPRegisters();
@@ -243,7 +242,7 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
     // We assume most instructions modify all registers that appear in their
     // postconditions, with a few exceptions.
     //
-    if (cg()->enableRematerialisation() && self()->getDependencyConditions()
+    if (cg()->enableRematerialisation() && getDependencyConditions()
         && (getOpCodeValue()
             != OP::assocreg) // reg associations aren't really instructions, so they don't modify anything
         && (getOpCodeValue() != OP::label) // labels must already be handled properly for a variety of reasons
@@ -254,8 +253,8 @@ void OMR::X86::Instruction::clobberRegsForRematerialisation()
         // instruction that kills the rematerialisable range of a register.
         //
         TR::ClobberingInstruction *clob = NULL;
-        TR::RegisterDependencyGroup *post = self()->getDependencyConditions()->getPostConditions();
-        for (uint32_t i = 0; i < self()->getDependencyConditions()->getNumPostConditions(); i++) {
+        TR::RegisterDependencyGroup *post = getDependencyConditions()->getPostConditions();
+        for (uint32_t i = 0; i < getDependencyConditions()->getNumPostConditions(); i++) {
             TR::Register *reg = post->getRegisterDependency(i)->getRegister();
             if (reg->isDiscardable()) {
                 if (!clob) {

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -130,7 +130,7 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
             // First traverse the existing associations and remove them
             // so that they don't interfere with the new ones
             //
-            for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
+            for (int32_t i = machine->getFirstGPR(); i <= machine->getLastAssignableGPR(); ++i) {
                 // Skip non-assignable registers
                 //
                 if (machine->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
@@ -159,7 +159,7 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
             TR::Machine *machine = cg()->machine();
 
             // Clear existing XMM associations
-            for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; ++i) {
+            for (int32_t i = machine->getFirstXMMR(); i <= machine->getLastXMMR(); ++i) {
                 if (machine->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
                     continue;
                 TR::Register *virtReg = machine->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i);

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -117,9 +117,9 @@ public:
     virtual bool isRegRegMove();
     virtual bool isPatchBarrier(TR::CodeGenerator *cg);
 
-    TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {
         return (_conditions = cond);
     }

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -504,6 +504,7 @@ void OMR::X86::Linkage::associatePreservedRegisters(TR::RegisterDependencyCondit
 {
     TR::Register *vmThreadReg = self()->cg()->getVMThreadRegister();
     TR_LiveRegisters *liveRegisters = self()->cg()->getLiveRegisters(TR_GPR);
+    TR::Machine *machine = self()->machine();
 
     for (TR_LiveRegisterInfo *liveReg = liveRegisters->getFirstLiveRegister(); liveReg; liveReg = liveReg->getNext()) {
         TR::Register *virtReg = liveReg->getRegister();
@@ -518,11 +519,10 @@ void OMR::X86::Linkage::associatePreservedRegisters(TR::RegisterDependencyCondit
         // Search all registers for the best one to associate with virtReg
         //
         TR::RealRegister::RegNum bestReal = TR::RealRegister::NoReg;
-        for (int realReg = TR::RealRegister::LastAssignableGPR; realReg >= TR::RealRegister::FirstGPR; realReg--) {
+        for (int32_t realReg = machine->getLastAssignableGPR(); realReg >= machine->getFirstGPR(); realReg--) {
             // Can't use locked regs
             //
-            if (self()->machine()->getRealRegister((TR::RealRegister::RegNum)realReg)->getState()
-                == TR::RealRegister::Locked)
+            if (machine->getRealRegister((TR::RealRegister::RegNum)realReg)->getState() == TR::RealRegister::Locked)
                 continue;
 
             // Volatile regs are no good for virtuals that live across a call
@@ -530,12 +530,12 @@ void OMR::X86::Linkage::associatePreservedRegisters(TR::RegisterDependencyCondit
             if (!self()->getProperties().isPreservedRegister((TR::RealRegister::RegNum)realReg))
                 continue;
 
-            if (self()->machine()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)realReg) == virtReg) {
+            if (machine->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)realReg) == virtReg) {
                 // virtReg is already associated with a preserved realReg, so obviously that's the best choice
                 //
                 bestReal = (TR::RealRegister::RegNum)realReg;
                 break;
-            } else if (self()->machine()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)realReg) == NULL) {
+            } else if (machine->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)realReg) == NULL) {
                 // realReg isn't associated with anything yet so it's a good choice,
                 // but keep looking in case we find a better choice.
                 //
@@ -547,10 +547,10 @@ void OMR::X86::Linkage::associatePreservedRegisters(TR::RegisterDependencyCondit
             // There are no more preserved regs to associate, so we're done.
             //
             break;
-        } else if (self()->machine()->getVirtualAssociatedWithReal(bestReal) == virtReg) {
+        } else if (machine->getVirtualAssociatedWithReal(bestReal) == virtReg) {
             // virtReg is already associated; do nothing
         } else {
-            self()->machine()->setVirtualAssociatedWithReal(bestReal, virtReg);
+            machine->setVirtualAssociatedWithReal(bestReal, virtReg);
         }
     }
 }

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -181,7 +181,7 @@ void OMR::X86::Machine::initialize()
 
 void OMR::X86::Machine::resetXMMGlobalRegisters()
 {
-    for (int32_t i = 0; i < TR::RealRegister::LastXMMR - TR::RealRegister::FirstXMMR + 1; i++)
+    for (int32_t i = 0; i < getLastXMMR() - getFirstXMMR() + 1; i++)
         self()->setXMMGlobalRegister(i, NULL);
 }
 
@@ -223,7 +223,8 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
             || (considerUnlatched
                 && _registerFile[virtReg->getAssociation()]->getState() == TR::RealRegister::Unlatched))) {
         if (_registerFile[virtReg->getAssociation()]->getState() != TR::RealRegister::Locked) {
-            if (requestedRegSize != TR_ByteReg || virtReg->getAssociation() <= TR::RealRegister::Last8BitGPR) {
+            if (requestedRegSize != TR_ByteReg
+                || virtReg->getAssociation() <= static_cast<uint32_t>(getLast8BitGPR())) {
                 cg()->setRegisterAssignmentFlag(TR_ByAssociation);
                 return _registerFile[virtReg->getAssociation()];
             }
@@ -232,8 +233,8 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
 
     switch (requestedRegSize) {
         case TR_ByteReg:
-            first = TR::RealRegister::FirstGPR;
-            last = TR::RealRegister::Last8BitGPR;
+            first = getFirstGPR();
+            last = getLast8BitGPR();
             break;
         case TR_DoubleWordReg:
 #if defined(TR_TARGET_32BIT)
@@ -241,16 +242,16 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
 #endif
         case TR_HalfWordReg:
         case TR_WordReg:
-            first = TR::RealRegister::FirstGPR;
-            last = TR::RealRegister::LastAssignableGPR;
+            first = getFirstGPR();
+            last = getLastAssignableGPR();
             break;
         case TR_QuadWordReg:
         case TR_VectorReg128:
         case TR_VectorReg256:
         case TR_VectorReg512:
             // xmm/ymm/zmm are aliased
-            first = TR::RealRegister::FirstXMMR;
-            last = TR::RealRegister::LastXMMR;
+            first = getFirstXMMR();
+            last = getLastXMMR();
             break;
         default:
             TR_ASSERT(0, "unknown register size requested\n");
@@ -311,7 +312,7 @@ TR::RealRegister *OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction *cur
             // with byte registers.
             //
             if (!(interference & 1)) {
-                if (byteRegisterInterference && i <= TR::RealRegister::Last8BitGPR)
+                if (byteRegisterInterference && i <= getLast8BitGPR())
                     weight += IA32_BYTE_REGISTER_INTERFERENCE_WEIGHT;
                 if (linkageProperties.isPreservedRegister((TR::RealRegister::RegNum)i))
                     weight += IA32_REGISTER_PRESERVED_WEIGHT;
@@ -405,8 +406,8 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
 
     switch (requestedRegSize) {
         case TR_ByteReg:
-            first = TR::RealRegister::FirstGPR;
-            last = TR::RealRegister::Last8BitGPR;
+            first = getFirstGPR();
+            last = getLast8BitGPR();
             break;
         case TR_DoubleWordReg:
 #if defined(TR_TARGET_32BIT)
@@ -414,16 +415,16 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
 #endif
         case TR_HalfWordReg:
         case TR_WordReg:
-            first = TR::RealRegister::FirstGPR;
-            last = TR::RealRegister::LastAssignableGPR;
+            first = getFirstGPR();
+            last = getLastAssignableGPR();
             break;
         case TR_QuadWordReg:
         case TR_VectorReg128:
         case TR_VectorReg256:
         case TR_VectorReg512:
             // xmm/ymm/zmm are aliased
-            first = TR::RealRegister::FirstXMMR;
-            last = TR::RealRegister::LastXMMR;
+            first = getFirstXMMR();
+            last = getLastXMMR();
             break;
         default:
             TR_ASSERT_FATAL(0, "unknown register size requested\n");
@@ -546,7 +547,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                         if (info->isRematerializableFromMemory() || info->isRematerializableFromAddress()) {
                             if (interferes)
                                 j = BestInterferingDiscardableMemory;
-                            else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                            else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                                 j = BestMayInterfereDiscardableMemory;
                             else
                                 j = BestNonInterferingDiscardableMemory;
@@ -555,7 +556,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                                 "freeBestGPRegister => unknown rematerialisable register type!");
                             if (interferes)
                                 j = BestInterferingDiscardableConstant;
-                            else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                            else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                                 j = BestMayInterfereDiscardableConstant;
                             else
                                 j = BestNonInterferingDiscardableConstant;
@@ -571,7 +572,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                         if (useRegisterInterferences) {
                             if (interferes)
                                 j = BestInterfering;
-                            else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                            else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                                 j = BestMayInterfere;
                             else
                                 j = BestNonInterfering;
@@ -611,14 +612,14 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
                 || candidates[i]->getRematerializationInfo()->isRematerializableFromAddress()) {
                 if (interferes)
                     j = BestInterferingDiscardableMemory;
-                else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                     j = BestMayInterfereDiscardableMemory;
                 else
                     j = BestNonInterferingDiscardableMemory;
             } else {
                 if (interferes)
                     j = BestInterferingDiscardableConstant;
-                else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                     j = BestMayInterfereDiscardableConstant;
                 else
                     j = BestNonInterferingDiscardableConstant;
@@ -627,7 +628,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
             if (useRegisterInterferences) {
                 if (interferes)
                     j = BestInterfering;
-                else if (byteRegisterInterference && registerNumber <= TR::RealRegister::Last8BitGPR)
+                else if (byteRegisterInterference && registerNumber <= getLast8BitGPR())
                     j = BestMayInterfere;
                 else
                     j = BestNonInterfering;
@@ -1324,7 +1325,7 @@ void OMR::X86::Machine::setGPRWeightsFromAssociations()
 {
     const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
-    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
+    for (int i = getFirstGPR(); i <= getLastAssignableGPR(); ++i) {
         // Skip non-assignable registers
         //
         if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
@@ -1358,7 +1359,7 @@ void OMR::X86::Machine::setXMMWeightsFromAssociations()
 {
     const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
-    for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; ++i) {
+    for (int i = getFirstXMMR(); i <= getLastXMMR(); ++i) {
         if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
 
@@ -1388,8 +1389,8 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
     TR::Compilation *comp = cg()->comp();
 
     // Calculate total number of registers (GPRs + XMMRs)
-    int numGPRs = TR::RealRegister::LastAssignableGPR;
-    int numXMMRs = TR::RealRegister::LastXMMR - TR::RealRegister::FirstXMMR + 1;
+    int numGPRs = getLastAssignableGPR();
+    int numXMMRs = getLastXMMR() - getFirstXMMR() + 1;
 
     TR::RegisterDependencyConditions *associations = RegDeps((uint8_t)0, numGPRs + numXMMRs, cg());
 
@@ -1398,7 +1399,7 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
     // so that when the register assigner goes backwards through this point
     // it updates the machine and register association states properly
     //
-    for (int i = 0; i < TR::RealRegister::LastAssignableGPR; i++) {
+    for (int i = 0; i < getLastAssignableGPR(); i++) {
         TR::RealRegister::RegNum regNum = (TR::RealRegister::RegNum)(i + 1);
 
         // Skip non-assignable registers
@@ -1410,7 +1411,7 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
     }
 
     // Add XMM associations
-    for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; i++) {
+    for (int i = getFirstXMMR(); i <= getLastXMMR(); i++) {
         if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
         associations->addPostCondition(self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i),
@@ -1427,14 +1428,14 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
     // its live range has ended.  One is enough.  So we clear out all the dead
     // registers from the associations.
     //
-    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++) {
+    for (int i = getFirstGPR(); i <= getLastAssignableGPR(); i++) {
         TR::Register *virtReg = self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i);
         if (virtReg && !virtReg->isLive())
             self()->setVirtualAssociatedWithReal((TR::RealRegister::RegNum)i, NULL);
     }
 
     // Clear dead XMM associations
-    for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; i++) {
+    for (int i = getFirstXMMR(); i <= getLastXMMR(); i++) {
         TR::Register *virtReg = self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i);
         if (virtReg && !virtReg->isLive())
             self()->setVirtualAssociatedWithReal((TR::RealRegister::RegNum)i, NULL);
@@ -1454,7 +1455,6 @@ void OMR::X86::Machine::initializeRegisterFile(const struct TR::X86LinkageProper
     //
     _registerFile[TR::RealRegister::NoReg] = NULL;
     _registerFile[TR::RealRegister::ByteReg] = NULL;
-    _registerFile[TR::RealRegister::BestFreeReg] = NULL;
 
     // GPRs
     //
@@ -1505,7 +1505,7 @@ void OMR::X86::Machine::initializeRegisterFile(const struct TR::X86LinkageProper
     _registerFile[TR::RealRegister::vfp]->setAssignedRegister(_registerFile[TR::RealRegister::NoReg]);
 
 #ifdef TR_TARGET_64BIT
-    for (reg = TR::RealRegister::r8; reg <= TR::RealRegister::LastAssignableGPR; reg++) {
+    for (reg = TR::RealRegister::r8; reg <= getLastAssignableGPR(); reg++) {
         _registerFile[reg] = new (cg()->trHeapMemory()) TR::RealRegister(TR_GPR,
             properties.isPreservedRegister((TR::RealRegister::RegNum)reg) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
             TR::RealRegister::Free, (TR::RealRegister::RegNum)reg,
@@ -1515,7 +1515,7 @@ void OMR::X86::Machine::initializeRegisterFile(const struct TR::X86LinkageProper
 
     // Other register kinds
     //
-    for (reg = TR::RealRegister::FirstXMMR; reg <= TR::RealRegister::LastXMMR; reg++) {
+    for (reg = getFirstXMMR(); reg <= getLastXMMR(); reg++) {
         _registerFile[reg] = new (cg()->trHeapMemory()) TR::RealRegister(TR_FPR,
             properties.isPreservedRegister((TR::RealRegister::RegNum)reg) ? PRESERVED_WEIGHT : NONPRESERVED_WEIGHT,
             TR::RealRegister::Free, (TR::RealRegister::RegNum)reg,
@@ -1548,8 +1548,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
     // Calculate number of register dependencies required.  This step is not really necessary, but
     // it is space conscious.
     //
-    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    for (i = getFirstGPR(); i <= getLastXMMR(); i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
             || realReg->getState() == TR::RealRegister::Blocked)
@@ -1560,14 +1559,13 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
 
     if (c) {
         deps = RegDeps(0, c, cg());
-        for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR;
-             i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+        for (i = getFirstGPR(); i <= getLastXMMR(); i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
             TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
             if (realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Blocked) {
                 TR::Register *virtReg;
                 if (realReg->getState() == TR::RealRegister::Free) {
-                    virtReg = cg()->allocateRegister(i <= TR::RealRegister::LastAssignableGPR ? TR_GPR : TR_FPR);
+                    virtReg = cg()->allocateRegister(i <= getLastAssignableGPR() ? TR_GPR : TR_FPR);
                     virtReg->setPlaceholderReg();
                 } else {
                     virtReg = realReg->getAssignedRegister();
@@ -1593,14 +1591,13 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
     // Calculate number of register dependencies required.  This step is not really necessary, but
     // it is space conscious.
     //
-    int32_t endReg = TR::RealRegister::LastAssignableGPR;
+    int32_t endReg = getLastAssignableGPR();
     TR_LiveRegisters *liveFPRs = cg()->getLiveRegisters(TR_FPR);
     TR_LiveRegisters *liveVRFs = cg()->getLiveRegisters(TR_VRF);
     if ((liveFPRs && liveFPRs->getNumberOfLiveRegisters() > 0)
         || (liveVRFs && liveVRFs->getNumberOfLiveRegisters() > 0))
-        endReg = TR::RealRegister::LastXMMR;
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+        endReg = getLastXMMR();
+    for (i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
@@ -1615,8 +1612,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
 
     if (c) {
         deps = RegDeps(0, c, cg());
-        for (i = TR::RealRegister::FirstGPR; i <= endReg;
-             i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+        for (i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
             TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
@@ -1650,9 +1646,8 @@ TR::RealRegister **OMR::X86::Machine::captureRegisterFile()
 
     TR::RealRegister **registerFileClone = (TR::RealRegister **)cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
 
-    int32_t endReg = TR::RealRegister::LastXMMR;
-    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    int32_t endReg = getLastXMMR();
+    for (int32_t i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         registerFileClone[i]
             = (TR::RealRegister *)cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
         *registerFileClone[i] = *_registerFile[i];
@@ -1667,13 +1662,12 @@ TR::RealRegister **OMR::X86::Machine::captureRegisterFile()
 
 void OMR::X86::Machine::installRegisterFile(TR::RealRegister **registerFileCopy)
 {
-    int32_t endReg = TR::RealRegister::LastXMMR;
+    int32_t endReg = getLastXMMR();
 
     // Unlink currently assigned registers from their virtuals.  This must be done
     // before the register file is installed to prevent unintended clobbering.
     //
-    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    for (int32_t i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         TR::Register *assignedVirtReg = _registerFile[i]->getAssignedRegister();
         if (assignedVirtReg != NULL) {
             TR_ASSERT(_registerFile[i]->getState() == TR::RealRegister::Assigned
@@ -1688,8 +1682,7 @@ void OMR::X86::Machine::installRegisterFile(TR::RealRegister **registerFileCopy)
 
     // Install register file.
     //
-    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    for (int32_t i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         // Some real register fields are sticky and their contents must be preserved.
         //
         // TODO: this will have to be made smarter to work cross platform.
@@ -1720,9 +1713,8 @@ TR::Register **OMR::X86::Machine::captureRegisterAssociations()
 
     TR::Register **registerAssociationsClone = (TR::Register **)cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
 
-    int32_t endReg = TR::RealRegister::LastXMMR;
-    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    int32_t endReg = getLastXMMR();
+    for (int32_t i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         if (_registerAssociations[i] != NULL) {
             registerAssociationsClone[i]
                 = (TR::Register *)cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
@@ -1769,9 +1761,9 @@ TR::RegisterDependencyConditions *TR_RegisterAssignerState::createDependenciesFr
 
     int32_t numDeps = 0;
     int32_t i;
-    int32_t endReg = TR::RealRegister::LastXMMR;
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    int32_t endReg = _machine->getLastXMMR();
+    for (i = _machine->getFirstGPR(); i <= endReg;
+         i = ((i == _machine->getLastAssignableGPR()) ? _machine->getFirstXMMR() : i + 1)) {
         if (_registerFile[i]->getState() == TR::RealRegister::Assigned)
             numDeps++;
     }
@@ -1791,8 +1783,8 @@ TR::RegisterDependencyConditions *TR_RegisterAssignerState::createDependenciesFr
 
     // Populate assignments from the register file.
     //
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    for (i = _machine->getFirstGPR(); i <= endReg;
+         i = ((i == _machine->getLastAssignableGPR()) ? _machine->getFirstXMMR() : i + 1)) {
         TR::RealRegister *realReg = _registerFile[i];
         if (realReg->getState() == TR::RealRegister::Assigned) {
             TR::Register *virtReg = realReg->getAssignedRegister();
@@ -1897,9 +1889,9 @@ bool TR_RegisterAssignerState::isLive(TR::Register *virtReg)
     // Check the register file
     //
     int32_t i;
-    int32_t endReg = TR::RealRegister::LastXMMR;
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    int32_t endReg = _machine->getLastXMMR();
+    for (i = _machine->getFirstGPR(); i <= endReg;
+         i = ((i == _machine->getLastAssignableGPR()) ? _machine->getFirstXMMR() : i + 1)) {
         if (_registerFile[i]->getState() == TR::RealRegister::Assigned) {
             if (_registerFile[i]->getAssignedRegister() == virtReg) {
                 return true;
@@ -1925,9 +1917,9 @@ void TR_RegisterAssignerState::dump()
         log->prints("\nREGISTER ASSIGNER STATE\n=======================\n\nAssigned Live Registers:\n");
 
         int32_t i;
-        int32_t endReg = TR::RealRegister::LastXMMR;
-        for (i = TR::RealRegister::FirstGPR; i <= endReg;
-             i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+        int32_t endReg = _machine->getLastXMMR();
+        for (i = _machine->getFirstGPR(); i <= endReg;
+             i = ((i == _machine->getLastAssignableGPR()) ? _machine->getFirstXMMR() : i + 1)) {
             if (_registerFile[i]->getState() == TR::RealRegister::Assigned) {
                 log->printf("         %s -> %s\n", comp->getDebug()->getName(_registerFile[i]->getAssignedRegister()),
                     comp->getDebug()->getName(_registerFile[i]));
@@ -1994,12 +1986,11 @@ void OMR::X86::Machine::adjustRegisterUseCountsDown(TR::list<OMR::RegisterUsage 
 void OMR::X86::Machine::disassociateUnspilledBackingStorage()
 {
     int32_t i;
-    int32_t endReg = TR::RealRegister::LastXMMR;
+    int32_t endReg = getLastXMMR();
     TR_BackingStore *location = NULL;
     TR::Compilation *comp = cg()->comp();
 
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    for (i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         if (_registerFile[i]->getState() == TR::RealRegister::Assigned) {
             TR::Register *virtReg = _registerFile[i]->getAssignedRegister();
             location = virtReg->getBackingStorage();
@@ -2031,9 +2022,8 @@ void OMR::X86::Machine::disassociateUnspilledBackingStorage()
 void OMR::X86::Machine::purgeDeadRegistersFromRegisterFile()
 {
     int32_t i;
-    int32_t endReg = TR::RealRegister::LastXMMR;
-    for (i = TR::RealRegister::FirstGPR; i <= endReg;
-         i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
+    int32_t endReg = getLastXMMR();
+    for (i = getFirstGPR(); i <= endReg; i = ((i == getLastAssignableGPR()) ? getFirstXMMR() : i + 1)) {
         if (_registerFile[i]->getState() == TR::RealRegister::Assigned) {
             TR::Register *virtReg = _registerFile[i]->getAssignedRegister();
             if (virtReg->getFutureUseCount() == 0) {
@@ -2073,8 +2063,7 @@ TR::MemoryReference *OMR::X86::Machine::getDummyLocalMR(TR::DataType dt)
 
 uint32_t OMR::X86::Machine::maxAssignableRegisters()
 {
-    return TR::RealRegister::LastXMMR - TR::RealRegister::FirstXMMR + 1 + TR::RealRegister::LastAssignableGPR
-        - TR::RealRegister::FirstGPR;
+    return getLastXMMR() - getFirstXMMR() + 1 + getLastAssignableGPR() - getFirstGPR();
 }
 
 #if defined(DEBUG)
@@ -2088,10 +2077,10 @@ void OMR::X86::Machine::printGPRegisterStatus(OMR::Logger *log, TR_FrontEnd *fe,
 {
     log->prints("\n  GP Reg Status:          Register         State        Assigned\n");
     int i;
-    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++) {
+    for (i = getFirstGPR(); i <= getLastAssignableGPR(); i++) {
         printOneRegisterStatus(log, fe, getDebug(), registerFile[i]);
     }
-    for (i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; i++) {
+    for (i = getFirstXMMR(); i <= getLastXMMR(); i++) {
         printOneRegisterStatus(log, fe, getDebug(), registerFile[i]);
     }
 

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -467,7 +467,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction *current
             continue;
         }
 
-        realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        realReg = getRealRegister((TR::RealRegister::RegNum)i);
 
         if (realReg->getState() == TR::RealRegister::Assigned) {
             candidates[numCandidates++] = realReg->getAssignedRegister();
@@ -1281,8 +1281,8 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction *currentInst
 void OMR::X86::Machine::swapGPRegisters(TR::Instruction *currentInstruction, TR::RealRegister::RegNum regNum1,
     TR::RealRegister::RegNum regNum2)
 {
-    TR::RealRegister *realReg1 = self()->getRealRegister(regNum1);
-    TR::RealRegister *realReg2 = self()->getRealRegister(regNum2);
+    TR::RealRegister *realReg1 = getRealRegister(regNum1);
+    TR::RealRegister *realReg2 = getRealRegister(regNum2);
     TR::Instruction *instr = new (cg()->trHeapMemory())
         TR::X86RegRegInstruction(currentInstruction, OP::XCHGRegReg(), realReg1, realReg2, cg());
 
@@ -1331,7 +1331,7 @@ void OMR::X86::Machine::setGPRWeightsFromAssociations()
     for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
         // Skip non-assignable registers
         //
-        if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
+        if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
 
         TR::Register *assocReg = _registerAssociations[i];
@@ -1363,7 +1363,7 @@ void OMR::X86::Machine::setXMMWeightsFromAssociations()
     const TR::X86LinkageProperties &linkageProperties = cg()->getProperties();
 
     for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; ++i) {
-        if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
+        if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
 
         TR::Register *assocReg = _registerAssociations[i];
@@ -1407,7 +1407,7 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
 
         // Skip non-assignable registers
         //
-        if (self()->getRealRegister(regNum)->getState() == TR::RealRegister::Locked)
+        if (getRealRegister(regNum)->getState() == TR::RealRegister::Locked)
             continue;
 
         associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum, cg(), 0, true);
@@ -1415,7 +1415,7 @@ void OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *curs
 
     // Add XMM associations
     for (int i = TR::RealRegister::FirstXMMR; i <= TR::RealRegister::LastXMMR; i++) {
-        if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
+        if (getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
             continue;
         associations->addPostCondition(self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i),
             (TR::RealRegister::RegNum)i, cg(), 0, true);
@@ -1554,7 +1554,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
     //
     for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
-        TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
             || realReg->getState() == TR::RealRegister::Blocked)
             c++;
@@ -1566,7 +1566,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createDepCondForLiveGPRs()
         deps = RegDeps(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
-            TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+            TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
             if (realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Blocked) {
                 TR::Register *virtReg;
@@ -1605,7 +1605,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
         endReg = TR::RealRegister::LastXMMR;
     for (i = TR::RealRegister::FirstGPR; i <= endReg;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
-        TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
             "cannot handle realReg state %d, (block state is %d)\n", realReg->getState(), TR::RealRegister::Blocked);
@@ -1621,7 +1621,7 @@ TR::RegisterDependencyConditions *OMR::X86::Machine::createCondForLiveAndSpilled
         deps = RegDeps(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= endReg;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i + 1)) {
-            TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+            TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
                 TR_ASSERT(!spilledRegisterList

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -161,22 +161,18 @@ static bool registersMayOverlap(TR::Register *reg1, TR::Register *reg2)
     return true;
 }
 
-OMR::X86::Machine::Machine(uint8_t numIntRegs, uint8_t numFPRegs, TR::CodeGenerator *cg,
-    TR::Register **registerAssociations, uint8_t numGlobalGPRs, uint8_t numGlobal8BitGPRs, uint8_t numGlobalFPRs,
-    TR::Register **xmmGlobalRegisters, uint32_t *globalRegisterNumberToRealRegisterMap)
+OMR::X86::Machine::Machine(TR::CodeGenerator *cg)
     : OMR::Machine(cg)
-    , _registerAssociations(registerAssociations)
-    , _numGlobalGPRs(numGlobalGPRs)
-    , _numGlobal8BitGPRs(numGlobal8BitGPRs)
-    , _numGlobalFPRs(numGlobalFPRs)
-    , _xmmGlobalRegisters(xmmGlobalRegisters)
-    , _globalRegisterNumberToRealRegisterMap(globalRegisterNumberToRealRegisterMap)
     , _spilledRegistersList(NULL)
-    , _numGPRs(numIntRegs)
+{}
+
+void OMR::X86::Machine::initialize()
 {
+    self()->OMR::Machine::initialize();
+
     self()->resetXMMGlobalRegisters();
 
-    for (int i = 0; i < TR::NumAllTypes; i++) {
+    for (int32_t i = 0; i < TR::NumAllTypes; i++) {
         _dummyLocal[i] = NULL;
     }
 

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -105,6 +105,7 @@ public:
 namespace OMR { namespace X86 {
 
 class OMR_EXTENSIBLE Machine : public OMR::Machine {
+protected:
     TR::Register **_registerAssociations;
 
     /**
@@ -122,10 +123,11 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine {
 
     TR::SymbolReference *_dummyLocal[TR::NumAllTypes];
 
-protected:
     uint32_t *_globalRegisterNumberToRealRegisterMap;
 
 public:
+    void initialize();
+
     void initializeRegisterFile(const struct TR::X86LinkageProperties &);
     uint32_t *getGlobalRegisterTable(const struct TR::X86LinkageProperties &);
     int32_t getGlobalReg(TR::RealRegister::RegNum reg);
@@ -226,9 +228,7 @@ public:
 #endif
 
 protected:
-    Machine(uint8_t numIntRegs, uint8_t numFPRegs, TR::CodeGenerator *cg, TR::Register **registerAssociations,
-        uint8_t numGlobalGPRs, uint8_t numGlobal8BitGPRs, uint8_t numGlobalFPRs, TR::Register **xmmGlobalRegisters,
-        uint32_t *globalRegisterNumberToRealRegisterMap);
+    Machine(TR::CodeGenerator *cg);
 };
 }} // namespace OMR::X86
 #endif

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -108,15 +108,22 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine {
 protected:
     TR::Register **_registerAssociations;
 
-    /**
-     * Number of general purpose registers
-     */
-    int8_t _numGPRs;
+    TR::RealRegister::RegNum _firstGPR;
+    TR::RealRegister::RegNum _lastGPR;
+    TR::RealRegister::RegNum _lastAssignableGPR;
+    TR::RealRegister::RegNum _last8BitGPR;
+    uint8_t _numAssignableGPRs;
 
-    // Floating point stack pseudo-registers: they can be mapped to real
-    // registers on demand, based on their relative position from the top of
-    // stack marker.
-    //
+    TR::RealRegister::RegNum _firstXMMR;
+    TR::RealRegister::RegNum _lastXMMR;
+    TR::RealRegister::RegNum _lastAssignableXMMR;
+    uint8_t _numAssignableXMMRs;
+
+    TR::RealRegister::RegNum _firstVMR;
+    TR::RealRegister::RegNum _lastVMR;
+    TR::RealRegister::RegNum _lastAssignableVMR;
+    uint8_t _numAssignableVMRs;
+
     TR::Register **_xmmGlobalRegisters;
 
     List<TR::Register> *_spilledRegistersList;
@@ -132,7 +139,96 @@ public:
     uint32_t *getGlobalRegisterTable(const struct TR::X86LinkageProperties &);
     int32_t getGlobalReg(TR::RealRegister::RegNum reg);
 
-    uint8_t getNumberOfGPRs() { return _numGPRs; }
+    /**
+     * @brief Getter/Setter for _firstGPR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getFirstGPR() { return _firstGPR; }
+
+    OMR_FINAL void setFirstGPR(TR::RealRegister::RegNum r) { _firstGPR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastGPR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastGPR() { return _lastGPR; }
+
+    OMR_FINAL void setLastGPR(TR::RealRegister::RegNum r) { _lastGPR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastAssignableGPR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastAssignableGPR() { return _lastAssignableGPR; }
+
+    OMR_FINAL void setLastAssignableGPR(TR::RealRegister::RegNum r) { _lastAssignableGPR = r; }
+
+    /**
+     * @brief Getter/Setter for _last8BitGPR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLast8BitGPR() { return _last8BitGPR; }
+
+    OMR_FINAL void setLast8BitGPR(TR::RealRegister::RegNum r) { _last8BitGPR = r; }
+
+    /**
+     * @brief Getter/Setter for _numAssignableGPRs
+     */
+    OMR_FINAL uint8_t getNumAssignableGPRs() { return _numAssignableGPRs; }
+
+    OMR_FINAL void setNumAssignableGPRs(uint8_t n) { _numAssignableGPRs = n; }
+
+    /**
+     * @brief Getter/Setter for _firstXMMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getFirstXMMR() { return _firstXMMR; }
+
+    OMR_FINAL void setFirstXMMR(TR::RealRegister::RegNum r) { _firstXMMR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastXMMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastXMMR() { return _lastXMMR; }
+
+    OMR_FINAL void setLastXMMR(TR::RealRegister::RegNum r) { _lastXMMR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastAssignableXMMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastAssignableXMMR() { return _lastAssignableXMMR; }
+
+    OMR_FINAL void setLastAssignableXMMR(TR::RealRegister::RegNum r) { _lastAssignableXMMR = r; }
+
+    /**
+     * @brief Getter/Setter for _numAssignableXMMRs
+     */
+    OMR_FINAL uint8_t getNumAssignableXMMRs() { return _numAssignableXMMRs; }
+
+    OMR_FINAL void setNumAssignableXMMRs(uint8_t n) { _numAssignableXMMRs = n; }
+
+    /**
+     * @brief Getter/Setter for _firstVMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getFirstVMR() { return _firstVMR; }
+
+    OMR_FINAL void setFirstVMR(TR::RealRegister::RegNum r) { _firstVMR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastVMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastVMR() { return _lastVMR; }
+
+    OMR_FINAL void setLastVMR(TR::RealRegister::RegNum r) { _lastVMR = r; }
+
+    /**
+     * @brief Getter/Setter for _lastAssignableVMR
+     */
+    OMR_FINAL TR::RealRegister::RegNum getLastAssignableVMR() { return _lastAssignableVMR; }
+
+    OMR_FINAL void setLastAssignableVMR(TR::RealRegister::RegNum r) { _lastAssignableVMR = r; }
+
+    /**
+     * @brief Getter/Setter for _numAssignableVMRs
+     */
+    OMR_FINAL uint8_t getNumAssignableVMRs() { return _numAssignableVMRs; }
+
+    OMR_FINAL void setNumAssignableVMRs(uint8_t n) { _numAssignableVMRs = n; }
 
     TR::RealRegister **captureRegisterFile();
     void installRegisterFile(TR::RealRegister **registerFileCopy);

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -306,7 +306,7 @@ uint32_t OMR::X86::RegisterDependencyConditions::unionDependencies(TR::RegisterD
                     deps->setDependencyInfo(candidate, vr, max, cg, flag, isAssocRegDependency);
                 } else if (max == TR::RealRegister::ByteReg) {
                     // Specific regs are stronger than ByteReg
-                    TR_ASSERT(min <= TR::RealRegister::Last8BitGPR,
+                    TR_ASSERT(min <= machine->getLast8BitGPR(),
                         "Only byte registers are compatible with ByteReg dependency");
                     deps->setDependencyInfo(candidate, vr, min, cg, flag, isAssocRegDependency);
                 } else {
@@ -595,8 +595,6 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction *current
     TR::RealRegister *assignedReg = NULL;
     TR::RealRegister::RegNum dependentRegNum = TR::RealRegister::NoReg;
     TR::RealRegister *dependentRealReg = NULL;
-    TR::RealRegister *bestFreeRealReg = NULL;
-    TR::RealRegister::RegNum bestFreeRealRegIndex = TR::RealRegister::NoReg;
     bool changed;
 
     TR::Compilation *comp = cg->comp();
@@ -614,26 +612,22 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction *current
 
     bool hasByteDeps = false;
     bool hasNoRegDeps = false;
-    bool hasBestFreeRegDeps = false;
     int32_t numRealAssocRegisters;
     int32_t numDependencyRegisters = 0;
     int32_t firstByteRegAssoc = 0, lastByteRegAssoc = 0;
     int32_t firstNoRegAssoc = 0, lastNoRegAssoc = 0;
-    int32_t bestFreeRegAssoc = 0;
 
     for (auto i = 0U; i < numberOfRegisters; i++) {
         TR::RegisterDependency &regDep = _dependencies[i];
         virtReg = regDep.getRegister();
 
         if (virtReg && (kindsToBeAssigned & virtReg->getKindAsMask()) && !regDep.isNoReg() && !regDep.isByteReg()
-            && !regDep.isSpilledReg() && !regDep.isBestFreeReg()) {
+            && !regDep.isSpilledReg()) {
             dependencies[numDependencyRegisters++] = self()->getRegisterDependency(i);
         } else if (regDep.isNoReg())
             hasNoRegDeps = true;
         else if (regDep.isByteReg())
             hasByteDeps = true;
-        else if (regDep.isBestFreeReg())
-            hasBestFreeRegDeps = true;
 
         // Handle spill registers first.
         //
@@ -707,19 +701,6 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction *current
         }
 
         lastNoRegAssoc = numDependencyRegisters - 1;
-    }
-
-    if (hasBestFreeRegDeps) {
-        bestFreeRegAssoc = numDependencyRegisters;
-        for (auto i = 0U; i < numberOfRegisters; i++) {
-            virtReg = _dependencies[i].getRegister();
-            if (virtReg && (kindsToBeAssigned & virtReg->getKindAsMask()) && _dependencies[i].isBestFreeReg()) {
-                dependencies[numDependencyRegisters++] = self()->getRegisterDependency(i);
-            }
-        }
-
-        TR_ASSERT((bestFreeRegAssoc == numDependencyRegisters - 1),
-            "there can only be one bestFreeRegDep in a dependency list");
     }
 
     // First look for long shot where two registers can be xchg'ed into their
@@ -861,14 +842,6 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction *current
         } while (changed);
     }
 
-    // Recommend the best available register without actually assigning it.
-    //
-    if (hasBestFreeRegDeps) {
-        virtReg = dependencies[bestFreeRegAssoc]->getRegister();
-        bestFreeRealReg = machine->findBestFreeGPRegister(currentInstruction, virtReg);
-        bestFreeRealRegIndex = bestFreeRealReg ? bestFreeRealReg->getRegisterNumber() : TR::RealRegister::NoReg;
-    }
-
     self()->unblockRegisters(numberOfRegisters);
 
     for (auto i = 0; i < numDependencyRegisters; i++) {
@@ -881,12 +854,6 @@ void OMR::X86::RegisterDependencyGroup::assignRegisters(TR::Instruction *current
         //
         if (dependencies[i]->isNoReg())
             dependencies[i]->setRealRegister(assignedReg->getRegisterNumber());
-
-        if (dependencies[i]->isBestFreeReg()) {
-            dependencies[i]->setRealRegister(bestFreeRealRegIndex);
-            virtRegister->decFutureUseCount();
-            continue;
-        }
 
         if (virtRegister->decFutureUseCount() == 0 && assignedReg->getState() != TR::RealRegister::Locked) {
             virtRegister->setAssignedRegister(NULL);

--- a/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
+++ b/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
@@ -47,13 +47,6 @@ namespace OMR { namespace X86 {
 
 struct RegisterDependency : OMR::RegisterDependency {
     /**
-     * @return Answers \c true if this register dependency is a request for the
-     *         best free register from the perspective of the register assigner;
-     *         \c false otherwise.
-     */
-    bool isBestFreeReg() { return _realRegister == TR::RealRegister::BestFreeReg; }
-
-    /**
      * @return Answers \c true if this register dependency is a request for a
      *         register that can be used as the byte operand in certain machine
      *         instructions; \c false otherwise.

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -397,7 +397,7 @@ TR::Instruction *OMR::X86::TreeEvaluator::insertLoadMemory(TR::Node *node, TR::R
     //
     if (type == TR_RematerializableByte && target->getAssignedRealRegister()) {
         TR::RealRegister::RegNum r = toRealRegister(target->getAssignedRealRegister())->getRegisterNumber();
-        if (r > TR::RealRegister::Last8BitGPR)
+        if (r > cg->machine()->getLast8BitGPR())
             opCode = OP::MOVZXReg4Mem1;
     }
 
@@ -778,7 +778,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
                 valueChild->setDirectMemoryUpdate(true);
             } else {
                 int32_t numRegs = cg->getLiveRegisters(TR_GPR)->getNumberOfLiveRegisters();
-                if (numRegs >= TR::RealRegister::LastAssignableGPR - 2) // -1 for VM thread reg, -1 fudge
+                if (numRegs >= cg->machine()->getLastAssignableGPR() - 2) // -1 for VM thread reg, -1 fudge
                     valueChild->setDirectMemoryUpdate(true);
             }
         }

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -84,7 +84,7 @@ TR::RealRegister *assign8BitGPRegister(TR::Instruction *instr, TR::Register *vir
     cg->clearRegisterAssignmentFlags();
     cg->setRegisterAssignmentFlag(TR_NormalAssignment);
 
-    if (candidate->getRegisterNumber() > TR::RealRegister::Last8BitGPR) {
+    if (candidate->getRegisterNumber() > machine->getLast8BitGPR()) {
         if ((candidate = machine->findBestFreeGPRegister(instr, virtReg, TR_ByteReg)) == NULL) {
             cg->setRegisterAssignmentFlag(TR_RegisterSpilled);
             candidate = machine->freeBestGPRegister(instr, virtReg, TR_ByteReg);

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -225,8 +225,6 @@ void TR_Debug::printDependencyConditions(OMR::Logger *log, TR::RegisterDependenc
             len = snprintf(cursor, remainingSize, "NoReg");
         } else if (regDep->isByteReg()) {
             len = snprintf(cursor, remainingSize, "ByteReg");
-        } else if (regDep->isBestFreeReg()) {
-            len = snprintf(cursor, remainingSize, "BestFreeReg");
         } else if (regDep->isSpilledReg()) {
             len = snprintf(cursor, remainingSize, "SpilledReg");
         } else {
@@ -281,8 +279,6 @@ void TR_Debug::dumpDependencyGroup(OMR::Logger *log, TR::RegisterDependencyGroup
             log->prints("NoReg]");
         else if (regDep->isByteReg())
             log->prints("ByteReg]");
-        else if (regDep->isBestFreeReg())
-            log->prints("BestFreeReg]");
         else if (regDep->isSpilledReg())
             log->prints("SpilledReg]");
         else
@@ -1495,7 +1491,7 @@ void TR_Debug::printX86GCRegisterMap(OMR::Logger *log, TR::GCRegisterMap *map)
     log->printf("    slot pushes: %d", ((map->getMap() & _cg->getRegisterMapInfoBitsMask()) >> 16));
 
     log->prints("    registers: {");
-    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i) {
+    for (int32_t i = machine->getFirstGPR(); i <= machine->getLastAssignableGPR(); ++i) {
         if (map->getMap() & (1 << (i - 1))) // TODO:AMD64: Use the proper mask value
             log->printf("%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum)i)));
     }
@@ -1568,8 +1564,6 @@ const char *TR_Debug::getName(uint32_t realRegisterIndex, TR_RegisterSizes size)
             return "noReg";
         case TR::RealRegister::ByteReg:
             return "byteReg";
-        case TR::RealRegister::BestFreeReg:
-            return "bestFreeReg";
         case TR::RealRegister::SpilledReg:
             return "spilledReg";
         case TR::RealRegister::eax:

--- a/compiler/x/i386/codegen/OMRMachine.cpp
+++ b/compiler/x/i386/codegen/OMRMachine.cpp
@@ -30,14 +30,28 @@ OMR::X86::I386::Machine::Machine(TR::CodeGenerator *cg)
     _registerAssociations = _registerAssociationsStorage;
     _xmmGlobalRegisters = _xmmGlobalRegisterStorage;
     _globalRegisterNumberToRealRegisterMap = _globalRegisterNumberToRealRegisterMapStorage;
-}
 
-void OMR::X86::I386::Machine::initialize()
-{
-    self()->OMR::X86::Machine::initialize();
+    // Initialize register limits
+    //
+    _firstGPR = TR::RealRegister::eax;
+    _lastGPR = TR::RealRegister::esp;
+    _lastAssignableGPR = TR::RealRegister::ebp;
+    _last8BitGPR = TR::RealRegister::edx;
+    _numAssignableGPRs = IA32_NUM_GPR;
 
-    _numGPRs = IA32_NUM_GPR;
+    _firstXMMR = TR::RealRegister::xmm0;
+    _lastXMMR = TR::RealRegister::xmm7;
+    _lastAssignableXMMR = TR::RealRegister::xmm7;
+    _numAssignableXMMRs = static_cast<uint8_t>(_lastAssignableXMMR - _firstXMMR);
+
+    _firstVMR = TR::RealRegister::k0;
+    _lastVMR = TR::RealRegister::k7;
+    _lastAssignableVMR = TR::RealRegister::k7;
+    _numAssignableVMRs = static_cast<uint8_t>(_lastAssignableVMR - _firstVMR);
+
     _numGlobalGPRs = IA32_MAX_GLOBAL_GPRS;
     _numGlobal8BitGPRs = IA32_MAX_8BIT_GLOBAL_GPRS;
     _numGlobalFPRs = IA32_MAX_GLOBAL_FPRS;
 }
+
+void OMR::X86::I386::Machine::initialize() { self()->OMR::X86::Machine::initialize(); }

--- a/compiler/x/i386/codegen/OMRMachine.cpp
+++ b/compiler/x/i386/codegen/OMRMachine.cpp
@@ -18,3 +18,26 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
+
+#include "codegen/Machine.hpp"
+#include "codegen/Machine_inlines.hpp"
+
+OMR::X86::I386::Machine::Machine(TR::CodeGenerator *cg)
+    : OMR::X86::Machine(cg)
+{
+    // Initialize fields in Machine superclass
+    //
+    _registerAssociations = _registerAssociationsStorage;
+    _xmmGlobalRegisters = _xmmGlobalRegisterStorage;
+    _globalRegisterNumberToRealRegisterMap = _globalRegisterNumberToRealRegisterMapStorage;
+}
+
+void OMR::X86::I386::Machine::initialize()
+{
+    self()->OMR::X86::Machine::initialize();
+
+    _numGPRs = IA32_NUM_GPR;
+    _numGlobalGPRs = IA32_MAX_GLOBAL_GPRS;
+    _numGlobal8BitGPRs = IA32_MAX_8BIT_GLOBAL_GPRS;
+    _numGlobalFPRs = IA32_MAX_GLOBAL_FPRS;
+}

--- a/compiler/x/i386/codegen/OMRMachine.hpp
+++ b/compiler/x/i386/codegen/OMRMachine.hpp
@@ -67,11 +67,9 @@ class OMR_EXTENSIBLE Machine : public OMR::X86::Machine {
     uint32_t _globalRegisterNumberToRealRegisterMapStorage[IA32_MAX_GLOBAL_GPRS + IA32_MAX_GLOBAL_FPRS];
 
 public:
-    Machine(TR::CodeGenerator *cg)
-        : OMR::X86::Machine(IA32_NUM_GPR, IA32_NUM_FPR, cg, _registerAssociationsStorage, IA32_MAX_GLOBAL_GPRS,
-              IA32_MAX_8BIT_GLOBAL_GPRS, IA32_MAX_GLOBAL_FPRS, _xmmGlobalRegisterStorage,
-              _globalRegisterNumberToRealRegisterMapStorage)
-    {}
+    Machine(TR::CodeGenerator *cg);
+
+    void initialize();
 };
 
 }}} // namespace OMR::X86::I386

--- a/compiler/x/i386/codegen/RealRegisterEnum.hpp
+++ b/compiler/x/i386/codegen/RealRegisterEnum.hpp
@@ -24,13 +24,20 @@
  * definitions are permitted.
  */
 
+// Pseudo register indicating any register
+//
 NoReg = 0,
 
-    // The order of the GPRS registers is defined by the linkage
-    // convention, and the VM may rely on it (eg. for GC).
+    // Some consumers of OMR may rely on this register ordering (e.g., for
+    // register masks for live references for garbage collection), so be
+    // mindful of altering it.
+    //
     eax = 1, FirstGPR = eax, ebx = 2, ecx = 3, edx = 4, Last8BitGPR = edx, edi = 5, esi = 6, ebp = 7,
     LastAssignableGPR = ebp, esp = 8, LastGPR = esp,
 
+    // Virtual frame pointer used as a placeholder for frame references before
+    // their offsets are known for rsp mapping
+    //
     vfp = 9,
 
     // st0Return is used for 32-bit linkages where floating point values are
@@ -42,17 +49,24 @@ NoReg = 0,
     xmm0 = 11, FirstXMMR = xmm0, xmm1 = 12, xmm2 = 13, xmm3 = 14, xmm4 = 15, xmm5 = 16, xmm6 = 17, xmm7 = 18,
     LastXMMR = xmm7,
 
-    ymm0 = xmm0, FirstYMMR = ymm0, ymm1 = xmm1, ymm2 = xmm2, ymm3 = xmm3, ymm4 = xmm4, ymm5 = xmm5, ymm6 = xmm6,
-    ymm7 = xmm7, LastYMMR = ymm7,
+    // Alias ymm registers with xmm registers as they architecturally overlap
+    //
+    ymm0 = xmm0, ymm1 = xmm1, ymm2 = xmm2, ymm3 = xmm3, ymm4 = xmm4, ymm5 = xmm5, ymm6 = xmm6, ymm7 = xmm7,
 
-    zmm0 = xmm0, FirstZMMR = zmm0, zmm1 = xmm1, zmm2 = xmm2, zmm3 = xmm3, zmm4 = xmm4, zmm5 = xmm5, zmm6 = xmm6,
-    zmm7 = xmm7, LastZMMR = zmm7,
+    // Alias zmm registers with xmm registers as they architecturally overlap
+    //
+    zmm0 = xmm0, zmm1 = xmm1, zmm2 = xmm2, zmm3 = xmm3, zmm4 = xmm4, zmm5 = xmm5, zmm6 = xmm6, zmm7 = xmm7,
 
-    // avx512 write mask registers
-    // k0 -> reserved for unmasked operations
+    // AVX-512 write mask registers
+    //
     k0 = 19, k1 = 20, k2 = 21, k3 = 22, k4 = 23, k5 = 24, k6 = 25, k7 = 26,
 
-    ByteReg = 27, BestFreeReg = 28, SpilledReg = 29, NumRegisters = 30,
+    // Pseudo register indicating any byte register
+    //
+    ByteReg = 27,
 
-    NumXMMRegisters = LastXMMR - FirstXMMR + 1,
-    MaxAssignableRegisters = NumXMMRegisters + (LastAssignableGPR - FirstGPR + 1) - 1 // -1 for stack pointer
+    // Pseudo register indicating a register in spill state
+    //
+    SpilledReg = 28,
+
+    NumRegisters = 29,

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -388,7 +388,7 @@ void OMR::Z::Instruction::useRegister(TR::Register *reg, bool isDummy)
 
 bool OMR::Z::Instruction::refsRegister(TR::Register *reg)
 {
-    return self()->getDependencyConditions() ? self()->getDependencyConditions()->refsRegister(reg) : false;
+    return getDependencyConditions() ? getDependencyConditions()->refsRegister(reg) : false;
 }
 
 bool OMR::Z::Instruction::defsAnyRegister(TR::Register *reg)
@@ -747,7 +747,7 @@ void OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 
             // Step 2 : loop through and set up the new associations (both on the machine and by associating the virtual
             // registers with their real dependencies)
-            TR::RegisterDependencyGroup *depGroup = self()->getDependencyConditions()->getPostConditions();
+            TR::RegisterDependencyGroup *depGroup = getDependencyConditions()->getPostConditions();
             for (int32_t j = 0; j < last; ++j) {
                 TR::Register *virtReg = depGroup->getRegisterDependency(j)->getRegister();
                 machine->setVirtualAssociatedWithReal((TR::RealRegister::RegNum)(j + 1), virtReg);
@@ -771,10 +771,10 @@ void OMR::Z::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
         if (deps) // merge the dependency into the EX deps
         {
             outOfLineEXInstr->resetDependencyConditions();
-            TR::RegisterDependencyConditions *exDeps = (self())->getDependencyConditions();
+            TR::RegisterDependencyConditions *exDeps = getDependencyConditions();
             TR::RegisterDependencyConditions *newDeps
                 = new (cg()->trHeapMemory()) TR::RegisterDependencyConditions(deps, exDeps, cg());
-            (self())->setDependencyConditionsNoBookKeeping(newDeps);
+            setDependencyConditionsNoBookKeeping(newDeps);
         }
 
         outOfLineEXInstr->setPrev(savePrev); // Restore Prev() of snippet
@@ -1246,8 +1246,8 @@ void OMR::Z::Instruction::assignOrderedRegisters(TR_RegisterKinds kindToBeAssign
         }
     }
 
-    if (self()->getDependencyConditions()) {
-        self()->getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
+    if (getDependencyConditions()) {
+        getDependencyConditions()->assignPreConditionRegisters(getPrev(), kindToBeAssigned, cg());
     }
 
     // unblock blocked targetRegs
@@ -1320,9 +1320,9 @@ void OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindTo
     // Any register or memory references must be blocked before the condition
     // is applied, then they must be subsequently unblocked.
     //
-    if (self()->getDependencyConditions()) {
+    if (getDependencyConditions()) {
         self()->block(_sourceReg, _sourceRegSize, _targetReg, _targetRegSize, _sourceMem, _targetMem);
-        self()->getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
+        getDependencyConditions()->assignPostConditionRegisters(self(), kindToBeAssigned, cg());
 
         // FPR and VRF register files overlap. Some of the FPRs are non-volatile but if they hold vector data
         // that part of the data would not be preserved. This code looks at the data stored in non-volatile FPRs
@@ -1395,7 +1395,7 @@ int32_t OMR::Z::Instruction::renameRegister(TR::Register *from, TR::Register *to
         }
     }
 
-    TR::RegisterDependencyConditions *conds = self()->getDependencyConditions();
+    TR::RegisterDependencyConditions *conds = getDependencyConditions();
     if (conds) {
         TR::RegisterDependencyGroup *preConds = conds->getPreConditions();
         TR::RegisterDependencyGroup *postConds = conds->getPostConditions();
@@ -1517,7 +1517,7 @@ void OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
 
     uint32_t indexSource = 0, indexTarget = 0, i;
     TR::RegisterPair *regPair;
-    TR::RegisterDependencyConditions *dependencies = self()->getDependencyConditions();
+    TR::RegisterDependencyConditions *dependencies = getDependencyConditions();
     if (cg()->getCodeGeneratorPhase() == TR::CodeGenPhase::PeepholePhase) {
         // In Peephole Phase, UseDefRegisters need to reset. The check on non Peephole Phase needs to be avoided here.
         if ((_useRegs != NULL && _useRegs->size() != 0) || (_defRegs != NULL && _defRegs->size() != 0)) {

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -83,13 +83,14 @@ protected:
 
 public:
     //  Register Dependency Routines
-    TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
-    TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond);
-    TR::RegisterDependencyConditions *setDependencyConditionsNoBookKeeping(TR::RegisterDependencyConditions *cond);
-    TR::RegisterDependencyConditions *updateDependencyConditions(TR::RegisterDependencyConditions *cond);
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond);
+    OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditionsNoBookKeeping(
+        TR::RegisterDependencyConditions *cond);
+    OMR_FINAL TR::RegisterDependencyConditions *updateDependencyConditions(TR::RegisterDependencyConditions *cond);
 
-    void resetDependencyConditions(TR::RegisterDependencyConditions *cond = NULL) { _conditions = cond; }
+    OMR_FINAL void resetDependencyConditions(TR::RegisterDependencyConditions *cond = NULL) { _conditions = cond; }
 
     TR::Register *tgtRegArrElem(int32_t i);
     TR::Register *srcRegArrElem(int32_t i);

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1154,8 +1154,8 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
 
             self()->coerceRegisterAssignment(currInst, firstReg,
                 (TR::RealRegister::RegNum)(toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
-            freeRegisterHigh = self()->getRealRegister(
-                (TR::RealRegister::RegNum)(toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
+            freeRegisterHigh
+                = getRealRegister((TR::RealRegister::RegNum)(toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
         } else if (!self()->isLegalOddRegister(freeRegisterLow, DISALLOWBLOCKED, availRegMask)) {
             // No need to check that the EVEN register is legal,
             // because otherwise we would have gone into the other branch.
@@ -1166,7 +1166,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
 
             self()->coerceRegisterAssignment(currInst, lastReg,
                 (TR::RealRegister::RegNum)(toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
-            freeRegisterLow = self()->getRealRegister(
+            freeRegisterLow = getRealRegister(
                 (TR::RealRegister::RegNum)(toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
         } else if (!self()->isLegalEvenOddPair(freeRegisterHigh, freeRegisterLow, availRegMask)) {
             // We could probably does something a little more  fancy to avoid
@@ -1182,7 +1182,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
 
                 self()->coerceRegisterAssignment(currInst, lastReg,
                     (TR::RealRegister::RegNum)(toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
-                freeRegisterLow = self()->getRealRegister(
+                freeRegisterLow = getRealRegister(
                     (TR::RealRegister::RegNum)(toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
             } else if (self()->isLegalOddRegister(freeRegisterLow, DISALLOWBLOCKED, availRegMask)) {
                 if (lastReg) {
@@ -1191,7 +1191,7 @@ TR::Register *OMR::Z::Machine::assignBestRegisterPair(TR::Register *regPair, TR:
 
                 self()->coerceRegisterAssignment(currInst, firstReg,
                     (TR::RealRegister::RegNum)(toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
-                freeRegisterHigh = self()->getRealRegister(
+                freeRegisterHigh = getRealRegister(
                     (TR::RealRegister::RegNum)(toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
             } else {
                 TR::RealRegister *tfreeRegisterHigh = NULL;
@@ -2100,7 +2100,7 @@ uint64_t OMR::Z::Machine::constructFreeRegBitVector(TR::Instruction *currentInst
     int32_t cnt = 1;
 
     for (int32_t i = first; i <= last; i++) {
-        TR::RealRegister *realReg = self()->getRealRegister(cnt + 1);
+        TR::RealRegister *realReg = getRealRegister(cnt + 1);
 
         if (realReg->getState() == TR::RealRegister::Free && !currentInstruction->usesRegister(realReg)
             && (realReg->getHasBeenAssignedInMethod() || !linkage->getPreserved((TR::RealRegister::RegNum)(cnt + 1)))) {
@@ -2122,7 +2122,7 @@ TR::RealRegister *OMR::Z::Machine::findRegNotUsedInInstruction(TR::Instruction *
     TR::RealRegister *spill = NULL;
 
     for (int32_t i = first; i <= last, spill == NULL; i++) {
-        TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
+        TR::RealRegister *realReg = getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() != TR::RealRegister::Locked && !currentInstruction->usesRegister(realReg)) {
             spill = realReg;
         }
@@ -3217,7 +3217,7 @@ int32_t OMR::Z::Machine::addGlobalReg(TR::RealRegister::RegNum reg, int32_t tabl
 {
     if (reg == TR::RealRegister::NoReg)
         return tableIndex;
-    if (self()->getRealRegister(reg)->getState() == TR::RealRegister::Locked)
+    if (getRealRegister(reg)->getState() == TR::RealRegister::Locked)
         return tableIndex;
     for (int32_t i = 0; i < tableIndex; i++)
         if (_globalRegisterNumberToRealRegisterMap[i] == reg)
@@ -3239,7 +3239,7 @@ int32_t OMR::Z::Machine::addGlobalRegLater(TR::RealRegister::RegNum reg, int32_t
 {
     if (reg == TR::RealRegister::NoReg)
         return tableIndex;
-    if (self()->getRealRegister(reg)->getState() == TR::RealRegister::Locked)
+    if (getRealRegister(reg)->getState() == TR::RealRegister::Locked)
         return tableIndex;
     for (int32_t i = 0; i < tableIndex; i++)
         if (_globalRegisterNumberToRealRegisterMap[i] == reg) {
@@ -3738,7 +3738,7 @@ TR::RegisterDependencyConditions *OMR::Z::Machine::createCondForLiveAndSpilledGP
     TR::Compilation *comp = cg()->comp();
     for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF;
          i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i + 1)) {
-        TR::RealRegister *realReg = self()->getRealRegister(i);
+        TR::RealRegister *realReg = getRealRegister(i);
 
         TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned || realReg->getState() == TR::RealRegister::Free
                 || realReg->getState() == TR::RealRegister::Locked,
@@ -3757,7 +3757,7 @@ TR::RegisterDependencyConditions *OMR::Z::Machine::createCondForLiveAndSpilledGP
             TR::RegisterDependencyConditions(0, c, cg());
         for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF;
              i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i + 1)) {
-            TR::RealRegister *realReg = self()->getRealRegister(i);
+            TR::RealRegister *realReg = getRealRegister(i);
             if (realReg->getState() == TR::RealRegister::Assigned) {
                 TR::Register *virtReg = realReg->getAssignedRegister();
                 deps->addPostCondition(virtReg, realReg->getRegisterNumber());


### PR DESCRIPTION
On x86, the number of GPRs and vector registers available for assignment depends
on the microarchitecture capabilities.  Prior to AVX-512F, only 16 vector
registers were available, but AVX-512F introduces 16 more (32 total).  Similarly,
Intel APX will make 16 additional GPRs available (32 total) in 64-bit mode.

Currently, the way ranges of registers are delimited is through fixed entries in
the `RealRegisterEnum` enum.  For example, `FirstGPR` and `LastAssignableGPR`
entries describe the range of GPRs that are available for register assignment.
Because of this, the same register ranges apply to all microarchitectures, which
is the reason why only 16 vector registers are available for assignment despite
AVX-512F being introduced a decade ago.

This scheme is obviously not flexible enough to support different register
capabilities based on microarchitecture. To address this, new fields are added
to the `Machine` class to describe these limits. They will be populated based on
the available registers on the target processor, and all references to the enum
values will be replaced with `Machine` class queries.

From a conceptual integrity point of view, it makes sense that the `Machine` class
defines these ranges as it is ultimately responsible for register assignment.

This PR makes the following contributions:
* Introduces register range limits as fields in the `Machine` class and
  populates them during `Machine` initialization to what they are currently
  assigned to in the `RealRegisterEnum`.  The existing enum values (e.g.,
  `FirstGPR`) are kept in place for now until known downstream projects can be
  refactored to use the Machine queries.
* Creates a factory for the `TR::Machine` class and refactors the x86 hierarchy
  to simplify
* Cleans up some unnecessary uses of `self()` function calls before member
  functions marked `OMR_FINAL`