### PR TITLE
Introduce Assert_GC_true_with_messageVM()

### DIFF
--- a/gc/base/ModronAssertions.cpp
+++ b/gc/base/ModronAssertions.cpp
@@ -35,24 +35,83 @@ extern "C" {
 
 /*
  * The purpose of moving of the body of macros GC Assertions with message to separate function is to prevent inlining
- * on fast path to keep stack frames small
+ * on fast path to keep stack frames small.
  */
 
+/**
+ * Print assertion message and duplicate it in the snap trace.
+ * Internal implementation.
+ *
+ * @param portLibrary - pointer to Port Library
+ * @param omrVMThread - pointer to current OMR VM Thread
+ * @param format - pointer to format string
+ * @param args - variadic list of parameters
+ */
 void
-omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...)
+omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, va_list args)
 {
 	char buffer[ASSERTION_MESSAGE_BUFFER_SIZE];
 
-	va_list args;
-	va_start(args, format);
 	portLibrary->str_vprintf(portLibrary, buffer, ASSERTION_MESSAGE_BUFFER_SIZE, format, args);
-	va_end(args);
 
 	if (NULL != omrVMThread) {
-		/* omrVMThread might be NULL if Environment is partially initialized at startup time */
+		/* omrVMThread might be NULL if Environment is partially initialized at startup time. */
 		Trc_MM_AssertionWithMessage_outputMessage(omrVMThread->_language_vmthread, buffer);
 	}
 	portLibrary->tty_printf(portLibrary, "%s", buffer);
+}
+
+/**
+ * Print assertion message and duplicate it in the snap trace.
+ * Front end call for the case OMR_VMThread is passed.
+ *
+ * @param portLibrary - pointer to Port Library
+ * @param omrVMThread - pointer to current OMR VM Thread
+ * @param format - pointer to format string
+ * @param ... - variadic list of parameters
+ */
+void
+omrGcDebugAssertionOutputThread(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...)
+{
+	if (NULL != portLibrary) {
+		va_list args;
+		va_start(args, format);
+		omrGcDebugAssertionOutput(portLibrary, omrVMThread, format, args);
+		va_end(args);
+	}
+}
+
+/**
+ * Print assertion message and duplicate it in the snap trace.
+ * Front end call for the case OMR_VM is passed.
+ * Current OMR VM thread is going to be read from TLS area.
+ *
+ * @param omrVM - pointer to OMR VM
+ * @param format - pointer to format string
+ * @param ... - variadic list of parameters
+ */
+void
+omrGcDebugAssertionOutputVM(OMR_VM *omrVM, const char *format, ...)
+{
+	if ((NULL != omrVM) && (NULL != omrVM->_runtime)) {
+		OMRPortLibrary *portLibrary = omrVM->_runtime->_portLibrary;
+
+		if (NULL != portLibrary) {
+			OMR_VMThread *omrVMThread = NULL;
+			omrthread_t omrthread = omrthread_self();
+
+			if ((NULL != omrthread) && (omrVM->_vmThreadKey > 0)) {
+				/* Read omrVMThread from thread's TLS area. */
+				omrVMThread = (OMR_VMThread *)omrthread_tls_get(omrthread, omrVM->_vmThreadKey);
+			}
+
+			/* NULL for omrVMThread is accepted. */
+			va_list args;
+			va_start(args, format);
+			omrGcDebugAssertionOutput(portLibrary, omrVMThread, format, args);
+			va_end(args);
+		}
+	}
 }
 
 #endif /* defined(OMR_GC_DEBUG_ASSERTS) */

--- a/gc/base/ModronAssertions.h
+++ b/gc/base/ModronAssertions.h
@@ -41,7 +41,8 @@ extern "C" {
 /* Currently, there are startup errors pointed out by these assertions so only enable them on combination spec until they are fixed for everyone */
 #if defined(OMR_GC_DEBUG_ASSERTS)
 
-extern void omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...);
+extern void omrGcDebugAssertionOutputThread(OMRPortLibrary *portLibrary, OMR_VMThread *omrVMThread, const char *format, ...);
+extern void omrGcDebugAssertionOutputVM(OMR_VM *omrVM, const char *format, ...);
 
 #define Assert_MM_true(arg) \
 	do {\
@@ -80,7 +81,15 @@ extern void omrGcDebugAssertionOutput(OMRPortLibrary *portLibrary, OMR_VMThread 
 #define Assert_GC_true_with_message(__env__, __condition, __message, ...) \
 do {\
 	if(!(__condition)) {\
-		omrGcDebugAssertionOutput(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __VA_ARGS__);\
+		omrGcDebugAssertionOutputThread(__env__->getPortLibrary(), __env__->getOmrVMThread(), __message, __VA_ARGS__);\
+		Assert_MM_unreachable();\
+	}\
+} while (false)
+
+#define Assert_GC_true_with_messageVM(__OMRVM__, __condition, __message, ...) \
+do {\
+	if(!(__condition)) {\
+		omrGcDebugAssertionOutputVM(__OMRVM__, __message, __VA_ARGS__);\
 		Assert_MM_unreachable();\
 	}\
 } while (false)
@@ -100,7 +109,8 @@ do {\
 #define Assert_MM_unimplemented() Assert_MM_unimplemented_internal()
 #define Assert_MM_invalidJNICall() Assert_MM_invalidJNICall_internal()
 
-#define Assert_GC_true_with_message(__env__,__condition,__message,__parameter) Assert_MM_true(__condition)
+#define Assert_GC_true_with_message(__env__, __condition, __message, ...) Assert_MM_true(__condition)
+#define Assert_GC_true_with_messageVM(__OMRVM__, __condition, __message, ...) Assert_MM_true(__condition)
 
 #define Assert_MM_objectAligned(__env__,__pointer) Assert_MM_true_internal((uintptr_t)(__pointer) & (__env__->getObjectAlignmentInBytes() - 1))
 #endif /* defined(OMR_GC_DEBUG_ASSERTS) */


### PR DESCRIPTION
Sometimes Assert_GC_true_with_message is hard to use due to lack of Environment pointer to pass. Introducing a new variation of macro designed to take OMR_VM and read thread ID from TLS block.