### PR TITLE
Apply clang-format check to the proper branch

### DIFF
--- a/buildenv/jenkins/clang_format/clangFormatCheck.groovy
+++ b/buildenv/jenkins/clang_format/clangFormatCheck.groovy
@@ -42,7 +42,7 @@ timestamps {
                         }
                     }
                     stage('Format Check') {
-                        sh "buildenv/jenkins/clang_format/clangFormatCheck.sh"
+                        sh "buildenv/jenkins/clang_format/clangFormatCheck.sh origin/${ghprbTargetBranch}"
                     }
                 } finally {
                     cleanWs()

--- a/buildenv/jenkins/clang_format/clangFormatCheck.sh
+++ b/buildenv/jenkins/clang_format/clangFormatCheck.sh
@@ -21,7 +21,10 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-allFiles=$(git diff -C --diff-filter=ACM --name-only origin/master HEAD --)
+# Optional argument identifies the target branch of the pull request.
+targetBranch="${1:-origin/master}"
+
+allFiles=$(git diff -C --diff-filter=ACM --name-only "$targetBranch" HEAD -- | grep '^compiler/')
 if [ x"$allFiles" = x ] ; then
     echo "There are no files to check for code formatting."
 else


### PR DESCRIPTION
Also filter file list using grep like openj9.

See also https://github.com/eclipse-openj9/openj9/pull/24397.