### PR TITLE
Disable const refs on AArch64

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3533,7 +3533,7 @@ void OMR::Options::jitPreProcess()
 
     self()->setOption(TR_RestrictStaticFieldFolding);
 
-#ifdef TR_ALLOW_NON_CONST_KNOWN_OBJECTS
+#if defined(TR_ALLOW_NON_CONST_KNOWN_OBJECTS) && !defined(TR_HOST_ARM64)
     self()->setOption(TR_EnableConstRefs);
 #endif
 


### PR DESCRIPTION
This is a temporary fix for eclipse-openj9/openj9#24337. It disables const refs on AArch64 only.