### PR TITLE
RISC-V: add getPreservedRegisterMapForGC() to linkage properties

### DIFF
--- a/compiler/riscv/codegen/OMRLinkage.cpp
+++ b/compiler/riscv/codegen/OMRLinkage.cpp
@@ -77,6 +77,17 @@ void TR::RVLinkageProperties::initialize()
     // TODO: following is safe default, can probably be lower. Q: how is this number computed?
     _numberOfDependencyRegisters = (TR::RealRegister::LastGPR - TR::RealRegister::FirstGPR + 1)
         + (TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR + 1);
+
+    // Compute preserved register map for GC
+    static_assert(
+        (sizeof(_preservedRegisterMapForGC) * 8) >= (TR::RealRegister::LastGPR - TR::RealRegister::FirstGPR + 1));
+
+    _preservedRegisterMapForGC = 0;
+    for (auto i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; i++) {
+        if (_registerFlags[i] == Preserved) {
+            _preservedRegisterMapForGC |= (1 << (i - TR::RealRegister::FirstGPR));
+        }
+    }
 }
 
 void OMR::RV::Linkage::mapStack(TR::ResolvedMethodSymbol *method) { /* do nothing */ }

--- a/compiler/riscv/codegen/OMRLinkage.hpp
+++ b/compiler/riscv/codegen/OMRLinkage.hpp
@@ -123,6 +123,7 @@ struct RVLinkageProperties {
     TR::RealRegister::RegNum _returnRegisters[TR::RealRegister::NumRegisters];
     uint8_t _numAllocatableIntegerRegisters;
     uint8_t _numAllocatableFloatRegisters;
+    uint32_t _preservedRegisterMapForGC;
     TR::RealRegister::RegNum _methodMetaDataRegister;
     TR::RealRegister::RegNum _stackPointerRegister;
     TR::RealRegister::RegNum _framePointerRegister;
@@ -218,6 +219,8 @@ struct RVLinkageProperties {
     int32_t getNumAllocatableIntegerRegisters() const { return _numAllocatableIntegerRegisters; }
 
     int32_t getNumAllocatableFloatRegisters() const { return _numAllocatableFloatRegisters; }
+
+    uint32_t getPreservedRegisterMapForGC() const { return _preservedRegisterMapForGC; }
 
     TR::RealRegister::RegNum getMethodMetaDataRegister() const { return _methodMetaDataRegister; }
 


### PR DESCRIPTION
This commit adds OMRLinkage::getPreservedRegisterMapForGC() and code that initializes it. While this is not used in OMR, it is used by OpenJ9's "private" linkage.