### PR TITLE
Early allocation restore on CS abort

### DIFF
--- a/gc/base/MemorySpace.cpp
+++ b/gc/base/MemorySpace.cpp
@@ -537,7 +537,7 @@ MM_MemorySpace::canContract(MM_EnvironmentBase *env, uintptr_t contractSize)
 uintptr_t
 MM_MemorySpace::maxContraction(MM_EnvironmentBase *env)
 {
-	return  (uintptr_t)(_currentSize - _minimumSize);
+	return (uintptr_t)(_currentSize - _minimumSize);
 }
 
 /**
@@ -546,10 +546,9 @@ MM_MemorySpace::maxContraction(MM_EnvironmentBase *env)
 void
 MM_MemorySpace::reset(MM_EnvironmentBase *env)
 {
-	MM_MemorySubSpace *memorySubSpace;
-	memorySubSpace = _memorySubSpaceList;
-	while(NULL != memorySubSpace) {
-		memorySubSpace->reset();
+	MM_MemorySubSpace *memorySubSpace = _memorySubSpaceList;
+	while (NULL != memorySubSpace) {
+		memorySubSpace->reset(env);
 		memorySubSpace = memorySubSpace->getNext();
 	}
 }
@@ -561,9 +560,8 @@ MM_MemorySpace::reset(MM_EnvironmentBase *env)
 void
 MM_MemorySpace::rebuildFreeList(MM_EnvironmentBase *env)
 {
-	MM_MemorySubSpace *memorySubSpace;
-	memorySubSpace = _memorySubSpaceList;
-	while(NULL != memorySubSpace) {
+	MM_MemorySubSpace *memorySubSpace = _memorySubSpaceList;
+	while (NULL != memorySubSpace) {
 		memorySubSpace->rebuildFreeList(env);
 		memorySubSpace = memorySubSpace->getNext();
 	}
@@ -584,11 +582,11 @@ MM_MemorySpace::getAllTypeFlags()
 uintptr_t
 MM_MemorySpace::releaseFreeMemoryPages(MM_EnvironmentBase* env, uintptr_t memoryType)
 {
-        uintptr_t releasedMemory = 0;
-        MM_MemorySubSpace* memorySubSpace = _memorySubSpaceList;
-        while(NULL != memorySubSpace) {
-                releasedMemory += memorySubSpace->releaseFreeMemoryPages(env, memoryType);
-                memorySubSpace = memorySubSpace->getNext();
-        }
-        return releasedMemory;
+	uintptr_t releasedMemory = 0;
+	MM_MemorySubSpace* memorySubSpace = _memorySubSpaceList;
+	while (NULL != memorySubSpace) {
+		releasedMemory += memorySubSpace->releaseFreeMemoryPages(env, memoryType);
+		memorySubSpace = memorySubSpace->getNext();
+	}
+	return releasedMemory;
 }

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1043,13 +1043,12 @@ MM_MemorySubSpace::garbageCollect(MM_EnvironmentBase* env, MM_AllocateDescriptio
 }
 
 void
-MM_MemorySubSpace::reset()
+MM_MemorySubSpace::reset(MM_EnvironmentBase *env)
 {
 	/* Call on children */
-	MM_MemorySubSpace* child;
-	child = _children;
+	MM_MemorySubSpace *child = _children;
 	while (child) {
-		child->reset();
+		child->reset(env);
 		child = child->getNext();
 	}
 }
@@ -1061,18 +1060,17 @@ void
 MM_MemorySubSpace::rebuildFreeList(MM_EnvironmentBase* env)
 {
 	/* Call on children */
-	MM_MemorySubSpace* child;
-	child = _children;
+	MM_MemorySubSpace *child = _children;
 	while (child) {
 		child->rebuildFreeList(env);
 		child = child->getNext();
 	}
 }
 
-void*
+void *
 MM_MemorySubSpace::allocateGeneric(MM_EnvironmentBase* env, MM_AllocateDescription* allocateDescription, AllocationType allocationType, MM_ObjectAllocationInterface* objectAllocationInterface, MM_MemorySubSpace* attemptSubspace)
 {
-	void* result = NULL;
+	void *result = NULL;
 
 	switch (allocationType) {
 	case ALLOCATION_TYPE_OBJECT:

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -343,7 +343,7 @@ public:
 	virtual bool percolateGarbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 	virtual bool garbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 
-	virtual void reset();
+	virtual void reset(MM_EnvironmentBase *env = NULL);
 	virtual void rebuildFreeList(MM_EnvironmentBase *env);
 
 	virtual void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription);

--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -512,7 +512,7 @@ MM_MemorySubSpaceGeneric::completeFreelistRebuildRequired(MM_EnvironmentBase* en
  */
 
 void
-MM_MemorySubSpaceGeneric::reset()
+MM_MemorySubSpaceGeneric::reset(MM_EnvironmentBase* env)
 {
 	/* TODO: Call the superclass reset() here as well (for children)? */
 	_memoryPool->reset();

--- a/gc/base/MemorySubSpaceGeneric.hpp
+++ b/gc/base/MemorySubSpaceGeneric.hpp
@@ -101,7 +101,7 @@ public:
 	virtual MM_MemorySubSpace* getDefaultMemorySubSpace();
 	virtual MM_MemorySubSpace* getTenureMemorySubSpace();
 
-	virtual void reset();
+	virtual void reset(MM_EnvironmentBase* env);
 	virtual void rebuildFreeList(MM_EnvironmentBase* env);
 
 	virtual bool completeFreelistRebuildRequired(MM_EnvironmentBase* env);

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -532,7 +532,13 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 		/* disable potentially successful allocation (in case of forced abort) to trigger another (percolate) GC */
 		_memorySubSpaceAllocate->isAllocatable(false);
 		getMemorySpace()->getTenureMemorySubSpace()->isAllocatable(false);
-
+		break;
+	case restore_allocate_after_backout:
+		Assert_MM_true(_extensions->concurrentScavenger);
+		Trc_MM_MSSSS_flip_step(env->getLanguageVMThread(), "restore_allocate_after_backout");
+		/* Restore allocation, which we had disabled in the backout step */
+		_memorySubSpaceAllocate->isAllocatable(true);
+		getMemorySpace()->getTenureMemorySubSpace()->isAllocatable(true);
 		break;
 	case restore_tilt_after_percolate:
 	{
@@ -577,10 +583,6 @@ MM_MemorySubSpaceSemiSpace::flip(MM_EnvironmentBase *env, Flip_step step)
 			env->getLanguageVMThread(), "adjusted ",
 			allocateSize, survivorSize);
 		tilt(env, allocateSize, survivorSize);
-
-		/* Restore allocation, which we had disabled in the backout step */
-		_memorySubSpaceAllocate->isAllocatable(true);
-		getMemorySpace()->getTenureMemorySubSpace()->isAllocatable(true);
 
 		_extensions->setScavengerBackOutState(backOutFlagCleared);
 	}
@@ -674,7 +676,7 @@ MM_MemorySubSpaceSemiSpace::mainTeardownForAbortedGC(MM_EnvironmentBase *env)
 	/* Build free list in survivor. */
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		/* There might be live objects in Survivor (newly allocated one since the start of Concurrent Scavenge cycle)
-		 * Sweep in percolate global will rebuild it, so we can skip it here
+		 * Sweep in percolate global will rebuild the free list, so we can skip it here
 		 */
 		flip(env, backout);
 	} else {
@@ -1016,6 +1018,20 @@ MM_MemorySubSpaceSemiSpace::checkSubSpaceMemoryPostCollectResize(MM_EnvironmentB
 	}
 }
 
+void
+MM_MemorySubSpaceSemiSpace::reset(MM_EnvironmentBase *env)
+{
+	/* To help with transition from aborted Scavenger into a Global GC, allocation was disabled via flip(backout) step, late in Scavenger.
+	 * This is supposed to be called early in Global to restore that allocation.
+	 * It should be done before any findLargestFreeEntry() during Global (like Compact triggers), that are affected by _isAllocatable.
+	 */
+	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
+		flip(env, restore_allocate_after_backout);
+	}
+
+	MM_MemorySubSpace::reset(env);
+}
+
 /**
  * Adjust the sub space memory consumed after a collect.
  * Adjusting semi space memory consumed after a collect includes changing the tilt and/or
@@ -1026,10 +1042,10 @@ void
 MM_MemorySubSpaceSemiSpace::checkResize(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool systemGC)
 {
 	uintptr_t oldVMState = env->pushVMstate(OMRVMSTATE_GC_CHECK_RESIZE);
-	/* this we are called at the end of precolate global GC, due to aborted Concurrent Scavenge,
+	/* If we are called at the end of percolate global GC, due to aborted Concurrent Scavenge,
 	 * we have to restore tilt (that has been set to 100% to do unified sliding compact of Nursery */
 	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
-		flip(env, MM_MemorySubSpaceSemiSpace::restore_tilt_after_percolate);
+		flip(env, restore_tilt_after_percolate);
 	} else {
 		checkSubSpaceMemoryPostCollectTilt(env);
 		checkSubSpaceMemoryPostCollectResize(env);

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -58,6 +58,7 @@ public:
 		restore_allocation,
 		restore_allocation_and_set_survivor,
 		backout,
+		restore_allocate_after_backout,
 		restore_tilt_after_percolate
 	};	 
 private:
@@ -153,6 +154,8 @@ public:
 	virtual	void mergeHeapStats(MM_HeapStats *heapStats);
 	virtual	void mergeHeapStats(MM_HeapStats *heapStats, uintptr_t includeMemoryType);
 	virtual void systemGarbageCollect(MM_EnvironmentBase *env, uint32_t gcCode);
+
+	virtual void reset(MM_EnvironmentBase *env);
 
 	/* Type specific methods */
 	void flip(MM_EnvironmentBase *env, Flip_step action);


### PR DESCRIPTION
To help with transition from aborted Scavenger into a Global GC, allocation was disabled via backout step (in flip() method), late in Scavenger.

Now we restore that allocation early in Global via a separate step (restore_allocate_after_backout), rather than doing it at the end of Global (via restore_tilt_after_percolate step).

Hence, it is done before any invocation of findLargestFreeEntry() during Global (like Compact triggers), that are affected by _isAllocatable.

At the moment the change has no effect, but generally helps to more precisely chose a proper compact trigger (and effectively a variant of compaction, like full heap compact or nursery-only compact (the latter soon to be introduced)).

Issue: https://github.com/eclipse-openj9/openj9/issues/20515