### PR TITLE
AArch64: Add is64bit parameter to generateCSetInstruction()

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -623,10 +623,10 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
 }
 
 TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::ARM64ConditionCode cc, TR::Instruction *preced)
+    TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of CSINC instruction with inverted condition code */
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::csincx;
+    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::csincx : TR::InstOpCode::csincw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), preced, cg);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -829,11 +829,12 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] node : node
  * @param[in] treg : target register
  * @param[in] cc : branch condition code
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
 TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
+    TR::ARM64ConditionCode cc, bool is64bit = true, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates CINC instruction


### PR DESCRIPTION
This commit adds a parameter "is64bit" to generateCSetInstruction() for AArch64, so that the function can generate the 32-bit variant of the instruction.