### PR TITLE
AArch64: Introduce Register::setAssignZeroRegister()

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1032,8 +1032,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
     TR::Register *tmpReg = NULL;
 
     TR::Register *zeroReg = cg->allocateRegister();
-    auto *cond = RegDeps(1, 1, cg);
-    TR::addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
+    zeroReg->setAssignZeroRegister();
 
     // imulh is generated for constant idiv and the second child is the magic number
     // assume magic number is usually a large odd number with little optimization opportunity
@@ -1045,7 +1044,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
         src2Reg = cg->evaluate(secondChild);
     }
 
-    generateTrg1Src3Instruction(cg, OP::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg, cond);
+    generateTrg1Src3Instruction(cg, OP::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg);
     cg->stopUsingRegister(zeroReg);
     /* logical shift right by 32 bits */
     generateLogicalShiftRightImmInstruction(cg, node, trgReg, trgReg, 32, true);

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -323,16 +323,6 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cg);
 }
 
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced)
-{
-    if (preced)
-        return new (cg->trHeapMemory())
-            TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cond, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cond, cg);
-}
-
 TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Instruction *preced)
 {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -473,23 +473,6 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic
     TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL);
 
 /*
- * @brief Generates src3-to-trg instruction with register dependency
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] treg : target register
- * @param[in] s1reg : source register 1
- * @param[in] s2reg : source register 2
- * @param[in] s3reg : source register 3
- * @param[in] cond : register dependency condition
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced = NULL);
-
-/*
  * @brief Generates mem-to-trg instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -544,7 +544,12 @@ TR::RealRegister *OMR::ARM64::Machine::assignOneRegister(TR::Instruction *curren
         cg->clearRegisterAssignmentFlags();
         cg->setRegisterAssignmentFlag(TR_NormalAssignment);
 
-        if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
+        if (virtualRegister->getAssignZeroRegister()) {
+            assignedRegister = getRealRegister(TR::RealRegister::xzr);
+            TR::Register *vr = assignedRegister->getAssignedRegister();
+            TR_ASSERT_FATAL((vr == NULL) || (vr == assignedRegister),
+                "xzr has been already assigned to another register");
+        } else if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount()) {
             cg->setRegisterAssignmentFlag(TR_RegisterReloaded);
             assignedRegister = self()->reverseSpillState(currentInstruction, virtualRegister, NULL);
         } else {

--- a/compiler/aarch64/codegen/OMRRegister.hpp
+++ b/compiler/aarch64/codegen/OMRRegister.hpp
@@ -49,18 +49,21 @@ class OMR_EXTENSIBLE Register : public OMR::Register {
 protected:
     Register(uint32_t f = 0)
         : OMR::Register(f)
+        , _assignZeroRegister(false)
     {
         _liveRegisterInfo._liveRegister = NULL;
     }
 
     Register(TR_RegisterKinds rk)
         : OMR::Register(rk)
+        , _assignZeroRegister(false)
     {
         _liveRegisterInfo._liveRegister = NULL;
     }
 
     Register(TR_RegisterKinds rk, uint16_t ar)
         : OMR::Register(rk, ar)
+        , _assignZeroRegister(false)
     {
         _liveRegisterInfo._liveRegister = NULL;
     }
@@ -77,11 +80,26 @@ public:
 
     uint32_t setInterference(uint64_t i) { return (_liveRegisterInfo._interference = i); }
 
+    /**
+     * @brief Returns the value of "assignZeroRegister" flag
+     * @return true if the flag is set, false otherwise
+     */
+    bool getAssignZeroRegister() { return _assignZeroRegister; }
+
+    /**
+     * @brief Changes the value of "assignZeroRegister" flag
+     * @param[in] b : true if "xzr" must be assigned to the register, false otherwise
+     * @return New value of "assignZeroRegister" flag
+     */
+    bool setAssignZeroRegister(bool b = true) { return (_assignZeroRegister = b); }
+
 private:
     union {
         TR_LiveRegisterInfo *_liveRegister; // Live register entry representing this register
         uint32_t _interference; // Real registers that interfere with this register
     } _liveRegisterInfo;
+
+    bool _assignZeroRegister;
 };
 
 }} // namespace OMR::ARM64

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -5672,10 +5672,8 @@ TR::Register *commonStoreEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size
         || ((valueChild->getDataType().isIntegral() || valueChild->getDataType().isAddress())
             && valueChild->isConstZeroValue() && (valueChild->getRegister() == NULL))) {
         TR::Register *zeroReg = cg->allocateRegister();
+        zeroReg->setAssignZeroRegister();
         generateMemSrc1Instruction(cg, op, node, tempMR, zeroReg);
-        auto *deps = RegDeps(0, 1, cg);
-        deps->addPostCondition(zeroReg, TR::RealRegister::xzr);
-        generateLabelInstruction(cg, OP::label, node, generateLabelSymbol(cg), deps);
         cg->stopUsingRegister(zeroReg);
     } else {
         generateMemSrc1Instruction(cg, op, node, tempMR, cg->evaluate(valueChild));


### PR DESCRIPTION
This commit adds a new function setAssignZeroRegister() to the Register class for AArch64.  It is used for assigning the zero register (xzr) to a virtual register without making a register dependency condition.
It also removes a variant of generateTrg1Src3Instruction(), which is no longer used after setAssignZeroRegister() is introduced.