### PR TITLE
Remove canTransformUnsafeSetMemory from OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1696,8 +1696,6 @@ public:
     // J9, X86
     bool canTransformUnsafeCopyToArrayCopy() { return false; }
 
-    bool canTransformUnsafeSetMemory() { return false; }
-
     bool canNullChkBeImplicit(TR::Node *);
     bool canNullChkBeImplicit(TR::Node *, bool doChecks);
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1611,15 +1611,6 @@ bool OMR::Compilation::canTransformUnsafeCopyToArrayCopy()
     return false;
 }
 
-bool OMR::Compilation::canTransformUnsafeSetMemory()
-{
-    if (!self()->getOptions()->realTimeGC() && !TR::Compiler->om.canGenerateArraylets()
-        && !self()->getOption(TR_DisableUnsafe) && self()->cg()->canTransformUnsafeSetMemory())
-        return true;
-
-    return false;
-}
-
 TR_PrefetchInfo *OMR::Compilation::removeExtraPrefetchInfo(TR::Node *node)
 {
     auto iter = self()->getExtraPrefetchInfo().begin();

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1105,7 +1105,6 @@ public:
     int32_t findPrefetchInfo(TR::Node *node);
 
     bool canTransformUnsafeCopyToArrayCopy();
-    bool canTransformUnsafeSetMemory();
 
     bool supportsInduceOSR();
     bool canAffordOSRControlFlow();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -766,8 +766,6 @@ bool OMR::Power::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
     return !comp()->getOption(TR_DisableArrayCopyOpts);
 }
 
-bool OMR::Power::CodeGenerator::canTransformUnsafeSetMemory() { return (comp()->target().is64Bit()); }
-
 void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
 {
     TR_InternalPointerMap *internalPtrMap = NULL;

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -217,7 +217,6 @@ public:
     int32_t getPreferredLoopUnrollFactor();
 
     bool canTransformUnsafeCopyToArrayCopy();
-    bool canTransformUnsafeSetMemory();
 
     bool supportsMergingGuards() { return false; }
 


### PR DESCRIPTION
Equivalent has been moved to OpenJ9 via https://github.com/eclipse-openj9/openj9/pull/24229