### PR TITLE
Define chkSafeForCGToFastPathUnsafeCall for use in logging flag

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5109,6 +5109,11 @@ void OMR::Node::setIsSafeForCGToFastPathUnsafeCall(bool v)
     _flags.set(unsafeFastPathCall);
 }
 
+bool OMR::Node::chkSafeForCGToFastPathUnsafeCall()
+{
+    return self()->getOpCode().isCall() && _flags.testAny(unsafeFastPathCall);
+}
+
 bool OMR::Node::isCallThatWasRefinedFromKnownObject()
 {
     return self()->getOpCode().isCall() && _flags.testAny(wasRefinedFromKnownObject);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1244,6 +1244,7 @@ public:
 
     bool isSafeForCGToFastPathUnsafeCall();
     void setIsSafeForCGToFastPathUnsafeCall(bool v);
+    bool chkSafeForCGToFastPathUnsafeCall();
 
     // Flag used by TR::ladd and TR::lsub or by TR::lshl and TR::lshr for compressedPointers
     bool containsCompressionSequence();

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -885,7 +885,7 @@ int32_t TR_Debug::nodePrintAllFlags(OMR::Logger *log, TR::Node *node)
     FLAG(chkNodeCreatedByPRE, "createdByPRE");
     FLAG(chkIsReferenceNonNull, "referenceIsNonNull");
     FLAG(isPreparedForDirectJNI, "preparedForDirectJNI");
-    FLAG(isSafeForCGToFastPathUnsafeCall, "safeForCGToFastPathUnsafeCall");
+    FLAG(chkSafeForCGToFastPathUnsafeCall, "safeForCGToFastPathUnsafeCall");
 
 #undef FLAG
 #undef FLAG_IF


### PR DESCRIPTION
The definition of `OMR::Node::isSafeForCGToFastPathUnsafeCall` contains an assertion testing that the operation on which the flag is being tested is actually a call operation.  Code in`TR_Debug::nodePrintAllFlags` that outputs a `Node`'s flags for logging called that method unconditionally for all kinds of operations, violating the assertion.

Following suit with other kinds of `Node` flags, define a `chkSafeForCGToFastPathUnsafeCall` query that can be called for any kind of node, and use that query for logging the setting of that flag.

Fixes:  #8369