### PR TITLE
AArch64: Remove deprecated function for RegisterDependencyCondition

### DIFF
--- a/compiler/aarch64/codegen/RegisterDependency.hpp
+++ b/compiler/aarch64/codegen/RegisterDependency.hpp
@@ -71,22 +71,4 @@ inline TR::RegisterDependencyConditions *RegDeps(uint32_t numPreConds, uint32_t 
     return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numPreConds, numPostConds, cg->trMemory());
 }
 
-/**
- * @brief Generates RegisterDependencyConditions
- * @param[in] cg : CodeGenerator object
- * @param[in] node : node
- * @param[in] extranum : additional # of conditions
- * @param[in] cursorPtr : instruction cursor
- * @return generated RegisterDependencyConditions
- *
- * THE USE OF THE generateRegisterDependencyConditions() FUNCTIONS IS
- * DEPRECATED IN FAVOUR OF THE MORE CONCISE RegDeps() FORMS AND SHOULD NOT BE
- * USED. THESE DEPRECATED FORMS WILL BE REMOVED IN A FUTURE OMR RELEASE.
- */
-inline TR::RegisterDependencyConditions *generateRegisterDependencyConditions(TR::CodeGenerator *cg, TR::Node *node,
-    uint32_t extranum, TR::Instruction **cursorPtr = NULL)
-{
-    return RegDeps(cg, node, extranum, cursorPtr);
-}
-
 #endif


### PR DESCRIPTION
This commit removes the function generateRegisterDependencyConditions() for AArch64, which is no longer in use.
PR #8243 has replaced it by RegDeps().