### PR TITLE
Pure functions should not limit privatization in LoopVersioner

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3814,7 +3814,8 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
             if (ttNode->getOpCodeValue() == TR::treetop || ttNode->getOpCode().isNullCheck()
                 || ttNode->getOpCode().isResolveCheck()) {
                 TR::Node *child = ttNode->getChild(0);
-                if (child->getOpCode().isFunctionCall()) {
+                if (child->getOpCode().isFunctionCall()
+                    && !child->getSymbol()->castToMethodSymbol()->isPureFunction()) {
                     newPrivatizationOK = false;
                     if (_curLoop->_privatizationOK)
                         traceCannot("privatize", child, comp());


### PR DESCRIPTION
- During privatization candidate analysis, LoopVersioner marks a loop
   as non-privatizable when it encounters a function call node.
- Pure functions cannot affect the correctness of loop privatization,
   and therefore, they can be excluded from that check.
