### PR TITLE
Remove obsolete reset

### DIFF
--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -343,7 +343,7 @@ public:
 	virtual bool percolateGarbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 	virtual bool garbageCollect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uint32_t gcCode);
 
-	virtual void reset(MM_EnvironmentBase *env = NULL);
+	virtual void reset(MM_EnvironmentBase *env);
 	virtual void rebuildFreeList(MM_EnvironmentBase *env);
 
 	virtual void payAllocationTax(MM_EnvironmentBase *env, MM_MemorySubSpace *baseSubSpace, MM_AllocateDescription *allocDescription);

--- a/gc/base/segregated/SegregatedGC.cpp
+++ b/gc/base/segregated/SegregatedGC.cpp
@@ -175,7 +175,7 @@ MM_SegregatedGC::abortCollection(MM_EnvironmentBase* env, CollectionAbortReason 
 bool
 MM_SegregatedGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription)
 {
-	env->_cycleState->_activeSubSpace->reset();
+	env->_cycleState->_activeSubSpace->reset(env);
 
 	/*
 	 * Marking

--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -639,8 +639,8 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 		}
 
 		/* Reset any free list information */
-		subSpaceAllocate->reset();
-		subSpaceSurvivor->reset();
+		subSpaceAllocate->reset(env);
+		subSpaceSurvivor->reset(env);
 
 		/* Was there any remaining leading free entry not consumed by the contraction? */
 		if(allocateSegmentBase < allocateLeadingFreeTop) {
@@ -823,8 +823,8 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 		Assert_MM_true(_highSemiSpaceRegion->getLowAddress() == _lowSemiSpaceRegion->getHighAddress());
 
 		/* Reset any free list information */
-		subSpaceAllocate->reset();
-		subSpaceSurvivor->reset();
+		subSpaceAllocate->reset(env);
+		subSpaceSurvivor->reset(env);
 
 		/* Was there any remaining leading free entry not consumed by the contraction? */
 		if(allocateSegmentBase < allocateLeadingFreeTop) {
@@ -1284,7 +1284,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::expandNoCheck(MM_EnvironmentBase *env
 		}
 		subSpaceAllocate->addExistingMemory(env, this, splitExpandSize, newLowAddress, _lowAddress, true);
 		
-		subSpaceSurvivor->reset();
+		subSpaceSurvivor->reset(env);
 		subSpaceSurvivor->addExistingMemory(
 			env,
 			this,
@@ -1350,7 +1350,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::expandNoCheck(MM_EnvironmentBase *env
 		}
 		subSpaceAllocate->addExistingMemory(env, this, allocateSpaceExpandSize, _highSemiSpaceRegion->getLowAddress(), previousHighSemiSpaceSegmentBase, true);
 
-		subSpaceSurvivor->reset();
+		subSpaceSurvivor->reset(env);
 		subSpaceSurvivor->addExistingMemory(
 			env,
 			this,


### PR DESCRIPTION
Remove the support for MemorySubSpace reset method with no parameters. Update all caller sites to always pass Environment as a parameter.