### PR TITLE
AArch64: Replace TR::InstOpCode by OP

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -116,7 +116,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
     uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = getOpCode().copyBinaryToBuffer(instructionStart);
 
-    if (getOpCodeValue() == TR::InstOpCode::bl) {
+    if (getOpCodeValue() == OP::bl) {
         TR::SymbolReference *symRef = getSymbolReference();
         TR::LabelSymbol *label = symRef->getSymbol()->getLabelSymbol();
 
@@ -203,10 +203,10 @@ uint8_t *TR::ARM64LabelInstruction::generateBinaryEncoding()
     uint8_t *cursor = instructionStart;
     TR::LabelSymbol *label = getLabelSymbol();
 
-    if (getOpCodeValue() == OMR::InstOpCode::label) {
+    if (getOpCodeValue() == OP::label) {
         label->setCodeLocation(instructionStart);
     } else {
-        TR_ASSERT(getOpCodeValue() == OMR::InstOpCode::b, "Unsupported opcode in LabelInstruction.");
+        TR_ASSERT(getOpCodeValue() == OP::b, "Unsupported opcode in LabelInstruction.");
 
         intptr_t destination = (intptr_t)label->getCodeLocation();
         cursor = getOpCode().copyBinaryToBuffer(instructionStart);
@@ -231,7 +231,7 @@ uint8_t *TR::ARM64LabelInstruction::generateBinaryEncoding()
 
 int32_t TR::ARM64LabelInstruction::estimateBinaryLength(int32_t currentEstimate)
 {
-    if (getOpCodeValue() == OMR::InstOpCode::label) {
+    if (getOpCodeValue() == OP::label) {
         setEstimatedBinaryLength(0);
         getLabelSymbol()->setEstimatedCodeLocation(currentEstimate);
     } else {
@@ -328,9 +328,9 @@ uint8_t *TR::ARM64RegBranchInstruction::generateBinaryEncoding()
 
 TR::Instruction *TR::ARM64AdminInstruction::expandInstruction()
 {
-    TR::InstOpCode::Mnemonic op = getOpCodeValue();
+    OP::Mnemonic op = getOpCodeValue();
 
-    if (op == TR::InstOpCode::retn) {
+    if (op == OP::retn) {
         /*
          * Generates instructions for epilogue after retn pseudo instruction.
          * We need to call expandInstruction on those instructions because
@@ -345,10 +345,10 @@ TR::Instruction *TR::ARM64AdminInstruction::expandInstruction()
 uint8_t *TR::ARM64AdminInstruction::generateBinaryEncoding()
 {
     uint8_t *instructionStart = cg()->getBinaryBufferCursor();
-    TR::InstOpCode::Mnemonic op = getOpCodeValue();
+    OP::Mnemonic op = getOpCodeValue();
     int32_t i;
 
-    if (op == TR::InstOpCode::fence) {
+    if (op == OP::fence) {
         TR::Node *fenceNode = getFenceNode();
         uint32_t rtype = fenceNode->getRelocationType();
         if (rtype == TR_AbsoluteAddress) {
@@ -441,7 +441,7 @@ uint8_t *TR::ARM64Trg1ImmSymInstruction::generateBinaryEncoding()
             if (label != NULL) {
                 cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, label));
             }
-        } else if ((getOpCodeValue() == TR::InstOpCode::adr) && (sym->isStartPC() || sym->isGCRPatchPoint())) {
+        } else if ((getOpCodeValue() == OP::adr) && (sym->isStartPC() || sym->isGCRPatchPoint())) {
             intptr_t offset = reinterpret_cast<intptr_t>(
                 reinterpret_cast<uint8_t *>(sym->getStaticSymbol()->getStaticAddress()) - cursor);
             if (!constantIsSignedImm21(offset)) {
@@ -619,10 +619,10 @@ uint8_t *TR::ARM64Trg1Src2ExtendedInstruction::generateBinaryEncoding()
 
 void TR::ARM64Trg1Src2IndexedElementInstruction::insertIndex(uint32_t *instruction)
 {
-    TR::InstOpCode::Mnemonic mnemonic = getOpCodeValue();
-    if ((mnemonic >= TR::InstOpCode::fmulelem_4s) && (mnemonic <= TR::InstOpCode::vfmulelem_2d)) {
+    OP::Mnemonic mnemonic = getOpCodeValue();
+    if ((mnemonic >= OP::fmulelem_4s) && (mnemonic <= OP::vfmulelem_2d)) {
         uint8_t h = 0, l = 0;
-        if ((mnemonic == TR::InstOpCode::fmulelem_4s) || (mnemonic == TR::InstOpCode::vfmulelem_4s)) {
+        if ((mnemonic == OP::fmulelem_4s) || (mnemonic == OP::vfmulelem_4s)) {
             h = (getIndex() >> 1) & 1;
             l = getIndex() & 1;
         } else {
@@ -914,7 +914,7 @@ uint8_t *TR::ARM64VirtualGuardNOPInstruction::generateBinaryEncoding()
     }
 
     setBinaryEncoding(cursor);
-    TR::InstOpCode opCode(TR::InstOpCode::nop);
+    OP opCode(OP::nop);
     opCode.copyBinaryToBuffer(cursor);
     length = ARM64_INSTRUCTION_LENGTH;
     setBinaryLength(length);

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -1085,7 +1085,7 @@ static TR_RegisterSizes getRegisterSizeFromFType(uint32_t ftype)
     }
 }
 
-const char *TR_Debug::getOpCodeName(TR::InstOpCode *opCode) { return opCodeToNameMap[opCode->getMnemonic()]; }
+const char *TR_Debug::getOpCodeName(OP *opCode) { return opCodeToNameMap[opCode->getMnemonic()]; }
 
 void TR_Debug::printMemoryReferenceComment(OMR::Logger *log, TR::MemoryReference *mr)
 {
@@ -1297,7 +1297,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64LabelInstruction *instr)
 
     TR::LabelSymbol *label = instr->getLabelSymbol();
     TR::Snippet *snippet = label ? label->getSnippet() : NULL;
-    if (instr->getOpCodeValue() == TR::InstOpCode::label) {
+    if (instr->getOpCodeValue() == OP::label) {
         print(log, label);
         log->printc(':');
         if (label->isStartInternalControlFlow())
@@ -1336,7 +1336,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64ConditionalBranchInstruction *in
 
     TR::LabelSymbol *label = instr->getLabelSymbol();
     TR::Snippet *snippet = label ? label->getSnippet() : NULL;
-    TR_ASSERT(instr->getOpCodeValue() == TR::InstOpCode::b_cond, "Unsupported instruction for conditional branch");
+    TR_ASSERT(instr->getOpCodeValue() == OP::b_cond, "Unsupported instruction for conditional branch");
     log->printf("b.%s \t", ARM64ConditionNames[instr->getConditionCode()]);
     print(log, label);
     if (snippet) {
@@ -1354,8 +1354,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64CompareBranchInstruction *instr)
 
     TR::LabelSymbol *label = instr->getLabelSymbol();
     TR::Snippet *snippet = label ? label->getSnippet() : NULL;
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
@@ -1404,7 +1404,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64RegBranchInstruction *instr)
 
 void TR_Debug::print(OMR::Logger *log, TR::ARM64AdminInstruction *instr)
 {
-    if (instr->getOpCodeValue() == TR::InstOpCode::assocreg) {
+    if (instr->getOpCodeValue() == OP::assocreg) {
         printAssocRegDirective(log, instr);
         return;
     }
@@ -1438,12 +1438,12 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Instruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1CondInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
 
-    if (op == TR::InstOpCode::csincx || (op == TR::InstOpCode::csincw)) {
+    if (op == OP::csincx || (op == OP::csincw)) {
         // cset alias
         log->printf("cset%c \t", (sf == 1) ? 'x' : 'w');
         print(log, instr->getTargetRegister(), regSize);
@@ -1479,30 +1479,29 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmInstruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    if ((op == TR::InstOpCode::adr) || (op == TR::InstOpCode::adrp)) {
+    OP::Mnemonic op = instr->getOpCodeValue();
+    if ((op == OP::adr) || (op == OP::adrp)) {
         int64_t offset = static_cast<int64_t>(static_cast<int32_t>(instr->getSourceImmediate()));
-        if (instr->getOpCodeValue() == TR::InstOpCode::adrp) {
+        if (instr->getOpCodeValue() == OP::adrp) {
             offset *= 4096;
         }
         print(log, instr->getTargetRegister(), TR_DoubleWordReg);
         log->printf(", " POINTER_PRINTF_FORMAT, (instr->getBinaryEncoding() + offset));
-    } else if (op == TR::InstOpCode::fmovimms || op == TR::InstOpCode::fmovimmd || op == TR::InstOpCode::vfmov4s
-        || op == TR::InstOpCode::vfmov2d) {
+    } else if (op == OP::fmovimms || op == OP::fmovimmd || op == OP::vfmov4s || op == OP::vfmov2d) {
         uint32_t imm = instr->getSourceImmediate() & 0xFF;
         TR_RegisterSizes regSize = TR_VectorReg128; // for vfmov4s and vfmov2d
-        if (op == TR::InstOpCode::fmovimms) {
+        if (op == OP::fmovimms) {
             regSize = TR_FloatReg;
-        } else if (op == TR::InstOpCode::fmovimmd) {
+        } else if (op == OP::fmovimmd) {
             regSize = TR_DoubleReg;
         }
         print(log, instr->getTargetRegister(), regSize);
         log->printf(", 0x%02x (%lf)", imm, getDoubleFromImm8(imm));
-    } else if (op == TR::InstOpCode::movzx || op == TR::InstOpCode::movzw || op == TR::InstOpCode::movnx
-        || op == TR::InstOpCode::movnw || op == TR::InstOpCode::movkx || op == TR::InstOpCode::movkw) {
+    } else if (op == OP::movzx || op == OP::movzw || op == OP::movnx || op == OP::movnw || op == OP::movkx
+        || op == OP::movkw) {
         uint32_t imm = instr->getSourceImmediate() & 0xFFFF;
         uint32_t shift = (instr->getSourceImmediate() & 0x30000) >> 12;
-        uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+        uint32_t enc = OP::getOpCodeBinaryEncoding(op);
         uint32_t sf = getSFbit(enc);
         TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
         print(log, instr->getTargetRegister(), regSize);
@@ -1510,7 +1509,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmInstruction *instr)
         if (shift != 0) {
             log->printf(", LSL #%d", shift);
         }
-    } else if (op == TR::InstOpCode::vmovi2d) {
+    } else if (op == OP::vmovi2d) {
         uint8_t imm8 = instr->getSourceImmediate() & 0xFF;
         uint64_t imm = 0;
         for (int i = 0; i < 8; i++) {
@@ -1534,12 +1533,12 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmShiftedInstruction *instr
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
     print(log, instr->getTargetRegister(), TR_WordReg);
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+    OP::Mnemonic op = instr->getOpCodeValue();
     uint32_t imm = instr->getSourceImmediate() & 0xFF;
     uint32_t shift = instr->getShiftAmount();
     log->printf(", 0x%02x", imm);
     if (shift != 0) {
-        if ((op == TR::InstOpCode::vmovi4s_one) || (op == TR::InstOpCode::vmvni4s_one)) {
+        if ((op == OP::vmovi4s_one) || (op == OP::vmvni4s_one)) {
             log->printf(", MSL #%d", shift);
         } else {
             log->printf(", LSL #%d", shift);
@@ -1565,11 +1564,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmSymInstruction *instr)
         }
     } else {
         int64_t offset = static_cast<int64_t>(static_cast<int32_t>(instr->getSourceImmediate()));
-        if ((instr->getOpCodeValue() != TR::InstOpCode::adr) && (instr->getOpCodeValue() != TR::InstOpCode::adrp)) {
+        if ((instr->getOpCodeValue() != OP::adr) && (instr->getOpCodeValue() != OP::adrp)) {
             // ldr literal variants
             offset *= 4;
         }
-        if (instr->getOpCodeValue() == TR::InstOpCode::adrp) {
+        if (instr->getOpCodeValue() == OP::adrp) {
             offset *= 4096;
         }
         log->printf(POINTER_PRINTF_FORMAT, (instr->getBinaryEncoding() + offset));
@@ -1581,25 +1580,25 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ImmSymInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1Instruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    if (op >= TR::InstOpCode::fcvt_stod && op <= TR::InstOpCode::scvtf_xtod) {
+    if (op >= OP::fcvt_stod && op <= OP::scvtf_xtod) {
         TR_RegisterSizes regSize1 = TR_UnknownSizeReg; // trg register size
         TR_RegisterSizes regSize2 = TR_UnknownSizeReg; // src register size
         uint32_t sf = getSFbit(enc);
         uint32_t ftype = getFType(enc);
-        if (op == TR::InstOpCode::fcvt_stod) {
+        if (op == OP::fcvt_stod) {
             regSize1 = TR_DoubleReg;
             regSize2 = TR_FloatReg;
-        } else if (op == TR::InstOpCode::fcvt_dtos) {
+        } else if (op == OP::fcvt_dtos) {
             regSize1 = TR_FloatReg;
             regSize2 = TR_DoubleReg;
-        } else if (op >= TR::InstOpCode::fcvtzs_stow && op <= TR::InstOpCode::fcvtzs_dtox) {
+        } else if (op >= OP::fcvtzs_stow && op <= OP::fcvtzs_dtox) {
             regSize1 = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
             regSize2 = getRegisterSizeFromFType(ftype);
-        } else if (op >= TR::InstOpCode::scvtf_wtos && op <= TR::InstOpCode::scvtf_xtod) {
+        } else if (op >= OP::scvtf_wtos && op <= OP::scvtf_xtod) {
             regSize1 = getRegisterSizeFromFType(ftype);
             regSize2 = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
         }
@@ -1620,7 +1619,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1Instruction *instr)
         log->prints(", ");
         print(log, instr->getSource1Register(), regSize);
 
-        if (op >= TR::InstOpCode::vshll_8h && op <= TR::InstOpCode::vshll2_2d) {
+        if (op >= OP::vshll_8h && op <= OP::vshll2_2d) {
             uint32_t size = (enc >> 22) & 0x3; /* bits 22-23 */
             uint32_t shiftAmount = 8 << size;
             log->printf(", %d", shiftAmount);
@@ -1633,19 +1632,19 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1Instruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ZeroSrc1Instruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     char suffix = (sf == 1) ? 'x' : 'w';
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
 
-    if (op == TR::InstOpCode::orrx || op == TR::InstOpCode::orrw) {
+    if (op == OP::orrx || op == OP::orrw) {
         // mov alias
         log->printf("mov%c \t", suffix);
-    } else if (op == TR::InstOpCode::ornx || op == TR::InstOpCode::ornw) {
+    } else if (op == OP::ornx || op == OP::ornw) {
         // mvn alias
         log->printf("mvn%c \t", suffix);
-    } else if (op == TR::InstOpCode::subx || op == TR::InstOpCode::subw) {
+    } else if (op == OP::subx || op == OP::subw) {
         // neg alias
         log->printf("neg%c \t", suffix);
     } else {
@@ -1661,29 +1660,28 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ZeroSrc1Instruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
     bool done = false;
-    if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw || op == TR::InstOpCode::addsimmx
-        || op == TR::InstOpCode::addsimmw) {
+    if (op == OP::subsimmx || op == OP::subsimmw || op == OP::addsimmx || op == OP::addsimmw) {
         done = true;
         TR::Register *r = instr->getTargetRegister();
         if (r && r->getRealRegister() && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr) {
             // cmp/cmn alias
             char *mnemonic = NULL;
             switch (op) {
-                case TR::InstOpCode::subsimmx:
+                case OP::subsimmx:
                     mnemonic = "cmpimmx";
                     break;
-                case TR::InstOpCode::subsimmw:
+                case OP::subsimmw:
                     mnemonic = "cmpimmw";
                     break;
-                case TR::InstOpCode::addsimmx:
+                case OP::addsimmx:
                     mnemonic = "cmnimmx";
                     break;
-                case TR::InstOpCode::addsimmw:
+                case OP::addsimmw:
                     mnemonic = "cmnimmw";
                     break;
                 default:
@@ -1703,8 +1701,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
         if (instr->getNbit()) {
             log->printf(", LSL #%d", 12);
         }
-    } else if ((op == TR::InstOpCode::subimmx || op == TR::InstOpCode::subimmw || op == TR::InstOpCode::addimmx
-                   || op == TR::InstOpCode::addimmw)) {
+    } else if ((op == OP::subimmx || op == OP::subimmw || op == OP::addimmx || op == OP::addimmw)) {
         done = true;
         log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
         print(log, instr->getTargetRegister(), regSize);
@@ -1714,11 +1711,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
         if (instr->getNbit()) {
             log->printf(", LSL #%d", 12);
         }
-    } else if (op == TR::InstOpCode::sbfmx || op == TR::InstOpCode::sbfmw) {
+    } else if (op == OP::sbfmx || op == OP::sbfmw) {
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
-        if (op == TR::InstOpCode::sbfmx) {
+        if (op == OP::sbfmx) {
             if (imms == 63) {
                 // asr alias
                 done = true;
@@ -1735,7 +1732,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
                 log->prints(", ");
                 print(log, instr->getSource1Register(), regSize);
             }
-        } else if ((op == TR::InstOpCode::sbfmw) && ((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0)) {
+        } else if ((op == OP::sbfmw) && ((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0)) {
             if (imms == 31) {
                 // asr alias
                 done = true;
@@ -1761,11 +1758,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(log, instr->getSource1Register(), regSize);
             log->printf(", %d, %d", immr, imms);
         }
-    } else if (op == TR::InstOpCode::ubfmx || op == TR::InstOpCode::ubfmw) {
+    } else if (op == OP::ubfmx || op == OP::ubfmw) {
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
-        if (op == TR::InstOpCode::ubfmx) {
+        if (op == OP::ubfmx) {
             if (imms == 63) {
                 // lsr alias
                 done = true;
@@ -1799,7 +1796,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
                 print(log, instr->getSource1Register(), regSize);
                 log->printf(", %d, %d", immr, imms + 1 - immr);
             }
-        } else if ((op == TR::InstOpCode::ubfmw) && ((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0)) {
+        } else if ((op == OP::ubfmw) && ((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0)) {
             if (imms == 31) {
                 // lsr alias
                 done = true;
@@ -1849,11 +1846,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(log, instr->getSource1Register(), regSize);
             log->printf(", %d, %d", immr, imms);
         }
-    } else if (op == TR::InstOpCode::bfmx || op == TR::InstOpCode::bfmw) {
+    } else if (op == OP::bfmx || op == OP::bfmw) {
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
-        if ((op == TR::InstOpCode::bfmx) || (((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0))) {
+        if ((op == OP::bfmx) || (((immr & (1 << 6)) == 0) && ((imms & (1 << 6)) == 0))) {
             char suffix = (sf == 1) ? 'x' : 'w';
             if (imms < immr) {
                 // bfi alias
@@ -1881,15 +1878,13 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
             print(log, instr->getSource1Register(), regSize);
             log->printf(", %d, %d", immr, imms);
         }
-    } else if (op == TR::InstOpCode::andimmx || op == TR::InstOpCode::andimmw || op == TR::InstOpCode::andsimmx
-        || op == TR::InstOpCode::andsimmw || op == TR::InstOpCode::orrimmx || op == TR::InstOpCode::orrimmw
-        || op == TR::InstOpCode::eorimmx || op == TR::InstOpCode::eorimmw) {
+    } else if (op == OP::andimmx || op == OP::andimmw || op == OP::andsimmx || op == OP::andsimmw || op == OP::orrimmx
+        || op == OP::orrimmw || op == OP::eorimmx || op == OP::eorimmw) {
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
         auto n = instr->getNbit();
-        if (op == TR::InstOpCode::andimmx || op == TR::InstOpCode::andsimmx || op == TR::InstOpCode::orrimmx
-            || op == TR::InstOpCode::eorimmx) {
+        if (op == OP::andimmx || op == OP::andsimmx || op == OP::orrimmx || op == OP::eorimmx) {
             uint64_t immediate;
             if (decodeBitMasks(n, immr, imms, immediate)) {
                 done = true;
@@ -1910,9 +1905,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
                 log->printf(", 0x%lx", immediate);
             }
         }
-    } else if ((op >= TR::InstOpCode::vshl16b) && (op <= TR::InstOpCode::vsri2d)) {
+    } else if ((op >= OP::vshl16b) && (op <= OP::vsri2d)) {
         done = true;
-        bool isShiftLeft = (op <= TR::InstOpCode::vsli2d);
+        bool isShiftLeft = (op <= OP::vsli2d);
         uint32_t immh = (enc >> 19) & 0xf; /* bits 19-22 */
         uint32_t elementSize = 8 << (31 - leadingZeroes(immh));
         uint32_t imm = instr->getSourceImmediate();
@@ -1922,17 +1917,15 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
         log->prints(", ");
         print(log, instr->getSource1Register(), TR_VectorReg128);
         log->printf(", %d", shiftAmount);
-    } else if ((op >= TR::InstOpCode::vdupe16b) && (op <= TR::InstOpCode::umovxd)) {
+    } else if ((op >= OP::vdupe16b) && (op <= OP::umovxd)) {
         done = true;
-        const uint32_t elementSizeShift = (op <= TR::InstOpCode::vdupe2d)
-            ? (op - TR::InstOpCode::vdupe16b)
-            : ((op <= TR::InstOpCode::smovwh) ? (op - TR::InstOpCode::smovwb)
-                                              : ((op <= TR::InstOpCode::smovxh) ? (op - TR::InstOpCode::smovxb)
-                                                                                : (op - TR::InstOpCode::umovwb)));
+        const uint32_t elementSizeShift = (op <= OP::vdupe2d)
+            ? (op - OP::vdupe16b)
+            : ((op <= OP::smovwh) ? (op - OP::smovwb) : ((op <= OP::smovxh) ? (op - OP::smovxb) : (op - OP::umovwb)));
 
         const uint32_t imm5 = instr->getSourceImmediate() & 0x1f;
         const uint32_t index = imm5 >> (elementSizeShift + 1);
-        if (op <= TR::InstOpCode::vdupe2d) {
+        if (op <= OP::vdupe2d) {
             regSize = TR_VectorReg128;
         } else {
             // SMOV or UMOV
@@ -1943,9 +1936,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
         log->prints(", ");
         print(log, instr->getSource1Register(), TR_VectorReg128);
         log->printf(".[%d]", index);
-    } else if ((op >= TR::InstOpCode::vinswb) && (op <= TR::InstOpCode::vinsxd)) {
+    } else if ((op >= OP::vinswb) && (op <= OP::vinsxd)) {
         done = true;
-        const uint32_t elementSizeShift = op - TR::InstOpCode::vinswb;
+        const uint32_t elementSizeShift = op - OP::vinswb;
         const uint32_t imm5 = instr->getSourceImmediate() & 0x1f;
         const uint32_t index = imm5 >> (elementSizeShift + 1);
 
@@ -1954,9 +1947,9 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
         log->printf(".[%d]", index);
         log->prints(", ");
         print(log, instr->getSource1Register(), ((imm5 % 8) == 0) ? TR_DoubleWordReg : TR_WordReg);
-    } else if ((op >= TR::InstOpCode::vinseb) && (op <= TR::InstOpCode::vinsed)) {
+    } else if ((op >= OP::vinseb) && (op <= OP::vinsed)) {
         done = true;
-        const uint32_t elementSizeShift = op - TR::InstOpCode::vinseb;
+        const uint32_t elementSizeShift = op - OP::vinseb;
         const uint32_t imm5 = (instr->getSourceImmediate() >> 5) & 0x1f;
         const uint32_t imm4 = instr->getSourceImmediate() & 0xf;
         const uint32_t dstIndex = imm5 >> (elementSizeShift + 1);
@@ -1987,15 +1980,15 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src1ImmInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ZeroImmInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+    OP::Mnemonic op = instr->getOpCodeValue();
     bool done = false;
-    if (op == TR::InstOpCode::orrimmx || op == TR::InstOpCode::orrimmw) {
+    if (op == OP::orrimmx || op == OP::orrimmw) {
         // mov (bitmask immediate) alias
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
         auto n = instr->getNbit();
-        if (op == TR::InstOpCode::orrimmx) {
+        if (op == OP::orrimmx) {
             uint64_t immediate;
             if (decodeBitMasks(n, immr, imms, immediate)) {
                 done = true;
@@ -2028,13 +2021,13 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1ZeroImmInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64ZeroSrc1ImmInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     char suffix = (sf == 1) ? 'x' : 'w';
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
     bool done = false;
-    if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw) {
+    if (op == OP::subsimmx || op == OP::subsimmw) {
         // cmp alias
         done = true;
         log->printf("cmpimm%c \t", suffix);
@@ -2043,7 +2036,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64ZeroSrc1ImmInstruction *instr)
         if (instr->getNbit()) {
             log->printf(", LSL #%d", 12);
         }
-    } else if (op == TR::InstOpCode::addsimmx || op == TR::InstOpCode::addsimmw) {
+    } else if (op == OP::addsimmx || op == OP::addsimmw) {
         // cmn alias
         done = true;
         log->printf("cmnimm%c \t", suffix);
@@ -2052,13 +2045,13 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64ZeroSrc1ImmInstruction *instr)
         if (instr->getNbit()) {
             log->printf(", LSL #%d", 12);
         }
-    } else if (op == TR::InstOpCode::andsimmx || op == TR::InstOpCode::andsimmw) {
+    } else if (op == OP::andsimmx || op == OP::andsimmw) {
         // tst alias
         uint32_t imm12 = instr->getSourceImmediate();
         auto immr = imm12 >> 6;
         auto imms = imm12 & 0x3f;
         auto n = instr->getNbit();
-        if (op == TR::InstOpCode::andsimmx) {
+        if (op == OP::andsimmx) {
             uint64_t immediate;
             if (decodeBitMasks(n, immr, imms, immediate)) {
                 done = true;
@@ -2089,8 +2082,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64ZeroSrc1ImmInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2Instruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
     uint32_t sf = getSFbit(enc);
     if (useGPR(enc)) {
@@ -2100,7 +2093,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2Instruction *instr)
     }
 
     bool done = false;
-    if (op == TR::InstOpCode::orrx || op == TR::InstOpCode::orrw) {
+    if (op == OP::orrx || op == OP::orrw) {
         TR::Register *r = instr->getSource1Register();
         if (r && r->getRealRegister() && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr) {
             // mov alias
@@ -2111,7 +2104,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2Instruction *instr)
             log->prints(", ");
             print(log, instr->getSource2Register(), regSize);
         }
-    } else if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw) {
+    } else if (op == OP::subsx || op == OP::subsw) {
         TR::Register *r = instr->getTargetRegister();
         if (r && r->getRealRegister() && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr) {
             // cmp alias
@@ -2142,18 +2135,18 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2Instruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64ZeroSrc2Instruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     char suffix = (sf == 1) ? 'x' : 'w';
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
-    if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw) {
+    if (op == OP::subsx || op == OP::subsw) {
         // cmp alias
         log->printf("cmp%c \t", suffix);
-    } else if (op == TR::InstOpCode::addsx || op == TR::InstOpCode::addsw) {
+    } else if (op == OP::addsx || op == OP::addsw) {
         // cmn alias
         log->printf("cmn%c \t", suffix);
-    } else if (op == TR::InstOpCode::andsx || op == TR::InstOpCode::andsw) {
+    } else if (op == OP::andsx || op == OP::andsw) {
         // tst alias
         log->printf("tst%c \t", suffix);
     } else {
@@ -2195,32 +2188,32 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Src2CondInstruction *instr)
     log->flush();
 }
 
-static const char *getBarrierLimitationName(TR::InstOpCode::AArch64BarrierLimitation lim)
+static const char *getBarrierLimitationName(OP::AArch64BarrierLimitation lim)
 {
     switch (lim) {
-        case TR::InstOpCode::sy:
+        case OP::sy:
             return "sy";
-        case TR::InstOpCode::st:
+        case OP::st:
             return "st";
-        case TR::InstOpCode::ld:
+        case OP::ld:
             return "ld";
-        case TR::InstOpCode::ish:
+        case OP::ish:
             return "ish";
-        case TR::InstOpCode::ishst:
+        case OP::ishst:
             return "ishst";
-        case TR::InstOpCode::ishld:
+        case OP::ishld:
             return "ishld";
-        case TR::InstOpCode::nsh:
+        case OP::nsh:
             return "nsh";
-        case TR::InstOpCode::nshst:
+        case OP::nshst:
             return "nshst";
-        case TR::InstOpCode::nshld:
+        case OP::nshld:
             return "nshld";
-        case TR::InstOpCode::osh:
+        case OP::osh:
             return "osh";
-        case TR::InstOpCode::oshst:
+        case OP::oshst:
             return "oshst";
-        case TR::InstOpCode::oshld:
+        case OP::oshld:
             return "oshld";
 
         default:
@@ -2231,8 +2224,7 @@ static const char *getBarrierLimitationName(TR::InstOpCode::AArch64BarrierLimita
 void TR_Debug::print(OMR::Logger *log, TR::ARM64SynchronizationInstruction *instr)
 {
     printPrefix(log, instr);
-    const char *lim
-        = getBarrierLimitationName(static_cast<TR::InstOpCode::AArch64BarrierLimitation>(instr->getSourceImmediate()));
+    const char *lim = getBarrierLimitationName(static_cast<OP::AArch64BarrierLimitation>(instr->getSourceImmediate()));
     log->printf("%s \t%s", getOpCodeName(&instr->getOpCode()), lim);
     log->flush();
 }
@@ -2242,11 +2234,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64CondTrg1Src2Instruction *instr)
     printPrefix(log, instr);
     TR::Register *r1 = instr->getSource1Register();
     TR::Register *r2 = instr->getSource2Register();
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
-    if ((r1 == r2) && ((op == TR::InstOpCode::csincx) || (op == TR::InstOpCode::csincw))) {
+    if ((r1 == r2) && ((op == OP::csincx) || (op == OP::csincw))) {
         log->printf("cinc%c \t", (sf == 1) ? 'x' : 'w');
         print(log, instr->getTargetRegister(), regSize);
         log->prints(", ");
@@ -2287,14 +2279,13 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ImmInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ShiftedInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
-    if ((op == TR::InstOpCode::extrw || op == TR::InstOpCode::extrx)
-        && (instr->getSource1Register() == instr->getSource2Register())) {
+    if ((op == OP::extrw || op == OP::extrx) && (instr->getSource1Register() == instr->getSource2Register())) {
         // ror alias
-        log->printf("ror%c \t", (op == TR::InstOpCode::extrx) ? 'x' : 'w');
+        log->printf("ror%c \t", (op == OP::extrx) ? 'x' : 'w');
         print(log, instr->getTargetRegister(), regSize);
         log->prints(", ");
         print(log, instr->getSource1Register(), regSize);
@@ -2316,8 +2307,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ShiftedInstruction *inst
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ExtendedInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
@@ -2349,11 +2340,11 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2IndexedElementInstructio
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ZeroInstruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t sf = getSFbit(enc);
     TR_RegisterSizes regSize = (sf == 1) ? TR_DoubleWordReg : TR_WordReg;
-    if (op == TR::InstOpCode::maddx || op == TR::InstOpCode::maddw) {
+    if (op == OP::maddx || op == OP::maddw) {
         // mul alias
         log->printf("mul%c \t", (sf == 1) ? 'x' : 'w');
     } else {
@@ -2370,8 +2361,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src2ZeroInstruction *instr)
 void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1Src3Instruction *instr)
 {
     printPrefix(log, instr);
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
     if (useGPR(enc)) {
         uint32_t sf = getSFbit(enc);
@@ -2399,8 +2390,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg1MemInstruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t vr = getVRbit(enc);
     uint32_t size = getLoadStoreSize(enc);
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
@@ -2445,8 +2436,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Trg2MemInstruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t vr = getVRbit(enc);
     uint32_t opc = (enc >> 30); /* bits 30-31 */
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
@@ -2498,10 +2489,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64MemInstruction *instr)
 
 void TR_Debug::print(OMR::Logger *log, TR::ARM64MemImmInstruction *instr)
 {
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+    OP::Mnemonic op = instr->getOpCodeValue();
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
-    if ((op == TR::InstOpCode::prfmoff || op == TR::InstOpCode::prfmimm)) {
+    if ((op == OP::prfmoff || op == OP::prfmimm)) {
         uint32_t immediate = instr->getImmediate();
         uint32_t typeValue = (immediate >> 3) & 0x3;
         uint32_t targetValue = (immediate >> 1) & 0x3;
@@ -2530,8 +2521,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64MemSrc1Instruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t vr = getVRbit(enc);
     uint32_t size = getLoadStoreSize(enc);
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
@@ -2567,8 +2558,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64MemSrc2Instruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     uint32_t vr = getVRbit(enc);
     uint32_t opc = (enc >> 30); /* bits 30-31 */
     TR_RegisterSizes regSize = TR_UnknownSizeReg;
@@ -2627,8 +2618,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Src1Instruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     TR_RegisterSizes regSize = getRegisterSizeFromFType(getFType(enc));
 
     print(log, instr->getSource1Register(), regSize);
@@ -2640,8 +2631,8 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64Src2Instruction *instr)
     printPrefix(log, instr);
     log->printf("%s \t", getOpCodeName(&instr->getOpCode()));
 
-    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-    uint32_t enc = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    OP::Mnemonic op = instr->getOpCodeValue();
+    uint32_t enc = OP::getOpCodeBinaryEncoding(op);
     TR_RegisterSizes regSize = getRegisterSizeFromFType(getFType(enc));
 
     print(log, instr->getSource1Register(), regSize);

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -39,8 +39,7 @@ uint8_t *TR::ARM64HelperCallSnippet::emitSnippetBodyInner(uint8_t *cursor)
         TR_ASSERT(constantIsSignedImm28(distance), "Trampoline too far away.");
     }
 
-    *(int32_t *)cursor
-        = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x3ffffff); // imm26
+    *(int32_t *)cursor = OP::getOpCodeBinaryEncoding(OP::bl) | ((distance >> 2) & 0x3ffffff); // imm26
 
     cg()->addExternalRelocation(
         TR::ExternalRelocation::create(cursor, (uint8_t *)getDestination(), TR_HelperAddress, cg()), __FILE__, __LINE__,
@@ -53,8 +52,7 @@ uint8_t *TR::ARM64HelperCallSnippet::emitSnippetBodyInner(uint8_t *cursor)
         distance = (intptr_t)(_restartLabel->getCodeLocation()) - (intptr_t)cursor;
         if (constantIsSignedImm28(distance)) {
             // b distance
-            *(int32_t *)cursor
-                = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b) | ((distance >> 2) & 0x3ffffff); // imm26
+            *(int32_t *)cursor = OP::getOpCodeBinaryEncoding(OP::b) | ((distance >> 2) & 0x3ffffff); // imm26
             cursor += ARM64_INSTRUCTION_LENGTH;
         } else {
             TR_ASSERT(false, "Target too far away.  Not supported yet");

--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -32,9 +32,9 @@ void TR::ARM64LabelInstruction::assignRegistersForOutOfLineCodeSection(TR_Regist
     OMR::Logger *log = comp->log();
     bool trace = comp->getOption(TR_TraceRA);
 
-    bool isLabel = getOpCodeValue() == TR::InstOpCode::label;
-    bool isBranch = (getOpCodeValue() == TR::InstOpCode::b) || (getKind() == IsConditionalBranch)
-        || (getKind() == IsCompareBranch) || (getKind() == IsTestBitBranch) || (getKind() == IsVirtualGuardNOP);
+    bool isLabel = getOpCodeValue() == OP::label;
+    bool isBranch = (getOpCodeValue() == OP::b) || (getKind() == IsConditionalBranch) || (getKind() == IsCompareBranch)
+        || (getKind() == IsTestBitBranch) || (getKind() == IsVirtualGuardNOP);
 
     cg()->freeUnlatchedRegisters();
     // this is the return label from OOL
@@ -94,7 +94,7 @@ void TR::ARM64LabelInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
 
 void TR::ARM64AdminInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
 {
-    if (getOpCodeValue() != TR::InstOpCode::assocreg) {
+    if (getOpCodeValue() != OP::assocreg) {
         OMR::ARM64::Instruction::assignRegisters(kindToBeAssigned);
     } else if (cg()->enableRegisterAssociations()) {
         TR::Machine *machine = cg()->machine();
@@ -408,7 +408,7 @@ void TR::ARM64MemSrc2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssig
 
 // TR::ARM64Trg1MemInstruction:: member functions
 
-TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::CodeGenerator *cg)
     /* Choose a correct variant of the opcode for this memory reference. */
     : ARM64Trg1Instruction(mr->mapOpCode(op), node, treg, cg)
@@ -418,7 +418,7 @@ TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op
     TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
 }
 
-TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::ARM64Trg1MemInstruction::ARM64Trg1MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
     /* Choose a correct variant of the opcode for this memory reference. */
     : ARM64Trg1Instruction(mr->mapOpCode(op), node, treg, precedingInstruction, cg)
@@ -516,7 +516,7 @@ void TR::ARM64Trg2MemInstruction::assignRegisters(TR_RegisterKinds kindToBeAssig
 
 // TR::ARM64MemInstruction:: member functions
 
-TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+TR::ARM64MemInstruction::ARM64MemInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
     TR::CodeGenerator *cg)
     /* Choose a correct variant of the opcode for this memory reference. */
     : TR::Instruction(mr->mapOpCode(op), node, cg)
@@ -526,7 +526,7 @@ TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op, TR::No
     TR::InstructionDelegate::setupImplicitNullPointerException(cg, this);
 }
 
-TR::ARM64MemInstruction::ARM64MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+TR::ARM64MemInstruction::ARM64MemInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
     TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
     /* Choose a correct variant of the opcode for this memory reference. */
     : TR::Instruction(mr->mapOpCode(op), node, precedingInstruction, cg)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -179,7 +179,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
+    ARM64ImmInstruction(OP::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _sourceImmediate(imm)
     {}
@@ -192,8 +192,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64ImmInstruction(OP::Mnemonic op, TR::Node *node, uint32_t imm, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _sourceImmediate(imm)
     {}
@@ -251,7 +251,7 @@ public:
      * @param[in] relocationKind : relocation kind
      * @param[in] cg : CodeGenerator
      */
-    ARM64RelocatableImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
+    ARM64RelocatableImmInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm,
         TR_ExternalRelocationTargetKind relocationKind, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _sourceImmediate(imm)
@@ -270,7 +270,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64RelocatableImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
+    ARM64RelocatableImmInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm,
         TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _sourceImmediate(imm)
@@ -289,7 +289,7 @@ public:
      * @param[in] sr : symbol reference
      * @param[in] cg : CodeGenerator
      */
-    ARM64RelocatableImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
+    ARM64RelocatableImmInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm,
         TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _sourceImmediate(imm)
@@ -309,7 +309,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64RelocatableImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
+    ARM64RelocatableImmInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm,
         TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *precedingInstruction,
         TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
@@ -394,17 +394,16 @@ class ARM64ImmSymInstruction : public TR::Instruction {
     TR::Snippet *_snippet;
 
 public:
-    ARM64ImmSymInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
-        TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::CodeGenerator *cg)
+    ARM64ImmSymInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm, TR::RegisterDependencyConditions *cond,
+        TR::SymbolReference *sr, TR::Snippet *s, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, cg)
         , _addrImmediate(imm)
         , _symbolReference(sr)
         , _snippet(s)
     {}
 
-    ARM64ImmSymInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uintptr_t imm,
-        TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64ImmSymInstruction(OP::Mnemonic op, TR::Node *node, uintptr_t imm, TR::RegisterDependencyConditions *cond,
+        TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, precedingInstruction, cg)
         , _addrImmediate(imm)
         , _symbolReference(sr)
@@ -487,11 +486,11 @@ public:
      * @param[in] sym : label symbol
      * @param[in] cg : CodeGenerator
      */
-    ARM64LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg)
+    ARM64LabelInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _symbol(sym)
     {
-        if (sym != NULL && op == TR::InstOpCode::label)
+        if (sym != NULL && op == OP::label)
             sym->setInstruction(this);
     }
 
@@ -503,12 +502,12 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64LabelInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _symbol(sym)
     {
-        if (sym != NULL && op == TR::InstOpCode::label)
+        if (sym != NULL && op == OP::label)
             sym->setInstruction(this);
     }
 
@@ -520,12 +519,12 @@ public:
      * @param[in] cond : register dependency condition
      * @param[in] cg : CodeGenerator
      */
-    ARM64LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+    ARM64LabelInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, cg)
         , _symbol(sym)
     {
-        if (sym != NULL && op == TR::InstOpCode::label)
+        if (sym != NULL && op == OP::label)
             sym->setInstruction(this);
     }
 
@@ -538,12 +537,12 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64LabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64LabelInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, precedingInstruction, cg)
         , _symbol(sym)
     {
-        if (sym != NULL && op == TR::InstOpCode::label)
+        if (sym != NULL && op == OP::label)
             sym->setInstruction(this);
     }
 
@@ -620,8 +619,8 @@ public:
      * @param[in] cc : branch condition code
      * @param[in] cg : CodeGenerator
      */
-    ARM64ConditionalBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::ARM64ConditionCode cc, TR::CodeGenerator *cg)
+    ARM64ConditionalBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc,
+        TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cg)
         , _cc(cc)
         , _estimatedBinaryLocation(0)
@@ -636,8 +635,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ConditionalBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::ARM64ConditionCode cc, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64ConditionalBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, precedingInstruction, cg)
         , _cc(cc)
         , _estimatedBinaryLocation(0)
@@ -652,8 +651,8 @@ public:
      * @param[in] cond : register dependency condition
      * @param[in] cg : CodeGenerator
      */
-    ARM64ConditionalBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+    ARM64ConditionalBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc,
+        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, cg)
         , _cc(cc)
         , _estimatedBinaryLocation(0)
@@ -669,9 +668,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ConditionalBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
-        TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction,
-        TR::CodeGenerator *cg)
+    ARM64ConditionalBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym, TR::ARM64ConditionCode cc,
+        TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, precedingInstruction, cg)
         , _cc(cc)
         , _estimatedBinaryLocation(0)
@@ -753,7 +751,7 @@ public:
      * @param[in] sym : label symbol
      * @param[in] cg : CodeGenerator
      */
-    ARM64CompareBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
+    ARM64CompareBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
         TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cg)
         , _source1Register(sreg)
@@ -771,7 +769,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64CompareBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
+    ARM64CompareBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -789,7 +787,7 @@ public:
      * @param[in] cond : register dependency condition
      * @param[in] cg : CodeGenerator
      */
-    ARM64CompareBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
+    ARM64CompareBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
         TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, cg)
         , _source1Register(sreg)
@@ -808,7 +806,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64CompareBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
+    ARM64CompareBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::LabelSymbol *sym,
         TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -922,7 +920,7 @@ public:
      * @param[in] sym    : label symbol
      * @param[in] cg     : CodeGenerator
      */
-    ARM64TestBitBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
+    ARM64TestBitBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
         TR::LabelSymbol *sym, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cg)
         , _source1Register(sreg)
@@ -942,7 +940,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg                   : CodeGenerator
      */
-    ARM64TestBitBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
+    ARM64TestBitBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
         TR::LabelSymbol *sym, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -962,7 +960,7 @@ public:
      * @param[in] cond   : register dependency condition
      * @param[in] cg     : CodeGenerator
      */
-    ARM64TestBitBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
+    ARM64TestBitBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
         TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, cg)
         , _source1Register(sreg)
@@ -983,7 +981,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg                   : CodeGenerator
      */
-    ARM64TestBitBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
+    ARM64TestBitBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t bitpos,
         TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction,
         TR::CodeGenerator *cg)
         : ARM64LabelInstruction(op, node, sym, cond, precedingInstruction, cg)
@@ -1118,7 +1116,7 @@ public:
      * @param[in] treg : branch target
      * @param[in] cg : CodeGenerator
      */
-    ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
+    ARM64RegBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _register(treg)
     {
@@ -1133,7 +1131,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+    ARM64RegBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _register(treg)
@@ -1149,7 +1147,7 @@ public:
      * @param[in] cond : register dependency condition
      * @param[in] cg : CodeGenerator
      */
-    ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+    ARM64RegBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg,
         TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, cg)
         , _register(treg)
@@ -1166,7 +1164,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+    ARM64RegBranchInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg,
         TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, precedingInstruction, cg)
         , _register(treg)
@@ -1251,7 +1249,7 @@ public:
      * @param[in] fenceNode : fence node
      * @param[in] cg : CodeGenerator
      */
-    ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Node *fenceNode, TR::CodeGenerator *cg)
+    ARM64AdminInstruction(OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _fenceNode(fenceNode)
     {}
@@ -1264,8 +1262,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64AdminInstruction(OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _fenceNode(fenceNode)
     {}
@@ -1278,8 +1276,8 @@ public:
      * @param[in] fenceNode : fence node
      * @param[in] cg : CodeGenerator
      */
-    ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node,
-        TR::Node *fenceNode, TR::CodeGenerator *cg)
+    ARM64AdminInstruction(OP::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node, TR::Node *fenceNode,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, cg)
         , _fenceNode(fenceNode)
     {}
@@ -1293,8 +1291,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node,
-        TR::Node *fenceNode, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64AdminInstruction(OP::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node, TR::Node *fenceNode,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, precedingInstruction, cg)
         , _fenceNode(fenceNode)
     {}
@@ -1350,7 +1348,7 @@ public:
      * @param[in] treg : target register
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
+    ARM64Trg1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _target1Register(treg)
     {
@@ -1365,8 +1363,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _target1Register(treg)
     {
@@ -1381,8 +1379,8 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+    ARM64Trg1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::RegisterDependencyConditions *cond,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, cg)
         , _target1Register(treg)
     {
@@ -1398,8 +1396,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::RegisterDependencyConditions *cond,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cond, precedingInstruction, cg)
         , _target1Register(treg)
     {
@@ -1484,7 +1482,7 @@ public:
      * @param[in] cc : branch condition code
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1CondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
+    ARM64Trg1CondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
         TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cg)
         , _cc(cc)
@@ -1499,7 +1497,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1CondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
+    ARM64Trg1CondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg)
         , _cc(cc)
@@ -1560,8 +1558,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
-        TR::CodeGenerator *cg)
+    ARM64Trg1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cg)
         , _sourceImmediate(imm)
     {}
@@ -1575,7 +1572,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    ARM64Trg1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg)
         , _sourceImmediate(imm)
@@ -1606,21 +1603,19 @@ public:
      */
     void insertImmediateField(uint32_t *instruction)
     {
-        TR::InstOpCode::Mnemonic op = getOpCodeValue();
+        OP::Mnemonic op = getOpCodeValue();
 
-        if (op == TR::InstOpCode::movzx || op == TR::InstOpCode::movzw || op == TR::InstOpCode::movnx
-            || op == TR::InstOpCode::movnw || op == TR::InstOpCode::movkx || op == TR::InstOpCode::movkw) {
+        if (op == OP::movzx || op == OP::movzw || op == OP::movnx || op == OP::movnw || op == OP::movkx
+            || op == OP::movkw) {
             *instruction |= ((_sourceImmediate & 0x3ffff) << 5);
-        } else if (op == TR::InstOpCode::fmovimms || op == TR::InstOpCode::fmovimmd) {
+        } else if (op == OP::fmovimms || op == OP::fmovimmd) {
             *instruction |= ((_sourceImmediate & 0xFF) << 13);
-        } else if (op == TR::InstOpCode::adr || op == TR::InstOpCode::adrp) {
+        } else if (op == OP::adr || op == OP::adrp) {
             *instruction |= ((_sourceImmediate & 0x1ffffc) << 3) | ((_sourceImmediate & 0x3) << 29);
-        } else if (op == TR::InstOpCode::vmovi16b || op == TR::InstOpCode::vmovi8h || op == TR::InstOpCode::vmovi4s
-            || op == TR::InstOpCode::vmovi4s_one || op == TR::InstOpCode::vmovi2s || op == TR::InstOpCode::movid
-            || op == TR::InstOpCode::vmovi2d || op == TR::InstOpCode::vfmov4s || op == TR::InstOpCode::vfmov2d
-            || op == TR::InstOpCode::vmvni8h || op == TR::InstOpCode::vmvni4s || op == TR::InstOpCode::vmvni4s_one
-            || op == TR::InstOpCode::vbicimm8h || op == TR::InstOpCode::vbicimm4s || op == TR::InstOpCode::vorrimm8h
-            || op == TR::InstOpCode::vorrimm4s) {
+        } else if (op == OP::vmovi16b || op == OP::vmovi8h || op == OP::vmovi4s || op == OP::vmovi4s_one
+            || op == OP::vmovi2s || op == OP::movid || op == OP::vmovi2d || op == OP::vfmov4s || op == OP::vfmov2d
+            || op == OP::vmvni8h || op == OP::vmvni4s || op == OP::vmvni4s_one || op == OP::vbicimm8h
+            || op == OP::vbicimm4s || op == OP::vorrimm8h || op == OP::vorrimm4s) {
             *instruction |= ((_sourceImmediate & 0xe0) << 11) | ((_sourceImmediate & 0x1f) << 5);
         } else {
             TR_ASSERT(false, "Unsupported opcode in ARM64Trg1ImmInstruction.");
@@ -1647,7 +1642,7 @@ public:
      * @param[in] shiftAmount : shiftAmount
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmShiftedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    ARM64Trg1ImmShiftedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
         uint32_t shiftAmount, TR::CodeGenerator *cg)
         : ARM64Trg1ImmInstruction(op, node, treg, imm, cg)
         , _shiftAmount(shiftAmount)
@@ -1663,7 +1658,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmShiftedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    ARM64Trg1ImmShiftedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
         uint32_t shiftAmount, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1ImmInstruction(op, node, treg, imm, precedingInstruction, cg)
         , _shiftAmount(shiftAmount)
@@ -1694,18 +1689,16 @@ public:
      */
     void insertShift(uint32_t *instruction)
     {
-        TR::InstOpCode::Mnemonic op = getOpCodeValue();
-        if ((op == TR::InstOpCode::vmovi8h) || (op == TR::InstOpCode::vmvni8h) || (op == TR::InstOpCode::vbicimm8h)
-            || (op == TR::InstOpCode::vorrimm8h)) {
+        OP::Mnemonic op = getOpCodeValue();
+        if ((op == OP::vmovi8h) || (op == OP::vmvni8h) || (op == OP::vbicimm8h) || (op == OP::vorrimm8h)) {
             TR_ASSERT_FATAL((_shiftAmount == 0) || (_shiftAmount == 8),
                 "shiftAmount other than 0 or 8 is not allowed for vmovi8h, vmvni8h, vbicimm8h and vorrimm8h");
             *instruction |= (_shiftAmount >> 3) << 13;
-        } else if ((op == TR::InstOpCode::vmovi4s) || (op == TR::InstOpCode::vmvni4s)
-            || (op == TR::InstOpCode::vbicimm4s) || (op == TR::InstOpCode::vorrimm4s)) {
+        } else if ((op == OP::vmovi4s) || (op == OP::vmvni4s) || (op == OP::vbicimm4s) || (op == OP::vorrimm4s)) {
             TR_ASSERT_FATAL((_shiftAmount == 0) || (_shiftAmount == 8) || (_shiftAmount == 16) || (_shiftAmount == 24),
                 "shiftAmount other than 0, 8, 16, or 24 is not allowed for vmovi4s, vmvni4s, vbicimm4s and vorrimm4s");
             *instruction |= (_shiftAmount >> 3) << 13;
-        } else if ((op == TR::InstOpCode::vmovi4s_one) || (op == TR::InstOpCode::vmvni4s_one)) {
+        } else if ((op == OP::vmovi4s_one) || (op == OP::vmvni4s_one)) {
             TR_ASSERT_FATAL((_shiftAmount == 8) || (_shiftAmount == 16),
                 "shiftAmount other than 8 or 16 is not allowed for vmovi8h and vmvni8h");
 
@@ -1735,8 +1728,8 @@ public:
      * @param[in] sym : symbol
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmSymInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
-        TR::Symbol *sym, TR::CodeGenerator *cg)
+    ARM64Trg1ImmSymInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm, TR::Symbol *sym,
+        TR::CodeGenerator *cg)
         : ARM64Trg1ImmInstruction(op, node, treg, imm, cg)
         , _symbol(sym)
     {}
@@ -1751,8 +1744,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ImmSymInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
-        TR::Symbol *sym, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1ImmSymInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm, TR::Symbol *sym,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1ImmInstruction(op, node, treg, imm, precedingInstruction, cg)
         , _symbol(sym)
     {}
@@ -1776,8 +1769,8 @@ public:
      */
     void insertImmediateField(uint32_t *instruction)
     {
-        TR::InstOpCode::Mnemonic op = getOpCodeValue();
-        if (op == TR::InstOpCode::adr || op == TR::InstOpCode::adrp) {
+        OP::Mnemonic op = getOpCodeValue();
+        if (op == OP::adr || op == OP::adrp) {
             *instruction |= ((getSourceImmediate() & 0x1ffffc) << 3) | ((getSourceImmediate() & 0x3) << 29);
         } else {
             *instruction |= ((getSourceImmediate() & 0x7ffff) << 5);
@@ -1803,7 +1796,7 @@ public:
      * @param[in] sreg : source register
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cg)
         , _source1Register(sreg)
@@ -1820,7 +1813,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -1837,7 +1830,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cond, cg)
         , _source1Register(sreg)
@@ -1855,7 +1848,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cond, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -1954,7 +1947,7 @@ public:
      * @param[in] sreg : source register
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ZeroSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1ZeroSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, cg)
     {}
@@ -1968,7 +1961,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1ZeroSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    ARM64Trg1ZeroSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, precedingInstruction, cg)
     {}
@@ -2022,7 +2015,7 @@ public:
      * @param[in]  imm : immediate value
      * @param[in]   cg : CodeGenerator
      */
-    ARM64Trg1ZeroImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    ARM64Trg1ZeroImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
         TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cg)
         , _source1Immediate(imm)
@@ -2038,7 +2031,7 @@ public:
      * @param[in]  imm : immediate value
      * @param[in]   cg : CodeGenerator
      */
-    ARM64Trg1ZeroImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
+    ARM64Trg1ZeroImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
         TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, cg)
         , _source1Immediate(imm)
@@ -2054,7 +2047,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in]                   cg : CodeGenerator
      */
-    ARM64Trg1ZeroImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    ARM64Trg1ZeroImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg)
         , _source1Immediate(imm)
@@ -2071,7 +2064,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in]                   cg : CodeGenerator
      */
-    ARM64Trg1ZeroImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
+    ARM64Trg1ZeroImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg)
         , _source1Immediate(imm)
@@ -2161,8 +2154,8 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        uint32_t imm, TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t imm,
+        TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, cg)
         , _source1Immediate(imm)
         , _Nbit(false)
@@ -2178,8 +2171,8 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        bool N, uint32_t imm, TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, bool N,
+        uint32_t imm, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, cg)
         , _source1Immediate(imm)
         , _Nbit(N)
@@ -2195,8 +2188,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        uint32_t imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t imm,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, precedingInstruction, cg)
         , _source1Immediate(imm)
         , _Nbit(false)
@@ -2213,8 +2206,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        bool N, uint32_t imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, bool N,
+        uint32_t imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, precedingInstruction, cg)
         , _source1Immediate(imm)
         , _Nbit(N)
@@ -2230,8 +2223,8 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        uint32_t imm, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t imm,
+        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, cond, cg)
         , _source1Immediate(imm)
         , _Nbit(false)
@@ -2248,9 +2241,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-        uint32_t imm, TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction,
-        TR::CodeGenerator *cg)
+    ARM64Trg1Src1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t imm,
+        TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, sreg, cond, precedingInstruction, cg)
         , _source1Immediate(imm)
         , _Nbit(false)
@@ -2294,13 +2286,13 @@ public:
      */
     void insertImmediateField(uint32_t *instruction)
     {
-        TR::InstOpCode::Mnemonic op = getOpCodeValue();
+        OP::Mnemonic op = getOpCodeValue();
 
-        if ((op >= TR::InstOpCode::vshl16b) && (op <= TR::InstOpCode::vsri2d)) {
+        if ((op >= OP::vshl16b) && (op <= OP::vsri2d)) {
             *instruction |= ((_source1Immediate & 0x7f) << 16); /* immh:immb */
-        } else if ((op >= TR::InstOpCode::vdupe16b) && (op <= TR::InstOpCode::vinsxd)) {
+        } else if ((op >= OP::vdupe16b) && (op <= OP::vinsxd)) {
             *instruction |= ((_source1Immediate & 0x1f) << 16); /* imm5 */
-        } else if ((op >= TR::InstOpCode::vinseb) && (op <= TR::InstOpCode::vinsed)) {
+        } else if ((op >= OP::vinseb) && (op <= OP::vinsed)) {
             *instruction |= ((_source1Immediate & 0x3ff) << 11); /* imm5 and imm4 */
         } else {
             *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */
@@ -2338,7 +2330,7 @@ public:
      * @param[in] s2reg : source register 2
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cg)
         , _source2Register(s2reg)
@@ -2356,7 +2348,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, s1reg, precedingInstruction, cg)
         , _source2Register(s2reg)
@@ -2374,7 +2366,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, cg)
         , _source2Register(s2reg)
@@ -2393,7 +2385,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction,
         TR::CodeGenerator *cg)
         : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, precedingInstruction, cg)
@@ -2496,7 +2488,7 @@ public:
      * @param[in] cc : branch condition code
      * @param[in] cg : CodeGenerator
      */
-    ARM64CondTrg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64CondTrg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _cc(cc)
@@ -2513,7 +2505,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64CondTrg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64CondTrg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _cc(cc)
@@ -2530,7 +2522,7 @@ public:
      * @param[in] cond : Register Dependency Condition
      * @param[in] cg : CodeGenerator
      */
-    ARM64CondTrg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64CondTrg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, cg)
         , _cc(cc)
@@ -2548,7 +2540,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64CondTrg1Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64CondTrg1Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, precedingInstruction, cg)
@@ -2601,7 +2593,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, uint32_t imm, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _sourceImmediate(imm)
@@ -2618,7 +2610,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, uint32_t imm, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _sourceImmediate(imm)
@@ -2672,8 +2664,8 @@ public:
      * @param[in] shiftAmount : shift amount
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ShiftedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, ARM64ShiftCode shiftType, uint32_t shiftAmount, TR::CodeGenerator *cg)
+    ARM64Trg1Src2ShiftedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, ARM64ShiftCode shiftType, uint32_t shiftAmount, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _shiftType(shiftType)
         , _shiftAmount(shiftAmount)
@@ -2691,9 +2683,9 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ShiftedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, ARM64ShiftCode shiftType, uint32_t shiftAmount,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Src2ShiftedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, ARM64ShiftCode shiftType, uint32_t shiftAmount, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _shiftType(shiftType)
         , _shiftAmount(shiftAmount)
@@ -2763,9 +2755,8 @@ public:
      * @param[in] shiftAmount : shift amount
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ExtendedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, ARM64ExtendCode extendType, uint32_t shiftAmount,
-        TR::CodeGenerator *cg)
+    ARM64Trg1Src2ExtendedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, ARM64ExtendCode extendType, uint32_t shiftAmount, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _extendType(extendType)
         , _shiftAmount(shiftAmount)
@@ -2783,9 +2774,9 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ExtendedInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, ARM64ExtendCode extendType, uint32_t shiftAmount,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1Src2ExtendedInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, ARM64ExtendCode extendType, uint32_t shiftAmount, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _extendType(extendType)
         , _shiftAmount(shiftAmount)
@@ -2853,8 +2844,8 @@ public:
      * @param[in] index : index of element in s2reg
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2IndexedElementInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::CodeGenerator *cg)
+    ARM64Trg1Src2IndexedElementInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, uint32_t index, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _index(index)
     {}
@@ -2870,9 +2861,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2IndexedElementInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *precedingInstruction,
-        TR::CodeGenerator *cg)
+    ARM64Trg1Src2IndexedElementInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+        TR::Register *s2reg, uint32_t index, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _index(index)
     {}
@@ -2916,7 +2906,7 @@ public:
      * @param[in] s2reg : source register 2
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ZeroInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2ZeroInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
     {}
@@ -2931,7 +2921,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src2ZeroInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src2ZeroInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
     {}
@@ -2973,7 +2963,7 @@ public:
      * @param[in] s3reg : source register 3
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src3Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Register *s3reg, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
         , _source3Register(s3reg)
@@ -2992,7 +2982,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src3Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
         , _source3Register(s3reg)
@@ -3011,7 +3001,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src3Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, cg)
         , _source3Register(s3reg)
@@ -3031,7 +3021,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1Src3Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+    ARM64Trg1Src3Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
         TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, precedingInstruction, cg)
@@ -3134,7 +3124,7 @@ public:
      * @param[in] mr : memory reference
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
+    ARM64Trg1MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
         TR::CodeGenerator *cg);
 
     /*
@@ -3146,7 +3136,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
+    ARM64Trg1MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
 
     /**
@@ -3253,7 +3243,7 @@ public:
      * @param[in] mr : memory reference
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg2MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg1, TR::Register *treg2,
+    ARM64Trg2MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg1, TR::Register *treg2,
         TR::MemoryReference *mr, TR::CodeGenerator *cg)
         : ARM64Trg1MemInstruction(op, node, treg1, mr, cg)
         , _target2Register(treg2)
@@ -3271,7 +3261,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg2MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg1, TR::Register *treg2,
+    ARM64Trg2MemInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg1, TR::Register *treg2,
         TR::MemoryReference *mr, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1MemInstruction(op, node, treg1, mr, precedingInstruction, cg)
         , _target2Register(treg2)
@@ -3363,7 +3353,7 @@ public:
      * @param[in] mr : memory reference
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::CodeGenerator *cg);
+    ARM64MemInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
     /*
      * @brief Constructor
@@ -3373,8 +3363,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg);
+    ARM64MemInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg);
 
     /**
      * @brief Gets instruction kind
@@ -3477,7 +3467,7 @@ public:
      * @param[in] sreg : source register
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *sreg,
+    ARM64MemSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *sreg,
         TR::CodeGenerator *cg)
         : ARM64MemInstruction(op, node, mr, cg)
         , _source1Register(sreg)
@@ -3494,7 +3484,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *sreg,
+    ARM64MemSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *sreg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64MemInstruction(op, node, mr, precedingInstruction, cg)
         , _source1Register(sreg)
@@ -3590,7 +3580,7 @@ public:
      * @param[in] s2reg : source register 2
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *s1reg,
+    ARM64MemSrc2Instruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *s1reg,
         TR::Register *s2reg, TR::CodeGenerator *cg)
         : ARM64MemSrc1Instruction(op, node, mr, s1reg, cg)
         , _source2Register(s2reg)
@@ -3608,7 +3598,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *s1reg,
+    ARM64MemSrc2Instruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, TR::Register *s1reg,
         TR::Register *s2reg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64MemSrc1Instruction(op, node, mr, s1reg, precedingInstruction, cg)
         , _source2Register(s2reg)
@@ -3705,8 +3695,8 @@ public:
      * @param[in] sreg : source register
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1MemSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::MemoryReference *mr, TR::Register *sreg, TR::CodeGenerator *cg)
+    ARM64Trg1MemSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
+        TR::Register *sreg, TR::CodeGenerator *cg)
         : ARM64Trg1MemInstruction(op, node, treg, mr, cg)
         , _source1Register(sreg)
     {
@@ -3723,8 +3713,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Trg1MemSrc1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
-        TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Trg1MemSrc1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *treg, TR::MemoryReference *mr,
+        TR::Register *sreg, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Trg1MemInstruction(op, node, treg, mr, precedingInstruction, cg)
         , _source1Register(sreg)
     {
@@ -3828,7 +3818,7 @@ public:
      * @param[in] immediate : 5bit immediate
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, uint32_t immediate,
+    ARM64MemImmInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, uint32_t immediate,
         TR::CodeGenerator *cg)
         : ARM64MemInstruction(op, node, mr, cg)
         , _immediate(immediate)
@@ -3843,7 +3833,7 @@ public:
      * @param[in] immediate : 5bit immediate
      * @param[in] cg : CodeGenerator
      */
-    ARM64MemImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, uint32_t immediate,
+    ARM64MemImmInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, uint32_t immediate,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64MemInstruction(op, node, mr, precedingInstruction, cg)
         , _immediate(immediate)
@@ -3892,7 +3882,7 @@ public:
      * @param[in] sreg : source register
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::CodeGenerator *cg)
+    ARM64Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::CodeGenerator *cg)
         : TR::Instruction(op, node, cg)
         , _source1Register(sreg)
     {
@@ -3907,8 +3897,8 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64Src1Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : TR::Instruction(op, node, precedingInstruction, cg)
         , _source1Register(sreg)
     {
@@ -4009,7 +3999,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t imm,
+    ARM64ZeroSrc1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t imm,
         TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, sreg, cg)
         , _source1Immediate(imm)
@@ -4025,7 +4015,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, bool N, uint32_t imm,
+    ARM64ZeroSrc1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, bool N, uint32_t imm,
         TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, sreg, cg)
         , _source1Immediate(imm)
@@ -4041,7 +4031,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t imm,
+    ARM64ZeroSrc1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, uint32_t imm,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, sreg, precedingInstruction, cg)
         , _source1Immediate(imm)
@@ -4058,7 +4048,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *sreg, bool N, uint32_t imm,
+    ARM64ZeroSrc1ImmInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *sreg, bool N, uint32_t imm,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, sreg, precedingInstruction, cg)
         , _source1Immediate(imm)
@@ -4146,7 +4136,7 @@ public:
      * @param[in] s2reg : source register 2
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, s1reg, cg)
         , _source2Register(s2reg)
@@ -4163,7 +4153,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64Src2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, s1reg, precedingInstruction, cg)
         , _source2Register(s2reg)
@@ -4264,7 +4254,7 @@ public:
      * @param[in] s2reg : source register 2
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64ZeroSrc2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::CodeGenerator *cg)
         : ARM64Src2Instruction(op, node, s1reg, s2reg, cg)
     {}
@@ -4278,7 +4268,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ZeroSrc2Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64ZeroSrc2Instruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64Src2Instruction(op, node, s1reg, s2reg, precedingInstruction, cg)
     {}
@@ -4375,7 +4365,7 @@ public:
      * @param[in] conditionFlags : 4-bit NZCV condition flags
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src1ImmCondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, uint32_t imm,
+    ARM64Src1ImmCondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, uint32_t imm,
         TR::ARM64ConditionCode cc, uint32_t conditionFlags, TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, s1reg, cg)
         , ARM64ConditionalCompareOp(cc, conditionFlags)
@@ -4393,7 +4383,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src1ImmCondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, uint32_t imm,
+    ARM64Src1ImmCondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, uint32_t imm,
         TR::ARM64ConditionCode cc, uint32_t conditionFlags, TR::Instruction *precedingInstruction,
         TR::CodeGenerator *cg)
         : ARM64Src1Instruction(op, node, s1reg, precedingInstruction, cg)
@@ -4451,7 +4441,7 @@ public:
      * @param[in] conditionFlags : 4-bit NZCV condition flags
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src2CondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64Src2CondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::ARM64ConditionCode cc, uint32_t conditionFlags, TR::CodeGenerator *cg)
         : ARM64Src2Instruction(op, node, s1reg, s2reg, cg)
         , ARM64ConditionalCompareOp(cc, conditionFlags)
@@ -4468,7 +4458,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64Src2CondInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    ARM64Src2CondInstruction(OP::Mnemonic op, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
         TR::ARM64ConditionCode cc, uint32_t conditionFlags, TR::Instruction *precedingInstruction,
         TR::CodeGenerator *cg)
         : ARM64Src2Instruction(op, node, s1reg, s2reg, precedingInstruction, cg)
@@ -4497,8 +4487,8 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
-        TR::InstOpCode::AArch64BarrierLimitation lim, TR::CodeGenerator *cg)
+    ARM64SynchronizationInstruction(OP::Mnemonic op, TR::Node *node, OP::AArch64BarrierLimitation lim,
+        TR::CodeGenerator *cg)
         : ARM64ImmInstruction(op, node, static_cast<uint32_t>(lim), cg)
     {}
 
@@ -4510,8 +4500,8 @@ public:
      * @param[in] preced : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
-        TR::InstOpCode::AArch64BarrierLimitation lim, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64SynchronizationInstruction(OP::Mnemonic op, TR::Node *node, OP::AArch64BarrierLimitation lim,
+        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : ARM64ImmInstruction(op, node, static_cast<uint32_t>(lim), precedingInstruction, cg)
     {}
 
@@ -4541,7 +4531,7 @@ public:
      * @param[in] imm : immediate value
      * @param[in] cg : CodeGenerator
      */
-    ARM64ExceptionInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
+    ARM64ExceptionInstruction(OP::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
         : ARM64ImmInstruction(op, node, imm, cg)
     {}
 
@@ -4553,8 +4543,8 @@ public:
      * @param[in] preced : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    ARM64ExceptionInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+    ARM64ExceptionInstruction(OP::Mnemonic op, TR::Node *node, uint32_t imm, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg)
         : ARM64ImmInstruction(op, node, imm, precedingInstruction, cg)
     {}
 
@@ -4583,13 +4573,13 @@ private:
 public:
     ARM64VirtualGuardNOPInstruction(TR::Node *node, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
         TR::LabelSymbol *sym, TR::CodeGenerator *cg)
-        : TR::ARM64LabelInstruction(TR::InstOpCode::vgnop, node, sym, cond, cg)
+        : TR::ARM64LabelInstruction(OP::vgnop, node, sym, cond, cg)
         , _site(site)
     {}
 
     ARM64VirtualGuardNOPInstruction(TR::Node *node, TR_VirtualGuardSite *site, TR::RegisterDependencyConditions *cond,
         TR::LabelSymbol *sym, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-        : TR::ARM64LabelInstruction(TR::InstOpCode::vgnop, node, sym, cond, precedingInstruction, cg)
+        : TR::ARM64LabelInstruction(OP::vgnop, node, sym, cond, precedingInstruction, cg)
         , _site(site)
     {}
 

--- a/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
+++ b/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
@@ -39,8 +39,7 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
     //
     swapInstructionListsWithCompilation();
 
-    TR::Instruction *entryLabelInstruction
-        = generateLabelInstruction(_cg, TR::InstOpCode::label, _callNode, _entryLabel);
+    TR::Instruction *entryLabelInstruction = generateLabelInstruction(_cg, OP::label, _callNode, _entryLabel);
 
     _cg->incOutOfLineColdPathNestedDepth();
     TR_Debug *debugObj = _cg->getDebug();
@@ -56,8 +55,7 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
     }
     _cg->decReferenceCount(_callNode);
 
-    TR::Instruction *returnBranchInstruction
-        = generateLabelInstruction(_cg, TR::InstOpCode::b, _callNode, _restartLabel);
+    TR::Instruction *returnBranchInstruction = generateLabelInstruction(_cg, OP::b, _callNode, _restartLabel);
 
     if (debugObj) {
         debugObj->addInstructionComment(returnBranchInstruction, "Denotes end of OOL: return to mainline");

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -442,7 +442,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
     uint32_t frameSize = (uint32_t)cg->getFrameSizeInBytes();
     if (frameSize > 0) {
         if (constantIsUnsignedImm12(frameSize)) {
-            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
+            cursor = generateTrg1Src1ImmInstruction(cg, OP::subimmx, firstNode, sp, sp, frameSize, cursor);
         } else {
             TR_UNIMPLEMENTED();
         }
@@ -451,7 +451,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
     // save link register (x30)
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = MRef_disp(cg, sp, 0);
-        cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::strimmx, firstNode, stackSlot,
+        cursor = generateMemSrc1Instruction(this->cg(), OP::strimmx, firstNode, stackSlot,
             machine->getRealRegister(TR::RealRegister::x30), cursor);
     }
 
@@ -461,7 +461,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, rr, cursor);
+            cursor = generateMemSrc1Instruction(this->cg(), OP::strimmx, firstNode, stackSlot, rr, cursor);
             offset += 8;
         }
     }
@@ -469,7 +469,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateMemSrc1Instruction(this->cg(), TR::InstOpCode::vstrimmq, firstNode, stackSlot, rr, cursor);
+            cursor = generateMemSrc1Instruction(this->cg(), OP::vstrimmq, firstNode, stackSlot, rr, cursor);
             offset += 16;
         }
     }
@@ -491,7 +491,7 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::ldrimmx, lastNode, rr, stackSlot, cursor);
+            cursor = generateTrg1MemInstruction(this->cg(), OP::ldrimmx, lastNode, rr, stackSlot, cursor);
             offset += 8;
         }
     }
@@ -499,7 +499,7 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::vldrimmq, lastNode, rr, stackSlot, cursor);
+            cursor = generateTrg1MemInstruction(this->cg(), OP::vldrimmq, lastNode, rr, stackSlot, cursor);
             offset += 16;
         }
     }
@@ -508,21 +508,21 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
     TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = MRef_disp(cg, sp, 0);
-        cursor = generateTrg1MemInstruction(this->cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
+        cursor = generateTrg1MemInstruction(this->cg(), OP::ldrimmx, lastNode, lr, stackSlot, cursor);
     }
 
     // remove space for preserved registers
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (frameSize > 0) {
         if (constantIsUnsignedImm12(frameSize)) {
-            cursor = generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
+            cursor = generateTrg1Src1ImmInstruction(cg, OP::addimmx, lastNode, sp, sp, frameSize, cursor);
         } else {
             TR_UNIMPLEMENTED();
         }
     }
 
     // return
-    cursor = generateRegBranchInstruction(cg, TR::InstOpCode::ret, lastNode, lr, cursor);
+    cursor = generateRegBranchInstruction(cg, OP::ret, lastNode, lr, cursor);
 }
 
 int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
@@ -616,7 +616,7 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
 
     for (i = firstArgumentChild; i < callNode->getNumChildren(); i++) {
         TR::Register *argRegister;
-        TR::InstOpCode::Mnemonic op;
+        OP::Mnemonic op;
 
         child = callNode->getChild(i);
         childType = child->getDataType();
@@ -660,13 +660,13 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
                     // numIntegerArgs >= properties.getNumIntArgRegs()
                     int offsetInc;
                     if (childType == TR::Address || childType == TR::Int64) {
-                        op = TR::InstOpCode::strimmx;
+                        op = OP::strimmx;
                         offsetInc = 8;
 #if defined(OSX)
                         argOffset = (argOffset + 7) & ~7; // adjust to 8-byte boundary
 #endif
                     } else {
-                        op = TR::InstOpCode::strimmw;
+                        op = OP::strimmw;
 #if defined(LINUX)
                         offsetInc = 8;
 #elif defined(OSX)
@@ -691,7 +691,7 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
                 if (numFloatArgs < properties.getNumFloatArgRegs()) {
                     if (!cg()->canClobberNodesRegister(child, 0)) {
                         tempReg = cg()->allocateRegister(TR_FPR);
-                        op = (childType == TR::Float) ? TR::InstOpCode::fmovs : TR::InstOpCode::fmovd;
+                        op = (childType == TR::Float) ? OP::fmovs : OP::fmovd;
                         generateTrg1Src1Instruction(cg(), op, callNode, tempReg, argRegister);
                         argRegister = tempReg;
                     }
@@ -712,13 +712,13 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
                     // numFloatArgs >= properties.getNumFloatArgRegs()
                     int offsetInc;
                     if (childType == TR::Double) {
-                        op = TR::InstOpCode::vstrimmd;
+                        op = OP::vstrimmd;
                         offsetInc = 8;
 #if defined(OSX)
                         argOffset = (argOffset + 7) & ~7; // adjust to 8-byte boundary
 #endif
                     } else {
-                        op = TR::InstOpCode::vstrimms;
+                        op = OP::vstrimms;
 #if defined(LINUX)
                         offsetInc = 8;
 #elif defined(OSX)
@@ -774,7 +774,7 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
 
     if (numMemArgs > 0) {
         TR::RealRegister *sp = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
-        generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::subimmx, callNode, argMemReg, sp, totalSize);
+        generateTrg1Src1ImmInstruction(cg(), OP::subimmx, callNode, argMemReg, sp, totalSize);
 
         for (argIndex = 0; argIndex < numMemArgs; argIndex++) {
             TR::Register *aReg = pushToMemory[argIndex].argRegister;
@@ -804,21 +804,21 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {
         if (constantIsUnsignedImm12(totalSize)) {
-            generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::subimmx, callNode, sp, sp, totalSize);
+            generateTrg1Src1ImmInstruction(cg(), OP::subimmx, callNode, sp, sp, totalSize);
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }
     }
 
     TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
-    generateImmSymInstruction(cg(), TR::InstOpCode::bl, callNode, (uintptr_t)callSymbol->getMethodAddress(),
-        dependencies, callSymRef ? callSymRef : callNode->getSymbolReference(), NULL);
+    generateImmSymInstruction(cg(), OP::bl, callNode, (uintptr_t)callSymbol->getMethodAddress(), dependencies,
+        callSymRef ? callSymRef : callNode->getSymbolReference(), NULL);
 
     cg()->machine()->setLinkRegisterKilled(true);
 
     if (totalSize > 0) {
         if (constantIsUnsignedImm12(totalSize)) {
-            generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::addimmx, callNode, sp, sp, totalSize);
+            generateTrg1Src1ImmInstruction(cg(), OP::addimmx, callNode, sp, sp, totalSize);
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -41,8 +41,8 @@
  * @param[in] cg : codegenerator
  * @return target register
  */
-static inline TR::Register *genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp,
-    TR::InstOpCode::Mnemonic regOpImm, bool is64Bit, TR::CodeGenerator *cg)
+static inline TR::Register *genericBinaryEvaluator(TR::Node *node, OP::Mnemonic regOp, OP::Mnemonic regOpImm,
+    bool is64Bit, TR::CodeGenerator *cg)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -83,51 +83,50 @@ static inline TR::Register *genericBinaryEvaluator(TR::Node *node, TR::InstOpCod
         if ((constantIsUnsignedImm12(value) || constantIsUnsignedImm12Shifted(value)) && regOp != regOpImm) {
             generateTrg1Src1ImmInstruction(cg, regOpImm, node, trgReg, src1Reg, value);
         } else if ((constantIsUnsignedImm12(-value) || constantIsUnsignedImm12Shifted(-value))
-            && (regOpImm == TR::InstOpCode::addimmw || regOpImm == TR::InstOpCode::addimmx
-                || regOpImm == TR::InstOpCode::subimmw || regOpImm == TR::InstOpCode::subimmx)) {
-            TR::InstOpCode::Mnemonic negatedOp;
+            && (regOpImm == OP::addimmw || regOpImm == OP::addimmx || regOpImm == OP::subimmw
+                || regOpImm == OP::subimmx)) {
+            OP::Mnemonic negatedOp;
             switch (regOpImm) {
-                case TR::InstOpCode::addimmw:
-                    negatedOp = TR::InstOpCode::subimmw;
+                case OP::addimmw:
+                    negatedOp = OP::subimmw;
                     break;
-                case TR::InstOpCode::addimmx:
-                    negatedOp = TR::InstOpCode::subimmx;
+                case OP::addimmx:
+                    negatedOp = OP::subimmx;
                     break;
-                case TR::InstOpCode::subimmw:
-                    negatedOp = TR::InstOpCode::addimmw;
+                case OP::subimmw:
+                    negatedOp = OP::addimmw;
                     break;
-                case TR::InstOpCode::subimmx:
-                    negatedOp = TR::InstOpCode::addimmx;
+                case OP::subimmx:
+                    negatedOp = OP::addimmx;
                     break;
                 default:
                     TR_ASSERT(false, "Unsupported op");
             }
             generateTrg1Src1ImmInstruction(cg, negatedOp, node, trgReg, src1Reg, -value);
         } else {
-            TR::InstOpCode::Mnemonic negatedOp = TR::InstOpCode::bad;
+            OP::Mnemonic negatedOp = OP::bad;
 
             if ((secondChild->getReferenceCount() == 1)
-                && (regOp == TR::InstOpCode::addw || regOp == TR::InstOpCode::addx || regOp == TR::InstOpCode::subw
-                    || regOp == TR::InstOpCode::subx)
+                && (regOp == OP::addw || regOp == OP::addx || regOp == OP::subw || regOp == OP::subx)
                 && (is64Bit ? shouldLoadNegatedConstant64(value) : shouldLoadNegatedConstant32(value))) {
                 switch (regOp) {
-                    case TR::InstOpCode::addw:
-                        negatedOp = TR::InstOpCode::subw;
+                    case OP::addw:
+                        negatedOp = OP::subw;
                         break;
-                    case TR::InstOpCode::addx:
-                        negatedOp = TR::InstOpCode::subx;
+                    case OP::addx:
+                        negatedOp = OP::subx;
                         break;
-                    case TR::InstOpCode::subw:
-                        negatedOp = TR::InstOpCode::addw;
+                    case OP::subw:
+                        negatedOp = OP::addw;
                         break;
-                    case TR::InstOpCode::subx:
-                        negatedOp = TR::InstOpCode::addx;
+                    case OP::subx:
+                        negatedOp = OP::addx;
                         break;
                     default:
                         TR_ASSERT_FATAL(false, "Unsupported op");
                 }
             }
-            if (negatedOp != TR::InstOpCode::bad) {
+            if (negatedOp != OP::bad) {
                 src2Reg = cg->allocateRegister();
 
                 if (is64Bit) {
@@ -155,8 +154,8 @@ static inline TR::Register *genericBinaryEvaluator(TR::Node *node, TR::InstOpCod
 
 // multiply and add
 // multiply and subtract
-static TR::Register *generateMaddOrMsub(TR::Node *node, TR::Node *mulNode, TR::Node *anotherNode,
-    TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *generateMaddOrMsub(TR::Node *node, TR::Node *mulNode, TR::Node *anotherNode, OP::Mnemonic op,
+    TR::CodeGenerator *cg)
 {
     if ((mulNode->getOpCodeValue() == TR::imul || mulNode->getOpCodeValue() == TR::lmul)
         && mulNode->getReferenceCount() == 1 && mulNode->getRegister() == NULL) {
@@ -291,8 +290,8 @@ static bool isShiftedBinaryOp(TR::Node *node, TR::Node *lhs, TR::Node *rhs, TR::
  * @return register which contains the result of the operation. NULL if the operation cannot be encoded in shifted
  * register instruction.
  */
-static TR::Register *generateShiftedBinaryOperation(TR::Node *node, TR::InstOpCode::Mnemonic op,
-    TR::InstOpCode::Mnemonic notOp, TR::CodeGenerator *cg)
+static TR::Register *generateShiftedBinaryOperation(TR::Node *node, OP::Mnemonic op, OP::Mnemonic notOp,
+    TR::CodeGenerator *cg)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -361,21 +360,21 @@ TR::Register *OMR::ARM64::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeG
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *retReg;
 
-    retReg = generateMaddOrMsub(node, firstChild, secondChild, TR::InstOpCode::maddw, cg); // x*y + z
+    retReg = generateMaddOrMsub(node, firstChild, secondChild, OP::maddw, cg); // x*y + z
     if (retReg) {
         return retReg;
     }
-    retReg = generateMaddOrMsub(node, secondChild, firstChild, TR::InstOpCode::maddw, cg); // x + y*z
-    if (retReg) {
-        return retReg;
-    }
-
-    retReg = generateShiftedBinaryOperation(node, TR::InstOpCode::addw, TR::InstOpCode::addw, cg);
+    retReg = generateMaddOrMsub(node, secondChild, firstChild, OP::maddw, cg); // x + y*z
     if (retReg) {
         return retReg;
     }
 
-    return genericBinaryEvaluator(node, TR::InstOpCode::addw, TR::InstOpCode::addimmw, false, cg);
+    retReg = generateShiftedBinaryOperation(node, OP::addw, OP::addw, cg);
+    if (retReg) {
+        return retReg;
+    }
+
+    return genericBinaryEvaluator(node, OP::addw, OP::addimmw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -384,21 +383,21 @@ TR::Register *OMR::ARM64::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *retReg;
 
-    retReg = generateMaddOrMsub(node, firstChild, secondChild, TR::InstOpCode::maddx, cg); // x*y + z
+    retReg = generateMaddOrMsub(node, firstChild, secondChild, OP::maddx, cg); // x*y + z
     if (retReg) {
         return retReg;
     }
-    retReg = generateMaddOrMsub(node, secondChild, firstChild, TR::InstOpCode::maddx, cg); // x + y*z
-    if (retReg) {
-        return retReg;
-    }
-
-    retReg = generateShiftedBinaryOperation(node, TR::InstOpCode::addx, TR::InstOpCode::addx, cg);
+    retReg = generateMaddOrMsub(node, secondChild, firstChild, OP::maddx, cg); // x + y*z
     if (retReg) {
         return retReg;
     }
 
-    return genericBinaryEvaluator(node, TR::InstOpCode::addx, TR::InstOpCode::addimmx, true, cg);
+    retReg = generateShiftedBinaryOperation(node, OP::addx, OP::addx, cg);
+    if (retReg) {
+        return retReg;
+    }
+
+    return genericBinaryEvaluator(node, OP::addx, OP::addimmx, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -407,17 +406,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeG
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *retReg;
 
-    retReg = generateMaddOrMsub(node, secondChild, firstChild, TR::InstOpCode::msubw, cg); // x - y*z
+    retReg = generateMaddOrMsub(node, secondChild, firstChild, OP::msubw, cg); // x - y*z
     if (retReg) {
         return retReg;
     }
 
-    retReg = generateShiftedBinaryOperation(node, TR::InstOpCode::subw, TR::InstOpCode::subw, cg);
+    retReg = generateShiftedBinaryOperation(node, OP::subw, OP::subw, cg);
     if (retReg) {
         return retReg;
     }
 
-    return genericBinaryEvaluator(node, TR::InstOpCode::subw, TR::InstOpCode::subimmw, false, cg);
+    return genericBinaryEvaluator(node, OP::subw, OP::subimmw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -426,21 +425,21 @@ TR::Register *OMR::ARM64::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeG
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *retReg;
 
-    retReg = generateMaddOrMsub(node, secondChild, firstChild, TR::InstOpCode::msubx, cg); // x - y*z
+    retReg = generateMaddOrMsub(node, secondChild, firstChild, OP::msubx, cg); // x - y*z
     if (retReg) {
         return retReg;
     }
 
-    retReg = generateShiftedBinaryOperation(node, TR::InstOpCode::subx, TR::InstOpCode::subx, cg);
+    retReg = generateShiftedBinaryOperation(node, OP::subx, OP::subx, cg);
     if (retReg) {
         return retReg;
     }
 
-    return genericBinaryEvaluator(node, TR::InstOpCode::subx, TR::InstOpCode::subimmx, true, cg);
+    return genericBinaryEvaluator(node, OP::subx, OP::subimmx, true, cg);
 }
 
-TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, binaryEvaluatorHelper evaluatorHelper)
+TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
+    binaryEvaluatorHelper evaluatorHelper)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -455,8 +454,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
 
     node->setRegister(resReg);
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, lhsReg, rhsReg, cg);
     } else {
@@ -473,25 +472,25 @@ TR::Register *OMR::ARM64::TreeEvaluator::vaddEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic addOp;
+    OP::Mnemonic addOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            addOp = TR::InstOpCode::vadd16b;
+            addOp = OP::vadd16b;
             break;
         case TR::Int16:
-            addOp = TR::InstOpCode::vadd8h;
+            addOp = OP::vadd8h;
             break;
         case TR::Int32:
-            addOp = TR::InstOpCode::vadd4s;
+            addOp = OP::vadd4s;
             break;
         case TR::Int64:
-            addOp = TR::InstOpCode::vadd2d;
+            addOp = OP::vadd2d;
             break;
         case TR::Float:
-            addOp = TR::InstOpCode::vfadd4s;
+            addOp = OP::vfadd4s;
             break;
         case TR::Double:
-            addOp = TR::InstOpCode::vfadd2d;
+            addOp = OP::vfadd2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -505,25 +504,25 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsubEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic subOp;
+    OP::Mnemonic subOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            subOp = TR::InstOpCode::vsub16b;
+            subOp = OP::vsub16b;
             break;
         case TR::Int16:
-            subOp = TR::InstOpCode::vsub8h;
+            subOp = OP::vsub8h;
             break;
         case TR::Int32:
-            subOp = TR::InstOpCode::vsub4s;
+            subOp = OP::vsub4s;
             break;
         case TR::Int64:
-            subOp = TR::InstOpCode::vsub2d;
+            subOp = OP::vsub2d;
             break;
         case TR::Float:
-            subOp = TR::InstOpCode::vfsub4s;
+            subOp = OP::vfsub4s;
             break;
         case TR::Double:
-            subOp = TR::InstOpCode::vfsub2d;
+            subOp = OP::vfsub2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -554,23 +553,23 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmulInt64Helper(TR::Node *node, TR::Reg
     TR::Register *tmp2Reg = cg->allocateRegister(TR_VRF);
 
     /* Reverse 32bit words in 64bit elements */
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vrev64_4s, node, tmp1Reg, lhsReg);
+    generateTrg1Src1Instruction(cg, OP::vrev64_4s, node, tmp1Reg, lhsReg);
 
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vmul4s, node, tmp2Reg, tmp1Reg, rhsReg);
+    generateTrg1Src2Instruction(cg, OP::vmul4s, node, tmp2Reg, tmp1Reg, rhsReg);
     /*
      * At this moment, upper 32bit of each 64-bit element of tmp2Reg is A*D, lower 32bit is B*C.
      * Get A*D + B*C into the lower 32bit.
      */
-    generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr2d, node, tmp1Reg, tmp2Reg, 32);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vadd4s, node, tmp2Reg, tmp1Reg, tmp2Reg);
+    generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, tmp1Reg, tmp2Reg, 32);
+    generateTrg1Src2Instruction(cg, OP::vadd4s, node, tmp2Reg, tmp1Reg, tmp2Reg);
     /* Shift left by 32bit to have the result in the upper 32bit part. */
-    generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshl2d, node, productReg, tmp2Reg, 32);
+    generateVectorShiftImmediateInstruction(cg, OP::vshl2d, node, productReg, tmp2Reg, 32);
 
     /* Move the lower 32-bit of the second element to the upper 32-bit of the first element. */
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vuzp1_4s, node, tmp1Reg, lhsReg, lhsReg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vuzp1_4s, node, tmp2Reg, rhsReg, rhsReg);
+    generateTrg1Src2Instruction(cg, OP::vuzp1_4s, node, tmp1Reg, lhsReg, lhsReg);
+    generateTrg1Src2Instruction(cg, OP::vuzp1_4s, node, tmp2Reg, rhsReg, rhsReg);
     /* Finally, get the result by UMLAL. */
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vumlal_2d, node, productReg, tmp1Reg, tmp2Reg);
+    generateTrg1Src2Instruction(cg, OP::vumlal_2d, node, productReg, tmp1Reg, tmp2Reg);
 
     cg->stopUsingRegister(tmp1Reg);
     cg->stopUsingRegister(tmp2Reg);
@@ -583,26 +582,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmulEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic mulOp = TR::InstOpCode::bad;
+    OP::Mnemonic mulOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            mulOp = TR::InstOpCode::vmul16b;
+            mulOp = OP::vmul16b;
             break;
         case TR::Int16:
-            mulOp = TR::InstOpCode::vmul8h;
+            mulOp = OP::vmul8h;
             break;
         case TR::Int32:
-            mulOp = TR::InstOpCode::vmul4s;
+            mulOp = OP::vmul4s;
             break;
         case TR::Int64:
             evaluatorHelper = vmulInt64Helper;
             break;
         case TR::Float:
-            mulOp = TR::InstOpCode::vfmul4s;
+            mulOp = OP::vfmul4s;
             break;
         case TR::Double:
-            mulOp = TR::InstOpCode::vfmul2d;
+            mulOp = OP::vfmul2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -615,16 +614,16 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
     TR::Register *rhsReg, TR::CodeGenerator *cg)
 {
     struct DivOps {
-        TR::InstOpCode::Mnemonic vectorToGPROp;
-        TR::InstOpCode::Mnemonic divOp;
-        TR::InstOpCode::Mnemonic gprToVectorOp;
+        OP::Mnemonic vectorToGPROp;
+        OP::Mnemonic divOp;
+        OP::Mnemonic gprToVectorOp;
         uint32_t numElements;
     };
     static const struct DivOps ops[4] = {
-        { TR::InstOpCode::smovwb, TR::InstOpCode::sdivw, TR::InstOpCode::vinswb, 16 },
-        { TR::InstOpCode::smovwh, TR::InstOpCode::sdivw, TR::InstOpCode::vinswh,  8 },
-        { TR::InstOpCode::umovws, TR::InstOpCode::sdivw, TR::InstOpCode::vinsws,  4 },
-        { TR::InstOpCode::umovxd, TR::InstOpCode::sdivx, TR::InstOpCode::vinsxd,  2 }
+        { OP::smovwb, OP::sdivw, OP::vinswb, 16 },
+        { OP::smovwh, OP::sdivw, OP::vinswh,  8 },
+        { OP::umovws, OP::sdivw, OP::vinsws,  4 },
+        { OP::umovxd, OP::sdivx, OP::vinsxd,  2 }
     };
     TR::DataType eType = node->getDataType().getVectorElementType();
     const uint32_t index = (eType == TR::Int8) ? 0 : ((eType == TR::Int16) ? 1 : ((eType == TR::Int32) ? 2 : 3));
@@ -697,11 +696,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
         TR::Register *counterReg = srm->findOrCreateScratchRegister(TR_GPR);
         TR::Register *tmp1VectorReg = srm->findOrCreateScratchRegister(TR_VRF);
         TR::Register *tmp2VectorReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, tmp1VectorReg, lhsReg, lhsReg);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, tmp2VectorReg, rhsReg, rhsReg);
+        generateTrg1Src2Instruction(cg, OP::vorr16b, node, tmp1VectorReg, lhsReg, lhsReg);
+        generateTrg1Src2Instruction(cg, OP::vorr16b, node, tmp2VectorReg, rhsReg, rhsReg);
         loadConstant32(cg, node, loopCount, counterReg);
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
-        generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr4s, node, resultReg, resultReg,
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, resultReg, resultReg,
             (eType == TR::Int8) ? 8 : 16);
         for (int32_t i = 0; i < numElementsPerLoop; i++) {
             generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp1Reg, tmp1VectorReg, i * loopCount);
@@ -710,11 +709,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
             generateMovGPRToVectorElementInstruction(cg, op.gprToVectorOp, node, resultReg, tmp1Reg,
                 (i + 1) * loopCount - 1);
         }
-        generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr4s, node, tmp1VectorReg, tmp1VectorReg,
+        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, tmp1VectorReg, tmp1VectorReg,
             (eType == TR::Int8) ? 8 : 16);
-        generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr4s, node, tmp2VectorReg, tmp2VectorReg,
+        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, tmp2VectorReg, tmp2VectorReg,
             (eType == TR::Int8) ? 8 : 16);
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmw, node, counterReg, counterReg, 1);
+        generateTrg1Src1ImmInstruction(cg, OP::subimmw, node, counterReg, counterReg, 1);
 
         auto *cond = RegDeps(0, 3 + srm->numAvailableRegisters(), cg);
         cond->addPostCondition(lhsReg, TR::RealRegister::NoReg);
@@ -722,7 +721,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
         cond->addPostCondition(resultReg, TR::RealRegister::NoReg);
         srm->addScratchRegistersToDependencyList(cond);
 
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzw, node, counterReg, loopLabel, cond);
+        generateCompareBranchInstruction(cg, OP::cbnzw, node, counterReg, loopLabel, cond);
     } else {
         for (int32_t i = 0; i < numElementsPerLoop; i++) {
             generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp1Reg, lhsReg, i);
@@ -742,7 +741,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic divOp = TR::InstOpCode::bad;
+    OP::Mnemonic divOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
@@ -752,10 +751,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivEvaluator(TR::Node *node, TR::CodeG
             evaluatorHelper = vdivIntHelper;
             break;
         case TR::Float:
-            divOp = TR::InstOpCode::vfdiv4s;
+            divOp = OP::vfdiv4s;
             break;
         case TR::Double:
-            divOp = TR::InstOpCode::vfdiv2d;
+            divOp = OP::vfdiv2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -769,13 +768,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vandEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic andOp;
+    OP::Mnemonic andOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            andOp = TR::InstOpCode::vand16b;
+            andOp = OP::vand16b;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -789,13 +788,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vorEvaluator(TR::Node *node, TR::CodeGe
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic orrOp;
+    OP::Mnemonic orrOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            orrOp = TR::InstOpCode::vorr16b;
+            orrOp = OP::vorr16b;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -809,13 +808,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vxorEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic xorOp;
+    OP::Mnemonic xorOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            xorOp = TR::InstOpCode::veor16b;
+            xorOp = OP::veor16b;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -857,9 +856,8 @@ static TR::Register *vminmaxInt64Helper(TR::Node *node, bool isMax, TR::Register
     TR_ASSERT_FATAL_WITH_NODE(node, lhsReg->getKind() == TR_VRF, "unexpected Register kind");
     TR_ASSERT_FATAL_WITH_NODE(node, rhsReg->getKind() == TR_VRF, "unexpected Register kind");
 
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmge2d, node, resReg, lhsReg, rhsReg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vbsl16b, node, resReg, (isMax ? lhsReg : rhsReg),
-        (isMax ? rhsReg : lhsReg));
+    generateTrg1Src2Instruction(cg, OP::vcmge2d, node, resReg, lhsReg, rhsReg);
+    generateTrg1Src2Instruction(cg, OP::vbsl16b, node, resReg, (isMax ? lhsReg : rhsReg), (isMax ? rhsReg : lhsReg));
 
     return resReg;
 }
@@ -881,17 +879,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::vminEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic minOp = TR::InstOpCode::bad;
+    OP::Mnemonic minOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            minOp = TR::InstOpCode::vsmin16b;
+            minOp = OP::vsmin16b;
             break;
         case TR::Int16:
-            minOp = TR::InstOpCode::vsmin8h;
+            minOp = OP::vsmin8h;
             break;
         case TR::Int32:
-            minOp = TR::InstOpCode::vsmin4s;
+            minOp = OP::vsmin4s;
             break;
         case TR::Int64:
             evaluatorHelper = vminInt64Helper;
@@ -902,10 +900,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::vminEvaluator(TR::Node *node, TR::CodeG
          * If comparing +0 and -0, the result is -0 for min, +0 for max.
          */
         case TR::Float:
-            minOp = TR::InstOpCode::vfmin4s;
+            minOp = OP::vfmin4s;
             break;
         case TR::Double:
-            minOp = TR::InstOpCode::vfmin2d;
+            minOp = OP::vfmin2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -919,17 +917,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmaxEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic maxOp = TR::InstOpCode::bad;
+    OP::Mnemonic maxOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            maxOp = TR::InstOpCode::vsmax16b;
+            maxOp = OP::vsmax16b;
             break;
         case TR::Int16:
-            maxOp = TR::InstOpCode::vsmax8h;
+            maxOp = OP::vsmax8h;
             break;
         case TR::Int32:
-            maxOp = TR::InstOpCode::vsmax4s;
+            maxOp = OP::vsmax4s;
             break;
         case TR::Int64:
             evaluatorHelper = vmaxInt64Helper;
@@ -940,10 +938,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmaxEvaluator(TR::Node *node, TR::CodeG
          * If comparing +0 and -0, the result is -0 for min, +0 for max.
          */
         case TR::Float:
-            maxOp = TR::InstOpCode::vfmax4s;
+            maxOp = OP::vfmax4s;
             break;
         case TR::Double:
-            maxOp = TR::InstOpCode::vfmax2d;
+            maxOp = OP::vfmax2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -1047,7 +1045,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
         src2Reg = cg->evaluate(secondChild);
     }
 
-    generateTrg1Src3Instruction(cg, TR::InstOpCode::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg, cond);
+    generateTrg1Src3Instruction(cg, OP::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg, cond);
     cg->stopUsingRegister(zeroReg);
     /* logical shift right by 32 bits */
     generateLogicalShiftRightImmInstruction(cg, node, trgReg, trgReg, 32, true);
@@ -1110,8 +1108,7 @@ static TR::Register *idivHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
 
-    generateTrg1Src2Instruction(cg, is64bit ? TR::InstOpCode::sdivx : TR::InstOpCode::sdivw, node, trgReg, src1Reg,
-        src2Reg);
+    generateTrg1Src2Instruction(cg, is64bit ? OP::sdivx : OP::sdivw, node, trgReg, src1Reg, src2Reg);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -1130,11 +1127,9 @@ static TR::Register *iremHelper(TR::Node *node, bool is64bit, bool isUnsigned, T
     TR::Register *tmpReg = cg->allocateRegister();
     TR::Register *trgReg = cg->allocateRegister();
 
-    TR::InstOpCode::Mnemonic op = is64bit ? (isUnsigned ? TR::InstOpCode::udivx : TR::InstOpCode::sdivx)
-                                          : (isUnsigned ? TR::InstOpCode::udivw : TR::InstOpCode::sdivw);
+    OP::Mnemonic op = is64bit ? (isUnsigned ? OP::udivx : OP::sdivx) : (isUnsigned ? OP::udivw : OP::sdivw);
     generateTrg1Src2Instruction(cg, op, node, tmpReg, src1Reg, src2Reg);
-    generateTrg1Src3Instruction(cg, is64bit ? TR::InstOpCode::msubx : TR::InstOpCode::msubw, node, trgReg, tmpReg,
-        src2Reg, src1Reg);
+    generateTrg1Src3Instruction(cg, is64bit ? OP::msubx : OP::msubw, node, trgReg, tmpReg, src2Reg, src1Reg);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -1162,7 +1157,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
         src2Reg = cg->evaluate(secondChild);
     }
 
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::smulh, node, trgReg, src1Reg, src2Reg);
+    generateTrg1Src2Instruction(cg, OP::smulh, node, trgReg, src1Reg, src2Reg);
 
     if (tmpReg) {
         cg->stopUsingRegister(tmpReg);
@@ -1184,10 +1179,10 @@ static TR::Register *subInt32DivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
     TR::Register *trgReg = cg->allocateRegister();
     const uint32_t operandBits = TR::DataType::getSize(node->getDataType()) * 8;
 
-    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, src1Reg, operandBits - 1); // sxtb or sxth
-    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, tmpReg, src2Reg, operandBits - 1); // sxtb or sxth
+    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, src1Reg, operandBits - 1); // sxtb or sxth
+    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, tmpReg, src2Reg, operandBits - 1); // sxtb or sxth
 
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::sdivw, node, trgReg, trgReg, tmpReg);
+    generateTrg1Src2Instruction(cg, OP::sdivw, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -1208,7 +1203,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::sdivEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::ARM64::TreeEvaluator::idivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return genericBinaryEvaluator(node, TR::InstOpCode::sdivw, TR::InstOpCode::sdivw, false, cg);
+    return genericBinaryEvaluator(node, OP::sdivw, OP::sdivw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::iremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1218,7 +1213,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::iremEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::ARM64::TreeEvaluator::iudivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return genericBinaryEvaluator(node, TR::InstOpCode::udivw, TR::InstOpCode::udivw, false, cg);
+    return genericBinaryEvaluator(node, OP::udivw, OP::udivw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::iuremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1228,7 +1223,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::iuremEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::ldivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return genericBinaryEvaluator(node, TR::InstOpCode::sdivx, TR::InstOpCode::sdivx, true, cg);
+    return genericBinaryEvaluator(node, OP::sdivx, OP::sdivx, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1238,7 +1233,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::ARM64::TreeEvaluator::ludivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return genericBinaryEvaluator(node, TR::InstOpCode::udivx, TR::InstOpCode::udivx, true, cg);
+    return genericBinaryEvaluator(node, OP::udivx, OP::udivx, true, cg);
 }
 
 /**
@@ -1292,7 +1287,7 @@ static TR::Register *generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGe
              * The result is always 0 in this case.
              */
             TR::Register *reg = cg->allocateRegister();
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, shiftNode, reg, 0);
+            generateTrg1ImmInstruction(cg, OP::movzx, shiftNode, reg, 0);
             shiftNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(andNode);
             cg->decReferenceCount(shiftValueNode);
@@ -1351,14 +1346,14 @@ static TR::Register *generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGe
                 TR::Register *shiftSrcReg = sreg;
                 if (shiftNode->getOpCode().isShiftLogical()) {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmw, andNode, reg, sreg,
+                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, andNode, reg, sreg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = reg;
                     }
                     generateLogicalShiftRightImmInstruction(cg, shiftNode, reg, shiftSrcReg, shiftValue, is64bit);
                 } else {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, andNode, reg, sreg,
+                        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, andNode, reg, sreg,
                             operandBits - 1); // sxth or sxtb
                         shiftSrcReg = reg;
                     }
@@ -1387,7 +1382,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
     bool is64bit = node->getDataType().isInt64();
     const uint32_t operandBits = TR::DataType::getSize(node->getDataType()) * 8;
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     if (secondOp == TR::iconst) {
         int32_t value = secondChild->getInt();
@@ -1409,7 +1404,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
                     break;
                 case TR::SH_LSR:
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmw, node, trgReg, srcReg,
+                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, node, trgReg, srcReg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = trgReg;
                     }
@@ -1417,7 +1412,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
                     break;
                 case TR::SH_ASR:
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg,
+                        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg,
                             operandBits - 1); // sxth or sxtb
                         shiftSrcReg = trgReg;
                     }
@@ -1434,20 +1429,20 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
 
         switch (shiftType) {
             case TR::SH_LSL:
-                op = is64bit ? TR::InstOpCode::lslvx : TR::InstOpCode::lslvw;
+                op = is64bit ? OP::lslvx : OP::lslvw;
                 break;
             case TR::SH_LSR:
-                op = is64bit ? TR::InstOpCode::lsrvx : TR::InstOpCode::lsrvw;
+                op = is64bit ? OP::lsrvx : OP::lsrvw;
                 if (operandBits < 32) {
-                    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmw, node, trgReg, srcReg,
+                    generateTrg1Src1ImmInstruction(cg, OP::ubfmw, node, trgReg, srcReg,
                         operandBits - 1); // uxth or uxtb
                     shiftSrcReg = trgReg;
                 }
                 break;
             case TR::SH_ASR:
-                op = is64bit ? TR::InstOpCode::asrvx : TR::InstOpCode::asrvw;
+                op = is64bit ? OP::asrvx : OP::asrvw;
                 if (operandBits < 32) {
-                    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg,
+                    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg,
                         operandBits - 1); // sxth or sxtb
                     shiftSrcReg = trgReg;
                 }
@@ -1479,7 +1474,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeG
             TR::Register *trgReg = (indexChild->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
             int32_t bitsToShift = secondChild->getInt();
             int32_t imm = ((64 - bitsToShift) << 6) | 31; // immr = 64 - bitsToShift, imms = 31
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, node, trgReg, srcReg, imm);
+            generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, trgReg, srcReg, imm);
             node->setRegister(trgReg);
             cg->recursivelyDecReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
@@ -1520,7 +1515,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *trgReg = cg->gprClobberEvaluate(firstChild);
     bool is64bit = node->getDataType().isInt64();
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     if (secondChild->getOpCode().isLoadConst()) {
         int32_t value = secondChild->getInt();
@@ -1528,7 +1523,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
 
         if (shift != 0) {
             shift = is64bit ? (64 - shift) : (32 - shift); // change ROL to ROR
-            op = is64bit ? TR::InstOpCode::extrx : TR::InstOpCode::extrw; // ROR is an alias of EXTR
+            op = is64bit ? OP::extrx : OP::extrw; // ROR is an alias of EXTR
             generateTrg1Src2ShiftedInstruction(cg, op, node, trgReg, trgReg, trgReg, TR::SH_LSL, shift);
         }
     } else {
@@ -1548,7 +1543,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
             if (is64bit) {
                 // 32->64 bit sign extension: SXTW is alias of SBFM
                 uint32_t imm = 0x1F; // immr=0, imms=31, N bit is pre-encoded in `sbfmx` opcode.
-                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, node, shiftAmountReg, shiftAmountSrcReg, imm);
+                generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountSrcReg, imm);
             }
             cg->decReferenceCount(shiftAmountNode);
         } else {
@@ -1561,10 +1556,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
             if (is64bit) {
                 // 32->64 bit sign extension: SXTW is alias of SBFM
                 uint32_t imm = 0x1F; // immr=0, imms=31, N bit is pre-encoded in `sbfmx` opcode.
-                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, node, shiftAmountReg, shiftAmountReg, imm);
+                generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountReg, imm);
             }
         }
-        op = is64bit ? TR::InstOpCode::rorvx : TR::InstOpCode::rorvw;
+        op = is64bit ? OP::rorvx : OP::rorvw;
         generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, shiftAmountReg);
 
         if (useTempReg) {
@@ -1747,8 +1742,8 @@ bool logicImmediateHelper(uint64_t value, bool is64Bit, bool &n, uint32_t &immEn
  * @param[in] cg : codegenerator
  * @return target register
  */
-static inline TR::Register *logicBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp,
-    TR::InstOpCode::Mnemonic regOpImm, TR::InstOpCode::Mnemonic regNotOp, bool is64Bit, TR::CodeGenerator *cg)
+static inline TR::Register *logicBinaryEvaluator(TR::Node *node, OP::Mnemonic regOp, OP::Mnemonic regOpImm,
+    OP::Mnemonic regNotOp, bool is64Bit, TR::CodeGenerator *cg)
 {
     TR::Register *trgReg = generateShiftedBinaryOperation(node, regOp, regNotOp, cg);
     if (trgReg != NULL) {
@@ -1844,7 +1839,7 @@ static TR::Register *generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGene
                  * The result is always 0 in this case.
                  */
                 TR::Register *reg = cg->allocateRegister();
-                generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, andNode, reg, 0);
+                generateTrg1ImmInstruction(cg, OP::movzx, andNode, reg, 0);
                 andNode->setRegister(reg);
                 cg->recursivelyDecReferenceCount(shiftNode);
                 cg->decReferenceCount(maskNode);
@@ -1906,7 +1901,7 @@ static TR::Register *generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGene
                 }
                 if (isLogicalShiftRight) {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmw, andNode, reg, sreg,
+                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, andNode, reg, sreg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = reg;
                     }
@@ -1931,7 +1926,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::iandEvaluator(TR::Node *node, TR::CodeG
         return reg;
     }
     // boolean and of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::andw, TR::InstOpCode::andimmw, TR::InstOpCode::bicw, false, cg);
+    return logicBinaryEvaluator(node, OP::andw, OP::andimmw, OP::bicw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -1941,31 +1936,31 @@ TR::Register *OMR::ARM64::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeG
         return reg;
     }
     // boolean and of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::andx, TR::InstOpCode::andimmx, TR::InstOpCode::bicx, true, cg);
+    return logicBinaryEvaluator(node, OP::andx, OP::andimmx, OP::bicx, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::iorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     // boolean or of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::orrw, TR::InstOpCode::orrimmw, TR::InstOpCode::ornw, false, cg);
+    return logicBinaryEvaluator(node, OP::orrw, OP::orrimmw, OP::ornw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     // boolean or of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::orrx, TR::InstOpCode::orrimmx, TR::InstOpCode::ornx, true, cg);
+    return logicBinaryEvaluator(node, OP::orrx, OP::orrimmx, OP::ornx, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::ixorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     // boolean xor of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::eorw, TR::InstOpCode::eorimmw, TR::InstOpCode::eonw, false, cg);
+    return logicBinaryEvaluator(node, OP::eorw, OP::eorimmw, OP::eonw, false, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     // boolean xor of 2 integers
-    return logicBinaryEvaluator(node, TR::InstOpCode::eorx, TR::InstOpCode::eorimmx, TR::InstOpCode::eonx, true, cg);
+    return logicBinaryEvaluator(node, OP::eorx, OP::eorimmx, OP::eonx, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::aladdEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -44,7 +44,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
 
     auto *deps = RegDeps(1, 0, cg);
     deps->addPreCondition(returnRegister, rnum);
-    generateAdminInstruction(cg, TR::InstOpCode::retn, node, deps);
+    generateAdminInstruction(cg, OP::retn, node, deps);
 
     cg->comp()->setReturnInfo(i);
     cg->decReferenceCount(firstChild);
@@ -70,7 +70,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::Co
 // void return
 TR::Register *OMR::ARM64::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateAdminInstruction(cg, TR::InstOpCode::retn, node);
+    generateAdminInstruction(cg, OP::retn, node);
     cg->comp()->setReturnInfo(TR_VoidReturn);
     return NULL;
 }
@@ -81,10 +81,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeG
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        generateLabelInstruction(cg, TR::InstOpCode::b, node, gotoLabel, RegDeps(cg, child, 0));
+        generateLabelInstruction(cg, OP::b, node, gotoLabel, RegDeps(cg, child, 0));
         cg->decReferenceCount(child);
     } else {
-        generateLabelInstruction(cg, TR::InstOpCode::b, node, gotoLabel);
+        generateLabelInstruction(cg, OP::b, node, gotoLabel);
     }
     return NULL;
 }
@@ -191,11 +191,11 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
             && ((node->getNumChildren() != 3)
                 || (countIntegerAndAddressTypesInGlRegDeps(node->getChild(2), cg)
                     < cg->getLinkage()->getProperties().getNumAllocatableIntegerRegisters()))) {
-            TR::InstOpCode::Mnemonic op;
+            OP::Mnemonic op;
             if (cc == TR::CC_EQ)
-                op = is64bit ? TR::InstOpCode::cbzx : TR::InstOpCode::cbzw;
+                op = is64bit ? OP::cbzx : OP::cbzw;
             else
-                op = is64bit ? TR::InstOpCode::cbnzx : TR::InstOpCode::cbnzw;
+                op = is64bit ? OP::cbnzx : OP::cbnzw;
 
             dstLabel = node->getBranchDestination()->getNode()->getLabel();
             if (node->getNumChildren() == 3) {
@@ -548,7 +548,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
     generateCompareInstruction(cg, node, src1Reg, src2Reg, true);
     generateCSetInstruction(cg, node, trgReg, TR::CC_GE);
     generateCSetInstruction(cg, node, tmpReg, TR::CC_LE);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::subw, node, trgReg, trgReg, tmpReg);
+    generateTrg1Src2Instruction(cg, OP::subw, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -590,12 +590,12 @@ static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNod
                 lookupNode->getChild(lowChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
 
             // default case
-            generateLabelInstruction(cg, TR::InstOpCode::b, lookupNode,
+            generateLabelInstruction(cg, OP::b, lookupNode,
                 lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
         } else {
             binarySearchCaseSpace(selectorReg, lookupNode, lowChild, pivot, tmpRegister, conditions, cg);
         }
-        generateLabelInstruction(cg, TR::InstOpCode::label, lookupNode, upperLabel);
+        generateLabelInstruction(cg, OP::label, lookupNode, upperLabel);
     }
 
     // upper half
@@ -611,7 +611,7 @@ static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNod
             lookupNode->getChild(highChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
 
         // default case
-        generateLabelInstruction(cg, TR::InstOpCode::b, lookupNode,
+        generateLabelInstruction(cg, OP::b, lookupNode,
             lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
     } else {
         binarySearchCaseSpace(selectorReg, lookupNode, pivot + 1, highChild, tmpRegister, conditions, cg);
@@ -670,8 +670,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
             cg->evaluate(defaultChild->getFirstChild());
             conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
         }
-        generateLabelInstruction(cg, TR::InstOpCode::b, node,
-            defaultChild->getBranchDestination()->getNode()->getLabel(), conditions);
+        generateLabelInstruction(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
+            conditions);
     }
 
     if (tmpRegister) {
@@ -713,8 +713,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
                 node->getChild(2 + i)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ);
         }
 
-        generateLabelInstruction(cg, TR::InstOpCode::b, node,
-            defaultChild->getBranchDestination()->getNode()->getLabel(), conditions);
+        generateLabelInstruction(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
+            conditions);
     } else {
         if (!constantIsUnsignedImm12(numBranchTableEntries)) {
             loadConstant32(cg, node, numBranchTableEntries, tmpRegister);
@@ -725,18 +725,16 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
 
         generateConditionalBranchInstruction(cg, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
             TR::CC_CS);
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::adr, node, tmpRegister,
+        generateTrg1ImmInstruction(cg, OP::adr, node, tmpRegister,
             12); // distance between this instruction to the jump table
-        generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, tmpRegister, tmpRegister, selectorReg,
-            TR::SH_LSL, 2);
-        generateRegBranchInstruction(cg, TR::InstOpCode::br, node, tmpRegister);
+        generateTrg1Src2ShiftedInstruction(cg, OP::addx, node, tmpRegister, tmpRegister, selectorReg, TR::SH_LSL, 2);
+        generateRegBranchInstruction(cg, OP::br, node, tmpRegister);
 
         for (i = 2; i < node->getNumChildren() - 1; i++) {
-            generateLabelInstruction(cg, TR::InstOpCode::b, node,
-                node->getChild(i)->getBranchDestination()->getNode()->getLabel());
+            generateLabelInstruction(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel());
         }
-        generateLabelInstruction(cg, TR::InstOpCode::b, node,
-            node->getChild(i)->getBranchDestination()->getNode()->getLabel(), conditions);
+        generateLabelInstruction(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel(),
+            conditions);
     }
 
     if (NULL != tmpRegister)
@@ -768,7 +766,7 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, bool is64bit, TR::ARM
     // Optimize the code by using generateCompareImmInstruction() when possible
     generateCompareInstruction(cg, node, src1Reg, src2Reg, is64bit);
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::cselx : TR::InstOpCode::cselw;
+    OP::Mnemonic op = is64bit ? OP::cselx : OP::cselw;
     generateCondTrg1Src2Instruction(cg, op, node, trgReg, src1Reg, src2Reg, cc);
 
     node->setRegister(trgReg);
@@ -911,14 +909,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::Co
         bool is64bit = (TR::DataType::getSize(cmp1Node->getDataType()) == 8);
 
         generateCompareInstruction(cg, node, cmp1Reg, cmp2Reg, is64bit);
-        generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, resultReg, trueReg, falseReg, cc);
+        generateCondTrg1Src2Instruction(cg, OP::cselx, node, resultReg, trueReg, falseReg, cc);
 
         cg->recursivelyDecReferenceCount(condNode);
     } else {
         TR::Register *condReg = cg->evaluate(condNode);
 
         generateCompareImmInstruction(cg, node, condReg, 0, true); // 64-bit compare
-        generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, resultReg, trueReg, falseReg, TR::CC_NE);
+        generateCondTrg1Src2Instruction(cg, OP::cselx, node, resultReg, trueReg, falseReg, TR::CC_NE);
 
         cg->decReferenceCount(condNode);
     }
@@ -1009,9 +1007,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::igotoEvaluator(TR::Node *node, TR::Code
         cg->decReferenceCount(glregdep);
     }
     if (deps)
-        generateRegBranchInstruction(cg, TR::InstOpCode::br, node, addrReg, deps);
+        generateRegBranchInstruction(cg, OP::br, node, addrReg, deps);
     else
-        generateRegBranchInstruction(cg, TR::InstOpCode::br, node, addrReg);
+        generateRegBranchInstruction(cg, OP::br, node, addrReg);
     cg->decReferenceCount(labelAddr);
     node->setRegister(NULL);
     return NULL;

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -29,7 +29,7 @@
 #include "il/Node_inlines.hpp"
 #include <math.h>
 
-static void fpBitsMovHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::Register *trgReg, TR::CodeGenerator *cg)
+static void fpBitsMovHelper(TR::Node *node, OP::Mnemonic op, TR::Register *trgReg, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
@@ -43,7 +43,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Co
 {
     TR::Register *trgReg = cg->allocateSinglePrecisionRegister();
 
-    fpBitsMovHelper(node, TR::InstOpCode::fmov_wtos, trgReg, cg);
+    fpBitsMovHelper(node, OP::fmov_wtos, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -53,7 +53,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
 {
     TR::Register *trgReg = cg->allocateRegister(TR_FPR);
 
-    fpBitsMovHelper(node, TR::InstOpCode::fmov_xtod, trgReg, cg);
+    fpBitsMovHelper(node, OP::fmov_xtod, trgReg, cg);
 
     node->setRegister(trgReg);
     return trgReg;
@@ -64,14 +64,14 @@ static TR::Register *fpBits2integerHelper(TR::Node *node, bool is64bit, TR::Code
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = cg->allocateRegister();
-    TR::InstOpCode::Mnemonic movOp = TR::InstOpCode::fmov_stow;
-    TR::InstOpCode::Mnemonic cmpOp = TR::InstOpCode::fcmps;
-    TR::InstOpCode::Mnemonic selOp = TR::InstOpCode::cselw;
+    OP::Mnemonic movOp = OP::fmov_stow;
+    OP::Mnemonic cmpOp = OP::fcmps;
+    OP::Mnemonic selOp = OP::cselw;
 
     if (is64bit) {
-        movOp = TR::InstOpCode::fmov_dtox;
-        cmpOp = TR::InstOpCode::fcmpd;
-        selOp = TR::InstOpCode::cselx;
+        movOp = OP::fmov_dtox;
+        cmpOp = OP::fcmpd;
+        selOp = OP::cselx;
     }
 
     generateTrg1Src1Instruction(cg, movOp, node, trgReg, srcReg);
@@ -198,7 +198,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::Cod
     uint16_t imm8 = getImm8forFloat(node->getFloat());
 
     if (imm8 != 256) {
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::fmovimms, node, trgReg, (uint32_t)imm8);
+        generateTrg1ImmInstruction(cg, OP::fmovimms, node, trgReg, (uint32_t)imm8);
     } else {
         union {
             float f;
@@ -208,11 +208,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::Cod
         fvalue.f = node->getFloat();
 
         if (fvalue.f == +0.0f && signbit(fvalue.f) == 0) {
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2s, node, trgReg, 0);
+            generateTrg1ImmInstruction(cg, OP::vmovi2s, node, trgReg, 0);
         } else {
             TR::Register *tmpReg = cg->allocateRegister();
             loadConstant32(cg, node, fvalue.i, tmpReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_wtos, node, trgReg, tmpReg);
+            generateTrg1Src1Instruction(cg, OP::fmov_wtos, node, trgReg, tmpReg);
             cg->stopUsingRegister(tmpReg);
         }
     }
@@ -227,7 +227,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
     uint16_t imm8 = getImm8forDouble(node->getDouble());
 
     if (imm8 != 256) {
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::fmovimmd, node, trgReg, (uint32_t)imm8);
+        generateTrg1ImmInstruction(cg, OP::fmovimmd, node, trgReg, (uint32_t)imm8);
     } else {
         union {
             double d;
@@ -237,11 +237,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
         dvalue.d = node->getDouble();
 
         if (dvalue.d == +0.0 && signbit(dvalue.d) == 0) {
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::movid, node, trgReg, 0);
+            generateTrg1ImmInstruction(cg, OP::movid, node, trgReg, 0);
         } else {
             TR::Register *tmpReg = cg->allocateRegister();
             loadConstant64(cg, node, dvalue.l, tmpReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, trgReg, tmpReg);
+            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, trgReg, tmpReg);
             cg->stopUsingRegister(tmpReg);
         }
     }
@@ -253,25 +253,25 @@ TR::Register *OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
 // also handles floadi
 TR::Register *OMR::ARM64::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::vldrimms, 4, cg);
+    return commonLoadEvaluator(node, OP::vldrimms, 4, cg);
 }
 
 // also handles dloadi
 TR::Register *OMR::ARM64::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::vldrimmd, 8, cg);
+    return commonLoadEvaluator(node, OP::vldrimmd, 8, cg);
 }
 
 // also handles fstorei
 TR::Register *OMR::ARM64::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, 4, cg);
+    return commonStoreEvaluator(node, OP::vstrimms, 4, cg);
 }
 
 // also handles dstorei
 TR::Register *OMR::ARM64::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, 8, cg);
+    return commonStoreEvaluator(node, OP::vstrimmd, 8, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -284,8 +284,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::dreturnEvaluator(TR::Node *node, TR::Co
     return genericReturnEvaluator(node, cg->getProperties().getDoubleReturnRegister(), TR_FPR, TR_DoubleReturn, cg);
 }
 
-static TR::Register *commonFpEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, bool isDouble,
-    TR::CodeGenerator *cg)
+static TR::Register *commonFpEvaluator(TR::Node *node, OP::Mnemonic op, bool isDouble, TR::CodeGenerator *cg)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -301,54 +300,54 @@ static TR::Register *commonFpEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic 
     return trgReg;
 }
 
-static TR::Register *singlePrecisionEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *singlePrecisionEvaluator(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     return commonFpEvaluator(node, op, false, cg);
 }
 
-static TR::Register *doublePrecisionEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *doublePrecisionEvaluator(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     return commonFpEvaluator(node, op, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::fadds, cg);
+    return singlePrecisionEvaluator(node, OP::fadds, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::daddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::faddd, cg);
+    return doublePrecisionEvaluator(node, OP::faddd, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::fsubs, cg);
+    return singlePrecisionEvaluator(node, OP::fsubs, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::dsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::fsubd, cg);
+    return doublePrecisionEvaluator(node, OP::fsubd, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::fmuls, cg);
+    return singlePrecisionEvaluator(node, OP::fmuls, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::dmulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::fmuld, cg);
+    return doublePrecisionEvaluator(node, OP::fmuld, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fdivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionEvaluator(node, TR::InstOpCode::fdivs, cg);
+    return singlePrecisionEvaluator(node, OP::fdivs, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::ddivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionEvaluator(node, TR::InstOpCode::fdivd, cg);
+    return doublePrecisionEvaluator(node, OP::fdivd, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -361,8 +360,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::dremEvaluator(TR::Node *node, TR::CodeG
     return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
-static TR::Register *commonFpUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, bool isDouble,
-    TR::CodeGenerator *cg)
+static TR::Register *commonFpUnaryEvaluator(TR::Node *node, OP::Mnemonic op, bool isDouble, TR::CodeGenerator *cg)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(firstChild);
@@ -379,47 +377,47 @@ static TR::Register *commonFpUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnem
     return trgReg;
 }
 
-static TR::Register *singlePrecisionUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *singlePrecisionUnaryEvaluator(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     return commonFpUnaryEvaluator(node, op, false, cg);
 }
 
-static TR::Register *doublePrecisionUnaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *doublePrecisionUnaryEvaluator(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     return commonFpUnaryEvaluator(node, op, true, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fabsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::fabss, cg);
+    return singlePrecisionUnaryEvaluator(node, OP::fabss, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::dabsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::fabsd, cg);
+    return doublePrecisionUnaryEvaluator(node, OP::fabsd, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::fnegs, cg);
+    return singlePrecisionUnaryEvaluator(node, OP::fnegs, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::dnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::fnegd, cg);
+    return doublePrecisionUnaryEvaluator(node, OP::fnegd, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::fsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return singlePrecisionUnaryEvaluator(node, TR::InstOpCode::fsqrts, cg);
+    return singlePrecisionUnaryEvaluator(node, OP::fsqrts, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return doublePrecisionUnaryEvaluator(node, TR::InstOpCode::fsqrtd, cg);
+    return doublePrecisionUnaryEvaluator(node, OP::fsqrtd, cg);
 }
 
-static TR::Register *intFpTypeConversionHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *intFpTypeConversionHelper(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
@@ -441,37 +439,37 @@ static TR::Register *intFpTypeConversionHelper(TR::Node *node, TR::InstOpCode::M
 
 TR::Register *OMR::ARM64::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::scvtf_wtos, cg);
+    return intFpTypeConversionHelper(node, OP::scvtf_wtos, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::scvtf_wtod, cg);
+    return intFpTypeConversionHelper(node, OP::scvtf_wtod, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::scvtf_xtos, cg);
+    return intFpTypeConversionHelper(node, OP::scvtf_xtos, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::scvtf_xtod, cg);
+    return intFpTypeConversionHelper(node, OP::scvtf_xtod, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvt_stod, cg);
+    return intFpTypeConversionHelper(node, OP::fcvt_stod, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvtzs_stow, cg);
+    return intFpTypeConversionHelper(node, OP::fcvtzs_stow, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvtzs_dtow, cg);
+    return intFpTypeConversionHelper(node, OP::fcvtzs_dtow, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::d2cEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -491,17 +489,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::d2bEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::ARM64::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvtzs_stox, cg);
+    return intFpTypeConversionHelper(node, OP::fcvtzs_stox, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvtzs_dtox, cg);
+    return intFpTypeConversionHelper(node, OP::fcvtzs_dtox, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return intFpTypeConversionHelper(node, TR::InstOpCode::fcvt_dtos, cg);
+    return intFpTypeConversionHelper(node, OP::fcvt_dtos, cg);
 }
 
 static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool isDouble,
@@ -511,13 +509,13 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
     TR::Node *secondChild = node->getSecondChild();
     TR::Node *thirdChild = NULL;
     TR::Register *src1Reg = cg->evaluate(firstChild);
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     bool useRegCompare = true;
 
     if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL) {
         double value = isDouble ? secondChild->getDouble() : secondChild->getFloat();
         if (value == 0.0) {
-            op = isDouble ? TR::InstOpCode::fcmpd_zero : TR::InstOpCode::fcmps_zero;
+            op = isDouble ? OP::fcmpd_zero : OP::fcmps_zero;
             generateSrc1Instruction(cg, op, node, src1Reg);
             useRegCompare = false;
         }
@@ -525,7 +523,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        op = isDouble ? TR::InstOpCode::fcmpd : TR::InstOpCode::fcmps;
+        op = isDouble ? OP::fcmpd : OP::fcmps;
         generateSrc2Instruction(cg, op, node, src1Reg, src2Reg);
     }
 
@@ -547,7 +545,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                 generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
                 generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
-                result = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
+                result = generateLabelInstruction(cg, OP::label, node, doneLabel);
             } else {
                 generateConditionalBranchInstruction(cg, node, dstLabel, cc);
                 result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS, deps);
@@ -562,7 +560,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                 generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
                 generateConditionalBranchInstruction(cg, node, dstLabel, cc);
-                result = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
+                result = generateLabelInstruction(cg, OP::label, node, doneLabel);
             } else {
                 generateConditionalBranchInstruction(cg, node, dstLabel, cc);
                 result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS);
@@ -657,13 +655,13 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *src1Reg = cg->evaluate(firstChild);
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     bool useRegCompare = true;
 
     if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL) {
         double value = isDouble ? secondChild->getDouble() : secondChild->getFloat();
         if (value == 0.0) {
-            op = isDouble ? TR::InstOpCode::fcmpd_zero : TR::InstOpCode::fcmps_zero;
+            op = isDouble ? OP::fcmpd_zero : OP::fcmps_zero;
             generateSrc1Instruction(cg, op, node, src1Reg);
             useRegCompare = false;
         }
@@ -671,7 +669,7 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        op = isDouble ? TR::InstOpCode::fcmpd : TR::InstOpCode::fcmps;
+        op = isDouble ? OP::fcmpd : OP::fcmps;
         generateSrc2Instruction(cg, op, node, src1Reg, src2Reg);
     }
 
@@ -679,7 +677,7 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
     if (needsExplicitUnorderedCheck) {
         TR::Register *tmpReg = cg->allocateRegister();
         TR::ARM64ConditionCode ccNan = (cc == TR::CC_NE) ? TR::CC_VC : TR::CC_VS;
-        op = (cc == TR::CC_NE) ? TR::InstOpCode::andx : TR::InstOpCode::orrx;
+        op = (cc == TR::CC_NE) ? OP::andx : OP::orrx;
         generateCSetInstruction(cg, node, tmpReg, ccNan);
         generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, tmpReg);
         cg->stopUsingRegister(tmpReg);
@@ -762,17 +760,17 @@ static TR::Register *floatThreeWayCompareHelper(TR::Node *node, bool isDouble, b
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
     TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-    TR::InstOpCode::Mnemonic cmpOp = isDouble ? TR::InstOpCode::fcmpd : TR::InstOpCode::fcmps;
-    TR::InstOpCode::Mnemonic movOp = isCmpl ? TR::InstOpCode::movzx : TR::InstOpCode::movnx;
+    OP::Mnemonic cmpOp = isDouble ? OP::fcmpd : OP::fcmps;
+    OP::Mnemonic movOp = isCmpl ? OP::movzx : OP::movnx;
     uint32_t movVal = isCmpl ? 1 : 0;
     TR::ARM64ConditionCode cc = isCmpl ? TR::CC_GT : TR::CC_MI;
 
     generateSrc2Instruction(cg, cmpOp, node, src1Reg, src2Reg); // compare
-    generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, trgReg, 0);
+    generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0);
     generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
     generateTrg1ImmInstruction(cg, movOp, node, trgReg, movVal); // 1 or -1
-    generateCondTrg1Src2Instruction(cg, TR::InstOpCode::csnegx, node, trgReg, trgReg, trgReg, cc);
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel);
+    generateCondTrg1Src2Instruction(cg, OP::csnegx, node, trgReg, trgReg, trgReg, cc);
+    generateLabelInstruction(cg, OP::label, node, doneLabel);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -822,7 +820,7 @@ static TR::Register *fpMinMaxHelper(TR::Node *node, bool isMax, bool isDouble, T
     TR::Register *src1Reg = cg->evaluate(firstChild);
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg;
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     TR_ASSERT(node->getNumChildren() == 2, "The number of children for fmax/fmin/dmax/dmin must be 2.");
 
@@ -835,9 +833,9 @@ static TR::Register *fpMinMaxHelper(TR::Node *node, bool isMax, bool isDouble, T
     }
 
     if (isMax) {
-        op = isDouble ? TR::InstOpCode::fmaxd : TR::InstOpCode::fmaxs;
+        op = isDouble ? OP::fmaxd : OP::fmaxs;
     } else {
-        op = isDouble ? TR::InstOpCode::fmind : TR::InstOpCode::fmins;
+        op = isDouble ? OP::fmind : OP::fmins;
     }
 
     generateTrg1Src2Instruction(cg, op, node, trgReg, src1Reg, src2Reg);
@@ -1035,7 +1033,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::fselectEvaluator(TR::Node *node, TR::Co
     }
 
     generateCompareImmInstruction(cg, node, condReg, 0, true); // 64-bit compare
-    TR::InstOpCode::Mnemonic fcselOp = isDouble ? TR::InstOpCode::fcseld : TR::InstOpCode::fcsels;
+    OP::Mnemonic fcselOp = isDouble ? OP::fcseld : OP::fcsels;
     generateCondTrg1Src2Instruction(cg, fcselOp, node, resultReg, trueReg, falseReg, TR::CC_NE);
 
     node->setRegister(resultReg);

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -39,23 +39,22 @@ class RegisterDependencyConditions;
 class SymbolReference;
 } // namespace TR
 
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Instruction *preced)
+TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::Instruction(op, node, preced, cg);
     return new (cg->trHeapMemory()) TR::Instruction(op, node, cg);
 }
 
-TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    uint32_t imm, TR::Instruction *preced)
+TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, cg);
 }
 
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced)
 {
     if (preced)
@@ -63,7 +62,7 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::In
     return new (cg->trHeapMemory()) TR::ARM64RelocatableImmInstruction(op, node, imm, relocationKind, cg);
 }
 
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced)
 {
     if (preced)
@@ -72,25 +71,24 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::In
     return new (cg->trHeapMemory()) TR::ARM64RelocatableImmInstruction(op, node, imm, relocationKind, sr, cg);
 }
 
-TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s,
-    TR::Instruction *preced)
+TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ImmSymInstruction(op, node, imm, cond, sr, s, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64ImmSymInstruction(op, node, imm, cond, sr, s, cg);
 }
 
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::Instruction *preced)
+TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cg);
 }
 
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cond, preced, cg);
@@ -101,9 +99,8 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
     TR::ARM64ConditionCode cc, TR::Instruction *preced)
 {
     if (preced)
-        return new (cg->trHeapMemory())
-            TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cg);
+        return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, preced, cg);
+    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, cg);
 }
 
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
@@ -111,12 +108,11 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
 {
     if (preced)
         return new (cg->trHeapMemory())
-            TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cond, preced, cg);
-    return new (cg->trHeapMemory())
-        TR::ARM64ConditionalBranchInstruction(TR::InstOpCode::b_cond, node, sym, cc, cond, cg);
+            TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, cond, preced, cg);
+    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, cond, cg);
 }
 
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced)
 {
     if (preced)
@@ -124,7 +120,7 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::Ins
     return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cg);
 }
 
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
@@ -132,7 +128,7 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::Ins
     return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cond, cg);
 }
 
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced)
 {
     if (preced)
@@ -140,7 +136,7 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::Ins
     return new (cg->trHeapMemory()) TR::ARM64TestBitBranchInstruction(op, node, sreg, bitpos, sym, cg);
 }
 
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
     TR::Instruction *preced)
 {
@@ -150,7 +146,7 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::Ins
     return new (cg->trHeapMemory()) TR::ARM64TestBitBranchInstruction(op, node, sreg, bitpos, sym, cond, cg);
 }
 
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Instruction *preced)
 {
     if (preced)
@@ -158,7 +154,7 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpC
     return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cg);
 }
 
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
@@ -166,15 +162,15 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpC
     return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cond, cg);
 }
 
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Node *fenceNode, TR::Instruction *preced)
+TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, node, fenceNode, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, node, fenceNode, cg);
 }
 
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::RegisterDependencyConditions *cond, TR::Node *fenceNode, TR::Instruction *preced)
 {
     if (preced)
@@ -182,23 +178,23 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
     return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, cond, node, fenceNode, cg);
 }
 
-TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Instruction *preced)
+TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, cg);
 }
 
-TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Instruction *preced)
+TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ImmInstruction(op, node, treg, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmInstruction(op, node, treg, imm, cg);
 }
 
-TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced)
 {
     if (preced)
@@ -207,7 +203,7 @@ TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, TR::In
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmShiftedInstruction(op, node, treg, imm, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced)
 {
     if (preced)
@@ -215,22 +211,21 @@ TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOp
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmSymInstruction(op, node, treg, imm, sym, cg);
 }
 
-TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Instruction *preced)
+TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src1Instruction(op, node, treg, s1reg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1Instruction(op, node, treg, s1reg, cg);
 }
 
-TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced)
 {
     bool isShifted = false;
 
-    if ((op == TR::InstOpCode::addimmx) || (op == TR::InstOpCode::addimmw) || (op == TR::InstOpCode::addsimmx)
-        || (op == TR::InstOpCode::addsimmw) || (op == TR::InstOpCode::subimmx) || (op == TR::InstOpCode::subimmw)
-        || (op == TR::InstOpCode::subsimmx) || (op == TR::InstOpCode::subsimmw)) {
+    if ((op == OP::addimmx) || (op == OP::addimmw) || (op == OP::addsimmx) || (op == OP::addsimmw)
+        || (op == OP::subimmx) || (op == OP::subimmw) || (op == OP::subsimmx) || (op == OP::subsimmw)) {
         if (constantIsUnsignedImm12(imm)) {
             isShifted = false;
         } else {
@@ -246,15 +241,15 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstO
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, s1reg, isShifted, imm, cg);
 }
 
-TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *preced)
 {
     if (preced)
@@ -262,7 +257,7 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::Inst
     return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cg);
 }
 
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
@@ -272,7 +267,7 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::Inst
     return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cond, cg);
 }
 
-TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
@@ -280,7 +275,7 @@ TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, TR::InstO
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ImmInstruction(op, node, treg, s1reg, s2reg, imm, cg);
 }
 
-TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
     TR::Instruction *preced)
 {
@@ -291,7 +286,7 @@ TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, TR::I
         TR::ARM64Trg1Src2ShiftedInstruction(op, node, treg, s1reg, s2reg, shiftType, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
     TR::Instruction *preced)
 {
@@ -302,12 +297,11 @@ TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, TR::
         TR::ARM64Trg1Src2ExtendedInstruction(op, node, treg, s1reg, s2reg, extendType, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index,
-    TR::Instruction *preced)
+TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced)
 {
-    if ((op >= TR::InstOpCode::fmulelem_4s) && (op <= TR::InstOpCode::vfmulelem_2d)) {
-        if ((op == TR::InstOpCode::fmulelem_4s) || (op == TR::InstOpCode::vfmulelem_4s)) {
+    if ((op >= OP::fmulelem_4s) && (op <= OP::vfmulelem_2d)) {
+        if ((op == OP::fmulelem_4s) || (op == OP::vfmulelem_4s)) {
             TR_ASSERT_FATAL_WITH_NODE(node, index <= 3, "index is out of range: %d", index);
         } else {
             TR_ASSERT_FATAL_WITH_NODE(node, index <= 1, "index is out of range: %d", index);
@@ -321,17 +315,17 @@ TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2IndexedElementInstruction(op, node, treg, s1reg, s2reg, index, cg);
 }
 
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced)
+TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cg);
 }
 
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory())
@@ -339,23 +333,23 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCo
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cond, cg);
 }
 
-TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Instruction *preced)
+TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::MemoryReference *mr, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1MemInstruction(op, node, treg, mr, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1MemInstruction(op, node, treg, mr, cg);
 }
 
-TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg1, TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced)
+TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
+    TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg2MemInstruction(op, node, treg1, treg2, mr, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg2MemInstruction(op, node, treg1, treg2, mr, cg);
 }
 
-TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
@@ -363,7 +357,7 @@ TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode
     return new (cg->trHeapMemory()) TR::ARM64MemImmInstruction(op, node, mr, imm, cg);
 }
 
-TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
 {
     if (preced)
@@ -371,7 +365,7 @@ TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCod
     return new (cg->trHeapMemory()) TR::ARM64MemSrc1Instruction(op, node, mr, sreg, cg);
 }
 
-TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
@@ -379,7 +373,7 @@ TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCod
     return new (cg->trHeapMemory()) TR::ARM64MemSrc2Instruction(op, node, mr, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
 {
     if (preced)
@@ -387,16 +381,16 @@ TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, TR::InstO
     return new (cg->trHeapMemory()) TR::ARM64Trg1MemSrc1Instruction(op, node, treg, mr, sreg, cg);
 }
 
-TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Instruction *preced)
+TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Src1Instruction(op, node, s1reg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Src1Instruction(op, node, s1reg, cg);
 }
 
-TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+    TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Src2Instruction(op, node, s1reg, s2reg, preced, cg);
@@ -410,7 +404,7 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *c
 
     TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::sbfmx : TR::InstOpCode::sbfmw;
+    OP::Mnemonic op = is64bit ? OP::sbfmx : OP::sbfmw;
     uint32_t imms = is64bit ? 0x3f : 0x1f;
     uint32_t immr = shiftAmount;
     uint32_t imm = (immr << 6) | imms;
@@ -427,7 +421,7 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, 
 
     TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw;
+    OP::Mnemonic op = is64bit ? OP::ubfmx : OP::ubfmw;
     uint32_t imms = is64bit ? 0x3f : 0x1f;
     uint32_t immr = shiftAmount;
     uint32_t imm = (immr << 6) | imms;
@@ -444,7 +438,7 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, T
 
     TR_ASSERT_FATAL(shiftAmount < (is64bit ? 64 : 32), "Shift amount out of range.");
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::Mnemonic::ubfmx : TR::InstOpCode::Mnemonic::ubfmw;
+    OP::Mnemonic op = is64bit ? OP::Mnemonic::ubfmx : OP::Mnemonic::ubfmw;
     uint32_t imms = (is64bit ? 63 : 31) - shiftAmount;
     uint32_t immr = imms + 1;
     uint32_t imm = (immr << 6) | imms;
@@ -454,7 +448,7 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, sreg, imm, cg);
 }
 
-TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
@@ -465,25 +459,25 @@ TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, TR::InstOp
 TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
     bool is64bit, TR::Instruction *preced)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     bool isShifted = false;
 
     if (constantIsUnsignedImm12(imm)) {
         /* Alias of SUBS instruction */
-        op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
+        op = is64bit ? OP::subsimmx : OP::subsimmw;
     } else if (constantIsUnsignedImm12Shifted(imm)) {
-        op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
+        op = is64bit ? OP::subsimmx : OP::subsimmw;
         isShifted = true;
         imm = imm >> 12;
     } else if (constantIsUnsignedImm12(-imm)) {
         /* Alias of ADDS instruction */
-        op = is64bit ? TR::InstOpCode::addsimmx : TR::InstOpCode::addsimmw;
+        op = is64bit ? OP::addsimmx : OP::addsimmw;
         imm = -imm;
     } else {
         TR_ASSERT_FATAL(constantIsUnsignedImm12Shifted(-imm), "Immediate value is out of range for cmp/cmn");
 
         /* Alias of ADDS instruction */
-        op = is64bit ? TR::InstOpCode::addsimmx : TR::InstOpCode::addsimmw;
+        op = is64bit ? OP::addsimmx : OP::addsimmw;
         isShifted = true;
         imm = (-imm) >> 12;
     }
@@ -498,7 +492,7 @@ TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *nod
 {
     /* Alias of ANDS instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsimmx : TR::InstOpCode::andsimmw;
+    OP::Mnemonic op = is64bit ? OP::andsimmx : OP::andsimmw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ZeroSrc1ImmInstruction(op, node, sreg, N, imm, preced, cg);
@@ -510,7 +504,7 @@ TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *nod
 {
     /* Alias of SUBS instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsx : TR::InstOpCode::subsw;
+    OP::Mnemonic op = is64bit ? OP::subsx : OP::subsw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ZeroSrc2Instruction(op, node, s1reg, s2reg, preced, cg);
@@ -522,7 +516,7 @@ TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, 
 {
     /* Alias of ANDS instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsx : TR::InstOpCode::andsw;
+    OP::Mnemonic op = is64bit ? OP::andsx : OP::andsw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ZeroSrc2Instruction(op, node, s1reg, s2reg, preced, cg);
@@ -533,8 +527,7 @@ TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg,
     uint32_t imm, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit, bool isNegative,
     TR::Instruction *preced)
 {
-    TR::InstOpCode::Mnemonic op = is64bit ? (isNegative ? TR::InstOpCode::ccmnimmx : TR::InstOpCode::ccmpimmx)
-                                          : (isNegative ? TR::InstOpCode::ccmnimmw : TR::InstOpCode::ccmpimmw);
+    OP::Mnemonic op = is64bit ? (isNegative ? OP::ccmnimmx : OP::ccmpimmx) : (isNegative ? OP::ccmnimmw : OP::ccmpimmw);
 
     TR_ASSERT_FATAL(constantIsUnsignedImm5(imm), "Immediate value is out of range for ccmp/ccmn");
 
@@ -548,8 +541,7 @@ TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR
     TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit, bool isNegative,
     TR::Instruction *preced)
 {
-    TR::InstOpCode::Mnemonic op = is64bit ? (isNegative ? TR::InstOpCode::ccmnx : TR::InstOpCode::ccmpx)
-                                          : (isNegative ? TR::InstOpCode::ccmnw : TR::InstOpCode::ccmpw);
+    OP::Mnemonic op = is64bit ? (isNegative ? OP::ccmnx : OP::ccmpx) : (isNegative ? OP::ccmnw : OP::ccmpw);
 
     if (preced)
         return new (cg->trHeapMemory())
@@ -562,7 +554,7 @@ TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, T
 {
     /* Alias of ORR instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::orrx : TR::InstOpCode::orrw;
+    OP::Mnemonic op = is64bit ? OP::orrx : OP::orrw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, preced, cg);
@@ -574,7 +566,7 @@ TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, T
 {
     /* Alias of ORN instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::ornx : TR::InstOpCode::ornw;
+    OP::Mnemonic op = is64bit ? OP::ornx : OP::ornw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, preced, cg);
@@ -586,7 +578,7 @@ TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, T
 {
     /* Alias of SUB instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subx : TR::InstOpCode::subw;
+    OP::Mnemonic op = is64bit ? OP::subx : OP::subw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, preced, cg);
@@ -597,7 +589,7 @@ TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *
     uint32_t imm, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of ORR instruction */
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::orrimmx : TR::InstOpCode::orrimmw;
+    OP::Mnemonic op = is64bit ? OP::orrimmx : OP::orrimmw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroImmInstruction(op, node, treg, N, imm, preced, cg);
@@ -615,7 +607,7 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
 {
     /* Alias of MADD instruction */
 
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::maddx : TR::InstOpCode::maddw;
+    OP::Mnemonic op = is64bit ? OP::maddx : OP::maddw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, preced, cg);
@@ -626,7 +618,7 @@ TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, 
     TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of CSINC instruction with inverted condition code */
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::csincx : TR::InstOpCode::csincw;
+    OP::Mnemonic op = is64bit ? OP::csincx : OP::csincw;
 
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), preced, cg);
@@ -637,20 +629,20 @@ TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, 
     TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of CSINC instruction with inverted condition code */
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::csincx : TR::InstOpCode::csincw;
+    OP::Mnemonic op = is64bit ? OP::csincx : OP::csincw;
     return generateCondTrg1Src2Instruction(cg, op, node, treg, sreg, sreg, cc_invert(cc), preced);
 }
 
-TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, TR::Node *node, TR::InstOpCode::AArch64BarrierLimitation lim, TR::Instruction *preced)
+TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
+    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, lim, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, lim, cg);
 }
 
-TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, uint32_t imm, TR::Instruction *preced)
+TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, preced, cg);
@@ -664,8 +656,8 @@ TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, 
     uint32_t immr = lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw, node, treg, sreg,
-        (immr << 6) | imms, preced);
+    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms,
+        preced);
 }
 
 TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
@@ -675,8 +667,8 @@ TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node,
     uint32_t immr = (is64bit ? 64 : 32) - lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::ubfmx : TR::InstOpCode::ubfmw, node, treg, sreg,
-        (immr << 6) | imms, preced);
+    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms,
+        preced);
 }
 
 TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
@@ -686,18 +678,18 @@ TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, T
     uint32_t immr = (is64bit ? 64 : 32) - lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for bfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? TR::InstOpCode::bfmx : TR::InstOpCode::bfmw, node, treg, sreg,
-        (immr << 6) | imms, preced);
+    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::bfmx : OP::bfmw, node, treg, sreg, (immr << 6) | imms,
+        preced);
 }
 
-TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
 {
-    TR_ASSERT_FATAL_WITH_NODE(node, (op >= TR::InstOpCode::vshl16b) && (op <= TR::InstOpCode::vsri2d),
+    TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vshl16b) && (op <= OP::vsri2d),
         "Illegal opcode for generateVectorShiftImmediateInstruction: %d", op);
 
-    bool isShiftLeft = (op <= TR::InstOpCode::vsli2d);
-    const auto opcodeBinaryEncoding = TR::InstOpCode::getOpCodeBinaryEncoding(op);
+    bool isShiftLeft = (op <= OP::vsli2d);
+    const auto opcodeBinaryEncoding = OP::getOpCodeBinaryEncoding(op);
     /* If bit 11 - 15 is 0b100xx, then it is a variant of shift right narrow instructions. */
     const bool isShiftRightNarrow = ((opcodeBinaryEncoding >> 11) & 0x1c) == 0x10;
     uint32_t immh = (opcodeBinaryEncoding >> 19) & 0xf;
@@ -717,16 +709,16 @@ TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, 
 TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node,
     TR::Register *treg, TR::Register *sreg, bool isUXTL2, TR::Instruction *preced)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     switch (elementType) {
         case TR::Int8:
-            op = isUXTL2 ? TR::InstOpCode::vushll2_8h : TR::InstOpCode::vushll_8h;
+            op = isUXTL2 ? OP::vushll2_8h : OP::vushll_8h;
             break;
         case TR::Int16:
-            op = isUXTL2 ? TR::InstOpCode::vushll2_4s : TR::InstOpCode::vushll_4s;
+            op = isUXTL2 ? OP::vushll2_4s : OP::vushll_4s;
             break;
         case TR::Int32:
-            op = isUXTL2 ? TR::InstOpCode::vushll2_2d : TR::InstOpCode::vushll_2d;
+            op = isUXTL2 ? OP::vushll2_2d : OP::vushll_2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -740,14 +732,14 @@ static bool isVectorRegister(TR::Register *reg)
     return (reg->getRealRegister() != NULL) ? (reg->getKind() == TR_FPR) : (reg->getKind() == TR_VRF);
 }
 
-TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
 {
-    TR_ASSERT_FATAL_WITH_NODE(node, (op >= TR::InstOpCode::vdupe16b) && (op <= TR::InstOpCode::vdupe2d),
+    TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vdupe16b) && (op <= OP::vdupe2d),
         "Illegal opcode for generateVectorDupElementInstruction: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && isVectorRegister(sreg),
         "The target and source register must be VRF");
-    const uint32_t elementSizeShift = op - TR::InstOpCode::vdupe16b;
+    const uint32_t elementSizeShift = op - OP::vdupe16b;
     const uint32_t nelements = 16 >> elementSizeShift;
     TR_ASSERT_FATAL_WITH_NODE(node, (srcIndex < nelements),
         "srcIndex (%d) must be less than the number of elements (%d)", srcIndex, nelements);
@@ -756,16 +748,15 @@ TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, TR::
     return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
+TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
 {
-    TR_ASSERT_FATAL_WITH_NODE(node, (op >= TR::InstOpCode::smovwb) && (op <= TR::InstOpCode::umovxd),
+    TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::smovwb) && (op <= OP::umovxd),
         "Illegal opcode for generateMovVectorElementToGPRInstruction: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, (treg->getKind() == TR_GPR) && isVectorRegister(sreg),
         "The target register must be GPR and the source register must be VRF");
-    const uint32_t elementSizeShift = (op >= TR::InstOpCode::umovwb)
-        ? (op - TR::InstOpCode::umovwb)
-        : ((op >= TR::InstOpCode::smovxb) ? (op - TR::InstOpCode::smovxb) : (op - TR::InstOpCode::smovwb));
+    const uint32_t elementSizeShift
+        = (op >= OP::umovwb) ? (op - OP::umovwb) : ((op >= OP::smovxb) ? (op - OP::smovxb) : (op - OP::smovwb));
     const uint32_t nelements = 16 >> elementSizeShift;
     TR_ASSERT_FATAL_WITH_NODE(node, (srcIndex < nelements),
         "srcIndex (%d) must be less than the number of elements (%d)", srcIndex, nelements);
@@ -774,14 +765,14 @@ TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg,
     return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced)
+TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced)
 {
-    TR_ASSERT_FATAL_WITH_NODE(node, (op >= TR::InstOpCode::vinswb) && (op <= TR::InstOpCode::vinsxd),
+    TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vinswb) && (op <= OP::vinsxd),
         "Illegal opcode for generateMovGPRToVectorElementInstruction: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && (sreg->getKind() == TR_GPR),
         "The target register must be VRF and the source register must be GPR");
-    const uint32_t elementSizeShift = op - TR::InstOpCode::vinswb;
+    const uint32_t elementSizeShift = op - OP::vinswb;
     const uint32_t nelements = 16 >> elementSizeShift;
     TR_ASSERT_FATAL_WITH_NODE(node, (trgIndex < nelements),
         "trgIndex (%d) must be less than the number of elements (%d)", trgIndex, nelements);
@@ -790,14 +781,14 @@ TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg,
     return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced)
 {
-    TR_ASSERT_FATAL_WITH_NODE(node, (op >= TR::InstOpCode::vinseb) && (op <= TR::InstOpCode::vinsed),
+    TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vinseb) && (op <= OP::vinsed),
         "Illegal opcode for generateMovVectorElementInstruction: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && isVectorRegister(sreg),
         "The target and source register must be VRF");
-    const uint32_t elementSizeShift = op - TR::InstOpCode::vinseb;
+    const uint32_t elementSizeShift = op - OP::vinseb;
     const uint32_t nelements = 16 >> elementSizeShift;
     TR_ASSERT_FATAL_WITH_NODE(node, (srcIndex < nelements) && (trgIndex < nelements),
         "srcIndex (%d) and trgIndex (%d) must be less than the number of elements (%d)", srcIndex, trgIndex, nelements);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -51,7 +51,7 @@ class SymbolReference;
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Instruction *preced = NULL);
 
 /*
@@ -63,8 +63,8 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    uint32_t imm, TR::Instruction *preced = NULL);
+TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+    TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates relocatable imm instruction
@@ -76,7 +76,7 @@ TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstO
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL);
 
 /*
@@ -90,7 +90,7 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::In
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr,
     TR::Instruction *preced = NULL);
 
@@ -106,9 +106,8 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, TR::In
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s,
-    TR::Instruction *preced = NULL);
+TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates label instruction
@@ -119,8 +118,8 @@ TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates label instruction with register dependency
@@ -132,8 +131,8 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+    TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates conditional branch instruction
@@ -170,7 +169,7 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
 
 /*
@@ -184,7 +183,7 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::Ins
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
 /*
@@ -199,7 +198,7 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::Ins
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
     TR::Instruction *preced = NULL);
 
@@ -214,7 +213,7 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::Ins
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
 
 /*
@@ -226,7 +225,7 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, TR::Ins
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Instruction *preced = NULL);
 
 /*
@@ -239,7 +238,7 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpC
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
 /*
@@ -251,7 +250,7 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpC
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
 /*
@@ -264,7 +263,7 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
 /*
@@ -276,8 +275,8 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates imm-to-trg instruction
@@ -289,8 +288,8 @@ TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, TR::InstOpCode::M
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates shifted imm--to-trg instruction
@@ -303,7 +302,7 @@ TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL);
 
 /*
@@ -317,7 +316,7 @@ TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, TR::In
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL);
 
 /*
@@ -330,8 +329,8 @@ TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOp
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates src1-and-imm-to-trg instruction
@@ -344,7 +343,7 @@ TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, TR::InstOpCo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL);
 
 /*
@@ -358,8 +357,8 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstO
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates src2-to-trg instruction (Conditional register)
@@ -373,7 +372,7 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
     TR::Instruction *preced = NULL);
 
@@ -390,7 +389,7 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::Inst
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
@@ -406,7 +405,7 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, TR::Inst
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL);
 
 /*
@@ -422,7 +421,7 @@ TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, TR::InstO
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
 
@@ -439,7 +438,7 @@ TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, TR::I
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
 
@@ -455,9 +454,8 @@ TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, TR::
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index,
-    TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates src3-to-trg instruction
@@ -471,8 +469,8 @@ TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates src3-to-trg instruction with register dependency
@@ -487,9 +485,9 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::RegisterDependencyConditions *cond,
+    TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates mem-to-trg instruction
@@ -501,8 +499,8 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, TR::InstOpCo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::MemoryReference *mr, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates mem-to-trg2 instruction
@@ -515,8 +513,8 @@ TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, TR::InstOpCod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *treg1, TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL);
+TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
+    TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates mem-imm instruction
@@ -528,7 +526,7 @@ TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, TR::InstOpCod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced = NULL);
 
 /*
@@ -541,7 +539,7 @@ TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
 
 /*
@@ -555,7 +553,7 @@ TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
 
 /*
@@ -569,7 +567,7 @@ TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
 
 /*
@@ -581,8 +579,8 @@ TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, TR::InstO
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Instruction *preced = NULL);
+TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+    TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates src2 instruction
@@ -594,8 +592,8 @@ TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
+TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+    TR::Register *s2reg, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates ASR instruction
@@ -651,7 +649,7 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL);
 
 /*
@@ -859,9 +857,8 @@ TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, TR::Node *node, TR::InstOpCode::AArch64BarrierLimitation lim,
-    TR::Instruction *preced = NULL);
+TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
+    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates exception generating instruction
@@ -872,8 +869,8 @@ TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::Code
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, uint32_t imm, TR::Instruction *preced = NULL);
+TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    uint32_t imm, TR::Instruction *preced = NULL);
 
 /**
  * @brief Generates ubfx instruction
@@ -950,8 +947,8 @@ TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL);
+TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL);
 
 /**
  * @brief Generates vector unsigned extend long instruction
@@ -979,7 +976,7 @@ TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataTy
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
 
 /**
@@ -994,8 +991,8 @@ TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, TR::
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
+TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
 
 /**
  * @brief Generates move general purpose register to vector element instruction
@@ -1009,8 +1006,8 @@ TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg,
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL);
+TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL);
 
 /**
  * @brief Generates move vector element instruction
@@ -1025,7 +1022,7 @@ TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg,
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL);
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/aarch64/codegen/InstOpCode.hpp
+++ b/compiler/aarch64/codegen/InstOpCode.hpp
@@ -44,5 +44,10 @@ public:
     {}
 };
 
+typedef InstOpCode OP;
+
 } // namespace TR
+
+using TR::OP;
+
 #endif

--- a/compiler/aarch64/codegen/Instruction.hpp
+++ b/compiler/aarch64/codegen/Instruction.hpp
@@ -36,8 +36,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Instruction *precedingInstruction,
-        TR::CodeGenerator *cg)
+    Instruction(OP::Mnemonic op, TR::Node *node, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : OMR::InstructionConnector(cg, precedingInstruction, op, node)
     {}
 
@@ -47,7 +46,7 @@ public:
      * @param[in] node : node
      * @param[in] cg : CodeGenerator
      */
-    Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
+    Instruction(OP::Mnemonic op, TR::Node *node, TR::CodeGenerator *cg)
         : OMR::InstructionConnector(cg, op, node)
     {}
 
@@ -59,7 +58,7 @@ public:
      * @param[in] precedingInstruction : preceding instruction
      * @param[in] cg : CodeGenerator
      */
-    Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+    Instruction(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
         : OMR::InstructionConnector(cg, precedingInstruction, op, cond, node)
     {}
@@ -71,8 +70,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] cg : CodeGenerator
      */
-    Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
-        TR::CodeGenerator *cg)
+    Instruction(OP::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
         : OMR::InstructionConnector(cg, op, cond, node)
     {}
 };

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -219,13 +219,12 @@ void OMR::ARM64::CodeGenerator::beginInstructionSelection()
     TR::Compilation *comp = self()->comp();
     TR::Node *startNode = comp->getStartTree()->getNode();
     if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private) {
-        _returnTypeInfoInstruction = generateImmInstruction(self(), TR::InstOpCode::dd, startNode, 0);
+        _returnTypeInfoInstruction = generateImmInstruction(self(), OP::dd, startNode, 0);
     } else {
         _returnTypeInfoInstruction = NULL;
     }
 
-    new (trHeapMemory())
-        TR::ARM64AdminInstruction(TR::InstOpCode::proc, startNode, NULL, _returnTypeInfoInstruction, self());
+    new (trHeapMemory()) TR::ARM64AdminInstruction(OP::proc, startNode, NULL, _returnTypeInfoInstruction, self());
 }
 
 void OMR::ARM64::CodeGenerator::endInstructionSelection()
@@ -253,7 +252,7 @@ void OMR::ARM64::CodeGenerator::doBinaryEncoding()
 
     data.cursorInstruction = getFirstInstruction();
 
-    while (data.cursorInstruction && data.cursorInstruction->getOpCodeValue() != TR::InstOpCode::proc) {
+    while (data.cursorInstruction && data.cursorInstruction->getOpCodeValue() != OP::proc) {
         TR::Instruction *prev = data.cursorInstruction->getPrev();
         /* The last instruction whose expansion is finished. */
         TR::Instruction *expandedOrSelf = data.cursorInstruction->expandInstruction();
@@ -782,9 +781,9 @@ bool OMR::ARM64::CodeGenerator::directCallRequiresTrampoline(intptr_t targetAddr
 TR::Instruction *OMR::ARM64::CodeGenerator::generateNop(TR::Node *node, TR::Instruction *preced)
 {
     if (preced)
-        return new (trHeapMemory()) TR::Instruction(TR::InstOpCode::nop, node, preced, self());
+        return new (trHeapMemory()) TR::Instruction(OP::nop, node, preced, self());
     else
-        return new (trHeapMemory()) TR::Instruction(TR::InstOpCode::nop, node, self());
+        return new (trHeapMemory()) TR::Instruction(OP::nop, node, self());
 }
 
 TR_ARM64OutOfLineCodeSection *OMR::ARM64::CodeGenerator::findARM64OutOfLineCodeSectionFromLabel(TR::LabelSymbol *label)
@@ -840,12 +839,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg,
-        MRef_disp(self(), addrReg, 0), cursor);
-    cursor
-        = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addimmw, node, counterReg, counterReg, delta, cursor);
-    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, MRef_disp(self(), addrReg, 0),
-        counterReg, cursor);
+    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = generateTrg1Src1ImmInstruction(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
+    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     if (cond) {
         TR::addDependency(cond, addrReg, TR::RealRegister::NoReg, TR_GPR, self());
@@ -869,11 +865,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg,
-        MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::addw, node, counterReg, counterReg, deltaReg, cursor);
-    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, MRef_disp(self(), addrReg, 0),
-        counterReg, cursor);
+    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = generateTrg1Src2Instruction(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
+    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     if (cond) {
         TR::addDependency(cond, addrReg, TR::RealRegister::NoReg, TR_GPR, self());
@@ -906,12 +900,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg,
-        MRef_disp(self(), addrReg, 0), cursor);
-    cursor
-        = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addimmw, node, counterReg, counterReg, delta, cursor);
-    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, MRef_disp(self(), addrReg, 0),
-        counterReg, cursor);
+    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = generateTrg1Src1ImmInstruction(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
+    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     srm.reclaimScratchRegister(addrReg);
     srm.reclaimScratchRegister(counterReg);
@@ -931,11 +922,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::ldrimmw, node, counterReg,
-        MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::addw, node, counterReg, counterReg, deltaReg, cursor);
-    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::strimmw, node, MRef_disp(self(), addrReg, 0),
-        counterReg, cursor);
+    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = generateTrg1Src2Instruction(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
+    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
     srm.reclaimScratchRegister(addrReg);
     srm.reclaimScratchRegister(counterReg);
     return cursor;

--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -30,19 +30,19 @@ namespace TR {
 class Register;
 }
 
-OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node)
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node)
     : OMR::Instruction(cg, op, node)
     , _conditions(NULL)
 {}
 
-OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::Node *node)
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, OP::Mnemonic op,
+    TR::Node *node)
     : OMR::Instruction(cg, precedingInstruction, op, node)
     , _conditions(NULL)
 {}
 
-OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
-    TR::RegisterDependencyConditions *cond, TR::Node *node)
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::RegisterDependencyConditions *cond,
+    TR::Node *node)
     : OMR::Instruction(cg, op, node)
     , _conditions(cond)
 {
@@ -50,8 +50,8 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
         cond->bookKeepingRegisterUses(self(), cg);
 }
 
-OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node)
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, OP::Mnemonic op,
+    TR::RegisterDependencyConditions *cond, TR::Node *node)
     : OMR::Instruction(cg, precedingInstruction, op, node)
     , _conditions(cond)
 {

--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in] op : opcode
      * @param[in] node : node
      */
-    Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node = NULL);
+    Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node = NULL);
     /**
      * @brief Constructor
      * @param[in] cg : CodeGenerator
@@ -71,8 +71,7 @@ public:
      * @param[in] op : opcode
      * @param[in] node : node
      */
-    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op,
-        TR::Node *node = NULL);
+    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, OP::Mnemonic op, TR::Node *node = NULL);
     /**
      * @brief Constructor
      * @param[in] cg : CodeGenerator
@@ -80,8 +79,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] node : node
      */
-    Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond,
-        TR::Node *node = NULL);
+    Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node = NULL);
     /**
      * @brief Constructor
      * @param[in] cg : CodeGenerator
@@ -90,7 +88,7 @@ public:
      * @param[in] cond : register dependency conditions
      * @param[in] node : node
      */
-    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op,
+    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, OP::Mnemonic op,
         TR::RegisterDependencyConditions *cond, TR::Node *node = NULL);
 
     /**
@@ -122,7 +120,7 @@ public:
      * @brief Answers if this instruction is a label or not
      * @return true if this instruction is a label, false otherwise
      */
-    virtual bool isLabel() { return _opcode.getMnemonic() == TR::InstOpCode::label; }
+    virtual bool isLabel() { return _opcode.getMnemonic() == OP::label; }
 
     /**
      * @brief Gets the base register of memory access

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -310,7 +310,7 @@ void OMR::ARM64::Linkage::initARM64RealRegisterLinkage() { /* do nothing */ }
 void OMR::ARM64::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method) { /* do nothing */ }
 
 TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register *baseReg, int32_t offset,
-    TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
+    TR::Register *argReg, OP::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
 {
     TR::MemoryReference *result = MRef_disp(cg(), baseReg, offset);
     memArg.argRegister = argReg;
@@ -406,18 +406,18 @@ int32_t OMR::ARM64::Linkage::numArgumentRegisters(TR_RegisterKinds kind)
  *
  * @return The opcode used to load parameters with the given type
  */
-static inline TR::InstOpCode::Mnemonic getOpCodeForParmLoads(TR::DataTypes type)
+static inline OP::Mnemonic getOpCodeForParmLoads(TR::DataTypes type)
 {
     switch (type) {
         case TR::Double:
-            return TR::InstOpCode::vldrimmd;
+            return OP::vldrimmd;
         case TR::Float:
-            return TR::InstOpCode::vldrimms;
+            return OP::vldrimms;
         case TR::Int64:
         case TR::Address:
-            return TR::InstOpCode::ldrimmx;
+            return OP::ldrimmx;
         default:
-            return TR::InstOpCode::ldrimmw;
+            return OP::ldrimmw;
     }
 }
 
@@ -428,18 +428,18 @@ static inline TR::InstOpCode::Mnemonic getOpCodeForParmLoads(TR::DataTypes type)
  *
  * @return The opcode used to store parameters with the given type
  */
-static inline TR::InstOpCode::Mnemonic getOpCodeForParmStores(TR::DataTypes type)
+static inline OP::Mnemonic getOpCodeForParmStores(TR::DataTypes type)
 {
     switch (type) {
         case TR::Double:
-            return TR::InstOpCode::vstrimmd;
+            return OP::vstrimmd;
         case TR::Float:
-            return TR::InstOpCode::vstrimms;
+            return OP::vstrimms;
         case TR::Int64:
         case TR::Address:
-            return TR::InstOpCode::strimmx;
+            return OP::strimmx;
         default:
-            return TR::InstOpCode::strimmw;
+            return OP::strimmw;
     }
 }
 
@@ -621,16 +621,14 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
                 TR::Register *trgReg = machine->getRealRegister(regCursor);
                 TR::Register *srcReg = machine->getRealRegister(source);
                 if ((paramType == TR::Double) || (paramType == TR::Float)) {
-                    cursor = generateTrg1Src1Instruction(cg(),
-                        (paramType == TR::Double) ? TR::InstOpCode::fmovd : TR::InstOpCode::fmovs, NULL, trgReg, srcReg,
-                        cursor);
+                    cursor = generateTrg1Src1Instruction(cg(), (paramType == TR::Double) ? OP::fmovd : OP::fmovs, NULL,
+                        trgReg, srcReg, cursor);
                 } else {
                     // generateMovInstruction cannot be used in the binary encoding phase because it relies on RegDep
                     // for assigning xzr for 1st source register.
                     cursor = generateTrg1Src2Instruction(cg(),
-                        (paramType == TR::Int64) || (paramType == TR::Address) ? TR::InstOpCode::orrx
-                                                                               : TR::InstOpCode::orrw,
-                        NULL, trgReg, machine->getRealRegister(TR::RealRegister::xzr), srcReg, cursor);
+                        (paramType == TR::Int64) || (paramType == TR::Address) ? OP::orrx : OP::orrw, NULL, trgReg,
+                        machine->getRealRegister(TR::RealRegister::xzr), srcReg, cursor);
                 }
 
                 // Update movStatus as we go so we don't generate redundant movs

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -66,7 +66,7 @@ public:
 
     TR::Register *argRegister;
     TR::MemoryReference *argMemory;
-    TR::InstOpCode::Mnemonic opCode;
+    OP::Mnemonic opCode;
 };
 
 // linkage properties
@@ -279,7 +279,7 @@ public:
      * @return MemoryReference for the argument
      */
     virtual TR::MemoryReference *getOutgoingArgumentMemRef(TR::Register *baseReg, int32_t offset, TR::Register *argReg,
-        TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg);
+        OP::Mnemonic opCode, TR::ARM64MemoryArgument &memArg);
 
     /**
      * @brief Loads parameters from stack

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -64,7 +64,7 @@ static bool boundNext(TR::Instruction *currentInstruction, int32_t realNum, TR::
     TR::RealRegister::RegNum realReg = static_cast<TR::RealRegister::RegNum>(realNum);
     TR::Node *nodeBBStart = NULL;
 
-    while (cursor->getOpCodeValue() != TR::InstOpCode::proc) {
+    while (cursor->getOpCodeValue() != OP::proc) {
         TR::RegisterDependencyConditions *conditions;
         if ((conditions = cursor->getDependencyConditions()) != NULL) {
             TR::Register *boundReg = conditions->searchPostConditionRegister(realReg);
@@ -256,8 +256,8 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
         TR_ASSERT(numCandidates != 0, "All registers are blocked");
 
         cursor = currentInstruction;
-        while (numCandidates > 1 && cursor != NULL && cursor->getOpCodeValue() != TR::InstOpCode::label
-            && cursor->getOpCodeValue() != TR::InstOpCode::proc) {
+        while (numCandidates > 1 && cursor != NULL && cursor->getOpCodeValue() != OP::label
+            && cursor->getOpCodeValue() != OP::proc) {
             for (int i = 0; i < numCandidates; i++) {
                 if (cursor->refsRegister(candidates[i])) {
                     candidates[i] = candidates[--numCandidates];
@@ -361,16 +361,16 @@ void OMR::ARM64::Machine::spillRegister(TR::Instruction *currentInstruction, TR:
         diagnostic("\n\tspilling %s (%s)", best->getAssignedRegister()->getRegisterName(comp),
             best->getRegisterName(comp));
     }
-    TR::InstOpCode::Mnemonic loadOp;
+    OP::Mnemonic loadOp;
     switch (rk) {
         case TR_GPR:
-            loadOp = TR::InstOpCode::ldrimmx;
+            loadOp = OP::ldrimmx;
             break;
         case TR_FPR:
-            loadOp = TR::InstOpCode::vldrimmd;
+            loadOp = OP::vldrimmd;
             break;
         case TR_VRF:
-            loadOp = TR::InstOpCode::vldrimmq;
+            loadOp = OP::vldrimmq;
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -397,7 +397,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
     TR_RegisterKinds rk = spilledRegister->getKind();
     TR_Debug *debugObj = cg()->getDebug();
     int32_t dataSize = 0;
-    TR::InstOpCode::Mnemonic storeOp;
+    OP::Mnemonic storeOp;
 
     if (targetRegister == NULL) {
         targetRegister = self()->findBestFreeRegister(currentInstruction, rk, false, spilledRegister);
@@ -516,13 +516,13 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
     }
     switch (rk) {
         case TR_GPR:
-            storeOp = TR::InstOpCode::strimmx;
+            storeOp = OP::strimmx;
             break;
         case TR_FPR:
-            storeOp = TR::InstOpCode::vstrimmd;
+            storeOp = OP::vstrimmd;
             break;
         case TR_VRF:
-            storeOp = TR::InstOpCode::vstrimmq;
+            storeOp = OP::vstrimmq;
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -585,11 +585,10 @@ static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds
             generateMovInstruction(cg, node, targetReg, sourceReg, true, precedingInstruction);
             break;
         case TR_FPR:
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmovd, node, targetReg, sourceReg, precedingInstruction);
+            generateTrg1Src1Instruction(cg, OP::fmovd, node, targetReg, sourceReg, precedingInstruction);
             break;
         case TR_VRF:
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, sourceReg, sourceReg,
-                precedingInstruction);
+            generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, sourceReg, sourceReg, precedingInstruction);
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -605,19 +604,13 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 
     TR::Node *node = precedingInstruction->getNode();
     if (rk == TR_GPR) {
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::eorx, node, targetReg, targetReg, sourceReg,
-            precedingInstruction);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::eorx, node, sourceReg, targetReg, sourceReg,
-            precedingInstruction);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::eorx, node, targetReg, targetReg, sourceReg,
-            precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::eorx, node, sourceReg, targetReg, sourceReg, precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
     } else {
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::veor16b, node, targetReg, targetReg, sourceReg,
-            precedingInstruction);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::veor16b, node, sourceReg, targetReg, sourceReg,
-            precedingInstruction);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::veor16b, node, targetReg, targetReg, sourceReg,
-            precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::veor16b, node, sourceReg, targetReg, sourceReg, precedingInstruction);
+        generateTrg1Src2Instruction(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
     }
 }
 
@@ -1022,7 +1015,7 @@ void OMR::ARM64::Machine::createRegisterAssociationDirective(TR::Instruction *cu
         associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum);
     }
 
-    generateAdminInstruction(cg(), TR::InstOpCode::assocreg, cursor->getNode(), associations, NULL, cursor);
+    generateAdminInstruction(cg(), OP::assocreg, cursor->getNode(), associations, NULL, cursor);
 }
 
 TR::Register *OMR::ARM64::Machine::setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register *virtReg)

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -77,12 +77,12 @@ static void loadRelocatableConstant(TR::Node *node, TR::SymbolReference *ref, TR
                                         : (uintptr_t)symbol->getMethodSymbol()->getMethodAddress();
 
     if (symbol->isStartPC()) {
-        generateTrg1ImmSymInstruction(cg, TR::InstOpCode::adr, node, reg, addr, symbol);
+        generateTrg1ImmSymInstruction(cg, OP::adr, node, reg, addr, symbol);
         return;
     }
 
     if (symbol->isGCRPatchPoint()) {
-        generateTrg1ImmSymInstruction(cg, TR::InstOpCode::adr, node, reg, addr, symbol);
+        generateTrg1ImmSymInstruction(cg, OP::adr, node, reg, addr, symbol);
         return;
     }
 
@@ -329,14 +329,13 @@ void OMR::ARM64::MemoryReference::validateImmediateOffsetAlignment(TR::Node *nod
 
         if (_baseRegister != NULL) {
             if (constantIsUnsignedImm12(displacement)) {
-                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, newBase, _baseRegister, displacement);
+                generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
             } else if (node->getOpCode().isLoadConst() && node->getRegister() && (node->getLongInt() == displacement)) {
-                generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister,
-                    node->getRegister());
+                generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
             } else {
                 TR::Register *tempReg = cg->allocateRegister();
                 loadConstant64(cg, node, displacement, tempReg);
-                generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister, tempReg);
+                generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, tempReg);
                 cg->stopUsingRegister(tempReg);
             }
         } else {
@@ -392,16 +391,14 @@ void OMR::ARM64::MemoryReference::normalize(TR::Node *node, TR::CodeGenerator *c
 
             if (_baseRegister != NULL) {
                 if (constantIsUnsignedImm12(displacement)) {
-                    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, newBase, _baseRegister,
-                        displacement);
+                    generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
                 } else if (node->getOpCode().isLoadConst() && node->getRegister()
                     && (node->getLongInt() == displacement)) {
-                    generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister,
-                        node->getRegister());
+                    generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
                 } else {
                     TR::Register *tempReg = cg->allocateRegister();
                     loadConstant64(cg, node, displacement, tempReg);
-                    generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, newBase, _baseRegister, tempReg);
+                    generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, tempReg);
                     cg->stopUsingRegister(tempReg);
                 }
             } else {
@@ -717,28 +714,26 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
 
     if (_baseRegister != NULL) {
         if (self()->isIndexZeroExtendedWord()) {
-            generateTrg1Src2ExtendedInstruction(cg, TR::InstOpCode::addextx, srcTree, tempTargetRegister, _baseRegister,
+            generateTrg1Src2ExtendedInstruction(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister,
                 _indexRegister, TR::EXT_UXTW, _scale);
         } else if (self()->isIndexSignExtendedWord()) {
-            generateTrg1Src2ExtendedInstruction(cg, TR::InstOpCode::addextx, srcTree, tempTargetRegister, _baseRegister,
+            generateTrg1Src2ExtendedInstruction(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister,
                 _indexRegister, TR::EXT_SXTW, _scale);
         } else {
-            generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, srcTree, tempTargetRegister, _baseRegister,
-                _indexRegister, TR::SH_LSL, _scale);
+            generateTrg1Src2ShiftedInstruction(cg, OP::addx, srcTree, tempTargetRegister, _baseRegister, _indexRegister,
+                TR::SH_LSL, _scale);
         }
     } else if (_scale != 0) {
         generateLogicalShiftLeftImmInstruction(cg, srcTree, tempTargetRegister, _indexRegister, _scale, true);
         if (self()->isIndexZeroExtendedWord()) {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, srcTree, tempTargetRegister, tempTargetRegister,
-                31);
+            generateTrg1Src1ImmInstruction(cg, OP::ubfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
         } else if (self()->isIndexSignExtendedWord()) {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, tempTargetRegister,
-                31);
+            generateTrg1Src1ImmInstruction(cg, OP::sbfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
         }
     } else if (self()->isIndexZeroExtendedWord()) {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, srcTree, tempTargetRegister, _indexRegister, 31);
+        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else if (self()->isIndexSignExtendedWord()) {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
+        generateTrg1Src1ImmInstruction(cg, OP::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else {
         TR_ASSERT_FATAL(false,
             "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexZeroExtendedWord() || "
@@ -848,56 +843,56 @@ void OMR::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstru
     }
 }
 
-TR::InstOpCode::Mnemonic OMR::ARM64::MemoryReference::mapOpCode(TR::InstOpCode::Mnemonic mnemonic)
+OP::Mnemonic OMR::ARM64::MemoryReference::mapOpCode(OP::Mnemonic mnemonic)
 {
     if (self()->getIndexRegister() != NULL) {
         switch (mnemonic) {
-            case TR::InstOpCode::ldrbimm:
-                return TR::InstOpCode::ldrboff;
-            case TR::InstOpCode::ldrsbimmw:
-                return TR::InstOpCode::ldrsboffw;
-            case TR::InstOpCode::ldrsbimmx:
-                return TR::InstOpCode::ldrsboffx;
-            case TR::InstOpCode::ldrhimm:
-                return TR::InstOpCode::ldrhoff;
-            case TR::InstOpCode::ldrshimmw:
-                return TR::InstOpCode::ldrshoffw;
-            case TR::InstOpCode::ldrshimmx:
-                return TR::InstOpCode::ldrshoffx;
-            case TR::InstOpCode::ldrimmw:
-                return TR::InstOpCode::ldroffw;
-            case TR::InstOpCode::ldrswimm:
-                return TR::InstOpCode::ldrswoff;
-            case TR::InstOpCode::ldrimmx:
-                return TR::InstOpCode::ldroffx;
-            case TR::InstOpCode::vldrimmb:
-                return TR::InstOpCode::vldroffb;
-            case TR::InstOpCode::vldrimmh:
-                return TR::InstOpCode::vldroffh;
-            case TR::InstOpCode::vldrimms:
-                return TR::InstOpCode::vldroffs;
-            case TR::InstOpCode::vldrimmd:
-                return TR::InstOpCode::vldroffd;
-            case TR::InstOpCode::vldrimmq:
-                return TR::InstOpCode::vldroffq;
-            case TR::InstOpCode::strbimm:
-                return TR::InstOpCode::strboff;
-            case TR::InstOpCode::strhimm:
-                return TR::InstOpCode::strhoff;
-            case TR::InstOpCode::strimmw:
-                return TR::InstOpCode::stroffw;
-            case TR::InstOpCode::strimmx:
-                return TR::InstOpCode::stroffx;
-            case TR::InstOpCode::vstrimmb:
-                return TR::InstOpCode::vstroffb;
-            case TR::InstOpCode::vstrimmh:
-                return TR::InstOpCode::vstroffh;
-            case TR::InstOpCode::vstrimms:
-                return TR::InstOpCode::vstroffs;
-            case TR::InstOpCode::vstrimmd:
-                return TR::InstOpCode::vstroffd;
-            case TR::InstOpCode::vstrimmq:
-                return TR::InstOpCode::vstroffq;
+            case OP::ldrbimm:
+                return OP::ldrboff;
+            case OP::ldrsbimmw:
+                return OP::ldrsboffw;
+            case OP::ldrsbimmx:
+                return OP::ldrsboffx;
+            case OP::ldrhimm:
+                return OP::ldrhoff;
+            case OP::ldrshimmw:
+                return OP::ldrshoffw;
+            case OP::ldrshimmx:
+                return OP::ldrshoffx;
+            case OP::ldrimmw:
+                return OP::ldroffw;
+            case OP::ldrswimm:
+                return OP::ldrswoff;
+            case OP::ldrimmx:
+                return OP::ldroffx;
+            case OP::vldrimmb:
+                return OP::vldroffb;
+            case OP::vldrimmh:
+                return OP::vldroffh;
+            case OP::vldrimms:
+                return OP::vldroffs;
+            case OP::vldrimmd:
+                return OP::vldroffd;
+            case OP::vldrimmq:
+                return OP::vldroffq;
+            case OP::strbimm:
+                return OP::strboff;
+            case OP::strhimm:
+                return OP::strhoff;
+            case OP::strimmw:
+                return OP::stroffw;
+            case OP::strimmx:
+                return OP::stroffx;
+            case OP::vstrimmb:
+                return OP::vstroffb;
+            case OP::vstrimmh:
+                return OP::vstroffh;
+            case OP::vstrimms:
+                return OP::vstroffs;
+            case OP::vstrimmd:
+                return OP::vstroffd;
+            case OP::vstrimmq:
+                return OP::vstroffq;
             default:
                 break;
         }
@@ -912,20 +907,18 @@ TR::InstOpCode::Mnemonic OMR::ARM64::MemoryReference::mapOpCode(TR::InstOpCode::
  * @param[in] mnemonic: mnemonic
  * @return true if the scale is valid
  */
-static bool isValidScale(uint8_t scale, TR::InstOpCode::Mnemonic mnemonic)
+static bool isValidScale(uint8_t scale, OP::Mnemonic mnemonic)
 {
     return (((scale == 1)
-                && ((mnemonic == TR::InstOpCode::ldrhoff) || (mnemonic == TR::InstOpCode::ldrshoffw)
-                    || (mnemonic == TR::InstOpCode::ldrshoffx) || (mnemonic == TR::InstOpCode::strhoff)
-                    || (mnemonic == TR::InstOpCode::vldroffh) || (mnemonic == TR::InstOpCode::vstroffh)))
+                && ((mnemonic == OP::ldrhoff) || (mnemonic == OP::ldrshoffw) || (mnemonic == OP::ldrshoffx)
+                    || (mnemonic == OP::strhoff) || (mnemonic == OP::vldroffh) || (mnemonic == OP::vstroffh)))
         || ((scale == 2)
-            && ((mnemonic == TR::InstOpCode::ldroffw) || (mnemonic == TR::InstOpCode::ldrswoff)
-                || (mnemonic == TR::InstOpCode::stroffw) || (mnemonic == TR::InstOpCode::vldroffs)
-                || (mnemonic == TR::InstOpCode::vstroffs)))
+            && ((mnemonic == OP::ldroffw) || (mnemonic == OP::ldrswoff) || (mnemonic == OP::stroffw)
+                || (mnemonic == OP::vldroffs) || (mnemonic == OP::vstroffs)))
         || ((scale == 3)
-            && ((mnemonic == TR::InstOpCode::ldroffx) || (mnemonic == TR::InstOpCode::stroffx)
-                || (mnemonic == TR::InstOpCode::vldroffd) || (mnemonic == TR::InstOpCode::vstroffd)))
-        || ((scale == 4) && ((mnemonic == TR::InstOpCode::vldroffq) || (mnemonic == TR::InstOpCode::vstroffq))));
+            && ((mnemonic == OP::ldroffx) || (mnemonic == OP::stroffx) || (mnemonic == OP::vldroffd)
+                || (mnemonic == OP::vstroffd)))
+        || ((scale == 4) && ((mnemonic == OP::vldroffq) || (mnemonic == OP::vstroffq))));
 }
 
 /* register offset */
@@ -955,129 +948,129 @@ static bool isAtomicOperationInstruction(uint32_t enc) { return ((enc & 0x3b200c
 /* vector memory access: vstrimmq or vldrimmq */
 static bool isImm12VectorMemoryAccess(uint32_t enc) { return ((enc & 0xffb00000) == 0x3d800000); }
 
-static TR::InstOpCode::Mnemonic getEquivalentRegisterOffsetMnemonic(TR::InstOpCode::Mnemonic op)
+static OP::Mnemonic getEquivalentRegisterOffsetMnemonic(OP::Mnemonic op)
 {
     switch (op) {
-        case TR::InstOpCode::ldurb:
-        case TR::InstOpCode::ldrbimm:
-            return TR::InstOpCode::ldrboff;
-        case TR::InstOpCode::ldursbw:
-        case TR::InstOpCode::ldrsbimmw:
-            return TR::InstOpCode::ldrsboffw;
-        case TR::InstOpCode::ldursbx:
-        case TR::InstOpCode::ldrsbimmx:
-            return TR::InstOpCode::ldrsboffx;
-        case TR::InstOpCode::ldurh:
-        case TR::InstOpCode::ldrhimm:
-            return TR::InstOpCode::ldrhoff;
-        case TR::InstOpCode::ldurshw:
-        case TR::InstOpCode::ldrshimmw:
-            return TR::InstOpCode::ldrshoffw;
-        case TR::InstOpCode::ldurshx:
-        case TR::InstOpCode::ldrshimmx:
-            return TR::InstOpCode::ldrshoffx;
-        case TR::InstOpCode::ldurw:
-        case TR::InstOpCode::ldrimmw:
-            return TR::InstOpCode::ldroffw;
-        case TR::InstOpCode::ldurx:
-        case TR::InstOpCode::ldrimmx:
-            return TR::InstOpCode::ldroffx;
-        case TR::InstOpCode::vldurb:
-        case TR::InstOpCode::vldrimmb:
-            return TR::InstOpCode::vldroffb;
-        case TR::InstOpCode::vldurh:
-        case TR::InstOpCode::vldrimmh:
-            return TR::InstOpCode::vldroffh;
-        case TR::InstOpCode::vldurs:
-        case TR::InstOpCode::vldrimms:
-            return TR::InstOpCode::vldroffs;
-        case TR::InstOpCode::vldurd:
-        case TR::InstOpCode::vldrimmd:
-            return TR::InstOpCode::vldroffd;
-        case TR::InstOpCode::vldurq:
-        case TR::InstOpCode::vldrimmq:
-            return TR::InstOpCode::vldroffq;
+        case OP::ldurb:
+        case OP::ldrbimm:
+            return OP::ldrboff;
+        case OP::ldursbw:
+        case OP::ldrsbimmw:
+            return OP::ldrsboffw;
+        case OP::ldursbx:
+        case OP::ldrsbimmx:
+            return OP::ldrsboffx;
+        case OP::ldurh:
+        case OP::ldrhimm:
+            return OP::ldrhoff;
+        case OP::ldurshw:
+        case OP::ldrshimmw:
+            return OP::ldrshoffw;
+        case OP::ldurshx:
+        case OP::ldrshimmx:
+            return OP::ldrshoffx;
+        case OP::ldurw:
+        case OP::ldrimmw:
+            return OP::ldroffw;
+        case OP::ldurx:
+        case OP::ldrimmx:
+            return OP::ldroffx;
+        case OP::vldurb:
+        case OP::vldrimmb:
+            return OP::vldroffb;
+        case OP::vldurh:
+        case OP::vldrimmh:
+            return OP::vldroffh;
+        case OP::vldurs:
+        case OP::vldrimms:
+            return OP::vldroffs;
+        case OP::vldurd:
+        case OP::vldrimmd:
+            return OP::vldroffd;
+        case OP::vldurq:
+        case OP::vldrimmq:
+            return OP::vldroffq;
 
-        case TR::InstOpCode::sturb:
-        case TR::InstOpCode::strbimm:
-            return TR::InstOpCode::strboff;
-        case TR::InstOpCode::sturh:
-        case TR::InstOpCode::strhimm:
-            return TR::InstOpCode::strhoff;
-        case TR::InstOpCode::sturw:
-        case TR::InstOpCode::strimmw:
-            return TR::InstOpCode::stroffw;
-        case TR::InstOpCode::sturx:
-        case TR::InstOpCode::strimmx:
-            return TR::InstOpCode::stroffx;
-        case TR::InstOpCode::vsturb:
-        case TR::InstOpCode::vstrimmb:
-            return TR::InstOpCode::vstroffb;
-        case TR::InstOpCode::vsturh:
-        case TR::InstOpCode::vstrimmh:
-            return TR::InstOpCode::vstroffh;
-        case TR::InstOpCode::vsturs:
-        case TR::InstOpCode::vstrimms:
-            return TR::InstOpCode::vstroffs;
-        case TR::InstOpCode::vsturd:
-        case TR::InstOpCode::vstrimmd:
-            return TR::InstOpCode::vstroffd;
-        case TR::InstOpCode::vsturq:
-        case TR::InstOpCode::vstrimmq:
-            return TR::InstOpCode::vstroffq;
+        case OP::sturb:
+        case OP::strbimm:
+            return OP::strboff;
+        case OP::sturh:
+        case OP::strhimm:
+            return OP::strhoff;
+        case OP::sturw:
+        case OP::strimmw:
+            return OP::stroffw;
+        case OP::sturx:
+        case OP::strimmx:
+            return OP::stroffx;
+        case OP::vsturb:
+        case OP::vstrimmb:
+            return OP::vstroffb;
+        case OP::vsturh:
+        case OP::vstrimmh:
+            return OP::vstroffh;
+        case OP::vsturs:
+        case OP::vstrimms:
+            return OP::vstroffs;
+        case OP::vsturd:
+        case OP::vstrimmd:
+            return OP::vstroffd;
+        case OP::vsturq:
+        case OP::vstrimmq:
+            return OP::vstroffq;
         default:
-            return TR::InstOpCode::bad;
+            return OP::bad;
     }
 }
 
-static TR::InstOpCode::Mnemonic getEquivalentUnscaledOffsetMnemonic(TR::InstOpCode::Mnemonic op)
+static OP::Mnemonic getEquivalentUnscaledOffsetMnemonic(OP::Mnemonic op)
 {
     switch (op) {
-        case TR::InstOpCode::ldrbimm:
-            return TR::InstOpCode::ldurb;
-        case TR::InstOpCode::ldrsbimmw:
-            return TR::InstOpCode::ldursbw;
-        case TR::InstOpCode::ldrsbimmx:
-            return TR::InstOpCode::ldursbx;
-        case TR::InstOpCode::ldrhimm:
-            return TR::InstOpCode::ldurh;
-        case TR::InstOpCode::ldrshimmw:
-            return TR::InstOpCode::ldurshw;
-        case TR::InstOpCode::ldrshimmx:
-            return TR::InstOpCode::ldurshx;
-        case TR::InstOpCode::ldrimmw:
-            return TR::InstOpCode::ldurw;
-        case TR::InstOpCode::ldrimmx:
-            return TR::InstOpCode::ldurx;
-        case TR::InstOpCode::vldrimmb:
-            return TR::InstOpCode::vldurb;
-        case TR::InstOpCode::vldrimmh:
-            return TR::InstOpCode::vldurh;
-        case TR::InstOpCode::vldrimms:
-            return TR::InstOpCode::vldurs;
-        case TR::InstOpCode::vldrimmd:
-            return TR::InstOpCode::vldurd;
-        case TR::InstOpCode::vldrimmq:
-            return TR::InstOpCode::vldurq;
+        case OP::ldrbimm:
+            return OP::ldurb;
+        case OP::ldrsbimmw:
+            return OP::ldursbw;
+        case OP::ldrsbimmx:
+            return OP::ldursbx;
+        case OP::ldrhimm:
+            return OP::ldurh;
+        case OP::ldrshimmw:
+            return OP::ldurshw;
+        case OP::ldrshimmx:
+            return OP::ldurshx;
+        case OP::ldrimmw:
+            return OP::ldurw;
+        case OP::ldrimmx:
+            return OP::ldurx;
+        case OP::vldrimmb:
+            return OP::vldurb;
+        case OP::vldrimmh:
+            return OP::vldurh;
+        case OP::vldrimms:
+            return OP::vldurs;
+        case OP::vldrimmd:
+            return OP::vldurd;
+        case OP::vldrimmq:
+            return OP::vldurq;
 
-        case TR::InstOpCode::strbimm:
-            return TR::InstOpCode::sturb;
-        case TR::InstOpCode::strhimm:
-            return TR::InstOpCode::sturh;
-        case TR::InstOpCode::strimmw:
-            return TR::InstOpCode::sturw;
-        case TR::InstOpCode::strimmx:
-            return TR::InstOpCode::sturx;
-        case TR::InstOpCode::vstrimmh:
-            return TR::InstOpCode::vsturh;
-        case TR::InstOpCode::vstrimms:
-            return TR::InstOpCode::vsturs;
-        case TR::InstOpCode::vstrimmd:
-            return TR::InstOpCode::vsturd;
-        case TR::InstOpCode::vstrimmq:
-            return TR::InstOpCode::vsturq;
+        case OP::strbimm:
+            return OP::sturb;
+        case OP::strhimm:
+            return OP::sturh;
+        case OP::strimmw:
+            return OP::sturw;
+        case OP::strimmx:
+            return OP::sturx;
+        case OP::vstrimmh:
+            return OP::vsturh;
+        case OP::vstrimms:
+            return OP::vsturs;
+        case OP::vstrimmd:
+            return OP::vsturd;
+        case OP::vstrimmq:
+            return OP::vsturq;
         default:
-            return TR::InstOpCode::bad;
+            return OP::bad;
     }
 }
 
@@ -1097,9 +1090,9 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
         TR_ASSERT_FATAL(!((base != NULL) && (index != NULL) && (displacement != 0)),
             "AArch64 does not support [base + index + offset] form of memory access");
 
-        TR::InstOpCode op = currentInstruction->getOpCode();
+        OP op = currentInstruction->getOpCode();
 
-        if (op.getMnemonic() != TR::InstOpCode::addimmx) {
+        if (op.getMnemonic() != OP::addimmx) {
             // load/store instruction
             uint32_t enc = (uint32_t)op.getOpCodeBinaryEncoding();
 
@@ -1209,7 +1202,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
                             : TR::RealRegister::x12);
                     stackPtr = cg->getStackPointerRegister();
                     // stur immreg, [sp, -8]
-                    *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::sturx) | (0x1F8 << 12);
+                    *wcursor = OP::getOpCodeBinaryEncoding(OP::sturx) | (0x1F8 << 12);
                     immreg->setRegisterFieldRT(wcursor);
                     stackPtr->setRegisterFieldRN(wcursor);
                     wcursor++;
@@ -1221,14 +1214,13 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
                 // movzw immreg, low16bit
                 // movkw immreg, high16bit, LSL #16
                 // addx treg, basereg, immreg, SXTW
-                *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::movzw) | (lower << 5);
+                *wcursor = OP::getOpCodeBinaryEncoding(OP::movzw) | (lower << 5);
                 immreg->setRegisterFieldRD(wcursor);
                 wcursor++;
-                *wcursor
-                    = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::movkw) | ((upper | TR::MOV_LSL16) << 5);
+                *wcursor = OP::getOpCodeBinaryEncoding(OP::movkw) | ((upper | TR::MOV_LSL16) << 5);
                 immreg->setRegisterFieldRD(wcursor);
                 wcursor++;
-                *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::addextx) | (TR::EXT_SXTW << 13);
+                *wcursor = OP::getOpCodeBinaryEncoding(OP::addextx) | (TR::EXT_SXTW << 13);
                 base->setRegisterFieldRN(wcursor);
                 immreg->setRegisterFieldRM(wcursor);
                 treg->setRegisterFieldRD(wcursor);
@@ -1237,7 +1229,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 
                 if (needSpill) {
                     // ldur immreg, [sp, -8]
-                    *wcursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::ldurx) | (0x1F8 << 12);
+                    *wcursor = OP::getOpCodeBinaryEncoding(OP::ldurx) | (0x1F8 << 12);
                     immreg->setRegisterFieldRT(wcursor);
                     stackPtr->setRegisterFieldRN(wcursor);
                     wcursor++;
@@ -1269,8 +1261,8 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
         bool trace = comp->getOption(TR_TraceCG);
         TR_Debug *debugObj = cg->getDebug();
 
-        TR::InstOpCode op = currentInstruction->getOpCode();
-        if (op.getMnemonic() != TR::InstOpCode::addimmx) {
+        OP op = currentInstruction->getOpCode();
+        if (op.getMnemonic() != OP::addimmx) {
             // load/store instruction
             if (self()->getIndexRegister()) {
                 return currentInstruction;
@@ -1285,9 +1277,8 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                         if (isImm9UnscaledOffsetInstruction(enc)) {
                             if (isBaseModifiable() && constantIsUnsignedImm12(displacement)) {
                                 TR::Instruction *prev = currentInstruction->getPrev();
-                                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw,
-                                    currentInstruction->getNode(), self()->getBaseRegister(), self()->getBaseRegister(),
-                                    displacement, prev);
+                                generateTrg1Src1ImmInstruction(cg, OP::addimmw, currentInstruction->getNode(),
+                                    self()->getBaseRegister(), self()->getBaseRegister(), displacement, prev);
                                 self()->setOffset(0);
                                 return currentInstruction;
                             } else {
@@ -1296,10 +1287,10 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                                 TR::RealRegister *x16 = cg->machine()->getRealRegister(TR::RealRegister::x16);
                                 TR::Instruction *prev = currentInstruction->getPrev();
                                 loadConstant32(cg, currentInstruction->getNode(), displacement, x16, prev);
-                                TR::InstOpCode::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
+                                OP::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
 
                                 if (trace && debugObj) {
-                                    TR::InstOpCode newOpCode(newOp);
+                                    OP newOpCode(newOp);
                                     log->printf("Replacing opcode of instruction %p from %s to %s\n",
                                         currentInstruction, debugObj->getOpCodeName(&op),
                                         debugObj->getOpCodeName(&newOpCode));
@@ -1324,10 +1315,10 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                         TR::RealRegister *x16 = cg->machine()->getRealRegister(TR::RealRegister::x16);
                         TR::Instruction *prev = currentInstruction->getPrev();
                         loadConstant32(cg, currentInstruction->getNode(), displacement, x16, prev);
-                        TR::InstOpCode::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
+                        OP::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
 
                         if (trace && debugObj) {
-                            TR::InstOpCode newOpCode(newOp);
+                            OP newOpCode(newOp);
                             comp->log()->printf("Replacing opcode of instruction %p from %s to %s\n",
                                 currentInstruction, debugObj->getOpCodeName(&op), debugObj->getOpCodeName(&newOpCode));
                         }
@@ -1342,10 +1333,10 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                     } else {
                         if (displacement < 0 && constantIsImm9(displacement)) {
                             /* rewrite the instruction ldrimm -> ldur  */
-                            TR::InstOpCode::Mnemonic newOp = getEquivalentUnscaledOffsetMnemonic(op.getMnemonic());
+                            OP::Mnemonic newOp = getEquivalentUnscaledOffsetMnemonic(op.getMnemonic());
 
                             if (trace && debugObj) {
-                                TR::InstOpCode newOpCode(newOp);
+                                OP newOpCode(newOp);
                                 log->printf("Replacing opcode of instruction %p from %s to %s\n", currentInstruction,
                                     debugObj->getOpCodeName(&op), debugObj->getOpCodeName(&newOpCode));
                             }
@@ -1357,10 +1348,10 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                             TR::RealRegister *x16 = cg->machine()->getRealRegister(TR::RealRegister::x16);
                             TR::Instruction *prev = currentInstruction->getPrev();
                             loadConstant32(cg, currentInstruction->getNode(), displacement, x16, prev);
-                            TR::InstOpCode::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
+                            OP::Mnemonic newOp = getEquivalentRegisterOffsetMnemonic(op.getMnemonic());
 
                             if (trace && debugObj) {
-                                TR::InstOpCode newOpCode(newOp);
+                                OP newOpCode(newOp);
                                 log->printf("Replacing opcode of instruction %p from %s to %s\n", currentInstruction,
                                     debugObj->getOpCodeName(&op), debugObj->getOpCodeName(&newOpCode));
                             }
@@ -1417,12 +1408,12 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
     return currentInstruction;
 }
 
-uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
+uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(OP op)
 {
     if (self()->getUnresolvedSnippet() != NULL) {
         TR_UNIMPLEMENTED();
     } else {
-        if (op.getMnemonic() != TR::InstOpCode::addimmx) {
+        if (op.getMnemonic() != OP::addimmx) {
             return ARM64_INSTRUCTION_LENGTH;
         } else {
             // addimmx instruction

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -467,7 +467,7 @@ public:
      * @param[in] mnemonic : mnemonic
      * @return mnemonic
      */
-    TR::InstOpCode::Mnemonic mapOpCode(TR::InstOpCode::Mnemonic op);
+    OP::Mnemonic mapOpCode(OP::Mnemonic op);
 
     /**
      * @brief Assigns registers
@@ -481,7 +481,7 @@ public:
      * @param[in] op : opcode of the instruction to attach this memory reference to
      * @return estimated binary length
      */
-    uint32_t estimateBinaryLength(TR::InstOpCode op);
+    uint32_t estimateBinaryLength(OP op);
 
     /**
      * @brief Generates binary encoding

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -110,12 +110,12 @@ OMR::ARM64::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeG
                 iCursor = generateMovInstruction(cg, node, copyReg, reg, true, iCursor);
             } else if (kind == TR_VRF) {
                 copyReg = cg->allocateRegister(TR_VRF);
-                iCursor = generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, copyReg, reg, reg, iCursor);
+                iCursor = generateTrg1Src2Instruction(cg, OP::vorr16b, node, copyReg, reg, reg, iCursor);
             } else {
                 bool isSinglePrecision = reg->isSinglePrecision();
                 copyReg = isSinglePrecision ? cg->allocateSinglePrecisionRegister() : cg->allocateRegister(TR_FPR);
-                iCursor = generateTrg1Src1Instruction(cg,
-                    isSinglePrecision ? TR::InstOpCode::fmovs : TR::InstOpCode::fmovd, node, copyReg, reg, iCursor);
+                iCursor = generateTrg1Src1Instruction(cg, isSinglePrecision ? OP::fmovs : OP::fmovd, node, copyReg, reg,
+                    iCursor);
             }
 
             reg = copyReg;
@@ -276,7 +276,7 @@ bool OMR::ARM64::RegisterDependencyConditions::usesRegister(TR::Register *r)
 
 void OMR::ARM64::RegisterDependencyConditions::bookKeepingRegisterUses(TR::Instruction *instr, TR::CodeGenerator *cg)
 {
-    if (instr->getOpCodeValue() == TR::InstOpCode::assocreg)
+    if (instr->getOpCodeValue() == OP::assocreg)
         return;
 
     // We create a register association directive for each dependency
@@ -416,16 +416,16 @@ void OMR::ARM64::RegisterDependencyGroup::assignRegisters(TR::Instruction *curre
                 TR::MemoryReference *tempMR = MRef_sym(cg, currentNode,
                     (TR::SymbolReference *)virtReg->getBackingStorage()->getSymbolReference());
                 TR_RegisterKinds rk = virtReg->getKind();
-                TR::InstOpCode::Mnemonic opCode;
+                OP::Mnemonic opCode;
                 switch (rk) {
                     case TR_GPR:
-                        opCode = TR::InstOpCode::ldrimmx;
+                        opCode = OP::ldrimmx;
                         break;
                     case TR_FPR:
-                        opCode = TR::InstOpCode::vldrimmd;
+                        opCode = OP::vldrimmd;
                         break;
                     case TR_VRF:
-                        opCode = TR::InstOpCode::vldrimmq;
+                        opCode = OP::vldrimmq;
                         break;
                     default:
                         TR_ASSERT(0, "\nRegister kind not supported in OOL spill");

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -875,7 +875,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::PassThroughEvaluator(TR::Node *node, TR
  * @return instruction cursor if an instruction is successfully generated and otherwise returns NULL
  */
 static TR::Instruction *tryToGenerateImm16ShiftedInstrucion(TR::Node *node, TR::CodeGenerator *cg, TR::Register *treg,
-    TR::InstOpCode::Mnemonic op, uint16_t value)
+    OP::Mnemonic op, uint16_t value)
 {
     if ((value & 0xff00) == 0) {
         return generateTrg1ImmInstruction(cg, op, node, treg, value & 0xff);
@@ -897,7 +897,7 @@ static TR::Instruction *tryToGenerateImm16ShiftedInstrucion(TR::Node *node, TR::
  * @return instruction cursor if an instruction is successfully generated and otherwise returns NULL
  */
 static TR::Instruction *tryToGenerateImm32ShiftedInstruction(TR::Node *node, TR::CodeGenerator *cg, TR::Register *treg,
-    TR::InstOpCode::Mnemonic op, uint32_t value)
+    OP::Mnemonic op, uint32_t value)
 {
     if ((value & 0xffffff00) == 0) {
         return generateTrg1ImmInstruction(cg, op, node, treg, value & 0xff);
@@ -923,7 +923,7 @@ static TR::Instruction *tryToGenerateImm32ShiftedInstruction(TR::Node *node, TR:
  * @return instruction cursor if an instruction is successfully generated and otherwise returns NULL
  */
 static TR::Instruction *tryToGenerateImm32ShiftingOnesInstruction(TR::Node *node, TR::CodeGenerator *cg,
-    TR::Register *treg, TR::InstOpCode::Mnemonic op, uint32_t value)
+    TR::Register *treg, OP::Mnemonic op, uint32_t value)
 {
     if ((value & 0xffff00ff) == 0xff) {
         return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 8) & 0xff, 8);
@@ -945,7 +945,7 @@ static TR::Instruction *tryToGenerateImm32ShiftingOnesInstruction(TR::Node *node
  * @return instruction cursor if an instruction is successfully generated and otherwise returns NULL
  */
 static TR::Instruction *tryToGenerateImm64Instruction(TR::Node *node, TR::CodeGenerator *cg, TR::Register *treg,
-    TR::InstOpCode::Mnemonic op, uint64_t value)
+    OP::Mnemonic op, uint64_t value)
 {
     /* Special encoding for the 64-bit variant of MOVI */
     uint8_t imm = 0;
@@ -977,13 +977,13 @@ static TR::Instruction *tryToGenerateMovImm16ShiftedInstruction(TR::Node *node, 
     uint8_t lower8bit = value & 0xff;
     uint8_t upper8bit = (value >> 8) & 0xff;
     if (lower8bit == upper8bit) {
-        return generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, treg, lower8bit);
+        return generateTrg1ImmInstruction(cg, OP::vmovi16b, node, treg, lower8bit);
     }
 
     TR::Instruction *instr;
-    if ((instr = tryToGenerateImm16ShiftedInstrucion(node, cg, treg, TR::InstOpCode::vmovi8h, value))) {
+    if ((instr = tryToGenerateImm16ShiftedInstrucion(node, cg, treg, OP::vmovi8h, value))) {
         return instr;
-    } else if ((instr = tryToGenerateImm16ShiftedInstrucion(node, cg, treg, TR::InstOpCode::vmvni8h, ~value))) {
+    } else if ((instr = tryToGenerateImm16ShiftedInstrucion(node, cg, treg, OP::vmvni8h, ~value))) {
         return instr;
     }
     return NULL;
@@ -1010,15 +1010,13 @@ static TR::Instruction *tryToGenerateMovImm32ShiftedInstruction(TR::Node *node, 
         if ((instr = tryToGenerateMovImm16ShiftedInstruction(node, cg, treg, lower16bit))) {
             return instr;
         }
-    } else if ((instr = tryToGenerateImm32ShiftedInstruction(node, cg, treg, TR::InstOpCode::vmovi4s, value))) {
+    } else if ((instr = tryToGenerateImm32ShiftedInstruction(node, cg, treg, OP::vmovi4s, value))) {
         return instr;
-    } else if ((instr = tryToGenerateImm32ShiftedInstruction(node, cg, treg, TR::InstOpCode::vmvni4s, ~value))) {
+    } else if ((instr = tryToGenerateImm32ShiftedInstruction(node, cg, treg, OP::vmvni4s, ~value))) {
         return instr;
-    } else if ((instr
-                   = tryToGenerateImm32ShiftingOnesInstruction(node, cg, treg, TR::InstOpCode::vmovi4s_one, value))) {
+    } else if ((instr = tryToGenerateImm32ShiftingOnesInstruction(node, cg, treg, OP::vmovi4s_one, value))) {
         return instr;
-    } else if ((instr
-                   = tryToGenerateImm32ShiftingOnesInstruction(node, cg, treg, TR::InstOpCode::vmvni4s_one, ~value))) {
+    } else if ((instr = tryToGenerateImm32ShiftingOnesInstruction(node, cg, treg, OP::vmvni4s_one, ~value))) {
         return instr;
     }
     return NULL;
@@ -1056,9 +1054,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mmAnyTrueEvaluator(TR::Node *node, TR::
      * cmp   x0, #0
      * cset  x0, ne
      */
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vand16b, node, tempReg, maskReg, mask2Reg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vumaxp4s, node, tempReg, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resultReg, tempReg, 0);
+    generateTrg1Src2Instruction(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
+    generateTrg1Src2Instruction(cg, OP::vumaxp4s, node, tempReg, tempReg, tempReg);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resultReg, tempReg, 0);
     generateCompareImmInstruction(cg, node, resultReg, 0, true);
     generateCSetInstruction(cg, node, resultReg, TR::CC_NE);
 
@@ -1091,9 +1089,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mmAllTrueEvaluator(TR::Node *node, TR::
      * cmn   x0, #1
      * cset  x0, eq
      */
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vand16b, node, tempReg, maskReg, mask2Reg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vuminp4s, node, tempReg, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resultReg, tempReg, 0);
+    generateTrg1Src2Instruction(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
+    generateTrg1Src2Instruction(cg, OP::vuminp4s, node, tempReg, tempReg, tempReg);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resultReg, tempReg, 0);
     generateCompareImmInstruction(cg, node, resultReg, -1, true);
     generateCSetInstruction(cg, node, resultReg, TR::CC_EQ);
 
@@ -1140,25 +1138,25 @@ TR::Register *OMR::ARM64::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR:
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *resReg = cg->allocateRegister();
-    TR::InstOpCode::Mnemonic negOp;
-    TR::InstOpCode::Mnemonic addvOp;
+    OP::Mnemonic negOp;
+    OP::Mnemonic addvOp;
 
     switch (et) {
         case TR::Int8:
-            negOp = TR::InstOpCode::vneg16b;
-            addvOp = TR::InstOpCode::vaddv16b;
+            negOp = OP::vneg16b;
+            addvOp = OP::vaddv16b;
             break;
         case TR::Int16:
-            negOp = TR::InstOpCode::vneg8h;
-            addvOp = TR::InstOpCode::vaddv8h;
+            negOp = OP::vneg8h;
+            addvOp = OP::vaddv8h;
             break;
         case TR::Int32:
-            negOp = TR::InstOpCode::vneg4s;
-            addvOp = TR::InstOpCode::vaddv4s;
+            negOp = OP::vneg4s;
+            addvOp = OP::vaddv4s;
             break;
         case TR::Int64:
-            negOp = TR::InstOpCode::vneg2d;
-            addvOp = TR::InstOpCode::vaddv4s; /* we do not have addv for long, but vaddv4s works for this case */
+            negOp = OP::vneg2d;
+            addvOp = OP::vaddv4s; /* we do not have addv for long, but vaddv4s works for this case */
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1167,7 +1165,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR:
 
     generateTrg1Src1Instruction(cg, negOp, node, tempReg, maskReg);
     generateTrg1Src1Instruction(cg, addvOp, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovwb, node, resReg, tempReg, 0);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovwb, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1200,10 +1198,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #2                  ; Divides by 4.
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, tempReg, maskReg, 4);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 2, true);
             break;
         case TR::Int16:
@@ -1214,10 +1212,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #3                  ; Divides by 8.
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_4h, node, tempReg, maskReg, 8);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 3, true);
             break;
         case TR::Int32:
@@ -1228,10 +1226,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #4                  ; Divides by 16.
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_2s, node, tempReg, maskReg, 16);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, true);
             break;
         case TR::Int64:
@@ -1242,9 +1240,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     w0, w0                      ; Counts leading zeros.
              * lsr     w0, w0, #4                  ; Divides by 16.
              */
-            generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tempReg, maskReg, maskReg, 2);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovws, node, resReg, tempReg, 3);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzw, node, resReg, resReg);
+            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 2);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 3);
+            generateTrg1Src1Instruction(cg, OP::clzw, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, false);
             break;
         default:
@@ -1285,12 +1283,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #2                  ; Divides by 4.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, tempReg, maskReg, 4);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 15, maxLaneReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 2, true);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, resReg, maxLaneReg, resReg);
+            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int16:
             /*
@@ -1301,12 +1299,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #3                  ; Divides by 8.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_4h, node, tempReg, maskReg, 8);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 7, maxLaneReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 3, true);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, resReg, maxLaneReg, resReg);
+            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int32:
             /*
@@ -1317,12 +1315,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #4                  ; Divides by 16.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_2s, node, tempReg, maskReg, 16);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 3, maxLaneReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, true);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, resReg, maxLaneReg, resReg);
+            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int64:
             /*
@@ -1333,12 +1331,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #5
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_2s, node, tempReg, maskReg, 32);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 32);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 1, maxLaneReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, resReg, resReg);
+            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
             generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 5, true);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, resReg, maxLaneReg, resReg);
+            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1377,11 +1375,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #24, #20            ; Inserts bit 0 - 19 into bit 24 - 43.
              * ubfx    x0, x0, #36, #16            ; Moves bit 36 - 51 to bit 0 - 15. Other bits are cleared.
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, tempReg, maskReg, 7);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli16b, node, tempReg, tempReg, 6);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr8h, node, tempReg, tempReg, 6);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli8h, node, tempReg, tempReg, 12);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 7);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli16b, node, tempReg, tempReg, 6);
+            generateVectorShiftImmediateInstruction(cg, OP::vushr8h, node, tempReg, tempReg, 6);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, tempReg, tempReg, 12);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             generateBFIInstruction(cg, node, resReg, resReg, 24, 20, true);
             generateUBFXInstruction(cg, node, resReg, resReg, 36, 16, true);
             break;
@@ -1394,9 +1392,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #28, #18            ; Inserts bit 0 - 17 into bit 28 - 45.
              * ubfx    x0, x0, #42, #8             ; Moves bit 42 - 49 to bit 0 - 7.
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_4h, node, tempReg, maskReg, 15);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli8h, node, tempReg, tempReg, 14);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 15);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, tempReg, tempReg, 14);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             generateBFIInstruction(cg, node, resReg, resReg, 28, 18, true);
             generateUBFXInstruction(cg, node, resReg, resReg, 42, 8, true);
             break;
@@ -1408,8 +1406,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #30, #2
              * ubfx    x0, x0, #30, #4
              */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_2s, node, tempReg, maskReg, 31);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 31);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
             generateBFIInstruction(cg, node, resReg, resReg, 30, 2, true);
             generateUBFXInstruction(cg, node, resReg, resReg, 30, 4, true);
             break;
@@ -1420,8 +1418,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * umov    w0, v1.4s[0]
              * ubfx    w0, w0, #7, #2
              */
-            generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tempReg, maskReg, maskReg, 7);
-            generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovws, node, resReg, tempReg, 0);
+            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
+            generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 0);
             generateUBFXInstruction(cg, node, resReg, resReg, 7, 2, false);
             break;
         default:
@@ -1465,14 +1463,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * sli     v0.8h, v0.8h, #7            ; Bit 0 of each lane in int8x16 vector have mask values.
              * cmtst   v0.16b, v0.16b, v1.16b      ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli2d, node, maskReg, maskReg, 24);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli4s, node, maskReg, maskReg, 12);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli8h, node, maskReg, maskReg, 6);
+            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 24);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 12);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 6);
             generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, tempReg, 1);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli8h, node, maskReg, maskReg, 7);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmtst16b, node, maskReg, maskReg, tempReg);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, tempReg, 1);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 7);
+            generateTrg1Src2Instruction(cg, OP::vcmtst16b, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int16:
             /*
@@ -1487,13 +1485,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * uxtl    v0.8h, v0.8b                ; The lsb of each lane in int16x8 vector has mask values.
              * cmtst   v0.8h, v0.8h, v1.8h         ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli2d, node, maskReg, maskReg, 28);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli4s, node, maskReg, maskReg, 14);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli8h, node, maskReg, maskReg, 7);
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi8h, node, tempReg, 1);
+            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 28);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 14);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 7);
+            generateTrg1ImmInstruction(cg, OP::vmovi8h, node, tempReg, 1);
             generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmtst8h, node, maskReg, maskReg, tempReg);
+            generateTrg1Src2Instruction(cg, OP::vcmtst8h, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int32:
         case TR::Float:
@@ -1507,12 +1505,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * uxtl    v0.4s, v0.4h                ; The lsb of each lane in int32x4 vector has mask values.
              * cmtst   v0.4s, v0.4s, v1.4s         ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli2d, node, maskReg, maskReg, 30);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsli4s, node, maskReg, maskReg, 15);
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi4s, node, tempReg, 1);
+            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 30);
+            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 15);
+            generateTrg1ImmInstruction(cg, OP::vmovi4s, node, tempReg, 1);
             generateVectorUXTLInstruction(cg, TR::Int16, node, maskReg, maskReg, false);
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmtst4s, node, maskReg, maskReg, tempReg);
+            generateTrg1Src2Instruction(cg, OP::vcmtst4s, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int64:
         case TR::Double:
@@ -1525,10 +1523,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * not     v0.16b, v0.16b
              */
             generateUBFIZInstruction(cg, node, tempReg, srcReg, 55, 2, true);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, maskReg, tempReg);
-            generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, maskReg, maskReg, maskReg, 15);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmeq2d_zero, node, maskReg, maskReg);
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::vnot16b, node, maskReg, maskReg);
+            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, tempReg);
+            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 15);
+            generateTrg1Src1Instruction(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
+            generateTrg1Src1Instruction(cg, OP::vnot16b, node, maskReg, maskReg);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1596,38 +1594,38 @@ template<TR::VectorOperation op> TR::ILOpCodes getLoadOpCodeForMaskConversion()
 }
 
 /* This template function should be declared as constexpr if the compiler supports it. */
-template<TR::VectorOperation op> TR::InstOpCode::Mnemonic getLoadInstOpCodeForMaskConversion()
+template<TR::VectorOperation op> OP::Mnemonic getLoadInstOpCodeForMaskConversion()
 {
     static_assert((op == TR::s2m) || (op == TR::i2m) || (op == TR::l2m) || (op == TR::v2m),
         "Expects s2m, i2m, l2m or v2m as opcode");
     switch (op) {
         case TR::s2m:
-            return TR::InstOpCode::vldrimmh;
+            return OP::vldrimmh;
         case TR::i2m:
-            return TR::InstOpCode::vldrimms;
+            return OP::vldrimms;
         case TR::l2m:
-            return TR::InstOpCode::vldrimmd;
+            return OP::vldrimmd;
         case TR::v2m:
         default:
-            return TR::InstOpCode::vldrimmq;
+            return OP::vldrimmq;
     }
 }
 
 /* This template function should be declared as constexpr if the compiler supports it. */
-template<TR::VectorOperation op> TR::InstOpCode::Mnemonic getCopyToGPRInstOpCodeForMaskConversion()
+template<TR::VectorOperation op> OP::Mnemonic getCopyToGPRInstOpCodeForMaskConversion()
 {
     static_assert((op == TR::s2m) || (op == TR::i2m) || (op == TR::l2m) || (op == TR::v2m),
         "Expects s2m, i2m, l2m or v2m as opcode");
     switch (op) {
         case TR::s2m:
-            return TR::InstOpCode::vinswh;
+            return OP::vinswh;
         case TR::i2m:
-            return TR::InstOpCode::vinsws;
+            return OP::vinsws;
         case TR::l2m:
-            return TR::InstOpCode::vinsxd;
+            return OP::vinsxd;
         case TR::v2m:
         default:
-            return TR::InstOpCode::bad;
+            return OP::bad;
     }
 }
 
@@ -1678,8 +1676,8 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
     /* These three variables should be declared as constexpr if the compiler supports it. */
     const TR::ILOpCodes loadOp = getLoadOpCodeForMaskConversion<op>();
     const int32_t size = getSizeForMaskConversion<op>();
-    const TR::InstOpCode::Mnemonic loadInstOp = getLoadInstOpCodeForMaskConversion<op>();
-    const TR::InstOpCode::Mnemonic copyToGPRInstOp = getCopyToGPRInstOpCodeForMaskConversion<op>();
+    const OP::Mnemonic loadInstOp = getLoadInstOpCodeForMaskConversion<op>();
+    const OP::Mnemonic copyToGPRInstOp = getCopyToGPRInstOpCodeForMaskConversion<op>();
 
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *firstReg;
@@ -1693,7 +1691,7 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
         maskReg = cg->allocateRegister(TR_VRF);
         if (op != TR::v2m) {
             /* Clear maskReg, then insert the mask value in GPR to the first element of maskReg. */
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, maskReg, 0);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, maskReg, 0);
             generateMovGPRToVectorElementInstruction(cg, copyToGPRInstOp, node, maskReg, firstReg, 0);
         }
     }
@@ -1704,8 +1702,8 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
          * This makes the first element to be in lower 64bit and the second element to be in upper 64bit.
          * Then, use cmeq to compare each 64bit element with 0.
          */
-        generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, maskReg, maskReg, maskReg, 9);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmeq2d_zero, node, maskReg, maskReg);
+        generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 9);
+        generateTrg1Src1Instruction(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
     } else if (op == TR::i2m) {
         /*
          * Use unsigned extend long instruction to convert 8bit elements to 16bit elements,
@@ -1715,7 +1713,7 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
          */
         generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
         generateVectorUXTLInstruction(cg, TR::Int16, node, maskReg, maskReg, false);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmgt4s_zero, node, maskReg, maskReg);
+        generateTrg1Src1Instruction(cg, OP::vcmgt4s_zero, node, maskReg, maskReg);
     } else if (op == TR::l2m) {
         /*
          * Use unsigned extend long instruction to convert 8bit elements to 16bit elements.
@@ -1723,10 +1721,10 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
          * use cmgt_zero to check if the mask is set.
          */
         generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmgt8h_zero, node, maskReg, maskReg);
+        generateTrg1Src1Instruction(cg, OP::vcmgt8h_zero, node, maskReg, maskReg);
     } else /* op == TR::v2m */
     {
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmeq16b_zero, node, maskReg, firstReg);
+        generateTrg1Src1Instruction(cg, OP::vcmeq16b_zero, node, maskReg, firstReg);
     }
 
     if ((op == TR::s2m) || (op == TR::v2m)) {
@@ -1734,7 +1732,7 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
             TR::Compilation *comp = cg->comp();
             logprintf(comp->getOption(TR_TraceCG), comp->log(), "omitting vnot instruction at node %p\n", node);
         } else {
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::vnot16b, node, maskReg, maskReg);
+            generateTrg1Src1Instruction(cg, OP::vnot16b, node, maskReg, maskReg);
         }
     }
 
@@ -1787,9 +1785,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2sEvaluator(TR::Node *node, TR::CodeGe
      * Use vector extract to move the 7th and 8th element to the 1st and 2nd element position respectively.
      * Then, perform unsigned shift right by 7bit to get boolean results.
      */
-    generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tempReg, maskReg, maskReg, 7);
-    generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr16b, node, tempReg, tempReg, 7);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovwh, node, resReg, tempReg, 0);
+    generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
+    generateVectorShiftImmediateInstruction(cg, OP::vushr16b, node, tempReg, tempReg, 7);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovwh, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1806,10 +1804,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2iEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *resReg = cg->allocateRegister(TR_GPR);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vxtn_4h, node, tempReg, maskReg);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vxtn_8b, node, tempReg, tempReg);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vneg16b, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovws, node, resReg, tempReg, 0);
+    generateTrg1Src1Instruction(cg, OP::vxtn_4h, node, tempReg, maskReg);
+    generateTrg1Src1Instruction(cg, OP::vxtn_8b, node, tempReg, tempReg);
+    generateTrg1Src1Instruction(cg, OP::vneg16b, node, tempReg, tempReg);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1826,9 +1824,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2lEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *resReg = cg->allocateRegister(TR_GPR);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vxtn_8b, node, tempReg, maskReg);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vneg16b, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, tempReg, 0);
+    generateTrg1Src1Instruction(cg, OP::vxtn_8b, node, tempReg, maskReg);
+    generateTrg1Src1Instruction(cg, OP::vneg16b, node, tempReg, tempReg);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1844,7 +1842,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2vEvaluator(TR::Node *node, TR::CodeGe
 
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vneg16b, node, resReg, maskReg);
+    generateTrg1Src1Instruction(cg, OP::vneg16b, node, resReg, maskReg);
 
     node->setRegister(resReg);
     cg->decReferenceCount(firstChild);
@@ -1859,7 +1857,7 @@ TR::Instruction *OMR::ARM64::TreeEvaluator::vsplatsImmediateHelper(TR::Node *nod
         auto constValue = firstChild->getConstValue();
         switch (elementType) {
             case TR::Int8:
-                return generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, treg, constValue & 0xff);
+                return generateTrg1ImmInstruction(cg, OP::vmovi16b, node, treg, constValue & 0xff);
 
             case TR::Int16: {
                 uint16_t value = static_cast<uint16_t>(constValue & 0xffff);
@@ -1880,7 +1878,7 @@ TR::Instruction *OMR::ARM64::TreeEvaluator::vsplatsImmediateHelper(TR::Node *nod
                 }
 
                 uint64_t concatValue = (static_cast<uint64_t>(value) << 32) | value;
-                if ((instr = tryToGenerateImm64Instruction(node, cg, treg, TR::InstOpCode::vmovi2d, concatValue))) {
+                if ((instr = tryToGenerateImm64Instruction(node, cg, treg, OP::vmovi2d, concatValue))) {
                     return instr;
                 }
                 break;
@@ -1897,7 +1895,7 @@ TR::Instruction *OMR::ARM64::TreeEvaluator::vsplatsImmediateHelper(TR::Node *nod
                     }
                 }
 
-                if ((instr = tryToGenerateImm64Instruction(node, cg, treg, TR::InstOpCode::vmovi2d, constValue))) {
+                if ((instr = tryToGenerateImm64Instruction(node, cg, treg, OP::vmovi2d, constValue))) {
                     return instr;
                 }
                 break;
@@ -1914,7 +1912,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
 {
     TR::Node *firstChild = node->getFirstChild();
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
@@ -1928,27 +1926,27 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
         switch (elementType) {
             case TR::Int8:
                 TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdup16b;
+                op = OP::vdup16b;
                 break;
             case TR::Int16:
                 TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdup8h;
+                op = OP::vdup8h;
                 break;
             case TR::Int32:
                 TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdup4s;
+                op = OP::vdup4s;
                 break;
             case TR::Int64:
                 TR_ASSERT(srcReg->getKind() == TR_GPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdup2d;
+                op = OP::vdup2d;
                 break;
             case TR::Float:
                 TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdupe4s;
+                op = OP::vdupe4s;
                 break;
             case TR::Double:
                 TR_ASSERT(srcReg->getKind() == TR_FPR, "unexpected Register kind");
-                op = TR::InstOpCode::vdupe2d;
+                op = OP::vdupe2d;
                 break;
             default:
                 TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -1972,14 +1970,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeG
     TR::Register *secondReg = cg->evaluate(secondChild);
     TR::Register *thirdReg = cg->evaluate(thirdChild);
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Float:
-            op = TR::InstOpCode::vfmla4s;
+            op = OP::vfmla4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfmla2d;
+            op = OP::vfmla2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -1992,7 +1990,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeG
         targetReg = thirdReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, thirdReg, thirdReg);
+        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
     }
     generateTrg1Src2Instruction(cg, op, node, targetReg, firstReg, secondReg);
     node->setRegister(targetReg);
@@ -2014,38 +2012,31 @@ enum VectorCompareOps : int32_t {
     NumVectorCompareOps
 };
 
-static const TR::InstOpCode::Mnemonic vectorCompareOpCodes[NumVectorCompareOps][TR::NumVectorElementTypes] = {
+static const OP::Mnemonic vectorCompareOpCodes[NumVectorCompareOps][TR::NumVectorElementTypes] = {
     //       TR::Int8                 TR::Int16                TR::Int32                TR::Int64  TR::Float  TR::Double
-    { TR::InstOpCode::vcmeq16b, TR::InstOpCode::vcmeq8h, TR::InstOpCode::vcmeq4s, TR::InstOpCode::vcmeq2d,
-     TR::InstOpCode::vfcmeq4s, TR::InstOpCode::vfcmeq2d }, // EQ
-    { TR::InstOpCode::vcmeq16b, TR::InstOpCode::vcmeq8h, TR::InstOpCode::vcmeq4s, TR::InstOpCode::vcmeq2d,
-     TR::InstOpCode::vfcmeq4s, TR::InstOpCode::vfcmeq2d }, // NE (apply not after compare)
-    { TR::InstOpCode::vcmgt16b, TR::InstOpCode::vcmgt8h, TR::InstOpCode::vcmgt4s, TR::InstOpCode::vcmgt2d,
-     TR::InstOpCode::vfcmgt4s, TR::InstOpCode::vfcmgt2d }, // LT (flip lhs and rhs)
-    { TR::InstOpCode::vcmge16b, TR::InstOpCode::vcmge8h, TR::InstOpCode::vcmge4s, TR::InstOpCode::vcmge2d,
-     TR::InstOpCode::vfcmge4s, TR::InstOpCode::vfcmge2d }, // LE (flip lhs and rhs)
-    { TR::InstOpCode::vcmgt16b, TR::InstOpCode::vcmgt8h, TR::InstOpCode::vcmgt4s, TR::InstOpCode::vcmgt2d,
-     TR::InstOpCode::vfcmgt4s, TR::InstOpCode::vfcmgt2d }, // GT
-    { TR::InstOpCode::vcmge16b, TR::InstOpCode::vcmge8h, TR::InstOpCode::vcmge4s, TR::InstOpCode::vcmge2d,
-     TR::InstOpCode::vfcmge4s, TR::InstOpCode::vfcmge2d }, // GE
+    { OP::vcmeq16b, OP::vcmeq8h, OP::vcmeq4s, OP::vcmeq2d, OP::vfcmeq4s, OP::vfcmeq2d }, // EQ
+    { OP::vcmeq16b, OP::vcmeq8h, OP::vcmeq4s, OP::vcmeq2d, OP::vfcmeq4s, OP::vfcmeq2d }, // NE (apply not after compare)
+    { OP::vcmgt16b, OP::vcmgt8h, OP::vcmgt4s, OP::vcmgt2d, OP::vfcmgt4s, OP::vfcmgt2d }, // LT (flip lhs and rhs)
+    { OP::vcmge16b, OP::vcmge8h, OP::vcmge4s, OP::vcmge2d, OP::vfcmge4s, OP::vfcmge2d }, // LE (flip lhs and rhs)
+    { OP::vcmgt16b, OP::vcmgt8h, OP::vcmgt4s, OP::vcmgt2d, OP::vfcmgt4s, OP::vfcmgt2d }, // GT
+    { OP::vcmge16b, OP::vcmge8h, OP::vcmge4s, OP::vcmge2d, OP::vfcmge4s, OP::vfcmge2d }, // GE
 };
 
-static const TR::InstOpCode::Mnemonic vectorCompareZeroOpCodes[NumVectorCompareOps][TR::NumVectorElementTypes] = {
+static const OP::Mnemonic vectorCompareZeroOpCodes[NumVectorCompareOps][TR::NumVectorElementTypes] = {
     //       TR::Int8                      TR::Int16                     TR::Int32                     TR::Int64
     //       TR::Float                     TR::Double
-    { TR::InstOpCode::vcmeq16b_zero, TR::InstOpCode::vcmeq8h_zero, TR::InstOpCode::vcmeq4s_zero,
-     TR::InstOpCode::vcmeq2d_zero, TR::InstOpCode::vfcmeq4s_zero,TR::InstOpCode::vfcmeq2d_zero                                                                 }, // EQ
-    { TR::InstOpCode::vcmeq16b_zero, TR::InstOpCode::vcmeq8h_zero, TR::InstOpCode::vcmeq4s_zero,
-     TR::InstOpCode::vcmeq2d_zero, TR::InstOpCode::vfcmeq4s_zero,
-     TR::InstOpCode::vfcmeq2d_zero                                                             }, // NE (apply not after compare)
-    { TR::InstOpCode::vcmlt16b_zero, TR::InstOpCode::vcmlt8h_zero, TR::InstOpCode::vcmlt4s_zero,
-     TR::InstOpCode::vcmlt2d_zero, TR::InstOpCode::vfcmlt4s_zero, TR::InstOpCode::vfcmlt2d_zero }, // LT
-    { TR::InstOpCode::vcmle16b_zero, TR::InstOpCode::vcmle8h_zero, TR::InstOpCode::vcmle4s_zero,
-     TR::InstOpCode::vcmle2d_zero, TR::InstOpCode::vfcmle4s_zero, TR::InstOpCode::vfcmle2d_zero }, // LE
-    { TR::InstOpCode::vcmgt16b_zero, TR::InstOpCode::vcmgt8h_zero, TR::InstOpCode::vcmgt4s_zero,
-     TR::InstOpCode::vcmgt2d_zero, TR::InstOpCode::vfcmgt4s_zero, TR::InstOpCode::vfcmgt2d_zero }, // GT
-    { TR::InstOpCode::vcmge16b_zero, TR::InstOpCode::vcmge8h_zero, TR::InstOpCode::vcmge4s_zero,
-     TR::InstOpCode::vcmge2d_zero, TR::InstOpCode::vfcmge4s_zero, TR::InstOpCode::vfcmge2d_zero }, // GE
+    { OP::vcmeq16b_zero, OP::vcmeq8h_zero, OP::vcmeq4s_zero, OP::vcmeq2d_zero, OP::vfcmeq4s_zero,
+     OP::vfcmeq2d_zero }, // EQ
+    { OP::vcmeq16b_zero, OP::vcmeq8h_zero, OP::vcmeq4s_zero, OP::vcmeq2d_zero, OP::vfcmeq4s_zero,
+     OP::vfcmeq2d_zero }, // NE (apply not after compare)
+    { OP::vcmlt16b_zero, OP::vcmlt8h_zero, OP::vcmlt4s_zero, OP::vcmlt2d_zero, OP::vfcmlt4s_zero,
+     OP::vfcmlt2d_zero }, // LT
+    { OP::vcmle16b_zero, OP::vcmle8h_zero, OP::vcmle4s_zero, OP::vcmle2d_zero, OP::vfcmle4s_zero,
+     OP::vfcmle2d_zero }, // LE
+    { OP::vcmgt16b_zero, OP::vcmgt8h_zero, OP::vcmgt4s_zero, OP::vcmgt2d_zero, OP::vfcmgt4s_zero,
+     OP::vfcmgt2d_zero }, // GT
+    { OP::vcmge16b_zero, OP::vcmge8h_zero, OP::vcmge4s_zero, OP::vcmge2d_zero, OP::vfcmge4s_zero,
+     OP::vfcmge2d_zero }, // GE
 };
 
 // prototype declaration of vcmpHelper
@@ -2125,7 +2116,7 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     bool notAfterCompare = (compareOp == VECTOR_COMPARE_NE);
     bool recursivelyDecRefCountOnSecondChild;
     TR::Register *firstReg = cg->evaluate(firstChild);
@@ -2163,15 +2154,14 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
         if (notAfterCompare) {
             if (flipMask) {
                 /* (not a) and (not b) = not (a or b) */
-                generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, targetReg, maskReg);
+                generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, targetReg, maskReg);
             } else {
                 /* a and (not b) = not ((not a) and b) */
-                generateTrg1Src2Instruction(cg, TR::InstOpCode::vbic16b, node, targetReg, maskReg, targetReg);
+                generateTrg1Src2Instruction(cg, OP::vbic16b, node, targetReg, maskReg, targetReg);
                 notAfterCompare = false;
             }
         } else {
-            generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbic16b : TR::InstOpCode::vand16b, node,
-                targetReg, targetReg, maskReg);
+            generateTrg1Src2Instruction(cg, flipMask ? OP::vbic16b : OP::vand16b, node, targetReg, targetReg, maskReg);
         }
 
         cg->decReferenceCount(thirdChild);
@@ -2183,7 +2173,7 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
      */
     if (!omitNot) {
         if (notAfterCompare) {
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::vnot16b, node, targetReg, targetReg);
+            generateTrg1Src1Instruction(cg, OP::vnot16b, node, targetReg, targetReg);
         }
     } else {
         if (notAfterCompare) {
@@ -2257,8 +2247,8 @@ typedef TR::Register *(*reductionEvaluatorHelper)(TR::Node *node, TR::DataType e
  * @param[in] evaluatorHelper: optional pointer to helper function which generates instruction stream for operation
  * @return vector register containing the result
  */
-static TR::Register *inlineVectorReductionOp(TR::Node *node, TR::CodeGenerator *cg, TR::DataType et,
-    TR::InstOpCode::Mnemonic op, reductionEvaluatorHelper evaluatorHelper = NULL)
+static TR::Register *inlineVectorReductionOp(TR::Node *node, TR::CodeGenerator *cg, TR::DataType et, OP::Mnemonic op,
+    reductionEvaluatorHelper evaluatorHelper = NULL)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *sourceReg = cg->evaluate(firstChild);
@@ -2268,27 +2258,27 @@ static TR::Register *inlineVectorReductionOp(TR::Node *node, TR::CodeGenerator *
     TR::Register *resReg = et.isIntegral() ? cg->allocateRegister(TR_GPR) : cg->allocateRegister(TR_VRF);
 
     node->setRegister(resReg);
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, et, resReg, sourceReg, cg);
     } else {
         TR::Register *tmpReg = NULL;
         if (et.isIntegral()) {
             tmpReg = cg->allocateRegister(TR_VRF);
-            TR::InstOpCode::Mnemonic movOp;
+            OP::Mnemonic movOp;
             switch (et) {
                 case TR::Int8:
-                    movOp = TR::InstOpCode::smovwb;
+                    movOp = OP::smovwb;
                     break;
                 case TR::Int16:
-                    movOp = TR::InstOpCode::smovwh;
+                    movOp = OP::smovwh;
                     break;
                 case TR::Int32:
-                    movOp = TR::InstOpCode::umovws;
+                    movOp = OP::umovws;
                     break;
                 case TR::Int64:
-                    movOp = TR::InstOpCode::umovxd;
+                    movOp = OP::umovxd;
                     break;
                 default:
                     TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -2322,11 +2312,11 @@ static TR::Register *vreductionAddFloatHelper(TR::Node *node, TR::DataType et, T
 {
     if (et == TR::Float) {
         TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vfaddp4s, node, tmpReg, srcReg, srcReg);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::faddp2s, node, resReg, tmpReg);
+        generateTrg1Src2Instruction(cg, OP::vfaddp4s, node, tmpReg, srcReg, srcReg);
+        generateTrg1Src1Instruction(cg, OP::faddp2s, node, resReg, tmpReg);
         cg->stopUsingRegister(tmpReg);
     } else if (et == TR::Double) {
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::faddp2d, node, resReg, srcReg);
+        generateTrg1Src1Instruction(cg, OP::faddp2d, node, resReg, srcReg);
     } else {
         TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
     }
@@ -2340,20 +2330,20 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionAddEvaluator(TR::Node *node, 
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vaddv16b;
+            op = OP::vaddv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vaddv8h;
+            op = OP::vaddv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vaddv4s;
+            op = OP::vaddv4s;
             break;
         case TR::Int64:
-            op = TR::InstOpCode::addp2d;
+            op = OP::addp2d;
             break;
         case TR::Float:
         case TR::Double:
@@ -2378,28 +2368,28 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionAddEvaluator(TR::Node *node, 
  * @param[in] cg: CodeGenerator
  * @return general purpose register containing the result
  */
-static TR::Register *vreductionHelper(TR::Node *node, TR::DataType et, TR::InstOpCode::Mnemonic op,
-    TR::Register *resReg, TR::Register *srcReg, TR::CodeGenerator *cg)
+static TR::Register *vreductionHelper(TR::Node *node, TR::DataType et, OP::Mnemonic op, TR::Register *resReg,
+    TR::Register *srcReg, TR::CodeGenerator *cg)
 {
     bool useGPRForResult = true;
 
-    TR::InstOpCode::Mnemonic movOp;
+    OP::Mnemonic movOp;
     switch (et) {
         case TR::Int8:
-            movOp = TR::InstOpCode::smovwb;
+            movOp = OP::smovwb;
             break;
         case TR::Int16:
-            movOp = TR::InstOpCode::smovwh;
+            movOp = OP::smovwh;
             break;
         case TR::Int32:
-            movOp = TR::InstOpCode::umovws;
+            movOp = OP::umovws;
             break;
         case TR::Int64:
-            movOp = TR::InstOpCode::umovxd;
+            movOp = OP::umovxd;
             break;
         default:
             useGPRForResult = false;
-            movOp = TR::InstOpCode::bad;
+            movOp = OP::bad;
             break;
     }
 
@@ -2409,19 +2399,19 @@ static TR::Register *vreductionHelper(TR::Node *node, TR::DataType et, TR::InstO
     /*
      * Generating an ext instruction to split elements into 2 vector registers and perform a lanewise operation.
      */
-    generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tmp1Reg, srcReg, srcReg, 8);
+    generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, srcReg, srcReg, 8);
     generateTrg1Src2Instruction(cg, op, node, tmp0Reg, srcReg, tmp1Reg);
 
     if ((et != TR::Int64) && (et != TR::Double)) {
-        generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 4);
+        generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 4);
         generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
 
         if ((et != TR::Int32) && (et != TR::Float)) {
-            generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 2);
+            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 2);
             generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
 
             if (et == TR::Int8) {
-                generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 1);
+                generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 1);
                 generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
             }
         }
@@ -2450,7 +2440,7 @@ static TR::Register *vreductionHelper(TR::Node *node, TR::DataType et, TR::InstO
 static TR::Register *vreductionAndHelper(TR::Node *node, TR::DataType et, TR::Register *resReg, TR::Register *srcReg,
     TR::CodeGenerator *cg)
 {
-    return vreductionHelper(node, et, TR::InstOpCode::vand16b, resReg, srcReg, cg);
+    return vreductionHelper(node, et, OP::vand16b, resReg, srcReg, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2464,7 +2454,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionAndEvaluator(TR::Node *node, 
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorReductionOp(node, cg, et, TR::InstOpCode::bad, vreductionAndHelper);
+            return inlineVectorReductionOp(node, cg, et, OP::bad, vreductionAndHelper);
         case TR::Float:
         case TR::Double:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s",
@@ -2498,12 +2488,11 @@ static TR::Register *vreductionMinMaxInt64Helper(TR::Node *node, bool isMax, TR:
 {
     TR::Register *tmpReg = cg->allocateRegister(TR_GPR);
 
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, tmpReg, srcReg, 0);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, srcReg, 1);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, tmpReg, srcReg, 0);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, srcReg, 1);
 
     generateCompareInstruction(cg, node, tmpReg, resReg, true);
-    generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, resReg, tmpReg, resReg,
-        isMax ? TR::CC_GT : TR::CC_LT);
+    generateCondTrg1Src2Instruction(cg, OP::cselx, node, resReg, tmpReg, resReg, isMax ? TR::CC_GT : TR::CC_LT);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -2533,27 +2522,27 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionMaxEvaluator(TR::Node *node, 
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vsmaxv16b;
+            op = OP::vsmaxv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsmaxv8h;
+            op = OP::vsmaxv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsmaxv4s;
+            op = OP::vsmaxv4s;
             break;
         case TR::Int64:
             /* SMAXV does not accept 64bit elements */
             evaluationHelper = vreductionMaxInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfmaxv4s;
+            op = OP::vfmaxv4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::fmaxp2d;
+            op = OP::fmaxp2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s",
@@ -2586,27 +2575,27 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionMinEvaluator(TR::Node *node, 
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vsminv16b;
+            op = OP::vsminv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsminv8h;
+            op = OP::vsminv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsminv4s;
+            op = OP::vsminv4s;
             break;
         case TR::Int64:
             /* SMINV does not accept 64bit elements */
             evaluationHelper = vreductionMinInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfminv4s;
+            op = OP::vfminv4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::fminp2d;
+            op = OP::fminp2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s",
@@ -2631,8 +2620,8 @@ static TR::Register *vreductionMulInt64Helper(TR::Node *node, TR::Register *resR
 {
     TR::Register *tmp0Reg = cg->allocateRegister(TR_GPR);
 
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, tmp0Reg, srcReg, 0);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, resReg, srcReg, 1);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, tmp0Reg, srcReg, 0);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, srcReg, 1);
     generateMulInstruction(cg, node, resReg, tmp0Reg, resReg, true);
 
     cg->stopUsingRegister(tmp0Reg);
@@ -2658,11 +2647,11 @@ static TR::Register *vreductionMulFloatingPointHelper(TR::Node *node, TR::DataTy
     TR::Register *srcReg, TR::CodeGenerator *cg)
 {
     if (et == TR::Float) {
-        generateTrg1Src2IndexedElementInstruction(cg, TR::InstOpCode::fmulelem_4s, node, resReg, srcReg, srcReg, 1);
-        generateTrg1Src2IndexedElementInstruction(cg, TR::InstOpCode::fmulelem_4s, node, resReg, resReg, srcReg, 2);
-        generateTrg1Src2IndexedElementInstruction(cg, TR::InstOpCode::fmulelem_4s, node, resReg, resReg, srcReg, 3);
+        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, srcReg, srcReg, 1);
+        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 2);
+        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 3);
     } else {
-        generateTrg1Src2IndexedElementInstruction(cg, TR::InstOpCode::fmulelem_2d, node, resReg, srcReg, srcReg, 1);
+        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_2d, node, resReg, srcReg, srcReg, 1);
     }
 
     return resReg;
@@ -2683,11 +2672,11 @@ static TR::Register *vreductionMulHelper(TR::Node *node, TR::DataType et, TR::Re
 {
     switch (et) {
         case TR::Int8:
-            return vreductionHelper(node, et, TR::InstOpCode::vmul16b, resReg, srcReg, cg);
+            return vreductionHelper(node, et, OP::vmul16b, resReg, srcReg, cg);
         case TR::Int16:
-            return vreductionHelper(node, et, TR::InstOpCode::vmul8h, resReg, srcReg, cg);
+            return vreductionHelper(node, et, OP::vmul8h, resReg, srcReg, cg);
         case TR::Int32:
-            return vreductionHelper(node, et, TR::InstOpCode::vmul4s, resReg, srcReg, cg);
+            return vreductionHelper(node, et, OP::vmul4s, resReg, srcReg, cg);
         case TR::Int64:
             return vreductionMulInt64Helper(node, resReg, srcReg, cg);
         case TR::Float:
@@ -2705,7 +2694,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionMulEvaluator(TR::Node *node, 
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    return inlineVectorReductionOp(node, cg, et, TR::InstOpCode::bad, vreductionMulHelper);
+    return inlineVectorReductionOp(node, cg, et, OP::bad, vreductionMulHelper);
 }
 
 /**
@@ -2721,7 +2710,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionMulEvaluator(TR::Node *node, 
 static TR::Register *vreductionOrHelper(TR::Node *node, TR::DataType et, TR::Register *resReg, TR::Register *srcReg,
     TR::CodeGenerator *cg)
 {
-    return vreductionHelper(node, et, TR::InstOpCode::vorr16b, resReg, srcReg, cg);
+    return vreductionHelper(node, et, OP::vorr16b, resReg, srcReg, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vreductionOrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2735,7 +2724,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionOrEvaluator(TR::Node *node, T
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorReductionOp(node, cg, et, TR::InstOpCode::bad, vreductionOrHelper);
+            return inlineVectorReductionOp(node, cg, et, OP::bad, vreductionOrHelper);
         case TR::Float:
         case TR::Double:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s",
@@ -2766,7 +2755,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionOrUncheckedEvaluator(TR::Node
 static TR::Register *vreductionXorHelper(TR::Node *node, TR::DataType et, TR::Register *resReg, TR::Register *srcReg,
     TR::CodeGenerator *cg)
 {
-    return vreductionHelper(node, et, TR::InstOpCode::veor16b, resReg, srcReg, cg);
+    return vreductionHelper(node, et, OP::veor16b, resReg, srcReg, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vreductionXorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2780,7 +2769,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vreductionXorEvaluator(TR::Node *node, 
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorReductionOp(node, cg, et, TR::InstOpCode::bad, vreductionXorHelper);
+            return inlineVectorReductionOp(node, cg, et, OP::bad, vreductionXorHelper);
         case TR::Float:
         case TR::Double:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s",
@@ -2842,14 +2831,14 @@ static TR::Register *vbitselectHelper(TR::Node *node, TR::CodeGenerator *cg, boo
         targetReg = maskReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, maskReg, maskReg);
+        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, maskReg, maskReg);
     }
 
     /*
      * vbitselect helper extracts bits from the "false" operand if the corresponding bit of the "mask" operand is 0,
      * otherwise from the "true" operand.
      */
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vbsl16b, node, targetReg, trueReg, falseReg);
+    generateTrg1Src2Instruction(cg, OP::vbsl16b, node, targetReg, trueReg, falseReg);
     node->setRegister(targetReg);
     cg->decReferenceCount(falseChild);
     cg->decReferenceCount(trueChild);
@@ -2901,7 +2890,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vRegStoreEvaluator(TR::Node *node, TR::
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *node, TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, binaryEvaluatorHelper evaluatorHelper)
+    OP::Mnemonic op, binaryEvaluatorHelper evaluatorHelper)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -2915,8 +2904,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *no
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
 
     node->setRegister(resReg);
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, lhsReg, rhsReg, cg);
     } else {
@@ -2930,8 +2919,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *no
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbit16b : TR::InstOpCode::vbif16b, node, resReg, lhsReg,
-        maskReg);
+    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, lhsReg, maskReg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -2940,7 +2928,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *no
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedUnaryOp(TR::Node *node, TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, unaryEvaluatorHelper evaluatorHelper)
+    OP::Mnemonic op, unaryEvaluatorHelper evaluatorHelper)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -2952,8 +2940,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedUnaryOp(TR::Node *nod
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
     node->setRegister(resReg);
 
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, srcReg, cg);
     } else {
@@ -2967,8 +2955,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedUnaryOp(TR::Node *nod
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbit16b : TR::InstOpCode::vbif16b, node, resReg, srcReg,
-        maskReg);
+    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, srcReg, maskReg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -2979,26 +2966,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmabsEvaluator(TR::Node *node, TR::Code
 {
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
-    TR::InstOpCode::Mnemonic absOp;
+    OP::Mnemonic absOp;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            absOp = TR::InstOpCode::vabs16b;
+            absOp = OP::vabs16b;
             break;
         case TR::Int16:
-            absOp = TR::InstOpCode::vabs8h;
+            absOp = OP::vabs8h;
             break;
         case TR::Int32:
-            absOp = TR::InstOpCode::vabs4s;
+            absOp = OP::vabs4s;
             break;
         case TR::Int64:
-            absOp = TR::InstOpCode::vabs2d;
+            absOp = OP::vabs2d;
             break;
         case TR::Float:
-            absOp = TR::InstOpCode::vfabs4s;
+            absOp = OP::vfabs4s;
             break;
         case TR::Double:
-            absOp = TR::InstOpCode::vfabs2d;
+            absOp = OP::vfabs2d;
             break;
         default:
             TR_ASSERT_FATAL(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3009,26 +2996,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmabsEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vadd16b;
+            op = OP::vadd16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vadd8h;
+            op = OP::vadd8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vadd4s;
+            op = OP::vadd4s;
             break;
         case TR::Int64:
-            op = TR::InstOpCode::vadd2d;
+            op = OP::vadd2d;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfadd4s;
+            op = OP::vfadd4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfadd2d;
+            op = OP::vfadd2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3039,14 +3026,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmaddEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            op = TR::InstOpCode::vand16b;
+            op = OP::vand16b;
             break;
 
         default:
@@ -3091,7 +3078,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmdivEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic divOp = TR::InstOpCode::bad;
+    OP::Mnemonic divOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
@@ -3101,10 +3088,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmdivEvaluator(TR::Node *node, TR::Code
             evaluatorHelper = vdivIntHelper;
             break;
         case TR::Float:
-            divOp = TR::InstOpCode::vfdiv4s;
+            divOp = OP::vfdiv4s;
             break;
         case TR::Double:
-            divOp = TR::InstOpCode::vfdiv2d;
+            divOp = OP::vfdiv2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3127,14 +3114,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmfmaEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, secondReg->getKind() == TR_VRF, "unexpected Register kind");
     TR_ASSERT_FATAL_WITH_NODE(node, thirdReg->getKind() == TR_VRF, "unexpected Register kind");
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Float:
-            op = TR::InstOpCode::vfmla4s;
+            op = OP::vfmla4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfmla2d;
+            op = OP::vfmla2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3147,7 +3134,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmfmaEvaluator(TR::Node *node, TR::Code
         targetReg = thirdReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, targetReg, thirdReg, thirdReg);
+        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
     }
     generateTrg1Src2Instruction(cg, op, node, targetReg, firstReg, secondReg);
 
@@ -3158,8 +3145,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmfmaEvaluator(TR::Node *node, TR::Code
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbit16b : TR::InstOpCode::vbif16b, node, targetReg,
-        firstReg, maskReg);
+    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, firstReg, maskReg);
 
     node->setRegister(targetReg);
     cg->decReferenceCount(firstChild);
@@ -3185,26 +3171,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmmaxEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vsmax16b;
+            op = OP::vsmax16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsmax8h;
+            op = OP::vsmax8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsmax4s;
+            op = OP::vsmax4s;
             break;
         case TR::Int64:
             evaluatorHelper = vmaxInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfmax4s;
+            op = OP::vfmax4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfmax2d;
+            op = OP::vfmax2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3218,26 +3204,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmminEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vsmin16b;
+            op = OP::vsmin16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsmin8h;
+            op = OP::vsmin8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsmin4s;
+            op = OP::vsmin4s;
             break;
         case TR::Int64:
             evaluatorHelper = vminInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfmin4s;
+            op = OP::vfmin4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfmin2d;
+            op = OP::vfmin2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3251,26 +3237,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmmulEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic mulOp = TR::InstOpCode::bad;
+    OP::Mnemonic mulOp = OP::bad;
     binaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            mulOp = TR::InstOpCode::vmul16b;
+            mulOp = OP::vmul16b;
             break;
         case TR::Int16:
-            mulOp = TR::InstOpCode::vmul8h;
+            mulOp = OP::vmul8h;
             break;
         case TR::Int32:
-            mulOp = TR::InstOpCode::vmul4s;
+            mulOp = OP::vmul4s;
             break;
         case TR::Int64:
             evaluatorHelper = vmulInt64Helper;
             break;
         case TR::Float:
-            mulOp = TR::InstOpCode::vfmul4s;
+            mulOp = OP::vfmul4s;
             break;
         case TR::Double:
-            mulOp = TR::InstOpCode::vfmul2d;
+            mulOp = OP::vfmul2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3281,29 +3267,29 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmmulEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic negOp;
+    OP::Mnemonic negOp;
 
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            negOp = TR::InstOpCode::vneg16b;
+            negOp = OP::vneg16b;
             break;
         case TR::Int16:
-            negOp = TR::InstOpCode::vneg8h;
+            negOp = OP::vneg8h;
             break;
         case TR::Int32:
-            negOp = TR::InstOpCode::vneg4s;
+            negOp = OP::vneg4s;
             break;
         case TR::Int64:
-            negOp = TR::InstOpCode::vneg2d;
+            negOp = OP::vneg2d;
             break;
         case TR::Float:
-            negOp = TR::InstOpCode::vfneg4s;
+            negOp = OP::vfneg4s;
             break;
         case TR::Double:
-            negOp = TR::InstOpCode::vfneg2d;
+            negOp = OP::vfneg2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3314,7 +3300,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmnegEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic notOp;
+    OP::Mnemonic notOp;
 
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
@@ -3324,7 +3310,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmnotEvaluator(TR::Node *node, TR::Code
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            notOp = TR::InstOpCode::vnot16b;
+            notOp = OP::vnot16b;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3335,14 +3321,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmnotEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            op = TR::InstOpCode::vorr16b;
+            op = OP::vorr16b;
             break;
 
         default:
@@ -3371,7 +3357,7 @@ typedef void (*loadIdentityVectorHelper)(TR::Node *node, TR::DataType et, TR::Re
  * @return vector register containing the result
  */
 static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGenerator *cg, TR::DataType et,
-    TR::InstOpCode::Mnemonic op, loadIdentityVectorHelper loadHelper, reductionEvaluatorHelper evaluatorHelper = NULL)
+    OP::Mnemonic op, loadIdentityVectorHelper loadHelper, reductionEvaluatorHelper evaluatorHelper = NULL)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Node *secondChild = node->getSecondChild();
@@ -3390,31 +3376,30 @@ static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGener
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbif16b : TR::InstOpCode::vbit16b, node, tmpReg,
-        sourceReg, maskReg);
+    generateTrg1Src2Instruction(cg, flipMask ? OP::vbif16b : OP::vbit16b, node, tmpReg, sourceReg, maskReg);
 
     TR::Register *resReg = et.isIntegral() ? cg->allocateRegister(TR_GPR) : cg->allocateRegister(TR_VRF);
 
     node->setRegister(resReg);
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, et, resReg, tmpReg, cg);
     } else {
         if (et.isIntegral()) {
-            TR::InstOpCode::Mnemonic movOp;
+            OP::Mnemonic movOp;
             switch (et) {
                 case TR::Int8:
-                    movOp = TR::InstOpCode::smovwb;
+                    movOp = OP::smovwb;
                     break;
                 case TR::Int16:
-                    movOp = TR::InstOpCode::smovwh;
+                    movOp = OP::smovwh;
                     break;
                 case TR::Int32:
-                    movOp = TR::InstOpCode::umovws;
+                    movOp = OP::umovws;
                     break;
                 case TR::Int64:
-                    movOp = TR::InstOpCode::umovxd;
+                    movOp = OP::umovxd;
                     break;
                 default:
                     TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -3443,7 +3428,7 @@ static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGener
  */
 static void loadZeroVector(TR::Node *node, TR::DataType et, TR::Register *identityReg, TR::CodeGenerator *cg)
 {
-    generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 0);
+    generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3452,20 +3437,20 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node,
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vaddv16b;
+            op = OP::vaddv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vaddv8h;
+            op = OP::vaddv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vaddv4s;
+            op = OP::vaddv4s;
             break;
         case TR::Int64:
-            op = TR::InstOpCode::addp2d;
+            op = OP::addp2d;
             break;
         case TR::Float:
         case TR::Double:
@@ -3490,7 +3475,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node,
 static void loadIdentityVectorForReductionAnd(TR::Node *node, TR::DataType et, TR::Register *identityReg,
     TR::CodeGenerator *cg)
 {
-    generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 0xff);
+    generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0xff);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3504,7 +3489,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAndEvaluator(TR::Node *node,
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorMaskedReductionOp(node, cg, et, TR::InstOpCode::bad, loadIdentityVectorForReductionAnd,
+            return inlineVectorMaskedReductionOp(node, cg, et, OP::bad, loadIdentityVectorForReductionAnd,
                 vreductionAndHelper);
         case TR::Float:
         case TR::Double:
@@ -3536,30 +3521,30 @@ static void loadIdentityVectorForReductionMax(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 0x80);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0x80);
             break;
         case TR::Int16:
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmovi8h, node, identityReg, 0x80, 8);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmovi8h, node, identityReg, 0x80, 8);
             break;
         case TR::Int32:
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmovi4s, node, identityReg, 0x80, 24);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0x80, 24);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2d, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
                 0x80); /* Loads 0xff000000_00000000 into each element */
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vbicimm4s, node, identityReg, 0x7f,
+            generateTrg1ImmShiftedInstruction(cg, OP::vbicimm4s, node, identityReg, 0x7f,
                 24); /* Clear unneeded bits. We do not have bic for 64bit integer, but vbicimm4s works for this case. */
             break;
         case TR::Float:
             /* Negative Infinity */
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmovi4s, node, identityReg, 0xff, 24);
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vorrimm4s, node, identityReg, 0x80, 16);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0xff, 24);
+            generateTrg1ImmShiftedInstruction(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
             break;
         case TR::Double:
             /* Negative Infinity */
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2d, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
                 0x80); /* Loads 0xff000000_00000000 into each element */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsshr2d, node, identityReg, identityReg,
+            generateVectorShiftImmediateInstruction(cg, OP::vsshr2d, node, identityReg, identityReg,
                 4); /* Do signed shift right by 4bits to get 0xfff00000_00000000 */
             break;
         default:
@@ -3572,27 +3557,27 @@ static void loadIdentityVectorForReductionMax(TR::Node *node, TR::DataType et, T
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionMaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vsmaxv16b;
+            op = OP::vsmaxv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsmaxv8h;
+            op = OP::vsmaxv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsmaxv4s;
+            op = OP::vsmaxv4s;
             break;
         case TR::Int64:
             /* SMAXV does not accept 64bit elements */
             evaluationHelper = vreductionMaxInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfmaxv4s;
+            op = OP::vfmaxv4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::fmaxp2d;
+            op = OP::fmaxp2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s",
@@ -3615,30 +3600,30 @@ static void loadIdentityVectorForReductionMin(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 0x7f);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0x7f);
             break;
         case TR::Int16:
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmvni8h, node, identityReg, 0x80, 8);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmvni8h, node, identityReg, 0x80, 8);
             break;
         case TR::Int32:
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmvni4s, node, identityReg, 0x80, 24);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmvni4s, node, identityReg, 0x80, 24);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 0xff);
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr2d, node, identityReg, identityReg, 1);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0xff);
+            generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, identityReg, identityReg, 1);
             break;
         case TR::Float:
             /* Positive Infinity */
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vmovi4s, node, identityReg, 0x7f, 24);
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vorrimm4s, node, identityReg, 0x80, 16);
+            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0x7f, 24);
+            generateTrg1ImmShiftedInstruction(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
             break;
         case TR::Double:
             /* Positive Infinity */
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2d, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
                 0x80); /* Loads 0xff000000_00000000 into each element */
-            generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vsshr2d, node, identityReg, identityReg,
+            generateVectorShiftImmediateInstruction(cg, OP::vsshr2d, node, identityReg, identityReg,
                 4); /* Do signed shift right by 4bits to get 0xfff00000_00000000 */
-            generateTrg1ImmShiftedInstruction(cg, TR::InstOpCode::vbicimm4s, node, identityReg, 0x80,
+            generateTrg1ImmShiftedInstruction(cg, OP::vbicimm4s, node, identityReg, 0x80,
                 24); /* Clear sign bit. We do not have bic for 64bit integer, but vbicimm4s works for this case. */
             break;
         default:
@@ -3654,27 +3639,27 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionMinEvaluator(TR::Node *node,
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     reductionEvaluatorHelper evaluationHelper = NULL;
     switch (et) {
         case TR::Int8:
-            op = TR::InstOpCode::vsminv16b;
+            op = OP::vsminv16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsminv8h;
+            op = OP::vsminv8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsminv4s;
+            op = OP::vsminv4s;
             break;
         case TR::Int64:
             /* SMINV does not accept 64bit elements */
             evaluationHelper = vreductionMinInt64Helper;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfminv4s;
+            op = OP::vfminv4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::fminp2d;
+            op = OP::fminp2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s",
@@ -3697,27 +3682,27 @@ static void loadIdentityVectorForReductionMul(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi16b, node, identityReg, 1);
+            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 1);
             break;
         case TR::Int16:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi8h, node, identityReg, 1);
+            generateTrg1ImmInstruction(cg, OP::vmovi8h, node, identityReg, 1);
             break;
         case TR::Int32:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi4s, node, identityReg, 1);
+            generateTrg1ImmInstruction(cg, OP::vmovi4s, node, identityReg, 1);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi2d, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
                 1); /* Loads 0x00000000_000000ff into each element */
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vbicimm4s, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vbicimm4s, node, identityReg,
                 0xfe); /* Clear unneeded bits. We do not have bic for 64bit integer, but vbicimm4s works for this case.
                         */
             break;
         case TR::Float:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vfmov4s, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vfmov4s, node, identityReg,
                 0x70); /* Loads 0x3f800000 (1.0f) into each element */
             break;
         case TR::Double:
-            generateTrg1ImmInstruction(cg, TR::InstOpCode::vfmov2d, node, identityReg,
+            generateTrg1ImmInstruction(cg, OP::vfmov2d, node, identityReg,
                 0x70); /* Loads 0x3ff00000_00000000 (1.0) into each element */
             break;
         default:
@@ -3733,8 +3718,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionMulEvaluator(TR::Node *node,
         "Only 128-bit vectors are supported %s", node->getFirstChild()->getDataType().toString());
 
     TR::DataType et = node->getFirstChild()->getDataType().getVectorElementType();
-    return inlineVectorMaskedReductionOp(node, cg, et, TR::InstOpCode::bad, loadIdentityVectorForReductionMul,
-        vreductionMulHelper);
+    return inlineVectorMaskedReductionOp(node, cg, et, OP::bad, loadIdentityVectorForReductionMul, vreductionMulHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionOrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3748,7 +3732,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionOrEvaluator(TR::Node *node, 
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorMaskedReductionOp(node, cg, et, TR::InstOpCode::bad, loadZeroVector, vreductionOrHelper);
+            return inlineVectorMaskedReductionOp(node, cg, et, OP::bad, loadZeroVector, vreductionOrHelper);
         case TR::Float:
         case TR::Double:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s",
@@ -3777,8 +3761,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionXorEvaluator(TR::Node *node,
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            return inlineVectorMaskedReductionOp(node, cg, et, TR::InstOpCode::bad, loadZeroVector,
-                vreductionXorHelper);
+            return inlineVectorMaskedReductionOp(node, cg, et, OP::bad, loadZeroVector, vreductionXorHelper);
         case TR::Float:
         case TR::Double:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type %s",
@@ -3795,14 +3778,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmsqrtEvaluator(TR::Node *node, TR::Cod
 {
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
-    TR::InstOpCode::Mnemonic sqrtOp;
+    OP::Mnemonic sqrtOp;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Float:
-            sqrtOp = TR::InstOpCode::vfsqrt4s;
+            sqrtOp = OP::vfsqrt4s;
             break;
         case TR::Double:
-            sqrtOp = TR::InstOpCode::vfsqrt2d;
+            sqrtOp = OP::vfsqrt2d;
             break;
         default:
             TR_ASSERT_FATAL(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3818,26 +3801,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmstoreiEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vsub16b;
+            op = OP::vsub16b;
             break;
         case TR::Int16:
-            op = TR::InstOpCode::vsub8h;
+            op = OP::vsub8h;
             break;
         case TR::Int32:
-            op = TR::InstOpCode::vsub4s;
+            op = OP::vsub4s;
             break;
         case TR::Int64:
-            op = TR::InstOpCode::vsub2d;
+            op = OP::vsub2d;
             break;
         case TR::Float:
-            op = TR::InstOpCode::vfsub4s;
+            op = OP::vfsub4s;
             break;
         case TR::Double:
-            op = TR::InstOpCode::vfsub2d;
+            op = OP::vfsub2d;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -3848,14 +3831,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmsubEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmxorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            op = TR::InstOpCode::veor16b;
+            op = OP::veor16b;
             break;
 
         default:
@@ -3884,12 +3867,12 @@ static TR::Register *vpopcntEvaluatorHelper(TR::Node *node, TR::Register *result
 {
     TR::DataType et = node->getDataType().getVectorElementType();
 
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vcnt16b, node, resultReg, srcReg);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vuaddlp16b, node, resultReg, resultReg);
+    generateTrg1Src1Instruction(cg, OP::vcnt16b, node, resultReg, srcReg);
+    generateTrg1Src1Instruction(cg, OP::vuaddlp16b, node, resultReg, resultReg);
     if (et != TR::Int16) {
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vuaddlp8h, node, resultReg, resultReg);
+        generateTrg1Src1Instruction(cg, OP::vuaddlp8h, node, resultReg, resultReg);
         if (et == TR::Int64) {
-            generateTrg1Src1Instruction(cg, TR::InstOpCode::vuaddlp4s, node, resultReg, resultReg);
+            generateTrg1Src1Instruction(cg, OP::vuaddlp4s, node, resultReg, resultReg);
         }
     }
     return resultReg;
@@ -3897,11 +3880,11 @@ static TR::Register *vpopcntEvaluatorHelper(TR::Node *node, TR::Register *result
 
 TR::Register *OMR::ARM64::TreeEvaluator::vpopcntEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     unaryEvaluatorHelper evaluationHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vcnt16b;
+            op = OP::vcnt16b;
             break;
         case TR::Int16:
         case TR::Int32:
@@ -3918,11 +3901,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::vpopcntEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmpopcntEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     unaryEvaluatorHelper evaluationHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            op = TR::InstOpCode::vcnt16b;
+            op = OP::vcnt16b;
             break;
         case TR::Int16:
         case TR::Int32:
@@ -3984,11 +3967,10 @@ static TR::Register *vectorShiftImmediateHelper(TR::Node *node, TR::CodeGenerato
     if ((value >= start) && (value <= end)) {
         TR::Register *targetReg = cg->allocateRegister(TR_VRF);
         TR::Register *lhsReg = cg->evaluate(firstChild);
-        TR::InstOpCode::Mnemonic op
-            = static_cast<TR::InstOpCode::Mnemonic>((isLeftShift                  ? TR::InstOpCode::vshl16b
-                                                            : isLogicalRightShift ? TR::InstOpCode::vushr16b
-                                                                                  : TR::InstOpCode::vsshr16b)
-                + (elementType - TR::Int8));
+        OP::Mnemonic op = static_cast<OP::Mnemonic>((isLeftShift                  ? OP::vshl16b
+                                                            : isLogicalRightShift ? OP::vushr16b
+                                                                                  : OP::vsshr16b)
+            + (elementType - TR::Int8));
         generateVectorShiftImmediateInstruction(cg, op, node, targetReg, lhsReg, value);
         if (isVectorMaskedShift) {
             bool flipMask = false;
@@ -3997,8 +3979,7 @@ static TR::Register *vectorShiftImmediateHelper(TR::Node *node, TR::CodeGenerato
              * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
              * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
              */
-            generateTrg1Src2Instruction(cg, flipMask ? TR::InstOpCode::vbit16b : TR::InstOpCode::vbif16b, node,
-                targetReg, lhsReg, maskReg);
+            generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, lhsReg, maskReg);
 
             cg->decReferenceCount(thirdChild);
         }
@@ -4023,19 +4004,19 @@ TR::Register *OMR::ARM64::TreeEvaluator::vshlEvaluator(TR::Node *node, TR::CodeG
         return resultReg;
     }
 
-    TR::InstOpCode::Mnemonic shiftOp;
+    OP::Mnemonic shiftOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            shiftOp = TR::InstOpCode::vsshl16b;
+            shiftOp = OP::vsshl16b;
             break;
         case TR::Int16:
-            shiftOp = TR::InstOpCode::vsshl8h;
+            shiftOp = OP::vsshl8h;
             break;
         case TR::Int32:
-            shiftOp = TR::InstOpCode::vsshl4s;
+            shiftOp = OP::vsshl4s;
             break;
         case TR::Int64:
-            shiftOp = TR::InstOpCode::vsshl2d;
+            shiftOp = OP::vsshl2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -4054,19 +4035,19 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmshlEvaluator(TR::Node *node, TR::Code
         return resultReg;
     }
 
-    TR::InstOpCode::Mnemonic shiftOp;
+    OP::Mnemonic shiftOp;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            shiftOp = TR::InstOpCode::vsshl16b;
+            shiftOp = OP::vsshl16b;
             break;
         case TR::Int16:
-            shiftOp = TR::InstOpCode::vsshl8h;
+            shiftOp = OP::vsshl8h;
             break;
         case TR::Int32:
-            shiftOp = TR::InstOpCode::vsshl4s;
+            shiftOp = OP::vsshl4s;
             break;
         case TR::Int64:
-            shiftOp = TR::InstOpCode::vsshl2d;
+            shiftOp = OP::vsshl2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -4096,10 +4077,9 @@ static TR::Register *vectorRightShiftHelper(TR::Node *node, TR::Register *result
     TR_ASSERT_FATAL_WITH_NODE(node, (elementType >= TR::Int8) && (elementType <= TR::Int64),
         "elementType must be integer");
     const bool isLogicalShift = (vectorOp == TR::vushr) || (vectorOp == TR::vmushr);
-    TR::InstOpCode::Mnemonic negOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vneg16b + (elementType - TR::Int8));
-    TR::InstOpCode::Mnemonic shiftOp = static_cast<TR::InstOpCode::Mnemonic>(
-        (isLogicalShift ? TR::InstOpCode::vushl16b : TR::InstOpCode::vsshl16b) + (elementType - TR::Int8));
+    OP::Mnemonic negOp = static_cast<OP::Mnemonic>(OP::vneg16b + (elementType - TR::Int8));
+    OP::Mnemonic shiftOp
+        = static_cast<OP::Mnemonic>((isLogicalShift ? OP::vushl16b : OP::vsshl16b) + (elementType - TR::Int8));
     generateTrg1Src1Instruction(cg, negOp, node, resultReg, rhsReg);
     generateTrg1Src2Instruction(cg, shiftOp, node, resultReg, lhsReg, resultReg);
 
@@ -4116,7 +4096,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vshrEvaluator(TR::Node *node, TR::CodeG
         return resultReg;
     }
 
-    return inlineVectorBinaryOp(node, cg, TR::InstOpCode::bad, vectorRightShiftHelper);
+    return inlineVectorBinaryOp(node, cg, OP::bad, vectorRightShiftHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4129,7 +4109,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmshrEvaluator(TR::Node *node, TR::Code
         return resultReg;
     }
 
-    return inlineVectorMaskedBinaryOp(node, cg, TR::InstOpCode::bad, vectorRightShiftHelper);
+    return inlineVectorMaskedBinaryOp(node, cg, OP::bad, vectorRightShiftHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4142,7 +4122,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vushrEvaluator(TR::Node *node, TR::Code
         return resultReg;
     }
 
-    return inlineVectorBinaryOp(node, cg, TR::InstOpCode::bad, vectorRightShiftHelper);
+    return inlineVectorBinaryOp(node, cg, OP::bad, vectorRightShiftHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4155,7 +4135,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmushrEvaluator(TR::Node *node, TR::Cod
         return resultReg;
     }
 
-    return inlineVectorMaskedBinaryOp(node, cg, TR::InstOpCode::bad, vectorRightShiftHelper);
+    return inlineVectorMaskedBinaryOp(node, cg, OP::bad, vectorRightShiftHelper);
 }
 
 /**
@@ -4177,14 +4157,10 @@ static TR::Register *vectorRotateHelper(TR::Node *node, TR::Register *resultReg,
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *temp2Reg = cg->allocateRegister(TR_VRF);
     TR::Register *temp3Reg = cg->allocateRegister(TR_VRF);
-    TR::InstOpCode::Mnemonic cmpOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vcmlt16b_zero + (elementType - TR::Int8));
-    TR::InstOpCode::Mnemonic addOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vadd16b + (elementType - TR::Int8));
-    TR::InstOpCode::Mnemonic shiftOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vushl16b + (elementType - TR::Int8));
-    TR::InstOpCode::Mnemonic subOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vsub16b + (elementType - TR::Int8));
+    OP::Mnemonic cmpOp = static_cast<OP::Mnemonic>(OP::vcmlt16b_zero + (elementType - TR::Int8));
+    OP::Mnemonic addOp = static_cast<OP::Mnemonic>(OP::vadd16b + (elementType - TR::Int8));
+    OP::Mnemonic shiftOp = static_cast<OP::Mnemonic>(OP::vushl16b + (elementType - TR::Int8));
+    OP::Mnemonic subOp = static_cast<OP::Mnemonic>(OP::vsub16b + (elementType - TR::Int8));
 
     if (elementType == TR::Int64) {
         /*
@@ -4192,13 +4168,12 @@ static TR::Register *vectorRotateHelper(TR::Node *node, TR::Register *resultReg,
          * integer elements. Loading the value to a vector of 32-bit integer elements and using UXTL to extend elements
          * to 64-bit.
          */
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::vmovi4s, node, tempReg, 64);
+        generateTrg1ImmInstruction(cg, OP::vmovi4s, node, tempReg, 64);
         generateVectorUXTLInstruction(cg, TR::Int32, node, tempReg, tempReg, false);
     } else {
         const int32_t sizeInBits = TR::DataType::getSize(elementType) * 8;
-        TR::InstOpCode::Mnemonic movOp = (elementType == TR::Int8)
-            ? TR::InstOpCode::vmovi16b
-            : ((elementType == TR::Int16) ? TR::InstOpCode::vmovi8h : TR::InstOpCode::vmovi4s);
+        OP::Mnemonic movOp
+            = (elementType == TR::Int8) ? OP::vmovi16b : ((elementType == TR::Int16) ? OP::vmovi8h : OP::vmovi4s);
         generateTrg1ImmInstruction(cg, movOp, node, tempReg, sizeInBits);
     }
 
@@ -4213,11 +4188,11 @@ static TR::Register *vectorRotateHelper(TR::Node *node, TR::Register *resultReg,
      */
     generateTrg1Src1Instruction(cg, cmpOp, node, temp2Reg, rhsReg);
     generateTrg1Src2Instruction(cg, addOp, node, temp3Reg, rhsReg, tempReg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vbif16b, node, temp3Reg, rhsReg, temp2Reg);
+    generateTrg1Src2Instruction(cg, OP::vbif16b, node, temp3Reg, rhsReg, temp2Reg);
     generateTrg1Src2Instruction(cg, subOp, node, temp2Reg, temp3Reg, tempReg);
     generateTrg1Src2Instruction(cg, shiftOp, node, resultReg, lhsReg, temp3Reg);
     generateTrg1Src2Instruction(cg, shiftOp, node, tempReg, lhsReg, temp2Reg);
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, resultReg, resultReg, tempReg);
+    generateTrg1Src2Instruction(cg, OP::vorr16b, node, resultReg, resultReg, tempReg);
 
     cg->stopUsingRegister(tempReg);
     cg->stopUsingRegister(temp2Reg);
@@ -4231,7 +4206,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vrolEvaluator(TR::Node *node, TR::CodeG
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    return inlineVectorBinaryOp(node, cg, TR::InstOpCode::bad, vectorRotateHelper);
+    return inlineVectorBinaryOp(node, cg, OP::bad, vectorRotateHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmrolEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4239,7 +4214,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmrolEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    return inlineVectorMaskedBinaryOp(node, cg, TR::InstOpCode::bad, vectorRotateHelper);
+    return inlineVectorMaskedBinaryOp(node, cg, OP::bad, vectorRotateHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::mcompressEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4268,31 +4243,30 @@ static TR::Register *vectorLeadingOrTrailingZeroesHelper(TR::Node *node, TR::Reg
         "elementType must be integer");
     const bool isTrailingZeroes = (vectorOp == TR::vnotz) || (vectorOp == TR::vmnotz);
     const bool is64bit = (elementType == TR::Int64);
-    const TR::InstOpCode::Mnemonic clzOp
-        = static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vclz16b + (elementType - TR::Int8));
+    const OP::Mnemonic clzOp = static_cast<OP::Mnemonic>(OP::vclz16b + (elementType - TR::Int8));
 
     TR_ARM64ScratchRegisterManager *srm = cg->generateScratchRegisterManager();
     TR::Register *dataReg = srcReg;
     if (isTrailingZeroes) {
-        const TR::InstOpCode::Mnemonic revOp = (elementType == TR::Int16) ? TR::InstOpCode::vrev16_16b
-            : (elementType == TR::Int32)                                  ? TR::InstOpCode::vrev32_16b
-                                                                          : TR::InstOpCode::vrev64_16b;
+        const OP::Mnemonic revOp = (elementType == TR::Int16) ? OP::vrev16_16b
+            : (elementType == TR::Int32)                      ? OP::vrev32_16b
+                                                              : OP::vrev64_16b;
         /* Reverses bit order in each element. */
         dataReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vrbit16b, node, dataReg, srcReg);
+        generateTrg1Src1Instruction(cg, OP::vrbit16b, node, dataReg, srcReg);
         if (elementType != TR::Int8) {
             generateTrg1Src1Instruction(cg, revOp, node, dataReg, dataReg);
         }
     }
     if (is64bit) {
         TR::Register *tempReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vclz4s, node, resultReg, dataReg);
-        generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vushr2d, node, tempReg, dataReg, 32);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vcmeq4s_zero, node, tempReg, tempReg);
+        generateTrg1Src1Instruction(cg, OP::vclz4s, node, resultReg, dataReg);
+        generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, tempReg, dataReg, 32);
+        generateTrg1Src1Instruction(cg, OP::vcmeq4s_zero, node, tempReg, tempReg);
         /* Clears lower 32-bit of each 64-bit element if upper 32-bit of the corresponding element in the original
          * vector is zero. */
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::vand16b, node, resultReg, resultReg, tempReg);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::vuaddlp4s, node, resultReg, resultReg);
+        generateTrg1Src2Instruction(cg, OP::vand16b, node, resultReg, resultReg, tempReg);
+        generateTrg1Src1Instruction(cg, OP::vuaddlp4s, node, resultReg, resultReg);
     } else {
         generateTrg1Src1Instruction(cg, clzOp, node, resultReg, dataReg);
     }
@@ -4306,7 +4280,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnotzEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    return inlineVectorUnaryOp(node, cg, TR::InstOpCode::bad, vectorLeadingOrTrailingZeroesHelper);
+    return inlineVectorUnaryOp(node, cg, OP::bad, vectorLeadingOrTrailingZeroesHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmnotzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4314,7 +4288,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmnotzEvaluator(TR::Node *node, TR::Cod
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    return inlineVectorMaskedUnaryOp(node, cg, TR::InstOpCode::bad, vectorLeadingOrTrailingZeroesHelper);
+    return inlineVectorMaskedUnaryOp(node, cg, OP::bad, vectorLeadingOrTrailingZeroesHelper);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vnolzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -4322,17 +4296,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnolzEvaluator(TR::Node *node, TR::Code
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic clzOp = TR::InstOpCode::bad;
+    OP::Mnemonic clzOp = OP::bad;
     unaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            clzOp = TR::InstOpCode::vclz16b;
+            clzOp = OP::vclz16b;
             break;
         case TR::Int16:
-            clzOp = TR::InstOpCode::vclz8h;
+            clzOp = OP::vclz8h;
             break;
         case TR::Int32:
-            clzOp = TR::InstOpCode::vclz4s;
+            clzOp = OP::vclz4s;
             break;
         case TR::Int64:
             evaluatorHelper = vectorLeadingOrTrailingZeroesHelper;
@@ -4349,17 +4323,17 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmnolzEvaluator(TR::Node *node, TR::Cod
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic clzOp = TR::InstOpCode::bad;
+    OP::Mnemonic clzOp = OP::bad;
     unaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            clzOp = TR::InstOpCode::vclz16b;
+            clzOp = OP::vclz16b;
             break;
         case TR::Int16:
-            clzOp = TR::InstOpCode::vclz8h;
+            clzOp = OP::vclz8h;
             break;
         case TR::Int32:
-            clzOp = TR::InstOpCode::vclz4s;
+            clzOp = OP::vclz4s;
             break;
         case TR::Int64:
             evaluatorHelper = vectorLeadingOrTrailingZeroesHelper;
@@ -4390,12 +4364,12 @@ static TR::Register *vectorBitSwapHelper(TR::Node *node, TR::Register *resultReg
     /* We do not expect elementType = TR::Int8 here. */
     TR_ASSERT_FATAL_WITH_NODE(node, (elementType >= TR::Int16) && (elementType <= TR::Int64),
         "elementType must be integer");
-    const TR::InstOpCode::Mnemonic revOp = (elementType == TR::Int16) ? TR::InstOpCode::vrev16_16b
-        : (elementType == TR::Int32)                                  ? TR::InstOpCode::vrev32_16b
-                                                                      : TR::InstOpCode::vrev64_16b;
+    const OP::Mnemonic revOp = (elementType == TR::Int16) ? OP::vrev16_16b
+        : (elementType == TR::Int32)                      ? OP::vrev32_16b
+                                                          : OP::vrev64_16b;
 
     /* Reverses bit order in each element. */
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vrbit16b, node, resultReg, srcReg);
+    generateTrg1Src1Instruction(cg, OP::vrbit16b, node, resultReg, srcReg);
     generateTrg1Src1Instruction(cg, revOp, node, resultReg, resultReg);
 
     return resultReg;
@@ -4406,11 +4380,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::vbitswapEvaluator(TR::Node *node, TR::C
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic bitSwapOp = TR::InstOpCode::bad;
+    OP::Mnemonic bitSwapOp = OP::bad;
     unaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            bitSwapOp = TR::InstOpCode::vrbit16b;
+            bitSwapOp = OP::vrbit16b;
             break;
         case TR::Int16:
         case TR::Int32:
@@ -4429,11 +4403,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmbitswapEvaluator(TR::Node *node, TR::
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic bitSwapOp = TR::InstOpCode::bad;
+    OP::Mnemonic bitSwapOp = OP::bad;
     unaryEvaluatorHelper evaluatorHelper = NULL;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            bitSwapOp = TR::InstOpCode::vrbit16b;
+            bitSwapOp = OP::vrbit16b;
             break;
         case TR::Int16:
         case TR::Int32:
@@ -4452,7 +4426,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vbyteswapEvaluator(TR::Node *node, TR::
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic byteSwapOp = TR::InstOpCode::bad;
+    OP::Mnemonic byteSwapOp = OP::bad;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8: {
             /* byteswap on vectors with byte elements is no-op */
@@ -4462,13 +4436,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vbyteswapEvaluator(TR::Node *node, TR::
             return reg;
         }
         case TR::Int16:
-            byteSwapOp = TR::InstOpCode::vrev16_16b;
+            byteSwapOp = OP::vrev16_16b;
             break;
         case TR::Int32:
-            byteSwapOp = TR::InstOpCode::vrev32_16b;
+            byteSwapOp = OP::vrev32_16b;
             break;
         case TR::Int64:
-            byteSwapOp = TR::InstOpCode::vrev64_16b;
+            byteSwapOp = OP::vrev64_16b;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -4482,7 +4456,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmbyteswapEvaluator(TR::Node *node, TR:
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
-    TR::InstOpCode::Mnemonic byteSwapOp = TR::InstOpCode::bad;
+    OP::Mnemonic byteSwapOp = OP::bad;
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8: {
             /* byteswap on vectors with byte elements is no-op */
@@ -4494,13 +4468,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmbyteswapEvaluator(TR::Node *node, TR:
             return reg;
         }
         case TR::Int16:
-            byteSwapOp = TR::InstOpCode::vrev16_16b;
+            byteSwapOp = OP::vrev16_16b;
             break;
         case TR::Int32:
-            byteSwapOp = TR::InstOpCode::vrev32_16b;
+            byteSwapOp = OP::vrev32_16b;
             break;
         case TR::Int64:
-            byteSwapOp = TR::InstOpCode::vrev64_16b;
+            byteSwapOp = OP::vrev64_16b;
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "unrecognized vector type %s", node->getDataType().toString());
@@ -4797,8 +4771,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node
         if (secondChild->getOpCode().isLoadConst()) {
             if (firstChild->getInt() < secondChild->getInt()) {
                 // Check will always fail, just jump to the exception handler
-                instr = generateImmSymInstruction(cg, TR::InstOpCode::bl, node,
-                    (uintptr_t)exceptionBNDCHK->getMethodAddress(), NULL, exceptionBNDCHK, NULL);
+                instr = generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)exceptionBNDCHK->getMethodAddress(),
+                    NULL, exceptionBNDCHK, NULL);
                 cg->machine()->setLinkRegisterKilled(true);
             } else {
                 // Check will always succeed, no need for an instruction
@@ -5137,7 +5111,7 @@ TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *n
             cg->getSnippetsToBePatchedOnClassUnload()->push_front(snippet);
         }
     }
-    return generateTrg1ImmSymInstruction(cg, TR::InstOpCode::ldrx, node, targetRegister, 0, labelSym, cursor);
+    return generateTrg1ImmSymInstruction(cg, OP::ldrx, node, targetRegister, 0, labelSym, cursor);
 }
 
 bool shouldLoadNegatedConstant32(int32_t value)
@@ -5226,24 +5200,24 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
     if (cursor == NULL)
         cursor = cg->getAppendInstruction();
 
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     uint32_t imm;
 
     if (value >= 0 && value <= 65535) {
-        op = TR::InstOpCode::movzw;
+        op = OP::movzw;
         imm = value & 0xFFFF;
     } else if (value >= -65535 && value < 0) {
-        op = TR::InstOpCode::movnw;
+        op = OP::movnw;
         imm = ~value & 0xFFFF;
     } else if ((value & 0xFFFF) == 0) {
-        op = TR::InstOpCode::movzw;
+        op = OP::movzw;
         imm = ((value >> 16) & 0xFFFF) | TR::MOV_LSL16;
     } else if ((value & 0xFFFF) == 0xFFFF) {
-        op = TR::InstOpCode::movnw;
+        op = OP::movnw;
         imm = ((~value >> 16) & 0xFFFF) | TR::MOV_LSL16;
     }
 
-    if (op != TR::InstOpCode::bad) {
+    if (op != OP::bad) {
         cursor = generateTrg1ImmInstruction(cg, op, node, trgReg, imm, cursor);
     } else {
         bool n;
@@ -5252,9 +5226,9 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
             cursor = generateMovBitMaskInstruction(cg, node, trgReg, n, immEncoded, false, cursor);
         } else {
             // need two instructions
-            cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movzw, node, trgReg, (value & 0xFFFF), cursor);
-            cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movkw, node, trgReg,
-                (((value >> 16) & 0xFFFF) | TR::MOV_LSL16), cursor);
+            cursor = generateTrg1ImmInstruction(cg, OP::movzw, node, trgReg, (value & 0xFFFF), cursor);
+            cursor = generateTrg1ImmInstruction(cg, OP::movkw, node, trgReg, (((value >> 16) & 0xFFFF) | TR::MOV_LSL16),
+                cursor);
         }
     }
 
@@ -5273,10 +5247,10 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
 
     if (value == 0LL) {
         // 0
-        cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, trgReg, 0, cursor);
+        cursor = generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0, cursor);
     } else if (~value == 0LL) {
         // -1
-        cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movnx, node, trgReg, 0, cursor);
+        cursor = generateTrg1ImmInstruction(cg, OP::movnx, node, trgReg, 0, cursor);
     } else {
         uint16_t h[4];
         int32_t i;
@@ -5292,27 +5266,27 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
 
             for (i = 0; i < 4; i++) {
                 uint32_t shift = TR::MOV_LSL16 * i;
-                TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+                OP::Mnemonic op = OP::bad;
                 uint32_t imm;
 
                 if (use_movz && (h[i] != 0)) {
                     imm = h[i] | shift;
                     if (cursor != start) {
-                        op = TR::InstOpCode::movkx;
+                        op = OP::movkx;
                     } else {
-                        op = TR::InstOpCode::movzx;
+                        op = OP::movzx;
                     }
                 } else if (!use_movz && (h[i] != 0xFFFF)) {
                     if (cursor != start) {
-                        op = TR::InstOpCode::movkx;
+                        op = OP::movkx;
                         imm = h[i] | shift;
                     } else {
-                        op = TR::InstOpCode::movnx;
+                        op = OP::movnx;
                         imm = (~h[i] & 0xFFFF) | shift;
                     }
                 }
 
-                if (op != TR::InstOpCode::bad) {
+                if (op != OP::bad) {
                     cursor = generateTrg1ImmInstruction(cg, op, node, trgReg, imm, cursor);
                 } else {
                     // generate no instruction here
@@ -5332,11 +5306,11 @@ void addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, 
     if (value == 0) {
         // Do nothing
     } else if (constantIsUnsignedImm12(value)) {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, trgReg, srcReg, value);
+        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, trgReg, srcReg, value);
     } else {
         TR::Register *tempReg = cg->allocateRegister();
         loadConstant64(cg, node, value, tempReg);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, trgReg, srcReg, tempReg);
+        generateTrg1Src2Instruction(cg, OP::addx, node, trgReg, srcReg, tempReg);
         cg->stopUsingRegister(tempReg);
     }
 }
@@ -5346,11 +5320,11 @@ void addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, 
     if (value == 0) {
         // Do nothing
     } else if (constantIsUnsignedImm12(value)) {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, trgReg, srcReg, value);
+        generateTrg1Src1ImmInstruction(cg, OP::addimmw, node, trgReg, srcReg, value);
     } else {
         TR::Register *tempReg = cg->allocateRegister();
         loadConstant32(cg, node, value, tempReg);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addw, node, trgReg, srcReg, tempReg);
+        generateTrg1Src2Instruction(cg, OP::addw, node, trgReg, srcReg, tempReg);
         cg->stopUsingRegister(tempReg);
     }
 }
@@ -5466,14 +5440,12 @@ static TR::Instruction *loadAddressConstantRelocatable(TR::CodeGenerator *cg, TR
     if (cursor == NULL)
         cursor = cg->getAppendInstruction();
 
-    cursor = firstInstruction
-        = generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, trgReg, value & 0x0000ffff, cursor);
-    cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movkx, node, trgReg,
-        ((value >> 16) & 0x0000ffff) | TR::MOV_LSL16, cursor);
-    cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movkx, node, trgReg,
-        ((value >> 32) & 0x0000ffff) | (TR::MOV_LSL16 * 2), cursor);
-    cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movkx, node, trgReg, (value >> 48) | (TR::MOV_LSL16 * 3),
+    cursor = firstInstruction = generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, value & 0x0000ffff, cursor);
+    cursor
+        = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, ((value >> 16) & 0x0000ffff) | TR::MOV_LSL16, cursor);
+    cursor = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, ((value >> 32) & 0x0000ffff) | (TR::MOV_LSL16 * 2),
         cursor);
+    cursor = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, (value >> 48) | (TR::MOV_LSL16 * 3), cursor);
 
     addMetaDataForLoadAddressConstantFixed(cg, node, firstInstruction, typeAddress, value);
 
@@ -5514,15 +5486,15 @@ TR::Register *OMR::ARM64::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::Co
     return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg)
+TR::Register *commonLoadEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::CodeGenerator *cg)
 {
     TR::Register *tempReg;
 
-    if (op == TR::InstOpCode::vldrimms) {
+    if (op == OP::vldrimms) {
         tempReg = cg->allocateSinglePrecisionRegister();
-    } else if (op == TR::InstOpCode::vldrimmd) {
+    } else if (op == OP::vldrimmd) {
         tempReg = cg->allocateRegister(TR_FPR);
-    } else if (op == TR::InstOpCode::vldrimmq) {
+    } else if (op == OP::vldrimmq) {
         tempReg = cg->allocateRegister(TR_VRF);
     } else {
         tempReg = cg->allocateRegister();
@@ -5531,7 +5503,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
     return commonLoadEvaluator(node, op, size, tempReg, cg);
 }
 
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::Register *targetReg,
+TR::Register *commonLoadEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::Register *targetReg,
     TR::CodeGenerator *cg)
 {
     TR::Symbol *sym = node->getSymbolReference()->getSymbol();
@@ -5544,7 +5516,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
     generateTrg1MemInstruction(cg, op, node, targetReg, tempMR);
 
     if (needSync) {
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ishld);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishld);
     }
 
     tempMR->decNodeReferenceCounts(cg);
@@ -5555,7 +5527,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
 // also handles iloadi
 TR::Register *OMR::ARM64::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::ldrimmw, 4, cg);
+    return commonLoadEvaluator(node, OP::ldrimmw, 4, cg);
 }
 
 // also handles aloadi
@@ -5582,20 +5554,20 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
     if (constRefLabel != NULL) {
         // Load from the const ref slot using ldr literal (ldrx), which has a range of +/- 1MB.
         // We may eventually need to handle farther slots for splitWarmAndColdBlocks, e.g. with adrp + ldrimmx.
-        generateTrg1ImmSymInstruction(cg, TR::InstOpCode::ldrx, node, tempReg, 0, constRefLabel);
+        generateTrg1ImmSymInstruction(cg, OP::ldrx, node, tempReg, 0, constRefLabel);
         return tempReg;
     }
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
     int32_t size;
 
     if (TR::Compiler->om.generateCompressedObjectHeaders()
         && (node->getSymbol()->isClassObject()
             || (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()))) {
-        op = TR::InstOpCode::ldrimmw;
+        op = OP::ldrimmw;
         size = 4;
     } else {
-        op = TR::InstOpCode::ldrimmx;
+        op = OP::ldrimmx;
         size = 8;
     }
     TR::MemoryReference *tempMR = MRef_node(cg, node);
@@ -5610,7 +5582,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
     TR::Symbol *sym = node->getSymbolReference()->getSymbol();
     bool needSync = cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease();
     if (needSync) {
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ishld);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishld);
     }
 
     tempMR->decNodeReferenceCounts(cg);
@@ -5621,25 +5593,25 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
 // also handles lloadi
 TR::Register *OMR::ARM64::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::ldrimmx, 8, cg);
+    return commonLoadEvaluator(node, OP::ldrimmx, 8, cg);
 }
 
 // also handles bloadi
 TR::Register *OMR::ARM64::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::ldrsbimmx, 1, cg);
+    return commonLoadEvaluator(node, OP::ldrsbimmx, 1, cg);
 }
 
 // also handles sloadi
 TR::Register *OMR::ARM64::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::ldrshimmx, 2, cg);
+    return commonLoadEvaluator(node, OP::ldrshimmx, 2, cg);
 }
 
 // also handles vloadi
 TR::Register *OMR::ARM64::TreeEvaluator::vloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonLoadEvaluator(node, TR::InstOpCode::vldrimmq, 16, cg);
+    return commonLoadEvaluator(node, OP::vldrimmq, 16, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -5647,7 +5619,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::Co
     return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 }
 
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg)
+TR::Register *commonStoreEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::CodeGenerator *cg)
 {
     TR::MemoryReference *tempMR = MRef_node(cg, node);
     tempMR->validateImmediateOffsetAlignment(node, size, cg);
@@ -5661,7 +5633,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
     }
 
     if (cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease()) {
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ishst);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishst);
     }
 
     TR::Node *valueChildRoot = NULL;
@@ -5703,14 +5675,14 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
         generateMemSrc1Instruction(cg, op, node, tempMR, zeroReg);
         auto *deps = RegDeps(0, 1, cg);
         deps->addPostCondition(zeroReg, TR::RealRegister::xzr);
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, generateLabelSymbol(cg), deps);
+        generateLabelInstruction(cg, OP::label, node, generateLabelSymbol(cg), deps);
         cg->stopUsingRegister(zeroReg);
     } else {
         generateMemSrc1Instruction(cg, op, node, tempMR, cg->evaluate(valueChild));
     }
 
     if (cg->comp()->target().isSMP() && sym->isVolatile()) {
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
     }
 
     if (valueChildRoot != NULL) {
@@ -5726,7 +5698,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, 
 // also handles lstorei
 TR::Register *OMR::ARM64::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::strimmx, 8, cg);
+    return commonStoreEvaluator(node, OP::strimmx, 8, cg);
 }
 
 // also handles bstorei
@@ -5745,7 +5717,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
                 TR::Register *tempReg = cg->allocateRegister();
                 deps->addPostCondition(tempMR->getBaseRegister(), TR::RealRegister::x0);
                 deps->addPostCondition(tempReg, TR::RealRegister::x1);
-                generateImmSymInstruction(cg, TR::InstOpCode::bl, node,
+                generateImmSymInstruction(cg, OP::bl, node,
                     reinterpret_cast<uintptr_t>(patchGCRHelperRef->getMethodAddress()), deps, patchGCRHelperRef, NULL);
 
                 cg->stopUsingRegister(tempReg);
@@ -5756,13 +5728,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
             }
         }
     }
-    return commonStoreEvaluator(node, TR::InstOpCode::strbimm, 1, cg);
+    return commonStoreEvaluator(node, OP::strbimm, 1, cg);
 }
 
 // also handles sstorei
 TR::Register *OMR::ARM64::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::strhimm, 2, cg);
+    return commonStoreEvaluator(node, OP::strhimm, 2, cg);
 }
 
 // also handles istorei
@@ -5770,7 +5742,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::Cod
 {
     TR::Compilation *comp = cg->comp();
 
-    commonStoreEvaluator(node, TR::InstOpCode::strimmw, 4, cg);
+    commonStoreEvaluator(node, OP::strimmw, 4, cg);
 
     if (comp->useCompressedPointers() && node->getOpCode().isIndirect())
         node->setStoreAlreadyEvaluated(true);
@@ -5785,8 +5757,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::Cod
     bool isCompressedClassPointerOfObjectHeader = TR::Compiler->om.generateCompressedObjectHeaders()
         && (node->getSymbol()->isClassObject()
             || (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()));
-    TR::InstOpCode::Mnemonic op
-        = isCompressedClassPointerOfObjectHeader ? TR::InstOpCode::strimmw : TR::InstOpCode::strimmx;
+    OP::Mnemonic op = isCompressedClassPointerOfObjectHeader ? OP::strimmw : OP::strimmx;
     int32_t size = isCompressedClassPointerOfObjectHeader ? 4 : 8;
 
     return commonStoreEvaluator(node, op, size, cg);
@@ -5795,7 +5766,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::Cod
 // also handles vstorei
 TR::Register *OMR::ARM64::TreeEvaluator::vstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonStoreEvaluator(node, TR::InstOpCode::vstrimmq, 16, cg);
+    return commonStoreEvaluator(node, OP::vstrimmq, 16, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vindexVectorEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -5933,7 +5904,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraytranslateEvaluator(TR::Node *node,
     // Array Translate helper call
     TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper);
     uintptr_t addr = reinterpret_cast<uintptr_t>(helperSym->getMethodAddress());
-    generateImmSymInstruction(cg, TR::InstOpCode::bl, node, addr, deps, helperSym, NULL);
+    generateImmSymInstruction(cg, OP::bl, node, addr, deps, helperSym, NULL);
 
     for (uint32_t i = 0; i < node->getNumChildren(); i++)
         cg->decReferenceCount(node->getChild(i));
@@ -5976,10 +5947,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
     TR::Register *lengthReg = NULL;
     const uint8_t elementSize
         = valueNode->getOpCode().isRef() ? TR::Compiler->om.sizeofReferenceField() : valueNode->getSize();
-    const TR::InstOpCode::Mnemonic dupOpCode = (!valueNode->getDataType().isFloatingPoint())
-        ? static_cast<TR::InstOpCode::Mnemonic>(TR::InstOpCode::vdup16b + trailingZeroes(elementSize))
-        : valueNode->getDataType().isFloat() ? TR::InstOpCode::vdupe4s
-                                             : TR::InstOpCode::vdupe2d;
+    const OP::Mnemonic dupOpCode = (!valueNode->getDataType().isFloatingPoint())
+        ? static_cast<OP::Mnemonic>(OP::vdup16b + trailingZeroes(elementSize))
+        : valueNode->getDataType().isFloat() ? OP::vdupe4s
+                                             : OP::vdupe2d;
     if (isLengthConstant) {
         const int64_t length = lengthNode->getConstValue(); /* length in bytes */
         if (length >= elementSize * 4) {
@@ -5993,112 +5964,106 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             if (length >= 32) {
                 int64_t lenMod32 = length & 0x1f;
                 if (length >= alignmentThresholdLength) {
-                    generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 0),
-                        vectorValueReg, vectorValueReg);
+                    generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg,
+                        vectorValueReg);
                     TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
                     if (constantIsUnsignedImm12(length) || constantIsUnsignedImm12Shifted(length)) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, dstEndReg, dstReg, length);
+                        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
                     } else {
                         loadConstant64(cg, node, length, dstEndReg);
-                        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstEndReg, dstReg, dstEndReg);
+                        generateTrg1Src2Instruction(cg, OP::addx, node, dstEndReg, dstReg, dstEndReg);
                     }
                     // N = true, immr:imms = 0xf3b for immediate value ~(0xf)
-                    generateLogicalImmInstruction(cg, TR::InstOpCode::andimmx, node, dstReg, dstReg, true, 0xf3b);
+                    generateLogicalImmInstruction(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
                     bool useLoop = (length - 32) > constLoopLen * 2;
                     if (useLoop) {
                         TR::Register *countReg = srm->findOrCreateScratchRegister();
                         loadConstant64(cg, node, (length - 32) / constLoopLen, countReg);
                         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-                        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, countReg, countReg, 1);
+                        generateLabelInstruction(cg, OP::label, node, loopLabel);
+                        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, countReg, countReg, 1);
                         for (int i = 1; i <= 7; i++) {
-                            generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node,
-                                MRef_disp(cg, dstReg, i * 32), vectorValueReg, vectorValueReg);
+                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i * 32),
+                                vectorValueReg, vectorValueReg);
                         }
-                        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, 256),
-                            vectorValueReg, vectorValueReg);
+                        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 256), vectorValueReg,
+                            vectorValueReg);
                         generateConditionalBranchInstruction(cg, node, loopLabel, TR::CC_GT);
                         srm->reclaimScratchRegister(countReg);
                     }
                     int64_t remainingLength = useLoop ? ((length - 32) % constLoopLen) : (length - 32);
                     for (int i = 32; i <= remainingLength; i += 32) {
-                        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, i),
-                            vectorValueReg, vectorValueReg);
+                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
+                            vectorValueReg);
                     }
                     if (lenMod32 <= elementSize) {
                         /*
                          * If (remainingLength mod 32) <= elementSize, then the left over is not larger than 16 bytes.
                          */
-                        generateMemSrc1Instruction(cg, TR::InstOpCode::vsturq, node, MRef_disp(cg, dstEndReg, -16),
-                            vectorValueReg);
+                        generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
                     } else if (lenMod32 <= (16 + elementSize)) {
                         /*
                          * If (remainingLength mod 32) <= (16 + elementSize), then the left over is not larger than 32
                          * bytes.
                          */
-                        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
+                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
                             vectorValueReg, vectorValueReg);
                     } else {
-                        generateMemSrc1Instruction(cg, TR::InstOpCode::vstrimmq, node,
+                        generateMemSrc1Instruction(cg, OP::vstrimmq, node,
                             MRef_disp(cg, dstReg, (remainingLength + 32) & (~0x1f)), vectorValueReg);
                         /* now the left over is not larger than 32 bytes. */
-                        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
+                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
                             vectorValueReg, vectorValueReg);
                     }
                     srm->reclaimScratchRegister(dstEndReg);
                 } else {
                     if (lenMod32 == 0) {
                         for (int i = 0; i < length; i += 32) {
-                            generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, i),
-                                vectorValueReg, vectorValueReg);
+                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
+                                vectorValueReg);
                         }
                     } else {
                         for (int i = 0; i < length - 32; i += 32) {
-                            generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, i),
-                                vectorValueReg, vectorValueReg);
+                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
+                                vectorValueReg);
                         }
                         if (lenMod32 == 16) {
-                            generateMemSrc1Instruction(cg, TR::InstOpCode::vstrimmq, node,
-                                MRef_disp(cg, dstReg, length - 16), vectorValueReg);
+                            generateMemSrc1Instruction(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, length - 16),
+                                vectorValueReg);
                         } else {
                             TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-                            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, dstEndReg, dstReg,
-                                length);
+                            generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
                             if (lenMod32 > 16) {
-                                generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node,
-                                    MRef_disp(cg, dstEndReg, -32), vectorValueReg, vectorValueReg);
+                                generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
+                                    vectorValueReg, vectorValueReg);
                             } else {
-                                generateMemSrc1Instruction(cg, TR::InstOpCode::vsturq, node,
-                                    MRef_disp(cg, dstEndReg, -16), vectorValueReg);
+                                generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16),
+                                    vectorValueReg);
                             }
                             srm->reclaimScratchRegister(dstEndReg);
                         }
                     }
                 }
             } else if (isPowerOf2(length)) {
-                TR::InstOpCode::Mnemonic op = (length == 16) ? TR::InstOpCode::vstrimmq
-                    : (length == 8)                          ? TR::InstOpCode::vstrimmd
-                                                             : TR::InstOpCode::vstrimms;
+                OP::Mnemonic op = (length == 16) ? OP::vstrimmq : (length == 8) ? OP::vstrimmd : OP::vstrimms;
                 generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
             } else {
-                TR::InstOpCode::Mnemonic op = (length >= 16) ? TR::InstOpCode::vstrimmq
-                    : (length >= 8)                          ? TR::InstOpCode::vstrimmd
-                                                             : TR::InstOpCode::vstrimms;
+                OP::Mnemonic op = (length >= 16) ? OP::vstrimmq : (length >= 8) ? OP::vstrimmd : OP::vstrimms;
                 int32_t offset = (length >= 16) ? -16 : (length >= 8) ? -8 : -4;
                 TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, dstEndReg, dstReg, length);
+                generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
                 generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
                 generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstEndReg, offset), vectorValueReg);
                 srm->reclaimScratchRegister(dstEndReg);
             }
         } else {
-            const TR::InstOpCode::Mnemonic strOpCode = (!valueNode->getDataType().isFloatingPoint())
-                ? ((elementSize == 1)          ? TR::InstOpCode::strbimm
-                          : (elementSize == 2) ? TR::InstOpCode::strhimm
-                          : (elementSize == 4) ? TR::InstOpCode::strimmw
-                                               : TR::InstOpCode::strimmx)
-                : valueNode->getDataType().isFloat() ? TR::InstOpCode::vstrimms
-                                                     : TR::InstOpCode::vstrimmd;
+            const OP::Mnemonic strOpCode = (!valueNode->getDataType().isFloatingPoint())
+                ? ((elementSize == 1)          ? OP::strbimm
+                          : (elementSize == 2) ? OP::strhimm
+                          : (elementSize == 4) ? OP::strimmw
+                                               : OP::strimmx)
+                : valueNode->getDataType().isFloat() ? OP::vstrimms
+                                                     : OP::vstrimmd;
             valueReg = isValueZero ? cg->allocateRegister() : cg->evaluate(valueNode);
             for (int i = 0; i < length / elementSize; i++) {
                 generateMemSrc1Instruction(cg, strOpCode, node, MRef_disp(cg, dstReg, i * elementSize), valueReg);
@@ -6108,7 +6073,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
             auto *conditions = RegDeps(0, 1, cg);
             conditions->addPostCondition(valueReg, TR::RealRegister::xzr);
-            generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+            generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
         }
     } else {
         /*
@@ -6173,21 +6138,19 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             generateTrg1Src1Instruction(cg, dupOpCode, node, vectorValueReg, valueReg);
         }
 
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
-        auto branchToDoneLabelInstr
-            = generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, lengthReg, doneLabel);
+        generateLabelInstruction(cg, OP::label, node, startLabel);
+        auto branchToDoneLabelInstr = generateCompareBranchInstruction(cg, OP::cbzx, node, lengthReg, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr, "Done if length is 0.");
         }
 
         TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstEndReg, dstReg, lengthReg);
+        generateTrg1Src2Instruction(cg, OP::addx, node, dstEndReg, dstReg, lengthReg);
         TR::LabelSymbol *lessThan32Label = generateLabelSymbol(cg);
         generateCompareImmInstruction(cg, node, lengthReg, 32, true);
         auto branchToLessThan32LabelInstr = generateConditionalBranchInstruction(cg, node, lessThan32Label, TR::CC_CC);
 
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg,
-            vectorValueReg);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg, vectorValueReg);
 
         TR::LabelSymbol *lessThanOrEqual96Label = generateLabelSymbol(cg);
         generateCompareImmInstruction(cg, node, lengthReg, 96, true);
@@ -6199,17 +6162,15 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                 "Jumps to lessThanOrEqual96Label if length <= 96.");
         }
 
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, node, lengthReg, lengthReg, 96);
+        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, lengthReg, lengthReg, 96);
         /* Makes dst address 16 byte aligned */
         TR::Register *remainderReg = srm->findOrCreateScratchRegister();
 
         // N = true, immr:imms = 3 for immediate value 0xf
-        auto mod16OfDstInstr
-            = generateLogicalImmInstruction(cg, TR::InstOpCode::andimmx, node, remainderReg, dstReg, true, 3);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, lengthReg, lengthReg, remainderReg);
+        auto mod16OfDstInstr = generateLogicalImmInstruction(cg, OP::andimmx, node, remainderReg, dstReg, true, 3);
+        generateTrg1Src2Instruction(cg, OP::addx, node, lengthReg, lengthReg, remainderReg);
         // N = true, immr:imms = 0xf3b for immediate value ~(0xf)
-        auto dstAdjustmentInstr
-            = generateLogicalImmInstruction(cg, TR::InstOpCode::andimmx, node, dstReg, dstReg, true, 0xf3b);
+        auto dstAdjustmentInstr = generateLogicalImmInstruction(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
 
         if (debugObj) {
             debugObj->addInstructionComment(mod16OfDstInstr, "The modulo 16 residue of src address.");
@@ -6220,18 +6181,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         srm->reclaimScratchRegister(remainderReg);
 
         TR::LabelSymbol *mainLoopLabel = generateLabelSymbol(cg);
-        auto mainLoopLabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, mainLoopLabel);
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, lengthReg, lengthReg, 64);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg,
-            vectorValueReg);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, 64), vectorValueReg,
-            vectorValueReg);
+        auto mainLoopLabelInstr = generateLabelInstruction(cg, OP::label, node, mainLoopLabel);
+        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 64);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
         auto branchBackToMainLoopLabelInstr = generateConditionalBranchInstruction(cg, node, mainLoopLabel, TR::CC_HI);
-        auto adjustDstRegInstr = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstReg, dstReg, lengthReg);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg,
-            vectorValueReg);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 64), vectorValueReg,
-            vectorValueReg);
+        auto adjustDstRegInstr = generateTrg1Src2Instruction(cg, OP::addx, node, dstReg, dstReg, lengthReg);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
 
         if (debugObj) {
             debugObj->addInstructionComment(mainLoopLabelInstr, "mainLoopLabel");
@@ -6240,22 +6197,20 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             debugObj->addInstructionComment(adjustDstRegInstr,
                 "Adjusts dst register so that they point to 64bytes before the end");
         }
-        auto branchToDoneLabelInstr2 = generateLabelInstruction(cg, TR::InstOpCode::b, node, doneLabel);
+        auto branchToDoneLabelInstr2 = generateLabelInstruction(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr2, "Jumps to doneLabel.");
         }
 
         TR::LabelSymbol *lessThan64Label = generateLabelSymbol(cg);
-        auto lessThanOrEqual96LabelInstr
-            = generateLabelInstruction(cg, TR::InstOpCode::label, node, lessThanOrEqual96Label);
+        auto lessThanOrEqual96LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThanOrEqual96Label);
         auto branchToLessThan64LabelInstr
-            = generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 6, lessThan64Label);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg,
+            = generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 6, lessThan64Label);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        auto lessThan64LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan64Label);
+        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
             vectorValueReg);
-        auto lessThan64LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, lessThan64Label);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
-            vectorValueReg);
-        auto branchToDoneLabelInstr3 = generateLabelInstruction(cg, TR::InstOpCode::b, node, doneLabel);
+        auto branchToDoneLabelInstr3 = generateLabelInstruction(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(lessThanOrEqual96LabelInstr, "lessThanOrEqual96Label");
             debugObj->addInstructionComment(branchToLessThan64LabelInstr, "Jumps to lessThan64Label if length < 64.");
@@ -6264,39 +6219,38 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         }
 
         TR::LabelSymbol *lessThan16Label = generateLabelSymbol(cg);
-        auto lessThan32LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, lessThan32Label);
+        auto lessThan32LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan32Label);
         auto branchToLessThan16LabelInstr
-            = generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 4, lessThan16Label);
+            = generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 4, lessThan16Label);
 
         if (debugObj) {
             debugObj->addInstructionComment(lessThan32LabelInstr, "lessThan32Label");
             debugObj->addInstructionComment(branchToLessThan16LabelInstr, "Jumps to lessThan16Label if length < 16.");
         }
 
-        generateMemSrc1Instruction(cg, TR::InstOpCode::vstrimmq, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
-        generateMemSrc1Instruction(cg, TR::InstOpCode::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
+        generateMemSrc1Instruction(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
+        generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
 
-        auto branchToDoneLabelInstr4 = generateLabelInstruction(cg, TR::InstOpCode::b, node, doneLabel);
+        auto branchToDoneLabelInstr4 = generateLabelInstruction(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr4, "Jumps to doneLabel.");
         }
 
-        auto lessThan16LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, lessThan16Label);
+        auto lessThan16LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan16Label);
         if (elementSize == 8) {
-            generateMemSrc1Instruction(cg,
-                valueNode->getDataType().isFloatingPoint() ? TR::InstOpCode::vstrimmd : TR::InstOpCode::strimmx, node,
-                MRef_disp(cg, dstReg, 0), valueReg);
+            generateMemSrc1Instruction(cg, valueNode->getDataType().isFloatingPoint() ? OP::vstrimmd : OP::strimmx,
+                node, MRef_disp(cg, dstReg, 0), valueReg);
         } else {
             TR::LabelSymbol *elementLoopLabel = generateLabelSymbol(cg);
-            auto elementLoopLabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, elementLoopLabel);
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, lengthReg, lengthReg, elementSize);
-            const TR::InstOpCode::Mnemonic strOpCode = (!valueNode->getDataType().isFloatingPoint())
-                ? ((elementSize == 1)          ? TR::InstOpCode::strbpost
-                          : (elementSize == 2) ? TR::InstOpCode::strhpost
-                          : (elementSize == 4) ? TR::InstOpCode::strpostw
-                                               : TR::InstOpCode::strpostx)
-                : valueNode->getDataType().isFloat() ? TR::InstOpCode::vstrposts
-                                                     : TR::InstOpCode::vstrpostd;
+            auto elementLoopLabelInstr = generateLabelInstruction(cg, OP::label, node, elementLoopLabel);
+            generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, elementSize);
+            const OP::Mnemonic strOpCode = (!valueNode->getDataType().isFloatingPoint())
+                ? ((elementSize == 1)          ? OP::strbpost
+                          : (elementSize == 2) ? OP::strhpost
+                          : (elementSize == 4) ? OP::strpostw
+                                               : OP::strpostx)
+                : valueNode->getDataType().isFloat() ? OP::vstrposts
+                                                     : OP::vstrpostd;
             generateMemSrc1Instruction(cg, strOpCode, node, MRef_disp(cg, dstReg, elementSize), valueReg);
             auto branchBackToElementLoopLabelInstr
                 = generateConditionalBranchInstruction(cg, node, elementLoopLabel, TR::CC_HI);
@@ -6315,7 +6269,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         conditions->addPostCondition(valueReg, isValueZero ? TR::RealRegister::xzr : TR::RealRegister::NoReg);
         srm->addScratchRegistersToDependencyList(conditions);
 
-        auto doneLabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+        auto doneLabelInstr = generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
         if (debugObj) {
             debugObj->addInstructionComment(doneLabelInstr, "doneLabel");
         }
@@ -6464,7 +6418,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
+    generateLabelInstruction(cg, OP::label, node, startLabel);
     if (isArrayCmpLen) {
         generateMovInstruction(cg, node, resultReg, lengthReg, true);
     } else {
@@ -6500,21 +6454,21 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
             debugObj->addInstructionComment(branchToLessThan16LabelInstr, "Jumps to lessThan16Label if length < 16.");
         }
     }
-    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, node, lengthReg, lengthReg, 16);
+    generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, lengthReg, lengthReg, 16);
 
     TR::LabelSymbol *loop16Label = generateLabelSymbol(cg);
     {
-        auto loop16LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, loop16Label);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::ldppostx, node, data1Reg, data3Reg, MRef_disp(cg, src1Reg, 16));
-        generateTrg2MemInstruction(cg, TR::InstOpCode::ldppostx, node, data2Reg, data4Reg, MRef_disp(cg, src2Reg, 16));
+        auto loop16LabelInstr = generateLabelInstruction(cg, OP::label, node, loop16Label);
+        generateTrg2MemInstruction(cg, OP::ldppostx, node, data1Reg, data3Reg, MRef_disp(cg, src1Reg, 16));
+        generateTrg2MemInstruction(cg, OP::ldppostx, node, data2Reg, data4Reg, MRef_disp(cg, src2Reg, 16));
         if (isArrayCmpLen) {
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::subsx, node, data1Reg, data1Reg, data2Reg);
+            generateTrg1Src2Instruction(cg, OP::subsx, node, data1Reg, data1Reg, data2Reg);
         } else {
             generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
         }
         generateConditionalCompareInstruction(cg, node, data3Reg, data4Reg, 0, TR::CC_EQ, true);
         auto branchToNotEqual16LabelInstr2 = generateConditionalBranchInstruction(cg, node, notEqual16Label, TR::CC_NE);
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, lengthReg, lengthReg, 16);
+        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 16);
         auto branchBacktoLoop16LabelInstr = generateConditionalBranchInstruction(cg, node, loop16Label, TR::CC_CS);
         if (debugObj) {
             debugObj->addInstructionComment(loop16LabelInstr, "loop16Label");
@@ -6527,11 +6481,10 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     if (isLengthGreaterThan15) {
         generateCompareImmInstruction(cg, node, lengthReg, -16, true);
         auto branchToDoneLabelInstr3 = generateConditionalBranchInstruction(cg, node, done0Label, TR::CC_EQ);
-        auto adjustSrc1RegInstr
-            = generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, src1Reg, src1Reg, lengthReg);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, src2Reg, src2Reg, lengthReg);
+        auto adjustSrc1RegInstr = generateTrg1Src2Instruction(cg, OP::addx, node, src1Reg, src1Reg, lengthReg);
+        generateTrg1Src2Instruction(cg, OP::addx, node, src2Reg, src2Reg, lengthReg);
         loadConstant64(cg, node, 0, lengthReg);
-        auto branchBacktoLoop16LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::b, node, loop16Label);
+        auto branchBacktoLoop16LabelInstr = generateLabelInstruction(cg, OP::b, node, loop16Label);
         if (debugObj) {
             if (isArrayCmpLen) {
                 debugObj->addInstructionComment(branchToDoneLabelInstr3,
@@ -6546,11 +6499,11 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     } else {
         TR::Instruction *branchToDoneLabelInstr3;
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, lengthReg, lengthReg, 16);
-        branchToDoneLabelInstr3 = generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, lengthReg,
-            isArrayCmpLen ? done0Label : doneLabel);
+        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, lengthReg, lengthReg, 16);
+        branchToDoneLabelInstr3
+            = generateCompareBranchInstruction(cg, OP::cbzx, node, lengthReg, isArrayCmpLen ? done0Label : doneLabel);
 
-        auto branchToLessThan16Label2 = generateLabelInstruction(cg, TR::InstOpCode::b, node, lessThan16Label);
+        auto branchToLessThan16Label2 = generateLabelInstruction(cg, OP::b, node, lessThan16Label);
 
         if (debugObj) {
             if (isArrayCmpLen) {
@@ -6564,7 +6517,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     }
 
-    auto notEqual16LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, notEqual16Label);
+    auto notEqual16LabelInstr = generateLabelInstruction(cg, OP::label, node, notEqual16Label);
     if (debugObj) {
         debugObj->addInstructionComment(notEqual16LabelInstr,
             "notEqual16Label. src register points 16-byte ahead of the location where the data in the registers was "
@@ -6572,16 +6525,16 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
 
     if (isArrayCmpLen) {
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::eorx, node, data3Reg, data3Reg, data4Reg);
+        generateTrg1Src2Instruction(cg, OP::eorx, node, data3Reg, data3Reg, data4Reg);
         generateCompareImmInstruction(cg, node, data1Reg, 0, true);
-        generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
+        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
         loadConstant32(cg, node, 1, data2Reg);
         auto getOffsetInstr = generateCIncInstruction(cg, node, data2Reg, data2Reg, TR::CC_NE, true);
-        auto adjustingBaseAddrInstr = generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::subx, node, src1Reg,
-            src1Reg, data2Reg, TR::SH_LSL, 3);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::rbitx, node, data1Reg, data1Reg);
-        auto getMismatchLocationInstr = generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, data1Reg, data1Reg);
-        generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, src1Reg, src1Reg, data1Reg, TR::SH_LSR, 3);
+        auto adjustingBaseAddrInstr
+            = generateTrg1Src2ShiftedInstruction(cg, OP::subx, node, src1Reg, src1Reg, data2Reg, TR::SH_LSL, 3);
+        generateTrg1Src1Instruction(cg, OP::rbitx, node, data1Reg, data1Reg);
+        auto getMismatchLocationInstr = generateTrg1Src1Instruction(cg, OP::clzx, node, data1Reg, data1Reg);
+        generateTrg1Src2ShiftedInstruction(cg, OP::addx, node, src1Reg, src1Reg, data1Reg, TR::SH_LSR, 3);
         if (debugObj) {
             debugObj->addInstructionComment(getOffsetInstr,
                 "register has 1 if mismatch is in the first 8-byte data. Otherwise it has 2.");
@@ -6591,21 +6544,21 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     } else {
         generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
-        generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
-        generateCondTrg1Src2Instruction(cg, TR::InstOpCode::cselx, node, data2Reg, data2Reg, data4Reg, TR::CC_NE);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::revx, node, data1Reg, data1Reg);
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::revx, node, data2Reg, data2Reg);
+        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
+        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data2Reg, data2Reg, data4Reg, TR::CC_NE);
+        generateTrg1Src1Instruction(cg, OP::revx, node, data1Reg, data1Reg);
+        generateTrg1Src1Instruction(cg, OP::revx, node, data2Reg, data2Reg);
     }
     srm->reclaimScratchRegister(data3Reg);
     srm->reclaimScratchRegister(data4Reg);
 
     if (!isLengthGreaterThan15) {
-        auto branchToDone0LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::b, node, done0Label);
+        auto branchToDone0LabelInstr = generateLabelInstruction(cg, OP::b, node, done0Label);
 
-        auto lessThan16LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, lessThan16Label);
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmx, node, lengthReg, lengthReg, 1);
-        generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbpost, node, data1Reg, MRef_disp(cg, src1Reg, 1));
-        generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbpost, node, data2Reg, MRef_disp(cg, src2Reg, 1));
+        auto lessThan16LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan16Label);
+        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 1);
+        generateTrg1MemInstruction(cg, OP::ldrbpost, node, data1Reg, MRef_disp(cg, src1Reg, 1));
+        generateTrg1MemInstruction(cg, OP::ldrbpost, node, data2Reg, MRef_disp(cg, src2Reg, 1));
         generateConditionalCompareInstruction(cg, node, data1Reg, data2Reg, 0, TR::CC_HI);
         auto branchBacktoLessThan16LabelInstr
             = generateConditionalBranchInstruction(cg, node, lessThan16Label, TR::CC_EQ);
@@ -6620,8 +6573,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
 
             TR::Register *offReg = srm->findOrCreateScratchRegister();
             generateCSetInstruction(cg, node, offReg, TR::CC_NE);
-            auto adjustSrc1AddrInstr
-                = generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, src1Reg, src1Reg, offReg);
+            auto adjustSrc1AddrInstr = generateTrg1Src2Instruction(cg, OP::subx, node, src1Reg, src1Reg, offReg);
             if (debugObj) {
                 debugObj->addInstructionComment(adjustSrc1AddrInstr,
                     "Subtracts 1 from src1 if the mismatch is found in the last byte of data.");
@@ -6630,14 +6582,13 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
 
     if (isArrayCmpLen) {
-        auto done0LabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, done0Label);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, resultReg, src1Reg, savedSrc1Reg);
+        auto done0LabelInstr = generateLabelInstruction(cg, OP::label, node, done0Label);
+        generateTrg1Src2Instruction(cg, OP::subx, node, resultReg, src1Reg, savedSrc1Reg);
         if (debugObj) {
             debugObj->addInstructionComment(done0LabelInstr, "done0Label");
         }
     } else {
-        auto done0LabelInstr
-            = generateLabelInstruction(cg, TR::InstOpCode::label, node, done0Label); /* Result: 0, 1 or 2 */
+        auto done0LabelInstr = generateLabelInstruction(cg, OP::label, node, done0Label); /* Result: 0, 1 or 2 */
         generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
         generateCSetInstruction(cg, node, resultReg, TR::CC_NE);
         generateCIncInstruction(cg, node, resultReg, resultReg, TR::CC_HI, false);
@@ -6654,7 +6605,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     conditions->addPostCondition(resultReg, TR::RealRegister::NoReg);
     srm->addScratchRegistersToDependencyList(conditions);
 
-    auto doneLabelInstr = generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+    auto doneLabelInstr = generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
     if (debugObj) {
         debugObj->addInstructionComment(doneLabelInstr, "doneLabel");
     }
@@ -6703,59 +6654,59 @@ static void inlineConstantLengthForwardArrayCopy(TR::Node *node, int64_t byteLen
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
 
         // Copy 32x4 bytes in a loop
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, node, cntReg, cntReg, 1);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, cntReg, loopLabel);
+        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, cntReg, cntReg, 1);
+        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        generateCompareBranchInstruction(cg, OP::cbnzx, node, cntReg, loopLabel);
 
         TR::LabelSymbol *loopEndLabel = generateLabelSymbol(cg);
         loopEndLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopEndLabel, deps);
+        generateLabelInstruction(cg, OP::label, node, loopEndLabel, deps);
     } else if (iteration == 1) {
         residue += 128;
     }
 
     while (residue >= 32) {
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
         residue -= 32;
     }
 
     int32_t offset = 0;
     while (residue > 0) {
-        TR::InstOpCode::Mnemonic loadOp;
-        TR::InstOpCode::Mnemonic storeOp;
+        OP::Mnemonic loadOp;
+        OP::Mnemonic storeOp;
         int32_t dataSize;
         TR::Register *dataReg = (residue >= 16) ? dataReg1 : dataReg3;
 
         if (residue >= 16) {
-            loadOp = TR::InstOpCode::vldrimmq;
-            storeOp = TR::InstOpCode::vstrimmq;
+            loadOp = OP::vldrimmq;
+            storeOp = OP::vstrimmq;
             dataSize = 16;
         } else if (residue >= 8) {
-            loadOp = TR::InstOpCode::ldrimmx;
-            storeOp = TR::InstOpCode::strimmx;
+            loadOp = OP::ldrimmx;
+            storeOp = OP::strimmx;
             dataSize = 8;
         } else if (residue >= 4) {
-            loadOp = TR::InstOpCode::ldrimmw;
-            storeOp = TR::InstOpCode::strimmw;
+            loadOp = OP::ldrimmw;
+            storeOp = OP::strimmw;
             dataSize = 4;
         } else if (residue >= 2) {
-            loadOp = TR::InstOpCode::ldrhimm;
-            storeOp = TR::InstOpCode::strhimm;
+            loadOp = OP::ldrhimm;
+            storeOp = OP::strhimm;
             dataSize = 2;
         } else {
-            loadOp = TR::InstOpCode::ldrbimm;
-            storeOp = TR::InstOpCode::strbimm;
+            loadOp = OP::ldrbimm;
+            storeOp = OP::strbimm;
             dataSize = 1;
         }
 
@@ -6802,58 +6753,58 @@ static void inlineConstantLengthBackwardArrayCopy(TR::Node *node, int64_t byteLe
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
 
         // Copy 32x4 bytes in a loop
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmx, node, cntReg, cntReg, 1);
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, cntReg, loopLabel);
+        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, cntReg, cntReg, 1);
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        generateCompareBranchInstruction(cg, OP::cbnzx, node, cntReg, loopLabel);
 
         TR::LabelSymbol *loopEndLabel = generateLabelSymbol(cg);
         loopEndLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopEndLabel, deps);
+        generateLabelInstruction(cg, OP::label, node, loopEndLabel, deps);
     } else if (iteration == 1) {
         residue += 128;
     }
 
     while (residue >= 32) {
-        generateTrg2MemInstruction(cg, TR::InstOpCode::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, TR::InstOpCode::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
         residue -= 32;
     }
 
     while (residue > 0) {
-        TR::InstOpCode::Mnemonic loadOp;
-        TR::InstOpCode::Mnemonic storeOp;
+        OP::Mnemonic loadOp;
+        OP::Mnemonic storeOp;
         int32_t dataSize;
         TR::Register *dataReg = (residue >= 16) ? dataReg1 : dataReg3;
 
         if (residue >= 16) {
-            loadOp = TR::InstOpCode::vldrpreq;
-            storeOp = TR::InstOpCode::vstrpreq;
+            loadOp = OP::vldrpreq;
+            storeOp = OP::vstrpreq;
             dataSize = 16;
         } else if (residue >= 8) {
-            loadOp = TR::InstOpCode::ldrprex;
-            storeOp = TR::InstOpCode::strprex;
+            loadOp = OP::ldrprex;
+            storeOp = OP::strprex;
             dataSize = 8;
         } else if (residue >= 4) {
-            loadOp = TR::InstOpCode::ldrprew;
-            storeOp = TR::InstOpCode::strprew;
+            loadOp = OP::ldrprew;
+            storeOp = OP::strprew;
             dataSize = 4;
         } else if (residue >= 2) {
-            loadOp = TR::InstOpCode::ldrhpre;
-            storeOp = TR::InstOpCode::strhpre;
+            loadOp = OP::ldrhpre;
+            storeOp = OP::strhpre;
             dataSize = 2;
         } else {
-            loadOp = TR::InstOpCode::ldrbpre;
-            storeOp = TR::InstOpCode::strbpre;
+            loadOp = OP::ldrbpre;
+            storeOp = OP::strbpre;
             dataSize = 1;
         }
 
@@ -6903,15 +6854,15 @@ static void generateCallToArrayCopyHelper(TR::Node *node, TR::Register *srcAddrR
         helper = TR_ARM64forwardArrayCopy;
     } else if (node->isBackwardArrayCopy()) {
         // Adjusting src and dst addresses
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, srcAddrReg, srcAddrReg, lengthReg);
-        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, dstAddrReg, dstAddrReg, lengthReg);
+        generateTrg1Src2Instruction(cg, OP::addx, node, srcAddrReg, srcAddrReg, lengthReg);
+        generateTrg1Src2Instruction(cg, OP::addx, node, dstAddrReg, dstAddrReg, lengthReg);
         helper = TR_ARM64backwardArrayCopy;
     }
 
     TR::SymbolReference *arrayCopyHelper = cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
 
-    generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), deps,
-        arrayCopyHelper, NULL);
+    generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), deps, arrayCopyHelper,
+        NULL);
     cg->machine()->setLinkRegisterKilled(true);
 
     return;
@@ -6930,15 +6881,15 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
     cg->getARM64OutOfLineCodeSectionList().push_front(oolSection);
     oolSection->swapInstructionListsWithCompilation();
 
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, oolArraycopyLabel);
+    generateLabelInstruction(cg, OP::label, node, oolArraycopyLabel);
 
     TR::SymbolReference *arrayCopyHelper
         = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64arrayCopy, false, false, false);
 
-    generateImmSymInstruction(cg, TR::InstOpCode::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), NULL,
-        arrayCopyHelper, NULL);
+    generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), NULL, arrayCopyHelper,
+        NULL);
 
-    generateLabelInstruction(cg, TR::InstOpCode::b, node, doneLabel);
+    generateLabelInstruction(cg, OP::b, node, doneLabel);
 
     cg->machine()->setLinkRegisterKilled(true);
     oolSection->swapInstructionListsWithCompilation();
@@ -6960,14 +6911,14 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
 
     static const char *breakOnInlineArraycopy = feGetEnv("TR_BreakOnInlineArraycopy");
     if (breakOnInlineArraycopy) {
-        generateExceptionInstruction(cg, TR::InstOpCode::brkarm64, node, 0);
+        generateExceptionInstruction(cg, OP::brkarm64, node, 0);
     }
 
     const int32_t inlineThresholdBytes = 63;
     generateCompareImmInstruction(cg, node, lengthReg, inlineThresholdBytes, true);
     generateConditionalBranchInstruction(cg, node, oolArraycopyLabel, TR::CC_HI);
 
-    generateTrg1Src2Instruction(cg, TR::InstOpCode::subsx, node, x3ScratchReg, dstAddrReg, srcAddrReg);
+    generateTrg1Src2Instruction(cg, OP::subsx, node, x3ScratchReg, dstAddrReg, srcAddrReg);
 
     // Skip if src and dest are the same
     //
@@ -6984,52 +6935,50 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
     // Copy 32 bytes
     //
     TR::LabelSymbol *fwAC16Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 5, fwAC16Label);
-    generateTrg2MemInstruction(cg, TR::InstOpCode::vldppostq, node, v30ScratchReg, v31ScratchReg,
-        MRef_disp(cg, srcAddrReg, 32));
-    generateMemSrc2Instruction(cg, TR::InstOpCode::vstppostq, node, MRef_disp(cg, dstAddrReg, 32), v30ScratchReg,
-        v31ScratchReg);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 5, fwAC16Label);
+    generateTrg2MemInstruction(cg, OP::vldppostq, node, v30ScratchReg, v31ScratchReg, MRef_disp(cg, srcAddrReg, 32));
+    generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstAddrReg, 32), v30ScratchReg, v31ScratchReg);
 
     // Copy 16 bytes
     //
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, fwAC16Label);
+    generateLabelInstruction(cg, OP::label, node, fwAC16Label);
     TR::LabelSymbol *fwAC8Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 4, fwAC8Label);
-    generateTrg1MemInstruction(cg, TR::InstOpCode::vldrpostq, node, v30ScratchReg, MRef_disp(cg, srcAddrReg, 16));
-    generateMemSrc1Instruction(cg, TR::InstOpCode::vstrpostq, node, MRef_disp(cg, dstAddrReg, 16), v30ScratchReg);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 4, fwAC8Label);
+    generateTrg1MemInstruction(cg, OP::vldrpostq, node, v30ScratchReg, MRef_disp(cg, srcAddrReg, 16));
+    generateMemSrc1Instruction(cg, OP::vstrpostq, node, MRef_disp(cg, dstAddrReg, 16), v30ScratchReg);
 
     // Copy 8 bytes
     //
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, fwAC8Label);
+    generateLabelInstruction(cg, OP::label, node, fwAC8Label);
     TR::LabelSymbol *fwAC4Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 3, fwAC4Label);
-    generateTrg1MemInstruction(cg, TR::InstOpCode::ldrpostx, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 8));
-    generateMemSrc1Instruction(cg, TR::InstOpCode::strpostx, node, MRef_disp(cg, dstAddrReg, 8), x3ScratchReg);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 3, fwAC4Label);
+    generateTrg1MemInstruction(cg, OP::ldrpostx, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 8));
+    generateMemSrc1Instruction(cg, OP::strpostx, node, MRef_disp(cg, dstAddrReg, 8), x3ScratchReg);
 
     // Copy 4 bytes
     //
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, fwAC4Label);
+    generateLabelInstruction(cg, OP::label, node, fwAC4Label);
     TR::LabelSymbol *fwAC2Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 2, fwAC2Label);
-    generateTrg1MemInstruction(cg, TR::InstOpCode::ldrpostw, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 4));
-    generateMemSrc1Instruction(cg, TR::InstOpCode::strpostw, node, MRef_disp(cg, dstAddrReg, 4), x3ScratchReg);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 2, fwAC2Label);
+    generateTrg1MemInstruction(cg, OP::ldrpostw, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 4));
+    generateMemSrc1Instruction(cg, OP::strpostw, node, MRef_disp(cg, dstAddrReg, 4), x3ScratchReg);
 
     // Copy 2 bytes
     //
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, fwAC2Label);
+    generateLabelInstruction(cg, OP::label, node, fwAC2Label);
     TR::LabelSymbol *fwAC1Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 1, fwAC1Label);
-    generateTrg1MemInstruction(cg, TR::InstOpCode::ldrhpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 2));
-    generateMemSrc1Instruction(cg, TR::InstOpCode::strhpost, node, MRef_disp(cg, dstAddrReg, 2), x3ScratchReg);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 1, fwAC1Label);
+    generateTrg1MemInstruction(cg, OP::ldrhpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 2));
+    generateMemSrc1Instruction(cg, OP::strhpost, node, MRef_disp(cg, dstAddrReg, 2), x3ScratchReg);
 
     // Copy 1 byte
     //
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, fwAC1Label);
-    generateTestBitBranchInstruction(cg, TR::InstOpCode::tbz, node, lengthReg, 0, doneLabel);
-    generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 1));
-    generateMemSrc1Instruction(cg, TR::InstOpCode::strbpost, node, MRef_disp(cg, dstAddrReg, 1), x3ScratchReg);
+    generateLabelInstruction(cg, OP::label, node, fwAC1Label);
+    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 0, doneLabel);
+    generateTrg1MemInstruction(cg, OP::ldrbpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 1));
+    generateMemSrc1Instruction(cg, OP::strbpost, node, MRef_disp(cg, dstAddrReg, 1), x3ScratchReg);
 
-    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
+    generateLabelInstruction(cg, OP::label, node, doneLabel, deps);
 
     cg->stopUsingRegister(x3ScratchReg);
     cg->stopUsingRegister(v30ScratchReg);
@@ -7240,22 +7189,21 @@ TR::Register *OMR::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
     } else {
         if (mref->useIndexedForm()) {
             resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
-            generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, resultReg, mref->getBaseRegister(),
+            generateTrg1Src2Instruction(cg, OP::addx, node, resultReg, mref->getBaseRegister(),
                 mref->getIndexRegister());
         } else {
             int32_t offset = mref->getOffset();
             if (mref->hasDelayedOffset() || offset != 0) {
                 resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
                 if (mref->hasDelayedOffset()) {
-                    generateTrg1MemInstruction(cg, TR::InstOpCode::addimmx, node, resultReg, mref);
+                    generateTrg1MemInstruction(cg, OP::addimmx, node, resultReg, mref);
                 } else {
                     if (offset >= 0 && constantIsUnsignedImm12(offset)) {
-                        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, resultReg,
-                            mref->getBaseRegister(), offset);
+                        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, resultReg, mref->getBaseRegister(),
+                            offset);
                     } else {
                         loadConstant64(cg, node, offset, resultReg);
-                        generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, resultReg, mref->getBaseRegister(),
-                            resultReg);
+                        generateTrg1Src2Instruction(cg, OP::addx, node, resultReg, mref->getBaseRegister(), resultReg);
                     }
                 }
             } else {
@@ -7367,12 +7315,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
         labelSym = generateLabelSymbol(cg);
         node->setLabel(labelSym);
     }
-    TR::Instruction *labelInst = generateLabelInstruction(cg, TR::InstOpCode::label, node, labelSym, deps);
+    TR::Instruction *labelInst = generateLabelInstruction(cg, OP::label, node, labelSym, deps);
     labelSym->setInstruction(labelInst);
     block->setFirstInstruction(labelInst);
 
     TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
-    TR::Instruction *fence = generateAdminInstruction(cg, TR::InstOpCode::fence, node, fenceNode);
+    TR::Instruction *fence = generateAdminInstruction(cg, OP::fence, node, fenceNode);
 
     if (block->isCatchBlock()) {
         cg->generateCatchBlockBBStartPrologue(node, fence);
@@ -7389,9 +7337,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
 
     if (NULL == block->getNextBlock()) {
         TR::Instruction *lastInstruction = cg->getAppendInstruction();
-        if (lastInstruction->getOpCodeValue() == TR::InstOpCode::bl
+        if (lastInstruction->getOpCodeValue() == OP::bl
             && lastInstruction->getNode()->getSymbolReference()->getReferenceNumber() == TR_aThrow) {
-            lastInstruction = generateInstruction(cg, TR::InstOpCode::bad, node, lastInstruction);
+            lastInstruction = generateInstruction(cg, OP::bad, node, lastInstruction);
         }
     }
 
@@ -7399,8 +7347,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
 
     TR::RegisterDependencyConditions *deps = NULL;
     if (!nextTT || !nextTT->getNode()->getBlock()->isExtensionOfPreviousBlock()) {
-        if (cg->enableRegisterAssociations()
-            && cg->getAppendInstruction()->getOpCodeValue() != TR::InstOpCode::assocreg) {
+        if (cg->enableRegisterAssociations() && cg->getAppendInstruction()->getOpCodeValue() != OP::assocreg) {
             cg->machine()->createRegisterAssociationDirective(cg->getAppendInstruction());
         }
 
@@ -7413,7 +7360,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
     }
 
     // put the dependencies (if any) on the fence
-    TR::Instruction *instr = generateAdminInstruction(cg, TR::InstOpCode::fence, node, deps, fenceNode);
+    TR::Instruction *instr = generateAdminInstruction(cg, OP::fence, node, deps, fenceNode);
     node->getBlock()->setLastInstruction(instr);
 
     return NULL;
@@ -7445,10 +7392,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR
                 generateMovInstruction(cg, node, copyReg, srcReg);
                 break;
             case TR_FPR:
-                generateTrg1Src1Instruction(cg, TR::InstOpCode::fmovd, node, copyReg, srcReg);
+                generateTrg1Src1Instruction(cg, OP::fmovd, node, copyReg, srcReg);
                 break;
             case TR_VRF:
-                generateTrg1Src2Instruction(cg, TR::InstOpCode::vorr16b, node, copyReg, srcReg, srcReg);
+                generateTrg1Src2Instruction(cg, OP::vorr16b, node, copyReg, srcReg, srcReg);
                 break;
             default:
                 TR_ASSERT_FATAL(false, "Unsupported RegisterKind.");
@@ -7550,7 +7497,7 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
          * but if we use staddl, acquire semantics is not applied.
          * We use ldaddal to ensure volatile semantics.
          */
-        auto op = is64Bit ? TR::InstOpCode::ldaddalx : TR::InstOpCode::ldaddalw;
+        auto op = is64Bit ? OP::ldaddalx : OP::ldaddalw;
         /*
          * As Trg1MemSrc1Instruction was introduced to support ldxr/stxr instructions, target and source register
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
@@ -7584,20 +7531,19 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
         TR::Register *oldValueReg = cg->allocateRegister();
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
 
-        auto loadop = is64Bit ? TR::InstOpCode::ldxrx : TR::InstOpCode::ldxrw;
+        auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
         generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
-        generateTrg1Src2Instruction(cg, (is64Bit ? TR::InstOpCode::addx : TR::InstOpCode::addw), node, newValueReg,
-            oldValueReg, valueReg);
+        generateTrg1Src2Instruction(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
 
         // store release exclusive register
-        auto storeop = is64Bit ? TR::InstOpCode::stlxrx : TR::InstOpCode::stlxrw;
+        auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
         generateTrg1MemSrc1Instruction(cg, storeop, node, oldValueReg, MRef_disp(cg, addressReg, 0), newValueReg);
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, oldValueReg, loopLabel);
+        generateCompareBranchInstruction(cg, OP::cbnzx, node, oldValueReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         auto conditions = RegDeps(0, 4, cg);
@@ -7608,7 +7554,7 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
         conditions->addPostCondition(valueReg, TR::RealRegister::NoReg);
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
         cg->stopUsingRegister(oldValueReg);
     }
 
@@ -7660,7 +7606,7 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
     if (comp->target().cpu.supportsFeature(OMR_FEATURE_ARM64_LSE) && (!disableLSE)) {
         valueReg = cg->evaluate(valueNode);
 
-        auto op = is64Bit ? TR::InstOpCode::ldaddalx : TR::InstOpCode::ldaddalw;
+        auto op = is64Bit ? OP::ldaddalx : OP::ldaddalw;
         /*
          * As Trg1MemSrc1Instruction was introduced to support ldxr/stxr instructions, target and source register
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
@@ -7722,30 +7668,29 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
         TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
 
         // load acquire exclusive register
-        auto loadop = is64Bit ? TR::InstOpCode::ldxrx : TR::InstOpCode::ldxrw;
+        auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
         generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
         if (valueReg == NULL) {
             if (!negate) {
-                generateTrg1Src1ImmInstruction(cg, (is64Bit ? TR::InstOpCode::addimmx : TR::InstOpCode::addimmw), node,
-                    newValueReg, oldValueReg, value);
+                generateTrg1Src1ImmInstruction(cg, (is64Bit ? OP::addimmx : OP::addimmw), node, newValueReg,
+                    oldValueReg, value);
             } else {
-                generateTrg1Src1ImmInstruction(cg, (is64Bit ? TR::InstOpCode::subimmx : TR::InstOpCode::subimmw), node,
-                    newValueReg, oldValueReg, -value);
+                generateTrg1Src1ImmInstruction(cg, (is64Bit ? OP::subimmx : OP::subimmw), node, newValueReg,
+                    oldValueReg, -value);
             }
         } else {
-            generateTrg1Src2Instruction(cg, (is64Bit ? TR::InstOpCode::addx : TR::InstOpCode::addw), node, newValueReg,
-                oldValueReg, valueReg);
+            generateTrg1Src2Instruction(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
         }
         // store release exclusive register
-        auto storeop = is64Bit ? TR::InstOpCode::stlxrx : TR::InstOpCode::stlxrw;
+        auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
         generateTrg1MemSrc1Instruction(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), newValueReg);
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, tempReg, loopLabel);
+        generateCompareBranchInstruction(cg, OP::cbnzx, node, tempReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         const int numDeps = (valueReg != NULL) ? 5 : 4;
@@ -7760,7 +7705,7 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
         }
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
 
         cg->stopUsingRegister(newValueReg);
         cg->stopUsingRegister(tempReg);
@@ -7813,7 +7758,7 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
     TR::Compilation *comp = cg->comp();
     static const bool disableLSE = feGetEnv("TR_aarch64DisableLSE") != NULL;
     if (comp->target().cpu.supportsFeature(OMR_FEATURE_ARM64_LSE) && (!disableLSE)) {
-        auto op = is64Bit ? TR::InstOpCode::swpalx : TR::InstOpCode::swpalw;
+        auto op = is64Bit ? OP::swpalx : OP::swpalw;
         /*
          * As Trg1MemSrc1Instruction was introduced to support ldxr/stxr instructions, target and source register
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
@@ -7846,18 +7791,18 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
         TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, loopLabel);
+        generateLabelInstruction(cg, OP::label, node, loopLabel);
 
         // load acquire exclusive register
-        auto loadop = is64Bit ? TR::InstOpCode::ldxrx : TR::InstOpCode::ldxrw;
+        auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
         generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
         // store release exclusive register
-        auto storeop = is64Bit ? TR::InstOpCode::stlxrx : TR::InstOpCode::stlxrw;
+        auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
         generateTrg1MemSrc1Instruction(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), valueReg);
-        generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, tempReg, loopLabel);
+        generateCompareBranchInstruction(cg, OP::cbnzx, node, tempReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
+        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         auto conditions = RegDeps(0, 4, cg);
@@ -7868,7 +7813,7 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
         conditions->addPostCondition(tempReg, TR::RealRegister::NoReg);
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
+        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
 
         cg->stopUsingRegister(tempReg);
     }

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -65,7 +65,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
  * @param[in] size : size
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
+TR::Register *commonLoadEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
 
 /**
  * @brief Helper function for xloadEvaluators
@@ -75,7 +75,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
  * @param[in] targetReg : target register
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::Register *targetReg,
+TR::Register *commonLoadEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::Register *targetReg,
     TR::CodeGenerator *cg);
 
 /**
@@ -85,7 +85,7 @@ TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, i
  * @param[in] size : size
  * @param[in] cg : CodeGenerator
  */
-TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
+TR::Register *commonStoreEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size, TR::CodeGenerator *cg);
 
 namespace OMR { namespace ARM64 {
 
@@ -445,7 +445,7 @@ public:
      * @param[in] evaluatorHelper: optional pointer to helper function which generates instruction stream for operation
      * @return vector register containing the result
      */
-    static TR::Register *inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+    static TR::Register *inlineVectorBinaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
         binaryEvaluatorHelper evaluatorHelper = NULL);
     /**
      * @brief Helper function for generating instruction sequence for masked binary operations
@@ -456,7 +456,7 @@ public:
      * @param[in] evaluatorHelper: optional pointer to helper function which generates instruction stream for operation
      * @return vector register containing the result
      */
-    static TR::Register *inlineVectorMaskedBinaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+    static TR::Register *inlineVectorMaskedBinaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
         binaryEvaluatorHelper evaluatorHelper = NULL);
 
     typedef TR::Register *(
@@ -470,7 +470,7 @@ public:
      * @param[in] evaluatorHelper: optional pointer to helper function which generates instruction stream for operation
      * @return vector register containing the result
      */
-    static TR::Register *inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+    static TR::Register *inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
         unaryEvaluatorHelper evaluatorHelper = NULL);
 
     /**
@@ -482,7 +482,7 @@ public:
      * @param[in] evaluatorHelper: optional pointer to helper function which generates instruction stream for operation
      * @return vector register containing the result
      */
-    static TR::Register *inlineVectorMaskedUnaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+    static TR::Register *inlineVectorMaskedUnaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
         unaryEvaluatorHelper evaluatorHelper = NULL);
 
     static TR::Register *f2iuEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -121,16 +121,16 @@ TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
     return trgReg;
 }
 
-TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg,
-    TR::InstOpCode::Mnemonic op, unaryEvaluatorHelper evaluatorHelper)
+TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR::CodeGenerator *cg, OP::Mnemonic op,
+    unaryEvaluatorHelper evaluatorHelper)
 {
     TR::Node *firstChild = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(firstChild);
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
 
     node->setRegister(resReg);
-    TR_ASSERT_FATAL_WITH_NODE(node, (op != TR::InstOpCode::bad) || (evaluatorHelper != NULL),
-        "If op is TR::InstOpCode::bad, evaluatorHelper must not be NULL");
+    TR_ASSERT_FATAL_WITH_NODE(node, (op != OP::bad) || (evaluatorHelper != NULL),
+        "If op is OP::bad, evaluatorHelper must not be NULL");
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, srcReg, cg);
     } else {
@@ -142,29 +142,29 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR:
 
 TR::Register *OMR::ARM64::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic negOp;
+    OP::Mnemonic negOp;
 
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            negOp = TR::InstOpCode::vneg16b;
+            negOp = OP::vneg16b;
             break;
         case TR::Int16:
-            negOp = TR::InstOpCode::vneg8h;
+            negOp = OP::vneg8h;
             break;
         case TR::Int32:
-            negOp = TR::InstOpCode::vneg4s;
+            negOp = OP::vneg4s;
             break;
         case TR::Int64:
-            negOp = TR::InstOpCode::vneg2d;
+            negOp = OP::vneg2d;
             break;
         case TR::Float:
-            negOp = TR::InstOpCode::vfneg4s;
+            negOp = OP::vfneg4s;
             break;
         case TR::Double:
-            negOp = TR::InstOpCode::vfneg2d;
+            negOp = OP::vfneg2d;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -175,7 +175,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnegEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::ARM64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::InstOpCode::Mnemonic notOp;
+    OP::Mnemonic notOp;
 
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
@@ -185,7 +185,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vnotEvaluator(TR::Node *node, TR::CodeG
         case TR::Int16:
         case TR::Int32:
         case TR::Int64:
-            notOp = TR::InstOpCode::vnot16b;
+            notOp = OP::vnot16b;
             break;
         default:
             TR_ASSERT(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -198,26 +198,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::vabsEvaluator(TR::Node *node, TR::CodeG
 {
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
-    TR::InstOpCode::Mnemonic absOp;
+    OP::Mnemonic absOp;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Int8:
-            absOp = TR::InstOpCode::vabs16b;
+            absOp = OP::vabs16b;
             break;
         case TR::Int16:
-            absOp = TR::InstOpCode::vabs8h;
+            absOp = OP::vabs8h;
             break;
         case TR::Int32:
-            absOp = TR::InstOpCode::vabs4s;
+            absOp = OP::vabs4s;
             break;
         case TR::Int64:
-            absOp = TR::InstOpCode::vabs2d;
+            absOp = OP::vabs2d;
             break;
         case TR::Float:
-            absOp = TR::InstOpCode::vfabs4s;
+            absOp = OP::vfabs4s;
             break;
         case TR::Double:
-            absOp = TR::InstOpCode::vfabs2d;
+            absOp = OP::vfabs2d;
             break;
         default:
             TR_ASSERT_FATAL(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -230,14 +230,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsqrtEvaluator(TR::Node *node, TR::Code
 {
     TR_ASSERT_FATAL_WITH_NODE(node, node->getDataType().getVectorLength() == TR::VectorLength128,
         "Only 128-bit vectors are supported %s", node->getDataType().toString());
-    TR::InstOpCode::Mnemonic sqrtOp;
+    OP::Mnemonic sqrtOp;
 
     switch (node->getDataType().getVectorElementType()) {
         case TR::Float:
-            sqrtOp = TR::InstOpCode::vfsqrt4s;
+            sqrtOp = OP::vfsqrt4s;
             break;
         case TR::Double:
-            sqrtOp = TR::InstOpCode::vfsqrt2d;
+            sqrtOp = OP::vfsqrt2d;
             break;
         default:
             TR_ASSERT_FATAL(false, "unrecognized vector type %s", node->getDataType().toString());
@@ -253,8 +253,8 @@ static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator
     TR::Register *tempReg = cg->allocateRegister();
 
     bool is64bit = node->getDataType().isInt64();
-    TR::InstOpCode::Mnemonic eorOp = is64bit ? TR::InstOpCode::eorx : TR::InstOpCode::eorw;
-    TR::InstOpCode::Mnemonic subOp = is64bit ? TR::InstOpCode::subx : TR::InstOpCode::subw;
+    OP::Mnemonic eorOp = is64bit ? OP::eorx : OP::eorw;
+    OP::Mnemonic subOp = is64bit ? OP::subx : OP::subw;
 
     generateArithmeticShiftRightImmInstruction(cg, node, tempReg, reg, is64bit ? 63 : 31, is64bit);
     generateTrg1Src2Instruction(cg, eorOp, node, reg, reg, tempReg);
@@ -276,7 +276,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::labsEvaluator(TR::Node *node, TR::CodeG
     return commonIntegerAbsEvaluator(node, cg);
 }
 
-static TR::Register *commonUnaryHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg)
+static TR::Register *commonUnaryHelper(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
@@ -290,19 +290,19 @@ static TR::Register *commonUnaryHelper(TR::Node *node, TR::InstOpCode::Mnemonic 
 
 TR::Register *OMR::ARM64::TreeEvaluator::sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::Register *trgReg = commonUnaryHelper(node, TR::InstOpCode::rev16w, cg);
-    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, trgReg, 15); // sign extension
+    TR::Register *trgReg = commonUnaryHelper(node, OP::rev16w, cg);
+    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, trgReg, 15); // sign extension
     return trgReg;
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonUnaryHelper(node, TR::InstOpCode::revw, cg);
+    return commonUnaryHelper(node, OP::revw, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonUnaryHelper(node, TR::InstOpCode::revx, cg);
+    return commonUnaryHelper(node, OP::revx, cg);
 }
 
 /*
@@ -314,21 +314,21 @@ static TR::Register *hbitHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = cg->allocateRegister();
     TR::Register *tmpReg = cg->allocateRegister();
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
-    op = is64bit ? TR::InstOpCode::clzx : TR::InstOpCode::clzw;
+    op = is64bit ? OP::clzx : OP::clzw;
     generateTrg1Src1Instruction(cg, op, node, tmpReg, srcReg);
     generateCompareImmInstruction(cg, node, srcReg, 0, is64bit);
     if (is64bit) {
         // mov trgReg, #0x80000000
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::movzx, node, trgReg, 0x8000 | TR::MOV_LSL48);
+        generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0x8000 | TR::MOV_LSL48);
     } else {
         // mov trgReg, #0x8000000000000000
-        generateTrg1ImmInstruction(cg, TR::InstOpCode::movzw, node, trgReg, 0x8000 | TR::MOV_LSL16);
+        generateTrg1ImmInstruction(cg, OP::movzw, node, trgReg, 0x8000 | TR::MOV_LSL16);
     }
-    op = is64bit ? TR::InstOpCode::cselx : TR::InstOpCode::cselw;
+    op = is64bit ? OP::cselx : OP::cselw;
     generateCondTrg1Src2Instruction(cg, op, node, trgReg, trgReg, srcReg, TR::CC_NE);
-    op = is64bit ? TR::InstOpCode::lsrvx : TR::InstOpCode::lsrvw;
+    op = is64bit ? OP::lsrvx : OP::lsrvw;
     generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
@@ -357,7 +357,7 @@ static TR::Register *lbitHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
     TR::Register *tmpReg = cg->allocateRegister();
-    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andx : TR::InstOpCode::andw;
+    OP::Mnemonic op = is64bit ? OP::andx : OP::andw;
 
     // x & -x
     generateNegInstruction(cg, node, tmpReg, srcReg, is64bit);
@@ -385,12 +385,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::llbitEvaluator(TR::Node *node, TR::Code
  */
 TR::Register *OMR::ARM64::TreeEvaluator::inolzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonUnaryHelper(node, TR::InstOpCode::clzw, cg);
+    return commonUnaryHelper(node, OP::clzw, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::lnolzEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return commonUnaryHelper(node, TR::InstOpCode::clzx, cg);
+    return commonUnaryHelper(node, OP::clzx, cg);
 }
 
 /*
@@ -401,11 +401,11 @@ static TR::Register *notzHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
-    op = is64bit ? TR::InstOpCode::rbitx : TR::InstOpCode::rbitw;
+    op = is64bit ? OP::rbitx : OP::rbitw;
     generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
-    op = is64bit ? TR::InstOpCode::clzx : TR::InstOpCode::clzw;
+    op = is64bit ? OP::clzx : OP::clzw;
     generateTrg1Src1Instruction(cg, op, node, trgReg, trgReg);
 
     node->setRegister(trgReg);
@@ -434,14 +434,14 @@ static TR::Register *popcntHelper(TR::Node *node, bool is64bit, TR::CodeGenerato
     TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
 
     if (is64bit) {
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, tmpReg, srcReg);
+        generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, tmpReg, srcReg);
     } else {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, node, trgReg, srcReg, 31); // zero extension
-        generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, tmpReg, trgReg);
+        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, node, trgReg, srcReg, 31); // zero extension
+        generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, tmpReg, trgReg);
     }
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vcnt8b, node, tmpReg, tmpReg);
-    generateTrg1Src1Instruction(cg, TR::InstOpCode::vaddv8b, node, tmpReg, tmpReg);
-    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovwb, node, trgReg, tmpReg, 0);
+    generateTrg1Src1Instruction(cg, OP::vcnt8b, node, tmpReg, tmpReg);
+    generateTrg1Src1Instruction(cg, OP::vaddv8b, node, tmpReg, tmpReg);
+    generateMovVectorElementToGPRInstruction(cg, OP::umovwb, node, trgReg, tmpReg, 0);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -486,7 +486,7 @@ static TR::Register *x2iHelper(TR::Node *node, TR::CodeGenerator *cg, bool isB2i
         TR::Node *intChild = child->getFirstChild();
         srcReg = cg->evaluate(intChild);
         trgReg = (intChild->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg, sbfmBit);
+        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
         node->setRegister(trgReg);
         cg->decReferenceCount(intChild);
         cg->decReferenceCount(child);
@@ -499,7 +499,7 @@ static TR::Register *x2iHelper(TR::Node *node, TR::CodeGenerator *cg, bool isB2i
                 generateMovInstruction(cg, node, trgReg, srcReg);
             }
         } else {
-            generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::sbfmw, node, trgReg, srcReg, sbfmBit);
+            generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
         }
         node->setRegister(trgReg);
         cg->decReferenceCount(child);
@@ -517,8 +517,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
     return x2iHelper(node, cg, false);
 }
 
-static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mnemonic op, uint32_t imms,
-    TR::CodeGenerator *cg)
+static TR::Register *extendToIntOrLongHelper(TR::Node *node, OP::Mnemonic op, uint32_t imms, TR::CodeGenerator *cg)
 {
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
@@ -536,17 +535,17 @@ static TR::Register *extendToIntOrLongHelper(TR::Node *node, TR::InstOpCode::Mne
 
 TR::Register *OMR::ARM64::TreeEvaluator::b2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return extendToIntOrLongHelper(node, TR::InstOpCode::sbfmx, 7, cg);
+    return extendToIntOrLongHelper(node, OP::sbfmx, 7, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::s2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return extendToIntOrLongHelper(node, TR::InstOpCode::sbfmx, 15, cg);
+    return extendToIntOrLongHelper(node, OP::sbfmx, 15, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::i2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return extendToIntOrLongHelper(node, TR::InstOpCode::sbfmx, 31, cg);
+    return extendToIntOrLongHelper(node, OP::sbfmx, 31, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -557,12 +556,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeG
         && (child->getOpCodeValue() == TR::bload || child->getOpCodeValue() == TR::bloadi)
         && child->getRegister() == NULL) {
         // Use unsigned load
-        TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrbimm, 1, cg);
+        TR::Register *trgReg = commonLoadEvaluator(child, OP::ldrbimm, 1, cg);
         node->setRegister(trgReg);
         cg->decReferenceCount(child);
         return trgReg;
     } else {
-        return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 7, cg);
+        return extendToIntOrLongHelper(node, OP::ubfmw, 7, cg);
     }
 }
 
@@ -574,23 +573,23 @@ TR::Register *OMR::ARM64::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
         && (child->getOpCodeValue() == TR::sload || child->getOpCodeValue() == TR::sloadi)
         && child->getRegister() == NULL) {
         // Use unsigned load
-        TR::Register *trgReg = commonLoadEvaluator(child, TR::InstOpCode::ldrhimm, 2, cg);
+        TR::Register *trgReg = commonLoadEvaluator(child, OP::ldrhimm, 2, cg);
         node->setRegister(trgReg);
         cg->decReferenceCount(child);
         return trgReg;
     } else {
-        return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmw, 15, cg);
+        return extendToIntOrLongHelper(node, OP::ubfmw, 15, cg);
     }
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmx, 7, cg);
+    return extendToIntOrLongHelper(node, OP::ubfmx, 7, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    return extendToIntOrLongHelper(node, TR::InstOpCode::ubfmx, 15, cg);
+    return extendToIntOrLongHelper(node, OP::ubfmx, 15, cg);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -605,7 +604,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeG
             generateMovInstruction(cg, node, trgReg, srcReg);
         }
     } else {
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::ubfmx, node, trgReg, srcReg, 31);
+        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, node, trgReg, srcReg, 31);
     }
     node->setRegister(trgReg);
     cg->decReferenceCount(child);


### PR DESCRIPTION
This commit introduces a new typedef OP to replace TR::InstOpCode for improving the readability of AArch64 JIT code.