### PR TITLE
x86 MemoryReference cleanup and readability enhancements

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1328,9 +1328,6 @@ public:
 
     TR::RegisterIterator *setVMRegisterIterator(TR::RegisterIterator *iter) { return (_vmRegisterIterator = iter); }
 
-    // X86 only
-    uint32_t estimateBinaryLength(TR::MemoryReference *) { return 0; }
-
     void dumpDataSnippets(OMR::Logger *log) {}
 
     // --------------------------------------------------------------------------

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -261,36 +261,49 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t next
     TR::CodeGenerator *cg)
 {
     TR::SymbolReference &sr = getSymbolReference();
+    TR::Symbol *sym = sr.getSymbol();
     intptr_t displacement = getDisplacement();
 
     if (_forceRIPRelative) {
         return false;
-    } else if (sr.getSymbol() != NULL && sr.isUnresolved()) {
-        return sr.getSymbol()->isShadow() ? false : true;
-    } else if (_baseRegister || _indexRegister)
+    } else if (sym && sr.isUnresolved()) {
+        return sym->isShadow() ? false : true;
+    } else if (_baseRegister || _indexRegister) {
         return !IS_32BIT_SIGNED(displacement);
-    else if (cg->needClassAndMethodPointerRelocations())
+    }
+
+    // At this point, the memory reference is known not to have a base or index register.
+    // The remaining logic determines how to interpret the displacement.
+    //
+    if (cg->needClassAndMethodPointerRelocations()) {
         return true;
-    else if (sr.getSymbol() && sr.getSymbol()->isRecompilationCounter() && cg->needRelocationsForBodyInfoData())
-        return true;
-    else if (sr.getSymbol() && sr.getSymbol()->isCountForRecompile() && cg->needRelocationsForPersistentInfoData())
-        return true;
-    else if (sr.getSymbol() && (sr.getSymbol()->isBlockFrequency() || sr.getSymbol()->isRecompQueuedFlag())
-        && cg->needRelocationsForPersistentProfileInfoData())
-        return true;
-    else if (sr.getSymbol() && sr.getSymbol()->isCatchBlockCounter() && cg->needRelocationsForBodyInfoData())
-        return true;
-    else if (cg->comp()->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject())
-        return true; // If a class gets replaced, it may no longer fit in an immediate
-    else if (IS_32BIT_SIGNED(displacement))
+    }
+
+    if (sym) {
+        if (sym->isRecompilationCounter() && cg->needRelocationsForBodyInfoData()) {
+            return true;
+        } else if (sym->isCountForRecompile() && cg->needRelocationsForPersistentInfoData()) {
+            return true;
+        } else if ((sym->isBlockFrequency() || sym->isRecompQueuedFlag())
+            && cg->needRelocationsForPersistentProfileInfoData()) {
+            return true;
+        } else if (sym->isCatchBlockCounter() && cg->needRelocationsForBodyInfoData()) {
+            return true;
+        } else if (cg->comp()->getOption(TR_EnableHCR) && sym->isClassObject()) {
+            return true; // If a class gets replaced, it may no longer fit in an immediate
+        }
+    }
+
+    if (IS_32BIT_SIGNED(displacement)) {
         return false;
-    else if (cg->comp()->isOutOfProcessCompilation() && sr.getSymbol() && sr.getSymbol()->isStatic()
-        && !sr.getSymbol()->isStaticAddressWithinMethodBounds())
+    } else if (cg->comp()->isOutOfProcessCompilation() && sym && sym->isStatic()
+        && !sym->isStaticAddressWithinMethodBounds()) {
         return true;
-    else if (IS_32BIT_RIP(displacement, nextInstructionAddress))
+    } else if (IS_32BIT_RIP(displacement, nextInstructionAddress)) {
         return false;
-    else
+    } else {
         return true;
+    }
 }
 
 void OMR::X86::AMD64::MemoryReference::assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg)
@@ -503,6 +516,12 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
             "malformed memory reference for RIP-relative addressing");
     }
 
+    if (getDataSnippet() || getLabel()) {
+        // The inherited logic has a special case for RIP-based ConstantDataSnippet and label references.
+        //
+        return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
+    }
+
     // If a RIP relative addressing mode might be used, compute the address of the next
     // instruction based on where the modRM byte is
     //
@@ -513,11 +532,7 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
     //
     intptr_t nextInstructionAddress = (intptr_t)(modRM + 5) + containingInstruction->getOpCode().info().ImmediateSize();
 
-    if (getDataSnippet() || getLabel()) {
-        // The inherited logic has a special case for RIP-based ConstantDataSnippet and label references.
-        //
-        return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
-    } else if (needsAddressLoadInstruction(nextInstructionAddress, cg)) {
+    if (needsAddressLoadInstruction(nextInstructionAddress, cg)) {
         TR_ASSERT(_addressRegister != NULL,
             "OMR::X86::AMD64::MemoryReference should have allocated an address register");
 
@@ -558,7 +573,7 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         // addressLoadInstruction's node should be that of containingInstruction
         //
         addressLoadInstruction->setNode(_baseNode ? _baseNode : containingInstruction->getNode());
-        if (cg->comp()->target().isSMP() && getUnresolvedDataSnippet()) {
+        if (comp->target().isSMP() && getUnresolvedDataSnippet()) {
             // Also adjust the node of the TR::X86PatchableCodeAlignmentInstruction
             //
             TR_ASSERT((addressLoadInstruction->getPrev()->getKind() == TR::Instruction::IsPatchableCodeAlignment)
@@ -609,7 +624,13 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         // Indicate to caller that it must try again to emit its binary
         //
         return NULL;
-    } else if (_baseRegister == NULL && _indexRegister == NULL) {
+    }
+
+    // If the memory reference is displacement-only without a secondary address
+    // register then it must be either an absolute 32-bit address reference or a
+    // RIP-relative reference.
+    //
+    if (_baseRegister == NULL && _indexRegister == NULL) {
         uint8_t *cursor = modRM + 1;
         if (IS_32BIT_SIGNED(displacement) && !_forceRIPRelative) {
             // Addresses in the low 2GB (or high 2GB) can be accessed absolutely using a SIB byte
@@ -642,11 +663,9 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         }
 
         return cursor + 4;
-    } else {
-        // The inherited binary encoding logic will work as-is
-        //
-        return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
     }
 
-    TR_ASSERT(0, "Should never get here");
+    // The inherited binary encoding logic will work as-is
+    //
+    return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
 }

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -170,7 +170,7 @@ OMR::X86::AMD64::MemoryReference::MemoryReference(TR::MemoryReference &mr, intpt
 void OMR::X86::AMD64::MemoryReference::finishInitialization(TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm)
 {
     TR::Machine *machine = cg->machine();
-    TR::SymbolReference &sr = self()->getSymbolReference();
+    TR::SymbolReference &sr = getSymbolReference();
     TR::Compilation *comp = cg->comp();
 
     // Figure out whether we need to allocate a register for the address
@@ -181,21 +181,21 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(TR::CodeGenerator *c
         // Binary encoding will fatally assert otherwise.
         //
         mightNeedAddressRegister = false;
-    } else if (self()->getDataSnippet()) {
+    } else if (getDataSnippet()) {
         // Assume snippets are in RIP range
         //
         mightNeedAddressRegister = false;
-    } else if (!self()->getBaseRegister() && !self()->getIndexRegister()
+    } else if (!getBaseRegister() && !getIndexRegister()
         && (cg->needRelocationsForStatics() || cg->needClassAndMethodPointerRelocations()
             || cg->needRelocationsForBodyInfoData() || cg->needRelocationsForPersistentInfoData()
             || cg->needRelocationsForPersistentProfileInfoData())) {
         mightNeedAddressRegister = true;
     } else if (sr.getSymbol() != NULL
-        && (sr.isUnresolved() || (sr.stackAllocatedArrayAccess() && !IS_32BIT_SIGNED(self()->getDisplacement())))) {
+        && (sr.isUnresolved() || (sr.stackAllocatedArrayAccess() && !IS_32BIT_SIGNED(getDisplacement())))) {
         // Once resolved, the address could be anything, so be conservative.
         //
         mightNeedAddressRegister = true;
-    } else if (self()->getBaseRegister() == cg->getFrameRegister()) {
+    } else if (getBaseRegister() == cg->getFrameRegister()) {
         // We should never see stack frames 2GB in size, so don't waste a register.
         // (Also, for the same reason, there's no need to consider the frame
         // pointer adjustment.)
@@ -216,7 +216,7 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(TR::CodeGenerator *c
         //    lea R4, [R2 + a]
         //    xxx R1, [R4 + scale*R3 + b]
         //
-        mightNeedAddressRegister = !IS_32BIT_SIGNED(self()->getDisplacement());
+        mightNeedAddressRegister = !IS_32BIT_SIGNED(getDisplacement());
     }
 
     // If we might need it, allocate it
@@ -260,8 +260,8 @@ void OMR::X86::AMD64::MemoryReference::useRegisters(TR::Instruction *instr, TR::
 bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptr_t nextInstructionAddress,
     TR::CodeGenerator *cg)
 {
-    TR::SymbolReference &sr = self()->getSymbolReference();
-    intptr_t displacement = self()->getDisplacement();
+    TR::SymbolReference &sr = getSymbolReference();
+    intptr_t displacement = getDisplacement();
 
     if (_forceRIPRelative) {
         return false;
@@ -347,8 +347,7 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::Instruction 
 {
     uint32_t estimate;
 
-    if (0 && REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION && self()->getBaseRegister() && self()->getIndexRegister()
-        && _addressRegister) {
+    if (0 && REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION && getBaseRegister() && getIndexRegister() && _addressRegister) {
         // We thought we might need _addressRegister during initialization
         // because _baseRegister or _indexRegister NULL.  However, someone
         // subsequently changed the registers, and we can't handle
@@ -389,11 +388,11 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::Instruction 
 void OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation,
     TR::Instruction *containingInstruction, TR::CodeGenerator *cg, TR::SymbolReference *srCopy)
 {
-    intptr_t displacement = self()->getDisplacement();
+    intptr_t displacement = getDisplacement();
 
     if (_symbolReference.getSymbol()) {
         TR::SymbolReference &sr = *srCopy;
-        if (self()->getUnresolvedDataSnippet()) {
+        if (getUnresolvedDataSnippet()) {
             TR::Compilation *comp = cg->comp();
             if (comp->getOption(TR_EnableHCR) && (!sr.getSymbol()->isStatic() || !sr.getSymbol()->isClassObject())) {
                 cg->jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(
@@ -471,7 +470,7 @@ void OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(uint8_t
             }
         }
     } else {
-        if (self()->needsCodeAbsoluteExternalRelocation()) {
+        if (needsCodeAbsoluteExternalRelocation()) {
             cg->addExternalRelocation(
                 TR::ExternalRelocation::create(displacementLocation, (uint8_t *)0, TR_AbsoluteMethodAddress, cg),
                 __FILE__, __LINE__, containingInstruction->getNode());
@@ -483,8 +482,8 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
     TR::Instruction *containingInstruction, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
-    TR::SymbolReference &sr = self()->getSymbolReference();
-    intptr_t displacement = self()->getDisplacement();
+    TR::SymbolReference &sr = getSymbolReference();
+    intptr_t displacement = getDisplacement();
 
     if (comp->getOption(TR_TraceCG)) {
         diagnostic("OMR::X86::AMD64::MemoryReference " POINTER_PRINTF_FORMAT
@@ -500,7 +499,7 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
     // Check and assert if this is an invalid form for RIP-relative addressing.
     //
     if (_forceRIPRelative) {
-        TR_ASSERT_FATAL(!self()->getBaseRegister() && !self()->getIndexRegister() && !self()->isForceSIBByte(),
+        TR_ASSERT_FATAL(!getBaseRegister() && !getIndexRegister() && !isForceSIBByte(),
             "malformed memory reference for RIP-relative addressing");
     }
 
@@ -514,11 +513,11 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
     //
     intptr_t nextInstructionAddress = (intptr_t)(modRM + 5) + containingInstruction->getOpCode().info().ImmediateSize();
 
-    if (self()->getDataSnippet() || self()->getLabel()) {
+    if (getDataSnippet() || getLabel()) {
         // The inherited logic has a special case for RIP-based ConstantDataSnippet and label references.
         //
         return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
-    } else if (self()->needsAddressLoadInstruction(nextInstructionAddress, cg)) {
+    } else if (needsAddressLoadInstruction(nextInstructionAddress, cg)) {
         TR_ASSERT(_addressRegister != NULL,
             "OMR::X86::AMD64::MemoryReference should have allocated an address register");
 
@@ -536,30 +535,30 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
 
             addressLoadInstruction
                 = Inst_RegImm64Sym(containingInstruction->getPrev(), OP::MOV8RegImm64, _addressRegister,
-                    (!self()->getUnresolvedDataSnippet() && sr.getSymbol()->isStatic()
-                        && sr.getSymbol()->isClassObject() && cg->needClassAndMethodPointerRelocations())
+                    (!getUnresolvedDataSnippet() && sr.getSymbol()->isStatic() && sr.getSymbol()->isClassObject()
+                        && cg->needClassAndMethodPointerRelocations())
                         ? (uint64_t)TR::Compiler->cls.persistentClassPointerFromClassPointer(comp,
                               (TR_OpaqueClassBlock *)displacement)
                         : displacement,
                     symRef, cg);
 
-            if (self()->getUnresolvedDataSnippet()) {
-                self()->getUnresolvedDataSnippet()->setDataReferenceInstruction(addressLoadInstruction);
-                self()->getUnresolvedDataSnippet()->setDataSymbolReference(symRef);
+            if (getUnresolvedDataSnippet()) {
+                getUnresolvedDataSnippet()->setDataReferenceInstruction(addressLoadInstruction);
+                getUnresolvedDataSnippet()->setDataSymbolReference(symRef);
             }
         } else {
-            TR_ASSERT(!self()->getUnresolvedDataSnippet(), "Unresolved references should always have a symbol");
+            TR_ASSERT(!getUnresolvedDataSnippet(), "Unresolved references should always have a symbol");
 
             addressLoadInstruction
                 = Inst_RegImm64(containingInstruction->getPrev(), OP::MOV8RegImm64, _addressRegister, displacement, cg);
         }
 
-        self()->addMetaDataForCodeAddressWithLoad(displacementLocation, containingInstruction, cg, symRef);
+        addMetaDataForCodeAddressWithLoad(displacementLocation, containingInstruction, cg, symRef);
 
         // addressLoadInstruction's node should be that of containingInstruction
         //
         addressLoadInstruction->setNode(_baseNode ? _baseNode : containingInstruction->getNode());
-        if (cg->comp()->target().isSMP() && self()->getUnresolvedDataSnippet()) {
+        if (cg->comp()->target().isSMP() && getUnresolvedDataSnippet()) {
             // Also adjust the node of the TR::X86PatchableCodeAlignmentInstruction
             //
             TR_ASSERT((addressLoadInstruction->getPrev()->getKind() == TR::Instruction::IsPatchableCodeAlignment)
@@ -577,17 +576,17 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         cursor = addressLoadInstruction->generateBinaryEncoding();
         cg->setBinaryBufferCursor(cursor);
 
-        if (self()->getBaseRegister() && self()->getIndexRegister()) {
-            TR::Instruction *addressAddInstruction = Inst_RegReg(addressLoadInstruction, OP::ADD8RegReg,
-                self()->getAddressRegister(), self()->getBaseRegister(), cg);
+        if (getBaseRegister() && getIndexRegister()) {
+            TR::Instruction *addressAddInstruction
+                = Inst_RegReg(addressLoadInstruction, OP::ADD8RegReg, getAddressRegister(), getBaseRegister(), cg);
             cursor = addressAddInstruction->generateBinaryEncoding();
             cg->setBinaryBufferCursor(cursor);
         }
 
         // If it's unresolved, tell the snippet where the data reference is
         //
-        if (self()->getUnresolvedDataSnippet())
-            self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor - 8);
+        if (getUnresolvedDataSnippet())
+            getUnresolvedDataSnippet()->setAddressOfDataReference(cursor - 8);
 
         // Transform this memref from [whatever + offset64] to [whatever + _addressRegister]
         // Also transforms [base + index + offset64] to [_addressRegister + index]
@@ -605,7 +604,7 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         _flags.reset(MemRef_NeedExternalCodeAbsoluteRelocation); // TODO:AMD64: Do I need this?
         _symbolReference.setSymbol(NULL);
         _symbolReference.setOffset(0);
-        self()->setUnresolvedDataSnippet(NULL); // Otherwise it will get damaged when we re-emit containingInstruction
+        setUnresolvedDataSnippet(NULL); // Otherwise it will get damaged when we re-emit containingInstruction
 
         // Indicate to caller that it must try again to emit its binary
         //
@@ -615,8 +614,8 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         if (IS_32BIT_SIGNED(displacement) && !_forceRIPRelative) {
             // Addresses in the low 2GB (or high 2GB) can be accessed absolutely using a SIB byte
             //
-            self()->ModRM(modRM)->setBase()->setHasSIB();
-            self()->SIB(cursor++)->setScale()->setNoIndex()->setIndexDisp32();
+            ModRM(modRM)->setBase()->setHasSIB();
+            SIB(cursor++)->setScale()->setNoIndex()->setIndexDisp32();
             *(uint32_t *)cursor = (uint32_t)displacement;
         } else {
             // Use RIP-relative addressing
@@ -625,7 +624,7 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
                 "destination displacement out of RIP-relative range");
             TR_ASSERT(!(comp->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject()),
                 "HCR runtime assumptions currently can't patch RIP-relative offsets");
-            self()->ModRM(modRM)->setIndexOnlyDisp32();
+            ModRM(modRM)->setIndexOnlyDisp32();
             *(uint32_t *)cursor = (uint32_t)(displacement - (intptr_t)nextInstructionAddress);
         }
 
@@ -635,11 +634,11 @@ uint8_t *OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(uint8_t *modRM
         // NOTE: this may not work in the highly unlikely case of a field offset > 64k
         //       where the implicit NULLCHK will not fire.
         //
-        if (self()->getUnresolvedDataSnippet()) {
-            self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+        if (getUnresolvedDataSnippet()) {
+            getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
             logprintf(comp->getOption(TR_TraceCG), comp->log(),
                 "found unresolved shadow with NULL base object : data reference instruction=%p, cursor=%p\n",
-                self()->getUnresolvedDataSnippet()->getDataReferenceInstruction(), cursor);
+                getUnresolvedDataSnippet()->getDataReferenceInstruction(), cursor);
         }
 
         return cursor + 4;

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -170,15 +170,15 @@ public: // Constructors
         OMR::X86::MemoryReference::unblockRegisters();
     }
 
-    void addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation, TR::Instruction *containingInstruction,
-        TR::CodeGenerator *cg, TR::SymbolReference *srCopy);
+    OMR_FINAL void addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation,
+        TR::Instruction *containingInstruction, TR::CodeGenerator *cg, TR::SymbolReference *srCopy);
 
 protected:
 #if defined(TR_TARGET_64BIT)
-    bool needsAddressLoadInstruction(intptr_t nextInstructionAddress, TR::CodeGenerator *cg);
+    OMR_FINAL bool needsAddressLoadInstruction(intptr_t nextInstructionAddress, TR::CodeGenerator *cg);
     void finishInitialization(TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm);
 #else
-    bool needsAddressLoadInstruction(intptr_t rip) { return false; }
+    OMR_FINAL bool needsAddressLoadInstruction(intptr_t rip) { return false; }
 
     void finishInitialization(TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm) {}
 #endif

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2481,11 +2481,6 @@ bool OMR::X86::CodeGenerator::supportsComplexAddressing()
         return true;
 }
 
-uint32_t OMR::X86::CodeGenerator::estimateBinaryLength(TR::MemoryReference *mr)
-{
-    return mr->estimateBinaryLength(NULL, self());
-}
-
 void OMR::X86::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label)
 {
     *cursor += static_cast<int32_t>((reinterpret_cast<uintptr_t>(label->getCodeLocation())));

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -727,7 +727,6 @@ public:
 
     // codegen methods referenced from ras/
     //
-    uint32_t estimateBinaryLength(TR::MemoryReference *);
 
     void apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *);
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1176,15 +1176,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
-            if (baseRegisterNumber == TR::RealRegister::vfp) {
-                TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
-                    "virtual frame pointer must be assigned before binary encoding!\n");
-
-                base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
-                baseRegisterNumber = base->getRegisterNumber();
-                setBaseRegister(base);
-            }
-
             if (base->needsDisp()) {
                 ModRM(modRM)->setBaseDisp8();
                 base->setRMRegisterFieldInModRM(modRM);
@@ -1228,16 +1219,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
         case MR_base + MR_index: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
-
-            if (baseRegisterNumber == TR::RealRegister::vfp) {
-                TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
-                    "virtual frame pointer must be assigned before binary encoding!\n");
-
-                base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
-                baseRegisterNumber = base->getRegisterNumber();
-                setBaseRegister(base);
-            }
-
             index = toRealRegister(getIndexRegister());
             *++cursor = 0x00;
             base->setBaseRegisterFieldInSIB(cursor);
@@ -1325,15 +1306,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
-            if (baseRegisterNumber == TR::RealRegister::vfp) {
-                TR_ASSERT_FATAL(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
-                    "virtual frame pointer must be assigned before binary encoding!\n");
-
-                base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
-                baseRegisterNumber = base->getRegisterNumber();
-                setBaseRegister(base);
-            }
-
             if (base->needsSIB() || isForceSIBByte()) {
                 *++cursor = 0x00;
                 ModRM(modRM)->setBase()->setHasSIB();
@@ -1378,16 +1350,6 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
         case MR_base + MR_index + MR_disp: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
-
-            if (baseRegisterNumber == TR::RealRegister::vfp) {
-                TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
-                    "virtual frame pointer must be assigned before binary encoding!\n");
-
-                base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
-                baseRegisterNumber = base->getRegisterNumber();
-                setBaseRegister(base);
-            }
-
             index = toRealRegister(getIndexRegister());
             *++cursor = 0x00;
             base->setBaseRegisterFieldInSIB(cursor);

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -773,6 +773,16 @@ void OMR::X86::MemoryReference::assignRegisters(TR::Instruction *currentInstruct
     }
 }
 
+namespace OMR { namespace X86 {
+
+enum {
+    MR_base = 1,
+    MR_index = 2,
+    MR_disp = 4,
+};
+
+}} // namespace OMR::X86
+
 uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg)
 {
     if (getBaseRegister() && toRealRegister(getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp) {
@@ -784,10 +794,9 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
 
     TR::RealRegister *base = toRealRegister(getBaseRegister());
 
-    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
-        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
-               || isForceWideDisplacement())
-                ? 4
+    uint32_t addressTypes = (getBaseRegister() ? MR_base : 0) | (getIndexRegister() ? MR_index : 0)
+        | ((getSymbolReference().getSymbol() || getSymbolReference().getOffset() != 0 || isForceWideDisplacement())
+                ? MR_disp
                 : 0);
     uint32_t length = 0;
 
@@ -809,7 +818,7 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
     }
 
     switch (addressTypes) {
-        case 1:
+        case MR_base:
             if (base->needsDisp()) {
                 length = 1;
             } else if (base->needsSIB()) {
@@ -817,12 +826,12 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
             }
             break;
 
-        case 6:
-        case 2:
+        case MR_index + MR_disp:
+        case MR_index:
             length = 5;
             break;
 
-        case 3:
+        case MR_base + MR_index:
             length = 1;
             if (base->needsDisp()) {
                 // Need a sib byte with 8bit displacement field of zero to get ebp as a base register
@@ -831,11 +840,11 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
             }
             break;
 
-        case 4:
+        case MR_disp:
             length = 4;
             break;
 
-        case 5:
+        case MR_base + MR_disp:
             displacement = getDisplacement();
             if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
                 && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
@@ -863,7 +872,7 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
             }
             break;
 
-        case 7:
+        case MR_base + MR_index + MR_disp:
             displacement = getDisplacement();
             if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
                 && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
@@ -889,10 +898,9 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
 uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
 {
     intptr_t displacement;
-    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
-        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
-               || isForceWideDisplacement())
-                ? 4
+    uint32_t addressTypes = (getBaseRegister() ? MR_base : 0) | (getIndexRegister() ? MR_index : 0)
+        | ((getSymbolReference().getSymbol() || getSymbolReference().getOffset() != 0 || isForceWideDisplacement())
+                ? MR_disp
                 : 0);
 
     uint32_t length = 0;
@@ -911,30 +919,30 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
 
     TR::RealRegister *base = cg->machine()->getRealRegister(registerNumber);
     switch (addressTypes) {
-        case 1:
+        case MR_base:
             if (base->needsDisp() || base->needsSIB())
                 length = 1;
             else
                 length = 0;
             break;
 
-        case 6:
-        case 2:
+        case MR_index + MR_disp:
+        case MR_index:
             length = 5;
             break;
 
-        case 3:
+        case MR_base + MR_index:
             length = 1;
             if (base->needsDisp()) {
                 length = 2;
             }
             break;
 
-        case 4:
+        case MR_disp:
             length = 4;
             break;
 
-        case 5:
+        case MR_base + MR_disp:
             displacement = getDisplacement();
 
             if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !isForceWideDisplacement()) {
@@ -954,7 +962,7 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
             }
             break;
 
-        case 7:
+        case MR_base + MR_index + MR_disp:
             displacement = getDisplacement();
             if (!isForceWideDisplacement())
                 length = 2;
@@ -1001,8 +1009,8 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
     TR::CodeGenerator *cg)
 {
     switch (addressTypes) {
-        case 6:
-        case 2: {
+        case MR_index + MR_disp:
+        case MR_index: {
             if (needsCodeAbsoluteExternalRelocation()) {
                 cg->addExternalRelocation(TR::ExternalRelocation::create(cursor, 0, TR_AbsoluteMethodAddress, cg),
                     __FILE__, __LINE__, node);
@@ -1015,7 +1023,7 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
             break;
         }
 
-        case 4: {
+        case MR_disp: {
             TR::Symbol *symbol = getSymbolReference().getSymbol();
             if (symbol) {
                 TR::StaticSymbol *staticSym = symbol->getStaticSymbol();
@@ -1139,10 +1147,9 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 {
     TR::Compilation *comp = cg->comp();
 
-    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
-        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
-               || isForceWideDisplacement())
-                ? 4
+    uint32_t addressTypes = (getBaseRegister() ? MR_base : 0) | (getIndexRegister() ? MR_index : 0)
+        | ((getSymbolReference().getSymbol() || getSymbolReference().getOffset() != 0 || isForceWideDisplacement())
+                ? MR_disp
                 : 0);
 
     intptr_t displacement;
@@ -1165,7 +1172,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
     }
 
     switch (addressTypes) {
-        case 1: {
+        case MR_base: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
@@ -1196,8 +1203,8 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             break;
         }
 
-        case 6:
-        case 2: {
+        case MR_index + MR_disp:
+        case MR_index: {
             index = toRealRegister(getIndexRegister());
             ModRM(modRM)->setBase()->setHasSIB();
             *++cursor = 0x00;
@@ -1218,7 +1225,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             break;
         }
 
-        case 3: {
+        case MR_base + MR_index: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
@@ -1248,7 +1255,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             break;
         }
 
-        case 4: {
+        case MR_disp: {
             ModRM(modRM)->setIndexOnlyDisp32();
             cursor++;
             symbol = getSymbolReference().getSymbol();
@@ -1314,7 +1321,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             break;
         }
 
-        case 5: {
+        case MR_base + MR_disp: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
@@ -1368,7 +1375,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             break;
         }
 
-        case 7: {
+        case MR_base + MR_index + MR_disp: {
             base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -68,7 +68,7 @@ static void rematerializeAddressAdds(TR::Node *rootLoadOrStore, TR::CodeGenerato
 
 intptr_t OMR::X86::MemoryReference::getDisplacement()
 {
-    TR::SymbolReference &symRef = self()->getSymbolReference();
+    TR::SymbolReference &symRef = getSymbolReference();
     intptr_t displacement = symRef.getOffset();
     TR::Symbol *symbol = symRef.getSymbol();
 
@@ -96,7 +96,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGene
     , _flags(0)
     , _reloKind(-1)
 {
-    self()->setForceWideDisplacement();
+    setForceWideDisplacement();
 }
 
 OMR::X86::MemoryReference::MemoryReference(TR::LabelSymbol *label, TR::CodeGenerator *cg)
@@ -111,7 +111,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::LabelSymbol *label, TR::CodeGener
     , _flags(0)
     , _reloKind(-1)
 {
-    self()->setForceWideDisplacement();
+    setForceWideDisplacement();
 }
 
 OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
@@ -207,9 +207,9 @@ OMR::X86::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGe
                     if (base->getOpCodeValue() == TR::loadaddr && base->getSymbol()->isLocalObject())
                         cg->evaluate(base);
 
-                    self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore,
-                        &_symbolReference, isStore, symRef->canCauseGC()));
-                    cg->addSnippet(self()->getUnresolvedDataSnippet());
+                    setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
+                        isStore, symRef->canCauseGC()));
+                    cg->addSnippet(getUnresolvedDataSnippet());
                 }
 
                 if (!debug("noAddressAddRemat") && canRematerializeAddressAdds) {
@@ -228,9 +228,9 @@ OMR::X86::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGe
         } else {
             if (symbol->isStatic()) {
                 if (isUnresolved) {
-                    self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore,
-                        &_symbolReference, isStore, symRef->canCauseGC()));
-                    cg->addSnippet(self()->getUnresolvedDataSnippet());
+                    setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference,
+                        isStore, symRef->canCauseGC()));
+                    cg->addSnippet(getUnresolvedDataSnippet());
                 }
                 _baseNode = rootLoadOrStore;
             } else {
@@ -249,7 +249,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGe
             // Need a wide field because we don't know how big the displacement
             // may turn out to be once resolved.
             //
-            self()->setForceWideDisplacement();
+            setForceWideDisplacement();
         }
 
     } else {
@@ -261,18 +261,18 @@ OMR::X86::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGe
 
 TR::UnresolvedDataSnippet *OMR::X86::MemoryReference::getUnresolvedDataSnippet()
 {
-    return self()->hasUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_dataSnippet : NULL;
+    return hasUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_dataSnippet : NULL;
 }
 
 TR::UnresolvedDataSnippet *OMR::X86::MemoryReference::setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s)
 {
-    self()->setHasUnresolvedDataSnippet();
+    setHasUnresolvedDataSnippet();
     return ((TR::UnresolvedDataSnippet *)(_dataSnippet = s));
 }
 
 TR::X86DataSnippet *OMR::X86::MemoryReference::getDataSnippet()
 {
-    return self()->hasUnresolvedDataSnippet() ? NULL : (TR::X86DataSnippet *)_dataSnippet;
+    return hasUnresolvedDataSnippet() ? NULL : (TR::X86DataSnippet *)_dataSnippet;
 }
 
 void OMR::X86::MemoryReference::initialize(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
@@ -297,10 +297,10 @@ void OMR::X86::MemoryReference::initialize(TR::SymbolReference *symRef, TR::Code
     _symbolReference.copyRefNumIfPossible(symRef, comp->getSymRefTab());
 
     if (symRef->isUnresolved()) {
-        self()->setUnresolvedDataSnippet(
+        setUnresolvedDataSnippet(
             TR::UnresolvedDataSnippet::create(cg, 0, &_symbolReference, false, symRef->canCauseGC()));
-        cg->addSnippet(self()->getUnresolvedDataSnippet());
-        self()->setForceWideDisplacement();
+        cg->addSnippet(getUnresolvedDataSnippet());
+        setForceWideDisplacement();
     }
     // TODO: aliasing sets?
 }
@@ -439,7 +439,7 @@ void OMR::X86::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
     if (comp->useCompressedPointers()) {
         if ((subTree->getOpCodeValue() == TR::l2a) && (subTree->getReferenceCount() == 1)
             && (subTree->getRegister() == NULL)
-            && !self()->hasUnresolvedDataSnippet()) // If there is unresolved data snippet, l2a cannot be skipped
+            && !hasUnresolvedDataSnippet()) // If there is unresolved data snippet, l2a cannot be skipped
         {
             cg->decReferenceCount(subTree);
             subTree = subTree->getFirstChild();
@@ -457,7 +457,7 @@ void OMR::X86::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
     //  I have no strong evidence that it is incorrect other than the formatting)
     //  so I added parentheses to eliminate a compiler warning and reformatted
     if ((evalSubTree && subTree->getReferenceCount() > 1) || (subTree->getRegister() != NULL)
-        || (self()->inUpcastingMode() && !subTree->cannotOverflow())) {
+        || (inUpcastingMode() && !subTree->cannotOverflow())) {
         if (_baseRegister != NULL) {
             if (_indexRegister != NULL) {
                 self()->consolidateRegisters(subTree, cg);
@@ -513,14 +513,14 @@ void OMR::X86::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
             _symbolReference.addToOffset(-TR::TreeEvaluator::integerConstNodeValue(constChild, cg));
             cg->decReferenceCount(constChild);
         } else if (subTreeOp == TR::i2l || subTreeOp == TR::s2l || subTreeOp == TR::s2i) {
-            self()->setInUpcastingMode();
+            setInUpcastingMode();
 
             logprintf(trace, log, "Entering UpcastingNoOverflow mode at node %x\n", subTree);
             rcount_t refCount = subTree->getFirstChild()->getReferenceCount();
             self()->populateMemoryReference(subTree->getFirstChild(), cg, subTree);
             self()->checkAndDecReferenceCount(subTree->getFirstChild(), refCount, cg);
 
-            self()->setInUpcastingMode(false);
+            setInUpcastingMode(false);
         } else if ((stride = TR::MemoryReference::getStrideForNode(subTree, cg)) != 0) {
             if (_indexRegister != NULL) {
                 if (_baseRegister != NULL || _stride != 0) {
@@ -601,10 +601,10 @@ void OMR::X86::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
             _symbolReference.copyRefNumIfPossible(symRef, comp->getSymRefTab());
 
             if (symRef->isUnresolved()) {
-                self()->setUnresolvedDataSnippet(
+                setUnresolvedDataSnippet(
                     TR::UnresolvedDataSnippet::create(cg, subTree, &_symbolReference, false, symRef->canCauseGC()));
-                cg->addSnippet(self()->getUnresolvedDataSnippet());
-                self()->setForceWideDisplacement();
+                cg->addSnippet(getUnresolvedDataSnippet());
+                setForceWideDisplacement();
             }
 
             // TODO: aliasing sets?
@@ -647,7 +647,7 @@ TR::Register *OMR::X86::MemoryReference::evaluate(TR::Node *node, TR::CodeGenera
 
     TR::Register *reg = cg->evaluate(node);
 
-    if (self()->inUpcastingMode()) {
+    if (inUpcastingMode()) {
         if (node->skipSignExtension()) {
             // We don't need to sign extend the node
         }
@@ -717,7 +717,7 @@ void OMR::X86::MemoryReference::assignRegisters(TR::Instruction *currentInstruct
 {
     TR::RealRegister *assignedBaseRegister = NULL;
     TR::RealRegister *assignedIndexRegister;
-    TR::UnresolvedDataSnippet *snippet = self()->getUnresolvedDataSnippet();
+    TR::UnresolvedDataSnippet *snippet = getUnresolvedDataSnippet();
 
     if (_baseRegister != NULL) {
         if (_baseRegister == cg->machine()->getRealRegister(TR::RealRegister::vfp)) {
@@ -775,19 +775,18 @@ void OMR::X86::MemoryReference::assignRegisters(TR::Instruction *currentInstruct
 
 uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg)
 {
-    if (self()->getBaseRegister()
-        && toRealRegister(self()->getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp) {
+    if (getBaseRegister() && toRealRegister(getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp) {
         // Rewrite VFP-relative memref in terms of an actual register
         //
         _baseRegister = cg->machine()->getRealRegister(cg->vfpState()._register);
-        self()->getSymbolReference().setOffset(self()->getSymbolReference().getOffset() + cg->vfpState()._displacement);
+        getSymbolReference().setOffset(getSymbolReference().getOffset() + cg->vfpState()._displacement);
     }
 
-    TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
+    TR::RealRegister *base = toRealRegister(getBaseRegister());
 
-    uint32_t addressTypes = (self()->getBaseRegister() != NULL ? 1 : 0) | (self()->getIndexRegister() != NULL ? 2 : 0)
-        | ((self()->getSymbolReference().getSymbol() != NULL || self()->getSymbolReference().getOffset() != 0
-               || self()->isForceWideDisplacement())
+    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
+        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
+               || isForceWideDisplacement())
                 ? 4
                 : 0);
     uint32_t length = 0;
@@ -837,20 +836,20 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
             break;
 
         case 5:
-            displacement = self()->getDisplacement();
+            displacement = getDisplacement();
             if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
                 && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
                 displacement /= displacementDivisor;
             } else if (isEvex) {
                 length = 4;
-                if (base->needsSIB() || self()->isForceSIBByte()) {
+                if (base->needsSIB() || isForceSIBByte()) {
                     length++;
                 }
                 break;
             }
-            if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !self()->isForceWideDisplacement()) {
+            if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !isForceWideDisplacement()) {
                 length = 0;
-            } else if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
+            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
                 length = 1;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
@@ -859,13 +858,13 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
                 length = 4;
             }
 
-            if (base->needsSIB() || self()->isForceSIBByte()) {
+            if (base->needsSIB() || isForceSIBByte()) {
                 length += 1;
             }
             break;
 
         case 7:
-            displacement = self()->getDisplacement();
+            displacement = getDisplacement();
             if (!isForceWideDisplacement() && canShortenEVEXDisplacement && (displacement % displacementDivisor) == 0
                 && IS_8BIT_SIGNED(displacement / displacementDivisor)) {
                 displacement /= displacementDivisor;
@@ -873,7 +872,7 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
                 length = 5;
                 break;
             }
-            if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
+            if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
                 length = 2;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
@@ -890,17 +889,17 @@ uint32_t OMR::X86::MemoryReference::estimateBinaryLength(TR::Instruction *contai
 uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
 {
     intptr_t displacement;
-    uint32_t addressTypes = (self()->getBaseRegister() != NULL ? 1 : 0) | (self()->getIndexRegister() != NULL ? 2 : 0)
-        | ((self()->getSymbolReference().getSymbol() != NULL || self()->getSymbolReference().getOffset() != 0
-               || self()->isForceWideDisplacement())
+    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
+        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
+               || isForceWideDisplacement())
                 ? 4
                 : 0);
 
     uint32_t length = 0;
     TR::RealRegister::RegNum registerNumber = TR::RealRegister::NoReg;
 
-    if (self()->getBaseRegister()) {
-        registerNumber = toRealRegister(self()->getBaseRegister())->getRegisterNumber();
+    if (getBaseRegister()) {
+        registerNumber = toRealRegister(getBaseRegister())->getRegisterNumber();
 
         if (registerNumber == TR::RealRegister::vfp) {
             TR_ASSERT(cg->machine()->getRealRegister(registerNumber)->getAssignedRealRegister(),
@@ -936,11 +935,11 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
             break;
 
         case 5:
-            displacement = self()->getDisplacement();
+            displacement = getDisplacement();
 
-            if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !self()->isForceWideDisplacement()) {
+            if (displacement == 0 && !base->needsDisp() && !base->needsSIB() && !isForceWideDisplacement()) {
                 length = 0;
-            } else if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
+            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
                 if (displacement != 0)
                     length = 1;
             } else
@@ -950,14 +949,14 @@ uint32_t OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator 
                 // value)
                 length = 4;
 
-            if (base->needsSIB() || self()->isForceSIBByte()) {
+            if (base->needsSIB() || isForceSIBByte()) {
                 length += 1;
             }
             break;
 
         case 7:
-            displacement = self()->getDisplacement();
-            if (!self()->isForceWideDisplacement())
+            displacement = getDisplacement();
+            if (!isForceWideDisplacement())
                 length = 2;
             else
                 length = 5;
@@ -976,7 +975,7 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
         return OMR::X86::EnlargementResult(0, 0);
 
     int32_t growth = 0;
-    if (!self()->isForceWideDisplacement()) {
+    if (!isForceWideDisplacement()) {
         int32_t currentEncodingAllocation = self()->estimateBinaryLength(containingInstruction, cg);
         int32_t currentPatchSize = self()->getBinaryLengthLowerBound(cg);
         _flags.set(MemRef_ForceWideDisplacement);
@@ -1004,10 +1003,10 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
     switch (addressTypes) {
         case 6:
         case 2: {
-            if (self()->needsCodeAbsoluteExternalRelocation()) {
+            if (needsCodeAbsoluteExternalRelocation()) {
                 cg->addExternalRelocation(TR::ExternalRelocation::create(cursor, 0, TR_AbsoluteMethodAddress, cg),
                     __FILE__, __LINE__, node);
-            } else if (self()->getReloKind() == TR_ACTIVE_CARD_TABLE_BASE) {
+            } else if (getReloKind() == TR_ACTIVE_CARD_TABLE_BASE) {
                 cg->addExternalRelocation(
                     TR::ExternalRelocation::create(cursor, (uint8_t *)TR_ActiveCardTableBase, TR_GlobalValue, cg),
                     __FILE__, __LINE__, node);
@@ -1017,16 +1016,16 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
         }
 
         case 4: {
-            TR::Symbol *symbol = self()->getSymbolReference().getSymbol();
+            TR::Symbol *symbol = getSymbolReference().getSymbol();
             if (symbol) {
                 TR::StaticSymbol *staticSym = symbol->getStaticSymbol();
 
                 if (staticSym) {
-                    if (self()->getUnresolvedDataSnippet() == NULL) {
+                    if (getUnresolvedDataSnippet() == NULL) {
                         if (symbol->isConst()) {
                             cg->addExternalRelocation(
                                 TR::ExternalRelocation::create(cursor,
-                                    (uint8_t *)self()->getSymbolReference().getOwningMethod(cg->comp())->constantPool(),
+                                    (uint8_t *)getSymbolReference().getOwningMethod(cg->comp())->constantPool(),
                                     node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                     TR_ConstantPool, cg),
                                 __FILE__, __LINE__, node);
@@ -1034,18 +1033,18 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                             if (cg->needClassAndMethodPointerRelocations()) {
                                 *(int32_t *)cursor
                                     = (int32_t)(TR::Compiler->cls.persistentClassPointerFromClassPointer(cg->comp(),
-                                        (TR_OpaqueClassBlock *)(self()->getSymbolReference().getOffset()
+                                        (TR_OpaqueClassBlock *)(getSymbolReference().getOffset()
                                             + (intptr_t)staticSym->getStaticAddress())));
                                 if (cg->comp()->getOption(TR_UseSymbolValidationManager)) {
                                     cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                                  (uint8_t *)(self()->getSymbolReference().getOffset()
+                                                                  (uint8_t *)(getSymbolReference().getOffset()
                                                                       + (intptr_t)staticSym->getStaticAddress()),
                                                                   (uint8_t *)TR::SymbolType::typeClass,
                                                                   TR_SymbolFromManager, cg),
                                         __FILE__, __LINE__, node);
                                 } else {
                                     cg->addExternalRelocation(
-                                        TR::ExternalRelocation::create(cursor, (uint8_t *)&self()->getSymbolReference(),
+                                        TR::ExternalRelocation::create(cursor, (uint8_t *)&getSymbolReference(),
                                             node ? (uint8_t *)(intptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                             TR_ClassAddress, cg),
                                         __FILE__, __LINE__, node);
@@ -1070,7 +1069,7 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                                     __LINE__, node);
                             } else if (symbol->isDebugCounter()) {
                                 TR::DebugCounterBase *counter
-                                    = cg->comp()->getCounterFromStaticAddress(&(self()->getSymbolReference()));
+                                    = cg->comp()->getCounterFromStaticAddress(&(getSymbolReference()));
                                 if (counter == NULL) {
                                     cg->comp()->failCompilation<TR::CompilationException>(
                                         "Could not generate relocation for debug counter in "
@@ -1079,26 +1078,26 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                                 TR::DebugCounter::generateRelocation(cg->comp(), cursor, node, counter);
                             } else if (symbol->isEnterEventHookAddress() || symbol->isExitEventHookAddress()) {
                                 cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                              (uint8_t *)&self()->getSymbolReference(), NULL,
+                                                              (uint8_t *)&getSymbolReference(), NULL,
                                                               TR_MethodEnterExitHookAddress, cg),
                                     __FILE__, __LINE__, node);
                             } else if (symbol->isCallSiteTableEntry()) {
                                 if (cg->comp()->compileRelocatableCode()) {
                                     cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                                  (uint8_t *)&self()->getSymbolReference(), NULL,
+                                                                  (uint8_t *)&getSymbolReference(), NULL,
                                                                   TR_CallsiteTableEntryAddress, cg),
                                         __FILE__, __LINE__, node);
                                 }
                             } else if (symbol->isMethodTypeTableEntry()) {
                                 if (cg->comp()->compileRelocatableCode()) {
                                     cg->addExternalRelocation(TR::ExternalRelocation::create(cursor,
-                                                                  (uint8_t *)&self()->getSymbolReference(), NULL,
+                                                                  (uint8_t *)&getSymbolReference(), NULL,
                                                                   TR_MethodTypeTableEntryAddress, cg),
                                         __FILE__, __LINE__, node);
                                 }
                             } else {
                                 cg->addExternalRelocation(
-                                    TR::ExternalRelocation::create(cursor, (uint8_t *)&self()->getSymbolReference(),
+                                    TR::ExternalRelocation::create(cursor, (uint8_t *)&getSymbolReference(),
                                         node ? (uint8_t *)(uintptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                         TR_DataAddress, cg),
                                     __FILE__, __LINE__, node);
@@ -1107,13 +1106,13 @@ void OMR::X86::MemoryReference::addMetaDataForCodeAddress(uint32_t addressTypes,
                     }
                 }
             } else {
-                TR::X86DataSnippet *cds = self()->getDataSnippet();
+                TR::X86DataSnippet *cds = getDataSnippet();
                 TR::LabelSymbol *label = NULL;
 
                 if (cds)
                     label = cds->getSnippetLabel();
                 else
-                    label = self()->getLabel();
+                    label = getLabel();
 
                 if (label != NULL) {
                     if (cg->comp()->target().is64Bit()) {
@@ -1140,9 +1139,9 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 {
     TR::Compilation *comp = cg->comp();
 
-    uint32_t addressTypes = (self()->getBaseRegister() != NULL ? 1 : 0) | (self()->getIndexRegister() != NULL ? 2 : 0)
-        | ((self()->getSymbolReference().getSymbol() != NULL || self()->getSymbolReference().getOffset() != 0
-               || self()->isForceWideDisplacement())
+    uint32_t addressTypes = (getBaseRegister() != NULL ? 1 : 0) | (getIndexRegister() != NULL ? 2 : 0)
+        | ((getSymbolReference().getSymbol() != NULL || getSymbolReference().getOffset() != 0
+               || isForceWideDisplacement())
                 ? 4
                 : 0);
 
@@ -1167,7 +1166,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
     switch (addressTypes) {
         case 1: {
-            base = toRealRegister(self()->getBaseRegister());
+            base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
             if (baseRegisterNumber == TR::RealRegister::vfp) {
@@ -1176,20 +1175,20 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
                 base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
                 baseRegisterNumber = base->getRegisterNumber();
-                self()->setBaseRegister(base);
+                setBaseRegister(base);
             }
 
             if (base->needsDisp()) {
-                self()->ModRM(modRM)->setBaseDisp8();
+                ModRM(modRM)->setBaseDisp8();
                 base->setRMRegisterFieldInModRM(modRM);
                 *++cursor = 0x00;
             } else if (base->needsSIB()) {
-                self()->ModRM(modRM)->setBase()->setHasSIB();
+                ModRM(modRM)->setBase()->setHasSIB();
                 *++cursor = 0x00;
-                self()->SIB(cursor)->setNoIndex();
+                SIB(cursor)->setNoIndex();
                 base->setBaseRegisterFieldInSIB(cursor);
             } else {
-                self()->ModRM(modRM)->setBase();
+                ModRM(modRM)->setBase();
                 base->setRMRegisterFieldInModRM(modRM);
             }
 
@@ -1199,20 +1198,20 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
         case 6:
         case 2: {
-            index = toRealRegister(self()->getIndexRegister());
-            self()->ModRM(modRM)->setBase()->setHasSIB();
+            index = toRealRegister(getIndexRegister());
+            ModRM(modRM)->setBase()->setHasSIB();
             *++cursor = 0x00;
-            self()->SIB(cursor)->setIndexDisp32();
+            SIB(cursor)->setIndexDisp32();
             index->setIndexRegisterFieldInSIB(cursor);
-            self()->setStrideFieldInSIB(cursor);
+            setStrideFieldInSIB(cursor);
             cursor++;
 
             immediateCursor = cursor;
 
-            *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+            *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
 
-            if (self()->getUnresolvedDataSnippet() != NULL) {
-                self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+            if (getUnresolvedDataSnippet() != NULL) {
+                getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
             }
 
             cursor += 4;
@@ -1220,7 +1219,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
         }
 
         case 3: {
-            base = toRealRegister(self()->getBaseRegister());
+            base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
             if (baseRegisterNumber == TR::RealRegister::vfp) {
@@ -1229,30 +1228,30 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
                 base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
                 baseRegisterNumber = base->getRegisterNumber();
-                self()->setBaseRegister(base);
+                setBaseRegister(base);
             }
 
-            index = toRealRegister(self()->getIndexRegister());
+            index = toRealRegister(getIndexRegister());
             *++cursor = 0x00;
             base->setBaseRegisterFieldInSIB(cursor);
             index->setIndexRegisterFieldInSIB(cursor);
-            self()->setStrideFieldInSIB(cursor);
+            setStrideFieldInSIB(cursor);
             if (base->needsDisp()) {
                 // Need a sib byte with 8bit displacement field of zero to get ebp as a base register
                 //
-                self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
+                ModRM(modRM)->setBaseDisp8()->setHasSIB();
                 *++cursor = 0x00;
             } else {
-                self()->ModRM(modRM)->setBase()->setHasSIB();
+                ModRM(modRM)->setBase()->setHasSIB();
             }
             ++cursor;
             break;
         }
 
         case 4: {
-            self()->ModRM(modRM)->setIndexOnlyDisp32();
+            ModRM(modRM)->setIndexOnlyDisp32();
             cursor++;
-            symbol = self()->getSymbolReference().getSymbol();
+            symbol = getSymbolReference().getSymbol();
             immediateCursor = cursor;
 
             if (symbol) {
@@ -1260,11 +1259,11 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 TR::MethodSymbol *methodSym = symbol->getMethodSymbol();
 
                 if (staticSym) {
-                    if (self()->getUnresolvedDataSnippet() == NULL) {
-                        *(int32_t *)cursor = (int32_t)(self()->getSymbolReference().getOffset()
-                            + (intptr_t)staticSym->getStaticAddress());
+                    if (getUnresolvedDataSnippet() == NULL) {
+                        *(int32_t *)cursor
+                            = (int32_t)(getSymbolReference().getOffset() + (intptr_t)staticSym->getStaticAddress());
                     } else {
-                        *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+                        *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                     }
                 } else if (methodSym) {
                     /* ----------------------------------------------------- */
@@ -1273,25 +1272,24 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                     /* ----------------------------------------------------- */
                     *(int32_t *)cursor = 0;
                 } else if (symbol->isRegisterMappedSymbol()) {
-                    displacement
-                        = self()->getSymbolReference().getOffset() + symbol->getRegisterMappedSymbol()->getOffset();
+                    displacement = getSymbolReference().getOffset() + symbol->getRegisterMappedSymbol()->getOffset();
                     TR_ASSERT(IS_32BIT_SIGNED(displacement),
                         "64-bit displacement should have been replaced in "
                         "TR_AMD64MemoryReference::generateBinaryEncoding");
                     *(int32_t *)cursor = (int32_t)displacement;
                 } else if (symbol->isShadow()) {
-                    *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+                    *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                 } else
                     TR_ASSERT(0, "generateBinaryEncoding, new symbol hierarchy problem");
             } else {
-                TR::X86DataSnippet *cds = self()->getDataSnippet();
-                TR_ASSERT(cds == NULL || self()->getLabel() == NULL,
+                TR::X86DataSnippet *cds = getDataSnippet();
+                TR_ASSERT(cds == NULL || getLabel() == NULL,
                     "a memRef cannot have both a constant data snippet and a label");
                 TR::LabelSymbol *label = NULL;
                 if (cds)
                     label = cds->getSnippetLabel();
                 else
-                    label = self()->getLabel();
+                    label = getLabel();
 
                 if (label != NULL) {
                     if (cg->comp()->target().is64Bit()) {
@@ -1304,12 +1302,12 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                         *(int32_t *)cursor = (int32_t)0;
                     }
                 } else {
-                    *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+                    *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                 }
             }
 
-            if (self()->getUnresolvedDataSnippet() != NULL) {
-                self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+            if (getUnresolvedDataSnippet() != NULL) {
+                getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
             }
 
             cursor += 4;
@@ -1317,7 +1315,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
         }
 
         case 5: {
-            base = toRealRegister(self()->getBaseRegister());
+            base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
             if (baseRegisterNumber == TR::RealRegister::vfp) {
@@ -1326,16 +1324,16 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
                 base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
                 baseRegisterNumber = base->getRegisterNumber();
-                self()->setBaseRegister(base);
+                setBaseRegister(base);
             }
 
-            if (base->needsSIB() || self()->isForceSIBByte()) {
+            if (base->needsSIB() || isForceSIBByte()) {
                 *++cursor = 0x00;
-                self()->ModRM(modRM)->setBase()->setHasSIB();
-                self()->SIB(cursor)->setNoIndex();
+                ModRM(modRM)->setBase()->setHasSIB();
+                SIB(cursor)->setNoIndex();
             }
 
-            displacement = self()->getDisplacement();
+            displacement = getDisplacement();
             TR_ASSERT_FATAL(IS_32BIT_SIGNED(displacement),
                 "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
 
@@ -1349,20 +1347,20 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
             base->setRMRegisterFieldInModRM(cursor++);
             immediateCursor = cursor;
 
-            if (displacement == 0 && !base->needsDisp() && !base->needsDisp() && !self()->isForceWideDisplacement()) {
-                self()->ModRM(modRM)->setBase();
-            } else if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
-                self()->ModRM(modRM)->setBaseDisp8();
+            if (displacement == 0 && !base->needsDisp() && !base->needsDisp() && !isForceWideDisplacement()) {
+                ModRM(modRM)->setBase();
+            } else if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+                ModRM(modRM)->setBaseDisp8();
                 *cursor = (uint8_t)displacement;
                 ++cursor;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
                 // then displacement will be 4 bytes.
                 //
-                self()->ModRM(modRM)->setBaseDisp32();
+                ModRM(modRM)->setBaseDisp32();
                 *(int32_t *)cursor = (int32_t)displacement;
-                if (self()->getUnresolvedDataSnippet() != NULL) {
-                    self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+                if (getUnresolvedDataSnippet() != NULL) {
+                    getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                 }
 
                 cursor += 4;
@@ -1371,7 +1369,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
         }
 
         case 7: {
-            base = toRealRegister(self()->getBaseRegister());
+            base = toRealRegister(getBaseRegister());
             baseRegisterNumber = base->getRegisterNumber();
 
             if (baseRegisterNumber == TR::RealRegister::vfp) {
@@ -1380,16 +1378,16 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
 
                 base = toRealRegister(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
                 baseRegisterNumber = base->getRegisterNumber();
-                self()->setBaseRegister(base);
+                setBaseRegister(base);
             }
 
-            index = toRealRegister(self()->getIndexRegister());
+            index = toRealRegister(getIndexRegister());
             *++cursor = 0x00;
             base->setBaseRegisterFieldInSIB(cursor);
             index->setIndexRegisterFieldInSIB(cursor);
-            self()->setStrideFieldInSIB(cursor);
+            setStrideFieldInSIB(cursor);
             ++cursor;
-            displacement = self()->getDisplacement();
+            displacement = getDisplacement();
             immediateCursor = cursor;
 
             TR_ASSERT(IS_32BIT_SIGNED(displacement),
@@ -1402,17 +1400,17 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                 setForceWideDisplacement();
             }
 
-            if (displacement >= -128 && displacement <= 127 && !self()->isForceWideDisplacement()) {
-                self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
+            if (displacement >= -128 && displacement <= 127 && !isForceWideDisplacement()) {
+                ModRM(modRM)->setBaseDisp8()->setHasSIB();
                 *cursor++ = (uint8_t)displacement;
             } else {
                 // If there is a symbol or if the displacement will not fit in a byte,
                 // then displacement will be 4 bytes.
                 //
-                self()->ModRM(modRM)->setBaseDisp32()->setHasSIB();
+                ModRM(modRM)->setBaseDisp32()->setHasSIB();
                 *(int32_t *)cursor = (int32_t)displacement;
-                if (self()->getUnresolvedDataSnippet() != NULL) {
-                    self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+                if (getUnresolvedDataSnippet() != NULL) {
+                    getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                 }
 
                 cursor += 4;
@@ -1486,7 +1484,7 @@ const uint8_t OMR::X86::MemoryReference::_multiplierToStrideMap[HIGHEST_STRIDE_M
 #ifdef DEBUG
 uint32_t OMR::X86::MemoryReference::getNumMRReferencedGPRegisters()
 {
-    return (self()->getBaseRegister() ? 1 : 0) + (self()->getIndexRegister() ? 1 : 0);
+    return (getBaseRegister() ? 1 : 0) + (getIndexRegister() ? 1 : 0);
 }
 #endif
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1280,7 +1280,7 @@ uint8_t *OMR::X86::MemoryReference::generateBinaryEncoding(uint8_t *modRM, TR::I
                     label = getLabel();
 
                 if (label != NULL) {
-                    if (cg->comp()->target().is64Bit()) {
+                    if (comp->target().is64Bit()) {
                         // This cast is ok because we only need the low 32 bits of the address
                         // *(int32_t *)cursor = -(int32_t)(intptr_t)(cursor+4);
                         // if it is X86MEMIMM instruction, offset need consider immedidate length

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -208,95 +208,98 @@ public:
 
     MemoryReference(TR::MemoryReference &mr, intptr_t n, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm = NULL);
 
-    TR::Register *getBaseRegister() { return _baseRegister; }
+    OMR_FINAL TR::Register *getBaseRegister() { return _baseRegister; }
 
-    TR::Register *setBaseRegister(TR::Register *br) { return (_baseRegister = br); }
+    OMR_FINAL TR::Register *setBaseRegister(TR::Register *br) { return (_baseRegister = br); }
 
-    TR::Node *getBaseNode() { return _baseNode; }
+    OMR_FINAL TR::Node *getBaseNode() { return _baseNode; }
 
-    TR::Node *setBaseNode(TR::Node *bn) { return (_baseNode = bn); }
+    OMR_FINAL TR::Node *setBaseNode(TR::Node *bn) { return (_baseNode = bn); }
 
-    TR::Register *getIndexRegister() { return _indexRegister; }
+    OMR_FINAL TR::Register *getIndexRegister() { return _indexRegister; }
 
-    TR::Register *setIndexRegister(TR::Register *ir) { return (_indexRegister = ir); }
+    OMR_FINAL TR::Register *setIndexRegister(TR::Register *ir) { return (_indexRegister = ir); }
 
-    TR::Node *getIndexNode() { return _indexNode; }
+    OMR_FINAL TR::Node *getIndexNode() { return _indexNode; }
 
-    TR::Node *setIndexNode(TR::Node *in) { return (_indexNode = in); }
+    OMR_FINAL TR::Node *setIndexNode(TR::Node *in) { return (_indexNode = in); }
 
     TR::Register *getAddressRegister() { return NULL; }
 
-    intptr_t getDisplacement();
+    OMR_FINAL intptr_t getDisplacement();
 
     // An unresolved data snippet, unresolved virtual call snippet, and constant data snippet are mutually exclusive for
     // a given memory reference.  Hence, they share the same pointer.
     //
-    TR::UnresolvedDataSnippet *getUnresolvedDataSnippet();
+    OMR_FINAL TR::UnresolvedDataSnippet *getUnresolvedDataSnippet();
 
-    TR::UnresolvedDataSnippet *setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s);
+    OMR_FINAL TR::UnresolvedDataSnippet *setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s);
 
-    TR::X86DataSnippet *getDataSnippet();
+    OMR_FINAL TR::X86DataSnippet *getDataSnippet();
 
-    TR::X86DataSnippet *setConstantDataSnippet(TR::X86DataSnippet *s)
+    OMR_FINAL TR::X86DataSnippet *setConstantDataSnippet(TR::X86DataSnippet *s)
     {
         return ((TR::X86DataSnippet *)(_dataSnippet = s));
     }
 
-    TR::LabelSymbol *getLabel() { return _label; }
+    OMR_FINAL TR::LabelSymbol *getLabel() { return _label; }
 
-    TR::LabelSymbol *setLabel(TR::LabelSymbol *l) { return (_label = l); }
+    OMR_FINAL TR::LabelSymbol *setLabel(TR::LabelSymbol *l) { return (_label = l); }
 
-    bool getFlags() { return _flags.getValue() != 0; }
+    OMR_FINAL bool getFlags() { return _flags.getValue() != 0; }
 
-    void setFlags(uint8_t f) { _flags.setValue(0xff, f); }
+    OMR_FINAL void setFlags(uint8_t f) { _flags.setValue(0xff, f); }
 
-    bool isForceWideDisplacement() { return _flags.testAny(MemRef_ForceWideDisplacement); }
+    OMR_FINAL bool isForceWideDisplacement() { return _flags.testAny(MemRef_ForceWideDisplacement); }
 
-    void setForceWideDisplacement() { _flags.set(MemRef_ForceWideDisplacement); }
+    OMR_FINAL void setForceWideDisplacement() { _flags.set(MemRef_ForceWideDisplacement); }
 
-    bool isForceSIBByte() { return _flags.testAny(MemRef_ForceSIBByte); }
+    OMR_FINAL bool isForceSIBByte() { return _flags.testAny(MemRef_ForceSIBByte); }
 
-    void setForceSIBByte() { _flags.set(MemRef_ForceSIBByte); }
+    OMR_FINAL void setForceSIBByte() { _flags.set(MemRef_ForceSIBByte); }
 
-    bool hasUnresolvedDataSnippet() { return _flags.testAny(MemRef_UnresolvedDataSnippet); }
+    OMR_FINAL bool hasUnresolvedDataSnippet() { return _flags.testAny(MemRef_UnresolvedDataSnippet); }
 
-    void setHasUnresolvedDataSnippet() { _flags.set(MemRef_UnresolvedDataSnippet); }
+    OMR_FINAL void setHasUnresolvedDataSnippet() { _flags.set(MemRef_UnresolvedDataSnippet); }
 
-    bool inUpcastingMode() { return _flags.testAny(MemRef_UpcastingMode); }
+    OMR_FINAL bool inUpcastingMode() { return _flags.testAny(MemRef_UpcastingMode); }
 
-    void setInUpcastingMode(bool b = true) { _flags.set(MemRef_UpcastingMode, b); }
-
-    // relevant only for 32 bit
-    //
-    bool processAsLongVolatileLow() { return _flags.testAny(MemRef_ProcessAsLongVolatileLow); }
-
-    void setProcessAsLongVolatileLow() { _flags.set(MemRef_ProcessAsLongVolatileLow); }
+    OMR_FINAL void setInUpcastingMode(bool b = true) { _flags.set(MemRef_UpcastingMode, b); }
 
     // relevant only for 32 bit
     //
-    bool processAsLongVolatileHigh() { return _flags.testAny(MemRef_ProcessAsLongVolatileHigh); }
+    OMR_FINAL bool processAsLongVolatileLow() { return _flags.testAny(MemRef_ProcessAsLongVolatileLow); }
 
-    void setProcessAsLongVolatileHigh() { _flags.set(MemRef_ProcessAsLongVolatileHigh); }
+    OMR_FINAL void setProcessAsLongVolatileLow() { _flags.set(MemRef_ProcessAsLongVolatileLow); }
+
+    // relevant only for 32 bit
+    //
+    OMR_FINAL bool processAsLongVolatileHigh() { return _flags.testAny(MemRef_ProcessAsLongVolatileHigh); }
+
+    OMR_FINAL void setProcessAsLongVolatileHigh() { _flags.set(MemRef_ProcessAsLongVolatileHigh); }
 
     // relevant only for 64 bit
     //
-    bool processAsFPVolatile() { return _flags.testAny(MemRef_ProcessAsFPVolatile); }
+    OMR_FINAL bool processAsFPVolatile() { return _flags.testAny(MemRef_ProcessAsFPVolatile); }
 
-    void setProcessAsFPVolatile() { _flags.set(MemRef_ProcessAsFPVolatile); }
+    OMR_FINAL void setProcessAsFPVolatile() { _flags.set(MemRef_ProcessAsFPVolatile); }
 
-    bool requiresLockPrefix() { return _flags.testAny(MemRef_RequiresLockPrefix); }
+    OMR_FINAL bool requiresLockPrefix() { return _flags.testAny(MemRef_RequiresLockPrefix); }
 
-    void setRequiresLockPrefix() { return _flags.set(MemRef_RequiresLockPrefix); }
+    OMR_FINAL void setRequiresLockPrefix() { return _flags.set(MemRef_RequiresLockPrefix); }
 
-    bool needsCodeAbsoluteExternalRelocation() { return _flags.testAny(MemRef_NeedExternalCodeAbsoluteRelocation); }
+    OMR_FINAL bool needsCodeAbsoluteExternalRelocation()
+    {
+        return _flags.testAny(MemRef_NeedExternalCodeAbsoluteRelocation);
+    }
 
-    void setNeedsCodeAbsoluteExternalRelocation() { _flags.set(MemRef_NeedExternalCodeAbsoluteRelocation); }
+    OMR_FINAL void setNeedsCodeAbsoluteExternalRelocation() { _flags.set(MemRef_NeedExternalCodeAbsoluteRelocation); }
 
-    bool ignoreVolatile() { return _flags.testAny(MemRef_IgnoreVolatile); }
+    OMR_FINAL bool ignoreVolatile() { return _flags.testAny(MemRef_IgnoreVolatile); }
 
-    void setIgnoreVolatile() { _flags.set(MemRef_IgnoreVolatile); }
+    OMR_FINAL void setIgnoreVolatile() { _flags.set(MemRef_IgnoreVolatile); }
 
-    bool refsRegister(TR::Register *reg)
+    OMR_FINAL bool refsRegister(TR::Register *reg)
     {
         if (reg == _baseRegister || reg == _indexRegister) {
             return true;
@@ -308,26 +311,26 @@ public:
     // uses. Use an argument of NULL on the first call, and after that use the
     // result of the previous call.
     //
-    TR::Register *getNextRegister(TR::Register *cur);
+    OMR_FINAL TR::Register *getNextRegister(TR::Register *cur);
 
-    uint8_t getStride() { return _stride; }
+    OMR_FINAL uint8_t getStride() { return _stride; }
 
-    uint8_t setStride(uint8_t s) { return (_stride = s); }
+    OMR_FINAL uint8_t setStride(uint8_t s) { return (_stride = s); }
 
-    uint8_t getStrideMultiplier() { return 1 << _stride; }
+    OMR_FINAL uint8_t getStrideMultiplier() { return 1 << _stride; }
 
-    uint8_t setStrideFromMultiplier(uint8_t s);
+    OMR_FINAL uint8_t setStrideFromMultiplier(uint8_t s);
 
-    TR::SymbolReference &getSymbolReference() { return _symbolReference; }
+    OMR_FINAL TR::SymbolReference &getSymbolReference() { return _symbolReference; }
 
-    int32_t isValidStrideMultiplier(int32_t constFactor)
+    OMR_FINAL int32_t isValidStrideMultiplier(int32_t constFactor)
     {
         return ((uint32_t)(constFactor - 1) < HIGHEST_STRIDE_MULTIPLIER) ? isNonNegativePowerOf2(constFactor) : 0;
     }
 
-    int32_t isValidStrideShift(int32_t shiftAmount) { return (uint32_t)shiftAmount <= HIGHEST_STRIDE_SHIFT; }
+    OMR_FINAL int32_t isValidStrideShift(int32_t shiftAmount) { return (uint32_t)shiftAmount <= HIGHEST_STRIDE_SHIFT; }
 
-    static int32_t getStrideForNode(TR::Node *node, TR::CodeGenerator *cg);
+    OMR_FINAL static int32_t getStrideForNode(TR::Node *node, TR::CodeGenerator *cg);
 
     uint32_t getBinaryLengthLowerBound(TR::CodeGenerator *cg);
     virtual uint32_t estimateBinaryLength(TR::Instruction *containingInstruction, TR::CodeGenerator *cg);
@@ -357,11 +360,11 @@ public:
 
     void addMetaDataForCodeAddress(uint32_t addressTypes, uint8_t *cursor, TR::Node *node, TR::CodeGenerator *cg);
 
-    inline TR::Instruction::ModRM *ModRM(uint8_t *modrm) const { return (TR::Instruction::ModRM *)modrm; }
+    OMR_FINAL inline TR::Instruction::ModRM *ModRM(uint8_t *modrm) const { return (TR::Instruction::ModRM *)modrm; }
 
-    inline TR::Instruction::SIB *SIB(uint8_t *sib) const { return (TR::Instruction::SIB *)sib; }
+    OMR_FINAL inline TR::Instruction::SIB *SIB(uint8_t *sib) const { return (TR::Instruction::SIB *)sib; }
 
-    void setStrideFieldInSIB(uint8_t *SIBByte) { ((TR::Instruction::SIB *)SIBByte)->setScale(_stride); }
+    OMR_FINAL void setStrideFieldInSIB(uint8_t *SIBByte) { ((TR::Instruction::SIB *)SIBByte)->setScale(_stride); }
 
     virtual void blockRegisters()
     {
@@ -387,7 +390,10 @@ public:
     uint32_t getNumMRReferencedGPRegisters();
 #endif
 
-    static int32_t convertMultiplierToStride(int32_t multiplier) { return _multiplierToStrideMap[multiplier]; }
+    OMR_FINAL static int32_t convertMultiplierToStride(int32_t multiplier)
+    {
+        return _multiplierToStrideMap[multiplier];
+    }
 
 #if defined(TR_TARGET_64BIT)
     uint8_t rexBits()
@@ -413,9 +419,9 @@ public:
     uint8_t rexBits() { return 0; }
 #endif
 
-    int32_t getReloKind() { return _reloKind; }
+    OMR_FINAL int32_t getReloKind() { return _reloKind; }
 
-    void setReloKind(int32_t reloKind) { _reloKind = reloKind; }
+    OMR_FINAL void setReloKind(int32_t reloKind) { _reloKind = reloKind; }
 };
 }} // namespace OMR::X86
 

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -200,9 +200,10 @@ uint8_t *OMR::X86::Instruction::generateBinaryEncoding()
         cursor = getOpCode().binary(cursor, getEncodingMethod(), rexBits());
         cursor = generateOperand(cursor);
 
-        // cursor is normally not NULL, and hence we can finish binary encoding and exit the loop
-        // cursor is NULL when generateOperand() requests to regenerate the binary code, which may happen during
-        // encoding of memref with unresolved symbols on 64-bit
+        // cursor is normally not NULL, and hence we can finish binary encoding and exit the loop.
+        // cursor is NULL when generateOperand() requests to regenerate the binary code, which
+        // will happen if binary encoding memory references on 64-bit require an address load
+        // instruction to be inserted to synthesize a 64-bit address immediate.
         //
         if (cursor) {
             if (!getSource2ndRegister()) {


### PR DESCRIPTION
* Add `OMR_FINAL` to OMRMemoryReference and remove unnecessary `self()` calls
* Improve readability of MemoryReference encoding switch statements
* Remove MemoryReference encoding vfp code
* AMD64 MemoryReference readability enhancements
* Remove unused estimateBinaryLength() function