### PR TITLE
Avoid warning from macOS linker on x86_64

### DIFF
--- a/cmake/modules/platform/os/osx.cmake
+++ b/cmake/modules/platform/os/osx.cmake
@@ -30,8 +30,8 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 list(APPEND TR_COMPILE_DEFINITIONS -DSUPPORTS_THREAD_LOCAL -DOSX)
 
 if(OMR_ENV_DATA64 AND NOT OMR_ARCH_AARCH64)
-	# Set page zero size to 4KB for mapping memory below 4GB.
+	# Set page zero size to 16KB for mapping memory below 4GB.
 	list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS
-		-pagezero_size 0x1000
+		-pagezero_size 0x4000
 	)
 endif()


### PR DESCRIPTION
The linker warns `-pagezero_size not aligned, rounded up to: 0x4000`; just specify the aligned size to avoid the warning.

For example, see https://openj9-jenkins.osuosl.org/job/Build_JDK21_x86-64_mac_OpenJDK21/97/console.