### PR TITLE
AArch64: Add indexZeroExtended to MemoryReference

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -2711,12 +2711,15 @@ void TR_Debug::print(OMR::Logger *log, TR::MemoryReference *mr)
             : TR_DoubleWordReg;
         print(log, mr->getIndexRegister(), indexSize);
 
-        if ((extendCode != TR::ARM64ExtendCode::EXT_UXTX) || (scale != 0)) {
-            if (extendCode != TR::ARM64ExtendCode::EXT_UXTX) {
-                log->printf(", %s %d", ARM64ExtendCodeNames[extendCode], scale);
-            } else {
-                log->printf(", lsl %d", scale);
+        if (extendCode != TR::ARM64ExtendCode::EXT_LSL) {
+            log->printf(", %s", ARM64ExtendCodeNames[extendCode]);
+            if (scale != 0) {
+                log->printf(" %d", scale);
             }
+        } else if (scale != 0) {
+            log->printf(", lsl %d", scale);
+        } else {
+            // print nothing for EXT_LSL with 0 scale (default)
         }
     } else
         log->printf("%d", mr->getOffset(true));

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -478,7 +478,7 @@ static bool checkOffset(TR::Node *node, TR::CodeGenerator *cg, uint32_t offset, 
 
 void OMR::ARM64::MemoryReference::moveIndexToBase(TR::Node *node, TR::CodeGenerator *cg)
 {
-    if ((_baseRegister != NULL) || self()->isIndexSignExtendedWord() || (_scale != 0)) {
+    if ((_baseRegister != NULL) || self()->isIndexExtended() || (_scale != 0)) {
         self()->consolidateRegisters(node, cg);
     } else {
         if (self()->isIndexModifiable()) {
@@ -716,7 +716,10 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
         tempTargetRegister = cg->allocateRegister();
 
     if (_baseRegister != NULL) {
-        if (self()->isIndexSignExtendedWord()) {
+        if (self()->isIndexZeroExtendedWord()) {
+            generateTrg1Src2ExtendedInstruction(cg, TR::InstOpCode::addextx, srcTree, tempTargetRegister, _baseRegister,
+                _indexRegister, TR::EXT_UXTW, _scale);
+        } else if (self()->isIndexSignExtendedWord()) {
             generateTrg1Src2ExtendedInstruction(cg, TR::InstOpCode::addextx, srcTree, tempTargetRegister, _baseRegister,
                 _indexRegister, TR::EXT_SXTW, _scale);
         } else {
@@ -725,15 +728,21 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
         }
     } else if (_scale != 0) {
         generateLogicalShiftLeftImmInstruction(cg, srcTree, tempTargetRegister, _indexRegister, _scale, true);
-        if (self()->isIndexSignExtendedWord()) {
+        if (self()->isIndexZeroExtendedWord()) {
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, srcTree, tempTargetRegister, tempTargetRegister,
+                31);
+        } else if (self()->isIndexSignExtendedWord()) {
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, tempTargetRegister,
                 31);
         }
+    } else if (self()->isIndexZeroExtendedWord()) {
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else if (self()->isIndexSignExtendedWord()) {
         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else {
         TR_ASSERT_FATAL(false,
-            "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexSignExtendedWord()");
+            "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexZeroExtendedWord() || "
+            "isIndexSignExtendedWord()");
     }
 
     if (_baseRegister != tempTargetRegister) {
@@ -751,7 +760,7 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
     _indexRegister = NULL;
     _scale = 0;
     self()->clearIndexModifiable();
-    self()->clearIndexSignExtendedWord();
+    self()->clearIndexExtended();
 }
 
 void OMR::ARM64::MemoryReference::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
@@ -1101,7 +1110,9 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
                     base->setRegisterFieldRN(wcursor);
                     index->setRegisterFieldRM(wcursor);
 
-                    if (self()->isIndexSignExtendedWord()) {
+                    if (self()->isIndexZeroExtendedWord()) {
+                        *wcursor |= TR::EXT_UXTW << 13;
+                    } else if (self()->isIndexSignExtendedWord()) {
                         *wcursor |= TR::EXT_SXTW << 13;
                     } else {
                         *wcursor |= TR::EXT_LSL << 13;

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -135,7 +135,7 @@ public:
         TR_ARM64MemoryReferenceControl_Base_Modifiable = 0x01,
         TR_ARM64MemoryReferenceControl_Index_Modifiable = 0x02,
         // 0x04: Available
-        // 0x08: Available
+        TR_ARM64MemoryReferenceControl_Index_ZeroExtendedWord = 0x08,
         TR_ARM64MemoryReferenceControl_Index_SignExtendedWord = 0x10,
         TR_ARM64MemoryReferenceControl_DelayedOffsetDone = 0x20
         /* To be added more if necessary */
@@ -328,6 +328,17 @@ public:
     void clearIndexModifiable() { _flag &= ~TR_ARM64MemoryReferenceControl_Index_Modifiable; }
 
     /**
+     * @brief The extend code for the index register is UXTW or not
+     * @return true when the extend code for index register is UXTW
+     */
+    bool isIndexZeroExtendedWord() { return ((_flag & TR_ARM64MemoryReferenceControl_Index_ZeroExtendedWord) != 0); }
+
+    /**
+     * @brief Sets the IndexZeroExtendedWord flag
+     */
+    void setIndexZeroExtendedWord() { _flag |= TR_ARM64MemoryReferenceControl_Index_ZeroExtendedWord; }
+
+    /**
      * @brief The extend code for the index register is SXTW or not
      * @return true when the extend code for index register is SXTW
      */
@@ -339,9 +350,19 @@ public:
     void setIndexSignExtendedWord() { _flag |= TR_ARM64MemoryReferenceControl_Index_SignExtendedWord; }
 
     /**
-     * @brief Clears the IndexSignExtendedWord flag
+     * @brief Index register is extended or not
+     * @return true when index register is zero-extended or sign-extended
      */
-    void clearIndexSignExtendedWord() { _flag &= ~TR_ARM64MemoryReferenceControl_Index_SignExtendedWord; }
+    bool isIndexExtended() { return (isIndexZeroExtendedWord() || isIndexSignExtendedWord()); }
+
+    /**
+     * @brief Clears the IndexExtended flags
+     */
+    void clearIndexExtended()
+    {
+        _flag &= ~(TR_ARM64MemoryReferenceControl_Index_ZeroExtendedWord
+            | TR_ARM64MemoryReferenceControl_Index_SignExtendedWord);
+    }
 
     /**
      * @brief Gets the flag indicating whether the delayed offset has already been applied.
@@ -368,10 +389,12 @@ public:
      */
     TR::ARM64ExtendCode getIndexExtendCode()
     {
-        if (isIndexSignExtendedWord()) {
+        if (isIndexZeroExtendedWord()) {
+            return TR::EXT_UXTW;
+        } else if (isIndexSignExtendedWord()) {
             return TR::EXT_SXTW;
         } else {
-            return TR::EXT_UXTX;
+            return TR::EXT_LSL; // default extend code
         }
     }
 


### PR DESCRIPTION
This commit adds a new flag to MemoryReference for AArch64. AArch64 LDR/STR (register) instructions support SXTW/UXTW for extending the index register value from 32 bits to 64 bits. This commit enables the use of UXTW.