### PR TITLE
Replace getName(TR::Snippet) with direct Logger output

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1308,7 +1308,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64LabelInstruction *instr)
         log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
         print(log, label);
         if (snippet) {
-            log->printf(" (%s)", getName(snippet));
+            log->prints(" (");
+            snippet->printName(log);
+            log->printc(')');
         }
     }
     printInstructionComment(log, 1, instr);
@@ -1340,7 +1342,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64ConditionalBranchInstruction *in
     log->printf("b.%s \t", ARM64ConditionNames[instr->getConditionCode()]);
     print(log, label);
     if (snippet) {
-        log->printf(" (%s)", getName(snippet));
+        log->prints(" (");
+        snippet->printName(log);
+        log->printc(')');
     }
     printInstructionComment(log, 1, instr);
     if (instr->getDependencyConditions())
@@ -1363,7 +1367,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64CompareBranchInstruction *instr)
     log->prints(", ");
     print(log, label);
     if (snippet) {
-        log->printf(" (%s)", getName(snippet));
+        log->prints(" (");
+        snippet->printName(log);
+        log->printc(')');
     }
     printInstructionComment(log, 1, instr);
     if (instr->getDependencyConditions())
@@ -1383,7 +1389,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64TestBitBranchInstruction *instr)
     log->printf("#%d, ", instr->getBitPos());
     print(log, label);
     if (snippet) {
-        log->printf(" (%s)", getName(snippet));
+        log->prints(" (");
+        snippet->printName(log);
+        log->printc(')');
     }
     printInstructionComment(log, 1, instr);
     if (instr->getDependencyConditions())
@@ -1560,7 +1568,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmSymInstruction *instr)
         print(log, label);
         TR::Snippet *snippet = label->getSnippet();
         if (snippet) {
-            log->printf("(%s)", getName(snippet));
+            log->prints(" (");
+            snippet->printName(log);
+            log->printc(')');
         }
     } else {
         int64_t offset = static_cast<int64_t>(static_cast<int32_t>(instr->getSourceImmediate()));
@@ -2999,53 +3009,6 @@ void TR_Debug::printARM64OOLSequences(OMR::Logger *log)
         log->prints("\n------------ end out-of-line instructions\n");
 
         ++oiIterator;
-    }
-}
-
-const char *TR_Debug::getNamea64(TR::Snippet *snippet)
-{
-    switch (snippet->getKind()) {
-        case TR::Snippet::IsCall:
-            return "Call Snippet";
-            break;
-        case TR::Snippet::IsUnresolvedCall:
-            return "Unresolved Call Snippet";
-            break;
-        case TR::Snippet::IsVirtualUnresolved:
-            return "Unresolved Virtual Call Snippet";
-            break;
-        case TR::Snippet::IsInterfaceCall:
-            return "Interface Call Snippet";
-            break;
-        case TR::Snippet::IsStackCheckFailure:
-            return "Stack Check Failure Snippet";
-            break;
-        case TR::Snippet::IsForceRecompilation:
-            return "Force Recompilation Snippet";
-            break;
-        case TR::Snippet::IsUnresolvedData:
-            return "Unresolved Data Snippet";
-            break;
-        case TR::Snippet::IsConstantData:
-            return "Constant Data Snippet";
-            break;
-        case TR::Snippet::IsRecompilation:
-            return "Recompilation Snippet";
-            break;
-        case TR::Snippet::IsHelperCall:
-            return "Helper Call Snippet";
-            break;
-        case TR::Snippet::IsMonitorEnter:
-            return "MonitorEnter Inc Counter";
-            break;
-        case TR::Snippet::IsMonitorExit:
-            return "MonitorExit Dec Counter";
-            break;
-        case TR::Snippet::IsHeapAlloc:
-            return "Heap Alloc Snippet";
-            break;
-        default:
-            return "<unknown snippet>";
     }
 }
 

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -72,7 +72,7 @@ void TR::ARM64HelperCallSnippet::print(OMR::Logger *log, TR_Debug *debug)
 {
     uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
 
-    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, debug->getName(this));
+    debug->printSnippetLabel(log, this, bufferPos);
     printInner(log, debug, bufferPos);
 }
 

--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -145,7 +145,7 @@ void TR::ARM64ConstantDataSnippet::print(OMR::Logger *log, TR_Debug *debug)
 {
     uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
 
-    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, debug->getName(this));
+    debug->printSnippetLabel(log, this, bufferPos);
     debug->printPrefix(log, NULL, bufferPos, getDataSize());
 
     switch (getDataSize()) {

--- a/compiler/aarch64/codegen/OMRSnippet.cpp
+++ b/compiler/aarch64/codegen/OMRSnippet.cpp
@@ -21,6 +21,7 @@
 
 #include "codegen/Snippet.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "ras/Logger.hpp"
 
 OMR::ARM64::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *label, bool isGCSafePoint)
     : OMR::Snippet(cg, node, label, isGCSafePoint)
@@ -29,3 +30,55 @@ OMR::ARM64::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSym
 OMR::ARM64::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *label)
     : OMR::Snippet(cg, node, label)
 {}
+
+void OMR::ARM64::Snippet::printName(OMR::Logger *log)
+{
+    const char *name;
+
+    switch (getKind()) {
+        case TR::Snippet::IsCall:
+            name = "Call Snippet";
+            break;
+        case TR::Snippet::IsUnresolvedCall:
+            name = "Unresolved Call Snippet";
+            break;
+        case TR::Snippet::IsVirtualUnresolved:
+            name = "Unresolved Virtual Call Snippet";
+            break;
+        case TR::Snippet::IsInterfaceCall:
+            name = "Interface Call Snippet";
+            break;
+        case TR::Snippet::IsStackCheckFailure:
+            name = "Stack Check Failure Snippet";
+            break;
+        case TR::Snippet::IsForceRecompilation:
+            name = "Force Recompilation Snippet";
+            break;
+        case TR::Snippet::IsUnresolvedData:
+            name = "Unresolved Data Snippet";
+            break;
+        case TR::Snippet::IsConstantData:
+            name = "Constant Data Snippet";
+            break;
+        case TR::Snippet::IsRecompilation:
+            name = "Recompilation Snippet";
+            break;
+        case TR::Snippet::IsHelperCall:
+            name = "Helper Call Snippet";
+            break;
+        case TR::Snippet::IsMonitorEnter:
+            name = "MonitorEnter Inc Counter";
+            break;
+        case TR::Snippet::IsMonitorExit:
+            name = "MonitorExit Dec Counter";
+            break;
+        case TR::Snippet::IsHeapAlloc:
+            name = "Heap Alloc Snippet";
+            break;
+        default:
+            name = "<unknown snippet>";
+            break;
+    }
+
+    log->prints(name);
+}

--- a/compiler/aarch64/codegen/OMRSnippet.hpp
+++ b/compiler/aarch64/codegen/OMRSnippet.hpp
@@ -47,6 +47,11 @@ class LabelSymbol;
 class Node;
 } // namespace TR
 
+namespace OMR {
+class Logger;
+} // namespace OMR
+  //
+
 namespace OMR { namespace ARM64 {
 
 class OMR_EXTENSIBLE Snippet : public OMR::Snippet {
@@ -88,6 +93,11 @@ public:
     };
 
     virtual Kind getKind() { return IsUnknown; }
+
+    /**
+     * @copydoc OMR::Snippet::printName(OMR::Logger *)
+     */
+    void printName(OMR::Logger *log);
 };
 
 }} // namespace OMR::ARM64

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -290,8 +290,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMLabelInstruction *instr)
     } else if (instr->getOpCodeValue() == TR::InstOpCode::b || instr->getOpCodeValue() == TR::InstOpCode::bl) {
         log->printf("%s\t", fullOpCodeName(instr));
         print(log, label);
-        if (snippet)
-            log->printf(" (%s)", getName(snippet));
+        if (snippet) {
+            log->prints(" (");
+            snippet->printName(log);
+            log->printc(')');
+        }
     } else {
         log->printf("%s\t", fullOpCodeName(instr));
         print(log, instr->getTarget1Register(), TR_WordReg);
@@ -399,9 +402,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMImmSymInstruction *instr)
             log->printf("%s\t%-24s; ", fullOpCodeName(instr), name);
 
             TR::Snippet *snippet = sym->getLabelSymbol() ? sym->getLabelSymbol()->getSnippet() : NULL;
-            if (snippet)
-                log->printf("(%s)", getName(snippet));
-            else
+            if (snippet) {
+                log->printc('(');
+                snippet->printName(log);
+                log->printc(')');
+            } else
                 log->printf("(" POINTER_PRINTF_FORMAT ")", imm);
         } else {
             log->printf("%s\t" POINTER_PRINTF_FORMAT, fullOpCodeName(instr), imm);
@@ -967,44 +972,6 @@ const char *TR_Debug::getName(uint32_t realRegisterIndex, TR_RegisterSizes size)
     }
 }
 
-const char *TR_Debug::getNamea(TR::Snippet *snippet)
-{
-    switch (snippet->getKind()) {
-        case TR::Snippet::IsCall:
-            return "Call Snippet";
-            break;
-        case TR::Snippet::IsUnresolvedCall:
-            return "Unresolved Call Snippet";
-            break;
-        case TR::Snippet::IsVirtualUnresolved:
-            return "Unresolved Virtual Call Snippet";
-            break;
-        case TR::Snippet::IsInterfaceCall:
-            return "Interface Call Snippet";
-            break;
-        case TR::Snippet::IsStackCheckFailure:
-            return "Stack Check Failure Snippet";
-            break;
-        case TR::Snippet::IsUnresolvedData:
-            return "Unresolved Data Snippet";
-            break;
-        case TR::Snippet::IsRecompilation:
-            return "Recompilation Snippet";
-            break;
-        case TR::Snippet::IsHelperCall:
-            return "Helper Call Snippet";
-            break;
-        case TR::Snippet::IsMonitorEnter:
-            return "MonitorEnter Inc Counter";
-            break;
-        case TR::Snippet::IsMonitorExit:
-            return "MonitorExit Dec Counter";
-            break;
-        default:
-            return "<unknown snippet>";
-    }
-}
-
 void TR_Debug::printa(OMR::Logger *log, TR::Snippet *snippet)
 {
     switch (snippet->getKind()) {
@@ -1057,7 +1024,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMCallSnippet *snippet)
     TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(methodSymRef));
+    log->printc(')');
 
     TR::Machine *machine = _cg->machine();
     TR::Linkage *linkage = _cg->getLinkage(methodSymbol->getLinkageConvention());
@@ -1209,7 +1179,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMVirtualUnresolvedSnippet *snippet)
     TR::SymbolReference *callSymRef = snippet->getNode()->getSymbolReference();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(callSymRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(callSymRef));
+    log->printc(')');
 
     TR::SymbolReference *glueRef = _cg->getSymRef(TR_ARMvirtualUnresolvedHelper);
     printARMHelperBranch(log, glueRef, bufferPos);
@@ -1236,7 +1209,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMInterfaceCallSnippet *snippet)
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(callSymRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(callSymRef));
+    log->printc(')');
 
     printARMHelperBranch(log, glueRef, bufferPos);
     bufferPos += 4;
@@ -1299,7 +1275,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMHelperCallSnippet *snippet)
 {
 #ifdef J9_PROJECT_SPECIFIC
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::LabelSymbol *restartLabel = snippet->getRestartLabel();
     // int32_t          distance  = target - (uintptr_t)bufferPos;
@@ -1320,7 +1296,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARMHelperCallSnippet *snippet)
 void TR_Debug::print(OMR::Logger *log, TR::ARMStackCheckFailureSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::ResolvedMethodSymbol *bodySymbol = _comp->getJittedMethodSymbol();
     TR::SymbolReference *sofRef = _comp->getSymRefTab()->element(TR_stackOverflow);
@@ -1390,7 +1366,10 @@ void TR_Debug::print(OMR::Logger *log, TR::UnresolvedDataSnippet *snippet)
     TR::SymbolReference *symRef = snippet->getDataSymbolReference();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(symRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(symRef));
+    log->printc(')');
 
     printARMHelperBranch(log, _cg->getSymRef(snippet->getHelper()), bufferPos);
     bufferPos += 4;

--- a/compiler/arm/codegen/OMRSnippet.cpp
+++ b/compiler/arm/codegen/OMRSnippet.cpp
@@ -21,6 +21,7 @@
 
 #include "codegen/Snippet.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "ras/Logger.hpp"
 
 OMR::ARM::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *label, bool isGCSafePoint)
     : OMR::Snippet(cg, node, label, isGCSafePoint)
@@ -29,3 +30,46 @@ OMR::ARM::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbo
 OMR::ARM::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *label)
     : OMR::Snippet(cg, node, label)
 {}
+
+void OMR::ARM::Snippet::printName(OMR::Logger *log)
+{
+    const char *name;
+
+    switch (getKind()) {
+        case TR::Snippet::IsCall:
+            name = "Call Snippet";
+            break;
+        case TR::Snippet::IsUnresolvedCall:
+            name = "Unresolved Call Snippet";
+            break;
+        case TR::Snippet::IsVirtualUnresolved:
+            name = "Unresolved Virtual Call Snippet";
+            break;
+        case TR::Snippet::IsInterfaceCall:
+            name = "Interface Call Snippet";
+            break;
+        case TR::Snippet::IsStackCheckFailure:
+            name = "Stack Check Failure Snippet";
+            break;
+        case TR::Snippet::IsUnresolvedData:
+            name = "Unresolved Data Snippet";
+            break;
+        case TR::Snippet::IsRecompilation:
+            name = "Recompilation Snippet";
+            break;
+        case TR::Snippet::IsHelperCall:
+            name = "Helper Call Snippet";
+            break;
+        case TR::Snippet::IsMonitorEnter:
+            name = "MonitorEnter Inc Counter";
+            break;
+        case TR::Snippet::IsMonitorExit:
+            name = "MonitorExit Dec Counter";
+            break;
+        default:
+            name = "<unknown snippet>";
+            break;
+    }
+
+    log->prints(name);
+}

--- a/compiler/arm/codegen/OMRSnippet.hpp
+++ b/compiler/arm/codegen/OMRSnippet.hpp
@@ -47,6 +47,10 @@ class LabelSymbol;
 class Node;
 } // namespace TR
 
+namespace OMR {
+class Logger;
+} // namespace OMR
+
 namespace OMR { namespace ARM {
 
 class OMR_EXTENSIBLE Snippet : public OMR::Snippet {
@@ -72,6 +76,11 @@ public:
     };
 
     virtual Kind getKind() { return IsUnknown; }
+
+    /**
+     * @copydoc OMR::Snippet::printName(OMR::Logger *)
+     */
+    void printName(OMR::Logger *log);
 };
 
 }} // namespace OMR::ARM

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -39,6 +39,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
 #include "env/FrontEnd.hpp"
+#include "env/StackMemoryRegion.hpp"
 #include "codegen/Instruction.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
@@ -2150,6 +2151,8 @@ uint8_t *OMR::CodeGenerator::emitSnippets()
     uint8_t *codeOffset;
     uint8_t *retVal;
 
+    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
+
     omrthread_jit_write_protect_disable();
 
     for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator) {
@@ -2161,7 +2164,7 @@ uint8_t *OMR::CodeGenerator::emitSnippets()
                     >= codeOffset,
                 "%s length estimate must be conservatively large (snippet @ " POINTER_PRINTF_FORMAT
                 ", estimate=%d, actual=%d)",
-                getDebug()->getName(*iterator), *iterator,
+                (*iterator)->getName(stackMemoryRegion), *iterator,
                 (*iterator)->getLength(
                     static_cast<int32_t>(self()->getBinaryBufferCursor() - self()->getBinaryBufferStart())),
                 codeOffset - self()->getBinaryBufferCursor());

--- a/compiler/codegen/OMRSnippet.cpp
+++ b/compiler/codegen/OMRSnippet.cpp
@@ -93,3 +93,28 @@ void OMR::Snippet::print(OMR::Logger *log, TR_Debug *debug)
         debug->printPrefix(log, NULL, cursor, self()->getLength(0) % sizeof(uint64_t));
     }
 }
+
+void OMR::Snippet::printName(OMR::Logger *log) { log->prints("<unknown snippet>"); }
+
+const char *OMR::Snippet::getName(TR::Region &region)
+{
+    const int32_t maxNameLen = 64;
+    char buf[maxNameLen];
+
+    // Render the name into a local buffer
+    //
+    OMR::Logger *log = OMR::MemoryBufferLogger::create(region, buf, maxNameLen);
+    self()->printName(log);
+
+    size_t len = strlen(buf);
+
+    // Trim the buffer that will be returned to the exact length
+    //
+    char *name = (char *)region.allocate(len + 1); // +1 for NUL-terminator
+    if (name) {
+        // Include the NUL-terminator
+        memcpy(name, buf, len + 1);
+    }
+
+    return name;
+}

--- a/compiler/codegen/OMRSnippet.hpp
+++ b/compiler/codegen/OMRSnippet.hpp
@@ -82,6 +82,27 @@ public:
 
     virtual void print(OMR::Logger *log, TR_Debug *debug);
 
+    /**
+     * @brief Print the name of this snippet to the provided Logger
+     *
+     * @details
+     *     Platforms and downstream projects are expected to specialize this function
+     *     to provide meaningful output.
+     *
+     * @param[in] log : the destination Logger
+     */
+    void printName(OMR::Logger *log);
+
+    /**
+     * @brief Retrieves a NUL-terminated `const char *` to the snippet name
+     *
+     * @param[in[ region : the memory `TR::Region` where storage for the string
+     *     is to be allocated
+     *
+     * @return A NUL-terminated string for the snippet name
+     */
+    const char *getName(TR::Region &region);
+
     void prepareSnippetForGCSafePoint();
 
     /////////////////////////////////////////////////////////////////////////////

--- a/compiler/codegen/OMRUnresolvedDataSnippet.cpp
+++ b/compiler/codegen/OMRUnresolvedDataSnippet.cpp
@@ -67,7 +67,7 @@ TR::UnresolvedDataSnippet *OMR::UnresolvedDataSnippet::create(TR::CodeGenerator 
 void TR_Debug::print(OMR::Logger *log, TR::UnresolvedDataSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 }
 
 #endif

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -610,13 +610,10 @@ uint8_t *TR_Debug::printPrefix(OMR::Logger *log, TR::Instruction *instr, uint8_t
     return cursor;
 }
 
-void TR_Debug::printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8_t *cursor, const char *comment1,
-    const char *comment2)
+void TR_Debug::printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8_t *cursor)
 {
-    int addressFieldWidth = TR::Compiler->debug.hexAddressFieldWidthInChars();
-    int codeByteColumnWidth = TR::Compiler->debug.codeByteColumnWidth();
-    int prefixWidth = addressFieldWidth * 2 + codeByteColumnWidth
-        + 12; // 8 bytes of offsets, 2 spaces, and opening and closing brackets
+    int32_t addressFieldWidth = TR::Compiler->debug.hexAddressFieldWidthInChars();
+    int32_t codeByteColumnWidth = TR::Compiler->debug.codeByteColumnWidth();
 
     uint32_t offset = static_cast<uint32_t>(cursor - _comp->cg()->getCodeStart());
 
@@ -624,6 +621,22 @@ void TR_Debug::printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8
         " ");
 
     print(log, label);
+}
+
+void TR_Debug::printSnippetLabel(OMR::Logger *log, TR::Snippet *snippet, uint8_t *cursor)
+{
+    printSnippetLabel(log, snippet->getSnippetLabel(), cursor);
+
+    log->printc(':');
+    log->printf("\t\t%c ", (_comp->target().cpu.isX86() && _comp->target().isLinux()) ? '#' : ';');
+    snippet->printName(log);
+}
+
+void TR_Debug::printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8_t *cursor, const char *comment1,
+    const char *comment2)
+{
+    printSnippetLabel(log, label, cursor);
+
     log->printc(':');
     if (comment1) {
         log->printf("\t\t%c %s", (_comp->target().cpu.isX86() && _comp->target().isLinux()) ? '#' : ';', comment1);
@@ -2331,23 +2344,6 @@ void TR_Debug::print(OMR::Logger *log, TR::list<TR::Snippet *> &snippetList)
 
     if (_comp->cg()->hasDataSnippets())
         _comp->cg()->dumpDataSnippets(log);
-}
-
-const char *TR_Debug::getName(TR::Snippet *snippet)
-{
-#if defined(TR_TARGET_X86)
-    if (_comp->target().cpu.isX86())
-        return getNamex(snippet);
-#endif
-#if defined(TR_TARGET_ARM)
-    if (_comp->target().cpu.isARM())
-        return getNamea(snippet);
-#endif
-#if defined(TR_TARGET_ARM64)
-    if (_comp->target().cpu.isARM64())
-        return getNamea64(snippet);
-#endif
-    return "<unknown snippet>"; // TODO: Return a more informative name
 }
 
 void TR_Debug::print(OMR::Logger *log, TR::Snippet *snippet)

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -581,7 +581,6 @@ public:
      * @return a const char * string for the name of the register
      */
     virtual const char *getGlobalRegisterName(TR_GlobalRegisterNumber regNum, TR::DataType dt);
-    virtual const char *getName(TR::Snippet *);
     virtual const char *getName(TR::Node *);
     virtual const char *getName(TR::Symbol *);
     virtual const char *getName(TR::Instruction *);
@@ -713,7 +712,6 @@ public:
     virtual void dumpInstructionWithVFPState(OMR::Logger *log, TR::Instruction *instr, const TR_VFPState *prevState);
 
     void print(OMR::Logger *log, TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
-    const char *getNamex(TR::Snippet *);
     void printRegMemInstruction(OMR::Logger *log, const char *, TR::RealRegister *reg, TR::RealRegister *base = 0,
         int32_t = 0);
     void printRegRegInstruction(OMR::Logger *log, const char *, TR::RealRegister *reg1, TR::RealRegister *reg2 = 0);
@@ -816,8 +814,39 @@ public:
         int32_t *offsetInfo, bool nummaps = false);
     void printJ9JITExceptionTableDetails(OMR::Logger *log, J9JITExceptionTable *data,
         J9JITExceptionTable *dbgextRemotePtr = NULL);
+
+    /**
+     * @brief Print a label and label offset in the code buffer in a format
+     *     suitable for showing Snippet labels
+     *
+     * @param[in] log : \c OMR::Logger
+     * @param[in] label : the \c LabelSymbol to print
+     * @param[in] cursor : the code address of the label
+     */
+    void printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8_t *cursor);
+
+    /**
+     * @brief Print a snippet label and the label offset in the code buffer
+     *
+     * @param[in] log : \c OMR::Logger
+     * @param[in] snippet : the snippet whose label to print
+     * @param[in] cursor : the code address of the label
+     */
+    void printSnippetLabel(OMR::Logger *log, TR::Snippet *snippet, uint8_t *cursor);
+
+    /**
+     * @brief Print a label, label offset in the code buffer, and one or more
+     *     comments in a a format suitable for showing Snippet labels
+     *
+     * @param[in] log : \c OMR::Logger
+     * @param[in] label : the \c LabelSymbol to print
+     * @param[in] cursor : the code address of the label
+     * @param[in] comment1 : a comment to print after the label
+     * @param[in] comment2 : a second, optional comment to print after comment1
+     */
     void printSnippetLabel(OMR::Logger *log, TR::LabelSymbol *label, uint8_t *cursor, const char *comment1,
         const char *comment2 = 0);
+
     uint8_t *printPrefix(OMR::Logger *log, TR::Instruction *, uint8_t *cursor, uint8_t size);
 
     void printLabelInstruction(OMR::Logger *log, const char *, TR::LabelSymbol *label);
@@ -1097,8 +1126,6 @@ public:
 
     void print(OMR::Logger *log, TR_ARMOperand2 *op, TR_RegisterSizes size = TR_WordReg);
 
-    const char *getNamea(TR::Snippet *);
-
     void print(OMR::Logger *log, TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
     void printARMGCRegisterMap(OMR::Logger *log, TR::GCRegisterMap *);
     void printInstructionComment(OMR::Logger *log, int32_t tabStops, TR::Instruction *instr);
@@ -1288,7 +1315,6 @@ public:
     const char *getName(uint32_t regNum, TR_RegisterSizes size);
 
     void printa64(OMR::Logger *log, TR::Snippet *);
-    const char *getNamea64(TR::Snippet *);
 
 #ifdef J9_PROJECT_SPECIFIC
     void print(OMR::Logger *log, TR::ARM64CallSnippet *);

--- a/compiler/ras/Logger.cpp
+++ b/compiler/ras/Logger.cpp
@@ -451,7 +451,13 @@ OMR::MemoryBufferLogger::MemoryBufferLogger(char *buf, size_t maxBufLen)
     , _bufCursor(buf)
     , _maxBufLen(maxBufLen)
     , _maxRemainingChars(maxBufLen)
-{}
+{
+    TR_ASSERT_FATAL(maxBufLen > 0, "Expecting a non-zero sized base buffer for MemoryBufferLogger");
+
+    // Initialize the backing array to an empty state
+    //
+    buf[0] = '\0';
+}
 
 int32_t OMR::MemoryBufferLogger::printf(const char *format, ...)
 {
@@ -516,3 +522,7 @@ template OMR::MemoryBufferLogger *OMR::MemoryBufferLogger::create(TR_HeapMemory 
 template OMR::MemoryBufferLogger *OMR::MemoryBufferLogger::create(PERSISTENT_NEW_DECLARE t, char *buf,
     size_t maxBufLen);
 
+OMR::MemoryBufferLogger *OMR::MemoryBufferLogger::create(TR::Region &region, char *buf, size_t maxBufLen)
+{
+    return new (region) OMR::MemoryBufferLogger(buf, maxBufLen);
+}

--- a/compiler/ras/Logger.hpp
+++ b/compiler/ras/Logger.hpp
@@ -726,11 +726,24 @@ public:
      * @param[in] buf : a non-NULL pointer to an already allocated memory buffer
      * @param[in] maxBufLen : the maximum capacity of the buffer in chars. Note
      *     that the size of the buffer must include space for one '\0'-termination
-     *     character.
+     *     character. The minimum `maxBufLen` size is therefore 1.
      *
      * @return An allocated \c MemoryBufferLogger object
      */
     template<typename AllocatorType> static MemoryBufferLogger *create(AllocatorType t, char *buf, size_t maxBufLen);
+
+    /**
+     * @brief \c MemoryBufferLogger factory function
+     *
+     * @param[in] region : \c TR::Region allocator from which to allocate
+     * @param[in] buf : a non-NULL pointer to an already allocated memory buffer
+     * @param[in] maxBufLen : the maximum capacity of the buffer in chars. Note
+     *     that the size of the buffer must include space for one '\0'-termination
+     *     character. The minimum `maxBufLen` size is therefore 1.
+     *
+     * @return An allocated \c MemoryBufferLogger object
+     */
+    static MemoryBufferLogger *create(TR::Region &region, char *buf, size_t maxBufLen);
 
     /**
      * @anchor membuf_printf

--- a/compiler/riscv/codegen/RVHelperCallSnippet.cpp
+++ b/compiler/riscv/codegen/RVHelperCallSnippet.cpp
@@ -71,7 +71,7 @@ void TR_Debug::print(OMR::Logger *log, TR::RVHelperCallSnippet *snippet)
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
     auto restartLabel = snippet->getRestartLabel();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     char *info = "";
     intptr_t target = (intptr_t)(snippet->getDestination()->getSymbol()->castToMethodSymbol()->getMethodAddress());

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -118,7 +118,7 @@ void TR::X86DataSnippet::print(OMR::Logger *log, TR_Debug *debug)
 {
     uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
 
-    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, debug->getName(this));
+    debug->printSnippetLabel(log, this, bufferPos);
     debug->printPrefix(log, NULL, bufferPos, static_cast<uint8_t>(getDataSize()));
 
     const char *toString;

--- a/compiler/x/codegen/DivideCheckSnippet.cpp
+++ b/compiler/x/codegen/DivideCheckSnippet.cpp
@@ -93,7 +93,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86DivideCheckSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::RealRegister *realDivisorReg = toRealRegister(snippet->getDivideInstruction()->getSourceRegister());
     TR::RealRegister *realDividendReg = toRealRegister(snippet->getDivideInstruction()->getTargetRegister());

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -279,7 +279,12 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
 void TR_Debug::print(OMR::Logger *log, TR::X86HelperCallSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(snippet->getDestination()));
+
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(snippet->getDestination()));
+    log->printc(')');
+
     printBody(log, snippet, bufferPos);
 }
 

--- a/compiler/x/codegen/OMRSnippet.cpp
+++ b/compiler/x/codegen/OMRSnippet.cpp
@@ -59,74 +59,6 @@ OMR::X86::Snippet::Snippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbo
     : OMR::Snippet(cg, node, label)
 {}
 
-const char *TR_Debug::getNamex(TR::Snippet *snippet)
-{
-    switch (snippet->getKind()) {
-#ifdef J9_PROJECT_SPECIFIC
-        case TR::Snippet::IsCall:
-            return "Call Snippet";
-            break;
-        case TR::Snippet::IsVPicData:
-            return "VPic Data";
-            break;
-        case TR::Snippet::IsIPicData:
-            return "IPic Data";
-            break;
-        case TR::Snippet::IsForceRecompilation:
-            return "Force Recompilation Snippet";
-            break;
-        case TR::Snippet::IsRecompilation:
-            return "Recompilation Snippet";
-            break;
-#endif
-        case TR::Snippet::IsCheckFailure:
-            return "Check Failure Snippet";
-            break;
-        case TR::Snippet::IsCheckFailureWithResolve:
-            return "Check Failure Snippet with Resolve Call";
-            break;
-        case TR::Snippet::IsBoundCheckWithSpineCheck:
-            return "Bound Check with Spine Check Snippet";
-            break;
-        case TR::Snippet::IsSpineCheck:
-            return "Spine Check Snippet";
-            break;
-        case TR::Snippet::IsConstantData:
-            return "Constant Data Snippet";
-            break;
-        case TR::Snippet::IsData:
-            return "Data Snippet";
-        case TR::Snippet::IsDivideCheck:
-            return "Divide Check Snippet";
-            break;
-#ifdef J9_PROJECT_SPECIFIC
-        case TR::Snippet::IsGuardedDevirtual:
-            return "Guarded Devirtual Snippet";
-            break;
-#endif
-        case TR::Snippet::IsHelperCall:
-            return "Helper Call Snippet";
-            break;
-        case TR::Snippet::IsFPConversion:
-            return "FP Conversion Snippet";
-            break;
-        case TR::Snippet::IsFPConvertToInt:
-            return "FP Convert To Int Snippet";
-            break;
-        case TR::Snippet::IsFPConvertToLong:
-            return "FP Convert To Long Snippet";
-            break;
-        case TR::Snippet::IsUnresolvedDataIA32:
-        case TR::Snippet::IsUnresolvedDataAMD64:
-            return "Unresolved Data Snippet";
-            break;
-        case TR::Snippet::IsRestart:
-        default:
-            TR_ASSERT(0, "unexpected snippet kind: %d", snippet->getKind());
-            return "Unknown snippet kind";
-    }
-}
-
 void TR_Debug::printx(OMR::Logger *log, TR::Snippet *snippet)
 {
     switch (snippet->getKind()) {
@@ -208,4 +140,57 @@ int32_t TR_Debug::printRestartJump(OMR::Logger *log, TR::X86RestartSnippet *snip
     printPrefix(log, NULL, bufferPos, size);
     printLabelInstruction(log, branchOpName, snippet->getRestartLabel());
     return size;
+}
+
+void OMR::X86::Snippet::printName(OMR::Logger *log)
+{
+    const char *name;
+
+    switch (getKind()) {
+        case TR::Snippet::IsCheckFailure:
+            name = "Check Failure Snippet";
+            break;
+        case TR::Snippet::IsCheckFailureWithResolve:
+            name = "Check Failure Snippet with Resolve Call";
+            break;
+        case TR::Snippet::IsBoundCheckWithSpineCheck:
+            name = "Bound Check with Spine Check Snippet";
+            break;
+        case TR::Snippet::IsSpineCheck:
+            name = "Spine Check Snippet";
+            break;
+        case TR::Snippet::IsConstantData:
+            name = "Constant Data Snippet";
+            break;
+        case TR::Snippet::IsData:
+            name = "Data Snippet";
+            break;
+        case TR::Snippet::IsDivideCheck:
+            name = "Divide Check Snippet";
+            break;
+        case TR::Snippet::IsHelperCall:
+            name = "Helper Call Snippet";
+            break;
+        case TR::Snippet::IsFPConversion:
+            name = "FP Conversion Snippet";
+            break;
+        case TR::Snippet::IsFPConvertToInt:
+            name = "FP Convert To Int Snippet";
+            break;
+        case TR::Snippet::IsFPConvertToLong:
+            name = "FP Convert To Long Snippet";
+            break;
+        case TR::Snippet::IsUnresolvedDataIA32:
+        case TR::Snippet::IsUnresolvedDataAMD64:
+            name = "Unresolved Data Snippet";
+            break;
+        case TR::Snippet::IsRestart:
+            name = "Restart Snippet";
+            break;
+        default:
+            name = "Unknown snippet kind";
+            break;
+    }
+
+    log->prints(name);
 }

--- a/compiler/x/codegen/OMRSnippet.hpp
+++ b/compiler/x/codegen/OMRSnippet.hpp
@@ -49,6 +49,10 @@ class LabelSymbol;
 class Node;
 } // namespace TR
 
+namespace OMR {
+class Logger;
+} // namespace OMR
+
 namespace OMR { namespace X86 {
 
 class OMR_EXTENSIBLE Snippet : public OMR::Snippet {
@@ -86,6 +90,11 @@ public:
     };
 
     virtual Kind getKind() { return IsUnknown; }
+
+    /**
+     * @copydoc OMR::Snippet::printName(OMR::Logger *)
+     */
+    void printName(OMR::Logger *log);
 };
 
 }} // namespace OMR::X86

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -438,8 +438,12 @@ void TR_Debug::print(OMR::Logger *log, TR::X86LabelInstruction *instr)
             printInstructionComment(log, 2, instr);
         }
 
-        if (snippet)
-            log->printf("\t%s (%s)", commentString(), getName(snippet));
+        if (snippet) {
+            log->printf("\t%s ", commentString());
+            log->printc('(');
+            snippet->printName(log);
+            log->printc(')');
+        }
     }
 
     dumpDependencies(log, instr);
@@ -558,12 +562,15 @@ void TR_Debug::print(OMR::Logger *log, TR::AMD64Imm64SymInstruction *instr)
         log->printf("%-24s%s %s (" POINTER_PRINTF_FORMAT ")", name, commentString(), getOpCodeName(&instr->getOpCode()),
             instr->getSourceImmediate());
     } else if (sym->getLabelSymbol() && name) {
-        if (sym->getLabelSymbol()->getSnippet())
-            log->printf("%-24s%s %s (%s)", name, commentString(), getOpCodeName(&instr->getOpCode()),
-                getName(sym->getLabelSymbol()->getSnippet()));
-        else
+        if (sym->getLabelSymbol()->getSnippet()) {
+            log->printf("%-24s%s %s ", name, commentString(), getOpCodeName(&instr->getOpCode()));
+            log->printc('(');
+            sym->getLabelSymbol()->getSnippet()->printName(log);
+            log->printc(')');
+        } else {
             log->printf("%-24s%s %s (" POINTER_PRINTF_FORMAT ")", name, commentString(),
                 getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
+        }
     } else {
         printIntConstant(log, instr->getSourceImmediate(), 16, getImmediateSizeFromInstruction(instr), true);
         printInstructionComment(log, 2, instr);
@@ -679,12 +686,15 @@ void TR_Debug::print(OMR::Logger *log, TR::X86ImmSymInstruction *instr)
         log->printf("%s %s (" POINTER_PRINTF_FORMAT ")", commentString(), getOpCodeName(&instr->getOpCode()),
             targetAddress);
     } else if (sym->getLabelSymbol() && name) {
-        if (sym->getLabelSymbol()->getSnippet())
-            log->printf("%s %s (%s)", commentString(), getOpCodeName(&instr->getOpCode()),
-                getName(sym->getLabelSymbol()->getSnippet()));
-        else
+        if (sym->getLabelSymbol()->getSnippet()) {
+            log->printf("%s %s ", commentString(), getOpCodeName(&instr->getOpCode()));
+            log->printc('(');
+            sym->getLabelSymbol()->getSnippet()->printName(log);
+            log->printc(')');
+        } else {
             log->printf("%s %s (" POINTER_PRINTF_FORMAT ")", commentString(), getOpCodeName(&instr->getOpCode()),
                 targetAddress);
+        }
     } else {
         log->printf(" \t\t%s %s", commentString(), getOpCodeName(&instr->getOpCode()));
     }
@@ -2173,7 +2183,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86CallSnippet *snippet)
     TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
     TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     bool isJitInduceOSRCall = false;
     bool isJitDispatchJ9Method = false;

--- a/compiler/x/codegen/X86FPConversionSnippet.cpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.cpp
@@ -166,7 +166,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86FPConvertToIntSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::RealRegister *targetRegister = toRealRegister(snippet->getConvertInstruction()->getTargetRegister());
     uint8_t reg = targetRegister->getRegisterNumber();
@@ -322,7 +322,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86FPConvertToLongSnippet *snippet)
 
     uint8_t action = TR::X86FPConvertToLongSnippet::_registerActions[snippet->getAction() & 0x7f];
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     if (snippet->getAction() & snippet->kNeedFXCH) {
         printPrefix(log, NULL, bufferPos, 2);


### PR DESCRIPTION
`getName(TR::Snippet)` is predominantly (if not exclusively) used to output a Snippet's entry label and other metadata to a log file.  Rather than allocate heap memory to hold the string, output it directly to a Logger to save pathlength and memory.