### PR TITLE
Record const provenance for classes embedded in VftTest guards

### DIFF
--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -46,6 +46,7 @@
 
 #ifdef J9_PROJECT_SPECIFIC
 #include "env/CHTable.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #endif
 
 TR_VirtualGuard::TR_VirtualGuard(TR_VirtualGuardTestType test, TR_VirtualGuardKind kind, TR::Compilation *comp,
@@ -198,6 +199,18 @@ TR::Node *TR_VirtualGuard::createVftGuardWithReceiver(TR_VirtualGuardKind kind, 
     aconstNode->setIsClassPointerConstant(true);
     aconstNode->setInlinedSiteIndex(calleeIndex);
     aconstNode->setByteCodeIndex(0);
+
+#ifdef J9_PROJECT_SPECIFIC
+    // The guard embeds a reference to thisClass, which otherwise might have no
+    // connection to the compiled body at all, e.g. a profiled class defined by
+    // a non-permanent loader. Record where it is referenced from so that known
+    // objects folded under the guard (such as its java/lang/Class instance)
+    // can be attributed to an owning class instead of being orphaned.
+    int16_t callerIndex = callNode->getByteCodeInfo().getCallerIndex();
+    TR_ResolvedMethod *callSiteMethod
+        = callerIndex == -1 ? comp->getMethodBeingCompiled() : comp->getInlinedResolvedMethod(callerIndex);
+    comp->constProvenanceGraph()->addEdge(callSiteMethod, thisClass);
+#endif
 
     TR::Node *guard = TR::Node::createif(TR::ifacmpne, vft, aconstNode, destination);
 


### PR DESCRIPTION
A VftTest virtual guard embeds a reference to the class being tested in the generated code. When the tested class comes from profiling (a profiled guard), it can be defined by a non-permanent class loader while having no other connection to the compiled body: it is not the defining class of any inlined method, and it appears in no constant pool visited during the compilation. Known objects from from the fixed class, such as its java/lang/Class instance, then have no path from any const provenance root, and if the folded constref load survives to codegen, orphaned constrefs check in codegen can fail and result in fatal assertion failures.

This commit records an edge from the method containing the guarded call site to the tested class when the guard node is created. The guard code itself references the class, and every use of a constant folded from the fixed-class knowledge is dominated by the guard, so the class is a valid provenance origin for such constants.

Issue: https://github.com/eclipse-openj9/openj9/issues/24336
Comment explaining the problem being addressed: https://github.com/eclipse-openj9/openj9/issues/24336#issuecomment-4937721554
Const-refs issue: https://github.com/eclipse-openj9/openj9/issues/16616