### PR TITLE
Always allocate VSX registers for FP-type vectors on POWER

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -434,7 +434,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
         return trgReg;
     } else if (node->getDataType().getVectorElementType() == TR::Float) {
         TR::Register *srcReg = cg->evaluate(child);
-        TR::Register *trgReg = cg->allocateRegister(TR_VRF);
+        TR::Register *trgReg = cg->allocateRegister(TR_VSX_VECTOR);
 
         generateTrg1Src1Instruction(cg, TR::InstOpCode::xscvdpsp, node, trgReg, srcReg);
         generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, trgReg, trgReg, 0);

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -1504,11 +1504,8 @@ static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds
             break;
         case TR_VSX_SCALAR:
         case TR_VSX_VECTOR:
-            instr = generateTrg1Src2Instruction(cg, TR::InstOpCode::xxlor, currentNode, targetReg, sourceReg, sourceReg,
-                precedingInstruction);
-            break;
         case TR_VRF:
-            instr = generateTrg1Src2Instruction(cg, TR::InstOpCode::vor, currentNode, targetReg, sourceReg, sourceReg,
+            instr = generateTrg1Src2Instruction(cg, TR::InstOpCode::xxlor, currentNode, targetReg, sourceReg, sourceReg,
                 precedingInstruction);
             break;
         default:

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -244,8 +244,6 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeG
                     opCode = TR::InstOpCode::fmr;
                     break;
                 case TR_VRF:
-                    opCode = TR::InstOpCode::vor;
-                    break;
                 case TR_VSX_VECTOR:
                     opCode = TR::InstOpCode::xxlor;
                     break;
@@ -269,7 +267,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeG
                     copyReg->setContainsInternalPointer();
                     copyReg->setPinningArrayPointer(reg->getPinningArrayPointer());
                 }
-                if (opCode == TR::InstOpCode::vor || opCode == TR::InstOpCode::xxlor)
+                if (opCode == TR::InstOpCode::xxlor)
                     iCursor = generateTrg1Src2Instruction(cg, opCode, node, copyReg, reg, reg, iCursor);
                 else
                     iCursor = generateTrg1Src1Instruction(cg, opCode, node, copyReg, reg, iCursor);
@@ -290,7 +288,7 @@ OMR::Power::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeG
                     highCopyReg->setContainsInternalPointer();
                     highCopyReg->setPinningArrayPointer(highReg->getPinningArrayPointer());
                 }
-                if (opCode == TR::InstOpCode::vor || opCode == TR::InstOpCode::xxlor)
+                if (opCode == TR::InstOpCode::xxlor)
                     iCursor = generateTrg1Src2Instruction(cg, opCode, node, highCopyReg, highReg, highReg, iCursor);
                 else
                     iCursor = generateTrg1Src1Instruction(cg, opCode, node, highCopyReg, highReg, iCursor);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3534,9 +3534,12 @@ TR::Register *OMR::Power::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::Code
             kind = TR_VRF;
             break;
         case TR::Int32:
-        case TR::Float:
             opcode = TR::InstOpCode::lxvw4x;
             kind = TR_VRF;
+            break;
+        case TR::Float:
+            opcode = TR::InstOpCode::lxvw4x;
+            kind = TR_VSX_VECTOR;
             break;
         case TR::Int64:
             opcode = TR::InstOpCode::lxvd2x;
@@ -3744,7 +3747,12 @@ TR::Register *OMR::Power::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR:
         maskReg = cg->evaluate(secondChild);
     }
 
-    TR::Register *resReg = cg->allocateRegister(TR_VRF);
+    TR::Register *resReg;
+    if (!TR::InstOpCode(op).isVMX())
+        resReg = cg->allocateRegister(TR_VSX_VECTOR);
+    else
+        resReg = cg->allocateRegister(TR_VRF);
+
     node->setRegister(resReg);
     generateTrg1Src1Instruction(cg, op, node, resReg, srcReg);
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -8031,9 +8031,6 @@ TR::Register *OMR::Power::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR
                 move_opcode = TR::InstOpCode::mcrf;
                 break;
             case TR_VRF:
-                move_opcode = TR::InstOpCode::vor;
-                move_with_or = true;
-                break;
             case TR_VSX_SCALAR:
             case TR_VSX_VECTOR:
                 move_opcode = TR::InstOpCode::xxlor;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/24204 with the following changes:

- Allocates VSX registers for any floating-point vector values, to eliminate any compatibility issues that may arise from using VMX registers with VSX instructions.
- Uses the VSX vector "or" instruction, `xxlor`, to copy the contents of one vector register into another, since it is compatible with both VMX and VSX registers and will reduce the likelihood of any assertion failures like the one linked above occurring in the future.