### PR TITLE
Always return NULL for PureFunction useDef aliases

### DIFF
--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -451,11 +451,11 @@ TR_BitVector *OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool i
                 return aliases;
             }
 
+            if (resolvedMethodSymbol->isPureFunction())
+                return NULL;
+
             if (!comp->getOption(TR_EnableHCR)
                 || comp->fej9()->isIntrinsicCandidate(resolvedMethodSymbol->getResolvedMethod())) {
-                if (resolvedMethodSymbol->isPureFunction())
-                    return NULL;
-
                 switch (resolvedMethodSymbol->getRecognizedMethod()) {
                     case TR::java_lang_Double_longBitsToDouble:
                     case TR::java_lang_Double_doubleToLongBits:


### PR DESCRIPTION
- since Pure functions don't modify any statics or fields, getuseDefAliasBV() can always return NULL for such methods