### PR TITLE
Use register-form div instruction for OffHeap array access divisions

### DIFF
--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -1949,7 +1949,14 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
         TR::Register *edxRegister = cg->allocateRegister();
         TR::Register *divisorRegister = NULL;
 
-        if (needsExplicitOverflowCheck) {
+        if (needsExplicitOverflowCheck
+#if defined(OMR_GC_SPARSE_HEAP_ALLOCATION)
+            // For OffHeap array accesses, use register form div instruction to prevent live dataAddr during
+            // div-instr exception causing involuntary GC.
+            || (TR::Compiler->om.isOffHeapAllocationEnabled() && secondChild->getOpCode().hasSymbolReference()
+                && secondChild->getSymbolReference()->getSymbol()->isArrayShadowSymbol())
+#endif
+        ) {
             // Get divisor in a register (1) to simplify the snippet, and (2)
             // because we need to use it twice anyway, so arguably it should be in
             // a register.


### PR DESCRIPTION
Division instruction can trigger divide error exception which can lead to a GC cycle. When using memory-form `div` on an array element divisor, the dataAddr register is live as source for the `div`. OffHeap currently does not support live dataAddr register during GC, hence this can cause a crash.

This PR uses register-form `div` instruction if the source of the division is an OffHeap array access.

Benchmarks show no performance difference.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23961