### PR TITLE
Add setter for OMR::Options::_dontInline

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1827,6 +1827,8 @@ public:
 
     TR::SimpleRegex *getDontInline() { return _dontInline; }
 
+    void setDontInline(TR::SimpleRegex *regex) { _dontInline = regex; }
+
     TR::SimpleRegex *getOnlyInline() { return _onlyInline; }
 
     TR::SimpleRegex *getTryToInline() { return _tryToInline; }


### PR DESCRIPTION
This commit adds a setter method for the Options::_dontInline field so that a third party could easily set a regex. This setter will be used in a downstream project (OpenJ9).