### PR TITLE
Remove MMINLINE annotation flagged as impossible to satisfy by gcc 16

### DIFF
--- a/gc/base/MemorySubSpaceGenerational.hpp
+++ b/gc/base/MemorySubSpaceGenerational.hpp
@@ -107,7 +107,7 @@ public:
 
 	virtual uintptr_t releaseFreeMemoryPages(MM_EnvironmentBase* env, uintptr_t memoryType);
 
-	virtual MMINLINE uintptr_t getContractionSize() const { return _memorySubSpaceOld->getContractionSize(); }
+	virtual uintptr_t getContractionSize() const { return _memorySubSpaceOld->getContractionSize(); }
 
 	/**
 	 * Create a MemorySubSpaceGenerational object.


### PR DESCRIPTION
The call is potentially recursive and so cannot always be inlined.

Using gcc 16 to build openj9 leads to a (fatal) warning:
```
In file included from jdk/omr/gc/base/MemorySubSpaceGenerational.cpp:31:
In member function ‘virtual uintptr_t MM_MemorySubSpaceGenerational::getContractionSize() const’,
    inlined from ‘virtual uintptr_t MM_MemorySubSpaceGenerational::getContractionSize() const’ at jdk/omr/gc/base/MemorySubSpaceGenerational.hpp:110:103:
jdk/omr/gc/base/MemorySubSpaceGenerational.hpp:110:36: error: inlining failed in call to ‘always_inline’ ‘virtual uintptr_t MM_MemorySubSpaceGenerational::getContractionSize() const’: recursive inlining
  110 |         virtual MMINLINE uintptr_t getContractionSize() const { return _memorySubSpaceOld->getContractionSize(); }
      |                                    ^~~~~~~~~~~~~~~~~~
jdk/omr/gc/base/MemorySubSpaceGenerational.hpp:110:110: note: called from here
  110 |         virtual MMINLINE uintptr_t getContractionSize() const { return _memorySubSpaceOld->getContractionSize(); }
      |                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```