### PR TITLE
fix(port): validate path length in win32 omrfile_findfirst()

### DIFF
--- a/port/win32/omrfile.c
+++ b/port/win32/omrfile.c
@@ -343,6 +343,11 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 
 	Trc_PRT_file_findfirst_Entry2(path, resultbuf);
 
+	if (strlen(path) >= EsMaxPath) {
+		Trc_PRT_file_findfirst_ExitFail(-1);
+		return (uintptr_t)-1;
+	}
+
 	strcpy(newPath, path);
 	strcat(newPath, "*");
 


### PR DESCRIPTION
## Problem

In `omrfile_findfirst()` (port/win32/omrfile.c), the caller-supplied path is copied into a fixed-size stack buffer `newPath[EsMaxPath + 1]` using `strcpy()`, then `"*"` is appended with `strcat()`.

- If `strlen(path) == EsMaxPath`, `strcpy` fills the buffer completely (1024 chars + NUL = 1025 bytes), then `strcat` writes `"*" + NUL` past the end → **stack buffer overflow**.
- If `strlen(path) > EsMaxPath`, `strcpy` itself overflows before the append.

## Fix

Added a length check before the copy: if `strlen(path) >= EsMaxPath`, the function returns `-1` (failure) early, preventing the overflow.

## Testing

Manual review: the fix ensures the buffer always has room for both the path and the trailing `"*" + NUL`.

Fixes #8173