### PR TITLE
RISC-V: call InstructionDelegate::encodeBranchToLabel()

### DIFF
--- a/compiler/riscv/codegen/OMRInstructionDelegate.hpp
+++ b/compiler/riscv/codegen/OMRInstructionDelegate.hpp
@@ -39,14 +39,53 @@ typedef OMR::RV::InstructionDelegate InstructionDelegateConnector;
 #error OMR::RV::InstructionDelegate expected to be a primary connector, but an OMR connector is already defined
 #endif
 
+#include "codegen/MemoryReference.hpp"
 #include "compiler/codegen/OMRInstructionDelegate.hpp"
 #include "infra/Annotations.hpp"
+
+namespace TR {
+class JtypeInstruction;
+class LoadInstruction;
+class StoreInstruction;
+} // namespace TR
 
 namespace OMR { namespace RV {
 
 class OMR_EXTENSIBLE InstructionDelegate : public OMR::InstructionDelegate {
 protected:
     InstructionDelegate() {}
+
+public:
+    /**
+     * @brief Sets the return address to CallSnippet for Label target
+     * @param[in] cg : CodeGenerator
+     * @param[in] ins : instruction associated with CallSnippet
+     * @param[in] cursor : instruction cursor
+     */
+    static void encodeBranchToLabel(TR::CodeGenerator *cg, TR::JtypeInstruction *ins, uint8_t *cursor)
+    {
+        // Do nothing in OMR
+    }
+
+    /**
+     * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+     * @param[in] cg    : CodeGenerator
+     * @param[in] instr : instruction with memory reference
+     */
+    static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::LoadInstruction *instr)
+    {
+        // Do nothing in OMR
+    }
+
+    /**
+     * @brief Determines if this instruction will throw an implicit null pointer exception and sets appropriate flags
+     * @param[in] cg    : CodeGenerator
+     * @param[in] instr : instruction with memory reference
+     */
+    static void setupImplicitNullPointerException(TR::CodeGenerator *cg, TR::StoreInstruction *instr)
+    {
+        // Do nothing in OMR
+    }
 };
 
 }} // namespace OMR::RV

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -26,6 +26,7 @@
 #include "codegen/CodeGenerator.hpp" // for CodeGenerator, etc
 #include "codegen/InstOpCode.hpp" // for InstOpCode, etc
 #include "codegen/Instruction.hpp" // for Instruction
+#include "codegen/InstructionDelegate.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Machine.hpp" // for Machine, etc
 #include "codegen/MemoryReference.hpp" // for MemoryReference
@@ -468,6 +469,7 @@ uint8_t *TR::JtypeInstruction::generateBinaryEncoding()
             offset = destination - reinterpret_cast<intptr_t>(cursor);
         } else {
             cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, getLabelSymbol()));
+            TR::InstructionDelegate::encodeBranchToLabel(cg(), this, cursor);
         }
     }
 


### PR DESCRIPTION
This PR adds InstructionDelegate::encodeBranchToLabel() and calls when encoding J-type instruction. 

This is needed in (at least) OpenJ9. 