### PR TITLE
Enable GRA for Vector and Mask Types on PPC

### DIFF
--- a/compiler/optimizer/OMRRegisterCandidate.cpp
+++ b/compiler/optimizer/OMRRegisterCandidate.cpp
@@ -2339,7 +2339,11 @@ bool OMR::RegisterCandidates::assign(TR::Block **cfgBlocks, int32_t numberOfBloc
 
             firstRegister = cg->getFirstGlobalFPR(), lastRegister = cg->getLastGlobalFPR();
         } else if (isVector) {
+#if defined(TR_TARGET_POWER) && defined(TR_TARGET_64BIT)
+            firstRegister = cg->getFirstGlobalFPR(), lastRegister = cg->getLastGlobalVRF();
+#else
             firstRegister = cg->getFirstGlobalVRF(), lastRegister = cg->getLastGlobalVRF();
+#endif
         } else {
             firstRegister = cg->getFirstGlobalGPR(), lastRegister = cg->getLastGlobalGPR();
         }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1015,6 +1015,24 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
         || sym->getDataType().isMask())
         gprCandidate = false;
 
+    static char *pMaxVSRsForGRA = feGetEnv("TR_MaxVSRsForGRA");
+    if (pMaxVSRsForGRA && (sym->getDataType().isVector() || sym->getDataType().isMask())) {
+        static uint32_t maxVSRsForGRA = atoi(pMaxVSRsForGRA);
+
+        // count how many registers have been allocated (i.e.: how many are not available)
+        int numAllocated;
+
+        if (sym->getDataType().getVectorElementType() == TR::Float
+            || sym->getDataType().getVectorElementType() == TR::Double)
+            numAllocated = 64 - availRegs.elementCount();
+        else
+            numAllocated = 32 - availRegs.elementCount();
+
+        // if max has already been met, exit
+        if (numAllocated >= maxVSRsForGRA)
+            return -1;
+    }
+
     if (gprCandidate) {
         int32_t numExtraRegs = 0;
         int32_t maxRegisterPressure = 0;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -991,7 +991,14 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
         default:
             if (sym->getDataType().isVector() || sym->getDataType().isMask()) {
                 isVector = true;
-                firstIndex = self()->getFirstGlobalVRF();
+
+                if (!sym->getDataType().isMask()
+                    && (sym->getDataType().getVectorElementType() == TR::Float
+                        || sym->getDataType().getVectorElementType() == TR::Double))
+                    firstIndex = _firstFPR;
+                else
+                    firstIndex = self()->getFirstGlobalVRF();
+
                 lastIndex = self()->getLastGlobalVRF();
                 lastVolIndex = lastIndex;
                 break;
@@ -1004,7 +1011,8 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
     }
 
     bool gprCandidate = true;
-    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVector() || sym->getDataType().isMask())
+    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVector()
+        || sym->getDataType().isMask())
         gprCandidate = false;
 
     if (gprCandidate) {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -795,9 +795,9 @@ void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
     map->setInternalPointerMap(internalPtrMap);
 }
 
-bool OMR::Power::CodeGenerator::considerTypeForGRA(TR::Node *node) { return !node->getDataType().isMask(); }
+bool OMR::Power::CodeGenerator::considerTypeForGRA(TR::Node *node) { return true; }
 
-bool OMR::Power::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !dt.isMask(); }
+bool OMR::Power::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return true; }
 
 bool OMR::Power::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
 {
@@ -989,15 +989,12 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             break;
 
         default:
-            if (sym->getDataType().isVector()) {
-                if (sym->getDataType().getVectorElementType() == TR::Int32
-                    || sym->getDataType().getVectorElementType() == TR::Double) {
-                    isVector = true;
-                    firstIndex = self()->getFirstGlobalVRF();
-                    lastIndex = self()->getLastGlobalVRF();
-                    lastVolIndex = lastIndex; // TODO: preserved VRF's !!
-                    break;
-                }
+            if (sym->getDataType().isVector() || sym->getDataType().isMask()) {
+                isVector = true;
+                firstIndex = self()->getFirstGlobalVRF();
+                lastIndex = self()->getLastGlobalVRF();
+                lastVolIndex = lastIndex;
+                break;
             }
 
             firstIndex = _firstGPR;
@@ -1007,7 +1004,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
     }
 
     bool gprCandidate = true;
-    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVector())
+    if ((sym->getDataType() == TR::Float) || (sym->getDataType() == TR::Double) || sym->getDataType().isVector() || sym->getDataType().isMask())
         gprCandidate = false;
 
     if (gprCandidate) {
@@ -1058,7 +1055,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             for (prev = candidates->getFirst(); prev; prev = prev->getNext()) {
                 bool gprCandidate = true;
                 if ((prev->getSymbol()->getDataType() == TR::Float) || (prev->getSymbol()->getDataType() == TR::Double)
-                    || sym->getDataType().isVector())
+                    || sym->getDataType().isVector() || sym->getDataType().isMask())
                     gprCandidate = false;
                 if (gprCandidate && prev->getBlocksLiveOnEntry().get(liveBlockNum)) {
                     numAssignedGlobalRegs++;
@@ -1103,7 +1100,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             i1 = sym->getParmSymbol()->getLinkageRegisterIndex();
             if (i1 >= 0) {
                 if (isVector)
-                    TR_ASSERT(false, "assertion failure"); // TODO
+                    TR_ASSERT(false, "vector symbols cannot yet be passed in as parameters");
                 i1 = (isFloatType ? _firstParmFPR : _firstParmGPR) - i1 - longLow;
                 if (availRegs.isSet(i1))
                     return (i1);
@@ -1121,7 +1118,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR::RegisterCand
             i1 = sym->getParmSymbol()->getLinkageRegisterIndex();
             if (i1 >= 0) {
                 if (isVector)
-                    TR_ASSERT(false, "assertion failure"); // TODO
+                    TR_ASSERT(false, "vector symbols cannot yet be passed in as parameters");
                 i1 = (isFloatType ? _firstParmFPR : _firstParmGPR) - i1 - longLow;
                 if (availRegs.isSet(i1))
                     return (i1);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1220,12 +1220,12 @@ TR::Register *OMR::Power::TreeEvaluator::mLongBitsToMaskHelper(TR::Node *node, T
 
 TR::Register *OMR::Power::TreeEvaluator::mRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vRegLoadEvaluator(node, cg);
 }
 
 TR::Register *OMR::Power::TreeEvaluator::mRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::vRegStoreEvaluator(node, cg);
 }
 
 TR::Register *OMR::Power::TreeEvaluator::mandEvaluator(TR::Node *node, TR::CodeGenerator *cg)


### PR DESCRIPTION
This contribution includes the following changes (all on PPC):
- Enables GRA for all vector types and vector mask types
- Allows GRA to allocate VSRs 0-31 for vectors with float or double-type elements
- Creates an environment variable, `TR_MaxVSRsForGRA`, that will allow the user to control how many vector registers can be allocated by GRA