### PR TITLE
AArch64: Revert #8342 partially

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -699,6 +699,8 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::mstorei:
         case TR::mRegLoad:
         case TR::mRegStore:
+        case TR::mToLongBits:
+        case TR::mLongBitsToMask:
         case TR::vsplats:
             return true;
         case TR::vfma:
@@ -709,8 +711,6 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::mTrueCount:
         case TR::mFirstTrue:
         case TR::mLastTrue:
-        case TR::mToLongBits:
-        case TR::mLongBitsToMask:
             TR_ASSERT_FATAL(et != TR::Float && et != TR::Double, "Unexpected element type for mask");
             return true;
         case TR::s2m:

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1401,6 +1401,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
             generateUBFXInstruction(cg, node, resReg, resReg, 42, 8, true);
             break;
         case TR::Int32:
+        case TR::Float:
             /*
              * shrn    v1.2s, v0.2d, #31
              * umov    w0, v1.2d[0]
@@ -1413,6 +1414,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
             generateUBFXInstruction(cg, node, resReg, resReg, 30, 4, true);
             break;
         case TR::Int64:
+        case TR::Double:
             /*
              * ext     v1.16b, v0.16b, v0.16b, #7
              * umov    w0, v1.4s[0]
@@ -1494,6 +1496,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
             generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmtst8h, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int32:
+        case TR::Float:
             /*
              * fmov    d0, x0
              * sli     v0.2d, v0.2d, #30           ; Shifts left v0 by 30 bits and inserts into v0.
@@ -1512,6 +1515,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
             generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmtst4s, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int64:
+        case TR::Double:
             /*
              * ubfiz   x1, x0, #55, #2             ; Copies 2 bits from the lsb of x0 into the bit 55 of x1.
              *                                     ; Other bits of x1 are cleared.


### PR DESCRIPTION
This commit reverts PR #8342 partially

- mToLongBits
- mLongBitsToMask

Fixes: https://github.com/eclipse-openj9/openj9/issues/24384