### PR TITLE
AArch64: Remove unused flags for MemoryReference

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -478,7 +478,7 @@ static bool checkOffset(TR::Node *node, TR::CodeGenerator *cg, uint32_t offset, 
 
 void OMR::ARM64::MemoryReference::moveIndexToBase(TR::Node *node, TR::CodeGenerator *cg)
 {
-    if ((_baseRegister != NULL) || self()->isIndexSignExtended() || (_scale != 0)) {
+    if ((_baseRegister != NULL) || self()->isIndexSignExtendedWord() || (_scale != 0)) {
         self()->consolidateRegisters(node, cg);
     } else {
         if (self()->isIndexModifiable()) {
@@ -716,26 +716,24 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
         tempTargetRegister = cg->allocateRegister();
 
     if (_baseRegister != NULL) {
-        if (self()->isIndexSignExtended()) {
+        if (self()->isIndexSignExtendedWord()) {
             generateTrg1Src2ExtendedInstruction(cg, TR::InstOpCode::addextx, srcTree, tempTargetRegister, _baseRegister,
-                _indexRegister, self()->getIndexExtendCode(), _scale);
+                _indexRegister, TR::EXT_SXTW, _scale);
         } else {
             generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, srcTree, tempTargetRegister, _baseRegister,
                 _indexRegister, TR::SH_LSL, _scale);
         }
     } else if (_scale != 0) {
         generateLogicalShiftLeftImmInstruction(cg, srcTree, tempTargetRegister, _indexRegister, _scale, true);
-        if (self()->isIndexSignExtended()) {
-            uint32_t imm = (self()->isIndexSignExtendedWord() ? 31 : (self()->isIndexSignExtendedHalf() ? 15 : 7));
+        if (self()->isIndexSignExtendedWord()) {
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, tempTargetRegister,
-                imm);
+                31);
         }
-    } else if (self()->isIndexSignExtended()) {
-        uint32_t imm = (self()->isIndexSignExtendedWord() ? 31 : (self()->isIndexSignExtendedHalf() ? 15 : 7));
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, _indexRegister, imm);
+    } else if (self()->isIndexSignExtendedWord()) {
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else {
         TR_ASSERT_FATAL(false,
-            "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexSignExtended()");
+            "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexSignExtendedWord()");
     }
 
     if (_baseRegister != tempTargetRegister) {
@@ -753,7 +751,7 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
     _indexRegister = NULL;
     _scale = 0;
     self()->clearIndexModifiable();
-    self()->clearIndexSignExtended();
+    self()->clearIndexSignExtendedWord();
 }
 
 void OMR::ARM64::MemoryReference::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
@@ -1098,8 +1096,6 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 
             if (index) {
                 TR_ASSERT(displacement == 0, "Non-zero offset with index register.");
-                TR_ASSERT_FATAL(!(self()->isIndexSignExtendedByte() || self()->isIndexSignExtendedHalf()),
-                    "Extend code for memory access must not be SXTB or SXTH.");
 
                 if (isRegisterOffsetInstruction(enc)) {
                     base->setRegisterFieldRN(wcursor);

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -134,8 +134,8 @@ public:
     typedef enum {
         TR_ARM64MemoryReferenceControl_Base_Modifiable = 0x01,
         TR_ARM64MemoryReferenceControl_Index_Modifiable = 0x02,
-        TR_ARM64MemoryReferenceControl_Index_SignExtendedByte = 0x04,
-        TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf = 0x08,
+        // 0x04: Available
+        // 0x08: Available
         TR_ARM64MemoryReferenceControl_Index_SignExtendedWord = 0x10,
         TR_ARM64MemoryReferenceControl_DelayedOffsetDone = 0x20
         /* To be added more if necessary */
@@ -328,41 +328,10 @@ public:
     void clearIndexModifiable() { _flag &= ~TR_ARM64MemoryReferenceControl_Index_Modifiable; }
 
     /**
-     * @brief Index register is sign extended or not
-     * @return true when index register is sign extended
-     */
-    bool isIndexSignExtended()
-    {
-        return (isIndexSignExtendedWord() || isIndexSignExtendedHalf() || isIndexSignExtendedByte());
-    }
-
-    /**
-     * @brief The extend code for the index register is SXTB or not
-     * @return true when the extend code for index register is SXTB
-     */
-    bool isIndexSignExtendedByte() { return ((_flag & TR_ARM64MemoryReferenceControl_Index_SignExtendedByte) != 0); }
-
-    /**
-     * @brief The extend code for the index register is SXTH or not
-     * @return true when the extend code for index register is SXTH
-     */
-    bool isIndexSignExtendedHalf() { return ((_flag & TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf) != 0); }
-
-    /**
      * @brief The extend code for the index register is SXTW or not
      * @return true when the extend code for index register is SXTW
      */
     bool isIndexSignExtendedWord() { return ((_flag & TR_ARM64MemoryReferenceControl_Index_SignExtendedWord) != 0); }
-
-    /**
-     * @brief Sets the IndexSignExtendedByte flag
-     */
-    void setIndexSignExtendedByte() { _flag |= TR_ARM64MemoryReferenceControl_Index_SignExtendedByte; }
-
-    /**
-     * @brief Sets the IndexSignExtendedHalf flag
-     */
-    void setIndexSignExtendedHalf() { _flag |= TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf; }
 
     /**
      * @brief Sets the IndexSignExtendedWord flag
@@ -370,14 +339,9 @@ public:
     void setIndexSignExtendedWord() { _flag |= TR_ARM64MemoryReferenceControl_Index_SignExtendedWord; }
 
     /**
-     * @brief Clears the IndexSignExtende flag
+     * @brief Clears the IndexSignExtendedWord flag
      */
-    void clearIndexSignExtended()
-    {
-        _flag &= ~(TR_ARM64MemoryReferenceControl_Index_SignExtendedByte
-            | TR_ARM64MemoryReferenceControl_Index_SignExtendedHalf
-            | TR_ARM64MemoryReferenceControl_Index_SignExtendedWord);
-    }
+    void clearIndexSignExtendedWord() { _flag &= ~TR_ARM64MemoryReferenceControl_Index_SignExtendedWord; }
 
     /**
      * @brief Gets the flag indicating whether the delayed offset has already been applied.
@@ -406,10 +370,6 @@ public:
     {
         if (isIndexSignExtendedWord()) {
             return TR::EXT_SXTW;
-        } else if (isIndexSignExtendedHalf()) {
-            return TR::EXT_SXTH;
-        } else if (isIndexSignExtendedByte()) {
-            return TR::EXT_SXTB;
         } else {
             return TR::EXT_UXTX;
         }


### PR DESCRIPTION
This commit removes unused flags and related functions in MemoryReference for AArch64.
SXTH (sign-extend halfword) and SXTB (sign-extend byte) are valid extend code for instructions like ADD (extended register), but they are not allowed in LDR/STR instructions with the index register.