### PR TITLE
Correctly handle direct callees after Not_Sane target removals

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4226,6 +4226,20 @@ TR_CallSite *TR_InlinerBase::findAndUpdateCallSiteInGraph(TR_CallStack *callStac
             if (findDirectCallSiteTarget(comp(), callsite, this)) {
                 // Can't do a partial inline anymore as the blocks are wrong.
                 callsite->getTarget(0)->_isPartialInliningCandidate = false;
+                // The new target bypasses the normal applyPolicyToTargets()
+                // path (since getSymbolAndFindInlineTargets() is called with
+                // findNewTargets=false below). Apply the
+                // TR_DontInlineUnloadableMethods check explicitly here to
+                // prevent attempts to create bonds during physical inlining.
+                // Note: the full applyPolicyToTargets() cannot be called here
+                // because it invokes exceedsSizeThreshold(), which accesses
+                // block information that is no longer valid at this point.
+                TR_CallTarget *newTarget = callsite->getTarget(0);
+                if (comp()->getOption(TR_DontInlineUnloadableMethods)
+                    && !callsite->_retainedMethods->willRemainLoaded(newTarget->_calleeMethod)) {
+                    tracer()->insertCounter(Unloadable_Callee, callsite->_callNodeTreeTop);
+                    callsite->removecalltarget(0, tracer(), Unloadable_Callee);
+                }
             }
         }
     }


### PR DESCRIPTION
Added a check for TR_DontInlineUnloadableMethods for direct targets added after Not_Sane target removals. When shouldRemoveDifferingTargets() refines an indirect call site to direct, all existing targets may be removed with reason Not_Sane and a fresh target added via findDirectCallSiteTarget(). This path bypasses applyPolicyToTargets(), causing the TR_DontInlineUnloadableMethods check to be skipped. The resulting target had _needsBond set, triggering a fatal assertion in inlineCallTarget2(). The full applyPolicyToTargets() cannot be called at this point because it invokes exceedsSizeThreshold(), which accesses block information that is no longer valid after the indirect-to-direct refinement. Instead, apply only the TR_DontInlineUnloadableMethods check inline, which is sufficient to prevent bond creation during physical inlining.

Issue: https://github.com/eclipse-openj9/openj9/issues/23683