### PR TITLE
Fix z/OS CPU usage error handling in retrieveZosCpuUsageStats

### DIFF
--- a/port/zos390/omrsysinfo_helpers.c
+++ b/port/zos390/omrsysinfo_helpers.c
@@ -361,6 +361,7 @@ calculateZosProcessCpuUtilization(struct OMRPortLibrary *portLibrary, struct Cpu
 int32_t
 retrieveZosCpuUsageStats(struct OMRPortLibrary *portLibrary, struct CpuUsageStats *usageStats)
 {
+	int32_t result = -1;
 	/* Read ccvutils. */
 	J9CVT * __ptr32 cvtp = ((J9PSA *)0)->flccvt;
 	J9RMCT * __ptr32 rcmtp = cvtp->cvtopctp;
@@ -395,5 +396,10 @@ retrieveZosCpuUsageStats(struct OMRPortLibrary *portLibrary, struct CpuUsageStat
 	/* Get CPU usage for current process. Also writes oldest and latest CPU time
 	 * to usageStats struct for manual calculation if needed.
 	 */
-	return calculateZosProcessCpuUtilization(portLibrary, usageStats);
+	result = calculateZosProcessCpuUtilization(portLibrary, usageStats);
+	if (0 != result) {
+		usageStats->perProcessUtilization = result;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Allow callers to access successfully populated CPU time fields even when calculateZosProcessCpuUtilization returns an error code.

The first call to calculateZosProcessCpuUtilization always returns OMRPORT_ERROR_INSUFFICIENT_DATA since it needs two data points to calculate CPU utilization. This is expected behavior when printing CPU counts at the top of the JIT verbose log.

Store the error code in perProcessUtilization and return 0, allowing callers to access other populated fields while detecting errors.