### PR TITLE
Log value of isSafeForCGToFastPathUnsafeCall() TR::Node flag query

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -885,6 +885,7 @@ int32_t TR_Debug::nodePrintAllFlags(OMR::Logger *log, TR::Node *node)
     FLAG(chkNodeCreatedByPRE, "createdByPRE");
     FLAG(chkIsReferenceNonNull, "referenceIsNonNull");
     FLAG(isPreparedForDirectJNI, "preparedForDirectJNI");
+    FLAG(isSafeForCGToFastPathUnsafeCall, "safeForCGToFastPathUnsafeCall");
 
 #undef FLAG
 #undef FLAG_IF


### PR DESCRIPTION
Add logging for the setting of the `isSafeForCGToFastPathUnsafeCall()` query on `TR::Node`.