### PR TITLE
Use allocateRAPersistentMemory() to allocate runtime assumptions in omr

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -310,8 +310,13 @@ OMR::Compilation::Compilation(int32_t id, OMR_VMThread *omrVMThread, TR_FrontEnd
     // while the PersistentMethodInfo is allocated during codegen creation
     // Access to this list must be performed with assumptionTableMutex in hand
     //
-    if (!options.getOption(TR_DisableFastAssumptionReclamation))
-        _metadataAssumptionList = new (m->trPersistentMemory()) TR::SentinelRuntimeAssumption();
+    if (!options.getOption(TR_DisableFastAssumptionReclamation)) {
+        void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR::SentinelRuntimeAssumption));
+        if (mem == NULL)
+            self()->failCompilation<TR::CompilationException>(
+                "Cannot allocate persistent memory for Runtime Assumption");
+        _metadataAssumptionList = ::new (mem) TR::SentinelRuntimeAssumption();
+    }
 #endif
 
     // Random fields must be set before allocating codegen


### PR DESCRIPTION
Before this commit, runtime assumptions were allocated using global JIT persistent memory.
This commit uses a special function for allocating runtime assumptions: `TR_RuntimeAssumptionTable::allocateRAPersistentMemory(size)` At the moment this special function still uses the global JIT persistent allocator, but in the future it can be made to use a dedicated alocator which enables us to implement memory disclaiming for runtime assumptions.