### PR TITLE
AArch64: Disable vector GRA by default

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -81,9 +81,12 @@ void OMR::ARM64::CodeGenerator::initialize()
     cg->setLastGlobalGPR(_numGPR - 1);
     cg->setLastGlobalFPR(_numGPR + _numFPR - 1);
 
-    // Use the same registers for FPR and VRF
-    cg->setFirstGlobalVRF(self()->getFirstGlobalFPR());
-    cg->setLastGlobalVRF(self()->getLastGlobalFPR());
+    static const bool enableVectorGRA = (feGetEnv("TR_enableVectorGRA") != NULL);
+    if (enableVectorGRA) {
+        // Use the same registers for FPR and VRF
+        cg->setFirstGlobalVRF(self()->getFirstGlobalFPR());
+        cg->setLastGlobalVRF(self()->getLastGlobalFPR());
+    }
 
     cg->getLinkage()->initARM64RealRegisterLinkage();
     cg->setSupportsGlRegDeps();


### PR DESCRIPTION
This commit disables vector GRA on AArch64 by default. It can be enabled by setting an environment variable.