### PR TITLE
Reduce uses of `getResolvedMethods()`

### DIFF
--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -1118,19 +1118,11 @@ void TR_FieldPrivatizer::addStringInitialization(TR::Block *block)
     TR::TreeTop *initTree = TR::TreeTop::create(comp(), initNode, 0, 0);
 
     if (!_initSymRef) {
-        List<TR_ResolvedMethod> stringBufferMethods(trMemory());
-        comp()->fej9()->getResolvedMethods(trMemory(), _stringBufferClass, &stringBufferMethods);
-        ListIterator<TR_ResolvedMethod> it(&stringBufferMethods);
-        for (TR_ResolvedMethod *method = it.getCurrent(); method; method = it.getNext()) {
-            if (method->isConstructor()) {
-                char *sig = method->signatureChars();
-                if (!strncmp(sig, "(Ljava/lang/String;)V", 21)) {
-                    _initSymRef = getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method,
-                        TR::MethodSymbol::Special);
-                    break;
-                }
-            }
-        }
+        TR_ResolvedMethod *method = comp()->fej9()->getResolvedMethodForConstructorWithSig(trMemory(),
+            _stringBufferClass, "(Ljava/lang/String;)V");
+        if (method)
+            _initSymRef
+                = getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method, TR::MethodSymbol::Special);
     }
 
     if (!_initSymRef) {
@@ -1213,19 +1205,11 @@ void TR_FieldPrivatizer::placeStringEpiloguesBackInExit(TR::Block *block, bool p
 {
 #if J9_PROJECT_SPECIFIC
     if (!_toStringSymRef) {
-        TR_ScratchList<TR_ResolvedMethod> stringBufferMethods(trMemory());
-        comp()->fej9()->getResolvedMethods(trMemory(), _stringBufferClass, &stringBufferMethods);
-        ListIterator<TR_ResolvedMethod> it(&stringBufferMethods);
-        for (TR_ResolvedMethod *method = it.getCurrent(); method; method = it.getNext()) {
-            if (!strncmp(method->nameChars(), "toString", 8)) {
-                char *sig = method->signatureChars();
-                if (!strncmp(sig, "()Ljava/lang/String;", 20)) {
-                    _toStringSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method,
-                        TR::MethodSymbol::Virtual);
-                    break;
-                }
-            }
-        }
+        TR_ResolvedMethod *method = comp()->fej9()->getResolvedMethodForNameAndSignature(trMemory(), _stringBufferClass,
+            "toString", "()Ljava/lang/String;");
+        if (method)
+            _toStringSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method,
+                TR::MethodSymbol::Virtual);
     }
 
     if (!_toStringSymRef) {
@@ -1276,19 +1260,11 @@ void TR_FieldPrivatizer::cleanupStringPeephole()
     }
 
     if (!_appendSymRef) {
-        TR_ScratchList<TR_ResolvedMethod> stringBufferMethods(trMemory());
-        comp()->fej9()->getResolvedMethods(trMemory(), _stringBufferClass, &stringBufferMethods);
-        ListIterator<TR_ResolvedMethod> it(&stringBufferMethods);
-        for (TR_ResolvedMethod *method = it.getCurrent(); method; method = it.getNext()) {
-            if ((method->nameLength() == 15) && !strncmp(method->nameChars(), "jitAppendUnsafe", 15)) {
-                char *sig = method->signatureChars();
-                if (!strncmp(sig, "(C)Ljava/lang/StringBuffer;", 27)) {
-                    _appendSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method,
-                        TR::MethodSymbol::Special);
-                    break;
-                }
-            }
-        }
+        TR_ResolvedMethod *method = comp()->fej9()->getResolvedMethodForNameAndSignature(trMemory(), _stringBufferClass,
+            "jitAppendUnsafe", "(C)Ljava/lang/StringBuffer;");
+        if (method)
+            _appendSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, method,
+                TR::MethodSymbol::Special);
 
         TR::TreeTop *currTree = _stringPeepholeTree;
         TR::TreeTop *prevTree = currTree->getPrevTreeTop();

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -4835,21 +4835,25 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
             if (jitHelpersClass && TR::Compiler->cls.isClassInitialized(vp->comp(), jitHelpersClass)) {
                 TR::SymbolReference *hashCodeMethodSymRef = NULL;
                 TR::SymbolReference *getHelpersSymRef = NULL;
-                TR_ScratchList<TR_ResolvedMethod> helperMethods(vp->trMemory());
-                vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &helperMethods);
-                ListIterator<TR_ResolvedMethod> it(&helperMethods);
-                for (TR_ResolvedMethod *m = it.getCurrent(); m; m = it.getNext()) {
-                    char *sig = m->nameChars();
-                    if (!strncmp(sig, "hashCodeImpl", 11)) {
-                        hashCodeMethodSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX,
-                            -1, m, TR::MethodSymbol::Virtual);
-                        hashCodeMethodSymRef->setOffset(
-                            TR::Compiler->cls.vTableSlot(vp->comp(), m->getPersistentIdentifier(), jitHelpersClass));
-                    } else if (!strncmp(sig, "getHelpers", 10)) {
-                        getHelpersSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1,
-                            m, TR::MethodSymbol::Static);
-                    }
+
+                TR_ScratchList<TR_ResolvedMethod> hashCodeMethods(vp->trMemory());
+                vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &hashCodeMethods,
+                    "hashCodeImpl");
+                TR_ResolvedMethod *hashCodeMethod = ListIterator<TR_ResolvedMethod>(&hashCodeMethods).getCurrent();
+                if (hashCodeMethod) {
+                    hashCodeMethodSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1,
+                        hashCodeMethod, TR::MethodSymbol::Virtual);
+                    hashCodeMethodSymRef->setOffset(TR::Compiler->cls.vTableSlot(vp->comp(),
+                        hashCodeMethod->getPersistentIdentifier(), jitHelpersClass));
                 }
+
+                TR_ScratchList<TR_ResolvedMethod> getHelpersMethods(vp->trMemory());
+                vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &getHelpersMethods,
+                    "getHelpers");
+                TR_ResolvedMethod *getHelpersMethod = ListIterator<TR_ResolvedMethod>(&getHelpersMethods).getCurrent();
+                if (getHelpersMethod)
+                    getHelpersSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1,
+                        getHelpersMethod, TR::MethodSymbol::Static);
 
                 if (vp->comp()->getOption(TR_EnableJITHelpershashCodeImpl) && hashCodeMethodSymRef && getHelpersSymRef
                     && performTransformation(vp->comp(), "%sChanging call to new hashCodeImpl at node [%p]\n",

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -689,20 +689,8 @@ static TR_ResolvedMethod *findResolvedClassMethod(TR::Compilation *comp, char *c
     TR_OpaqueClassBlock *classHandle
         = comp->fe()->getClassFromSignature(className, strlen(className), comp->getCurrentMethod());
 
-    if (classHandle) {
-        TR_ScratchList<TR_ResolvedMethod> classMethods(comp->trMemory());
-        comp->fej9()->getResolvedMethods(comp->trMemory(), classHandle, &classMethods);
-
-        ListIterator<TR_ResolvedMethod> it(&classMethods);
-        TR_ResolvedMethod *method;
-        int methodNameLen = strlen(methodName);
-        int methodSigLen = strlen(methodSig);
-        for (method = it.getCurrent(); method; method = it.getNext()) {
-            if (!strncmp(method->nameChars(), methodName, methodNameLen)
-                && !strncmp(method->signatureChars(), methodSig, methodSigLen))
-                return method;
-        }
-    }
+    if (classHandle)
+        return comp->fej9()->getResolvedMethodForNameAndSignature(comp->trMemory(), classHandle, methodName, methodSig);
     return NULL;
 }
 #endif
@@ -3340,17 +3328,11 @@ void OMR::ValuePropagation::transformRTMultiLeafArrayCopy(TR_RealTimeArrayCopy *
         return;
 
     TR_ScratchList<TR_ResolvedMethod> helperMethods(trMemory());
-    comp()->fej9()->getResolvedMethods(trMemory(), helperClass, &helperMethods);
-    ListIterator<TR_ResolvedMethod> it(&helperMethods);
+    comp()->fej9()->getResolvedMethods(trMemory(), helperClass, &helperMethods, "multiLeafArrayCopy");
     TR::SymbolReference *helperSymRef = NULL;
-    for (TR_ResolvedMethod *m = it.getCurrent(); m && !helperSymRef; m = it.getNext()) {
-        char *sig = m->nameChars();
-        logprintf(trace(), log, " sig = %s\n", sig);
-
-        if (!strncmp(sig, "multiLeafArrayCopy", 18))
-            helperSymRef
-                = getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, m, TR::MethodSymbol::Static);
-    }
+    TR_ResolvedMethod *m = ListIterator<TR_ResolvedMethod>(&helperMethods).getCurrent();
+    if (m)
+        helperSymRef = getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, m, TR::MethodSymbol::Static);
 
     logprintf(trace(), log, " helper sym = %p\n", helperSymRef);
     if (!helperSymRef)


### PR DESCRIPTION
Refactors usages of `getResolvedMethods()` in the optimizer to use the 
more targeted APIs introduced in https://github.com/eclipse-openj9/openj9/pull/24088, reducing the number of unnecessary TR_ResolvedMethod allocations.

Issue: https://github.com/eclipse-openj9/openj9/issues/23591
Companion PR: https://github.com/eclipse-openj9/openj9/pull/24088