### PR TITLE
Fix out-of-bounds array access for optimization group IDs

### DIFF
--- a/compiler/optimizer/OMROptimizationManager.cpp
+++ b/compiler/optimizer/OMROptimizationManager.cpp
@@ -55,10 +55,10 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
     , _numPassesCompleted(0)
     , _optData(NULL)
     , _optPolicy(NULL)
-    , _enabled(!o->comp()->isDisabled(optNum))
+    , _enabled(optNum >= OMR::numOpts || !o->comp()->isDisabled(optNum))
     , _requested(false)
     , _requestedBlocks(o->trMemory())
-    , _trace(o->comp()->getOptions()->trace(optNum))
+    , _trace(optNum < OMR::numOpts && o->comp()->getOptions()->trace(optNum))
 {
     if (_id < OMR::Optimizations::numGroups)
         TR_ASSERT_SAFE_FATAL(_id < OMR::Optimizations::numGroups, "The optimization id requested (%d) is too high",


### PR DESCRIPTION
- _disabledOptimizations and _traceOptimizations are sized
  OMR::numOpts, but group IDs (e.g. globalDeadStoreGroup) are
  enumerated above numOpts.
- The OptimizationManager constructor was calling isDisabled(optNum)
  and trace(optNum) unconditionally, causing an out-of-bounds read
  for any group manager.
- Since groups can never be individually disabled or traced, skip
  those calls entirely for group IDs: _enabled is initialized to
  true and _trace to false when optNum >= OMR::numOpts.