### PR TITLE
Fix incorrect usage of STG with Int8 for OpMemToMem

### DIFF
--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -1736,6 +1736,9 @@ TR::Instruction *MemInitVarLenTypedMacroOp::generateInstruction()
     TR::MemoryReference *newMR = generateS390MemoryReference(_endReg, (int32_t)0, _cg);
 
     switch (_destType) {
+        case TR::Int8:
+            cursor = generateRXInstruction(_cg, TR::InstOpCode::STC, _dstNode, _initReg, newMR);
+            break;
         case TR::Int16:
             cursor = generateRXInstruction(_cg, TR::InstOpCode::STH, _dstNode, _initReg, newMR);
             break;


### PR DESCRIPTION
There is an issue when handling byte sized operands, where OpMemToMem was
initially falling back and using STG (4 byte instruction) to store the
values. This change adds the missing instruction (STC) that needs to be
rightfully used when handling bytes.

---

Related links: https://github.com/eclipse-openj9/openj9/pull/23854/changes
(uses `arraysetEvaluator` , which passes operands and calls OpMemToMem)
