### PR TITLE
Change inverted CMOVE condition and source register in msplatsEvaluator

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -6135,13 +6135,13 @@ TR::Register *OMR::X86::TreeEvaluator::msplatsEvaluator(TR::Node *node, TR::Code
 
         // if child (boolean) is true, set mask
         Inst_RegReg(OP::TESTRegReg(), node, boolReg, boolReg, cg);
-        Inst_RegReg(OP::CMOVERegReg(), node, maskGPR, tmpGPR, cg);
+        Inst_RegReg(OP::CMOVNERegReg(), node, maskGPR, tmpGPR, cg);
 
         if (resultReg->getKind() == TR_VMR) {
             TR::InstOpCode movOpcode = (numLanes > 16) ? OP::KMOVQRegMask : OP::KMOVWRegMask;
             Inst_RegReg(movOpcode.getMnemonic(), node, resultReg, maskGPR, cg);
         } else {
-            Inst_RegReg(OP::MOVQRegReg8, node, resultReg, tmpGPR, cg);
+            Inst_RegReg(OP::MOVQRegReg8, node, resultReg, maskGPR, cg);
 
             if (dt.getVectorLength() == TR::VectorLength128) {
                 Inst_RegRegImm(OP::PSHUFDRegRegImm1, node, resultReg, resultReg, 0x44, cg);


### PR DESCRIPTION
The test result from running Vector API openjdk tests shows that when exercising the maskAll() operation, it vectorized msplats opcode and the output is reversed comparing to the expected results. The following change has been made to correct this failure test case. 
- msplatsEvaluator's non-constant fallback branch used CMOVE where it should use CMOVNE, causing maskAll(false) to incorrectly return an all-true mask. 
- Changed reading from tmpGPR (unconditionally all-true) instead of maskGPR (the conditionally-set register) when populating the TR_VRF result register, discarding the conditional move entirely.