### PR TITLE
Fix lookup peeloff using wrong opCode

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3680,7 +3680,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
             loadConstant(cg, node, caseConst, highRegister);
             generateTrg1Src2Instruction(cg, cmp_opcode, node, cndRegister, selector, highRegister);
         } else {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, cndRegister, selector, caseConst);
+            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, cndRegister, selector, caseConst);
         }
         generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node,
             hotChild->getBranchDestination()->getNode()->getLabel(), cndRegister);
@@ -3695,7 +3695,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
                 loadConstant(cg, node, caseConst, highRegister);
                 generateTrg1Src2Instruction(cg, cmp_opcode, node, cndRegister, selector, highRegister);
             } else {
-                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, cndRegister, selector, caseConst);
+                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, cndRegister, selector, caseConst);
             }
             generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node,
                 hotChild->getBranchDestination()->getNode()->getLabel(), cndRegister);


### PR DESCRIPTION
The constant case value was tested for signed value ranges, but logical compare opcode was used for it. That is certainly inappropriate, since the constant can overflow the immediate field limits from logical perspective.