### PR TITLE
AArch64: Enable GRA for vector registers

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -81,6 +81,10 @@ void OMR::ARM64::CodeGenerator::initialize()
     cg->setLastGlobalGPR(_numGPR - 1);
     cg->setLastGlobalFPR(_numGPR + _numFPR - 1);
 
+    // Use the same registers for FPR and VRF
+    cg->setFirstGlobalVRF(self()->getFirstGlobalFPR());
+    cg->setLastGlobalVRF(self()->getLastGlobalFPR());
+
     cg->getLinkage()->initARM64RealRegisterLinkage();
     cg->setSupportsGlRegDeps();
     cg->setSupportsGlRegDepOnFirstBlock();
@@ -693,6 +697,8 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::CPU *cpu, TR::I
         case TR::vloadi:
         case TR::vstore:
         case TR::vstorei:
+        case TR::vRegLoad:
+        case TR::vRegStore:
         case TR::mload:
         case TR::mloadi:
         case TR::mstore:
@@ -751,9 +757,9 @@ bool OMR::ARM64::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode
     return TR::CodeGenerator::getSupportsOpCodeForAutoSIMD(&comp()->target().cpu, opcode);
 }
 
-bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::Node *node) { return !node->getOpCode().isVectorOpCode(); }
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::Node *node) { return true; }
 
-bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return !(dt.isVector() || dt.isMask()); }
+bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::DataType dt) { return true; }
 
 bool OMR::ARM64::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
 {

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -1544,13 +1544,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
 
 TR::Register *OMR::ARM64::TreeEvaluator::mRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::Register *globalReg = node->getRegister();
-
-    if (globalReg == NULL) {
-        globalReg = cg->allocateRegister(TR_VRF);
-        node->setRegister(globalReg);
-    }
-    return globalReg;
+    return TR::TreeEvaluator::vRegLoadEvaluator(node, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::mRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2889,14 +2883,21 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::C
     return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
+// Also handles mRegLoad
 TR::Register *OMR::ARM64::TreeEvaluator::vRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    TR::Register *globalReg = node->getRegister();
+
+    if (globalReg == NULL) {
+        globalReg = cg->allocateRegister(TR_VRF);
+        node->setRegister(globalReg);
+    }
+    return globalReg;
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return TR::TreeEvaluator::unImpOpEvaluator(node, cg);
+    return TR::TreeEvaluator::iRegStoreEvaluator(node, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *node, TR::CodeGenerator *cg,
@@ -7307,7 +7308,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::iRegLoadEvaluator(TR::Node *node, TR::C
     return (globalReg);
 }
 
-// Also handles sRegStore, bRegStore, lRegStore, and aRegStore
+// Also handles sRegStore, bRegStore, lRegStore, aRegStore, fRegStore, dRegStore, vRegStore, and mRegStore
 TR::Register *OMR::ARM64::TreeEvaluator::iRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();


### PR DESCRIPTION
This commit implements vRegLoad/vRegStore evaluators for AArch64, and enables GRA for vector registers.