### PR TITLE
Ensure symmetry between x86 MemRef length estimation and binary encodings

### DIFF
--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -342,7 +342,8 @@ void OMR::X86::AMD64::MemoryReference::assignRegisters(TR::Instruction *currentI
     }
 }
 
-uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
+uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::Instruction *containingInstruction,
+    TR::CodeGenerator *cg)
 {
     uint32_t estimate;
 
@@ -359,7 +360,7 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerato
         _addressRegister = NULL;
     }
 
-    estimate = OMR::X86::MemoryReference::estimateBinaryLength(cg);
+    estimate = OMR::X86::MemoryReference::estimateBinaryLength(containingInstruction, cg);
 
     // For [disp32], AMD64 needs a SIB byte
     //

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -62,7 +62,7 @@ public:
     virtual void decNodeReferenceCounts(TR::CodeGenerator *cg);
     virtual void useRegisters(TR::Instruction *instr, TR::CodeGenerator *cg);
     virtual void assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg);
-    virtual uint32_t estimateBinaryLength(TR::CodeGenerator *cg);
+    virtual uint32_t estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg);
     virtual uint8_t *generateBinaryEncoding(uint8_t *modRM, TR::Instruction *containingInstruction,
         TR::CodeGenerator *cg);
 #endif

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2483,7 +2483,7 @@ bool OMR::X86::CodeGenerator::supportsComplexAddressing()
 
 uint32_t OMR::X86::CodeGenerator::estimateBinaryLength(TR::MemoryReference *mr)
 {
-    return mr->estimateBinaryLength(self());
+    return mr->estimateBinaryLength(NULL, self());
 }
 
 void OMR::X86::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label)

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -773,7 +773,7 @@ void OMR::X86::MemoryReference::assignRegisters(TR::Instruction *currentInstruct
     }
 }
 
-uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
+uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg)
 {
     if (self()->getBaseRegister()
         && toRealRegister(self()->getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp) {
@@ -785,13 +785,29 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
 
     TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
 
-    intptr_t displacement;
     uint32_t addressTypes = (self()->getBaseRegister() != NULL ? 1 : 0) | (self()->getIndexRegister() != NULL ? 2 : 0)
         | ((self()->getSymbolReference().getSymbol() != NULL || self()->getSymbolReference().getOffset() != 0
                || self()->isForceWideDisplacement())
                 ? 4
                 : 0);
     uint32_t length = 0;
+
+    intptr_t displacement;
+    uint8_t displacementDivisor = 0;
+    bool isEvex = false;
+    bool canShortenEVEXDisplacement = false;
+    if (containingInstruction) {
+        isEvex = containingInstruction->getOpCode().info().isEvex()
+            || (containingInstruction->getEncodingMethod() >= OMR::X86::EVEX_L128
+                && containingInstruction->getEncodingMethod() <= OMR::X86::EVEX_L512);
+        if (isEvex) {
+            canShortenEVEXDisplacement = containingInstruction->getOpCode().canShortenEVEXDisplacement();
+            if (canShortenEVEXDisplacement) {
+                displacementDivisor = containingInstruction->getOpCode().getSIMDMemOperandSize(
+                    containingInstruction->getEncodingMethod());
+            }
+        }
+    }
 
     switch (addressTypes) {
         case 1:
@@ -822,6 +838,16 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
 
         case 5:
             displacement = self()->getDisplacement();
+            if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
+                && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
+                displacement /= displacementDivisor;
+            } else if (isEvex) {
+                length = 4;
+                if (base->needsSIB() || self()->isForceSIBByte()) {
+                    length++;
+                }
+                break;
+            }
             if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !self()->isForceWideDisplacement()) {
                 length = 0;
             } else if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
@@ -840,6 +866,13 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
 
         case 7:
             displacement = self()->getDisplacement();
+            if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
+                && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
+                displacement /= displacementDivisor;
+            } else if (isEvex) {
+                length = 5;
+                break;
+            }
             if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
                 length = 2;
             } else {
@@ -934,8 +967,9 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
     return length;
 }
 
-OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator *cg, int32_t requestedEnlargementSize,
-    int32_t maxEnlargementSize, bool allowPartialEnlargement)
+OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator *cg,
+    TR::Instruction *containingInstruction, int32_t requestedEnlargementSize, int32_t maxEnlargementSize,
+    bool allowPartialEnlargement)
 {
     static char *disableMemRefExpansion = feGetEnv("TR_DisableMemRefExpansion");
     if (!disableMemRefExpansion)
@@ -943,10 +977,10 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
 
     int32_t growth = 0;
     if (!self()->isForceWideDisplacement()) {
-        int32_t currentEncodingAllocation = self()->estimateBinaryLength(cg);
+        int32_t currentEncodingAllocation = self()->estimateBinaryLength(containingInstruction, cg);
         int32_t currentPatchSize = self()->getBinaryLengthLowerBound(cg);
         _flags.set(MemRef_ForceWideDisplacement);
-        int32_t potentialEncodingGrowth = self()->estimateBinaryLength(cg) - currentPatchSize;
+        int32_t potentialEncodingGrowth = self()->estimateBinaryLength(containingInstruction, cg) - currentPatchSize;
         int32_t potentialPatchGrowth = self()->getBinaryLengthLowerBound(cg) - currentEncodingAllocation;
 
         if (potentialPatchGrowth > 0 && (potentialPatchGrowth >= requestedEnlargementSize || allowPartialEnlargement)
@@ -957,7 +991,7 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
             return OMR::X86::EnlargementResult(potentialPatchGrowth, potentialEncodingGrowth);
         } else {
             _flags.reset(MemRef_ForceWideDisplacement);
-            self()->estimateBinaryLength(cg);
+            self()->estimateBinaryLength(containingInstruction, cg);
             return OMR::X86::EnlargementResult(0, 0);
         }
     }

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -330,9 +330,9 @@ public:
     static int32_t getStrideForNode(TR::Node *node, TR::CodeGenerator *cg);
 
     uint32_t getBinaryLengthLowerBound(TR::CodeGenerator *cg);
-    virtual uint32_t estimateBinaryLength(TR::CodeGenerator *cg);
-    virtual OMR::X86::EnlargementResult enlarge(TR::CodeGenerator *cg, int32_t requestedEnlargementSize,
-        int32_t maxEnlargementSize, bool allowPartialEnlargement);
+    virtual uint32_t estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg);
+    virtual OMR::X86::EnlargementResult enlarge(TR::CodeGenerator *cg, TR::Instruction *containingInstruction,
+        int32_t requestedEnlargementSize, int32_t maxEnlargementSize, bool allowPartialEnlargement);
 
     virtual void decNodeReferenceCounts(TR::CodeGenerator *cg);
 

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1850,7 +1850,7 @@ int32_t TR::X86MemInstruction::estimateBinaryLength(int32_t currentEstimate)
     if (getOpCode().needsLockPrefix() || (barrier & LockPrefix))
         length++;
 
-    length += getMemoryReference()->estimateBinaryLength(cg());
+    length += getMemoryReference()->estimateBinaryLength(this, cg());
 
     if (barrier & NeedsExplicitBarrier)
         length += estimateMemoryBarrierBinaryLength(barrier, cg());
@@ -1870,8 +1870,8 @@ OMR::X86::EnlargementResult TR::X86MemInstruction::enlarge(int32_t requestedEnla
     if ((maxEnlargementSize < requestedEnlargementSize && !allowPartialEnlargement) || requestedEnlargementSize < 1)
         return OMR::X86::EnlargementResult(0, 0);
 
-    OMR::X86::EnlargementResult result
-        = getMemoryReference()->enlarge(cg(), requestedEnlargementSize, maxEnlargementSize, allowPartialEnlargement);
+    OMR::X86::EnlargementResult result = getMemoryReference()->enlarge(cg(), this, requestedEnlargementSize,
+        maxEnlargementSize, allowPartialEnlargement);
     if (result.getEncodingGrowth() > 0)
         setEstimatedBinaryLength(getEstimatedBinaryLength() + result.getEncodingGrowth());
 
@@ -2015,7 +2015,7 @@ uint8_t TR::X86MemImmInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86MemImmInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    int32_t length = getMemoryReference()->estimateBinaryLength(cg());
+    int32_t length = getMemoryReference()->estimateBinaryLength(this, cg());
 
     int32_t barrier = memoryBarrierRequired(getOpCode(), getMemoryReference(), cg(), false);
 
@@ -2244,7 +2244,7 @@ uint8_t TR::X86MemRegImmInstruction::getBinaryLengthLowerBound()
 
 int32_t TR::X86MemRegImmInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    int32_t length = getMemoryReference()->estimateBinaryLength(cg());
+    int32_t length = getMemoryReference()->estimateBinaryLength(this, cg());
 
     int32_t barrier = memoryBarrierRequired(getOpCode(), getMemoryReference(), cg(), false);
 
@@ -2313,7 +2313,7 @@ int32_t TR::X86RegMemInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
     int32_t barrier = memoryBarrierRequired(getOpCode(), getMemoryReference(), cg(), false);
 
-    int32_t length = getMemoryReference()->estimateBinaryLength(cg());
+    int32_t length = getMemoryReference()->estimateBinaryLength(this, cg());
 
     if (barrier & LockPrefix)
         length++;
@@ -2336,8 +2336,8 @@ OMR::X86::EnlargementResult TR::X86RegMemInstruction::enlarge(int32_t requestedE
     if ((maxEnlargementSize < requestedEnlargementSize && !allowPartialEnlargement) || requestedEnlargementSize < 1)
         return OMR::X86::EnlargementResult(0, 0);
 
-    OMR::X86::EnlargementResult result
-        = getMemoryReference()->enlarge(cg(), requestedEnlargementSize, maxEnlargementSize, allowPartialEnlargement);
+    OMR::X86::EnlargementResult result = getMemoryReference()->enlarge(cg(), this, requestedEnlargementSize,
+        maxEnlargementSize, allowPartialEnlargement);
     if (result.getEncodingGrowth() > 0)
         setEstimatedBinaryLength(getEstimatedBinaryLength() + result.getEncodingGrowth());
     return result;
@@ -2455,7 +2455,7 @@ int32_t TR::X86RegMemImmInstruction::estimateBinaryLength(int32_t currentEstimat
 {
     int32_t barrier = memoryBarrierRequired(getOpCode(), getMemoryReference(), cg(), false);
 
-    int32_t length = getMemoryReference()->estimateBinaryLength(cg());
+    int32_t length = getMemoryReference()->estimateBinaryLength(this, cg());
 
     if (barrier & LockPrefix)
         length++;


### PR DESCRIPTION
- Ensuring symmetry between length estimation and binary encoding for EVEX memory references.

Issue: #8225