### PR TITLE
Fix BPP insertion bug in transaction regions

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1150,7 +1150,7 @@ void OMR::Z::CodeGenerator::insertInstructionPrefetches()
                 TR::InstOpCode op = first->getOpCode();
                 if (!op.isAdmin()) {
                     real = first;
-                    if (op.isLabel() || op.isCall()) {
+                    if (op.isLabel() || op.isCall() || first->getOpCodeValue() == TR::InstOpCode::TEND) {
                         break;
                     }
                     count++;


### PR DESCRIPTION
On IBM Z, a BPP instruction to preload branch target was inserted inside of transaction region which would cause system or user abend due to executing BPP instruction while it is in contrained transaction. This commit fixes to break the scan for insertion of BPP instruction if it encounters TEND instruction in addition to label or call instruction.