### PR TITLE
RISC-V: implement and use MemoryReference::generateBinaryEncoding()

### DIFF
--- a/compiler/riscv/codegen/OMRMemoryReference.cpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.cpp
@@ -379,6 +379,13 @@ void OMR::RV::MemoryReference::assignRegisters(TR::Instruction *currentInstructi
     }
 }
 
+uint8_t *OMR::RV::MemoryReference::generateBinaryEncoding(TR::Instruction *ci, uint8_t *cursor, TR::CodeGenerator *cg)
+{
+    return cursor;
+}
+
+uint32_t OMR::RV::MemoryReference::estimateBinaryLength(TR::Instruction *ci) { return 0; }
+
 /* register offset */
 static bool isRegisterOffsetInstruction(uint32_t enc) { return ((enc & 0x3b200c00) == 0x38200800); }
 

--- a/compiler/riscv/codegen/OMRMemoryReference.hpp
+++ b/compiler/riscv/codegen/OMRMemoryReference.hpp
@@ -302,6 +302,24 @@ public:
      * @param[in] cg : CodeGenerator
      */
     void assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg);
+
+    /**
+     * @brief Generates binary encoding. Note that final load or store instruction
+     *        is generated in LoadInstruction::generateBinaryEncoding() or
+     *        StoreInstruction::generateBinaryEncoding()
+     * @param[in] ci : current instruction
+     * @param[in] cursor : instruction cursor
+     * @param[in] cg : CodeGenerator
+     * @return instruction cursor after encoding
+     */
+    uint8_t *generateBinaryEncoding(TR::Instruction *ci, uint8_t *cursor, TR::CodeGenerator *cg);
+
+    /**
+     * @brief Estimates the length of generated binary. See comment on generateBinaryEncoding()!
+     * @param[in] ci : current instruction
+     * @return estimated binary length
+     */
+    uint32_t estimateBinaryLength(TR::Instruction *ci);
 };
 
 }} // namespace OMR::RV

--- a/compiler/riscv/codegen/RVInstruction.cpp
+++ b/compiler/riscv/codegen/RVInstruction.cpp
@@ -217,15 +217,22 @@ uint8_t *TR::LoadInstruction::generateBinaryEncoding()
 {
     uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = instructionStart;
-    uint32_t *iPtr = (uint32_t *)instructionStart;
+    uint32_t *iPtr = (uint32_t *)(getMemoryReference()->generateBinaryEncoding(this, cursor, cg()));
 
     *iPtr = TR_RISCV_ITYPE(getOpCode().getMnemonic(), getTargetRegister(), getMemoryBase(),
         getMemoryReference()->getOffset(true));
 
     cursor += RISCV_INSTRUCTION_LENGTH;
-    setBinaryLength(RISCV_INSTRUCTION_LENGTH);
+
+    setBinaryLength((uintptr_t)cursor - (uintptr_t)instructionStart);
     setBinaryEncoding(instructionStart);
     return cursor;
+}
+
+int32_t TR::LoadInstruction::estimateBinaryLength(int32_t currentEstimate)
+{
+    setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(this) + RISCV_INSTRUCTION_LENGTH);
+    return currentEstimate + self()->getEstimatedBinaryLength();
 }
 
 // TR::StypeInstruction:: member functions
@@ -323,15 +330,21 @@ uint8_t *TR::StoreInstruction::generateBinaryEncoding()
 {
     uint8_t *instructionStart = cg()->getBinaryBufferCursor();
     uint8_t *cursor = instructionStart;
-    uint32_t *iPtr = (uint32_t *)instructionStart;
+    uint32_t *iPtr = (uint32_t *)(getMemoryReference()->generateBinaryEncoding(this, cursor, cg()));
 
     *iPtr = TR_RISCV_STYPE(getOpCode().getMnemonic(), getMemoryBase(), getSource1Register(),
         getMemoryReference()->getOffset(true));
 
     cursor += RISCV_INSTRUCTION_LENGTH;
-    setBinaryLength(RISCV_INSTRUCTION_LENGTH);
+    setBinaryLength((uintptr_t)cursor - (uintptr_t)instructionStart);
     setBinaryEncoding(instructionStart);
     return cursor;
+}
+
+int32_t TR::StoreInstruction::estimateBinaryLength(int32_t currentEstimate)
+{
+    setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(this) + RISCV_INSTRUCTION_LENGTH);
+    return currentEstimate + self()->getEstimatedBinaryLength();
 }
 
 // TR::BtypeInstruction:: member functions

--- a/compiler/riscv/codegen/RVInstruction.hpp
+++ b/compiler/riscv/codegen/RVInstruction.hpp
@@ -406,6 +406,12 @@ public:
      * @return instruction cursor
      */
     virtual uint8_t *generateBinaryEncoding();
+    /**
+     * @brief Estimates binary length
+     * @param[in] currentEstimate : current estimated length
+     * @return estimated binary length
+     */
+    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
 };
 
 class StypeInstruction : public TR::Instruction {
@@ -627,6 +633,13 @@ public:
      * @return instruction cursor
      */
     virtual uint8_t *generateBinaryEncoding();
+
+    /**
+     * @brief Estimates binary length
+     * @param[in] currentEstimate : current estimated length
+     * @return estimated binary length
+     */
+    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
 };
 
 class BtypeInstruction : public StypeInstruction {


### PR DESCRIPTION
This commit introduces MemoryReference::generateBinaryEncoding() which is called from (Load|Store)Instruction::generateBinaryEncoding() before the actual load or store instruction is encoded.

For now it is a no-op.