### PR TITLE
Preserve parameter stores in OSR-capable compilations

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2030,6 +2030,13 @@ bool OMR::Node::dontEliminateStores(bool isForLocalDeadStore)
         || (self()->getSymbol()->isAutoOrParm() && self()->storedValueIsIrrelevant()))
         return true;
 
+    // While OSR transitions remain possible, stores to parameters must be preserved even
+    // if no load of the parameter remains in the trees. On a transition, the interpreter
+    // frame for the outermost method reuses the incoming argument slots in place instead
+    // of restoring them from the OSR buffer
+    if (self()->getSymbol()->isParm() && comp->getOption(TR_EnableOSR) && !comp->osrInfrastructureRemoved())
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
When an OSR transition reconstructs interpreter state, the interpreter frame for the outermost method reuses the incoming argument slots in place rather than restoring them from the OSR buffer. In the OpenJ9 VM, decompilation of the outermost method copies only the non-argument locals, and does not update the parameter slots from the OSR buffer. The jitted body must therefore keep parameter stack slots up to date so that if the interpreter resumes at a point after an update to the parameter slot, loads from that parameter slot are up-to-date.

Historically, prepareForOSR node loaded every live local, so a store to a parameter always had at least one remaining use in the trees and was never removed by dead store elimination. With const refs enabled, value propagation can fold address-typed loads of known objects into constref loads, including the loads under prepareForOSR call nodes. When a parameter is overwritten with such a foldable value, every use of it becomes a constref load. As a result, store to the parameter slot appears dead, and any of the dead store elimination passes will remove it.

This commit addresses this problem by refusing to eliminate stores to parameter symbols if OSR transitions are possible.

Issue: https://github.com/eclipse-openj9/openj9/issues/24337
My analysis of the the problem:
1. https://github.com/eclipse-openj9/openj9/issues/24337#issuecomment-4972857276
2. https://github.com/eclipse-openj9/openj9/issues/24337#issuecomment-4985204046

Constrefs issue: https://github.com/eclipse-openj9/openj9/issues/16616