### PR TITLE
Change Power's lookup peeloff by using symbolic constants

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3670,8 +3670,9 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
 
     // Deciding if we can perform better by peeling off the hottest two cases
     // For the time being, hot criteria: more than 50% of the containing block frequency
-    if ((2 * ordering[2].frequency) > cg->getCurrentEvaluationBlock()->getFrequency()) {
-        int32_t hotIdx = ordering[2].index;
+    if ((2 * ordering[OMR::SwitchCaseOrdering::HOTTEST_IDX].frequency)
+        > cg->getCurrentEvaluationBlock()->getFrequency()) {
+        int32_t hotIdx = ordering[OMR::SwitchCaseOrdering::HOTTEST_IDX].index;
         TR::Node *hotChild = node->getChild(hotIdx);
         int32_t caseConst = hotChild->getCaseConstant();
 
@@ -3684,8 +3685,9 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
         generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node,
             hotChild->getBranchDestination()->getNode()->getLabel(), cndRegister);
 
-        if ((2 * ordering[3].frequency) > cg->getCurrentEvaluationBlock()->getFrequency()) {
-            hotIdx = ordering[3].index;
+        if ((2 * ordering[OMR::SwitchCaseOrdering::SECHOT_IDX].frequency)
+            > cg->getCurrentEvaluationBlock()->getFrequency()) {
+            hotIdx = ordering[OMR::SwitchCaseOrdering::SECHOT_IDX].index;
             hotChild = node->getChild(hotIdx);
             caseConst = hotChild->getCaseConstant();
 


### PR DESCRIPTION
This is entirely for cosmetic reasons.