### PR TITLE
Add "disableRuntimeAssumptionDataDisclaiming" JIT option

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -855,6 +855,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
      "M\tDisable retrying code cache allocation when kind cannot be respected", SET_OPTION_BIT(TR_DisableRetryCodeCacheAllocAndIgnoreKind), "F", NOT_IN_SUBSET },
     { "disableRMODE64", "O\tDisable residence mode of compiled bodies on z/OS to reside above the 2-gigabyte bar",
      RESET_OPTION_BIT(TR_EnableRMODE64), "F" },
+    { "disableRuntimeAssumptionDataDisclaiming",
+     "M\tdisable memory disclaiming for Runtime Assumption memory segments (linux specific).", SET_OPTION_BIT(TR_DisableRuntimeAssumptionDataDisclaiming), "F", NOT_IN_SUBSET },
     { "disableRXusage", "O\tdisable increased usage of RX instructions", SET_OPTION_BIT(TR_DisableRXusage), "F" },
     { "disableSamplingJProfiling", "O\tDisable profiling in the jitted code",
      SET_OPTION_BIT(TR_DisableSamplingJProfiling), "F" },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -406,7 +406,7 @@ enum TR_CompilationOptions {
     TR_DisableNoServerDuringStartup                           = 0x04000000 + 9, // set TR_NoOptServer during startup and insert GCR trees
     TR_BreakOnNew                                             = 0x08000000 + 9,
     TR_DisableInliningUnrecognizedIntrinsics                  = 0x10000000 + 9,
-    // Available                                              = 0x20000000 + 9,
+    TR_DisableRuntimeAssumptionDataDisclaiming                = 0x20000000 + 9,
     TR_MoveOOLInstructionsToWarmCode                          = 0x40000000 + 9,
     TR_MoveSnippetsToWarmCode                                 = 0x80000000 + 9,
 


### PR DESCRIPTION
This commit adds a new option:
`-Xjit:disableRuntimeAssumptionDataDisclaiming`, which will be used later in a downstream project (openj9).
The new option is not available in a subset.