### PR TITLE
AArch64: Implement binary search in lookupEvaluator

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -18,6 +18,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
+// Assisted-by: Claude (Anthropic)
 
 #include "codegen/ARM64ConditionCode.hpp"
 #include "codegen/ARM64HelperCallSnippet.hpp"
@@ -557,6 +558,66 @@ TR::Register *OMR::ARM64::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
     return trgReg;
 }
 
+// BINARY SEARCH IMPLEMENTATION
+static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNode, int32_t lowChild, int32_t highChild,
+    TR::Register *tmpRegister, TR::RegisterDependencyConditions *conditions, TR::CodeGenerator *cg)
+{
+    int32_t numCases = highChild - lowChild + 1;
+    int32_t pivot = lowChild + (numCases / 2) - 1;
+
+    // lower half
+    if (pivot >= lowChild) {
+        int32_t pivotValue = lookupNode->getChild(pivot)->getCaseConstant();
+
+        if (!constantIsUnsignedImm12(pivotValue)) {
+            loadConstant32(cg, lookupNode, pivotValue, tmpRegister);
+            generateCompareInstruction(cg, lookupNode, selectorReg, tmpRegister);
+        } else {
+            generateCompareImmInstruction(cg, lookupNode, selectorReg, pivotValue);
+        }
+
+        int32_t lowVal = lookupNode->getChild(lowChild)->getCaseConstant();
+        int32_t highVal = lookupNode->getChild(highChild)->getCaseConstant();
+        // Use unsigned comparison (CC_HI) if cases straddle the signed/unsigned boundary
+        // (highVal < lowVal in signed terms), otherwise use signed comparison (CC_GT)
+        TR::ARM64ConditionCode branchCond = (highVal < lowVal) ? TR::CC_HI : TR::CC_GT;
+
+        TR::LabelSymbol *upperLabel = generateLabelSymbol(cg);
+        generateConditionalBranchInstruction(cg, lookupNode, upperLabel, branchCond);
+
+        if (lowChild == pivot) {
+            generateConditionalBranchInstruction(cg, lookupNode,
+                lookupNode->getChild(lowChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
+
+            // default case
+            generateLabelInstruction(cg, TR::InstOpCode::b, lookupNode,
+                lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
+        } else {
+            binarySearchCaseSpace(selectorReg, lookupNode, lowChild, pivot, tmpRegister, conditions, cg);
+        }
+        generateLabelInstruction(cg, TR::InstOpCode::label, lookupNode, upperLabel);
+    }
+
+    // upper half
+    if (highChild == pivot + 1) {
+        int32_t highValue = lookupNode->getChild(highChild)->getCaseConstant();
+        if (!constantIsUnsignedImm12(highValue)) {
+            loadConstant32(cg, lookupNode, highValue, tmpRegister);
+            generateCompareInstruction(cg, lookupNode, selectorReg, tmpRegister);
+        } else {
+            generateCompareImmInstruction(cg, lookupNode, selectorReg, highValue);
+        }
+        generateConditionalBranchInstruction(cg, lookupNode,
+            lookupNode->getChild(highChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
+
+        // default case
+        generateLabelInstruction(cg, TR::InstOpCode::b, lookupNode,
+            lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
+    } else {
+        binarySearchCaseSpace(selectorReg, lookupNode, pivot + 1, highChild, tmpRegister, conditions, cg);
+    }
+}
+
 TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     int32_t numChildren = node->getNumChildren();
@@ -578,35 +639,40 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
 
     OMR::SwitchCaseOrdering *ordering = cg->sortSwitchCases(node);
 
-    for (int32_t i = 2; i < numChildren; i++) {
-        TR::Node *child = node->getChild(ordering[i].index);
-        int32_t caseValue = child->getCaseConstant();
+    static const char *binaryLookup = feGetEnv("TR_BINARY_LOOKUP");
+    if (binaryLookup != NULL) {
+        binarySearchCaseSpace(selectorReg, node, 2, numChildren - 1, tmpRegister, conditions, cg);
+    } else {
+        for (int32_t i = 2; i < numChildren; i++) {
+            TR::Node *child = node->getChild(ordering[i].index);
+            int32_t caseValue = child->getCaseConstant();
 
-        if (!constantIsUnsignedImm12(caseValue)) {
-            loadConstant32(cg, node, caseValue, tmpRegister);
-            generateCompareInstruction(cg, node, selectorReg, tmpRegister);
-        } else {
-            generateCompareImmInstruction(cg, node, selectorReg, caseValue);
+            if (!constantIsUnsignedImm12(caseValue)) {
+                loadConstant32(cg, node, caseValue, tmpRegister);
+                generateCompareInstruction(cg, node, selectorReg, tmpRegister);
+            } else {
+                generateCompareImmInstruction(cg, node, selectorReg, caseValue);
+            }
+
+            TR::RegisterDependencyConditions *cond = conditions;
+            if (child->getNumChildren() > 0) {
+                // GRA
+                cg->evaluate(child->getFirstChild());
+                cond = cond->clone(cg, RegDeps(cg, child->getFirstChild(), 0));
+            }
+            generateConditionalBranchInstruction(cg, node, child->getBranchDestination()->getNode()->getLabel(),
+                TR::CC_EQ, cond);
         }
 
-        TR::RegisterDependencyConditions *cond = conditions;
-        if (child->getNumChildren() > 0) {
+        // Branch to default
+        if (defaultChild->getNumChildren() > 0) {
             // GRA
-            cg->evaluate(child->getFirstChild());
-            cond = cond->clone(cg, RegDeps(cg, child->getFirstChild(), 0));
+            cg->evaluate(defaultChild->getFirstChild());
+            conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
         }
-        generateConditionalBranchInstruction(cg, node, child->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ,
-            cond);
+        generateLabelInstruction(cg, TR::InstOpCode::b, node,
+            defaultChild->getBranchDestination()->getNode()->getLabel(), conditions);
     }
-
-    // Branch to default
-    if (defaultChild->getNumChildren() > 0) {
-        // GRA
-        cg->evaluate(defaultChild->getFirstChild());
-        conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
-    }
-    generateLabelInstruction(cg, TR::InstOpCode::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
-        conditions);
 
     if (tmpRegister) {
         cg->stopUsingRegister(tmpRegister);

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -47,6 +47,7 @@ omr_add_executable(comptest NOWARNINGS
 	VectorTestUtils.cpp
 	CallTest.cpp
 	LongAndAsRotateTest.cpp
+	LookupTest.cpp
 	MockStrategyTest.cpp
 	LogicalTest.cpp
 	LinkageTest.cpp

--- a/fvtest/compilertriltest/LookupTest.cpp
+++ b/fvtest/compilertriltest/LookupTest.cpp
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+// Assisted-by: IBM Bob
+
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+
+class LookupTest : public TRTest::JitTest {};
+
+TEST_F(LookupTest, Lookup5Cases) {
+  // Test function that returns different values based on input
+  // Case 10 -> return 100
+  // Case 20 -> return 200
+  // Case 30 -> return 300
+  // Case 40 -> return 400
+  // Case 50 -> return 500
+  // Default -> return -1
+
+  auto inputTrees = "(method return=Int32 args=[Int32]"
+                    "  (block name=\"entry\""
+                    "    (lookup"
+                    "      (iload parm=0)"
+                    "      (case target=\"default\")"
+                    "      (case value=10 target=\"case10\")"
+                    "      (case value=20 target=\"case20\")"
+                    "      (case value=30 target=\"case30\")"
+                    "      (case value=40 target=\"case40\")"
+                    "      (case value=50 target=\"case50\")))"
+                    "  (block name=\"case10\""
+                    "    (ireturn (iconst 100)))"
+                    "  (block name=\"case20\""
+                    "    (ireturn (iconst 200)))"
+                    "  (block name=\"case30\""
+                    "    (ireturn (iconst 300)))"
+                    "  (block name=\"case40\""
+                    "    (ireturn (iconst 400)))"
+                    "  (block name=\"case50\""
+                    "    (ireturn (iconst 500)))"
+                    "  (block name=\"default\""
+                    "    (ireturn (iconst -1))))";
+
+  auto trees = parseString(inputTrees);
+  ASSERT_NOTNULL(trees);
+
+  Tril::DefaultCompiler compiler(trees);
+  ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n"
+                                   << "Input trees: " << inputTrees;
+
+  auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+  // Test each case
+  EXPECT_EQ(100, entry_point(10));
+  EXPECT_EQ(200, entry_point(20));
+  EXPECT_EQ(300, entry_point(30));
+  EXPECT_EQ(400, entry_point(40));
+  EXPECT_EQ(500, entry_point(50));
+
+  // Test default case
+  EXPECT_EQ(-1, entry_point(0));
+  EXPECT_EQ(-1, entry_point(15));
+  EXPECT_EQ(-1, entry_point(100));
+  EXPECT_EQ(-1, entry_point(-5));
+}
+
+TEST_F(LookupTest, LookupWithNegativeValues) {
+  // Test with negative case values
+  auto inputTrees = "(method return=Int32 args=[Int32]"
+                    "  (block name=\"entry\""
+                    "    (lookup"
+                    "      (iload parm=0)"
+                    "      (case target=\"default\")"
+                    "      (case value=-10 target=\"caseNeg10\")"
+                    "      (case value=0 target=\"case0\")"
+                    "      (case value=10 target=\"case10\")))"
+                    "  (block name=\"caseNeg10\""
+                    "    (ireturn (iconst -100)))"
+                    "  (block name=\"case0\""
+                    "    (ireturn (iconst 0)))"
+                    "  (block name=\"case10\""
+                    "    (ireturn (iconst 100)))"
+                    "  (block name=\"default\""
+                    "    (ireturn (iconst -1))))";
+
+  auto trees = parseString(inputTrees);
+  ASSERT_NOTNULL(trees);
+
+  Tril::DefaultCompiler compiler(trees);
+  ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n"
+                                   << "Input trees: " << inputTrees;
+
+  auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+  EXPECT_EQ(-100, entry_point(-10));
+  EXPECT_EQ(0, entry_point(0));
+  EXPECT_EQ(100, entry_point(10));
+  EXPECT_EQ(-1, entry_point(5));
+  EXPECT_EQ(-1, entry_point(-5));
+}
+
+TEST_F(LookupTest, LookupSparseValues) {
+  // Test with sparse case values (good for binary search)
+  auto inputTrees = "(method return=Int32 args=[Int32]"
+                    "  (block name=\"entry\""
+                    "    (lookup"
+                    "      (iload parm=0)"
+                    "      (case target=\"default\")"
+                    "      (case value=5 target=\"case5\")"
+                    "      (case value=100 target=\"case100\")"
+                    "      (case value=500 target=\"case500\")"
+                    "      (case value=1000 target=\"case1000\")"
+                    "      (case value=5000 target=\"case5000\")))"
+                    "  (block name=\"case5\""
+                    "    (ireturn (iconst 1)))"
+                    "  (block name=\"case100\""
+                    "    (ireturn (iconst 2)))"
+                    "  (block name=\"case500\""
+                    "    (ireturn (iconst 3)))"
+                    "  (block name=\"case1000\""
+                    "    (ireturn (iconst 4)))"
+                    "  (block name=\"case5000\""
+                    "    (ireturn (iconst 5)))"
+                    "  (block name=\"default\""
+                    "    (ireturn (iconst 0))))";
+
+  auto trees = parseString(inputTrees);
+  ASSERT_NOTNULL(trees);
+
+  Tril::DefaultCompiler compiler(trees);
+  ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n"
+                                   << "Input trees: " << inputTrees;
+
+  auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+  EXPECT_EQ(1, entry_point(5));
+  EXPECT_EQ(2, entry_point(100));
+  EXPECT_EQ(3, entry_point(500));
+  EXPECT_EQ(4, entry_point(1000));
+  EXPECT_EQ(5, entry_point(5000));
+  EXPECT_EQ(0, entry_point(50));
+  EXPECT_EQ(0, entry_point(2000));
+}
+
+TEST_F(LookupTest, LookupSingleCase) {
+  // Test with just one case (edge case)
+  auto inputTrees = "(method return=Int32 args=[Int32]"
+                    "  (block name=\"entry\""
+                    "    (lookup"
+                    "      (iload parm=0)"
+                    "      (case target=\"default\")"
+                    "      (case value=42 target=\"case42\")))"
+                    "  (block name=\"case42\""
+                    "    (ireturn (iconst 1)))"
+                    "  (block name=\"default\""
+                    "    (ireturn (iconst 0))))";
+
+  auto trees = parseString(inputTrees);
+  ASSERT_NOTNULL(trees);
+
+  Tril::DefaultCompiler compiler(trees);
+  ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n"
+                                   << "Input trees: " << inputTrees;
+
+  auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+  EXPECT_EQ(1, entry_point(42));
+  EXPECT_EQ(0, entry_point(0));
+  EXPECT_EQ(0, entry_point(41));
+  EXPECT_EQ(0, entry_point(43));
+}
+
+TEST_F(LookupTest, LookupWithComputation) {
+  // Test lookup with a computed selector value
+  auto inputTrees = "(method return=Int32 args=[Int32]"
+                    "  (block name=\"entry\""
+                    "    (lookup"
+                    "      (imul"
+                    "        (iload parm=0)"
+                    "        (iconst 10))"
+                    "      (case target=\"default\")"
+                    "      (case value=10 target=\"case10\")"
+                    "      (case value=20 target=\"case20\")"
+                    "      (case value=30 target=\"case30\")))"
+                    "  (block name=\"case10\""
+                    "    (ireturn (iconst 100)))"
+                    "  (block name=\"case20\""
+                    "    (ireturn (iconst 200)))"
+                    "  (block name=\"case30\""
+                    "    (ireturn (iconst 300)))"
+                    "  (block name=\"default\""
+                    "    (ireturn (iconst -1))))";
+
+  auto trees = parseString(inputTrees);
+  ASSERT_NOTNULL(trees);
+
+  Tril::DefaultCompiler compiler(trees);
+  ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n"
+                                   << "Input trees: " << inputTrees;
+
+  auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+  // Input 1 * 10 = 10 -> case10
+  EXPECT_EQ(100, entry_point(1));
+  // Input 2 * 10 = 20 -> case20
+  EXPECT_EQ(200, entry_point(2));
+  // Input 3 * 10 = 30 -> case30
+  EXPECT_EQ(300, entry_point(3));
+  // Input 4 * 10 = 40 -> default
+  EXPECT_EQ(-1, entry_point(4));
+}

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -35,6 +35,7 @@ omr_add_library(tril NOWARNINGS STATIC
 	parser.cpp
 	ilgen.cpp
 	CallConverter.cpp
+	CaseNodeConverter.cpp
 	GenericNodeConverter.cpp
 	simple_compiler.cpp
 )

--- a/fvtest/tril/tril/CaseNodeConverter.cpp
+++ b/fvtest/tril/tril/CaseNodeConverter.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+// Assisted-by: IBM Bob
+
+#include "CaseNodeConverter.hpp"
+#include "ilgen.hpp"
+#include "ras/Logger.hpp"
+
+namespace Tril {
+
+TR::Node *CaseNodeConverter::impl(const ASTNode *tree, IlGenState *state)
+{
+    // Check if this is a case node
+    if (strcmp("case", tree->getName()) != 0) {
+        return NULL;
+    }
+
+    TraceIL("Creating case node from ASTNode %p\n", tree);
+
+    // Get the target block
+    const auto targetArg = tree->getArgByName("target");
+    if (targetArg == NULL) {
+        TraceIL("  case node missing required 'target' argument\n");
+        throw CaseNodeGenError("case node missing required 'target' argument");
+    }
+
+    const auto targetName = targetArg->getValue()->getString();
+    auto targetId = state->findBlockByName(targetName);
+    auto targetEntry = state->blocks()[targetId]->getEntry();
+    TraceIL("  case target block %d (\"%s\", entry = %p)\n", targetId, targetName, targetEntry);
+
+    // Check if this is a case with a value (not default)
+    const auto valueArg = tree->getArgByName("value");
+    if (valueArg != NULL) {
+        // This is a regular case with a constant value
+        int32_t caseValue = valueArg->getValue()->get<int32_t>();
+        TR::Node *node = TR::Node::createCase(0, targetEntry, caseValue);
+        TraceIL("  created case node with value %d\n", caseValue);
+        return node;
+    } else {
+        // This is the default case - case constant of 0 for default
+        TR::Node *node = TR::Node::createCase(0, targetEntry, 0);
+        TraceIL("  created default case node\n", "");
+        return node;
+    }
+}
+
+} // namespace Tril

--- a/fvtest/tril/tril/CaseNodeConverter.hpp
+++ b/fvtest/tril/tril/CaseNodeConverter.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+// Assisted-by: IBM Bob
+
+#ifndef CASENODECONVERTER_HPP
+#define CASENODECONVERTER_HPP
+
+#include "converter.hpp"
+
+namespace Tril {
+
+class CaseNodeConverter: public ASTToTRNode {
+    public:
+        /**
+         * @brief Constructs an instance of Tril::CaseNodeConverter
+         * @param next is the next object that gets a chance to convert the AST node if the current one fails
+         */
+        explicit CaseNodeConverter(ASTToTRNode* next = NULL) : ASTToTRNode(next) {}
+
+    protected:
+        /**
+         * @brief Generates the TR::Node for case nodes used in lookup switches
+         * @param tree the AST structure
+         * @param state the object that encapsulating the IL generator state
+         * @return TR::Node represented by the AST
+         */
+        TR::Node* impl(const ASTNode* tree, IlGenState* state); /* override */
+};
+
+class CaseNodeGenError : public ILGenError {
+    public:
+        explicit CaseNodeGenError(std::string message): ILGenError(message) {}
+};
+
+}
+#endif

--- a/fvtest/tril/tril/GenericNodeConverter.cpp
+++ b/fvtest/tril/tril/GenericNodeConverter.cpp
@@ -168,6 +168,10 @@ TR::Node *GenericNodeConverter::impl(const ASTNode *tree, IlGenState *state)
         TraceIL("  is branch to target block %d (%s, entry = %p", targetId, targetName, targetEntry);
         node = TR::Node::create(opcode.getOpCodeValue(), childCount);
         node->setBranchDestination(targetEntry);
+    } else if (opcode.getOpCodeValue() == TR::lookup) {
+        TraceIL("  is lookup switch with %d children\n", childCount);
+        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+        // Branch destinations for case children will be set when child nodes are created
     } else {
         TraceIL("  unrecognized opcode; using default creation mechanism\n", "");
         node = TR::Node::create(opcode.getOpCodeValue(), childCount);

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -94,7 +94,10 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode * const tree, IlGenState *state)
     // visit the children first
     const ASTNode *t = tree->getChildren();
     while (t) {
-        isFallthroughNeeded = isFallthroughNeeded && cfgFor(t, state);
+        // Don't recurse into case nodes - lookup handles them directly
+        if (strcmp(t->getName(), "case") != 0) {
+            isFallthroughNeeded = isFallthroughNeeded && cfgFor(t, state);
+        }
         t = t->next;
     }
 
@@ -111,6 +114,23 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode * const tree, IlGenState *state)
         isFallthroughNeeded = isFallthroughNeeded && opcode.isIf();
         TraceIL("Added CFG edge from block %d to block %d (\"%s\") -> %s\n", _currentBlockNumber, targetId, targetName,
             tree->getName());
+    } else if (opcode.getOpCodeValue() == TR::lookup) {
+        // Add CFG edges for all case destinations.
+        // Child 0 is the selector; children 1+ are case nodes with targets.
+        const ASTNode *childTree = tree->getChildren();
+        if (childTree)
+            childTree = childTree->next;
+        while (childTree) {
+            if (childTree->getArgByName("target")) {
+                const auto caseTargetName = childTree->getArgByName("target")->getValue()->getString();
+                auto caseTargetId = state->findBlockByName(caseTargetName);
+                cfg()->addEdge(_currentBlock, _blocks[caseTargetId]);
+                TraceIL("Added CFG edge from block %d to block %d (\"%s\") -> lookup case\n", _currentBlockNumber,
+                    caseTargetId, caseTargetName);
+            }
+            childTree = childTree->next;
+        }
+        isFallthroughNeeded = false;
     }
 
     if (!isFallthroughNeeded) {

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -21,6 +21,7 @@
 
 #include "simple_compiler.hpp"
 #include "CallConverter.hpp"
+#include "CaseNodeConverter.hpp"
 #include "GenericNodeConverter.hpp"
 
 #include "env/jittypes.h"
@@ -50,7 +51,8 @@ int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     auto methodInfo = getMethodInfo();
     TR::TypeDictionary types;
     GenericNodeConverter genericNodeConverter;
-    CallConverter callConverter(&genericNodeConverter);
+    CaseNodeConverter caseNodeConverter(&genericNodeConverter);
+    CallConverter callConverter(&caseNodeConverter);
     Tril::TRLangBuilder ilgenerator(methodInfo.getBodyAST(), &types, &callConverter);
 
     // get a list of the method's argument types and transform it


### PR DESCRIPTION
## Summary
Implements binary search in `lookupEvaluator()` for AArch64 to replace 
the existing naive O(n) linear scan with an O(log n) binary search, 
consistent with the x86 implementation.

## Changes
- Added `binarySearchCaseSpace()` recursive helper function
- Updated `lookupEvaluator()` to call it instead of the linear loop
- Fixes the large immediate bug from abandoned PR #4233 by using 
  `loadConstant32` + `generateCompareInstruction` for values > 4095

## Open questions
- GRA handling — the original code had GlRegDeps evaluation interleaved 
  with comparisons, not yet included in binary search implementation
- Internal control flow markers (`setStartInternalControlFlow` / 
  `setEndInternalControlFlow`) — x86 has these, we don't yet
- Tril test still needs to be written

## Testing
- Build passes on AArch64 (macOS M2)
- All 30 existing tests pass
- Tril test for lookupSwitch pending


/cc @rahilshah @knn-k