### PR TITLE
Reinstate virtual keyword for getDependencyConditions()

### DIFF
--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -146,7 +146,7 @@ public:
      * @brief Gets the register dependency conditions
      * @return register dependency conditions
      */
-    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     /**
      * @brief Sets the register dependency conditions

--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -105,7 +105,7 @@ public:
 
     virtual bool isLabel() { return _opcode.getOpCodeValue() == TR::InstOpCode::label; }
 
-    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -95,7 +95,7 @@ public:
 
     virtual bool setsCountRegister();
 
-    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     OMR_FINAL TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
     {

--- a/compiler/riscv/codegen/OMRInstruction.hpp
+++ b/compiler/riscv/codegen/OMRInstruction.hpp
@@ -134,7 +134,7 @@ public:
      * @brief Gets the register dependency conditions
      * @return register dependency conditions
      */
-    OMR_FINAL TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
+    virtual TR::RegisterDependencyConditions *getDependencyConditions() { return _conditions; }
 
     /**
      * @brief Sets the register dependency conditions


### PR DESCRIPTION
Some platforms' Instruction::getDependencyConditions() functions are in fact virtual and should not be marked `OMR_FINAL`.  Reinstate the virtual keyword on these functions as it should not have been removed in the first place.