### PR TITLE
Avoid compilation failures with memcpy() and memset()

### DIFF
--- a/compiler/cs2/hashtab.h
+++ b/compiler/cs2/hashtab.h
@@ -833,8 +833,7 @@ CS2_HT_TEMP void inline CS2_HT_DECL::GrowAndRehash(HashIndex oldSize, HashTableE
             if (hashIndex > fHighestIndex)
                 fHighestIndex = hashIndex;
 
-            // Just bitwise copy the old element to the new.
-            memcpy(fTable + hashIndex, oldBase + oldIndex, sizeof(HashTableEntry));
+            fTable[hashIndex] = oldBase[oldIndex];
             fTable[hashIndex].SetCollisionChain(0);
         }
     }
@@ -1002,7 +1001,7 @@ CS2_HT_TEMP void inline CS2_HT_DECL::Remove(HashIndex hashIndex)
         if (collisionChain) {
             HashIndex firstCollision = collisionChain;
 
-            memcpy(fTable + hashIndex, fTable + firstCollision, sizeof(HashTableEntry));
+            fTable[hashIndex] = fTable[firstCollision];
             fTable[firstCollision].SetCollisionChain(fNextFree);
             fTable[firstCollision].Invalidate();
             fNextFree = firstCollision;

--- a/compiler/il/NodePool.cpp
+++ b/compiler/il/NodePool.cpp
@@ -41,8 +41,9 @@ void TR::NodePool::cleanUp() { TR::Region::reset(_nodeRegion, _comp->trMemory()-
 
 TR::Node *TR::NodePool::allocate()
 {
-    TR::Node *newNode = static_cast<TR::Node *>(_nodeRegion.allocate(sizeof(TR::Node)));
-    memset(newNode, 0, sizeof(TR::Node));
+    void *space = _nodeRegion.allocate(sizeof(TR::Node));
+    memset(space, 0, sizeof(TR::Node));
+    TR::Node *newNode = static_cast<TR::Node *>(space);
     newNode->_globalIndex = ++_globalIndex;
     TR_ASSERT(_globalIndex < MAX_NODE_COUNT, "Reached TR::Node allocation limit");
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -231,7 +231,7 @@ OMR::Node::Node(TR::Node *from, uint16_t numChildren)
     , _unionPropertyA()
 {
     TR::Compilation *comp = TR::comp();
-    memcpy(self(), from, sizeof(TR::Node));
+    memcpy(static_cast<void *>(self()), from, sizeof(TR::Node));
     if (self()->hasDataType())
         self()->setDataType(TR::NoType);
 

--- a/compiler/infra/Array.hpp
+++ b/compiler/infra/Array.hpp
@@ -79,14 +79,16 @@ public:
         _zeroInit = zeroInit;
         _trMemory = m;
         _trPersistentMemory = pm;
+        void *space = NULL;
         if (m)
-            _array = (T *)m->allocateMemory(initialSize * sizeof(T), _allocationKind, TR_MemoryBase::Array);
+            space = m->allocateMemory(initialSize * sizeof(T), _allocationKind, TR_MemoryBase::Array);
         else if (pm)
-            _array = (T *)pm->allocatePersistentMemory(initialSize * sizeof(T));
+            space = pm->allocatePersistentMemory(initialSize * sizeof(T));
         else
             TR_ASSERT(false, "Attempting to allocate an array without a memory object");
         if (zeroInit)
-            memset(_array, 0, initialSize * sizeof(T));
+            memset(space, 0, initialSize * sizeof(T));
+        _array = static_cast<T *>(space);
     }
 
     TR_Array(const TR_Array<T> &other) { copy(other); }


### PR DESCRIPTION
This commit changes some memcpy() and memset() calls:

- Change memcpy() to an assignment
- Add a type cast to the destination of memcpy()
- Use a variable of type "void *" as the destination of memset()

to avoid compilation errors with recent Xcode versions.

Co-authored-by: Kevin Grigorenko <kevin.grigorenko@us.ibm.com>